### PR TITLE
Make new Oid("").Value always be ""

### DIFF
--- a/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OidLookup.cs
+++ b/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/OidLookup.cs
@@ -63,6 +63,8 @@ namespace Internal.Cryptography
         {
             if (friendlyName == null)
                 throw new ArgumentNullException("friendlyName");
+            if (friendlyName.Length == 0)
+                return null;
 
             string mappedOid;
             bool shouldUseCache = ShouldUseCache(oidGroup);

--- a/src/System.Security.Cryptography.Encoding/tests/Oid.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/Oid.cs
@@ -8,6 +8,14 @@ namespace System.Security.Cryptography.Encoding.Tests
 {
     public static class OidTests
     {
+        [Fact]
+        public static void EmptyOid()
+        {
+            Oid oid = new Oid("");
+            Assert.Equal("", oid.Value);
+            Assert.Null(oid.FriendlyName);
+        }
+
         [Theory]
         [MemberData("ValidOidFriendlyNamePairs")]
         public static void LookupOidByValue_Ctor(string oidValue, string friendlyName)


### PR DESCRIPTION
Windows FindOIDInfo appears to match the empty string with 1.2.840.113549.1.9.9, which is confusing.  Desktop had a guard in place to prevent that from being returned, and this change restores that guard, and adds a test.

Fixes #4303.

cc: @AtsushiKan @stephentoub 