### PR TITLE
Remove obsolete TODOs from xplat SslStream code

### DIFF
--- a/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
@@ -466,7 +466,6 @@ internal static partial class Interop
             }
         }
 
-        //TODO (Issue #3362) should we check Bio should retry?
         private static int BioRead(SafeBioHandle bio, byte[] buffer, int count)
         {
             Debug.Assert(buffer != null);
@@ -481,7 +480,6 @@ internal static partial class Interop
             return bytes;
         }
 
-        //TODO (Issue #3362) should we check Bio should retry?
         private static int BioWrite(SafeBioHandle bio, byte[] buffer, int offset, int count)
         {
             Debug.Assert(buffer != null);

--- a/src/Common/src/Interop/Unix/libssl/StreamSizes.cs
+++ b/src/Common/src/Interop/Unix/libssl/StreamSizes.cs
@@ -15,11 +15,6 @@ namespace System.Net
 
         static StreamSizes()
         {
-            // TODO (Issue #3362) : Trailer size requirement is changing based on protocol
-            //       SSL3/TLS1.0 - 68, TLS1.1 - 37 and TLS1.2 - 24
-            //       Current usage is only to compute max input buffer size for
-            //       encryption and so the native code returns the max
-
             Interop.Ssl.GetStreamSizes(
                 out s_header,
                 out s_trailer,

--- a/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -608,7 +608,7 @@ extern "C" void GetStreamSizes(int32_t* header, int32_t* trailer, int32_t* maxim
 
     if (trailer)
     {
-        // TODO (Issue #3362) : Trailer size requirement is changing based on protocol
+        // TODO (Issue #4223) : Trailer size requirement is changing based on protocol
         //       SSL3/TLS1.0 - 68, TLS1.1 - 37 and TLS1.2 - 24
         //       Current usage is only to compute max input buffer size for
         //       encryption and so setting to the max

--- a/src/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
@@ -243,11 +243,5 @@ namespace System.Net
                 return -1;
             }
         }
-
-        private static int QueryContextIssuerList(SafeDeleteContext securityContext, out Object issuerList)
-        {
-            // TODO (Issue #3362) To be implemented
-            throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
-        }
     }
 }

--- a/src/System.Net.Security/src/System/Net/_SslSessionsCache.cs
+++ b/src/System.Net.Security/src/System/Net/_SslSessionsCache.cs
@@ -53,7 +53,7 @@ namespace System.Net.Security
 
                 _HashCode ^= allowedProtocols;
                 _HashCode ^= (int)encryptionPolicy;
-                _HashCode ^= serverMode ? 5 : 7; //TODO (Issue #3362) used a prime number here as it's a XOR. Figure out appropriate value.
+                _HashCode ^= serverMode ? 0x10000 : 0x20000;
                 _AllowedProtocols = allowedProtocols;
                 _EncryptionPolicy = encryptionPolicy;
                 _isServerMode = serverMode;


### PR DESCRIPTION
This includes removing TODOs from the places which are already investigated and fixed . 
There are few places where TODO was kept but after investigation no changes needed.
At few places updated the TODO with new issue id where we have scope to further investigate and fix.