### PR TITLE
Optimize Task Extension Methods

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketTaskExtensions.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketTaskExtensions.cs
@@ -11,45 +11,39 @@ namespace System.Net.Sockets
     {
         public static Task<Socket> AcceptAsync(this Socket socket)
         {
-            return Task<Socket>.Factory.FromAsync(socket.BeginAccept, socket.EndAccept, null);
+            return Task<Socket>.Factory.FromAsync(socket.BeginAccept(null, null), socket.EndAccept);
         }
 
         public static Task<Socket> AcceptAsync(this Socket socket, Socket acceptSocket)
         {
-            return Task<Socket>.Factory.FromAsync(socket.BeginAccept, socket.EndAccept, acceptSocket, 0, null);
+            return Task<Socket>.Factory.FromAsync(socket.BeginAccept(acceptSocket, 0, null, null), socket.EndAccept);
         }
 
         public static Task ConnectAsync(this Socket socket, EndPoint remoteEndPoint)
         {
-            return Task.Factory.FromAsync(socket.BeginConnect, socket.EndConnect, remoteEndPoint, null);
+            return Task.Factory.FromAsync(socket.BeginConnect(remoteEndPoint, null, null), socket.EndConnect);
         }
 
         public static Task ConnectAsync(this Socket socket, IPAddress address, int port)
         {
-            return Task.Factory.FromAsync(socket.BeginConnect, socket.EndConnect, address, port, null);
+            return Task.Factory.FromAsync(socket.BeginConnect(address, port, null, null), socket.EndConnect);
         }
 
         public static Task ConnectAsync(this Socket socket, IPAddress[] addresses, int port)
         {
-            return Task.Factory.FromAsync(socket.BeginConnect, socket.EndConnect, addresses, port, null);
+            return Task.Factory.FromAsync(socket.BeginConnect(addresses, port, null, null), socket.EndConnect);
         }
 
         public static Task ConnectAsync(this Socket socket, string host, int port)
         {
-            return Task.Factory.FromAsync(socket.BeginConnect, socket.EndConnect, host, port, null);
+            return Task.Factory.FromAsync(socket.BeginConnect(host, port, null, null), socket.EndConnect);
         }
 
         public static Task<int> ReceiveAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags)
         {
             return Task<int>.Factory.FromAsync(
-                (callback, state) => socket.BeginReceive(
-                                                buffer.Array, 
-                                                buffer.Offset, 
-                                                buffer.Count, 
-                                                socketFlags, 
-                                                callback, 
-                                                state), 
-                socket.EndReceive, null);
+                socket.BeginReceive(buffer.Array, buffer.Offset, buffer.Count, socketFlags, null, null),
+                socket.EndReceive);
         }
 
         public static Task<int> ReceiveAsync(
@@ -57,7 +51,9 @@ namespace System.Net.Sockets
             IList<ArraySegment<byte>> buffers, 
             SocketFlags socketFlags)
         {
-            return Task<int>.Factory.FromAsync(socket.BeginReceive, socket.EndReceive, buffers, socketFlags, null);
+            return Task<int>.Factory.FromAsync(
+                socket.BeginReceive(buffers, socketFlags, null, null),
+                socket.EndReceive);
         }
 
         public static Task<SocketReceiveFromResult> ReceiveFromAsync(
@@ -67,22 +63,21 @@ namespace System.Net.Sockets
             EndPoint remoteEndPoint)
         {
             return Task<SocketReceiveFromResult>.Factory.FromAsync(
-                (callback, state) => socket.BeginReceiveFrom(
+                socket.BeginReceiveFrom(
                     buffer.Array, 
                     buffer.Offset, 
                     buffer.Count, 
                     socketFlags, 
                     ref remoteEndPoint, 
-                    callback, 
-                    state),
+                    null, 
+                    null),
                 asyncResult => {
                     int bytesReceived = socket.EndReceiveFrom(asyncResult, ref remoteEndPoint);
 
                     return new SocketReceiveFromResult() {
                         ReceivedBytes = bytesReceived,
                         RemoteEndPoint = remoteEndPoint };
-                },
-                null);
+                });
         }
 
         public static Task<SocketReceiveMessageFromResult> ReceiveMessageFromAsync(
@@ -92,14 +87,14 @@ namespace System.Net.Sockets
             EndPoint remoteEndPoint)
         {
             return Task<SocketReceiveMessageFromResult>.Factory.FromAsync(
-                (callback, state) => socket.BeginReceiveMessageFrom(
+                socket.BeginReceiveMessageFrom(
                     buffer.Array, 
                     buffer.Offset, 
                     buffer.Count, 
                     socketFlags, 
                     ref remoteEndPoint, 
-                    callback, 
-                    state),
+                    null, 
+                    null),
                 asyncResult => {
                     IPPacketInformation ipPacket;
                     int bytesReceived = socket.EndReceiveMessageFrom(
@@ -113,22 +108,20 @@ namespace System.Net.Sockets
                         ReceivedBytes = bytesReceived,
                         RemoteEndPoint = remoteEndPoint,
                         SocketFlags = socketFlags };
-                },
-                null);
+                });
         }
 
         public static Task<int> SendAsync(this Socket socket, ArraySegment<byte> buffer, SocketFlags socketFlags)
         {
             return Task<int>.Factory.FromAsync(
-                (callback, state) => socket.BeginSend(
+                socket.BeginSend(
                     buffer.Array, 
                     buffer.Offset, 
                     buffer.Count, 
                     socketFlags, 
-                    callback, 
-                    state),
-                socket.EndSend, 
-                null);
+                    null, 
+                    null),
+                socket.EndSend);
         }
 
         public static Task<int> SendAsync(
@@ -136,7 +129,7 @@ namespace System.Net.Sockets
             IList<ArraySegment<byte>> buffers, 
             SocketFlags socketFlags)
         {
-            return Task<int>.Factory.FromAsync(socket.BeginSend, socket.EndSend, buffers, socketFlags, null);
+            return Task<int>.Factory.FromAsync(socket.BeginSend(buffers, socketFlags, null, null), socket.EndSend);
         }
 
         public static Task<int> SendToAsync(
@@ -146,16 +139,15 @@ namespace System.Net.Sockets
             EndPoint remoteEndPoint)
         {
             return Task<int>.Factory.FromAsync(
-                (callback, state) => socket.BeginSendTo(
+                socket.BeginSendTo(
                     buffer.Array, 
                     buffer.Offset, 
                     buffer.Count, 
                     socketFlags, 
                     remoteEndPoint, 
-                    callback, 
-                    state),
-                socket.EndSendTo,
-                null);
+                    null, 
+                    null),
+                socket.EndSendTo);
         }
     }
 }


### PR DESCRIPTION
Calling directly all begin methods to avoid delegate allocations which
improves the performance overall.

Fix #4052