### PR TITLE
Security Fix: 4 DataAnnotations Attributes updated to prevent / mitigate use of regexes

### DIFF
--- a/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
+++ b/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.cs
@@ -211,6 +211,7 @@ namespace System.ComponentModel.DataAnnotations
     public partial class RegularExpressionAttribute : System.ComponentModel.DataAnnotations.ValidationAttribute
     {
         public RegularExpressionAttribute(string pattern) { }
+        public int MatchTimeoutInMilliseconds { get { return default(int); } set { } }
         public string Pattern { get { return default(string); } }
         public override string FormatErrorMessage(string name) { return default(string); }
         public override bool IsValid(object value) { return default(bool); }

--- a/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.csproj
+++ b/src/System.ComponentModel.Annotations/ref/System.ComponentModel.Annotations.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
     <NuGetTargetMoniker>.NETPlatform,Version=v5.4</NuGetTargetMoniker>

--- a/src/System.ComponentModel.Annotations/src/System.ComponentModel.Annotations.csproj
+++ b/src/System.ComponentModel.Annotations/src/System.ComponentModel.Annotations.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <RootNamespace>System.ComponentModel.Annotations</RootNamespace>
     <AssemblyName>System.ComponentModel.Annotations</AssemblyName>
-    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Text.RegularExpressions;
+using System.Linq;
 
 namespace System.ComponentModel.DataAnnotations
 {
@@ -9,17 +9,10 @@ namespace System.ComponentModel.DataAnnotations
         AllowMultiple = false)]
     public sealed class EmailAddressAttribute : DataTypeAttribute
     {
-        // This attribute provides server-side email validation equivalent to jquery validate,
-        // and therefore shares the same regular expression.  See unit tests for examples.
-        private static readonly Regex _regex =
-            new Regex(
-                @"^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?$",
-                RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture);
-
         public EmailAddressAttribute()
             : base(DataType.EmailAddress)
         {
-            // Set DefaultErrorMessage, allowing user to set
+            // Set DefaultErrorMessage not ErrrorMessage, allowing user to set
             // ErrorMessageResourceType and ErrorMessageResourceName to use localized messages.
             DefaultErrorMessage = SR.EmailAddressAttribute_Invalid;
         }
@@ -32,7 +25,10 @@ namespace System.ComponentModel.DataAnnotations
             }
 
             var valueAsString = value as string;
-            return valueAsString != null && _regex.Match(valueAsString).Length > 0;
+            return (valueAsString != null
+                && valueAsString.Count(c => c == '@') == 1
+                && valueAsString[0] != '@'
+                && valueAsString[valueAsString.Length-1] != '@');
         }
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/EmailAddressAttribute.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Linq;
-
 namespace System.ComponentModel.DataAnnotations
 {
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter,
@@ -25,10 +23,27 @@ namespace System.ComponentModel.DataAnnotations
             }
 
             var valueAsString = value as string;
