### PR TITLE
Enabling System.Net.Security tests in Linux

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
@@ -27,20 +27,14 @@ namespace System.Net.Security.Tests
 
         private static readonly SslProtocols[] s_eachSslProtocol = new SslProtocols[]
         {
-            SslProtocols.Ssl2,
             SslProtocols.Ssl3,
             SslProtocols.Tls,
             SslProtocols.Tls11,
             SslProtocols.Tls12,
         };
 
-        public static IEnumerable<object[]> ProtocolMismatchData()
+        private static IEnumerable<object[]> ProtocolMismatchData()
         {
-            yield return new object[] { SslProtocols.Ssl2, SslProtocols.Ssl3, typeof(IOException) };
-            yield return new object[] { SslProtocols.Ssl2, SslProtocols.Tls, typeof(IOException) };
-            yield return new object[] { SslProtocols.Ssl2, SslProtocols.Tls11, typeof(IOException) };
-            yield return new object[] { SslProtocols.Ssl2, SslProtocols.Tls12, typeof(IOException) };
-
             yield return new object[] { SslProtocols.Ssl3, SslProtocols.Ssl2, typeof(IOException) };
             yield return new object[] { SslProtocols.Ssl3, SslProtocols.Tls, typeof(IOException) };
             yield return new object[] { SslProtocols.Ssl3, SslProtocols.Tls11, typeof(IOException) };
@@ -60,6 +54,14 @@ namespace System.Net.Security.Tests
             yield return new object[] { SslProtocols.Tls12, SslProtocols.Ssl3, typeof(AuthenticationException) };
             yield return new object[] { SslProtocols.Tls12, SslProtocols.Tls, typeof(AuthenticationException) };
             yield return new object[] { SslProtocols.Tls12, SslProtocols.Tls11, typeof(AuthenticationException) };
+        }
+
+        private static IEnumerable<object[]> ProtocolMismatchDataSsl2Specific()
+        {
+            yield return new object[] {SslProtocols.Ssl2, SslProtocols.Ssl3, typeof (IOException)};
+            yield return new object[] {SslProtocols.Ssl2, SslProtocols.Tls, typeof (IOException)};
+            yield return new object[] {SslProtocols.Ssl2, SslProtocols.Tls11, typeof (IOException)};
+            yield return new object[] {SslProtocols.Ssl2, SslProtocols.Tls12, typeof (IOException)};
         }
 
         public ClientAsyncAuthenticateTest()
@@ -98,7 +100,23 @@ namespace System.Net.Security.Tests
             Assert.Throws(expected, () => ClientAsyncSslHelper(server, client));
         }
 
