### PR TITLE
Finish Unix support for X509 extensions

### DIFF
--- a/src/Common/src/System/Security/Cryptography/DerEncoder.cs
+++ b/src/Common/src/System/Security/Cryptography/DerEncoder.cs
@@ -301,6 +301,24 @@ namespace System.Security.Cryptography
         }
 
         /// <summary>
+        /// Encode the segments { tag, length, value } of an octet string (byte array).
+        /// </summary>
+        /// <param name="data">The data to encode</param>
+        /// <returns>The encoded segments { tag, length, value }</returns>
+        internal static byte[][] SegmentedEncodeOctetString(byte[] data)
+        {
+            Debug.Assert(data != null);
+
+            // Because this is not currently public API the data array is not being cloned.
+            return new byte[][]
+            {
+                new byte[] { (byte)DerSequenceReader.DerTag.OctetString }, 
+                EncodeLength(data.Length),
+                data,
+            };
+        }
+
+        /// <summary>
         /// Encode the segments { tag, length, value } of an object identifier (Oid).
         /// </summary>
         /// <returns>The encoded segments { tag, length, value }</returns>

--- a/src/Common/src/System/Security/Cryptography/DerSequenceReader.cs
+++ b/src/Common/src/System/Security/Cryptography/DerSequenceReader.cs
@@ -264,6 +264,7 @@ namespace System.Security.Cryptography
 
         internal enum DerTag : byte
         {
+            Boolean = 0x01,
             Integer = 0x02,
             BitString = 0x03,
             OctetString = 0x04,

--- a/src/System.Security.Cryptography.Encoding/tests/DerEncoderTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/DerEncoderTests.cs
@@ -71,6 +71,24 @@ namespace System.Security.Cryptography.Encoding.Tests
         }
 
         [Theory]
+        [InlineData("010203040506070809", "09")]
+        [InlineData("", "00")]
+        public static void ValidateOctetStringEncodings(string hexData, string hexLength)
+        {
+            byte[] input = hexData.HexToByteArray();
+            const byte tag = 0x04;
+            byte[] length = hexLength.HexToByteArray();
+
+            byte[][] segments = DerEncoder.SegmentedEncodeOctetString(input);
+
+            Assert.Equal(3, segments.Length);
+
+            Assert.Equal(new[] { tag }, segments[0]);
+            Assert.Equal(length, segments[1]);
+            Assert.Equal(input, segments[2]);
+        }
+
+        [Theory]
         [InlineData("1.3.6.1.5.5.7.3.1", "08", "2B06010505070301")]
         [InlineData("1.3.6.1.5.5.7.3.2", "08", "2B06010505070302")]
         [InlineData("2.999.3", "03", "883703")]

--- a/src/System.Security.Cryptography.Encoding/tests/DerEncoderTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/DerEncoderTests.cs
@@ -70,6 +70,27 @@ namespace System.Security.Cryptography.Encoding.Tests
             Assert.Equal(expectedOutput, segments[2]);
         }
 
+        [Theory]
+        [InlineData("1.3.6.1.5.5.7.3.1", "08", "2B06010505070301")]
+        [InlineData("1.3.6.1.5.5.7.3.2", "08", "2B06010505070302")]
+        [InlineData("2.999.3", "03", "883703")]
+        [InlineData("2.999.19427512891.25", "08", "8837C8AFE1A43B19")]
+        public static void ValidateOidEncodings(string oidValue, string hexLength, string encodedData)
+        {
+            Oid oid = new Oid(oidValue, oidValue);
+            const byte tag = 0x06;
+            byte[] length = hexLength.HexToByteArray();
+            byte[] expectedOutput = encodedData.HexToByteArray();
+
+            byte[][] segments = DerEncoder.SegmentedEncodeOid(oid);
+
+            Assert.Equal(3, segments.Length);
+
+            Assert.Equal(new[] { tag }, segments[0]);
+            Assert.Equal(length, segments[1]);
+            Assert.Equal(expectedOutput, segments[2]);
+        }
+
         [Fact]
         public static void ConstructSequence()
         {

--- a/src/System.Security.Cryptography.Encoding/tests/DerEncoderTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/DerEncoderTests.cs
@@ -45,6 +45,35 @@ namespace System.Security.Cryptography.Encoding.Tests
         }
 
         [Theory]
