### PR TITLE
Implement GetEnumerator for InternalIPAddressCollection

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/InternalIPAddressCollection.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/InternalIPAddressCollection.cs
@@ -62,5 +62,10 @@ namespace System.Net.NetworkInformation
                 return _addresses[index];
             }
         }
+
+        public override IEnumerator<IPAddress> GetEnumerator()
+        {
+            return _addresses.GetEnumerator();
+        }
     }
 }


### PR DESCRIPTION
Right now, there's a bit of a mix-up with this type/method. Both the Windows and x-plat libraries use this type to return IPAddress collections. The base class (IPAddressCollection) throws a NotImplemented exception for the GetEnumerator method, which is not overridden here in System.Net.NetworkInformation. The Windows tests are not catching this issue because they are running against the "System.Private.Networking" version of System.Net.Primitives, which DOES implement the enumerator.

This change just adds a very simple overload for GetEnumerator which defers to the wrapped List.