### PR TITLE
Implement NetworkAddressChanged event on OSX

### DIFF
--- a/src/Common/src/Interop/OSX/Interop.Libraries.cs
+++ b/src/Common/src/Interop/OSX/Interop.Libraries.cs
@@ -9,5 +9,6 @@ internal static partial class Interop
         internal const string CoreServicesLibrary   = "/System/Library/Frameworks/CoreServices.framework/CoreServices";
         internal const string libproc = "libproc";
         internal const string LibSystemKernel = "/usr/lib/system/libsystem_kernel";
+        internal const string SystemConfigurationLibrary = "/System/Library/Frameworks/SystemConfiguration.framework/SystemConfiguration";
     }
 }

--- a/src/Common/src/Interop/OSX/Interop.RunLoop.cs
+++ b/src/Common/src/Interop/OSX/Interop.RunLoop.cs
@@ -7,6 +7,8 @@ using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 
 using CFRunLoopRef = System.IntPtr;
+using CFRunLoopSourceRef = System.IntPtr;
+using CFStringRef = System.IntPtr;
 
 internal static partial class Interop
 {
@@ -40,5 +42,23 @@ internal static partial class Interop
         /// <returns>Returns a pointer to a CFRunLoop on success; otherwise, returns IntPtr.Zero</returns>
         [DllImport(Interop.Libraries.CoreFoundationLibrary)]
         internal static extern CFRunLoopRef CFRunLoopGetCurrent();
+
+        /// <summary>
+        /// Adds a CFRunLoopSource object to a run loop mode.
+        /// </summary>
+        /// <param name="rl">The run loop to modify.</param>
+        /// <param name="rl">The run loop source to add. The source is retained by the run loop.</param>
+        /// <param name="rl">The run loop mode to which to add source.</param>
+        [DllImport(Interop.Libraries.CoreFoundationLibrary)]
+        internal static extern void CFRunLoopAddSource(CFRunLoopRef rl, CFRunLoopSourceRef source, CFStringRef mode);
+
+        /// <summary>
+        /// Removes a CFRunLoopSource object from a run loop mode.
+        /// </summary>
+        /// <param name="rl">The run loop to modify.</param>
+        /// <param name="rl">The run loop source to remove.</param>
+        /// <param name="rl">The run loop mode of rl from which to remove source.</param>
+        [DllImport(Interop.Libraries.CoreFoundationLibrary)]
+        internal static extern void CFRunLoopRemoveSource(CFRunLoopRef rl, CFRunLoopSourceRef source, CFStringRef mode);
     }
 }

