### PR TITLE
Handle CURLE_UNKNOWN_OPTION when registering HTTPS callbacks on older…

### DIFF
--- a/src/Common/src/Interop/Unix/libcurl/Interop.CURLcode.cs
+++ b/src/Common/src/Interop/Unix/libcurl/Interop.CURLcode.cs
@@ -16,6 +16,7 @@ internal static partial class Interop
             internal const int CURLE_COULDNT_RESOLVE_PROXY =  5;
             internal const int CURLE_COULDNT_RESOLVE_HOST  =  6;
             internal const int CURLE_ABORTED_BY_CALLBACK = 42;
+            internal const int CURLE_UNKNOWN_OPTION = 48;
         }
     }
 }

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
@@ -28,6 +28,9 @@ namespace System.Net.Http
                 {
                     case Interop.libcurl.CURLcode.CURLE_OK:
                         break;
+                    // Curl 7.38 and prior
+                    case Interop.libcurl.CURLcode.CURLE_UNKNOWN_OPTION:
+                    // Curl 7.39 and later
                     case Interop.libcurl.CURLcode.CURLE_NOT_BUILT_IN:
                         VerboseTrace("CURLOPT_SSL_CTX_FUNCTION is not supported, platform default https chain building in use");
                         break;


### PR DESCRIPTION
… versions of curl.

Prior to curl 7.39 the case label for CURLOPT_SSL_CTX_FUNCTION was compiled out, resulting in CURLE_UNKNOWN_OPTION.  In 7.39 they changed it to always present, but reporting CURLE_NOT_BUILT_IN when the backend SSL provider didn't support that callback.

The code was written based on the behavior of curl 7.43, so didn't know about the legacy behavioral difference.

Fixes #4233.

cc: @stephentoub @eerhardt @kapilash 