### PR TITLE
Fixing Debug code to do proper snapshot isolation of the ref-count variable

### DIFF
--- a/src/Common/src/System/Net/SafeCloseSocket.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.cs
@@ -52,9 +52,10 @@ namespace System.Net.Sockets
             try
             {
                 // The inner socket can be closed by CloseAsIs and when SafeHandle runs ReleaseHandle.
-                if (_innerSocket != null)
+                InnerSafeCloseSocket innerSocket = Volatile.Read(ref _innerSocket);
+                if (innerSocket != null)
                 {
-                    _innerSocket.AddRef();
+                    innerSocket.AddRef();
                 }
             }
             catch (Exception e)
@@ -68,9 +69,10 @@ namespace System.Net.Sockets
             try
             {
                 // The inner socket can be closed by CloseAsIs and when SafeHandle runs ReleaseHandle.
-                if (_innerSocket != null)
+                InnerSafeCloseSocket innerSocket = Volatile.Read(ref _innerSocket);
+                if (innerSocket != null)
                 {
-                    _innerSocket.Release();
+                    innerSocket.Release();
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
Adding snapshot isolation to debugging ref-count code to avoid a race condition with SafeCloseSocket.Dispose() or .CloseAsIs().

Fix #4204

Validated that the original setup: VM with 2 CPUs and 8 instances of the same test.

@josguil @davidsh @pgavlin PTAL