--- a/src/Common/src/Interop/OSX/Interop.SystemConfiguration.cs
+++ b/src/Common/src/Interop/OSX/Interop.SystemConfiguration.cs
@@ -1,0 +1,134 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+
+using CFStringRef = System.IntPtr;
+using CFArrayRef = System.IntPtr;
+using CFIndex = System.IntPtr;
+using SCDynamicStoreRef = System.IntPtr;
+
+internal static partial class Interop
+{
+    internal static partial class SystemConfiguration
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct SCDynamicStoreContext
+        {
+            public CFIndex version;
+            public IntPtr Info;
+            public IntPtr RetainFunc;
+            public IntPtr ReleaseFunc;
+            public CFStringRef CopyDescriptionFunc;
+        }
+
+        internal delegate void SCDynamicStoreCallBack(
+            SCDynamicStoreRef store,
+            CFArrayRef changedKeys,
+            IntPtr info);
+
+        /// <summary>
+        /// Creates a new session used to interact with the dynamic store maintained by the System Configuration server.
+        /// Follows the "Create Rule" where if you create it, you delete it.
+        /// </summary>
+        /// <param name="allocator">Should be IntPtr.Zero</param>
+        /// <param name="name">The name of the calling process or plug-in of the caller.</param>
+        /// <param name="callout">The function to be called when a watched value in the dynamic store is changed.
+        /// Pass null if no callouts are desired.</param>
+        /// <param name="context">The context associated with the callout.</param>
+        /// <returns>A reference to the new dynamic store session.</returns>
+        [DllImport(Libraries.SystemConfigurationLibrary)]
+        private static unsafe extern SafeCreateHandle SCDynamicStoreCreate(
+            IntPtr allocator,
+            CFStringRef name,
+            SCDynamicStoreCallBack callout,
+            SCDynamicStoreContext* context);
+
+        /// <summary>
+        /// Creates a new session used to interact with the dynamic store maintained by the System Configuration server.
+        /// Follows the "Create Rule" where if you create it, you delete it.
+        /// </summary>
+        /// <param name="name">The name of the calling process or plug-in of the caller.</param>
+        /// <param name="callout">The function to be called when a watched value in the dynamic store is changed.
+        /// Pass null if no callouts are desired.</param>
+        /// <param name="context">The context associated with the callout.</param>
+        /// <returns>A reference to the new dynamic store session.</returns>
+        internal static unsafe SafeCreateHandle SCDynamicStoreCreate(CFStringRef name, SCDynamicStoreCallBack callout, SCDynamicStoreContext* context)
+        {
+            return SCDynamicStoreCreate(IntPtr.Zero, name, callout, context);
+        }
+
+        /// <summary>
+        /// Creates a dynamic store key that can be used to access the per-service network configuration information.
+        /// Follows the "Create Rule" where if you create it, you delete it.
+        /// </summary>
+        /// <param name="allocator">Should be IntPtr.Zero</param>
+        /// <param name="domain">The desired domain, such as the requested configuration or the current state.</param>
+        /// <param name="serviceID">The service ID or a regular expression pattern.</param>
+        /// <param name="entity">The specific global entity, such as IPv4 or DNS.</param>
+        /// <returns>A string containing the formatted key.</returns>
+        [DllImport(Libraries.SystemConfigurationLibrary)]
+        private static extern SafeCreateHandle SCDynamicStoreKeyCreateNetworkServiceEntity(
+            IntPtr allocator,
+            CFStringRef domain,
+            CFStringRef serviceID,
+            CFStringRef entity);
+
+        /// <summary>
+        /// Creates a dynamic store key that can be used to access the per-service network configuration information.
+        /// Follows the "Create Rule" where if you create it, you delete it.
+        /// </summary>
+        /// <param name="domain">The desired domain, such as the requested configuration or the current state.</param>
+        /// <param name="serviceID">The service ID or a regular expression pattern.</param>
+        /// <param name="entity">The specific global entity, such as IPv4 or DNS.</param>
+        /// <returns>A string containing the formatted key.</returns>
+        internal static SafeCreateHandle SCDynamicStoreKeyCreateNetworkServiceEntity(
+            CFStringRef domain,
+            CFStringRef serviceID,
+            CFStringRef entity)
+        {
+            return SCDynamicStoreKeyCreateNetworkServiceEntity(IntPtr.Zero, domain, serviceID, entity);
+        }
+
+        /// <summary>
+        /// Creates a run loop source object that can be added to the application's run loop.
+        /// Follows the "Create Rule" where if you create it, you delete it.
+        /// </summary>
+        /// <param name="allocator">Should be IntPtr.Zero</param>
+        /// <param name="store">The dynamic store session.</param>
+        /// <param name="order">The order in which the sources that are ready to be processed are handled,
+        /// on platforms that support it and for source versions that support it.</param>
+        /// <returns>The new run loop source object.</returns>
+        [DllImport(Libraries.SystemConfigurationLibrary)]
+        private static extern SafeCreateHandle SCDynamicStoreCreateRunLoopSource(
+            IntPtr allocator,
+            SCDynamicStoreRef store,
+            CFIndex order);
+
+        /// <summary>
+        /// Creates a run loop source object that can be added to the application's run loop.
+        /// Follows the "Create Rule" where if you create it, you delete it.
+        /// </summary>
+        /// <param name="store">The dynamic store session.</param>
+        /// <param name="order">The order in which the sources that are ready to be processed are handled,
+        /// on platforms that support it and for source versions that support it.</param>
+        /// <returns>The new run loop source object.</returns>
+        internal static SafeCreateHandle SCDynamicStoreCreateRunLoopSource(SCDynamicStoreRef store, CFIndex order)
+        {
+            return SCDynamicStoreCreateRunLoopSource(IntPtr.Zero, store, order);
+        }
+
+        /// <summary>
+        /// Specifies a set of keys and key patterns that should be monitored for changes.
+        /// </summary>
+        /// <param name="store">The dynamic store session being watched.</param>
+        /// <param name="keys">An array of keys to be monitored or IntPtr.Zero if no specific keys are to be monitored.</param>
+        /// <param name="patterns">An array of POSIX regex pattern strings used to match keys to be monitored,
+        /// or IntPtr.Zero if no key patterns are to be monitored.</param>
+        /// <returns>True if the set of notification keys and patterns was successfully updated; false otherwise.</returns>
+        [DllImport(Libraries.SystemConfigurationLibrary)]
+        internal static extern bool SCDynamicStoreSetNotificationKeys(SCDynamicStoreRef store, CFArrayRef keys, CFArrayRef patterns);
+    }
+}

