### PR TITLE
Fixing the python style script to fix CI builds

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -30,7 +30,7 @@ def prCCJob = job(Utilities.getFullJobName(project, 'code_coverage_windows', tru
 [true, false].each { isPR -> 
   def codeFormatterJobName = Utilities.getFullJobName(project, 'native_code_format_check', isPR)
   def codeFormatterJob = job(codeFormatterJobName) {
-    label('windows')
+    label('ubuntu')
     steps {
       batchFile('python src/Native/format-code.py checkonly')
     }

--- a/src/Native/.clang-format
+++ b/src/Native/.clang-format
@@ -2,7 +2,6 @@
 Language:        Cpp
 # BasedOnStyle:  LLVM
 AlignEscapedNewlinesLeft: false
-AlignAfterOpenBracket: true
 AllowShortFunctionsOnASingleLine: false
 AlwaysBreakTemplateDeclarations: true
 BinPackArguments: false

--- a/src/Native/System.Security.Cryptography.Native/openssl.c
+++ b/src/Native/System.Security.Cryptography.Native/openssl.c
@@ -1170,7 +1170,7 @@ Return values:
 1 on success
 0 on a NULL stack, or an error within sk_X509_push
 */
-int32_t PushX509StackField(STACK_OF(X509) * stack, X509* x509)
+int32_t PushX509StackField(STACK_OF(X509) * stack, X509 * x509)
 {
     if (!stack)
     {

--- a/src/Native/System.Security.Cryptography.Native/pal_x509_name.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509_name.cpp
@@ -36,7 +36,7 @@ extern "C" STACK_OF(X509_NAME) * NewX509NameStack()
     return sk_X509_NAME_new_null();
 }
 
-extern "C" int32_t PushX509NameStackField(STACK_OF(X509_NAME) * stack, X509_NAME* x509Name)
+extern "C" int32_t PushX509NameStackField(STACK_OF(X509_NAME) * stack, X509_NAME * x509Name)
 {
     if (!stack)
     {

--- a/src/Native/System.Security.Cryptography.Native/pal_x509_name.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509_name.h
@@ -51,7 +51,7 @@ Return values:
 1 on success
 0 on a NULL stack, or an error within sk_X509_NAME_push
 */
-extern "C" int32_t PushX509NameStackField(STACK_OF(X509_NAME) * stack, X509_NAME* x509Name);
+extern "C" int32_t PushX509NameStackField(STACK_OF(X509_NAME) * stack, X509_NAME * x509Name);
 
 /*
 Function:

--- a/src/Native/format-code.py
+++ b/src/Native/format-code.py
@@ -26,7 +26,7 @@ except:
 if a.checkonly is None:
     args = '-style=file -i '
 else:
-    args = '-style=file '
+    args = '-style=file -output-replacements-xml '
 
 print 'Running clang-format style cop on native code...'
 
@@ -37,6 +37,9 @@ for extension in extensions:
     for nativefile in glob.glob('**/*.' + extension):
         cmd = cf + args + os.path.realpath(nativefile)
         print 'Formatting native file with command: ' + cmd
-        if len(subprocess.check_output(cmd, shell=True)) != 0:
-            print 'File not style compliant, exiting: ' + nativefile
-            sys.exit(-1)
+        if a.checkonly is None:
+            subprocess.call(cmd, shell=True)
+        else:
+            if len(subprocess.check_output(cmd, shell=True)) != 74:
+                print 'File not style compliant, exiting: ' + nativefile
+                sys.exit(-1)


### PR DESCRIPTION
Fixing the python style script to output only the differences when the checkonly flag has been placed. This will normalize the output and allows us to check for the expected output length to determine if any style replacements happened in the file

/cc @stephentoub @mmitche 