### PR TITLE
HashSet<T> performance constructor tuning

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -112,18 +112,35 @@ namespace System.Collections.Generic
             }
             Contract.EndContractBlock();
 
-            // to avoid excess resizes, first set size based on collection's count. Collection
-            // may contain duplicates, so call TrimExcess if resulting hashset is larger than
-            // threshold
-            int suggestedCapacity = 0;
-            ICollection<T> coll = collection as ICollection<T>;
-            if (coll != null)
+            var otherAsHashSet = collection as HashSet<T>;
+            if (otherAsHashSet != null && AreEqualityComparersEqual(this, otherAsHashSet))
             {
-                suggestedCapacity = coll.Count;
-            }
-            Initialize(suggestedCapacity);
+                _buckets = (int[])otherAsHashSet._buckets.Clone();
+                _slots = (Slot[])otherAsHashSet._slots.Clone();
 
-            this.UnionWith(collection);
+                _count = otherAsHashSet._count;
+                _lastIndex = otherAsHashSet._lastIndex;
+                _freeList = otherAsHashSet._freeList;
+                _version = otherAsHashSet._version;
+
+                // _comparer is already the same
+            }
+            else
+            {
+                // to avoid excess resizes, first set size based on collection's count. Collection
+                // may contain duplicates, so call TrimExcess if resulting hashset is larger than
+                // threshold
+                int suggestedCapacity = 0;
+                ICollection<T> coll = collection as ICollection<T>;
+                if (coll != null)
+                {
+                    suggestedCapacity = coll.Count;
+                }
+                Initialize(suggestedCapacity);
+
+                this.UnionWith(collection);
+            }
+
             if ((_count == 0 && _slots.Length > HashHelpers.GetMinPrime()) ||
                 (_count > 0 && _slots.Length / _count > ShrinkThreshold))
             {

--- a/src/System.Collections/tests/Generic/HashSet/HashSet_ConstructorTests.cs
+++ b/src/System.Collections/tests/Generic/HashSet/HashSet_ConstructorTests.cs
@@ -281,5 +281,53 @@ namespace Tests
         }
 
         #endregion
+
+        #region Constructor_IEnumerable / HashSet
+
+        [Fact]
+        public static void Ctor_IEnumerable_HashSet_Empty()
+        {
+            var items = new int[0];
+            HashSet<int> source = new HashSet<int>(items);
+
+            HashSet<int> hashSet = new HashSet<int>(source);
+            HashSetTestSupport<int> driver = new HashSetTestSupport<int>(hashSet, s_intGenerator, items);
+            driver.VerifyHashSetTests();
+        }
+
+        [Fact]
+        public static void Ctor_IEnumerable_HashSet_Empty_Neg()
+        {
+            var items = new int[0];
+            HashSet<int> source = new HashSet<int>(items);
+
+            HashSet<int> hashSet = new HashSet<int>(source);
+            HashSetTestSupport<int> driver = new HashSetTestSupport<int>(hashSet, s_intGenerator, items);
+            driver.VerifyHashSet_NegativeTests();
+        }
+
+        [Fact]
+        public static void Ctor_IEnumerable_HashSet_Multiple()
+        {
+            var items = new[] { 1, 2, 3, 4, 5 };
+            HashSet<int> source = new HashSet<int>(items);
+
+            HashSet<int> hashSet = new HashSet<int>(source);
+            HashSetTestSupport<int> driver = new HashSetTestSupport<int>(hashSet, s_intGenerator, items);
+            driver.VerifyHashSetTests();
+        }
+
+        [Fact]
+        public static void Ctor_IEnumerable_HashSet_Multiple_Neg()
+        {
+            var items = new[] { 1, 2, 3, 4, 5 };
+            HashSet<int> source = new HashSet<int>(items);
+
+            HashSet<int> hashSet = new HashSet<int>(source);
+            HashSetTestSupport<int> driver = new HashSetTestSupport<int>(hashSet, s_intGenerator, items);
+            driver.VerifyHashSet_NegativeTests();
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
A simple constructor optimization when constructing from another HashSet with the same comparer. The constructor simply copies all fields in that case.

This resolves issue #498.