--- a/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -333,6 +333,21 @@
     <Compile Include="$(CommonPath)\Interop\OSX\System.Native\Interop.TcpConnectionInfo.cs">
       <Link>Interop\OSX\System.Native\Interop.TcpConnectionInfo.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\Interop.CoreFoundation.cs">
+      <Link>Interop\OSX\Interop.CoreFoundation.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
+      <Link>Interop\OSX\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\Interop.RunLoop.cs">
+      <Link>Interop\OSX\Interop.RunLoop.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\OSX\Interop.SystemConfiguration.cs">
+      <Link>Interop\OSX\Interop.SystemConfiguration.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.OSX.cs
@@ -24,6 +24,9 @@ namespace System.Net.NetworkInformation
         // When those keys change, our callback below is called (OnAddressChanged).
         private static SafeCreateHandle s_dynamicStoreRef;
 
+        // The callback used when registered keys in the dynamic store change.
+        private static readonly Interop.SystemConfiguration.SCDynamicStoreCallBack s_storeCallback = OnAddressChanged;
+
         // The RunLoop source, created over the above SCDynamicStore.
         private static SafeCreateHandle s_runLoopSource;
 
@@ -35,7 +38,7 @@ namespace System.Net.NetworkInformation
 
         // Use an event to try to prevent StartRaisingEvents from returning before the
         // RunLoop actually begins. This will mitigate a race condition where the watcher
-        // thread hasn't completed initialization and stop is called before the RunLoop even starts.
+        // thread hasn't completed initialization and stop is called before the RunLoop has even started.
         private static readonly AutoResetEvent s_runLoopStartedEvent = new AutoResetEvent(false);
         private static readonly AutoResetEvent s_runLoopEndedEvent = new AutoResetEvent(false);
 
@@ -77,7 +80,7 @@ namespace System.Net.NetworkInformation
             {
                 s_dynamicStoreRef = Interop.SystemConfiguration.SCDynamicStoreCreate(
                     storeName.DangerousGetHandle(),
-                    OnAddressChanged,
+                    s_storeCallback,
                     &storeContext);
             }
 

--- a/src/System.Net.NetworkInformation/src/project.json
+++ b/src/System.Net.NetworkInformation/src/project.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "System.Diagnostics.Contracts": "4.0.0-*",
     "System.Threading": "4.0.0-*",
+    "System.Threading.Thread": "4.0.0-*",
     "System.Net.Primitives": "4.0.10-*",
     "System.Net.Sockets": "4.0.10-*",
     "System.Linq": "4.0.0"

--- a/src/System.Net.NetworkInformation/src/project.lock.json
+++ b/src/System.Net.NetworkInformation/src/project.lock.json
@@ -598,6 +598,18 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
+      "System.Threading.Thread/4.0.0-beta-23504": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Threading.Thread.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Thread.dll": {}
+        }
+      },
       "System.Threading.ThreadPool/4.0.10-beta-23213": {
         "type": "package",
         "dependencies": {
@@ -612,7 +624,7 @@
         }
       }
     },
-    "DNXCore,Version=v5.0/win7-x86": {
+    "DNXCore,Version=v5.0/osx.10.10-x86": {
       "Microsoft.Win32.Primitives/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -789,6 +801,22 @@
         },
         "runtime": {
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
+      "System.Linq/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Linq.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -1192,6 +1220,18 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
+      "System.Threading.Thread/4.0.0-beta-23504": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Threading.Thread.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Thread.dll": {}
+        }
+      },
       "System.Threading.ThreadPool/4.0.10-beta-23213": {
         "type": "package",
         "dependencies": {
@@ -1206,7 +1246,7 @@
         }
       }
     },
