### PR TITLE
Grammar and clarity updates for Windows build instructions

### DIFF
--- a/Documentation/building/windows-instructions.md
+++ b/Documentation/building/windows-instructions.md
@@ -17,7 +17,7 @@ Note: In order to build our C++ projects be sure to select "Programming Language
 
 ## Building From the Command Line
 
-Open a [Visual Studio Command Prompt](http://msdn.microsoft.com/en-us/library/ms229859(v=vs.110).aspx). 
+Open a [Visual Studio Command Prompt](http://msdn.microsoft.com/en-us/library/ms229859(v=vs.110).aspx).
 From the root of the repository, type `build`. This will build everything and run
 the core tests for the project. Visual Studio Solution (.sln) files exist for
 related groups of libraries. These can be loaded to build, debug and test inside
@@ -26,81 +26,84 @@ the Visual Studio IDE.
 [Building CoreFX on FreeBSD, Linux and OS X](unix-instructions.md)
 ## Tests
 
-We use the OSS testing framework [xunit](http://xunit.github.io/)
+We use the OSS testing framework [xunit](http://xunit.github.io/).
 
 ### Running tests on the command line
 
 By default, the core tests are run as part of the build. Running the tests from
-the command line is as simple as invoking `build.cmd` on windows, and `run-test.sh` on linux and osx. 
+the command line is as simple as invoking `build.cmd` on windows, and `run-test.sh` on linux and osx.
 
-You can also run the test for an individual project by building just one test
-project, e.g.:
+You can also run the tests for an individual project by building it individually, e.g.:
 
 ```
 cd src\System.Collections.Immutable\tests
 msbuild /t:BuildAndTest (or /t:Test to just run the tests if the binaries are already built)
 ```
+
 It is possible to pass parameters to the underlying xunit runner via the `XunitOptions` parameter, e.g.:
-````
+```cmd
 msbuild /t:Test "/p:XunitOptions=-class Test.ClassUnderTests -notrait category=outerloop"
-````
-
-In some test directories there may be multiple test projects or directories so you may need to specify the specific test project to get it to build and run the tests.
-
-Tests participate in the incremental build.  This means that if tests have already been run, and inputs to the incremental build have not changed, rerunning the tests target will not execute the test runner again.  To force re-executing tests in this situation, use msbuild /t:clean;build;test.
-
-The tests can also be filtered based on xunit trait attributes defined in XunitTraitDiscoverers project. These attributes are to be specified over the test method. The available xunit attributes are:
-
-_**OuterLoop:**_
-This attribute returns the 'outerloop' category, so to run outerloop tests use the following commandline,
 ```
+
+There may be multiple projects in some directories so you may need to specify the path to a specific test project to get it to build and run the tests.
+
+Tests participate in the incremental build.  This means that if tests have already been run, and inputs to the incremental build have not changed, rerunning the tests target will not execute the test runner again.  To force re-executing tests in this situation, use `msbuild /t:clean;build;test`.
+
+The tests can also be filtered based on xunit trait attributes defined in [`xunit.netcore.extensions`](https://github.com/dotnet/buildtools/tree/master/src/xunit.netcore.extensions). These attributes are to be specified over the test method. The available attributes are:
+
+_**`OuterLoop`:**_
+This attribute applies the 'outerloop' category; to run outerloop tests, use the following commandline
+```cmd
 xunit.console.netcore.exe *.dll -trait category=outerloop
 build.cmd *.csproj /p:RunTestsWithCategories=OuterLoop
 ```
-_**PlatformSpecific(Xunit.PlatformID platforms):**_
-Use this attribute on test methods, to specifiy that this test may only be run on the specified platforms. This attribute returns the following categories based on platform 
 
-       - nonwindowstests: for tests that don't run on Windows
-       - nonlinuxtests: for tests that don't run on Linux
-       - nonosxtests: for tests that don't run on OSX
+_**`PlatformSpecific(Xunit.PlatformID platforms)`:**_
+Use this attribute on test methods to specify that this test may only be run on the specified platforms. This attribute returns the following categories based on platform
+
+       - `nonwindowstests`: for tests that don't run on Windows
+       - `nonlinuxtests`: for tests that don't run on Linux
+       - `nonosxtests`: for tests that don't run on OS X
 
 To run Linux specific tests on a Linux box, use the following commandline,
-```
+```sh
 xunit.console.netcore.exe *.dll -notrait category=nonlinuxtests
 ```
-_**ActiveIssue(int issue, Xunit.PlatformID platforms):**_
+
+_**`ActiveIssue(int issue, Xunit.PlatformID platforms)`:**_
 Use this attribute over tests methods, to skip failing tests only on the specific platforms, if no platforms is specified, then the test is skipped on all platforms. This attribute returns the 'failing' category, so to run all acceptable tests on Linux that are not failing, use the following commandline,
-```
+```sh
 xunit.console.netcore.exe *.dll -notrait category=failing -notrait category=nonlinuxtests
 ```
-And to run all acceptable tests on Linux that are failing,
-```
+
+And to run all Linux-compatible tests that are failing,
+```sh
 xunit.console.netcore.exe *.dll -trait category=failing -notrait category=nonlinuxtests
 ```
 
 _**A few common examples with the above attributes:**_
 
 - Run all tests acceptable on Windows
-```
+```cmd
 xunit.console.netcore.exe *.dll -notrait category=nonwindowstests
 ```
 - Run all inner loop tests acceptable on Linux
-```
+```sh
 xunit.console.netcore.exe *.dll -notrait category=nonlinuxtests -notrait category=OuterLoop
 ```
-- Run all outer loop tests acceptable on OSX that are not currently associated with active issues
-```
+- Run all outer loop tests acceptable on OS X that are not currently associated with active issues
+```sh
 xunit.console.netcore.exe *.dll -notrait category=nonosxtests -trait category=OuterLoop -notrait category=failing
 ```
 - Run all tests acceptable on Linux that are currently associated with active issues
-```
+```sh
 xunit.console.netcore.exe *.dll -notrait category=nonlinuxtests -trait category=failing
 ```
 
-All the required dlls to run a test project can be found in the bin\\tests\\{Flavor}\\{Project}.Tests\\aspnetcore50\\ which should be created on building the test project.
+All the required dlls to run a test project can be found in `bin\tests\{Flavor}\{Project}.Tests\aspnetcore50\` which should be created when the test project is built.
 
-To skip an entire test project from being run on a specific platform, for ex, skip running registry tests on linux and mac, use the <UnsupportedPlatforms> msbuild property on the csproj. Valid platform values are
-```
+To skip an entire test project on a specific platform, for example, to skip running registry tests on Linux and Mac OS X, use the `<UnsupportedPlatforms>` MSBuild property in the csproj. Valid platform values are
+```xml
 <UnsupportedPlatforms>Windows_NT;Linux;OSX</UnsupportedPlatforms>
 ```
 
@@ -122,7 +125,7 @@ To skip an entire test project from being run on a specific platform, for ex, sk
 
 Code coverage is built into the corefx build system.  It utilizes OpenCover for generating coverage data and ReportGenerator for generating reports about that data.  To run:
 
-```
+```cmd
 // Run full coverage
 build.cmd /p:Coverage=true
 
@@ -134,7 +137,7 @@ If coverage succeeds, the code coverage report will be generated automatically a
 
 Code coverage reports from the continuous integration system are available from the links on the front page of the corefx repo.
 
-### Notes 
+### Notes
 * Running tests from using the VS test explorer does not currently work after we switched to running on CoreCLR. [We will be working on enabling full VS test integration](https://github.com/dotnet/corefx/issues/1318) but we don't have an ETA yet. In the meantime, use the steps above to launch/debug the tests using the console runner.
 
 * VS 2015 is required to debug tests running on CoreCLR as the CoreCLR


### PR DESCRIPTION
When looking at how CoreFX does platform-specific tests, I found a stale reference to `XunitTraitDiscoverers`, which was removed with #1668.  While updating the documentation for that I made a few other clarity edits.