### PR TITLE
Improve WebUtility.HtmlEncode/Decode perf

### DIFF
--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.CoreCLR.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.CoreCLR.csproj
@@ -28,8 +28,6 @@
     <Compile Include="System\BitConverter.cs" />
     <Compile Include="System\IO\Path.cs" />
     <Compile Include="System\Net\WebUtility.cs" />
-    <Compile Include="System\Net\Configuration\UnicodeDecodingConformance.cs" />
-    <Compile Include="System\Net\Configuration\UnicodeEncodingConformance.cs" />
     <Compile Include="System\Runtime\Versioning\FrameworkName.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.CoreCLR.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.CoreCLR.csproj
@@ -26,8 +26,6 @@
   <ItemGroup>
     <Compile Include="System\Diagnostics\Stopwatch.cs" />
     <Compile Include="System\BitConverter.cs" />
-    <Compile Include="System\IO\LowLevelTextWriter.cs" />
-    <Compile Include="System\IO\LowLevelStringWriter.cs" />
     <Compile Include="System\IO\Path.cs" />
     <Compile Include="System\Net\WebUtility.cs" />
     <Compile Include="System\Net\Configuration\UnicodeDecodingConformance.cs" />

--- a/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
+++ b/src/System.Runtime.Extensions/tests/System/Net/WebUtility.cs
@@ -53,8 +53,8 @@ namespace System.Net.Tests
         [Fact]
         public static void HtmlEncodeWithoutTextWriter()
         {
-            string input = "Hello! '\"<&>\u2665\u00E7";
-            string expected = "Hello! &#39;&quot;&lt;&amp;&gt;\u2665&#231;";
+            string input = "Hello! '\"<&>\u2665\u00E7 World";
+            string expected = "Hello! &#39;&quot;&lt;&amp;&gt;\u2665&#231; World";
 
             string returned = WebUtility.HtmlEncode(input);
 


### PR DESCRIPTION
- It was unnecessarily duplicating calls to IndexOfHtmlEncodingChars and StringRequiresHtmlDecoding.
- It was unnecessarily checking args that were already validated.
- It was unnecessarily allocating LowLevelTextWriter wrappers when the only usage needed was StringBuilder.
- It was unnecessarily making virtual calls for each append.
- It was unnecessarily allocating StringBuilders, as StringBuilderCache is already in use by this assembly.

In benchmarks measuring the throughput of HtmlEncode/Decode on strings that required changes, on my machine this commit doubles the throughput of HtmlEncode/Decode.

I also removed some dead code from the .CoreCLR.csproj project.

cc: @KrzysztofCwalina, @mellinoe 