### PR TITLE
Added Support for GetChannelBinding() in xplat

### DIFF
--- a/src/Common/src/Interop/Unix/libssl/SecuritySafeHandles.cs
+++ b/src/Common/src/Interop/Unix/libssl/SecuritySafeHandles.cs
@@ -277,8 +277,34 @@ namespace System.Net.Security
         }
     }
 
-    internal abstract class SafeFreeContextBufferChannelBinding : ChannelBinding
+    internal sealed class SafeFreeContextBufferChannelBinding : ChannelBinding
     {
-        // TODO (Issue #3362) To be implemented
+        private readonly SafeChannelBindingHandle _channelBinding = null;
+
+        public override int Size
+        {
+            get { return _channelBinding.Length; }
+        }
+
+        public override bool IsInvalid
+        {
+            get { return _channelBinding.IsInvalid; }
+        }
+
+        public SafeFreeContextBufferChannelBinding(SafeChannelBindingHandle binding)
+        {
+            Debug.Assert(null != binding && !binding.IsInvalid, "input channelBinding is invalid");
+            bool gotRef = false;
+            binding.DangerousAddRef(ref gotRef);
+            handle = binding.DangerousGetHandle();
+            _channelBinding = binding;
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            _channelBinding.DangerousRelease();
+            _channelBinding.Dispose();
+            return true;
+        }
     }
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -140,6 +140,25 @@ extern "C" const char* SslGetVersion(SSL* ssl)
     return SSL_get_version(ssl);
 }
 
+extern "C" int32_t SslGetFinished(SSL* ssl, void* buf, int32_t count)
+{
+	size_t result = SSL_get_finished(ssl, buf, size_t(count));
+	assert(result <= INT32_MAX);
+	return static_cast<int32_t>(result);
+}
+
+extern "C" int32_t SslGetPeerFinished(SSL* ssl, void* buf, int32_t count)
+{
+	size_t result = SSL_get_peer_finished(ssl, buf, size_t(count));
+	assert(result <= INT32_MAX);
+	return static_cast<int32_t>(result);
+}
+
+extern "C" bool SslSessionReused(SSL* ssl)
+{
+	return SSL_session_reused(ssl) == 1;
+}
+
 /*
 The values used in OpenSSL for SSL_CIPHER algorithm_enc.
 */

--- a/src/Native/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_ssl.h
@@ -361,3 +361,19 @@ extern "C" void SslCtxSetClientCAList(SSL_CTX* ctx, X509NameStack* list);
 Gets the SSL stream sizes to use.
 */
 extern "C" void GetStreamSizes(int32_t* header, int32_t* trailer, int32_t* maximumMessage);
+
+/*
+Shims the SSL_get_finished method.
+*/
+extern "C" int32_t SslGetFinished(SSL* ssl, void* buf, int32_t count);
+
+/*
+Shims the SSL_get_peer_finished method.
+*/
+extern "C" int32_t SslGetPeerFinished(SSL* ssl, void* buf, int32_t count);
+
+/*
+Returns true/false based on if existing ssl session was re-used or not.
+Shims the SSL_session_reused macro.
+*/
+extern "C" bool SslSessionReused(SSL* ssl);

--- a/src/System.Net.Security/src/Resources/Strings.resx
+++ b/src/System.Net.Security/src/Resources/Strings.resx
@@ -369,4 +369,10 @@
   <data name="net_ssl_get_connection_info_failed" xml:space="preserve">
     <value>Getting SSL connection info failed with OpenSSL error - {0}.</value>
   </data>
+  <data name="net_ssl_get_channel_binding_token_failed" xml:space="preserve">
+    <value>Fetching channel binding token failed with OpenSSL error - {0}.</value>
+  </data>
+  <data name="net_ssl_invalid_certificate" xml:space="preserve">
+    <value>SSL certificate returned is invalid, OpenSSL error - {0}.</value>
+  </data>
 </root>

--- a/src/System.Net.Security/src/System/Net/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/SslStreamPal.Unix.cs
@@ -64,10 +64,11 @@ namespace System.Net
             return retVal;
         }
 
-        public static SafeFreeContextBufferChannelBinding QueryContextChannelBinding(SafeDeleteContext phContext, ChannelBindingKind attribute)
+        public static SafeFreeContextBufferChannelBinding QueryContextChannelBinding(SafeDeleteContext securityContext, ChannelBindingKind attribute)
         {
-            // TODO (Issue #3954) To be implemented
-            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
+            SafeChannelBindingHandle bindingHandle = Interop.OpenSsl.QueryChannelBinding(securityContext.SslContext, attribute);
+            var refHandle = bindingHandle == null ? null : new SafeFreeContextBufferChannelBinding(bindingHandle);
+            return refHandle;
         }
 
         public static void QueryContextStreamSizes(SafeDeleteContext securityContext, out StreamSizes streamSizes)


### PR DESCRIPTION
Added Support for GetChannelBinding() in xplat System.Net.Security
- Added support for both EndPoint & Unique type of channel binding.
- Validated cbt with what we get with Windows.
- corresponding tests passed as well.

There is no inbuilt openssl library which gives you channel binding token directly. It have to be framed using basic APIs.