+        [Theory]
+        [MemberData("ProtocolMismatchDataSsl2Specific")]
+        [PlatformSpecific(PlatformID.Windows)]
+        public void ClientAsyncAuthenticate_MismatchProtocols_Ssl2_Fails(SslProtocols server, SslProtocols client, Type expected)
+        {
+            Assert.Throws(expected, () => ClientAsyncSslHelper(server, client));
+        }
+
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public void ClientAsyncAuthenticate_EachProtocol_Ssl2_Success()
+        {
+            ClientAsyncSslHelper(SslProtocols.Ssl2, SslProtocols.Ssl2);
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void ClientAsyncAuthenticate_Ssl2Tls12ServerSsl2Client_Fails()
         {
             Assert.Throws<Win32Exception>(() =>
@@ -109,6 +127,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void ClientAsyncAuthenticate_Ssl2Tls12ServerTls12Client_Fails()
         {
             Assert.Throws<Win32Exception>(() =>
@@ -119,6 +138,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void ClientAsyncAuthenticate_Ssl2ServerSsl2Tls12Client_Success()
         {
             ClientAsyncSslHelper(SslProtocols.Ssl2, SslProtocols.Ssl2 | SslProtocols.Tls12);

--- a/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
@@ -56,12 +56,20 @@ namespace System.Net.Security.Tests
             yield return new object[] { SslProtocols.Tls12, SslProtocols.Tls11, typeof(AuthenticationException) };
         }
 
-        private static IEnumerable<object[]> ProtocolMismatchDataSsl2Specific()
+        private static IEnumerable<object[]> ProtocolMismatchDataSsl2SpecificWindows()
         {
             yield return new object[] {SslProtocols.Ssl2, SslProtocols.Ssl3, typeof (IOException)};
             yield return new object[] {SslProtocols.Ssl2, SslProtocols.Tls, typeof (IOException)};
             yield return new object[] {SslProtocols.Ssl2, SslProtocols.Tls11, typeof (IOException)};
             yield return new object[] {SslProtocols.Ssl2, SslProtocols.Tls12, typeof (IOException)};
+        }
+
+        private static IEnumerable<object[]> ProtocolMismatchDataSsl2SpecificLinux()
+        {
+            yield return new object[] { SslProtocols.Ssl2, SslProtocols.Ssl3, typeof(AuthenticationException) };
+            yield return new object[] { SslProtocols.Ssl2, SslProtocols.Tls, typeof(AuthenticationException) };
+            yield return new object[] { SslProtocols.Ssl2, SslProtocols.Tls11, typeof(AuthenticationException) };
+            yield return new object[] { SslProtocols.Ssl2, SslProtocols.Tls12, typeof(AuthenticationException) };
         }
 
         public ClientAsyncAuthenticateTest()
@@ -101,9 +109,17 @@ namespace System.Net.Security.Tests
         }
 
         [Theory]
-        [MemberData("ProtocolMismatchDataSsl2Specific")]
+        [MemberData("ProtocolMismatchDataSsl2SpecificWindows")]
         [PlatformSpecific(PlatformID.Windows)]
-        public void ClientAsyncAuthenticate_MismatchProtocols_Ssl2_Fails(SslProtocols server, SslProtocols client, Type expected)
+        public void ClientAsyncAuthenticate_MismatchProtocols_Ssl2_Fails_Windows(SslProtocols server, SslProtocols client, Type expected)
+        {
+            Assert.Throws(expected, () => ClientAsyncSslHelper(server, client));
+        }
+
+        [Theory]
+        [MemberData("ProtocolMismatchDataSsl2SpecificLinux")]
+        [PlatformSpecific(PlatformID.Linux)]
+        public void ClientAsyncAuthenticate_MismatchProtocols_Ssl2_Fails_Linux(SslProtocols server, SslProtocols client, Type expected)
         {
             Assert.Throws(expected, () => ClientAsyncSslHelper(server, client));
         }

--- a/src/System.Net.Security/tests/FunctionalTests/ParameterValidationTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ParameterValidationTest.cs
@@ -24,7 +24,7 @@ namespace System.Net.Security.Tests
         public void SslStreamConstructor_BadEncryptionPolicy_ThrowException()
         {
             using (var _remoteServer = new DummyTcpServer(
-                new IPEndPoint(IPAddress.Loopback, 600), EncryptionPolicy.RequireEncryption))
+                new IPEndPoint(IPAddress.Loopback, 0), EncryptionPolicy.RequireEncryption))
             using (var client = new TcpClient())
             {
                 client.Connect(_remoteServer.RemoteEndPoint);

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -6,7 +6,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <UnsupportedPlatforms>Linux;OSX;FreeBSD</UnsupportedPlatforms>
+    <UnsupportedPlatforms>OSX;FreeBSD</UnsupportedPlatforms>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -6,7 +6,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <UnsupportedPlatforms>OSX;FreeBSD</UnsupportedPlatforms>
+    <UnsupportedPlatforms>FreeBSD</UnsupportedPlatforms>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />

--- a/src/System.Net.Security/tests/FunctionalTests/TransportContextTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/TransportContextTest.cs
@@ -24,6 +24,7 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
+        [ActiveIssue(3954, PlatformID.AnyUnix)]
         public void TransportContext_ConnectToServerWithSsl_GetExpectedChannelBindings()
         {
             using (var testServer = new DummyTcpServer(


### PR DESCRIPTION
Enabled the tests to run on Linux .
Marked all ssl2 related tests to run on windows only as Openssl doesn't allow ssl2 ..