+        [InlineData("", 0, "01", "00")]
+        [InlineData("00", 0, "02", "0000")]
+        [InlineData("00", 7, "02", "0700")]
+        [InlineData("0000", 0, "03", "000000")]
+        [InlineData("007F", 7, "03", "070000")]
+        [InlineData("007F", 6, "03", "060040")]
+        [InlineData("007F", 5, "03", "050060")]
+        [InlineData("007F", 4, "03", "040070")]
+        [InlineData("007F", 3, "03", "030078")]
+        [InlineData("007F", 2, "03", "02007C")]
+        [InlineData("007F", 1, "03", "01007E")]
+        [InlineData("007F", 0, "03", "00007F")]
+        public static void ValidateBitStringEncodings(string hexRaw, int unusedBits, string hexLength, string encodedData)
+        {
+            byte[] input = hexRaw.HexToByteArray();
+            const byte tag = 0x03;
+            byte[] length = hexLength.HexToByteArray();
+            byte[] expectedOutput = encodedData.HexToByteArray();
+
+            byte[][] segments = DerEncoder.SegmentedEncodeBitString(unusedBits, input);
+
+            Assert.Equal(3, segments.Length);
+
+            Assert.Equal(new[] { tag }, segments[0]);
+            Assert.Equal(length, segments[1]);
+            Assert.Equal(expectedOutput, segments[2]);
+        }
+
+        [Theory]
         [InlineData("", 9, "01", "00")]
         [InlineData("00", 9, "01", "00")]
         [InlineData("0000", 9, "01", "00")]

--- a/src/System.Security.Cryptography.Encoding/tests/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Encoding/tests/Resources/Strings.resx
@@ -17,12 +17,12 @@
     <resheader name="version">2.0</resheader>
     <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
     <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-    <data name="zzName1"><value>this is my long string</value><comment>this is a comment</comment></data>
-    <data name="zzColor1" type="System.Drawing.Color, System.Drawing">Blue</data>
-    <data name="zzBitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
         <value>[base64 mime encoded serialized .NET Framework object]</value>
     </data>
-    <data name="zzIcon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
@@ -117,31 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="Arg_CryptographyException" xml:space="preserve">
-    <value>Error occurred during a cryptographic operation.</value>
-  </data>
   <data name="Argument_InvalidOidValue" xml:space="preserve">
     <value>The OID value was invalid.</value>
-  </data>
-  <data name="Argument_InvalidValue" xml:space="preserve">
-    <value>Value was invalid.</value>
-  </data>
-  <data name="Cryptography_CSP_NoPrivateKey" xml:space="preserve">
-    <value>Object contains only the public half of a key pair. A private key must also be provided.</value>
-  </data>
-  <data name="Cryptography_HashAlgorithmNameNullOrEmpty" xml:space="preserve">
-    <value>The hash algorithm name cannot be null or empty.</value>
-  </data>
-  <data name="Cryptography_InvalidPaddingMode" xml:space="preserve">
-    <value>Specified padding mode is not valid for this algorithm.</value>
-  </data>
-  <data name="Cryptography_OpenInvalidHandle" xml:space="preserve">
-    <value>Cannot open an invalid handle.</value>
-  </data>
-  <data name="Cryptography_UnknownHashAlgorithm" xml:space="preserve">
-    <value>'{0}' is not a known hash algorithm.</value>
-  </data>
-  <data name="Cryptography_UnsupportedEcKeyAlgorithm" xml:space="preserve">
-    <value>Cannot use imported EC_KEY. '{0}' is not a supported algorithm.</value>
   </data>
 </root>

--- a/src/System.Security.Cryptography.OpenSsl/src/project.json
+++ b/src/System.Security.Cryptography.OpenSsl/src/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "System.Collections": "4.0.0",
     "System.Diagnostics.Contracts": "4.0.0",
     "System.Diagnostics.Debug": "4.0.10",
     "System.IO": "4.0.10",

