### PR TITLE
SqlClient - Fix SqlUDT Type Exception

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlEnums.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlEnums.cs
@@ -704,6 +704,7 @@ namespace System.Data.SqlClient
                 case TdsEnums.SQLNVARCHAR: return MetaNVarChar;
                 case TdsEnums.SQLNTEXT: return MetaNText;
                 case TdsEnums.SQLVARIANT: return s_metaVariant;
+                case TdsEnums.SQLUDT: return s_metaUdt;
                 case TdsEnums.SQLXMLTYPE: return MetaXml;
                 case TdsEnums.SQLTABLE: return s_metaTable;
                 case TdsEnums.SQLDATE: return s_metaDate;
@@ -832,6 +833,8 @@ namespace System.Data.SqlClient
         private static readonly MetaType s_metaVariant = new MetaType
             (255, 255, -1, true, false, false, TdsEnums.SQLVARIANT, TdsEnums.SQLVARIANT, MetaTypeName.VARIANT, typeof(System.Object), typeof(System.Object), SqlDbType.Variant, DbType.Object, 0);
 
+        private static readonly MetaType s_metaUdt = new MetaType
+           (255, 255, -1, false, false, true, TdsEnums.SQLUDT, TdsEnums.SQLUDT, MetaTypeName.UDT, typeof(System.Object), typeof(System.Object), SqlDbType.Udt, DbType.Object, 0);
 
         private static readonly MetaType s_metaTable = new MetaType
             (255, 255, -1, false, false, false, TdsEnums.SQLTABLE, TdsEnums.SQLTABLE, MetaTypeName.TABLE, typeof(IEnumerable<DbDataRecord>), typeof(IEnumerable<DbDataRecord>), SqlDbType.Structured, DbType.Object, 0);

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -3199,6 +3199,8 @@ namespace System.Data.SqlClient
 
             if (tdsType == TdsEnums.SQLUDT)
             {
+                _state = TdsParserState.Broken;
+                _connHandler.BreakConnection();
                 throw SQL.UnsupportedFeatureAndToken(_connHandler, SqlDbType.Udt.ToString());
             }
 


### PR DESCRIPTION
**Issue**           
When we throw "UDT Not Supported" Exception, that exception was overridden by Internal Error.
          This Internal Error was caused by try{}catch{} which try to close the connection.
          Inside Close Connection, if the TDSParser.State == OpenedLoggedin, it will try to continue reading TDS Packet.
          That TDS Packet is invalid since we throw UDT Exception on the earlier calls which result Invalid Token and throw Internal Error Exception.

**Fix**
          Set TDSParser state as broken and break the connection when we throw exception will stop cleanup (close connection) code to continue reading TDS packet.
          This is following the same pattern in TDSParser.TryRun when there is error in InvalidToken, it set the status as broken and break the connection. I just called this earlier so that it won't called the cleanup and continue read the TDS.