### PR TITLE
[NetworkInformation] Add basic API surface tests for Linux, OSX

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
@@ -423,23 +423,23 @@ namespace System.Net.NetworkInformation
 
                         return new IPInterfaceStatisticsTable()
                         {
-                            BytesReceived = uint.Parse(pieces[1]),
-                            PacketsReceived = uint.Parse(pieces[2]),
-                            ErrorsReceived = uint.Parse(pieces[3]),
-                            IncomingPacketsDropped = uint.Parse(pieces[4]),
-                            FifoBufferErrorsReceived = uint.Parse(pieces[5]),
-                            PacketFramingErrorsReceived = uint.Parse(pieces[6]),
-                            CompressedPacketsReceived = uint.Parse(pieces[7]),
-                            MulticastFramesReceived = uint.Parse(pieces[8]),
+                            BytesReceived = ParseUInt64AndClampToUInt32(pieces[1]),
+                            PacketsReceived = ParseUInt64AndClampToUInt32(pieces[2]),
+                            ErrorsReceived = ParseUInt64AndClampToUInt32(pieces[3]),
+                            IncomingPacketsDropped = ParseUInt64AndClampToUInt32(pieces[4]),
+                            FifoBufferErrorsReceived = ParseUInt64AndClampToUInt32(pieces[5]),
+                            PacketFramingErrorsReceived = ParseUInt64AndClampToUInt32(pieces[6]),
+                            CompressedPacketsReceived = ParseUInt64AndClampToUInt32(pieces[7]),
+                            MulticastFramesReceived = ParseUInt64AndClampToUInt32(pieces[8]),
 
-                            BytesTransmitted = uint.Parse(pieces[9]),
-                            PacketsTransmitted = uint.Parse(pieces[10]),
-                            ErrorsTransmitted = uint.Parse(pieces[11]),
-                            OutgoingPacketsDropped = uint.Parse(pieces[12]),
-                            FifoBufferErrorsTransmitted = uint.Parse(pieces[13]),
-                            CollisionsDetected = uint.Parse(pieces[14]),
-                            CarrierLosses = uint.Parse(pieces[15]),
-                            CompressedPacketsTransmitted = uint.Parse(pieces[16])
+                            BytesTransmitted = ParseUInt64AndClampToUInt32(pieces[9]),
+                            PacketsTransmitted = ParseUInt64AndClampToUInt32(pieces[10]),
+                            ErrorsTransmitted = ParseUInt64AndClampToUInt32(pieces[11]),
+                            OutgoingPacketsDropped = ParseUInt64AndClampToUInt32(pieces[12]),
+                            FifoBufferErrorsTransmitted = ParseUInt64AndClampToUInt32(pieces[13]),
+                            CollisionsDetected = ParseUInt64AndClampToUInt32(pieces[14]),
+                            CarrierLosses = ParseUInt64AndClampToUInt32(pieces[15]),
+                            CompressedPacketsTransmitted = ParseUInt64AndClampToUInt32(pieces[16]),
                         };
                     }
                     index += 1;
@@ -447,6 +447,11 @@ namespace System.Net.NetworkInformation
 
                 throw new NetworkInformationException();
             }
+        }
+
+        private static uint ParseUInt64AndClampToUInt32(string value)
+        {
+            return (uint)Math.Min(uint.MaxValue, ulong.Parse(value));
         }
     }
 }

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixUnicastIPAddressInformation.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixUnicastIPAddressInformation.cs
@@ -43,5 +43,7 @@ namespace System.Net.NetworkInformation
 
         public override IPAddress IPv4Mask { get { return _netMask; } }
 
