### PR TITLE
Array Segment change in Global Log

### DIFF
--- a/src/Common/src/System/Net/Logging/GlobalLog.cs
+++ b/src/Common/src/System/Net/Logging/GlobalLog.cs
@@ -255,7 +255,7 @@ namespace System.Net
 
             if (length == 0)
             {
-                EventSourceLogging.Log.DebugMessage("lenth of ArraySegment in Dump is 0");
+                EventSourceLogging.Log.DebugMessage("length of ArraySegment in Dump is 0");
                 return;
             }
 

--- a/src/Common/src/System/Net/Logging/GlobalLog.cs
+++ b/src/Common/src/System/Net/Logging/GlobalLog.cs
@@ -264,6 +264,7 @@ namespace System.Net
             {
                 bufferSegment[i] = buffer[offset + i];
             }
+
             EventSourceLogging.Log.DebugDumpArray(bufferSegment);
         }
     }

--- a/src/Common/src/System/Net/Logging/GlobalLog.cs
+++ b/src/Common/src/System/Net/Logging/GlobalLog.cs
@@ -253,13 +253,10 @@ namespace System.Net
                 return;
             }
 
-            var bufferSegment = new byte[length];
-            for (int i = 0; i < length; i++)
-            {
-                bufferSegment[i] = buffer[offset + i];
-            }
+            ArraySegment<byte> bufferSegment = new ArraySegment<byte>(buffer, offset, length);
+            byte[] bufferSegmentArray = bufferSegment.Array;
 
-            EventSourceLogging.Log.DebugDumpArray(bufferSegment);
+            EventSourceLogging.Log.DebugDumpArray(bufferSegmentArray);
         }
     }
 

--- a/src/Common/src/System/Net/Logging/GlobalLog.cs
+++ b/src/Common/src/System/Net/Logging/GlobalLog.cs
@@ -253,10 +253,18 @@ namespace System.Net
                 return;
             }
 
-            ArraySegment<byte> bufferSegment = new ArraySegment<byte>(buffer, offset, length);
-            byte[] bufferSegmentArray = bufferSegment.Array;
+            if (length == 0)
+            {
+                EventSourceLogging.Log.DebugMessage("lenth of ArraySegment in Dump is 0");
+                return;
+            }
 
-            EventSourceLogging.Log.DebugDumpArray(bufferSegmentArray);
+            var bufferSegment = new byte[length];
+            for (int i = 0; i < length; i++)
+            {
+                bufferSegment[i] = buffer[offset + i];
+            }
+            EventSourceLogging.Log.DebugDumpArray(bufferSegment);
         }
     }
 


### PR DESCRIPTION
When length was equal to 0, bufferSegment was not correctly initialized
and does not let logging work. Instead of copying from a loop, now we
use the ArraySegment constructor for this, which has a better behavior
when length is 0.