### PR TITLE
Add support for exporting as a PKCS#7 on Unix

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Pkcs7.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Pkcs7.cs
@@ -19,10 +19,22 @@ internal static partial class Interop
         internal static extern SafePkcs7Handle D2IPkcs7Bio(SafeBioHandle bp);
 
         [DllImport(Libraries.CryptoNative)]
+        internal static extern SafePkcs7Handle Pkcs7CreateSigned();
+
+        [DllImport(Libraries.CryptoNative)]
         internal static extern void Pkcs7Destroy(IntPtr p7);
 
         [DllImport(Libraries.CryptoNative)]
         private static extern int GetPkcs7Certificates(SafePkcs7Handle p7, out SafeSharedX509StackHandle certs);
+
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern bool Pkcs7AddCertificate(SafePkcs7Handle p7, IntPtr x509);
+
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern int GetPkcs7DerSize(SafePkcs7Handle p7);
+
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern int EncodePkcs7(SafePkcs7Handle p7, byte[] buf);
 
         internal static SafeSharedX509StackHandle GetPkcs7Certificates(SafePkcs7Handle p7)
         {

--- a/src/Native/System.Security.Cryptography.Native/pal_pkcs7.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_pkcs7.cpp
@@ -25,6 +25,25 @@ extern "C" PKCS7* D2IPkcs7Bio(BIO* bp)
     return d2i_PKCS7_bio(bp, nullptr);
 }
 
+extern "C" PKCS7* Pkcs7CreateSigned()
+{
+    PKCS7* pkcs7 = PKCS7_new();
+
+    if (pkcs7 == nullptr)
+    {
+        return nullptr;
+    }
+
+    if (!PKCS7_set_type(pkcs7, NID_pkcs7_signed) ||
+        !PKCS7_content_new(pkcs7, NID_pkcs7_data))
+    {
+        PKCS7_free(pkcs7);
+        return nullptr;
+    }
+
+    return pkcs7;
+}
+
 extern "C" void Pkcs7Destroy(PKCS7* p7)
 {
     if (p7 != nullptr)
@@ -51,4 +70,24 @@ extern "C" int32_t GetPkcs7Certificates(PKCS7* p7, X509Stack** certs)
     }
 
     return 0;
+}
+
+extern "C" int32_t Pkcs7AddCertificate(PKCS7* p7, X509* x509)
+{
+    if (p7 == nullptr || x509 == nullptr)
+    {
+        return 0;
+    }
+
+    return PKCS7_add_certificate(p7, x509);
+}
+
+extern "C" int32_t GetPkcs7DerSize(PKCS7* p7)
+{
+    return i2d_PKCS7(p7, nullptr);
+}
+
+extern "C" int32_t EncodePkcs7(PKCS7* p7, uint8_t* buf)
+{
+    return i2d_PKCS7(p7, &buf);
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_pkcs7.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_pkcs7.h
@@ -29,6 +29,14 @@ Returns the new PKCS7 instance.
 extern "C" PKCS7* D2IPkcs7Bio(BIO* bp);
 
 /*
+Create a new PKCS7 instance and prepare it to be a signed PKCS7
+with a data payload.
+
+Returns the new PKCS7 instance.
+*/
+extern "C" PKCS7* Pkcs7CreateSigned();
+
+/*
 Cleans up and deletes a PKCS7 instance.
 
 Implemented by calling PKCS7_free.
@@ -52,3 +60,21 @@ Return values:
 certificate contents of the structure.
 */
 extern "C" int32_t GetPkcs7Certificates(PKCS7* p7, X509Stack** certs);
+
+/*
+Shims the PKCS7_add_certificate function and makes it easier to invoke from managed code.
+*/
+extern "C" int32_t Pkcs7AddCertificate(PKCS7* p7, X509* x509);
+
+/*
+Returns the number of bytes it will take to convert
+the PKCS7 to a DER format.
+*/
+extern "C" int32_t GetPkcs7DerSize(PKCS7* p7);
+
+/*
+Shims the i2d_PKCS7 method.
+
+Returns the number of bytes written to buf.
+*/
+extern "C" int32_t EncodePkcs7(PKCS7* p7, uint8_t* buf);

--- a/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -174,6 +174,9 @@
   <data name="Cryptography_Unix_X509_MachineStoresRootOnly" xml:space="preserve">
     <value>Unix LocalMachine X509Store is limited to the Root and CertificateAuthority stores.</value>
   </data>
+  <data name="Cryptography_Unix_X509_SerializedExport" xml:space="preserve">
+    <value>X509ContentType.SerializedCert and X509ContentType.SerializedStore are not supported on Unix.</value>
+  </data>
   <data name="Cryptography_X509_ExportFailed" xml:space="preserve">
     <value>The certificate export operation failed.</value>
   </data>

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -620,7 +620,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ExportPkcs7()
         {
             TestExportStore(X509ContentType.Pkcs7);


### PR DESCRIPTION
This change also finishes off the exceptions for unsupported export formats in Unix.  SerializedStore and SerializedCert are PlatformNotSupportedException, anything else is the same "unknown type" CryptographicException from Windows.

Fixes #2913.

cc: @stephentoub @AtsushiKan @eerhardt 