### PR TITLE
[System.Net.NetworkInformation] Address performance to-do markers

### DIFF
--- a/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -236,10 +236,12 @@
   </ItemGroup>
   <!-- Unix -->
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
+    <Compile Include="System\Net\NetworkInformation\IPAddressUtil.cs" />
     <Compile Include="System\Net\NetworkInformation\NetworkFiles.cs" />
     <Compile Include="System\Net\NetworkInformation\SimpleGatewayIPAddressInformation.cs" />
     <Compile Include="System\Net\NetworkInformation\SimpleTcpConnectionInformation.cs" />
     <Compile Include="System\Net\NetworkInformation\StringParsingHelpers.Dns.cs" />
+    <Compile Include="System\Net\NetworkInformation\UnixIPGlobalProperties.cs" />
     <Compile Include="System\Net\NetworkInformation\UnixIPInterfaceProperties.cs" />
     <Compile Include="System\Net\NetworkInformation\UnixIPv4InterfaceProperties.cs" />
     <Compile Include="System\Net\NetworkInformation\UnixIPv6InterfaceProperties.cs" />

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPAddressUtil.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPAddressUtil.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Sockets;
+
+namespace System.Net.NetworkInformation
+{
+    internal static class IPAddressUtil
+    {
+        /// <summary>
+        /// Returns a value indicating whether the given IPAddress is a multicast address.
+        /// </summary>
+        /// <param name="address">The address to test.</param>
+        /// <returns>True if the address is a multicast address; false otherwise.</returns>
+        public static bool IsMulticast(IPAddress address)
+        {
+            if (address.AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                return address.IsIPv6Multicast;
+            }
+            else
+            {
+                byte firstByte = address.GetAddressBytes()[0];
+                return firstByte >= 224 && firstByte <= 239;
+            }
+        }
+
+        /// <summary>
+        /// Copies the address bytes out of the given native info's buffer and constructs a new IPAddress.
+        /// </summary>
+        /// <param name="addressInfo">A pointer to a native IpAddressInfo structure.</param>
+        /// <returns>A new IPAddress created with the information in the native structure.</returns>
+        public static unsafe IPAddress GetIPAddressFromNativeInfo(Interop.Sys.IpAddressInfo* addressInfo)
+        {
+            byte[] ipBytes = new byte[addressInfo->NumAddressBytes];
+            fixed (byte* ipArrayPtr = ipBytes)
+            {
+                Buffer.MemoryCopy(addressInfo->AddressBytes, ipArrayPtr, ipBytes.Length, ipBytes.Length);
+            }
+            IPAddress ipAddress = new IPAddress(ipBytes);
+            return ipAddress;
+        }
+    }
+}

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPGlobalProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPGlobalProperties.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.NetworkInformation
 {
-    internal class LinuxIPGlobalProperties : IPGlobalProperties
+    internal class LinuxIPGlobalProperties : UnixIPGlobalProperties
     {
         public override string DhcpScopeName
         {
@@ -104,24 +104,6 @@ namespace System.Net.NetworkInformation
         public override UdpStatistics GetUdpIPv6Statistics()
         {
             return new LinuxUdpStatistics(false);
-        }
-
-        private UnicastIPAddressInformationCollection GetUnicastAddresses()
-        {
-            UnicastIPAddressInformationCollection collection = new UnicastIPAddressInformationCollection();
-            foreach (UnicastIPAddressInformation info in
-                LinuxNetworkInterface.GetLinuxNetworkInterfaces().SelectMany(lni => lni.GetIPProperties().UnicastAddresses))
-            {
-                // PERF: Use Interop.Sys.EnumerateInterfaceAddresses directly here.
-                collection.InternalAdd(info);
-            }
-
-            return collection;
-        }
-
-        public override Task<UnicastIPAddressInformationCollection> GetUnicastAddressesAsync()
-        {
-            return Task.Run((Func<UnicastIPAddressInformationCollection>)GetUnicastAddresses);
         }
     }
 }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPGlobalStatistics.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPGlobalStatistics.cs
@@ -87,14 +87,21 @@ namespace System.Net.NetworkInformation
 
         public override long ReceivedPacketsWithUnknownProtocol { get { return _table.InUnknownProtocols; } }
 
-        private static int GetNumIPAddresses()
+        private static unsafe int GetNumIPAddresses()
         {
-            // PERF: Use EnumerateInterfaceAddresses directly.
             int count = 0;
-            foreach (LinuxNetworkInterface lni in LinuxNetworkInterface.GetLinuxNetworkInterfaces())
-            {
-                count += lni.Addresses.Count;
-            }
+            Interop.Sys.EnumerateInterfaceAddresses(
+                (name, ipAddressInfo, netmaskInfo) =>
+                {
+                    count++;
+                },
+                (name, ipAddressInfo, scopeId) =>
+                {
+                    count++;
+                },
+                // Ignore link-layer addresses that are discovered; don't create a callback.
+                null);
+
             return count;
         }
     }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxIPGlobalProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxIPGlobalProperties.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace System.Net.NetworkInformation
 {
-    internal class OsxIPGlobalProperties : IPGlobalProperties
+    internal class OsxIPGlobalProperties : UnixIPGlobalProperties
     {
         public override string DhcpScopeName
         {
@@ -182,24 +182,6 @@ namespace System.Net.NetworkInformation
         {
             // OSX does not provide separated UDP-IPv4 and UDP-IPv6 stats.
             return new OsxUdpStatistics();
-        }
-
-        private UnicastIPAddressInformationCollection GetUnicastAddresses()
-        {
-            UnicastIPAddressInformationCollection collection = new UnicastIPAddressInformationCollection();
-            foreach (UnicastIPAddressInformation info in
-                OsxNetworkInterface.GetOsxNetworkInterfaces().SelectMany(oni => oni.GetIPProperties().UnicastAddresses))
-            {
-                // PERF: Use Interop.Sys.EnumerateInterfaceAddresses directly here.
-                collection.InternalAdd(info);
-            }
-
-            return collection;
-        }
-
-        public override Task<UnicastIPAddressInformationCollection> GetUnicastAddressesAsync()
-        {
-            return Task.Run((Func<UnicastIPAddressInformationCollection>)GetUnicastAddresses);
         }
     }
 }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPGlobalProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPGlobalProperties.cs
@@ -1,0 +1,42 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.NetworkInformation
+{
+    internal abstract class UnixIPGlobalProperties : IPGlobalProperties
+    {
+        public sealed override Task<UnicastIPAddressInformationCollection> GetUnicastAddressesAsync()
+        {
+            return Task.Factory.StartNew(s => ((UnixIPGlobalProperties)s).GetUnicastAddresses(), this,
+                CancellationToken.None, TaskCreationOptions.DenyChildAttach, TaskScheduler.Default);
+        }
+
+        private unsafe UnicastIPAddressInformationCollection GetUnicastAddresses()
+        {
+            UnicastIPAddressInformationCollection collection = new UnicastIPAddressInformationCollection();
+
+            Interop.Sys.EnumerateInterfaceAddresses(
+                (name, ipAddressInfo, netmaskInfo) =>
+                {
+                    IPAddress ipAddress = IPAddressUtil.GetIPAddressFromNativeInfo(ipAddressInfo);
+                    if (!IPAddressUtil.IsMulticast(ipAddress))
+                    {
+                        IPAddress netMaskAddress = IPAddressUtil.GetIPAddressFromNativeInfo(netmaskInfo);
+                        collection.InternalAdd(new UnixUnicastIPAddressInformation(ipAddress, netMaskAddress));
+                    }
+                },
+                (name, ipAddressInfo, scopeId) =>
+                {
+                    IPAddress ipAddress = IPAddressUtil.GetIPAddressFromNativeInfo(ipAddressInfo);
+                    if (!IPAddressUtil.IsMulticast(ipAddress))
+                    {
+                        collection.InternalAdd(new UnixUnicastIPAddressInformation(ipAddress, IPAddress.Any));
+                    }
+                },
+                // Ignore link-layer addresses that are discovered; don't create a callback.
+                null);
+
+            return collection;
+        }
+    }
+}

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPInterfaceProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPInterfaceProperties.cs
@@ -53,7 +53,7 @@ namespace System.Net.NetworkInformation
         private static UnicastIPAddressInformationCollection GetUnicastAddresses(UnixNetworkInterface uni)
         {
             var collection = new UnicastIPAddressInformationCollection();
-            foreach (IPAddress address in uni.Addresses.Where((addr) => !IsMulticast(addr)))
+            foreach (IPAddress address in uni.Addresses.Where((addr) => !IPAddressUtil.IsMulticast(addr)))
             {
                 IPAddress netMask = (address.AddressFamily == AddressFamily.InterNetwork)
                                     ? uni.GetNetMaskForIPv4Address(address)
@@ -67,25 +67,12 @@ namespace System.Net.NetworkInformation
         private static MulticastIPAddressInformationCollection GetMulticastAddresses(UnixNetworkInterface uni)
         {
             var collection = new MulticastIPAddressInformationCollection();
-            foreach (IPAddress address in uni.Addresses.Where(IsMulticast))
+            foreach (IPAddress address in uni.Addresses.Where(IPAddressUtil.IsMulticast))
             {
                 collection.InternalAdd(new UnixMulticastIPAddressInformation(address));
             }
 
             return collection;
-        }
-
-        private static bool IsMulticast(IPAddress address)
-        {
-            if (address.AddressFamily == AddressFamily.InterNetworkV6)
-            {
-                return address.IsIPv6Multicast;
-            }
-            else
-            {
-                byte firstByte = address.GetAddressBytes()[0];
-                return firstByte >= 224 && firstByte <= 239;
-            }
         }
 
         private static string GetDnsSuffix()

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixNetworkInterface.cs
@@ -72,20 +72,8 @@ namespace System.Net.NetworkInformation
                                                 Interop.Sys.IpAddressInfo* addressInfo,
                                                 Interop.Sys.IpAddressInfo* netMask)
         {
-            byte[] ipBytes = new byte[addressInfo->NumAddressBytes];
-            fixed (byte* ipArrayPtr = ipBytes)
-            {
-                Buffer.MemoryCopy(addressInfo->AddressBytes, ipArrayPtr, ipBytes.Length, ipBytes.Length);
-            }
-            IPAddress ipAddress = new IPAddress(ipBytes);
-
-            byte[] ipBytes2 = new byte[netMask->NumAddressBytes];
-            fixed (byte* ipArrayPtr = ipBytes2)
-            {
-                Buffer.MemoryCopy(netMask->AddressBytes, ipArrayPtr, ipBytes2.Length, ipBytes2.Length);
-            }
-            IPAddress netMaskAddress = new IPAddress(ipBytes2);
-
+            IPAddress ipAddress = IPAddressUtil.GetIPAddressFromNativeInfo(addressInfo);
+            IPAddress netMaskAddress = IPAddressUtil.GetIPAddressFromNativeInfo(netMask);
             uni.AddAddress(ipAddress);
             uni._netMasks[ipAddress] = netMaskAddress;
         }
@@ -94,13 +82,7 @@ namespace System.Net.NetworkInformation
                                                         Interop.Sys.IpAddressInfo* addressInfo,
                                                         uint scopeId)
         {
-            byte[] ipBytes = new byte[addressInfo->NumAddressBytes];
-            fixed (byte* ipArrayPtr = ipBytes)
-            {
-                Buffer.MemoryCopy(addressInfo->AddressBytes, ipArrayPtr, ipBytes.Length, ipBytes.Length);
-            }
-            IPAddress address = new IPAddress(ipBytes);
-
+            IPAddress address = IPAddressUtil.GetIPAddressFromNativeInfo(addressInfo);
             uni.AddAddress(address);
             uni._ipv6ScopeId = scopeId;
         }


### PR DESCRIPTION
Contains a few changes based on the perf markers I left in the code.

* I made it optional to pass in callbacks to the Interop.Sys.EnumerateInterfaceAddresses function. In the new usages, I don't need to know about the link-layer addresses, so I don't pass a callback for them.

* I pulled out two common methods into an IPAddressUtil class for use when dealing with Interop.SysEnumerateInterfaceAddresses.

* The implemention for GetUnicastAddresses(Async) is the same for Linux and OSX, so I've created a "UnixIPGlobalProperties" base class that implements that method for both operating systems.

* There was an additional marker regarding using sysctl to query the machine's address count. Looking at it again, I don't think it's actually worth bothering. All we are doing instead is adding up the number of addresses from the list of interfaces we already have. It's probably faster than PInvoking for a single number.

Addresses the first part of #4060.