--- a/src/System.Security.Cryptography.OpenSsl/src/project.lock.json
+++ b/src/System.Security.Cryptography.OpenSsl/src/project.lock.json
@@ -3,6 +3,15 @@
   "version": 2,
   "targets": {
     "DNXCore,Version=v5.0": {
+      "System.Collections/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.dll": {}
+        }
+      },
       "System.Diagnostics.Contracts/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -1714,6 +1723,7 @@
   },
   "projectFileDependencyGroups": {
     "": [
+      "System.Collections >= 4.0.0",
       "System.Diagnostics.Contracts >= 4.0.0",
       "System.Diagnostics.Debug >= 4.0.10",
       "System.IO >= 4.0.10",

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/IX509Pal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/IX509Pal.cs
@@ -17,6 +17,7 @@ namespace Internal.Cryptography.Pal
         X509ContentType GetCertContentType(String fileName);
         byte[] EncodeX509KeyUsageExtension(X509KeyUsageFlags keyUsages);
         void DecodeX509KeyUsageExtension(byte[] encoded, out X509KeyUsageFlags keyUsages);
+        bool SupportsLegacyBasicConstraintsExtension { get; }
         byte[] EncodeX509BasicConstraints2Extension(bool certificateAuthority, bool hasPathLengthConstraint, int pathLengthConstraint);
         void DecodeX509BasicConstraintsExtension(byte[] encoded, out bool certificateAuthority, out bool hasPathLengthConstraint, out int pathLengthConstraint);
         void DecodeX509BasicConstraints2Extension(byte[] encoded, out bool certificateAuthority, out bool hasPathLengthConstraint, out int pathLengthConstraint);

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
@@ -281,7 +281,20 @@ namespace Internal.Cryptography.Pal
 
         public byte[] EncodeX509EnhancedKeyUsageExtension(OidCollection usages)
         {
-            throw new NotImplementedException();
+            //extKeyUsage EXTENSION ::= {
+            //    SYNTAX SEQUENCE SIZE(1..MAX) OF KeyPurposeId
+            //    IDENTIFIED BY id - ce - extKeyUsage }
+            //
+            //KeyPurposeId::= OBJECT IDENTIFIER
+
+            List<byte[][]> segments = new List<byte[][]>(usages.Count);
+
+            foreach (Oid usage in usages)
+            {
+                segments.Add(DerEncoder.SegmentedEncodeOid(usage));
+            }
+
+            return DerEncoder.ConstructSequence(segments);
         }
 
         public void DecodeX509EnhancedKeyUsageExtension(byte[] encoded, out OidCollection usages)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
@@ -327,7 +327,18 @@ namespace Internal.Cryptography.Pal
 
         public byte[] EncodeX509SubjectKeyIdentifierExtension(byte[] subjectKeyIdentifier)
         {
-            throw new NotImplementedException();
+            //subjectKeyIdentifier EXTENSION ::= {
+            //    SYNTAX SubjectKeyIdentifier
+            //    IDENTIFIED BY id - ce - subjectKeyIdentifier }
+            //
+            //SubjectKeyIdentifier::= KeyIdentifier
+            //
+            //KeyIdentifier ::= OCTET STRING
+
+            byte[][] segments = DerEncoder.SegmentedEncodeOctetString(subjectKeyIdentifier);
+
+            // The extension is not a sequence, just the octet string
+            return ConcatenateArrays(segments);
         }
 
         public void DecodeX509SubjectKeyIdentifierExtension(byte[] encoded, out byte[] subjectKeyIdentifier)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.CustomExtensions.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.CustomExtensions.cs
@@ -59,6 +59,11 @@ namespace Internal.Cryptography.Pal
             }
         }
 
