### PR TITLE
SqlClient - Fix Inifinite Timeout

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIHandle.cs
@@ -40,9 +40,9 @@ namespace System.Data.SqlClient.SNI
         /// Receive a packet synchronously
         /// </summary>
         /// <param name="packet">SNI packet</param>
-        /// <param name="timeout">Timeout</param>
+        /// <param name="timeoutInMilliseconds">Timeout in Milliseconds</param>
         /// <returns>SNI error code</returns>
-        public abstract uint Receive(ref SNIPacket packet, int timeout);
+        public abstract uint Receive(ref SNIPacket packet, int timeoutInMilliseconds);
 
         /// <summary>
         /// Receive a packet asynchronously

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
@@ -427,9 +427,9 @@ namespace System.Data.SqlClient.SNI
         /// Receive a packet synchronously
         /// </summary>
         /// <param name="packet">SNI packet</param>
-        /// <param name="timeout">Timeout</param>
+        /// <param name="timeoutInMilliseconds">Timeout in Milliseconds</param>
         /// <returns>SNI error code</returns>
-        public override uint Receive(ref SNIPacket packet, int timeout)
+        public override uint Receive(ref SNIPacket packet, int timeoutInMilliseconds)
         {
             int queueCount;
             uint result = TdsEnums.SNI_SUCCESS_IO_PENDING;
@@ -470,7 +470,7 @@ namespace System.Data.SqlClient.SNI
                     return result;
                 }
 
-                if (!_packetEvent.Wait(timeout))
+                if (!_packetEvent.Wait(timeoutInMilliseconds))
                 {
                     SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.SMUX_PROV, 0, 0, "Timeout error");
                     return TdsEnums.SNI_WAIT_TIMEOUT;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -264,15 +264,27 @@ namespace System.Data.SqlClient.SNI
         /// Receive a packet synchronously
         /// </summary>
         /// <param name="packet">SNI packet</param>
-        /// <param name="timeout">Timeout</param>
+        /// <param name="timeoutInMilliseconds">Timeout in Milliseconds</param>
         /// <returns>SNI error code</returns>
-        public override uint Receive(ref SNIPacket packet, int timeout)
+        public override uint Receive(ref SNIPacket packet, int timeoutInMilliseconds)
         {
             lock (this)
             {
                 try
                 {
-                    _tcpClient.ReceiveTimeout = (timeout != 0) ? timeout : 1;
+                    if (timeoutInMilliseconds < 0)
+                    {   //  infinite timeout (-1) means (0) in TCPClient 
+                        _tcpClient.ReceiveTimeout = 0;
+                    }
+                    else if (timeoutInMilliseconds == 0)
+                    {
+                        // 0 timeout is equal -1 in TCPClient
+                        _tcpClient.ReceiveTimeout = -1;
+                    }
+                    else
+                    {
+                        _tcpClient.ReceiveTimeout = timeoutInMilliseconds;
+                    }
                     packet = new SNIPacket(null);
                     packet.Allocate(_bufferSize);
                     packet.ReadFromStream(_stream);

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -272,19 +272,21 @@ namespace System.Data.SqlClient.SNI
             {
                 try
                 {
-                    if (timeoutInMilliseconds < 0)
-                    {   //  infinite timeout (-1) means (0) in TCPClient 
-                        _tcpClient.ReceiveTimeout = 0;
-                    }
-                    else if (timeoutInMilliseconds == 0)
-                    {
-                        // 0 timeout is equal -1 in TCPClient
-                        _tcpClient.ReceiveTimeout = -1;
-                    }
-                    else
+                    if (timeoutInMilliseconds > 0)
                     {
                         _tcpClient.ReceiveTimeout = timeoutInMilliseconds;
                     }
+                    else if (timeoutInMilliseconds == -1)
+                    {   // SqlCient internally represents infinite timeout by -1, and for TcpClient this is translated to a timeout of 0 
+                        _tcpClient.ReceiveTimeout = 0;
+                    }
+                    else
+                    {
+                        // otherwise it is timeout for 0 or less than -1
+                        ReportTcpSNIError(SR.SNI_ERROR_11); //timeout error message
+                        return TdsEnums.SNI_WAIT_TIMEOUT;
+                    }
+
                     packet = new SNIPacket(null);
                     packet.Allocate(_bufferSize);
                     packet.ReadFromStream(_stream);


### PR DESCRIPTION
-1 for infinite need to be translated to 0 in tcp client for infinitive
0 timeout need to be translated to -1 in tcp client for timeout

https://github.com/dotnet/corefx/issues/4361