### PR TITLE
Fix a race in DynamicWinsockMethods.

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/_DynamicWinsockMethods.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/_DynamicWinsockMethods.cs
@@ -3,6 +3,7 @@
 
 using System.Security;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 
@@ -62,31 +63,37 @@ namespace System.Net.Sockets
             if (typeof(T) == typeof(AcceptExDelegate))
             {
                 EnsureAcceptEx(socketHandle);
+                Debug.Assert(_acceptEx != null);
                 return (T)(object)_acceptEx;
             }
             else if (typeof(T) == typeof(GetAcceptExSockaddrsDelegate))
             {
                 EnsureGetAcceptExSockaddrs(socketHandle);
+                Debug.Assert(_getAcceptExSockaddrs != null);
                 return (T)(object)_getAcceptExSockaddrs;
             }
             else if (typeof(T) == typeof(ConnectExDelegate))
             {
                 EnsureConnectEx(socketHandle);
+                Debug.Assert(_connectEx != null);
                 return (T)(object)_connectEx;
             }
             else if (typeof(T) == typeof(WSARecvMsgDelegate))
             {
                 EnsureWSARecvMsg(socketHandle);
+                Debug.Assert(_recvMsg != null);
                 return (T)(object)_recvMsg;
             }
             else if (typeof(T) == typeof(WSARecvMsgDelegateBlocking))
             {
                 EnsureWSARecvMsgBlocking(socketHandle);
+                Debug.Assert(_recvMsgBlocking != null);
                 return (T)(object)_recvMsgBlocking;
             }
             else if (typeof(T) == typeof(TransmitPacketsDelegate))
             {
                 EnsureTransmitPackets(socketHandle);
+                Debug.Assert(_transmitPackets != null);
                 return (T)(object)_transmitPackets;
             }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/_DynamicWinsockMethods.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/_DynamicWinsockMethods.cs
@@ -4,6 +4,7 @@
 using System.Security;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace System.Net.Sockets
 {
@@ -172,7 +173,7 @@ namespace System.Net.Sockets
 
         private void EnsureWSARecvMsg(SafeCloseSocket socketHandle)
         {
-            if (_recvMsg == null)
+            if (Volatile.Read(ref _recvMsg) == null)
             {
                 lock (_lockObject)
                 {
@@ -180,8 +181,8 @@ namespace System.Net.Sockets
                     {
                         Guid guid = new Guid("{0xf689d7c8,0x6f1f,0x436b,{0x8a,0x53,0xe5,0x4f,0xe3,0x51,0xc3,0x22}}");
                         IntPtr ptrWSARecvMsg = LoadDynamicFunctionPointer(socketHandle, ref guid);
-                        _recvMsg = Marshal.GetDelegateForFunctionPointer<WSARecvMsgDelegate>(ptrWSARecvMsg);
                         _recvMsgBlocking = Marshal.GetDelegateForFunctionPointer<WSARecvMsgDelegateBlocking>(ptrWSARecvMsg);
+                        Volatile.Write(ref _recvMsg, Marshal.GetDelegateForFunctionPointer<WSARecvMsgDelegate>(ptrWSARecvMsg));
                     }
                 }
             }


### PR DESCRIPTION
There was a race between an initialization check and an initializer: in
EnsureWSARecvMsg, the field used to check that multiple fields had been
initialized was written to before the other field. The writes have been
reordered and appropriate barriers have been added.

Fixes #4172.