### PR TITLE
SqlClient - Revert back to use UnicodeEncoding

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlSequentialTextReader.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlSequentialTextReader.cs
@@ -484,38 +484,13 @@ namespace System.Data.SqlClient
         }
     }
 
-    sealed internal class SqlUnicodeEncoding : Encoding
+    sealed internal class SqlUnicodeEncoding : UnicodeEncoding
     {
         private static SqlUnicodeEncoding s_singletonEncoding = new SqlUnicodeEncoding();
 
-        private SqlUnicodeEncoding()
+        private SqlUnicodeEncoding() : base(bigEndian: false, byteOrderMark: false, throwOnInvalidBytes: false)
         { }
-
-        public override int GetByteCount(char[] chars, int index, int count)
-        {
-            return GetMaxByteCount(count);
-        }
-
-        public override int GetBytes(char[] chars, int charIndex, int charCount, byte[] bytes, int byteIndex)
-        {
-            throw NotImplemented.ByDesignWithMessage("Not required");
-        }
-
-        public override int GetCharCount(byte[] bytes, int index, int count)
-        {
-            return GetMaxCharCount(count);
-        }
-
-        public override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
-        {
-            throw NotImplemented.ByDesignWithMessage("Not required");
-        }
-
-        public override int GetMaxCharCount(int byteCount)
-        {
-            return byteCount / 2;
-        }
-
+        
         public override Decoder GetDecoder()
         {
             return new SqlUnicodeDecoder();

--- a/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLString.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLString.cs
@@ -49,7 +49,7 @@ namespace System.Data.SqlTypes
         /// </devdoc>
         public static readonly SqlString Null = new SqlString(true);
 
-        internal static readonly Encoding x_UnicodeEncoding = Encoding.Unicode;
+        internal static readonly UnicodeEncoding x_UnicodeEncoding = new UnicodeEncoding();
 
         /// <devdoc>
         /// </devdoc>


### PR DESCRIPTION
Revert back to use UnicodeEncoding since we have bring back Encoding.Extension into this package