+        public bool SupportsLegacyBasicConstraintsExtension
+        {
+            get { return true; }
+        }
+
         public byte[] EncodeX509BasicConstraints2Extension(bool certificateAuthority, bool hasPathLengthConstraint, int pathLengthConstraint)
         {
             unsafe

--- a/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -225,6 +225,9 @@
   <data name="NotSupported_KeyAlgorithm" xml:space="preserve">
     <value>The certificate key algorithm is not supported.</value>
   </data>
+  <data name="NotSupported_LegacyBasicConstraints" xml:space="preserve">
+    <value>The X509 Basic Constraints extension with OID 2.5.29.10 is not supported.</value>
+  </data>
   <data name="PersistedFiles_NoHomeDirectory" xml:space="preserve">
     <value>The home directory of the current user could not be determined.</value>
   </data>

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate2.cs
@@ -486,10 +486,14 @@ namespace System.Security.Cryptography.X509Certificates
 
         private static X509Extension CreateCustomExtensionIfAny(Oid oid)
         {
-            String oidValue = oid.Value;
+            string oidValue = oid.Value;
             switch (oidValue)
             {
                 case Oids.BasicConstraints:
+                    return X509Pal.Instance.SupportsLegacyBasicConstraintsExtension ?
+                        new X509BasicConstraintsExtension() :
+                        null;
+
                 case Oids.BasicConstraints2:
                     return new X509BasicConstraintsExtension();
 

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509SubjectKeyIdentifierExtension.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509SubjectKeyIdentifierExtension.cs
@@ -127,7 +127,10 @@ namespace System.Security.Cryptography.X509Certificates
 
         private static byte[] ComputeSha1(byte[] data)
         {
-            return SHA1.Create().ComputeHash(data);
+            using (SHA1 sha1 = SHA1.Create())
+            {
+                return sha1.ComputeHash(data);
+            }
         }
 
         private String _subjectKeyIdentifier;

--- a/src/System.Security.Cryptography.X509Certificates/tests/ExtensionsTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ExtensionsTests.cs
@@ -265,7 +265,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void EnhancedKeyUsageExtension_Empty()
         {
             OidCollection usages = new OidCollection();
@@ -273,7 +272,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void EnhancedKeyUsageExtension_2Oids()
         {
             Oid oid1 = Oid.FromOidValue("1.3.6.1.5.5.7.3.1", OidGroup.EnhancedKeyUsage);

--- a/src/System.Security.Cryptography.X509Certificates/tests/ExtensionsTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ExtensionsTests.cs
@@ -205,7 +205,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Theory]
         [MemberData("BasicConstraintsData")]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void BasicConstraintsExtensionEncode(
             bool certificateAuthority,
             bool hasPathLengthConstraint,
@@ -233,16 +232,18 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             string rawDataString)
         {
             byte[] rawData = rawDataString.HexToByteArray();
+            int expectedPathLengthConstraint = hasPathLengthConstraint ? pathLengthConstraint : 0;
 
             X509BasicConstraintsExtension ext = new X509BasicConstraintsExtension(new AsnEncodedData(rawData), critical);
             Assert.Equal(certificateAuthority, ext.CertificateAuthority);
             Assert.Equal(hasPathLengthConstraint, ext.HasPathLengthConstraint);
-            Assert.Equal(pathLengthConstraint, ext.PathLengthConstraint);
+            Assert.Equal(expectedPathLengthConstraint, ext.PathLengthConstraint);
         }
 
         public static object[][] BasicConstraintsData = new object[][]
         {
             new object[] { false, false, 0, false, "3000" },
+            new object[] { false, false, 121, false, "3000" },
             new object[] { true, false, 0, false, "30030101ff" },
             new object[] { false, true, 0, false, "3003020100" },
             new object[] { false, true, 7654321, false, "3005020374cbb1" },

--- a/src/System.Security.Cryptography.X509Certificates/tests/ExtensionsTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ExtensionsTests.cs
@@ -363,7 +363,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void SubjectKeyIdentifierExtension_PublicKeyCapiSha1()
         {
             TestSubjectKeyIdentifierExtension(

--- a/src/System.Security.Cryptography.X509Certificates/tests/ExtensionsTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ExtensionsTests.cs
@@ -299,7 +299,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void SubjectKeyIdentifierExtension_Bytes()
         {
             byte[] sk = { 1, 2, 3, 4 };
@@ -314,7 +313,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void SubjectKeyIdentifierExtension_String()
         {
             string sk = "01ABcd";
@@ -329,7 +327,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void SubjectKeyIdentifierExtension_PublicKey()
         {
             PublicKey pk = new X509Certificate2(TestData.MsCertificate).PublicKey;
@@ -344,7 +341,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void SubjectKeyIdentifierExtension_PublicKeySha1()
         {
             TestSubjectKeyIdentifierExtension(
@@ -356,7 +352,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void SubjectKeyIdentifierExtension_PublicKeyShortSha1()
         {
             TestSubjectKeyIdentifierExtension(

--- a/src/System.Security.Cryptography.X509Certificates/tests/ExtensionsTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ExtensionsTests.cs
@@ -283,6 +283,20 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             TestEnhancedKeyUsageExtension(usages, false, "301606082b06010505070301060a2b0601040182370a0301".HexToByteArray());
         }
 
+        [Theory]
+        [InlineData("1")]
+        [InlineData("3.0")]
+        [InlineData("Invalid Value")]
+        public static void EnhancedKeyUsageExtension_InvalidOid(string invalidOidValue)
+        {
+            OidCollection oids = new OidCollection
+            {
+                new Oid(invalidOidValue)
+            };
+
+            Assert.ThrowsAny<CryptographicException>(() => new X509EnhancedKeyUsageExtension(oids, false));
+        }
+
         [Fact]
         public static void SubjectKeyIdentifierExtensionDefault()
         {


### PR DESCRIPTION
With this change all of the tests in ExtensionsTests.cs are enabled (and passing) on Unix builds.

New DER encoding helpers were added
* Boolean (dead simple, only two answers :smile:)
* OID (slightly complicated, in a commit by itself)
* Octet String (dead simple)
* (non-named-list) Bit String (remarkably simple)

The `byte[][]` Segmented helpers are reducing the amount of memory copying, but also kind of a pain.  I considered trying to make rich types for them in the middle of this change, but if we can avoid too much more I think still that's better suited to public API (post-1.0.0-rtm).

This is a partial fix for #1993.  I count 8 total NotImplementedExceptions remaining in the Unix X509 code; with perhaps 6 of them moving to PlatformNotSupportedException.

cc: @stephentoub @morganbr @AtsushiKan 