+        public override int PrefixLength { get { throw new PlatformNotSupportedException(); } }
+
     }
 }

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Linux.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Linux.cs
@@ -1,0 +1,179 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Sockets;
+using System.Net.Test.Common;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.NetworkInformation.Tests
+{
+    [PlatformSpecific(PlatformID.Linux)]
+    public class IPInterfacePropertiesTest_Linux
+    {
+        private readonly ITestOutputHelper _log;
+
+        public IPInterfacePropertiesTest_Linux()
+        {
+            _log = TestLogging.GetInstance();
+        }
+
+        [Fact]
+        public void IPInfoTest_AccessAllProperties_NoErrors()
+        {
+            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                _log.WriteLine("Nic: " + nic.Name);
+                _log.WriteLine("- Supports IPv4: " + nic.Supports(NetworkInterfaceComponent.IPv4));
+                _log.WriteLine("- Supports IPv6: " + nic.Supports(NetworkInterfaceComponent.IPv6));
+
+                IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                Assert.NotNull(ipProperties);
+
+                Assert.Throws<PlatformNotSupportedException>(() => ipProperties.AnycastAddresses);
+
+                Assert.NotNull(ipProperties.DhcpServerAddresses);
+                _log.WriteLine("- Dhcp Server Addresses: " + ipProperties.DhcpServerAddresses.Count);
+                foreach (IPAddress dhcp in ipProperties.DhcpServerAddresses)
+                {
+                    _log.WriteLine("-- " + dhcp.ToString());
+                }
+
+                Assert.NotNull(ipProperties.DnsAddresses);
+                _log.WriteLine("- Dns Addresses: " + ipProperties.DnsAddresses.Count);
+                foreach (IPAddress dns in ipProperties.DnsAddresses)
+                {
+                    _log.WriteLine("-- " + dns.ToString());
+                }
+
+                Assert.NotNull(ipProperties.DnsSuffix);
+                _log.WriteLine("- Dns Suffix: " + ipProperties.DnsSuffix);
+
+                Assert.NotNull(ipProperties.GatewayAddresses);
+                _log.WriteLine("- Gateway Addresses: " + ipProperties.GatewayAddresses.Count);
+                foreach (GatewayIPAddressInformation gateway in ipProperties.GatewayAddresses)
+                {
+                    _log.WriteLine("-- " + gateway.Address.ToString());
+                }
+
+                _log.WriteLine("- Dns Enabled: " + ipProperties.IsDnsEnabled);
+
+                Assert.Throws<PlatformNotSupportedException>(() => ipProperties.IsDynamicDnsEnabled);
+
+                Assert.NotNull(ipProperties.MulticastAddresses);
+                _log.WriteLine("- Multicast Addresses: " + ipProperties.MulticastAddresses.Count);
+                foreach (IPAddressInformation multi in ipProperties.MulticastAddresses)
+                {
+                    _log.WriteLine("-- " + multi.Address.ToString());
+                    Assert.Throws<PlatformNotSupportedException>(() => multi.IsDnsEligible);
+                    Assert.Throws<PlatformNotSupportedException>(() => multi.IsTransient);
+                }
+
+                Assert.NotNull(ipProperties.UnicastAddresses);
+                _log.WriteLine("- Unicast Addresses: " + ipProperties.UnicastAddresses.Count);
+                foreach (UnicastIPAddressInformation uni in ipProperties.UnicastAddresses)
+                {
+                    _log.WriteLine("-- " + uni.Address.ToString());
+                    Assert.Throws<PlatformNotSupportedException>(() => uni.AddressPreferredLifetime);
+                    Assert.Throws<PlatformNotSupportedException>(() => uni.AddressValidLifetime);
+                    Assert.Throws<PlatformNotSupportedException>(() => uni.DhcpLeaseLifetime);
+                    Assert.Throws<PlatformNotSupportedException>(() => uni.DuplicateAddressDetectionState);
+
+                    Assert.NotNull(uni.IPv4Mask);
+                    _log.WriteLine("--- IPv4 Mask: " + uni.IPv4Mask);
+                    Assert.Throws<PlatformNotSupportedException>(() => uni.IsDnsEligible);
+                    Assert.Throws<PlatformNotSupportedException>(() => uni.IsTransient);
+                    Assert.Throws<PlatformNotSupportedException>(() => uni.PrefixOrigin);
+                    Assert.Throws<PlatformNotSupportedException>(() => uni.SuffixOrigin);
+
+                    // Prefix Length
+                    Assert.Throws<PlatformNotSupportedException>(() => uni.PrefixLength);
+                }
+
+                Assert.NotNull(ipProperties.WinsServersAddresses);
+                _log.WriteLine("- Wins Addresses: " + ipProperties.WinsServersAddresses.Count);
+                foreach (IPAddress wins in ipProperties.WinsServersAddresses)
+                {
+                    _log.WriteLine("-- " + wins.ToString());
+                }
+            }
+        }
+
+        [Fact]
+        public void IPInfoTest_AccessAllIPv4Properties_NoErrors()
+        {
+            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                _log.WriteLine("Nic: " + nic.Name);
+
+                IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                _log.WriteLine("IPv4 Properties:");
+
+                IPv4InterfaceProperties ipv4Properties = ipProperties.GetIPv4Properties();
+
+                _log.WriteLine("Index: " + ipv4Properties.Index);
+                Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsAutomaticPrivateAddressingActive);
+                Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsAutomaticPrivateAddressingEnabled);
+                Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsDhcpEnabled);
+                _log.WriteLine("IsForwardingEnabled: " + ipv4Properties.IsForwardingEnabled);
+                _log.WriteLine("Mtu: " + ipv4Properties.Mtu);
+                _log.WriteLine("UsesWins: " + ipv4Properties.UsesWins);
+            }
+        }
+
+        [Fact]
+        public void IPInfoTest_AccessAllIPv6Properties_NoErrors()
+        {
+            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                _log.WriteLine("Nic: " + nic.Name);
+
+                IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                _log.WriteLine("IPv6 Properties:");
+
+                IPv6InterfaceProperties ipv6Properties = ipProperties.GetIPv6Properties();
+
+                if (ipv6Properties == null)
+                {
+                    _log.WriteLine("IPv6Properties is null");
+                    continue;
+                }
+
+                _log.WriteLine("Index: " + ipv6Properties.Index);
+                _log.WriteLine("Mtu: " + ipv6Properties.Mtu);
+                Assert.Throws<PlatformNotSupportedException>(() => ipv6Properties.GetScopeId(ScopeLevel.Link));
+            }
+        }
+
+        [Fact]
+        [Trait("IPv6", "true")]
+        public void IPv6ScopeId_AccessAllValues_Success()
+        {
+            Assert.True(Capability.IPv6Support());
+
+            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                _log.WriteLine("Nic: " + nic.Name);
+
+                if (!nic.Supports(NetworkInterfaceComponent.IPv6))
+                {
+                    continue;
+                }
+
+                IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                IPv6InterfaceProperties ipv6Properties = ipProperties.GetIPv6Properties();
+
+                Array values = Enum.GetValues(typeof(ScopeLevel));
+                foreach (ScopeLevel level in values)
+                {
+                    Assert.Throws<PlatformNotSupportedException>(() => ipv6Properties.GetScopeId(level));
+                }
+            }
+        }
+    }
+}

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_OSX.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_OSX.cs
@@ -1,0 +1,168 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Sockets;
+using System.Net.Test.Common;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.NetworkInformation.Tests
+{
+    [PlatformSpecific(PlatformID.OSX)]
+    public class IPInterfacePropertiesTest_OSX
+    {
+        private readonly ITestOutputHelper _log;
+
+        public IPInterfacePropertiesTest_OSX()
+        {
+            _log = TestLogging.GetInstance();
+        }
+
+        [Fact]
+        public void IPInfoTest_AccessAllProperties_NoErrors()
+        {
+            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                _log.WriteLine("Nic: " + nic.Name);
+                _log.WriteLine("- Supports IPv4: " + nic.Supports(NetworkInterfaceComponent.IPv4));
+                _log.WriteLine("- Supports IPv6: " + nic.Supports(NetworkInterfaceComponent.IPv6));
+
+                IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                Assert.NotNull(ipProperties);
+
+                Assert.Throws<PlatformNotSupportedException>(() => ipProperties.AnycastAddresses);
+
+                Assert.Throws<PlatformNotSupportedException>(() => ipProperties.DhcpServerAddresses);
+
+                Assert.NotNull(ipProperties.DnsAddresses);
+                _log.WriteLine("- Dns Addresses: " + ipProperties.DnsAddresses.Count);
+                foreach (IPAddress dns in ipProperties.DnsAddresses)
+                {
+                    _log.WriteLine("-- " + dns.ToString());
+                }
+                Assert.NotNull(ipProperties.DnsSuffix);
+                _log.WriteLine("- Dns Suffix: " + ipProperties.DnsSuffix);
+
+                Assert.NotNull(ipProperties.GatewayAddresses);
+                _log.WriteLine("- Gateway Addresses: " + ipProperties.GatewayAddresses.Count);
+                foreach (GatewayIPAddressInformation gateway in ipProperties.GatewayAddresses)
+                {
+                    _log.WriteLine("-- " + gateway.Address.ToString());
+                }
+
+                Assert.Throws<PlatformNotSupportedException>(() => ipProperties.IsDnsEnabled);
+
+                Assert.Throws<PlatformNotSupportedException>(() => ipProperties.IsDynamicDnsEnabled);
+
+                Assert.NotNull(ipProperties.MulticastAddresses);
+                _log.WriteLine("- Multicast Addresses: " + ipProperties.MulticastAddresses.Count);
+                foreach (IPAddressInformation multi in ipProperties.MulticastAddresses)
+                {
+                    _log.WriteLine("-- " + multi.Address.ToString());
+                    Assert.Throws<PlatformNotSupportedException>(() => multi.IsDnsEligible);
+                    Assert.Throws<PlatformNotSupportedException>(() => multi.IsTransient);
+                }
+
+                Assert.NotNull(ipProperties.UnicastAddresses);
+                _log.WriteLine("- Unicast Addresses: " + ipProperties.UnicastAddresses.Count);
+                foreach (UnicastIPAddressInformation uni in ipProperties.UnicastAddresses)
+                {
+                    _log.WriteLine("-- " + uni.Address.ToString());
+                    Assert.Throws<PlatformNotSupportedException>(() => uni.AddressPreferredLifetime);
+                    Assert.Throws<PlatformNotSupportedException>(() => uni.AddressValidLifetime);
+                    Assert.Throws<PlatformNotSupportedException>(() => uni.DhcpLeaseLifetime);
+                    Assert.Throws<PlatformNotSupportedException>(() => uni.DuplicateAddressDetectionState);
+
+                    Assert.NotNull(uni.IPv4Mask);
+                    _log.WriteLine("--- IPv4 Mask: " + uni.IPv4Mask);
+                    Assert.Throws<PlatformNotSupportedException>(() => uni.IsDnsEligible);
+                    Assert.Throws<PlatformNotSupportedException>(() => uni.IsTransient);
+                    Assert.Throws<PlatformNotSupportedException>(() => uni.PrefixOrigin);
+                    Assert.Throws<PlatformNotSupportedException>(() => uni.SuffixOrigin);
+
+                    // Prefix Length
+                    Assert.Throws<PlatformNotSupportedException>(() => uni.PrefixLength);
+                }
+
+                Assert.Throws<PlatformNotSupportedException>(() => ipProperties.WinsServersAddresses);
+            }
+        }
+
+        [Fact]
+        public void IPInfoTest_AccessAllIPv4Properties_NoErrors()
+        {
+            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                _log.WriteLine("Nic: " + nic.Name);
+
+                IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                _log.WriteLine("IPv4 Properties:");
+
+                IPv4InterfaceProperties ipv4Properties = ipProperties.GetIPv4Properties();
+
+                _log.WriteLine("Index: " + ipv4Properties.Index);
+                Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsAutomaticPrivateAddressingActive);
+                Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsAutomaticPrivateAddressingEnabled);
+                Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsDhcpEnabled);
+                Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.IsForwardingEnabled);
+                _log.WriteLine("Mtu: " + ipv4Properties.Mtu);
+                Assert.Throws<PlatformNotSupportedException>(() => ipv4Properties.UsesWins);
+            }
+        }
+
+        [Fact]
+        public void IPInfoTest_AccessAllIPv6Properties_NoErrors()
+        {
+            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                _log.WriteLine("Nic: " + nic.Name);
+
+                IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                _log.WriteLine("IPv6 Properties:");
+
+                IPv6InterfaceProperties ipv6Properties = ipProperties.GetIPv6Properties();
+
+                if (ipv6Properties == null)
+                {
+                    _log.WriteLine("IPv6Properties is null");
+                    continue;
+                }
+
+                _log.WriteLine("Index: " + ipv6Properties.Index);
+                _log.WriteLine("Mtu: " + ipv6Properties.Mtu);
+                Assert.Throws<PlatformNotSupportedException>(() => ipv6Properties.GetScopeId(ScopeLevel.Link));
+            }
+        }
+
+        [Fact]
+        [Trait("IPv6", "true")]
+        public void IPv6ScopeId_AccessAllValues_Success()
+        {
+            Assert.True(Capability.IPv6Support());
+
+            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                _log.WriteLine("Nic: " + nic.Name);
+
+                if (!nic.Supports(NetworkInterfaceComponent.IPv6))
+                {
+                    continue;
+                }
+
+                IPInterfaceProperties ipProperties = nic.GetIPProperties();
+
+                IPv6InterfaceProperties ipv6Properties = ipProperties.GetIPv6Properties();
+
+                Array values = Enum.GetValues(typeof(ScopeLevel));
+                foreach (ScopeLevel level in values)
+                {
+                    Assert.Throws<PlatformNotSupportedException>(() => ipv6Properties.GetScopeId(level));
+                }
+            }
+        }
+    }
+}

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Windows.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_Windows.cs
@@ -9,17 +9,17 @@ using Xunit.Abstractions;
 
 namespace System.Net.NetworkInformation.Tests
 {
-    public class IPInterfacePropertiesTest
+    [PlatformSpecific(PlatformID.Windows)]
+    public class IPInterfacePropertiesTest_Windows
     {
         private readonly ITestOutputHelper _log;
 
-        public IPInterfacePropertiesTest()
+        public IPInterfacePropertiesTest_Windows()
         {
             _log = TestLogging.GetInstance();
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // Linux and OSX do not support some of these
         public void IPInfoTest_AccessAllProperties_NoErrors()
         {
             foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
@@ -110,7 +110,6 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // Linux and OSX do not support some of these
         public void IPInfoTest_AccessAllIPv4Properties_NoErrors()
         {
             foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
@@ -141,7 +140,6 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // Linux and OSX do not support some of these
         public void IPInfoTest_AccessAllIPv6Properties_NoErrors()
         {
             foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
@@ -175,7 +173,6 @@ namespace System.Net.NetworkInformation.Tests
 
         [Fact]
         [Trait("IPv6", "true")]
-        [PlatformSpecific(PlatformID.Windows)] // Linux and OSX do not support GetScopeId
         public void IPv6ScopeId_GetLinkLevel_MatchesIndex()
         {
             Assert.True(Capability.IPv6Support());
@@ -197,7 +194,6 @@ namespace System.Net.NetworkInformation.Tests
 
         [Fact]
         [Trait("IPv6", "true")]
-        [PlatformSpecific(PlatformID.Windows)] // Linux and OSX do not support GetScopeId
         public void IPv6ScopeId_AccessAllValues_Success()
         {
             Assert.True(Capability.IPv6Support());

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkFiles/dev
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkFiles/dev
@@ -1,4 +1,4 @@
 Inter-|   Receive                                                |  Transmit
  face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
  wlan0:   26622     394    2    4    6     8         10        12    27465     208    1    2    3     4       5          6
-    lo:   30008     302    0    0    0     0          0         0    30008     302    0    0    0     0       0          0
+    lo:   4294967300     302    0    0    0     0          0         0    30008     302    0    0    0     0       0          0

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkInterfaceBasicTest.cs
@@ -44,6 +44,52 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Linux)]
+        public void BasicTest_AccessInstanceProperties_NoExceptions_Linux()
+        {
+            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                _log.WriteLine("- NetworkInterface -");
+                _log.WriteLine("Name: " + nic.Name);
+                Assert.Throws<PlatformNotSupportedException>(() => nic.Description);
+                Assert.Throws<PlatformNotSupportedException>(() => nic.Id);
+                Assert.Throws<PlatformNotSupportedException>(() => nic.IsReceiveOnly);
+                _log.WriteLine("Type: " + nic.NetworkInterfaceType);
+                _log.WriteLine("Status: " + nic.OperationalStatus);
+                try
+                {
+                    _log.WriteLine("Speed: " + nic.Speed);
+                    Assert.True(nic.Speed >= 0, "Overflow");
+                }
+                // We cannot guarantee this works on all devices.
+                catch (PlatformNotSupportedException)
+                { }
+                _log.WriteLine("SupportsMulticast: " + nic.SupportsMulticast);
+                _log.WriteLine("GetPhysicalAddress(): " + nic.GetPhysicalAddress());
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.OSX)]
+        public void BasicTest_AccessInstanceProperties_NoExceptions_Osx()
+        {
+            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                _log.WriteLine("- NetworkInterface -");
+                _log.WriteLine("Name: " + nic.Name);
+                Assert.Throws<PlatformNotSupportedException>(() => nic.Description);
+                _log.WriteLine("ID: " + nic.Id);
+                Assert.Throws<PlatformNotSupportedException>(() => nic.IsReceiveOnly);
+                _log.WriteLine("Type: " + nic.NetworkInterfaceType);
+                _log.WriteLine("Status: " + nic.OperationalStatus);
+                _log.WriteLine("Speed: " + nic.Speed);
+                Assert.True(nic.Speed >= 0, "Overflow");
+                _log.WriteLine("SupportsMulticast: " + nic.SupportsMulticast);
+                _log.WriteLine("GetPhysicalAddress(): " + nic.GetPhysicalAddress());
+            }
+        }
+
+        [Fact]
         [Trait("IPv4", "true")]
         public void BasicTest_StaticLoopbackIndex_MatchesLoopbackNetworkInterface()
         {
@@ -107,7 +153,7 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [PlatformSpecific(PlatformID.Windows)] // Linux and OSX do not support some of these.
+        [PlatformSpecific(PlatformID.Windows)]
         public void BasicTest_GetIPInterfaceStatistics_Success()
         {
             // This API is not actually IPv4 specific.
@@ -124,6 +170,56 @@ namespace System.Net.NetworkInformation.Tests
                 _log.WriteLine("NonUnicastPacketsReceived: " + stats.NonUnicastPacketsReceived);
                 _log.WriteLine("NonUnicastPacketsSent: " + stats.NonUnicastPacketsSent);
                 _log.WriteLine("OutgoingPacketsDiscarded: " + stats.OutgoingPacketsDiscarded);
+                _log.WriteLine("OutgoingPacketsWithErrors: " + stats.OutgoingPacketsWithErrors);
+                _log.WriteLine("OutputQueueLength: " + stats.OutputQueueLength);
+                _log.WriteLine("UnicastPacketsReceived: " + stats.UnicastPacketsReceived);
+                _log.WriteLine("UnicastPacketsSent: " + stats.UnicastPacketsSent);
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.Linux)]
+        public void BasicTest_GetIPInterfaceStatistics_Success_Linux()
+        {
+            // This API is not actually IPv4 specific.
+            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                IPInterfaceStatistics stats = nic.GetIPStatistics();
+
+                _log.WriteLine("- Stats for : " + nic.Name);
+                _log.WriteLine("BytesReceived: " + stats.BytesReceived);
+                _log.WriteLine("BytesSent: " + stats.BytesSent);
+                _log.WriteLine("IncomingPacketsDiscarded: " + stats.IncomingPacketsDiscarded);
+                _log.WriteLine("IncomingPacketsWithErrors: " + stats.IncomingPacketsWithErrors);
+                Assert.Throws<PlatformNotSupportedException>(() => stats.IncomingUnknownProtocolPackets);
+                _log.WriteLine("NonUnicastPacketsReceived: " + stats.NonUnicastPacketsReceived);
+                Assert.Throws<PlatformNotSupportedException>(() => stats.NonUnicastPacketsSent);
+                _log.WriteLine("OutgoingPacketsDiscarded: " + stats.OutgoingPacketsDiscarded);
+                _log.WriteLine("OutgoingPacketsWithErrors: " + stats.OutgoingPacketsWithErrors);
+                _log.WriteLine("OutputQueueLength: " + stats.OutputQueueLength);
+                _log.WriteLine("UnicastPacketsReceived: " + stats.UnicastPacketsReceived);
+                _log.WriteLine("UnicastPacketsSent: " + stats.UnicastPacketsSent);
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.OSX)]
+        public void BasicTest_GetIPInterfaceStatistics_Success_OSX()
+        {
+            // This API is not actually IPv4 specific.
+            foreach (NetworkInterface nic in NetworkInterface.GetAllNetworkInterfaces())
+            {
+                IPInterfaceStatistics stats = nic.GetIPStatistics();
+
+                _log.WriteLine("- Stats for : " + nic.Name);
+                _log.WriteLine("BytesReceived: " + stats.BytesReceived);
+                _log.WriteLine("BytesSent: " + stats.BytesSent);
+                _log.WriteLine("IncomingPacketsDiscarded: " + stats.IncomingPacketsDiscarded);
+                _log.WriteLine("IncomingPacketsWithErrors: " + stats.IncomingPacketsWithErrors);
+                _log.WriteLine("IncomingUnknownProtocolPackets: " + stats.IncomingUnknownProtocolPackets);
+                _log.WriteLine("NonUnicastPacketsReceived: " + stats.NonUnicastPacketsReceived);
+                _log.WriteLine("NonUnicastPacketsSent: " + stats.NonUnicastPacketsSent);
+                Assert.Throws<PlatformNotSupportedException>(() => stats.OutgoingPacketsDiscarded);
                 _log.WriteLine("OutgoingPacketsWithErrors: " + stats.OutgoingPacketsWithErrors);
                 _log.WriteLine("OutputQueueLength: " + stats.OutputQueueLength);
                 _log.WriteLine("UnicastPacketsReceived: " + stats.UnicastPacketsReceived);

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/StatisticsParsingTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/StatisticsParsingTests.cs
@@ -213,7 +213,7 @@ namespace System.Net.NetworkInformation.Tests
             FileUtil.NormalizeLineEndings("dev", "dev_normalized1");
             IPInterfaceStatisticsTable table = StringParsingHelpers.ParseInterfaceStatisticsTableFromFile("dev_normalized1", "lo");
 
-            Assert.Equal(30008u, table.BytesReceived);
+            Assert.Equal(uint.MaxValue, table.BytesReceived);
             Assert.Equal(302u, table.PacketsReceived);
             Assert.Equal(0u, table.ErrorsReceived);
             Assert.Equal(0u, table.IncomingPacketsDropped);

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/System.Net.NetworkInformation.Functional.Tests.csproj
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/System.Net.NetworkInformation.Functional.Tests.csproj
@@ -41,7 +41,9 @@
     <Compile Include="AddressParsingTests.cs" />
     <Compile Include="DnsParsingTests.cs" />
     <Compile Include="FileUtil.cs" />
-    <Compile Include="IPInterfacePropertiesTest.cs" />
+    <Compile Include="IPInterfacePropertiesTest_Linux.cs" />
+    <Compile Include="IPInterfacePropertiesTest_OSX.cs" />
+    <Compile Include="IPInterfacePropertiesTest_Windows.cs" />
     <Compile Include="MiscParsingTests.cs" />
     <Compile Include="NetworkChangeTest.cs" />
     <Compile Include="NetworkInterfaceBasicTest.cs" />


### PR DESCRIPTION
I've copied out the existing tests that Windows uses, which log all of the properties available on various types in the library, to separate versions for Linux and OSX. For those properties that aren't supported on Linux or OSX, I instead assert that a PlatformNotSupportedException is thrown. Although this doesn't give us guarantees about the results of those methods, it does let us know if they have stopped working
altogether.

One issue I discovered was that UnixUnicastIPAddressInformation was throwing a NotImplementedException (from the base class) rather than a PlatformNotSupportedException. I've fixed this as well.