### PR TITLE
WinHttpHandler ResponseStream reads should return back with partial data

### DIFF
--- a/src/Common/src/Interop/Windows/winhttp/Interop.winhttp.cs
+++ b/src/Common/src/Interop/Windows/winhttp/Interop.winhttp.cs
@@ -98,6 +98,12 @@ internal partial class Interop
 
         [DllImport(Interop.Libraries.WinHttp, CharSet = CharSet.Unicode, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool WinHttpQueryDataAvailable(
+            SafeWinHttpHandle requestHandle,
+            IntPtr parameterIgnoredAndShouldBeNullForAsync);
+
+        [DllImport(Interop.Libraries.WinHttp, CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool WinHttpReadData(
             SafeWinHttpHandle requestHandle,
             IntPtr buffer,

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
@@ -96,6 +96,7 @@ namespace System.Net.Http
         public TaskCompletionSource<bool> TcsWriteToRequestStream { get; set; }
         public TaskCompletionSource<bool> TcsInternalWriteDataToRequestStream { get; set; }
         public TaskCompletionSource<bool> TcsReceiveResponseHeaders { get; set; }
+        public TaskCompletionSource<int> TcsQueryDataAvailable { get; set; }
         public TaskCompletionSource<int> TcsReadFromResponseStream { get; set; }
 
         #region IDisposable Members

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
@@ -22,7 +22,7 @@ namespace System.Net.Http.WinHttpHandlerFunctional.Tests
         // TODO: This is a placeholder until GitHub Issue #2383 gets resolved.
         private const string SlowServer = "http://httpbin.org/drip?numbytes=1&duration=1&delay=40&code=200";
         
-        readonly ITestOutputHelper _output;
+        private readonly ITestOutputHelper _output;
 
         public WinHttpHandlerTest(ITestOutputHelper output)
         {

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeMarshal.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeMarshal.cs
@@ -76,5 +76,10 @@ namespace System.Net.Http
         {
             return System.Runtime.InteropServices.Marshal.SizeOf<T>(structure);
         }
+
+        public static int ReadInt32(IntPtr ptr)
+        {
+            return System.Runtime.InteropServices.Marshal.ReadInt32(ptr);
+        }
     }
 }

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/TestControl.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/TestControl.cs
@@ -10,6 +10,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
     public static class TestControl
     {
         public static ApiControl WinHttpOpen { get; private set; }
+        public static ApiControl WinHttpQueryDataAvailable { get; private set; }
         public static ApiControl WinHttpReadData { get; private set; }
         public static ApiControl WinHttpReceiveResponse { get; private set; }
         public static ApiControl WinHttpWriteData { get; private set; }
@@ -26,6 +27,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         public static void Reset()
         {
             WinHttpOpen = new ApiControl();
+            WinHttpQueryDataAvailable = new ApiControl();
             WinHttpReadData = new ApiControl();
             WinHttpReceiveResponse = new ApiControl();
             WinHttpWriteData = new ApiControl();

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/TestServer.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/TestServer.cs
@@ -19,6 +19,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         private static MemoryStream requestBody = null;
         private static MemoryStream responseBody = null;
         private static string responseHeaders = null;
+        private static double dataAvailablePercentage = 1.0;
 
         public static byte[] RequestBody
         {
@@ -47,6 +48,39 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             set
             {
                 responseHeaders = value;
+            }
+        }
+
+        public static double DataAvailablePercentage
+        {
+            get
+            {
+                return dataAvailablePercentage;
+            }
+            
+            set
+            {
+                dataAvailablePercentage = value;
+            }
+        }
+
+        public static int DataAvailable
+        {
+            get
+            {
+                if (responseBody == null)
+                {
+                    return 0;
+                }
+
+                int totalBytesLeftToRead = (int)(responseBody.Length - responseBody.Position);
+                int allowedBytesToRead = (int)((double)totalBytesLeftToRead * dataAvailablePercentage);
+                if (allowedBytesToRead == 0 && totalBytesLeftToRead != 0)
+                {
+                    allowedBytesToRead = 1;
+                }
+                
+                return allowedBytesToRead;
             }
         }
 
@@ -132,6 +166,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             requestBody = new MemoryStream();
             responseBody = new MemoryStream();
             responseHeaders = null;
+            dataAvailablePercentage = 1.0;
         }
     }
 }

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpResponseStreamTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpResponseStreamTest.cs
@@ -210,7 +210,43 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         }
 
         [Fact]
-        public void ReadAsync_NetworkFails_TaskIsFaultedWithIOException()
+        public void ReadAsync_QueryDataAvailableFailsWithApiCall_TaskIsFaultedWithIOException()
+        {
+            Stream stream = MakeResponseStream();
+
+            TestControl.WinHttpQueryDataAvailable.ErrorWithApiCall = true;
+            
+            Task t = stream.ReadAsync(new byte[1], 0, 1);
+            AggregateException ex = Assert.Throws<AggregateException>(() => t.Wait());
+            Assert.IsType<IOException>(ex.InnerException);
+        }
+
+        [Fact]
+        public void ReadAsync_QueryDataAvailableFailsOnCompletionCallback_TaskIsFaultedWithIOException()
+        {
+            Stream stream = MakeResponseStream();
+
+            TestControl.WinHttpQueryDataAvailable.ErrorOnCompletion = true;
+            
+            Task t = stream.ReadAsync(new byte[1], 0, 1);
+            AggregateException ex = Assert.Throws<AggregateException>(() => t.Wait());
+            Assert.IsType<IOException>(ex.InnerException);
+        }
+
+        [Fact]
+        public void ReadAsync_ReadDataFailsWithApiCall_TaskIsFaultedWithIOException()
+        {
+            Stream stream = MakeResponseStream();
+
+            TestControl.WinHttpReadData.ErrorWithApiCall = true;
+            
+            Task t = stream.ReadAsync(new byte[1], 0, 1);
+            AggregateException ex = Assert.Throws<AggregateException>(() => t.Wait());
+            Assert.IsType<IOException>(ex.InnerException);
+        }
+
+        [Fact]
+        public void ReadAsync_ReadDataFailsOnCompletionCallback_TaskIsFaultedWithIOException()
         {
             Stream stream = MakeResponseStream();
 
@@ -256,7 +292,34 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         }
 
         [Fact]
-        public void Read_NetworkFails_ThrowsIOException()
+        public void Read_QueryDataAvailableFailsWithApiCall_ThrowsIOException()
+        {
+            Stream stream = MakeResponseStream();
+
+            TestControl.WinHttpQueryDataAvailable.ErrorWithApiCall = true;
+            Assert.Throws<IOException>(() => { stream.Read(new byte[1], 0, 1); });
+        }
+
+        [Fact]
+        public void Read_QueryDataAvailableFailsOnCompletionCallback_ThrowsIOException()
+        {
+            Stream stream = MakeResponseStream();
+
+            TestControl.WinHttpQueryDataAvailable.ErrorOnCompletion = true;
+            Assert.Throws<IOException>(() => { stream.Read(new byte[1], 0, 1); });
+        }
+
+        [Fact]
+        public void Read_ReadDataFailsWithApiCall_ThrowsIOException()
+        {
+            Stream stream = MakeResponseStream();
+
+            TestControl.WinHttpReadData.ErrorWithApiCall = true;
+            Assert.Throws<IOException>(() => { stream.Read(new byte[1], 0, 1); });
+        }
+
+        [Fact]
+        public void Read_ReadDataFailsOnCompletionCallback_ThrowsIOException()
         {
             Stream stream = MakeResponseStream();
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -374,6 +374,28 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [ActiveIssue(4259, PlatformID.AnyUnix)]
+        [Fact]
+        public async Task SendAsync_ReadFromSlowStreamingServer_PartialDataReturned()
+        {
+            // TODO: This is a placeholder until GitHub Issue #2383 gets resolved.
+            const string SlowStreamingServer = "http://httpbin.org/drip?numbytes=8192&duration=15&delay=1&code=200";
+            
+            int bytesRead;
+            byte[] buffer = new byte[8192];
+            using (var client = new HttpClient())
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, SlowStreamingServer);
+                using (var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead))
+                {
+                    var stream = await response.Content.ReadAsStreamAsync();
+                    bytesRead = await stream.ReadAsync(buffer, 0, buffer.Length);
+                }
+                _output.WriteLine("Bytes read from stream: {0}", bytesRead);
+                Assert.True(bytesRead < buffer.Length, "bytesRead should be less than buffer.Length");
+            }            
+        }
+
         #region Post Methods Tests
 
         [Theory, MemberData("PostServers")]


### PR DESCRIPTION
.NET Stream.Read() semantics leave it to the implementation to decide how much data to return given a buffer of size N:

https://msdn.microsoft.com/en-us/library/system.io.stream.read(v=vs.110).aspx
"An implementation is free to return fewer bytes than requested even if the end of the stream has not been reached."

The behavior of System.Net HTTP APIs (i.e. .NET Framework) are such that stream reads are able to return as soon as data is available. They don't wait until the provided buffer is full. The current WinHttpHandler was not behaving that way because it didn't call WinHttpQueryDataAvailable before calling WinHttpReadData. WinHttpQueryDataAvailable would indicate how many bytes can be read immediately.

This fix changes the WinHttpResponseStream.Read* methods to use WinHttpQueryDataAvailable before calling WinHttpReadData.

Added both WinHttpHandler unit tests (helps with simulating/testing network errors) and HttpClientHandler functional tests (which will test x-plat).

Fixes #1825