### PR TITLE
Enabling ChannelBinding testcase in Unix

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/TransportContextTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/TransportContextTest.cs
@@ -24,7 +24,6 @@ namespace System.Net.Security.Tests
         }
 
         [Fact]
-        [ActiveIssue(3954, PlatformID.AnyUnix)]
         public void TransportContext_ConnectToServerWithSsl_GetExpectedChannelBindings()
         {
             using (var testServer = new DummyTcpServer(


### PR DESCRIPTION
Channel binding implementation has been added by Rajan , so enabling the testcase ,