### PR TITLE
HttpWebRequest request stream WriteAsync, FlushAsync overrides

### DIFF
--- a/src/System.Net.Requests/src/System/Net/RequestStream.cs
+++ b/src/System.Net.Requests/src/System/Net/RequestStream.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace System.Net
@@ -51,6 +52,14 @@ namespace System.Net
             // Nothing to do.
         }
 
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            // Nothing to do.
+            return cancellationToken.IsCancellationRequested ?
+                Task.FromCanceled(cancellationToken) :
+                Task.CompletedTask;
+        }
+
         public override long Length
         {
             get
@@ -89,6 +98,11 @@ namespace System.Net
         public override void Write(byte[] buffer, int offset, int count)
         {
             _buffer.Write(buffer, offset, count);
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return _buffer.WriteAsync(buffer, offset, count, cancellationToken);
         }
 
         public ArraySegment<byte> GetBuffer()

--- a/src/System.Net.Requests/tests/RequestStreamTest.cs
+++ b/src/System.Net.Requests/tests/RequestStreamTest.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace System.Net.Tests
+{
+    public class RequestStreamTest
+    {
+        readonly byte[] buffer = new byte[1];
+        
+        [Fact]
+        public void WriteAsync_BufferIsNull_ThrowsArgumentNullException()
+        {
+            using (Stream stream = GetRequestStream())
+            {
+                Assert.Throws<ArgumentNullException>(() => { Task t = stream.WriteAsync(null, 0, 1); });
+            }
+        }
+
+        [Fact]
+        public void WriteAsync_OffsetIsNegative_ThrowsArgumentOutOfRangeException()
+        {
+            using (Stream stream = GetRequestStream())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => { Task t = stream.WriteAsync(buffer, -1, buffer.Length); });
+            }
+        }
+
+        [Fact]
+        public void WriteAsync_CountIsNegative_ThrowsArgumentOutOfRangeException()
+        {
+            using (Stream stream = GetRequestStream())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(() => { Task t = stream.WriteAsync(buffer, 0, -1); });
+            }
+        }
+
+        [Fact]
+        public void WriteAsync_OffsetPlusCountExceedsBufferLength_ThrowsArgumentException()
+        {
+            using (Stream stream = GetRequestStream())
+            {
+                Assert.Throws<ArgumentException>(() => { Task t = stream.WriteAsync(buffer, 0, buffer.Length+1); });
+            }
+        }
+
+        [Fact]
+        public void WriteAsync_OffsetPlusCountMaxValueExceedsBufferLength_ThrowsArgumentException()
+        {
+            using (Stream stream = GetRequestStream())
+            {
+                Assert.Throws<ArgumentException>(() => { Task t = stream.WriteAsync(buffer, int.MaxValue, int.MaxValue); });
+            }
+        }
+
+        [Fact]
+        public void WriteAsync_ValidParameters_TaskRanToCompletion()
+        {
+            using (Stream stream = GetRequestStream())
+            {
+                Task t = stream.WriteAsync(buffer, 0, buffer.Length);
+                Assert.Equal(TaskStatus.RanToCompletion, t.Status);
+            }
+        }
+
+        [Fact]
+        public void WriteAsync_TokenIsCanceled_TaskIsCanceled()
+        {
+            using (Stream stream = GetRequestStream())
+            {
+                var cts = new CancellationTokenSource();
+                cts.Cancel();
+                Task t = stream.WriteAsync(buffer, 0, buffer.Length, cts.Token);
+                Assert.True(t.IsCanceled);
+            }
+        }
+
+        [Fact]
+        public void FlushAsync_TaskRanToCompletion()
+        {
+            using (Stream stream = GetRequestStream())
+            {
+                Task t = stream.FlushAsync();
+                Assert.Equal(TaskStatus.RanToCompletion, t.Status);
+            }
+        }
+
+        [Fact]
+        public void FlushAsync_TokenIsCanceled_TaskIsCanceled()
+        {
+            using (Stream stream = GetRequestStream())
+            {
+                var cts = new CancellationTokenSource();
+                cts.Cancel();
+                Task t = stream.FlushAsync(cts.Token);
+                Assert.True(t.IsCanceled);
+            }
+        }
+
+        private Stream GetRequestStream()
+        {
+            HttpWebRequest request = HttpWebRequest.CreateHttp(HttpTestServers2.RemoteEchoServer);
+            request.Method = "POST";
+            return request.GetRequestStreamAsync().GetAwaiter().GetResult();
+        }
+    }
+}

--- a/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
+++ b/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <Compile Include="HttpWebRequestTest.cs" />
     <Compile Include="HttpWebResponseTest.cs" />
+    <Compile Include="RequestStreamTest.cs" />
     <Compile Include="WebRequestTest.cs" />
 
     <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers.cs">


### PR DESCRIPTION
This was a prior TODO from PR #2386.

Added overrides for Stream's WriteAsync and FlushAync methods. As the request stream is a memory stream, it'll perform the operations synchronously anyways. Whereas if these methods remain not overridden, it'll default to the base stream's implementation which will queue work items that just call Write and Flush, respectively. So, this improves performance a little bit by not having to queue work items.

Added tests for RequestStream class that is returned via the HttpWebRequest.GetRequstStream* methods.