-    "DNXCore,Version=v5.0/win7-x64": {
+    "DNXCore,Version=v5.0/osx.10.10-x64": {
       "Microsoft.Win32.Primitives/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -1383,6 +1423,22 @@
         },
         "runtime": {
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
+      "System.Linq/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Linq.dll": {}
         }
       },
       "System.Net.Primitives/4.0.10": {
@@ -1784,6 +1840,18 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
+        }
+      },
+      "System.Threading.Thread/4.0.0-beta-23504": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Threading.Thread.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Thread.dll": {}
         }
       },
       "System.Threading.ThreadPool/4.0.10-beta-23213": {
@@ -3075,6 +3143,38 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
+    "System.Threading.Thread/4.0.0-beta-23504": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "D3zvCZDSjODrr0TjaPErBitArzcfqnTCU2tnXodFpLXncU/7SSIaVSyir7eTb9nAsGje9IEu2C4HDNQppgStRQ==",
+      "files": [
+        "lib/DNXCore50/System.Threading.Thread.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Threading.Thread.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet5.4/de/System.Threading.Thread.xml",
+        "ref/dotnet5.4/es/System.Threading.Thread.xml",
+        "ref/dotnet5.4/fr/System.Threading.Thread.xml",
+        "ref/dotnet5.4/it/System.Threading.Thread.xml",
+        "ref/dotnet5.4/ja/System.Threading.Thread.xml",
+        "ref/dotnet5.4/ko/System.Threading.Thread.xml",
+        "ref/dotnet5.4/ru/System.Threading.Thread.xml",
+        "ref/dotnet5.4/System.Threading.Thread.dll",
+        "ref/dotnet5.4/System.Threading.Thread.xml",
+        "ref/dotnet5.4/zh-hans/System.Threading.Thread.xml",
+        "ref/dotnet5.4/zh-hant/System.Threading.Thread.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Threading.Thread.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Threading.Thread.4.0.0-beta-23504.nupkg",
+        "System.Threading.Thread.4.0.0-beta-23504.nupkg.sha512",
+        "System.Threading.Thread.nuspec"
+      ]
+    },
     "System.Threading.ThreadPool/4.0.10-beta-23213": {
       "type": "package",
       "sha512": "N3LOO3EFTwqchQsmZiKc/PdIvH47ByA7KbhhJK/OM3CnPfogsCKkBBgO3T4KNSw1zT1GTg43p047L2jv/hguLQ==",
@@ -3111,6 +3211,7 @@
     "": [
       "System.Diagnostics.Contracts >= 4.0.0-*",
       "System.Threading >= 4.0.0-*",
+      "System.Threading.Thread >= 4.0.0-*",
       "System.Net.Primitives >= 4.0.10-*",
       "System.Net.Sockets >= 4.0.10-*",
       "System.Linq >= 4.0.0"

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkChangeTest.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/NetworkChangeTest.cs
@@ -8,7 +8,6 @@ namespace System.Net.NetworkInformation.Tests
     public class NetworkChangeTest
     {
         [Fact]
-        [ActiveIssue(4058, PlatformID.OSX)]
         public void NetworkAddressChanged_AddRemove_Success()
         {
             NetworkAddressChangedEventHandler handler = NetworkChange_NetworkAddressChanged;
@@ -17,7 +16,6 @@ namespace System.Net.NetworkInformation.Tests
         }
 
         [Fact]
-        [ActiveIssue(4058, PlatformID.OSX)]
         public void NetworkAddressChanged_JustRemove_Success()
         {
             NetworkAddressChangedEventHandler handler = NetworkChange_NetworkAddressChanged;


### PR DESCRIPTION
This is the last work item I have for NetworkInformation. It addresses Issue #4058 .

I'm using the OSX SystemConfiguration Framework to listen for notifications about network address changes. The implementation here works, but I'd like some feedback on the threading approach and the general style I've used for cleaning up the temporary OSX string objects that need to be created for the native calls. It's fairly messy right now.

@sokket I followed your general example from FileSystemWatcher and adapted it a bit for this.

Please take a look, @sokket, @stephentoub , @CIPop 