### PR TITLE
Add support for X509VerificationFlags on Unix 

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
@@ -11,6 +11,8 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
+        internal delegate int X509StoreVerifyCallback(int ok, IntPtr ctx);
+
         [DllImport(Libraries.CryptoNative)]
         internal static extern SafeEvpPKeyHandle GetX509EvpPublicKey(SafeX509Handle x509);
 
@@ -116,6 +118,9 @@ internal static partial class Interop
 
         [DllImport(Libraries.CryptoNative)]
         internal static extern int X509StoreCtxGetErrorDepth(SafeX509StoreCtxHandle ctx);
+
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern void X509StoreCtxSetVerifyCallback(SafeX509StoreCtxHandle ctx, X509StoreVerifyCallback callback);
 
         internal static string GetX509VerifyCertErrorString(X509VerifyStatusCode n)
         {

--- a/src/Native/System.Security.Cryptography.Native/pal_x509.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509.cpp
@@ -236,6 +236,11 @@ extern "C" X509VerifyStatusCode X509StoreCtxGetError(X509_STORE_CTX* ctx)
     return static_cast<X509VerifyStatusCode>(X509_STORE_CTX_get_error(ctx));
 }
 
+extern "C" void X509StoreCtxSetVerifyCallback(X509_STORE_CTX* ctx, X509StoreVerifyCallback callback)
+{
+    X509_STORE_CTX_set_verify_cb(ctx, callback);
+}
+
 extern "C" int32_t X509StoreCtxGetErrorDepth(X509_STORE_CTX* ctx)
 {
     return X509_STORE_CTX_get_error_depth(ctx);

--- a/src/Native/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509.h
@@ -60,6 +60,8 @@ enum X509VerifyStatusCode : int32_t
     PAL_X509_V_ERR_NO_EXPLICIT_POLICY = 43,
 };
 
+typedef int32_t (*X509StoreVerifyCallback)(int32_t, X509_STORE_CTX*);
+
 /*
 Function:
 GetX509EvpPublicKey
@@ -248,6 +250,11 @@ extern "C" X509VerifyStatusCode X509StoreCtxGetError(X509_STORE_CTX* ctx);
 Shims the X509_STORE_CTX_get_error_depth method.
 */
 extern "C" int32_t X509StoreCtxGetErrorDepth(X509_STORE_CTX* ctx);
+
+/*
+Shims the X509_STORE_CTX_set_verify_cb function.
+*/
+extern "C" void X509StoreCtxSetVerifyCallback(X509_STORE_CTX* ctx, X509StoreVerifyCallback callback);
 
 /*
 Shims the X509_verify_cert_error_string method.

--- a/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ChainTests.cs
@@ -9,7 +9,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class ChainTests
     {
         [Fact]
-        [ActiveIssue(3475, PlatformID.OSX)]
         public static void BuildChain()
         {
             using (var microsoftDotCom = new X509Certificate2(TestData.MicrosoftDotComSslCertBytes))
@@ -22,6 +21,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 chain.ChainPolicy.ExtraStore.Add(unrelated);
                 chain.ChainPolicy.ExtraStore.Add(microsoftDotComRoot);
                 chain.ChainPolicy.ExtraStore.Add(microsoftDotComIssuer);
+                chain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
 
                 // Halfway between microsoftDotCom's NotBefore and NotAfter
                 // This isn't a boundary condition test.
@@ -30,9 +30,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
                 bool valid = chain.Build(microsoftDotCom);
                 Assert.True(valid, "Chain built validly");
-
-                // If there was nothing wrong, it should have 0 ChainStatus members.
-                Assert.Equal(0, chain.ChainStatus.Length);
 
                 // The chain should have 3 members
                 Assert.Equal(3, chain.ChainElements.Count);


### PR DESCRIPTION
Rather than let OpenSSL stop processing at the first error encountered, implement a callback to collect the errors it reports (and tell it to keep going).

Then, in the Verify step, loop over all errors found, and report on any that are not suppressed by the verification flags.

Note that the use of the verification flags does not remove the information from the ChainElementStatus or ChainStatus arrays, this matches the Windows behavior.

Fixes #2204.
Fixes #3475.

cc: @AtsushiKan @stephentoub @nguerrera 