### PR TITLE
Adjust System.Net.Sockets implementation to match contract

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
@@ -111,7 +111,7 @@ namespace System.Net.Sockets
 
             try
             {
-                chkSocket.Close(0);
+                chkSocket.Dispose();
             }
             catch (ObjectDisposedException)
             {
@@ -519,25 +519,6 @@ namespace System.Net.Sockets
 #endif
         }
 
-        private int _closeTimeout = Socket.DefaultCloseTimeout; // 1 ms; -1 = respect linger options
-
-        public void Close(int timeout)
-        {
-#if DEBUG
-            using (GlobalLog.SetThreadKind(ThreadKinds.User | ThreadKinds.Sync))
-            {
-#endif
-                if (timeout < -1)
-                {
-                    throw new ArgumentOutOfRangeException("timeout");
-                }
-                _closeTimeout = timeout;
-                Dispose();
-#if DEBUG
-            }
-#endif
-        }
-
         private volatile bool _cleanedUp = false;
         protected override void Dispose(bool disposing)
         {
@@ -568,7 +549,7 @@ namespace System.Net.Sockets
                             if (chkStreamSocket != null)
                             {
                                 chkStreamSocket.InternalShutdown(SocketShutdown.Both);
-                                chkStreamSocket.Close(_closeTimeout);
+                                chkStreamSocket.Dispose();
                             }
                         }
                     }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -1050,17 +1050,6 @@ namespace System.Net.Sockets
             }
         }
 
-        public void Close(int timeout)
-        {
-            if (timeout < -1)
-            {
-                throw new ArgumentOutOfRangeException("timeout");
-            }
-            _closeTimeout = timeout;
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Close() timeout = " + _closeTimeout);
-            ((IDisposable)this).Dispose();
-        }
-
         // Places a socket in a listening state.
         public void Listen(int backlog)
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -211,12 +211,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        public void Close_TimeoutLessThanNegativeOne_ArgumentOutOfRange()
-        {
-            Assert.Throws<ArgumentOutOfRangeException>(() => GetSocket().Close(-2));
-        }
-
-        [Fact]
         public void Accept_NotBound_Throws_InvalidOperation()
         {
             Assert.Throws<InvalidOperationException>(() => GetSocket().Accept());


### PR DESCRIPTION
The System.Net.Sockets 4.1 contract (refs folder) does NOT have public methods for Socket.Close() or NetworkStream.Close().
However, the implementional DLL was still having public methods for these.

Changed the 'public' to 'internal' for the Close() methods and removed a test that isn't needed anymore.