### PR TITLE
Fix System.Net.Http.Native compilation error on CentOS

### DIFF
--- a/src/Native/Common/pal_config.h.in
+++ b/src/Native/Common/pal_config.h.in
@@ -40,6 +40,7 @@
 #cmakedefine01 HAVE_INOTIFY
 #cmakedefine01 HAVE_CLOCK_MONOTONIC
 #cmakedefine01 HAVE_MACH_ABSOLUTE_TIME
+#cmakedefine01 HAVE_CURLM_ADDED_ALREADY
 
 // Mac OS X has stat64, but it is deprecated since plain stat now
 // provides the same 64-bit aware struct when targeting OS X > 10.5

--- a/src/Native/System.Net.Http.Native/pal_multi.cpp
+++ b/src/Native/System.Net.Http.Native/pal_multi.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#include "pal_config.h"
 #include "pal_multi.h"
 
 #include <assert.h>
@@ -12,7 +13,9 @@ static_assert(PAL_CURLM_OUT_OF_MEMORY == CURLM_OUT_OF_MEMORY, "");
 static_assert(PAL_CURLM_INTERNAL_ERROR == CURLM_INTERNAL_ERROR, "");
 static_assert(PAL_CURLM_BAD_SOCKET == CURLM_BAD_SOCKET, "");
 static_assert(PAL_CURLM_UNKNOWN_OPTION == CURLM_UNKNOWN_OPTION, "");
+#if HAVE_CURLM_ADDED_ALREADY
 static_assert(PAL_CURLM_ADDED_ALREADY == CURLM_ADDED_ALREADY, "");
+#endif
 
 static_assert(PAL_CURLMSG_DONE == CURLMSG_DONE, "");
 

--- a/src/Native/System.Net.Http.Native/pal_multi.h
+++ b/src/Native/System.Net.Http.Native/pal_multi.h
@@ -16,7 +16,7 @@ enum PAL_CURLMcode : int32_t
     PAL_CURLM_INTERNAL_ERROR = 4,
     PAL_CURLM_BAD_SOCKET = 5,
     PAL_CURLM_UNKNOWN_OPTION = 6,
-    PAL_CURLM_ADDED_ALREADY = 7,
+    PAL_CURLM_ADDED_ALREADY = 7, // Added in libcurl 7.32.1
 };
 
 enum PAL_CURLMSG : int32_t

--- a/src/Native/configure.cmake
+++ b/src/Native/configure.cmake
@@ -270,6 +270,13 @@ check_function_exists(
     inotify_rm_watch
     HAVE_INOTIFY_RM_WATCH)
 
+check_cxx_source_compiles(
+    "
+    #include <curl/multi.h>
+    int main() { int i = CURLM_ADDED_ALREADY; }
+    "
+    HAVE_CURLM_ADDED_ALREADY)
+
 set (HAVE_INOTIFY 0)
 if (HAVE_INOTIFY_INIT AND HAVE_INOTIFY_ADD_WATCH AND HAVE_INOTIFY_RM_WATCH)
 	set (HAVE_INOTIFY 1)


### PR DESCRIPTION
Older versions of libcurl don't have an error code we're referencing.

It's not actually needed in managed code other than to throw the right
exception when this error code is returned.  If we're using an older
version of libcurl where the error doesn't exist, it'll never be
returned, so the managed code that references it will just be a nop.

Fixes #4308 
cc: @ellismg, @eerhardt 