### PR TITLE
Use Ordinal string comparison for Linux network file parsing

### DIFF
--- a/src/Common/src/System/IO/RowConfigReader.cs
+++ b/src/Common/src/System/IO/RowConfigReader.cs
@@ -10,6 +10,7 @@ namespace System.IO
     {
         private string _buffer;
         private int _currentIndex;
+        private StringComparison _comparisonKind;
 
         /// <summary>
         /// Constructs a new RowConfigReader which reads from the given string.
@@ -19,6 +20,19 @@ namespace System.IO
         {
             _buffer = buffer;
             _currentIndex = 0;
+            _comparisonKind = StringComparison.Ordinal;
+        }
+
+        /// <summary>
+        /// Constructs a new RowConfigReader which reads from the given string.
+        /// <param name="buffer">The string to parse through.</param>
+        /// <param name="comparisonKind">The comparison kind to use.</param>
+        /// </summary>
+        public RowConfigReader(string buffer, StringComparison comparisonKind)
+        {
+            _buffer = buffer;
+            _currentIndex = 0;
+            _comparisonKind = comparisonKind;
         }
 
         /// <summary>
@@ -52,7 +66,7 @@ namespace System.IO
             }
 
             // First, find the key
-            int keyIndex = _buffer.IndexOf(key, _currentIndex);
+            int keyIndex = _buffer.IndexOf(key, _currentIndex, _comparisonKind);
             if (keyIndex == -1)
             {
                 value = null;
@@ -63,7 +77,7 @@ namespace System.IO
             // NOTE: This assumes that the "value" does not have any whitespace in it, nor is there any
             // after. This is the format of most "row-based" config files in /proc/net, etc.
             int afterKey = keyIndex + key.Length;
-            int endOfLine = _buffer.IndexOf(Environment.NewLine, afterKey);
+            int endOfLine = _buffer.IndexOf(Environment.NewLine, afterKey, _comparisonKind);
             Debug.Assert(endOfLine != -1, "RowConfigReader needs a newline after the key, and one was not found.");
 
             int valueIndex = _buffer.LastIndexOf('\t', endOfLine);

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Addresses.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Addresses.cs
@@ -44,13 +44,13 @@ namespace System.Net.NetworkInformation
                 string fileContents = File.ReadAllText(filePath);
                 int leaseIndex = -1;
                 int secondBrace = -1;
-                while ((leaseIndex = fileContents.IndexOf("lease", leaseIndex + 1)) != -1)
+                while ((leaseIndex = fileContents.IndexOf("lease", leaseIndex + 1, StringComparison.Ordinal)) != -1)
                 {
-                    int firstBrace = fileContents.IndexOf("{", leaseIndex);
-                    secondBrace = fileContents.IndexOf("}", leaseIndex);
+                    int firstBrace = fileContents.IndexOf('{', leaseIndex);
+                    secondBrace = fileContents.IndexOf('}', leaseIndex);
                     int blockLength = secondBrace - firstBrace;
 
-                    int interfaceIndex = fileContents.IndexOf("interface", firstBrace, blockLength);
+                    int interfaceIndex = fileContents.IndexOf("interface", firstBrace, blockLength, StringComparison.Ordinal);
                     int afterName = fileContents.IndexOf(';', interfaceIndex);
                     int beforeName = fileContents.LastIndexOf(' ', afterName);
                     string interfaceName = fileContents.Substring(beforeName + 2, afterName - beforeName - 3);
@@ -59,8 +59,8 @@ namespace System.Net.NetworkInformation
                         continue;
                     }
 
-                    int indexOfDhcp = fileContents.IndexOf("dhcp-server-identifier", firstBrace, blockLength);
-                    int afterAddress = fileContents.IndexOf(";", indexOfDhcp);
+                    int indexOfDhcp = fileContents.IndexOf("dhcp-server-identifier", firstBrace, blockLength, StringComparison.Ordinal);
+                    int afterAddress = fileContents.IndexOf(';', indexOfDhcp);
                     int beforeAddress = fileContents.LastIndexOf(' ', afterAddress);
                     string dhcpAddressString = fileContents.Substring(beforeAddress + 1, afterAddress - beforeAddress - 1);
                     IPAddress dhcpAddress;
@@ -86,7 +86,7 @@ namespace System.Net.NetworkInformation
                 string fileContents = File.ReadAllText(smbConfFilePath);
                 string label = "wins server = ";
                 int labelIndex = fileContents.IndexOf(label);
-                int labelLineStart = fileContents.LastIndexOf(Environment.NewLine, labelIndex);
+                int labelLineStart = fileContents.LastIndexOf(Environment.NewLine, labelIndex, StringComparison.Ordinal);
                 if (labelLineStart < labelIndex)
                 {
                     int commentIndex = fileContents.IndexOf(';', labelLineStart, labelIndex - labelLineStart);
@@ -95,7 +95,7 @@ namespace System.Net.NetworkInformation
                         return collection;
                     }
                 }
