### PR TITLE
System.Net.NetworkInformation: Use List<T> instead of Collection<T>

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/GatewayIPAddressInformationCollection.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/GatewayIPAddressInformationCollection.cs
@@ -2,21 +2,19 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace System.Net.NetworkInformation
 {
     public class GatewayIPAddressInformationCollection : ICollection<GatewayIPAddressInformation>
     {
-        private readonly Collection<GatewayIPAddressInformation> _addresses;
-            
+        private readonly List<GatewayIPAddressInformation> _addresses;
 
         protected internal GatewayIPAddressInformationCollection()
         {
-            _addresses = new Collection<GatewayIPAddressInformation>();
+            _addresses = new List<GatewayIPAddressInformation>();
         }
 
-        internal GatewayIPAddressInformationCollection(Collection<GatewayIPAddressInformation> addresses)
+        internal GatewayIPAddressInformationCollection(List<GatewayIPAddressInformation> addresses)
         {
             _addresses = addresses;
         }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/InternalIPAddressCollection.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/InternalIPAddressCollection.cs
@@ -1,20 +1,20 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.ObjectModel;
+using System.Collections.Generic;
 
 namespace System.Net.NetworkInformation
 {
     internal class InternalIPAddressCollection : IPAddressCollection
     {
-        private readonly Collection<IPAddress> _addresses;
+        private readonly List<IPAddress> _addresses;
 
         protected internal InternalIPAddressCollection()
         {
-            _addresses = new Collection<IPAddress>();
+            _addresses = new List<IPAddress>();
         }
 
-        internal InternalIPAddressCollection(Collection<IPAddress> addresses)
+        internal InternalIPAddressCollection(List<IPAddress> addresses)
         {
             _addresses = addresses;
         }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPInterfaceProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPInterfaceProperties.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.ObjectModel;
-using System.IO;
+using System.Collections.Generic;
 
 namespace System.Net.NetworkInformation
 {
@@ -74,21 +73,21 @@ namespace System.Net.NetworkInformation
         // and seperates the information about by each interface.
         public GatewayIPAddressInformationCollection GetGatewayAddresses()
         {
-            Collection<GatewayIPAddressInformation> innerCollection
+            List<GatewayIPAddressInformation> innerCollection
                 = StringParsingHelpers.ParseGatewayAddressesFromRouteFile(NetworkFiles.Ipv4RouteFile, _linuxNetworkInterface.Name);
             return new GatewayIPAddressInformationCollection(innerCollection);
         }
 
         private IPAddressCollection GetDhcpServerAddresses()
         {
-            Collection<IPAddress> internalCollection
+            List<IPAddress> internalCollection
                 = StringParsingHelpers.ParseDhcpServerAddressesFromLeasesFile(NetworkFiles.DHClientLeasesFile, _linuxNetworkInterface.Name);
             return new InternalIPAddressCollection(internalCollection);
         }
 
         private IPAddressCollection GetWinsServerAddresses()
         {
-            Collection<IPAddress> internalCollection
+            List<IPAddress> internalCollection
                 = StringParsingHelpers.ParseWinsServerAddressesFromSmbConfFile(NetworkFiles.SmbConfFile);
             return new InternalIPAddressCollection(internalCollection);
         }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/MulticastIPAddressInformationCollection.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/MulticastIPAddressInformationCollection.cs
@@ -2,13 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace System.Net.NetworkInformation
 {
     public class MulticastIPAddressInformationCollection : ICollection<MulticastIPAddressInformation>
     {
-        private readonly Collection<MulticastIPAddressInformation> _addresses = new Collection<MulticastIPAddressInformation>();
+        private readonly List<MulticastIPAddressInformation> _addresses = new List<MulticastIPAddressInformation>();
 
         protected internal MulticastIPAddressInformationCollection()
         {

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Addresses.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Addresses.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.IO;
 
 namespace System.Net.NetworkInformation
@@ -10,9 +10,9 @@ namespace System.Net.NetworkInformation
     {
         // /proc/net/route contains some information about gateway addresses,
         // and seperates the information about by each interface.
-        internal static Collection<GatewayIPAddressInformation> ParseGatewayAddressesFromRouteFile(string filePath, string interfaceName)
+        internal static List<GatewayIPAddressInformation> ParseGatewayAddressesFromRouteFile(string filePath, string interfaceName)
         {
-            Collection<GatewayIPAddressInformation> collection = new Collection<GatewayIPAddressInformation>();
+            List<GatewayIPAddressInformation> collection = new List<GatewayIPAddressInformation>();
             // Columns are as follows (first-line header):
             // Iface  Destination  Gateway  Flags  RefCnt  Use  Metric  Mask  MTU  Window  IRTT
             string[] fileLines = File.ReadAllLines(filePath);
@@ -33,12 +33,12 @@ namespace System.Net.NetworkInformation
             return collection;
         }
 
-        internal static Collection<IPAddress> ParseDhcpServerAddressesFromLeasesFile(string filePath, string name)
+        internal static List<IPAddress> ParseDhcpServerAddressesFromLeasesFile(string filePath, string name)
         {
             // Parse the /var/lib/dhcp/dhclient.leases file, if it exists.
             // If any errors occur, like the file not existing or being
             // improperly formatted, just bail and return an empty collection.
-            Collection<IPAddress> collection = new Collection<IPAddress>();
+            List<IPAddress> collection = new List<IPAddress>();
             try
             {
                 string fileContents = File.ReadAllText(filePath);
@@ -78,9 +78,9 @@ namespace System.Net.NetworkInformation
             return collection;
         }
 
-        internal static Collection<IPAddress> ParseWinsServerAddressesFromSmbConfFile(string smbConfFilePath)
+        internal static List<IPAddress> ParseWinsServerAddressesFromSmbConfFile(string smbConfFilePath)
         {
-            Collection<IPAddress> collection = new Collection<IPAddress>();
+            List<IPAddress> collection = new List<IPAddress>();
             try
             {
                 string fileContents = File.ReadAllText(smbConfFilePath);

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Dns.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Dns.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using System.IO;
 
 namespace System.Net.NetworkInformation
@@ -17,7 +17,7 @@ namespace System.Net.NetworkInformation
             return rcr.TryGetNextValue("search", out dnsSuffix) ? dnsSuffix : string.Empty;
         }
 
-        internal static Collection<IPAddress> ParseDnsAddressesFromResolvConfFile(string filePath)
+        internal static List<IPAddress> ParseDnsAddressesFromResolvConfFile(string filePath)
         {
             // Parse /etc/resolv.conf for all of the "nameserver" entries.
             // These are the DNS servers the machine is configured to use.
@@ -26,7 +26,7 @@ namespace System.Net.NetworkInformation
             // the machine's DNS servers listed in it.
             string data = File.ReadAllText(filePath);
             RowConfigReader rcr = new RowConfigReader(data);
-            Collection<IPAddress> addresses = new Collection<IPAddress>();
+            List<IPAddress> addresses = new List<IPAddress>();
 
             string addressString = null;
             while (rcr.TryGetNextValue("nameserver", out addressString))

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnicastIPAddressInformationCollection.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnicastIPAddressInformationCollection.cs
@@ -2,14 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace System.Net.NetworkInformation
 {
     public class UnicastIPAddressInformationCollection : ICollection<UnicastIPAddressInformation>
     {
-        private readonly Collection<UnicastIPAddressInformation> _addresses =
-            new Collection<UnicastIPAddressInformation>();
+        private readonly List<UnicastIPAddressInformation> _addresses =
+            new List<UnicastIPAddressInformation>();
 
         protected internal UnicastIPAddressInformationCollection()
         {

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPInterfaceProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPInterfaceProperties.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.ObjectModel;
-using System.IO;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net.Sockets;
 
@@ -96,7 +95,7 @@ namespace System.Net.NetworkInformation
 
         private static IPAddressCollection GetDnsAddresses()
         {
-            Collection<IPAddress> internalAddresses = StringParsingHelpers.ParseDnsAddressesFromResolvConfFile(NetworkFiles.EtcResolvConfFile);
+            List<IPAddress> internalAddresses = StringParsingHelpers.ParseDnsAddressesFromResolvConfFile(NetworkFiles.EtcResolvConfFile);
             return new InternalIPAddressCollection(internalAddresses);
         }
     }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/ipaddressinformationcollection.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/ipaddressinformationcollection.cs
@@ -2,13 +2,12 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 
 namespace System.Net.NetworkInformation
 {
     public class IPAddressInformationCollection : ICollection<IPAddressInformation>
     {
-        private readonly Collection<IPAddressInformation> _addresses = new Collection<IPAddressInformation>();
+        private readonly List<IPAddressInformation> _addresses = new List<IPAddressInformation>();
 
         internal IPAddressInformationCollection()
         {

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/AddressParsingTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/AddressParsingTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Net.NetworkInformation.Tests
@@ -12,7 +12,7 @@ namespace System.Net.NetworkInformation.Tests
         public static void GatewayAddressParsing()
         {
             FileUtil.NormalizeLineEndings("route", "route_normalized1");
-            Collection<GatewayIPAddressInformation> gatewayAddresses = StringParsingHelpers.ParseGatewayAddressesFromRouteFile("route_normalized1", "wlan0");
+            List<GatewayIPAddressInformation> gatewayAddresses = StringParsingHelpers.ParseGatewayAddressesFromRouteFile("route_normalized1", "wlan0");
             Assert.Equal(3, gatewayAddresses.Count);
 
             Assert.Equal(StringParsingHelpers.ParseHexIPAddress("0180690A"), gatewayAddresses[0].Address);
@@ -24,7 +24,7 @@ namespace System.Net.NetworkInformation.Tests
         public static void DhcpServerAddressParsing()
         {
             FileUtil.NormalizeLineEndings("dhclient.leases", "dhclient.leases_normalized0");
-            Collection<IPAddress> dhcpServerAddresses = StringParsingHelpers.ParseDhcpServerAddressesFromLeasesFile("dhclient.leases_normalized0", "wlan0");
+            List<IPAddress> dhcpServerAddresses = StringParsingHelpers.ParseDhcpServerAddressesFromLeasesFile("dhclient.leases_normalized0", "wlan0");
             Assert.Equal(1, dhcpServerAddresses.Count);
             Assert.Equal(IPAddress.Parse("10.105.128.4"), dhcpServerAddresses[0]);
         }
@@ -34,7 +34,7 @@ namespace System.Net.NetworkInformation.Tests
         {
             FileUtil.NormalizeLineEndings("smb.conf", "smb.conf_normalized");
 
-            Collection<IPAddress> winsServerAddresses = StringParsingHelpers.ParseWinsServerAddressesFromSmbConfFile("smb.conf_normalized");
+            List<IPAddress> winsServerAddresses = StringParsingHelpers.ParseWinsServerAddressesFromSmbConfFile("smb.conf_normalized");
             Assert.Equal(1, winsServerAddresses.Count);
             Assert.Equal(IPAddress.Parse("255.1.255.1"), winsServerAddresses[0]);
         }


### PR DESCRIPTION
Avoids unnecessary `Collection<T>` overhead.

cc: @CIPop, @mellinoe