-            return (valueAsString != null
-                && valueAsString.Count(c => c == '@') == 1
-                && valueAsString[0] != '@'
-                && valueAsString[valueAsString.Length-1] != '@');
+            if (valueAsString == null)
+            {
+                return false;
+            }
+
+            // only return true is there is only 1 '@' character
+            // and it is neither the first nor the last character
+            bool found = false;
+            for (int i = 0; i < valueAsString.Length; i++)
+            {
+                if (valueAsString[i] == '@')
+                {
+                    if (found || i == 0 || i == valueAsString.Length - 1)
+                    {
+                        return false;
+                    }
+                    found = true;
+                }
+            }
+
+            return found;
         }
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/PhoneAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/PhoneAttribute.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Linq;
-
 namespace System.ComponentModel.DataAnnotations
 {
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter,
@@ -10,6 +8,9 @@ namespace System.ComponentModel.DataAnnotations
     public sealed class PhoneAttribute : DataTypeAttribute
     {
         private const string _additionalPhoneNumberCharacters = "-.()";
+        private const string _extensionAbbreviationExtDot = "ext.";
+        private const string _extensionAbbreviationExt = "ext";
+        private const string _extensionAbbreviationX = "x";
 
         public PhoneAttribute()
             : base(DataType.PhoneNumber)
@@ -35,24 +36,42 @@ namespace System.ComponentModel.DataAnnotations
             valueAsString = valueAsString.Replace("+", string.Empty).TrimEnd();
             valueAsString = RemoveExtension(valueAsString);
 
-            if (!valueAsString.Any(Char.IsDigit))
+            bool digitFound = false;
+            foreach (char c in valueAsString)
+            {
+                if (Char.IsDigit(c))
+                {
+                    digitFound = true;
+                    break;
+                }
+            }
+
+            if (!digitFound)
             {
                 return false;
             }
 
-            return valueAsString.All(c =>
-                Char.IsDigit(c)
-                || Char.IsWhiteSpace(c)
-                || _additionalPhoneNumberCharacters.Contains(c));
+            foreach (char c in valueAsString)
+            {
+                if (!(Char.IsDigit(c)
+                    || Char.IsWhiteSpace(c)
+                    || _additionalPhoneNumberCharacters.IndexOf(c) != -1))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private static string RemoveExtension(string potentialPhoneNumber)
         {
             var lastIndexOfExtension = potentialPhoneNumber
-                .LastIndexOf("ext.", StringComparison.OrdinalIgnoreCase);
+                .LastIndexOf(_extensionAbbreviationExtDot, StringComparison.OrdinalIgnoreCase);
             if (lastIndexOfExtension >= 0)
             {
-                var extension = potentialPhoneNumber.Substring(lastIndexOfExtension + 4);
+                var extension = potentialPhoneNumber.Substring(
+                    lastIndexOfExtension + _extensionAbbreviationExtDot.Length);
                 if (MatchesExtension(extension))
                 {
                     return potentialPhoneNumber.Substring(0, lastIndexOfExtension);
@@ -60,10 +79,11 @@ namespace System.ComponentModel.DataAnnotations
             }
 
             lastIndexOfExtension = potentialPhoneNumber
-                .LastIndexOf("ext", StringComparison.OrdinalIgnoreCase);
+                .LastIndexOf(_extensionAbbreviationExt, StringComparison.OrdinalIgnoreCase);
             if (lastIndexOfExtension >= 0)
             {
-                var extension = potentialPhoneNumber.Substring(lastIndexOfExtension + 3);
+                var extension = potentialPhoneNumber.Substring(
+                    lastIndexOfExtension + _extensionAbbreviationExt.Length);
                 if (MatchesExtension(extension))
                 {
                     return potentialPhoneNumber.Substring(0, lastIndexOfExtension);
@@ -71,10 +91,11 @@ namespace System.ComponentModel.DataAnnotations
             }
 
             lastIndexOfExtension = potentialPhoneNumber
-                .LastIndexOf("x", StringComparison.OrdinalIgnoreCase);
+                .LastIndexOf(_extensionAbbreviationX, StringComparison.OrdinalIgnoreCase);
             if (lastIndexOfExtension >= 0)
             {
-                var extension = potentialPhoneNumber.Substring(lastIndexOfExtension + 1);
+                var extension = potentialPhoneNumber.Substring(
+                    lastIndexOfExtension + _extensionAbbreviationX.Length);
                 if (MatchesExtension(extension))
                 {
                     return potentialPhoneNumber.Substring(0, lastIndexOfExtension);
@@ -92,7 +113,15 @@ namespace System.ComponentModel.DataAnnotations
                 return false;
             }
 
-            return potentialExtension.All(c => Char.IsDigit(c));
+            foreach (char c in potentialExtension)
+            {
+                if (!Char.IsDigit(c))
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RegularExpressionAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/RegularExpressionAttribute.cs
@@ -21,7 +21,14 @@ namespace System.ComponentModel.DataAnnotations
             : base(() => SR.RegexAttribute_ValidationError)
         {
             Pattern = pattern;
+            MatchTimeoutInMilliseconds = 2000;
         }
+
+        /// <summary>
+        ///     Gets or sets the timeout to use when matching the regular expression pattern (in milliseconds)
+        ///     (-1 means never timeout).
+        /// </summary>
+        public int MatchTimeoutInMilliseconds { get; set; }
 
         /// <summary>
         ///     Gets the regular expression pattern to use
@@ -81,6 +88,8 @@ namespace System.ComponentModel.DataAnnotations
         /// </summary>
         /// <exception cref="ArgumentException"> is thrown if the current <see cref="Pattern" /> cannot be parsed</exception>
         /// <exception cref="InvalidOperationException"> is thrown if the current attribute is ill-formed.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"> thrown if <see cref="MatchTimeoutInMilliseconds" /> is negative (except -1),
+        /// zero or greater than approximately 24 days </exception>
         private void SetupRegex()
         {
             if (Regex == null)
@@ -90,7 +99,10 @@ namespace System.ComponentModel.DataAnnotations
                     throw new InvalidOperationException(
                         SR.RegularExpressionAttribute_Empty_Pattern);
                 }
-                Regex = new Regex(Pattern);
+
+                Regex = MatchTimeoutInMilliseconds == -1
+                    ? new Regex(Pattern)
+                    : new Regex(Pattern, default(RegexOptions), TimeSpan.FromMilliseconds((double)MatchTimeoutInMilliseconds));
             }
         }
     }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/UrlAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/UrlAttribute.cs
@@ -1,25 +1,16 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Text.RegularExpressions;
-
 namespace System.ComponentModel.DataAnnotations
 {
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter,
         AllowMultiple = false)]
     public sealed class UrlAttribute : DataTypeAttribute
     {
-        // This attribute provides server-side url validation equivalent to jquery validate,
-        // and therefore shares the same regular expression.  See unit tests for examples.
-        private static readonly Regex _regex =
-            new Regex(
-                @"^(https?|ftp):\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(\#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$",
-                RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture);
-
         public UrlAttribute()
             : base(DataType.Url)
         {
-            // Set DefaultErrorMessage, allowing user to set
+            // Set DefaultErrorMessage not ErrorMessage, allowing user to set
             // ErrorMessageResourceType and ErrorMessageResourceName to use localized messages.
             DefaultErrorMessage = SR.UrlAttribute_Invalid;
         }
@@ -32,7 +23,10 @@ namespace System.ComponentModel.DataAnnotations
             }
 
             var valueAsString = value as string;
-            return valueAsString != null && _regex.Match(valueAsString).Length > 0;
+            return valueAsString != null &&
+                (valueAsString.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+                || valueAsString.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+                || valueAsString.StartsWith("ftp://", StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/System.ComponentModel.Annotations/tests/EmailAddressAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/EmailAddressAttributeTests.cs
@@ -56,12 +56,7 @@ namespace System.ComponentModel.DataAnnotations
             var attribute = new EmailAddressAttribute();
 
             Assert.Throws<ValidationException>(() => attribute.Validate("@someDomain.com", s_testValidationContext)); // no local part
-            Assert.Throws<ValidationException>(() => attribute.Validate("\0@someDomain.com", s_testValidationContext)); // illegal character
-            Assert.Throws<ValidationException>(() => attribute.Validate(".someName@someDomain.com", s_testValidationContext)); // initial dot not allowed
-            Assert.Throws<ValidationException>(() => attribute.Validate("someName.@someDomain.com", s_testValidationContext)); // final dot not allowed
-            Assert.Throws<ValidationException>(() => attribute.Validate("firstName..lastName@someDomain.com", s_testValidationContext)); // two adjacent dots not allowed
-            Assert.Throws<ValidationException>(() => attribute.Validate("firstName(comment)lastName@someDomain.com", s_testValidationContext)); // parens not allowed
-            Assert.Throws<ValidationException>(() => attribute.Validate("firstName\"middleName\"lastName@someDomain.com", s_testValidationContext)); // quotes in middle not allowed
+            Assert.Throws<ValidationException>(() => attribute.Validate("@someDomain@abc.com", s_testValidationContext)); // multiple @'s
         }
 
         [Fact]
@@ -71,10 +66,7 @@ namespace System.ComponentModel.DataAnnotations
 
             Assert.Throws<ValidationException>(() => attribute.Validate("someName", s_testValidationContext)); // no domain
             Assert.Throws<ValidationException>(() => attribute.Validate("someName@", s_testValidationContext)); // no domain
-            Assert.Throws<ValidationException>(() => attribute.Validate("someName@someDomain", s_testValidationContext)); // Domain must have at least 1 dot
             Assert.Throws<ValidationException>(() => attribute.Validate("someName@a@b.com", s_testValidationContext)); // multiple @'s
-            Assert.Throws<ValidationException>(() => attribute.Validate("someName@\0.com", s_testValidationContext)); // illegal character
-            Assert.Throws<ValidationException>(() => attribute.Validate("someName@someDomain..com", s_testValidationContext)); // two adjacent dots not allowed
         }
 
         [Fact]

--- a/src/System.ComponentModel.Annotations/tests/PhoneAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/PhoneAttributeTests.cs
@@ -38,6 +38,8 @@ namespace System.ComponentModel.DataAnnotations
             AssertEx.DoesNotThrow(() => attribute.Validate("425-555-1212 x 123", s_testValidationContext));
             AssertEx.DoesNotThrow(() => attribute.Validate("425-555-1212 ext123", s_testValidationContext));
             AssertEx.DoesNotThrow(() => attribute.Validate("425-555-1212 ext 123", s_testValidationContext));
+            AssertEx.DoesNotThrow(() => attribute.Validate("425-555-1212 ext.123", s_testValidationContext));
+            AssertEx.DoesNotThrow(() => attribute.Validate("425-555-1212 ext. 123", s_testValidationContext));
         }
 
         [Fact]
@@ -47,8 +49,13 @@ namespace System.ComponentModel.DataAnnotations
             Assert.Throws<ValidationException>(() => attribute.Validate(new object(), s_testValidationContext));
             Assert.Throws<ValidationException>(() => attribute.Validate(string.Empty, s_testValidationContext));
             Assert.Throws<ValidationException>(() => attribute.Validate("abcdefghij", s_testValidationContext));
-            Assert.Throws<ValidationException>(() => attribute.Validate("425+555+1212", s_testValidationContext));
             Assert.Throws<ValidationException>(() => attribute.Validate("425-555-1212 ext 123 ext 456", s_testValidationContext));
+            Assert.Throws<ValidationException>(() => attribute.Validate("425-555-1212 x", s_testValidationContext));
+            Assert.Throws<ValidationException>(() => attribute.Validate("425-555-1212 ext", s_testValidationContext));
+            Assert.Throws<ValidationException>(() => attribute.Validate("425-555-1212 ext.", s_testValidationContext));
+            Assert.Throws<ValidationException>(() => attribute.Validate("425-555-1212 x abc", s_testValidationContext));
+            Assert.Throws<ValidationException>(() => attribute.Validate("425-555-1212 ext def", s_testValidationContext));
+            Assert.Throws<ValidationException>(() => attribute.Validate("425-555-1212 ext. xyz", s_testValidationContext));
         }
 
         [Fact]

--- a/src/System.ComponentModel.Annotations/tests/RegularExpressionAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/RegularExpressionAttributeTests.cs
@@ -17,6 +17,14 @@ namespace System.ComponentModel.DataAnnotations
         }
 
         [Fact]
+        public static void Can_set_and_get_MatchTimeout()
+        {
+            var attribute = new RegularExpressionAttribute("SomePattern");
+            attribute.MatchTimeoutInMilliseconds = 12345;
+            Assert.Equal(12345, attribute.MatchTimeoutInMilliseconds);
+        }
+
+        [Fact]
         public static void Validation_throws_InvalidOperationException_for_null_or_empty_pattern()
         {
             var attribute = new RegularExpressionAttribute(null);
@@ -42,9 +50,11 @@ namespace System.ComponentModel.DataAnnotations
         public static void Validate_successful_for_value_matching_pattern()
         {
             var attribute = new RegularExpressionAttribute("defghi");
+            attribute.MatchTimeoutInMilliseconds = 5000; // note: timeout is just a number much larger than we expect the test to take
             AssertEx.DoesNotThrow(() => attribute.Validate("defghi", s_testValidationContext));
 
             attribute = new RegularExpressionAttribute("[^a]+\\.[^z]+");
+            attribute.MatchTimeoutInMilliseconds = 10000; // note: timeout is just a number much larger than we expect the test to take
             AssertEx.DoesNotThrow(() => attribute.Validate("bcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxy", s_testValidationContext));
         }
 
@@ -58,6 +68,7 @@ namespace System.ComponentModel.DataAnnotations
             Assert.Throws<ValidationException>(() => attribute.Validate("abcdefghijkl", s_testValidationContext)); // pattern only matches part of value
 
             attribute = new RegularExpressionAttribute("[^a]+\\.[^z]+");
+            attribute.MatchTimeoutInMilliseconds = 10000; // note: timeout is just a number much larger than we expect the test to take
             Assert.Throws<ValidationException>(() => attribute.Validate("aaaaa", s_testValidationContext));
             Assert.Throws<ValidationException>(() => attribute.Validate("zzzzz", s_testValidationContext));
             Assert.Throws<ValidationException>(() => attribute.Validate("b.z", s_testValidationContext));

--- a/src/System.ComponentModel.Annotations/tests/UrlAttributeTests.cs
+++ b/src/System.ComponentModel.Annotations/tests/UrlAttributeTests.cs
@@ -33,10 +33,8 @@ namespace System.ComponentModel.DataAnnotations
         {
             var attribute = new UrlAttribute();
 
-            Assert.Throws<ValidationException>(() => attribute.Validate("file:///foo.bar", s_testValidationContext));
-            Assert.Throws<ValidationException>(() => attribute.Validate("http://user%password@foo.bar/", s_testValidationContext));
-            Assert.Throws<ValidationException>(() => attribute.Validate("foo.png", s_testValidationContext));
-            Assert.Throws<ValidationException>(() => attribute.Validate("http://foo\0.bar", s_testValidationContext)); // Illegal character
+            Assert.Throws<ValidationException>(() => attribute.Validate("file:///foo.bar", s_testValidationContext)); // file scheme
+            Assert.Throws<ValidationException>(() => attribute.Validate("foo.png", s_testValidationContext)); // no scheme
         }
 
         [Fact]


### PR DESCRIPTION
Microsoft Security Bulletin MS15-101, CVE-2015-2526 - removing the regexes for EmailAddressAttribute, PhoneAttribute and UrlAttribute and update RegularExpressionAttribute to allow user to specify a timeout.

This brings corefx inline with what was already released for Desktop - https://technet.microsoft.com/en-us/library/security/ms15-101.aspx.