-                int endOfLine = fileContents.IndexOf(Environment.NewLine, labelIndex);
+                int endOfLine = fileContents.IndexOf(Environment.NewLine, labelIndex, StringComparison.Ordinal);
                 string addressString = fileContents.Substring(labelIndex + label.Length, endOfLine - (labelIndex + label.Length));
                 IPAddress address = IPAddress.Parse(addressString);
                 collection.Add(address);

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Connections.cs
@@ -15,8 +15,8 @@ namespace System.Net.NetworkInformation
         {
             // Parse the number of active connections out of /proc/net/sockstat
             string sockstatFile = File.ReadAllText(filePath);
-            int indexOfTcp = sockstatFile.IndexOf(protocolName);
-            int endOfTcpLine = sockstatFile.IndexOf(Environment.NewLine, indexOfTcp + 1);
+            int indexOfTcp = sockstatFile.IndexOf(protocolName, StringComparison.Ordinal);
+            int endOfTcpLine = sockstatFile.IndexOf(Environment.NewLine, indexOfTcp + 1, StringComparison.Ordinal);
             string tcpLineData = sockstatFile.Substring(indexOfTcp, endOfTcpLine - indexOfTcp);
             StringParser sockstatParser = new StringParser(tcpLineData, ' ');
             sockstatParser.MoveNextOrFail(); // Skip "<name>:"

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Misc.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Misc.cs
@@ -35,9 +35,9 @@ namespace System.Net.NetworkInformation
         {
             // snmp6 does not include Default TTL info. Read it from snmp.
             string snmp4FileContents = File.ReadAllText(filePath);
-            int firstIpHeader = snmp4FileContents.IndexOf("Ip:");
-            int secondIpHeader = snmp4FileContents.IndexOf("Ip:", firstIpHeader + 1);
-            int endOfSecondLine = snmp4FileContents.IndexOf(Environment.NewLine, secondIpHeader);
+            int firstIpHeader = snmp4FileContents.IndexOf("Ip:", StringComparison.Ordinal);
+            int secondIpHeader = snmp4FileContents.IndexOf("Ip:", firstIpHeader + 1, StringComparison.Ordinal);
+            int endOfSecondLine = snmp4FileContents.IndexOf(Environment.NewLine, secondIpHeader, StringComparison.Ordinal);
             string ipData = snmp4FileContents.Substring(secondIpHeader, endOfSecondLine - secondIpHeader);
             StringParser parser = new StringParser(ipData, ' ');
             parser.MoveNextOrFail(); // Skip Ip:
@@ -80,7 +80,7 @@ namespace System.Net.NetworkInformation
             int occurrences = 0;
             while (index != -1)
             {
-                index = candidate.IndexOf(value, index + 1);
+                index = candidate.IndexOf(value, index + 1, StringComparison.Ordinal);
                 if (index != -1)
                 {
                     occurrences++;

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
@@ -175,9 +175,9 @@ namespace System.Net.NetworkInformation
         public static Icmpv4StatisticsTable ParseIcmpv4FromSnmpFile(string filePath)
         {
             string fileContents = File.ReadAllText(filePath);
-            int firstIpHeader = fileContents.IndexOf("Icmp:");
-            int secondIpHeader = fileContents.IndexOf("Icmp:", firstIpHeader + 1);
-            int endOfSecondLine = fileContents.IndexOf(Environment.NewLine, secondIpHeader);
+            int firstIpHeader = fileContents.IndexOf("Icmp:", StringComparison.Ordinal);
+            int secondIpHeader = fileContents.IndexOf("Icmp:", firstIpHeader + 1, StringComparison.Ordinal);
+            int endOfSecondLine = fileContents.IndexOf(Environment.NewLine, secondIpHeader, StringComparison.Ordinal);
             string icmpData = fileContents.Substring(secondIpHeader, endOfSecondLine - secondIpHeader);
             StringParser parser = new StringParser(icmpData, ' ');
 
@@ -264,9 +264,9 @@ namespace System.Net.NetworkInformation
         {
             string fileContents = File.ReadAllText(filePath);
 
-            int firstIpHeader = fileContents.IndexOf("Ip:");
-            int secondIpHeader = fileContents.IndexOf("Ip:", firstIpHeader + 1);
-            int endOfSecondLine = fileContents.IndexOf(Environment.NewLine, secondIpHeader);
+            int firstIpHeader = fileContents.IndexOf("Ip:", StringComparison.Ordinal);
+            int secondIpHeader = fileContents.IndexOf("Ip:", firstIpHeader + 1, StringComparison.Ordinal);
+            int endOfSecondLine = fileContents.IndexOf(Environment.NewLine, secondIpHeader, StringComparison.Ordinal);
             string ipData = fileContents.Substring(secondIpHeader, endOfSecondLine - secondIpHeader);
             StringParser parser = new StringParser(ipData, ' ');
 
@@ -333,9 +333,9 @@ namespace System.Net.NetworkInformation
             // NOTE: There is no information in the snmp6 file regarding TCP statistics,
             // so the statistics are always pulled from /proc/net/snmp.
             string fileContents = File.ReadAllText(filePath);
-            int firstTcpHeader = fileContents.IndexOf("Tcp:");
-            int secondTcpHeader = fileContents.IndexOf("Tcp:", firstTcpHeader + 1);
-            int endOfSecondLine = fileContents.IndexOf(Environment.NewLine, secondTcpHeader);
+            int firstTcpHeader = fileContents.IndexOf("Tcp:", StringComparison.Ordinal);
+            int secondTcpHeader = fileContents.IndexOf("Tcp:", firstTcpHeader + 1, StringComparison.Ordinal);
+            int endOfSecondLine = fileContents.IndexOf(Environment.NewLine, secondTcpHeader, StringComparison.Ordinal);
             string tcpData = fileContents.Substring(secondTcpHeader, endOfSecondLine - secondTcpHeader);
             StringParser parser = new StringParser(tcpData, ' ');
 
@@ -367,9 +367,9 @@ namespace System.Net.NetworkInformation
         internal static UdpGlobalStatisticsTable ParseUdpv4GlobalStatisticsFromSnmpFile(string filePath)
         {
             string fileContents = File.ReadAllText(filePath);
-            int firstUdpHeader = fileContents.IndexOf("Udp:");
-            int secondUdpHeader = fileContents.IndexOf("Udp:", firstUdpHeader + 1);
-            int endOfSecondLine = fileContents.IndexOf(Environment.NewLine, secondUdpHeader);
+            int firstUdpHeader = fileContents.IndexOf("Udp:", StringComparison.Ordinal);
+            int secondUdpHeader = fileContents.IndexOf("Udp:", firstUdpHeader + 1, StringComparison.Ordinal);
+            int endOfSecondLine = fileContents.IndexOf(Environment.NewLine, secondUdpHeader, StringComparison.Ordinal);
             string tcpData = fileContents.Substring(secondUdpHeader, endOfSecondLine - secondUdpHeader);
             StringParser parser = new StringParser(tcpData, ' ');
 


### PR DESCRIPTION
The files that we are parsing are already expected to be well-formatted and uniform text files provided by the kernel. Therefore, we should just use ordinal comparisons for these checks.