### PR TITLE
Move test-runtime to newest packages

### DIFF
--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -1,9 +1,9 @@
 {
     "dependencies": {
-      "Microsoft.NETCore.Platforms": "1.0.1-beta-23429",
-      "Microsoft.NETCore.TestHost": "1.0.0-beta-23429",
-      "Microsoft.NETCore.Console": "1.0.0-beta-23429",
-      "System.IO.Compression": "4.1.0-beta-23429",
+      "Microsoft.NETCore.Platforms": "1.0.1-beta-23506",
+      "Microsoft.NETCore.TestHost": "1.0.0-beta-23506",
+      "Microsoft.NETCore.Console": "1.0.0-beta-23506",
+      "System.IO.Compression": "4.1.0-beta-23506",
 
       "coveralls.io": "1.4",
       "OpenCover": "4.6.166",

--- a/src/Common/test-runtime/project.lock.json
+++ b/src/Common/test-runtime/project.lock.json
@@ -6,7 +6,7 @@
       "coveralls.io/1.4.0": {
         "type": "package"
       },
-      "Microsoft.CSharp/4.0.1-beta-23429": {
+      "Microsoft.CSharp/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -42,169 +42,147 @@
           "xunit.runner.console": "2.1.0"
         }
       },
-      "Microsoft.NETCore/5.0.1-beta-23429": {
+      "Microsoft.NETCore/5.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "Microsoft.CSharp": "4.0.1-beta-23429",
-          "Microsoft.NETCore.Targets": "1.0.1-beta-23429",
-          "Microsoft.VisualBasic": "10.0.1-beta-23429",
-          "System.AppContext": "4.0.1-beta-23429",
-          "System.Collections": "4.0.11-beta-23429",
-          "System.Collections.Concurrent": "4.0.11-beta-23429",
-          "System.Collections.Immutable": "1.1.38-beta-23429",
-          "System.ComponentModel": "4.0.1-beta-23429",
-          "System.ComponentModel.Annotations": "4.0.11-beta-23429",
-          "System.Diagnostics.Debug": "4.0.11-beta-23429",
-          "System.Diagnostics.Tools": "4.0.1-beta-23429",
-          "System.Diagnostics.Tracing": "4.0.21-beta-23429",
-          "System.Dynamic.Runtime": "4.0.11-beta-23429",
-          "System.Globalization": "4.0.11-beta-23429",
-          "System.Globalization.Calendars": "4.0.1-beta-23429",
-          "System.Globalization.Extensions": "4.0.1-beta-23429",
-          "System.IO": "4.0.11-beta-23429",
-          "System.IO.Compression": "4.1.0-beta-23429",
-          "System.IO.Compression.ZipFile": "4.0.1-beta-23429",
-          "System.IO.FileSystem": "4.0.1-beta-23429",
-          "System.IO.FileSystem.Primitives": "4.0.1-beta-23429",
-          "System.IO.UnmanagedMemoryStream": "4.0.1-beta-23429",
-          "System.Linq": "4.0.1-beta-23429",
-          "System.Linq.Expressions": "4.0.11-beta-23429",
-          "System.Linq.Parallel": "4.0.1-beta-23429",
-          "System.Linq.Queryable": "4.0.1-beta-23429",
-          "System.Net.Http": "4.0.1-beta-23429",
-          "System.Net.NetworkInformation": "4.1.0-beta-23429",
-          "System.Net.Primitives": "4.0.11-beta-23429",
-          "System.Numerics.Vectors": "4.1.1-beta-23429",
-          "System.ObjectModel": "4.0.11-beta-23429",
-          "System.Reflection": "4.1.0-beta-23429",
-          "System.Reflection.DispatchProxy": "4.0.1-beta-23429",
-          "System.Reflection.Extensions": "4.0.1-beta-23429",
-          "System.Reflection.Metadata": "1.1.1-beta-23429",
-          "System.Reflection.Primitives": "4.0.1-beta-23429",
-          "System.Reflection.TypeExtensions": "4.1.0-beta-23429",
-          "System.Resources.ResourceManager": "4.0.1-beta-23429",
-          "System.Runtime": "4.0.21-beta-23429",
-          "System.Runtime.Extensions": "4.0.11-beta-23429",
-          "System.Runtime.Handles": "4.0.1-beta-23429",
-          "System.Runtime.InteropServices": "4.0.21-beta-23429",
-          "System.Runtime.Numerics": "4.0.1-beta-23429",
-          "System.Security.Claims": "4.0.1-beta-23429",
-          "System.Security.Principal": "4.0.1-beta-23429",
-          "System.Text.Encoding": "4.0.11-beta-23429",
-          "System.Text.Encoding.Extensions": "4.0.11-beta-23429",
-          "System.Text.RegularExpressions": "4.0.11-beta-23429",
-          "System.Threading": "4.0.11-beta-23429",
-          "System.Threading.Tasks": "4.0.11-beta-23429",
-          "System.Threading.Tasks.Dataflow": "4.5.26-beta-23429",
-          "System.Threading.Tasks.Parallel": "4.0.1-beta-23429",
-          "System.Threading.Timer": "4.0.1-beta-23429",
-          "System.Xml.ReaderWriter": "4.0.11-beta-23429",
-          "System.Xml.XDocument": "4.0.11-beta-23429"
+          "Microsoft.CSharp": "4.0.1-beta-23506",
+          "Microsoft.NETCore.Platforms": "1.0.1-beta-23506",
+          "Microsoft.VisualBasic": "10.0.1-beta-23506",
+          "System.AppContext": "4.0.1-beta-23506",
+          "System.Collections": "4.0.11-beta-23506",
+          "System.Collections.Concurrent": "4.0.11-beta-23506",
+          "System.Collections.Immutable": "1.1.38-beta-23506",
+          "System.ComponentModel": "4.0.1-beta-23506",
+          "System.ComponentModel.Annotations": "4.0.11-beta-23506",
+          "System.Diagnostics.Debug": "4.0.11-beta-23506",
+          "System.Diagnostics.Tools": "4.0.1-beta-23506",
+          "System.Diagnostics.Tracing": "4.0.21-beta-23506",
+          "System.Dynamic.Runtime": "4.0.11-beta-23506",
+          "System.Globalization": "4.0.11-beta-23506",
+          "System.Globalization.Calendars": "4.0.1-beta-23506",
+          "System.Globalization.Extensions": "4.0.1-beta-23506",
+          "System.IO": "4.0.11-beta-23506",
+          "System.IO.Compression": "4.1.0-beta-23506",
+          "System.IO.Compression.ZipFile": "4.0.1-beta-23506",
+          "System.IO.FileSystem": "4.0.1-beta-23506",
+          "System.IO.FileSystem.Primitives": "4.0.1-beta-23506",
+          "System.IO.UnmanagedMemoryStream": "4.0.1-beta-23506",
+          "System.Linq": "4.0.1-beta-23506",
+          "System.Linq.Expressions": "4.0.11-beta-23506",
+          "System.Linq.Parallel": "4.0.1-beta-23506",
+          "System.Linq.Queryable": "4.0.1-beta-23506",
+          "System.Net.Http": "4.0.1-beta-23506",
+          "System.Net.NetworkInformation": "4.1.0-beta-23506",
+          "System.Net.Primitives": "4.0.11-beta-23506",
+          "System.Numerics.Vectors": "4.1.1-beta-23506",
+          "System.ObjectModel": "4.0.11-beta-23506",
+          "System.Reflection": "4.1.0-beta-23506",
+          "System.Reflection.DispatchProxy": "4.0.1-beta-23506",
+          "System.Reflection.Extensions": "4.0.1-beta-23506",
+          "System.Reflection.Metadata": "1.1.1-beta-23506",
+          "System.Reflection.Primitives": "4.0.1-beta-23506",
+          "System.Reflection.TypeExtensions": "4.1.0-beta-23506",
+          "System.Resources.ResourceManager": "4.0.1-beta-23506",
+          "System.Runtime": "4.0.21-beta-23506",
+          "System.Runtime.Extensions": "4.0.11-beta-23506",
+          "System.Runtime.Handles": "4.0.1-beta-23506",
+          "System.Runtime.InteropServices": "4.0.21-beta-23506",
+          "System.Runtime.Numerics": "4.0.1-beta-23506",
+          "System.Security.Claims": "4.0.1-beta-23506",
+          "System.Security.Principal": "4.0.1-beta-23506",
+          "System.Text.Encoding": "4.0.11-beta-23506",
+          "System.Text.Encoding.Extensions": "4.0.11-beta-23506",
+          "System.Text.RegularExpressions": "4.0.11-beta-23506",
+          "System.Threading": "4.0.11-beta-23506",
+          "System.Threading.Tasks": "4.0.11-beta-23506",
+          "System.Threading.Tasks.Dataflow": "4.5.26-beta-23506",
+          "System.Threading.Tasks.Parallel": "4.0.1-beta-23506",
+          "System.Threading.Timer": "4.0.1-beta-23506",
+          "System.Xml.ReaderWriter": "4.0.11-beta-23506",
+          "System.Xml.XDocument": "4.0.11-beta-23506"
         }
       },
-      "Microsoft.NETCore.Console/1.0.0-beta-23429": {
+      "Microsoft.NETCore.Console/1.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore": "5.0.1-beta-23429",
-          "Microsoft.NETCore.ConsoleHost": "1.0.0-beta-23429",
-          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23429",
-          "Microsoft.Win32.Primitives": "4.0.1-beta-23429",
-          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23429",
-          "System.Console": "4.0.0-beta-23429",
-          "System.Data.Common": "4.0.1-beta-23429",
-          "System.Data.SqlClient": "4.0.0-beta-23429",
-          "System.Diagnostics.Contracts": "4.0.1-beta-23429",
-          "System.Diagnostics.FileVersionInfo": "4.0.0-beta-23429",
-          "System.Diagnostics.Process": "4.1.0-beta-23429",
-          "System.Diagnostics.StackTrace": "4.0.1-beta-23429",
-          "System.IO.FileSystem.DriveInfo": "4.0.0-beta-23429",
-          "System.IO.FileSystem.Watcher": "4.0.0-beta-23429",
-          "System.IO.MemoryMappedFiles": "4.0.0-beta-23429",
-          "System.IO.Pipes": "4.0.0-beta-23429",
-          "System.Net.NameResolution": "4.0.0-beta-23429",
-          "System.Net.NetworkInformation": "4.1.0-beta-23429",
-          "System.Net.Requests": "4.0.11-beta-23429",
-          "System.Net.Security": "4.0.0-beta-23429",
-          "System.Net.Sockets": "4.1.0-beta-23429",
-          "System.Net.Utilities": "4.0.0-beta-23429",
-          "System.Net.WebHeaderCollection": "4.0.1-beta-23429",
-          "System.Net.WebSockets": "4.0.0-beta-23429",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23429",
-          "System.Reflection.Emit": "4.0.1-beta-23429",
-          "System.Reflection.Emit.ILGeneration": "4.0.1-beta-23429",
-          "System.Reflection.Emit.Lightweight": "4.0.1-beta-23429",
-          "System.Resources.ReaderWriter": "4.0.0-beta-23429",
-          "System.Runtime.CompilerServices.VisualC": "4.0.0-beta-23429",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23429",
-          "System.Runtime.Loader": "4.0.0-beta-23429",
-          "System.Runtime.Serialization.Json": "4.0.1-beta-23429",
-          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23429",
-          "System.Runtime.Serialization.Xml": "4.1.0-beta-23429",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
-          "System.ServiceModel.Duplex": "4.0.1-beta-23429",
-          "System.ServiceModel.Http": "4.0.11-beta-23429",
-          "System.ServiceModel.NetTcp": "4.1.0-beta-23429",
-          "System.ServiceModel.Primitives": "4.1.0-beta-23429",
-          "System.ServiceModel.Security": "4.0.1-beta-23429",
-          "System.Xml.XmlSerializer": "4.0.11-beta-23429"
+          "Microsoft.NETCore": "5.0.1-beta-23506",
+          "Microsoft.NETCore.ConsoleHost": "1.0.0-beta-23506",
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23506",
+          "Microsoft.Win32.Primitives": "4.0.1-beta-23506",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23506",
+          "System.Console": "4.0.0-beta-23506",
+          "System.Data.Common": "4.0.1-beta-23506",
+          "System.Data.SqlClient": "4.0.0-beta-23506",
+          "System.Diagnostics.Contracts": "4.0.1-beta-23506",
+          "System.Diagnostics.FileVersionInfo": "4.0.0-beta-23506",
+          "System.Diagnostics.Process": "4.1.0-beta-23506",
+          "System.Diagnostics.StackTrace": "4.0.1-beta-23506",
+          "System.IO.FileSystem.DriveInfo": "4.0.0-beta-23506",
+          "System.IO.FileSystem.Watcher": "4.0.0-beta-23506",
+          "System.IO.MemoryMappedFiles": "4.0.0-beta-23506",
+          "System.IO.Pipes": "4.0.0-beta-23506",
+          "System.Net.NameResolution": "4.0.0-beta-23506",
+          "System.Net.NetworkInformation": "4.1.0-beta-23506",
+          "System.Net.Requests": "4.0.11-beta-23506",
+          "System.Net.Security": "4.0.0-beta-23506",
+          "System.Net.Sockets": "4.1.0-beta-23506",
+          "System.Net.Utilities": "4.0.0-beta-23506",
+          "System.Net.WebHeaderCollection": "4.0.1-beta-23506",
+          "System.Net.WebSockets": "4.0.0-beta-23506",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23506",
+          "System.Reflection.Emit": "4.0.1-beta-23506",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-beta-23506",
+          "System.Reflection.Emit.Lightweight": "4.0.1-beta-23506",
+          "System.Resources.ReaderWriter": "4.0.0-beta-23506",
+          "System.Runtime.CompilerServices.VisualC": "4.0.0-beta-23506",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23506",
+          "System.Runtime.Loader": "4.0.0-beta-23506",
+          "System.Runtime.Serialization.Json": "4.0.1-beta-23506",
+          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23506",
+          "System.Runtime.Serialization.Xml": "4.1.0-beta-23506",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
+          "System.ServiceModel.Duplex": "4.0.1-beta-23506",
+          "System.ServiceModel.Http": "4.0.11-beta-23506",
+          "System.ServiceModel.NetTcp": "4.1.0-beta-23506",
+          "System.ServiceModel.Primitives": "4.1.0-beta-23506",
+          "System.ServiceModel.Security": "4.0.1-beta-23506",
+          "System.Xml.XmlSerializer": "4.0.11-beta-23506"
         }
       },
-      "Microsoft.NETCore.ConsoleHost/1.0.0-beta-23429": {
+      "Microsoft.NETCore.ConsoleHost/1.0.0-beta-23506": {
         "type": "package"
       },
-      "Microsoft.NETCore.Platforms/1.0.1-beta-23429": {
-        "type": "package"
-      },
-      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23429": {
+      "Microsoft.NETCore.Platforms/1.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-beta-23429",
-          "System.Collections": "[4.0.11-beta-23429]",
-          "System.Diagnostics.Contracts": "[4.0.1-beta-23429]",
-          "System.Diagnostics.Debug": "[4.0.11-beta-23429]",
-          "System.Diagnostics.StackTrace": "[4.0.1-beta-23429]",
-          "System.Diagnostics.Tools": "[4.0.1-beta-23429]",
-          "System.Diagnostics.Tracing": "[4.0.21-beta-23429]",
-          "System.Globalization": "[4.0.11-beta-23429]",
-          "System.Globalization.Calendars": "[4.0.1-beta-23429]",
-          "System.IO": "[4.0.11-beta-23429]",
-          "System.ObjectModel": "[4.0.11-beta-23429]",
-          "System.Private.Uri": "[4.0.1-beta-23429]",
-          "System.Reflection": "[4.1.0-beta-23429]",
-          "System.Reflection.Extensions": "[4.0.1-beta-23429]",
-          "System.Reflection.Primitives": "[4.0.1-beta-23429]",
-          "System.Resources.ResourceManager": "[4.0.1-beta-23429]",
-          "System.Runtime": "[4.0.21-beta-23429]",
-          "System.Runtime.Extensions": "[4.0.11-beta-23429]",
-          "System.Runtime.Handles": "[4.0.1-beta-23429]",
-          "System.Runtime.InteropServices": "[4.0.21-beta-23429]",
-          "System.Text.Encoding": "[4.0.11-beta-23429]",
-          "System.Text.Encoding.Extensions": "[4.0.11-beta-23429]",
-          "System.Threading": "[4.0.11-beta-23429]",
-          "System.Threading.Tasks": "[4.0.11-beta-23429]",
-          "System.Threading.Timer": "[4.0.1-beta-23429]"
+          "Microsoft.NETCore.Targets": "1.0.1-beta-23506"
         }
       },
-      "Microsoft.NETCore.Targets/1.0.1-beta-23429": {
+      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1-beta-23429",
-          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-beta-23429"
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-beta-23506"
         }
       },
-      "Microsoft.NETCore.Targets.DNXCore/5.0.0-beta-23429": {
+      "Microsoft.NETCore.Targets/1.0.1-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-beta-23506"
+        }
+      },
+      "Microsoft.NETCore.Targets.DNXCore/5.0.0-beta-23506": {
         "type": "package"
       },
-      "Microsoft.NETCore.TestHost/1.0.0-beta-23429": {
+      "Microsoft.NETCore.TestHost/1.0.0-beta-23506": {
         "type": "package"
       },
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23429": {
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23506": {
         "type": "package"
       },
-      "Microsoft.VisualBasic/10.0.1-beta-23429": {
+      "Microsoft.VisualBasic/10.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -231,13 +209,13 @@
           "lib/dotnet5.4/Microsoft.VisualBasic.dll": {}
         }
       },
-      "Microsoft.Win32.Primitives/4.0.1-beta-23429": {
+      "Microsoft.Win32.Primitives/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/Microsoft.Win32.Primitives.dll": {}
+          "ref/dotnet5.4/Microsoft.Win32.Primitives.dll": {}
         }
       },
       "OpenCover/4.6.166": {
@@ -246,22 +224,22 @@
       "ReportGenerator/2.3.1": {
         "type": "package"
       },
-      "System.AppContext/4.0.1-beta-23429": {
+      "System.AppContext/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.AppContext.dll": {}
+          "ref/dotnet5.4/System.AppContext.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.AppContext.dll": {}
         }
       },
-      "System.Collections/4.0.11-beta-23429": {
+      "System.Collections/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Runtime": "4.0.21-beta-23429"
+          "System.Runtime": "4.0.21-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Collections.dll": {}
@@ -270,7 +248,7 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Collections.Concurrent/4.0.11-beta-23429": {
+      "System.Collections.Concurrent/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -290,7 +268,7 @@
           "lib/dotnet5.4/System.Collections.Concurrent.dll": {}
         }
       },
-      "System.Collections.Immutable/1.1.38-beta-23429": {
+      "System.Collections.Immutable/1.1.38-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -309,7 +287,7 @@
           "lib/dotnet5.1/System.Collections.Immutable.dll": {}
         }
       },
-      "System.Collections.NonGeneric/4.0.1-beta-23429": {
+      "System.Collections.NonGeneric/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -320,13 +298,13 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Collections.NonGeneric.dll": {}
+          "ref/dotnet5.4/System.Collections.NonGeneric.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Collections.NonGeneric.dll": {}
         }
       },
-      "System.Collections.Specialized/4.0.1-beta-23429": {
+      "System.Collections.Specialized/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections.NonGeneric": "4.0.0",
@@ -338,13 +316,13 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Collections.Specialized.dll": {}
+          "ref/dotnet5.4/System.Collections.Specialized.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Collections.Specialized.dll": {}
         }
       },
-      "System.ComponentModel/4.0.1-beta-23429": {
+      "System.ComponentModel/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -356,7 +334,7 @@
           "lib/dotnet5.4/System.ComponentModel.dll": {}
         }
       },
-      "System.ComponentModel.Annotations/4.0.11-beta-23429": {
+      "System.ComponentModel.Annotations/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -378,7 +356,7 @@
           "lib/dotnet5.4/System.ComponentModel.Annotations.dll": {}
         }
       },
-      "System.ComponentModel.EventBasedAsync/4.0.11-beta-23429": {
+      "System.ComponentModel.EventBasedAsync/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -393,17 +371,17 @@
           "lib/dotnet5.4/System.ComponentModel.EventBasedAsync.dll": {}
         }
       },
-      "System.Console/4.0.0-beta-23429": {
+      "System.Console/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Console.dll": {}
+          "ref/dotnet5.4/System.Console.dll": {}
         }
       },
-      "System.Data.Common/4.0.1-beta-23429": {
+      "System.Data.Common/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -417,13 +395,13 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Data.Common.dll": {}
+          "ref/dotnet5.4/System.Data.Common.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Data.Common.dll": {}
         }
       },
-      "System.Data.SqlClient/4.0.0-beta-23429": {
+      "System.Data.SqlClient/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Data.Common": "4.0.0",
@@ -434,10 +412,10 @@
           "System.Xml.ReaderWriter": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Data.SqlClient.dll": {}
+          "ref/dotnet5.4/System.Data.SqlClient.dll": {}
         }
       },
-      "System.Diagnostics.Contracts/4.0.1-beta-23429": {
+      "System.Diagnostics.Contracts/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -449,7 +427,7 @@
           "lib/DNXCore50/System.Diagnostics.Contracts.dll": {}
         }
       },
-      "System.Diagnostics.Debug/4.0.11-beta-23429": {
+      "System.Diagnostics.Debug/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -458,16 +436,16 @@
           "ref/dotnet5.4/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.FileVersionInfo/4.0.0-beta-23429": {
+      "System.Diagnostics.FileVersionInfo/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Diagnostics.FileVersionInfo.dll": {}
+          "ref/dotnet5.4/System.Diagnostics.FileVersionInfo.dll": {}
         }
       },
-      "System.Diagnostics.Process/4.1.0-beta-23429": {
+      "System.Diagnostics.Process/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -479,20 +457,20 @@
           "ref/dotnet5.5/System.Diagnostics.Process.dll": {}
         }
       },
-      "System.Diagnostics.StackTrace/4.0.1-beta-23429": {
+      "System.Diagnostics.StackTrace/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Diagnostics.StackTrace.dll": {}
+          "ref/dotnet5.4/System.Diagnostics.StackTrace.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Diagnostics.StackTrace.dll": {}
         }
       },
-      "System.Diagnostics.Tools/4.0.1-beta-23429": {
+      "System.Diagnostics.Tools/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -504,7 +482,7 @@
           "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
         }
       },
-      "System.Diagnostics.Tracing/4.0.21-beta-23429": {
+      "System.Diagnostics.Tracing/4.0.21-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -516,7 +494,7 @@
           "lib/DNXCore50/System.Diagnostics.Tracing.dll": {}
         }
       },
-      "System.Dynamic.Runtime/4.0.11-beta-23429": {
+      "System.Dynamic.Runtime/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -542,7 +520,7 @@
           "lib/DNXCore50/System.Dynamic.Runtime.dll": {}
         }
       },
-      "System.Globalization/4.0.11-beta-23429": {
+      "System.Globalization/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -554,20 +532,20 @@
           "lib/DNXCore50/System.Globalization.dll": {}
         }
       },
-      "System.Globalization.Calendars/4.0.1-beta-23429": {
+      "System.Globalization.Calendars/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Globalization.Calendars.dll": {}
+          "ref/dotnet5.4/System.Globalization.Calendars.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Globalization.Calendars.dll": {}
         }
       },
-      "System.Globalization.Extensions/4.0.1-beta-23429": {
+      "System.Globalization.Extensions/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -575,10 +553,10 @@
           "System.Runtime.Extensions": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Globalization.Extensions.dll": {}
+          "ref/dotnet5.4/System.Globalization.Extensions.dll": {}
         }
       },
-      "System.IO/4.0.11-beta-23429": {
+      "System.IO/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20",
@@ -592,7 +570,7 @@
           "lib/DNXCore50/System.IO.dll": {}
         }
       },
-      "System.IO.Compression/4.1.0-beta-23429": {
+      "System.IO.Compression/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -604,7 +582,7 @@
           "ref/dotnet5.4/System.IO.Compression.dll": {}
         }
       },
-      "System.IO.Compression.ZipFile/4.0.1-beta-23429": {
+      "System.IO.Compression.ZipFile/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -617,13 +595,13 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.2/System.IO.Compression.ZipFile.dll": {}
+          "ref/dotnet5.4/System.IO.Compression.ZipFile.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.IO.Compression.ZipFile.dll": {}
         }
       },
-      "System.IO.FileSystem/4.0.1-beta-23429": {
+      "System.IO.FileSystem/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -637,7 +615,7 @@
           "ref/dotnet5.4/System.IO.FileSystem.dll": {}
         }
       },
-      "System.IO.FileSystem.DriveInfo/4.0.0-beta-23429": {
+      "System.IO.FileSystem.DriveInfo/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -648,28 +626,28 @@
           "ref/dotnet5.4/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
-      "System.IO.FileSystem.Primitives/4.0.1-beta-23429": {
+      "System.IO.FileSystem.Primitives/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet5.1/System.IO.FileSystem.Primitives.dll": {}
+          "ref/dotnet5.4/System.IO.FileSystem.Primitives.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.IO.FileSystem.Primitives.dll": {}
         }
       },
-      "System.IO.FileSystem.Watcher/4.0.0-beta-23429": {
+      "System.IO.FileSystem.Watcher/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.IO.FileSystem.Watcher.dll": {}
+          "ref/dotnet5.4/System.IO.FileSystem.Watcher.dll": {}
         }
       },
-      "System.IO.MemoryMappedFiles/4.0.0-beta-23429": {
+      "System.IO.MemoryMappedFiles/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO.FileSystem": "4.0.0",
@@ -683,7 +661,7 @@
           "ref/dotnet5.4/System.IO.MemoryMappedFiles.dll": {}
         }
       },
-      "System.IO.Pipes/4.0.0-beta-23429": {
+      "System.IO.Pipes/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -696,7 +674,7 @@
           "ref/dotnet5.4/System.IO.Pipes.dll": {}
         }
       },
-      "System.IO.UnmanagedMemoryStream/4.0.1-beta-23429": {
+      "System.IO.UnmanagedMemoryStream/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -708,13 +686,13 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.2/System.IO.UnmanagedMemoryStream.dll": {}
+          "ref/dotnet5.4/System.IO.UnmanagedMemoryStream.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.IO.UnmanagedMemoryStream.dll": {}
         }
       },
-      "System.Linq/4.0.1-beta-23429": {
+      "System.Linq/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -730,33 +708,17 @@
           "lib/dotnet5.4/System.Linq.dll": {}
         }
       },
-      "System.Linq.Expressions/4.0.11-beta-23429": {
+      "System.Linq.Expressions/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.Linq": "4.0.0",
-          "System.ObjectModel": "4.0.10",
-          "System.Reflection": "4.0.10",
-          "System.Reflection.Emit": "4.0.0",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Reflection.TypeExtensions": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Threading": "4.0.10"
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Linq.Expressions.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Linq.Expressions.dll": {}
         }
       },
-      "System.Linq.Parallel/4.0.1-beta-23429": {
+      "System.Linq.Parallel/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -777,7 +739,7 @@
           "lib/dotnet5.4/System.Linq.Parallel.dll": {}
         }
       },
-      "System.Linq.Queryable/4.0.1-beta-23429": {
+      "System.Linq.Queryable/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -795,7 +757,7 @@
           "lib/dotnet5.4/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23429": {
+      "System.Net.Http/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -808,7 +770,7 @@
           "ref/dotnet5.2/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23429": {
+      "System.Net.NameResolution/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -819,7 +781,7 @@
           "ref/dotnet5.4/System.Net.NameResolution.dll": {}
         }
       },
-      "System.Net.NetworkInformation/4.1.0-beta-23429": {
+      "System.Net.NetworkInformation/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -830,7 +792,7 @@
           "ref/dotnet5.4/System.Net.NetworkInformation.dll": {}
         }
       },
-      "System.Net.Primitives/4.0.11-beta-23429": {
+      "System.Net.Primitives/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -840,7 +802,7 @@
           "ref/dotnet5.4/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Requests/4.0.11-beta-23429": {
+      "System.Net.Requests/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -853,20 +815,20 @@
           "ref/dotnet5.4/System.Net.Requests.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23429": {
+      "System.Net.Security/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Net.Primitives": "4.0.10",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.Security.dll": {}
         }
       },
-      "System.Net.Sockets/4.1.0-beta-23429": {
+      "System.Net.Sockets/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -875,13 +837,13 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.5/System.Net.Sockets.dll": {}
+          "ref/dotnet5.4/System.Net.Sockets.dll": {}
         }
       },
-      "System.Net.Utilities/4.0.0-beta-23429": {
+      "System.Net.Utilities/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23429"
+          "System.Private.Networking": "4.0.1-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.Utilities.dll": {}
@@ -890,7 +852,7 @@
           "lib/DNXCore50/System.Net.Utilities.dll": {}
         }
       },
-      "System.Net.WebHeaderCollection/4.0.1-beta-23429": {
+      "System.Net.WebHeaderCollection/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -906,35 +868,35 @@
           "lib/dotnet5.4/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23429": {
+      "System.Net.WebSockets/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
-          "System.Threading.Tasks": "4.0.0"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Net.WebSockets.dll": {}
+          "ref/dotnet5.4/System.Net.WebSockets.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23429": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
-          "System.Net.WebSockets": "4.0.0-beta-23429",
+          "System.Net.WebSockets": "4.0.0-beta-23506",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.WebSockets.Client.dll": {}
         }
       },
-      "System.Numerics.Vectors/4.1.1-beta-23429": {
+      "System.Numerics.Vectors/4.1.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -949,7 +911,7 @@
           "lib/dotnet5.4/System.Numerics.Vectors.dll": {}
         }
       },
-      "System.ObjectModel/4.0.11-beta-23429": {
+      "System.ObjectModel/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -965,38 +927,13 @@
           "lib/dotnet5.4/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.DataContractSerialization/4.1.0-beta-23429": {
+      "System.Private.DataContractSerialization/4.1.0-beta-23506": {
         "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.10",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Reflection.TypeExtensions": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23429",
-          "System.Text.Encoding": "4.0.10",
-          "System.Text.Encoding.Extensions": "4.0.10",
-          "System.Text.RegularExpressions": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Xml.ReaderWriter": "4.0.10",
-          "System.Xml.XmlSerializer": "4.0.10"
-        },
         "compile": {
           "ref/dnxcore50/_._": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23429": {
+      "System.Private.Networking/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -1015,14 +952,14 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23429",
+          "System.Security.Principal.Windows": "4.0.0-beta-23506",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23429"
+          "System.Threading.ThreadPool": "4.0.10-beta-23506"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -1031,53 +968,53 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23429": {
+      "System.Private.ServiceModel/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.11-beta-23429",
-          "System.Collections.Concurrent": "4.0.11-beta-23429",
-          "System.Collections.NonGeneric": "4.0.1-beta-23429",
-          "System.Collections.Specialized": "4.0.1-beta-23429",
-          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23429",
-          "System.Diagnostics.Debug": "4.0.11-beta-23429",
-          "System.Diagnostics.Tracing": "4.0.21-beta-23429",
-          "System.Globalization": "4.0.11-beta-23429",
-          "System.IO": "4.0.11-beta-23429",
-          "System.IO.Compression": "4.1.0-beta-23429",
-          "System.Linq": "4.0.1-beta-23429",
-          "System.Linq.Expressions": "4.0.11-beta-23429",
-          "System.Linq.Queryable": "4.0.1-beta-23429",
-          "System.Net.Http": "4.0.1-beta-23429",
-          "System.Net.NameResolution": "4.0.0-beta-23429",
-          "System.Net.Primitives": "4.0.11-beta-23429",
-          "System.Net.Security": "4.0.0-beta-23429",
-          "System.Net.Sockets": "4.1.0-beta-23429",
-          "System.Net.WebHeaderCollection": "4.0.1-beta-23429",
-          "System.Net.WebSockets": "4.0.0-beta-23429",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23429",
-          "System.ObjectModel": "4.0.11-beta-23429",
-          "System.Reflection": "4.1.0-beta-23429",
-          "System.Reflection.DispatchProxy": "4.0.1-beta-23429",
-          "System.Reflection.Extensions": "4.0.1-beta-23429",
-          "System.Reflection.Primitives": "4.0.1-beta-23429",
-          "System.Reflection.TypeExtensions": "4.0.1-beta-23429",
-          "System.Resources.ResourceManager": "4.0.1-beta-23429",
-          "System.Runtime": "4.0.21-beta-23429",
-          "System.Runtime.Extensions": "4.0.11-beta-23429",
-          "System.Runtime.InteropServices": "4.0.21-beta-23429",
+          "System.Collections": "4.0.11-beta-23506",
+          "System.Collections.Concurrent": "4.0.11-beta-23506",
+          "System.Collections.NonGeneric": "4.0.1-beta-23506",
+          "System.Collections.Specialized": "4.0.1-beta-23506",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23506",
+          "System.Diagnostics.Debug": "4.0.11-beta-23506",
+          "System.Diagnostics.Tracing": "4.0.21-beta-23506",
+          "System.Globalization": "4.0.11-beta-23506",
+          "System.IO": "4.0.11-beta-23506",
+          "System.IO.Compression": "4.1.0-beta-23506",
+          "System.Linq": "4.0.1-beta-23506",
+          "System.Linq.Expressions": "4.0.11-beta-23506",
+          "System.Linq.Queryable": "4.0.1-beta-23506",
+          "System.Net.Http": "4.0.1-beta-23506",
+          "System.Net.NameResolution": "4.0.0-beta-23506",
+          "System.Net.Primitives": "4.0.11-beta-23506",
+          "System.Net.Security": "4.0.0-beta-23506",
+          "System.Net.Sockets": "4.1.0-beta-23506",
+          "System.Net.WebHeaderCollection": "4.0.1-beta-23506",
+          "System.Net.WebSockets": "4.0.0-beta-23506",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23506",
+          "System.ObjectModel": "4.0.11-beta-23506",
+          "System.Reflection": "4.1.0-beta-23506",
+          "System.Reflection.DispatchProxy": "4.0.1-beta-23506",
+          "System.Reflection.Extensions": "4.0.1-beta-23506",
+          "System.Reflection.Primitives": "4.0.1-beta-23506",
+          "System.Reflection.TypeExtensions": "4.0.1-beta-23506",
+          "System.Resources.ResourceManager": "4.0.1-beta-23506",
+          "System.Runtime": "4.0.21-beta-23506",
+          "System.Runtime.Extensions": "4.0.11-beta-23506",
+          "System.Runtime.InteropServices": "4.0.21-beta-23506",
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
-          "System.Security.Claims": "4.0.1-beta-23429",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
-          "System.Security.Principal": "4.0.1-beta-23429",
-          "System.Security.Principal.Windows": "4.0.0-beta-23429",
-          "System.Text.Encoding": "4.0.11-beta-23429",
-          "System.Threading": "4.0.11-beta-23429",
-          "System.Threading.Tasks": "4.0.11-beta-23429",
-          "System.Threading.Timer": "4.0.1-beta-23429",
-          "System.Xml.ReaderWriter": "4.0.11-beta-23429",
-          "System.Xml.XmlDocument": "4.0.1-beta-23429",
-          "System.Xml.XmlSerializer": "4.0.11-beta-23429"
+          "System.Security.Claims": "4.0.1-beta-23506",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
+          "System.Security.Principal": "4.0.1-beta-23506",
+          "System.Security.Principal.Windows": "4.0.0-beta-23506",
+          "System.Text.Encoding": "4.0.11-beta-23506",
+          "System.Threading": "4.0.11-beta-23506",
+          "System.Threading.Tasks": "4.0.11-beta-23506",
+          "System.Threading.Timer": "4.0.1-beta-23506",
+          "System.Xml.ReaderWriter": "4.0.11-beta-23506",
+          "System.Xml.XmlDocument": "4.0.1-beta-23506",
+          "System.Xml.XmlSerializer": "4.0.11-beta-23506"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -1086,13 +1023,13 @@
           "lib/DNXCore50/System.Private.ServiceModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.1-beta-23429": {
+      "System.Private.Uri/4.0.1-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
         }
       },
-      "System.Reflection/4.1.0-beta-23429": {
+      "System.Reflection/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -1106,26 +1043,17 @@
           "lib/DNXCore50/System.Reflection.dll": {}
         }
       },
-      "System.Reflection.DispatchProxy/4.0.1-beta-23429": {
+      "System.Reflection.DispatchProxy/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.10",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Threading": "4.0.10"
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Reflection.DispatchProxy.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Reflection.DispatchProxy.dll": {}
+          "ref/dotnet5.4/System.Reflection.DispatchProxy.dll": {}
         }
       },
-      "System.Reflection.Emit/4.0.1-beta-23429": {
+      "System.Reflection.Emit/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -1141,7 +1069,7 @@
           "lib/DNXCore50/System.Reflection.Emit.dll": {}
         }
       },
-      "System.Reflection.Emit.ILGeneration/4.0.1-beta-23429": {
+      "System.Reflection.Emit.ILGeneration/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -1155,7 +1083,7 @@
           "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
         }
       },
-      "System.Reflection.Emit.Lightweight/4.0.1-beta-23429": {
+      "System.Reflection.Emit.Lightweight/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -1170,7 +1098,7 @@
           "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll": {}
         }
       },
-      "System.Reflection.Extensions/4.0.1-beta-23429": {
+      "System.Reflection.Extensions/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -1183,7 +1111,7 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.1.1-beta-23429": {
+      "System.Reflection.Metadata/1.1.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -1208,7 +1136,7 @@
           "lib/dotnet5.2/System.Reflection.Metadata.dll": {}
         }
       },
-      "System.Reflection.Primitives/4.0.1-beta-23429": {
+      "System.Reflection.Primitives/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -1220,20 +1148,20 @@
           "lib/DNXCore50/System.Reflection.Primitives.dll": {}
         }
       },
-      "System.Reflection.TypeExtensions/4.1.0-beta-23429": {
+      "System.Reflection.TypeExtensions/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Reflection.TypeExtensions.dll": {}
+          "ref/dotnet5.4/System.Reflection.TypeExtensions.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
         }
       },
-      "System.Resources.ReaderWriter/4.0.0-beta-23429": {
+      "System.Resources.ReaderWriter/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1245,13 +1173,13 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Resources.ReaderWriter.dll": {}
+          "ref/dotnet5.4/System.Resources.ReaderWriter.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Resources.ReaderWriter.dll": {}
         }
       },
-      "System.Resources.ResourceManager/4.0.1-beta-23429": {
+      "System.Resources.ResourceManager/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -1265,10 +1193,10 @@
           "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
         }
       },
-      "System.Runtime/4.0.21-beta-23429": {
+      "System.Runtime/4.0.21-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.Uri": "4.0.1-beta-23429"
+          "System.Private.Uri": "4.0.1-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Runtime.dll": {}
@@ -1277,19 +1205,19 @@
           "lib/DNXCore50/System.Runtime.dll": {}
         }
       },
-      "System.Runtime.CompilerServices.VisualC/4.0.0-beta-23429": {
+      "System.Runtime.CompilerServices.VisualC/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Runtime.CompilerServices.VisualC.dll": {}
+          "ref/dotnet5.4/System.Runtime.CompilerServices.VisualC.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Runtime.CompilerServices.VisualC.dll": {}
         }
       },
-      "System.Runtime.Extensions/4.0.11-beta-23429": {
+      "System.Runtime.Extensions/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -1298,7 +1226,7 @@
           "ref/dotnet5.4/System.Runtime.Extensions.dll": {}
         }
       },
-      "System.Runtime.Handles/4.0.1-beta-23429": {
+      "System.Runtime.Handles/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -1310,7 +1238,7 @@
           "lib/DNXCore50/System.Runtime.Handles.dll": {}
         }
       },
-      "System.Runtime.InteropServices/4.0.21-beta-23429": {
+      "System.Runtime.InteropServices/4.0.21-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -1325,16 +1253,16 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23429": {
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+          "ref/dotnet5.2/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "System.Runtime.Loader/4.0.0-beta-23429": {
+      "System.Runtime.Loader/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -1348,7 +1276,7 @@
           "lib/DNXCore50/System.Runtime.Loader.dll": {}
         }
       },
-      "System.Runtime.Numerics/4.0.1-beta-23429": {
+      "System.Runtime.Numerics/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -1363,10 +1291,10 @@
           "lib/dotnet5.4/System.Runtime.Numerics.dll": {}
         }
       },
-      "System.Runtime.Serialization.Json/4.0.1-beta-23429": {
+      "System.Runtime.Serialization.Json/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.1.0-beta-23429"
+          "System.Private.DataContractSerialization": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.1/System.Runtime.Serialization.Json.dll": {}
@@ -1375,7 +1303,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Json.dll": {}
         }
       },
-      "System.Runtime.Serialization.Primitives/4.1.0-beta-23429": {
+      "System.Runtime.Serialization.Primitives/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -1388,11 +1316,11 @@
           "lib/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
         }
       },
-      "System.Runtime.Serialization.Xml/4.1.0-beta-23429": {
+      "System.Runtime.Serialization.Xml/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.1.0-beta-23429",
-          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23429"
+          "System.Private.DataContractSerialization": "4.1.0-beta-23506",
+          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Runtime.Serialization.Xml.dll": {}
@@ -1401,7 +1329,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Xml.dll": {}
         }
       },
-      "System.Security.Claims/4.0.1-beta-23429": {
+      "System.Security.Claims/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -1414,33 +1342,33 @@
           "System.Security.Principal": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Claims.dll": {}
+          "ref/dotnet5.4/System.Security.Claims.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23429": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Cryptography.Algorithms.dll": {}
+          "ref/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23429": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Cryptography.Encoding.dll": {}
+          "ref/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23429": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -1452,25 +1380,25 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Cryptography.Primitives.dll": {}
+          "ref/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23429": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23429"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
-      "System.Security.Principal/4.0.1-beta-23429": {
+      "System.Security.Principal/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -1482,7 +1410,7 @@
           "lib/dotnet5.1/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23429": {
+      "System.Security.Principal.Windows/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -1505,10 +1433,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23429": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429"
+          "System.Private.ServiceModel": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.2/System.ServiceModel.Duplex.dll": {}
@@ -1517,10 +1445,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23429": {
+      "System.ServiceModel.Http/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429",
+          "System.Private.ServiceModel": "4.1.0-beta-23506",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -1530,10 +1458,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.1.0-beta-23429": {
+      "System.ServiceModel.NetTcp/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429"
+          "System.Private.ServiceModel": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.ServiceModel.NetTcp.dll": {}
@@ -1542,10 +1470,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.1.0-beta-23429": {
+      "System.ServiceModel.Primitives/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429"
+          "System.Private.ServiceModel": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.ServiceModel.Primitives.dll": {}
@@ -1554,10 +1482,10 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
-      "System.ServiceModel.Security/4.0.1-beta-23429": {
+      "System.ServiceModel.Security/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429"
+          "System.Private.ServiceModel": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.2/System.ServiceModel.Security.dll": {}
@@ -1566,7 +1494,7 @@
           "lib/DNXCore50/System.ServiceModel.Security.dll": {}
         }
       },
-      "System.Text.Encoding/4.0.11-beta-23429": {
+      "System.Text.Encoding/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -1578,7 +1506,7 @@
           "lib/DNXCore50/System.Text.Encoding.dll": {}
         }
       },
-      "System.Text.Encoding.Extensions/4.0.11-beta-23429": {
+      "System.Text.Encoding.Extensions/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1591,7 +1519,7 @@
           "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
         }
       },
-      "System.Text.RegularExpressions/4.0.11-beta-23429": {
+      "System.Text.RegularExpressions/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1608,7 +1536,7 @@
           "lib/dotnet5.4/System.Text.RegularExpressions.dll": {}
         }
       },
-      "System.Threading/4.0.11-beta-23429": {
+      "System.Threading/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1631,7 +1559,7 @@
           "lib/DNXCore50/System.Threading.Overlapped.dll": {}
         }
       },
-      "System.Threading.Tasks/4.0.11-beta-23429": {
+      "System.Threading.Tasks/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -1643,7 +1571,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.Tasks.Dataflow/4.5.26-beta-23429": {
+      "System.Threading.Tasks.Dataflow/4.5.26-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -1665,7 +1593,7 @@
           "lib/dotnet5.2/System.Threading.Tasks.Dataflow.dll": {}
         }
       },
-      "System.Threading.Tasks.Parallel/4.0.1-beta-23429": {
+      "System.Threading.Tasks.Parallel/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections.Concurrent": "4.0.10",
@@ -1684,20 +1612,20 @@
           "lib/dotnet5.4/System.Threading.Tasks.Parallel.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23429": {
+      "System.Threading.ThreadPool/4.0.10-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.InteropServices": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.2/System.Threading.ThreadPool.dll": {}
+          "ref/dotnet5.4/System.Threading.ThreadPool.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
-      "System.Threading.Timer/4.0.1-beta-23429": {
+      "System.Threading.Timer/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -1709,7 +1637,7 @@
           "lib/DNXCore50/System.Threading.Timer.dll": {}
         }
       },
-      "System.Xml.ReaderWriter/4.0.11-beta-23429": {
+      "System.Xml.ReaderWriter/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1734,7 +1662,7 @@
           "lib/dotnet5.4/System.Xml.ReaderWriter.dll": {}
         }
       },
-      "System.Xml.XDocument/4.0.11-beta-23429": {
+      "System.Xml.XDocument/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1757,7 +1685,7 @@
           "lib/dotnet5.4/System.Xml.XDocument.dll": {}
         }
       },
-      "System.Xml.XmlDocument/4.0.1-beta-23429": {
+      "System.Xml.XmlDocument/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1772,37 +1700,21 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Xml.XmlDocument.dll": {}
+          "ref/dotnet5.4/System.Xml.XmlDocument.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Xml.XmlDocument.dll": {}
         }
       },
-      "System.Xml.XmlSerializer/4.0.11-beta-23429": {
+      "System.Xml.XmlSerializer/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.10",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Reflection.TypeExtensions": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Text.RegularExpressions": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Xml.ReaderWriter": "4.0.10",
-          "System.Xml.XmlDocument": "4.0.0"
+          "System.IO": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet5.4/System.Xml.XmlSerializer.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
         }
       },
       "xunit/2.1.0": {
@@ -1959,7 +1871,7 @@
       "coveralls.io/1.4.0": {
         "type": "package"
       },
-      "Microsoft.CSharp/4.0.1-beta-23429": {
+      "Microsoft.CSharp/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1995,169 +1907,147 @@
           "xunit.runner.console": "2.1.0"
         }
       },
-      "Microsoft.NETCore/5.0.1-beta-23429": {
+      "Microsoft.NETCore/5.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "Microsoft.CSharp": "4.0.1-beta-23429",
-          "Microsoft.NETCore.Targets": "1.0.1-beta-23429",
-          "Microsoft.VisualBasic": "10.0.1-beta-23429",
-          "System.AppContext": "4.0.1-beta-23429",
-          "System.Collections": "4.0.11-beta-23429",
-          "System.Collections.Concurrent": "4.0.11-beta-23429",
-          "System.Collections.Immutable": "1.1.38-beta-23429",
-          "System.ComponentModel": "4.0.1-beta-23429",
-          "System.ComponentModel.Annotations": "4.0.11-beta-23429",
-          "System.Diagnostics.Debug": "4.0.11-beta-23429",
-          "System.Diagnostics.Tools": "4.0.1-beta-23429",
-          "System.Diagnostics.Tracing": "4.0.21-beta-23429",
-          "System.Dynamic.Runtime": "4.0.11-beta-23429",
-          "System.Globalization": "4.0.11-beta-23429",
-          "System.Globalization.Calendars": "4.0.1-beta-23429",
-          "System.Globalization.Extensions": "4.0.1-beta-23429",
-          "System.IO": "4.0.11-beta-23429",
-          "System.IO.Compression": "4.1.0-beta-23429",
-          "System.IO.Compression.ZipFile": "4.0.1-beta-23429",
-          "System.IO.FileSystem": "4.0.1-beta-23429",
-          "System.IO.FileSystem.Primitives": "4.0.1-beta-23429",
-          "System.IO.UnmanagedMemoryStream": "4.0.1-beta-23429",
-          "System.Linq": "4.0.1-beta-23429",
-          "System.Linq.Expressions": "4.0.11-beta-23429",
-          "System.Linq.Parallel": "4.0.1-beta-23429",
-          "System.Linq.Queryable": "4.0.1-beta-23429",
-          "System.Net.Http": "4.0.1-beta-23429",
-          "System.Net.NetworkInformation": "4.1.0-beta-23429",
-          "System.Net.Primitives": "4.0.11-beta-23429",
-          "System.Numerics.Vectors": "4.1.1-beta-23429",
-          "System.ObjectModel": "4.0.11-beta-23429",
-          "System.Reflection": "4.1.0-beta-23429",
-          "System.Reflection.DispatchProxy": "4.0.1-beta-23429",
-          "System.Reflection.Extensions": "4.0.1-beta-23429",
-          "System.Reflection.Metadata": "1.1.1-beta-23429",
-          "System.Reflection.Primitives": "4.0.1-beta-23429",
-          "System.Reflection.TypeExtensions": "4.1.0-beta-23429",
-          "System.Resources.ResourceManager": "4.0.1-beta-23429",
-          "System.Runtime": "4.0.21-beta-23429",
-          "System.Runtime.Extensions": "4.0.11-beta-23429",
-          "System.Runtime.Handles": "4.0.1-beta-23429",
-          "System.Runtime.InteropServices": "4.0.21-beta-23429",
-          "System.Runtime.Numerics": "4.0.1-beta-23429",
-          "System.Security.Claims": "4.0.1-beta-23429",
-          "System.Security.Principal": "4.0.1-beta-23429",
-          "System.Text.Encoding": "4.0.11-beta-23429",
-          "System.Text.Encoding.Extensions": "4.0.11-beta-23429",
-          "System.Text.RegularExpressions": "4.0.11-beta-23429",
-          "System.Threading": "4.0.11-beta-23429",
-          "System.Threading.Tasks": "4.0.11-beta-23429",
-          "System.Threading.Tasks.Dataflow": "4.5.26-beta-23429",
-          "System.Threading.Tasks.Parallel": "4.0.1-beta-23429",
-          "System.Threading.Timer": "4.0.1-beta-23429",
-          "System.Xml.ReaderWriter": "4.0.11-beta-23429",
-          "System.Xml.XDocument": "4.0.11-beta-23429"
+          "Microsoft.CSharp": "4.0.1-beta-23506",
+          "Microsoft.NETCore.Platforms": "1.0.1-beta-23506",
+          "Microsoft.VisualBasic": "10.0.1-beta-23506",
+          "System.AppContext": "4.0.1-beta-23506",
+          "System.Collections": "4.0.11-beta-23506",
+          "System.Collections.Concurrent": "4.0.11-beta-23506",
+          "System.Collections.Immutable": "1.1.38-beta-23506",
+          "System.ComponentModel": "4.0.1-beta-23506",
+          "System.ComponentModel.Annotations": "4.0.11-beta-23506",
+          "System.Diagnostics.Debug": "4.0.11-beta-23506",
+          "System.Diagnostics.Tools": "4.0.1-beta-23506",
+          "System.Diagnostics.Tracing": "4.0.21-beta-23506",
+          "System.Dynamic.Runtime": "4.0.11-beta-23506",
+          "System.Globalization": "4.0.11-beta-23506",
+          "System.Globalization.Calendars": "4.0.1-beta-23506",
+          "System.Globalization.Extensions": "4.0.1-beta-23506",
+          "System.IO": "4.0.11-beta-23506",
+          "System.IO.Compression": "4.1.0-beta-23506",
+          "System.IO.Compression.ZipFile": "4.0.1-beta-23506",
+          "System.IO.FileSystem": "4.0.1-beta-23506",
+          "System.IO.FileSystem.Primitives": "4.0.1-beta-23506",
+          "System.IO.UnmanagedMemoryStream": "4.0.1-beta-23506",
+          "System.Linq": "4.0.1-beta-23506",
+          "System.Linq.Expressions": "4.0.11-beta-23506",
+          "System.Linq.Parallel": "4.0.1-beta-23506",
+          "System.Linq.Queryable": "4.0.1-beta-23506",
+          "System.Net.Http": "4.0.1-beta-23506",
+          "System.Net.NetworkInformation": "4.1.0-beta-23506",
+          "System.Net.Primitives": "4.0.11-beta-23506",
+          "System.Numerics.Vectors": "4.1.1-beta-23506",
+          "System.ObjectModel": "4.0.11-beta-23506",
+          "System.Reflection": "4.1.0-beta-23506",
+          "System.Reflection.DispatchProxy": "4.0.1-beta-23506",
+          "System.Reflection.Extensions": "4.0.1-beta-23506",
+          "System.Reflection.Metadata": "1.1.1-beta-23506",
+          "System.Reflection.Primitives": "4.0.1-beta-23506",
+          "System.Reflection.TypeExtensions": "4.1.0-beta-23506",
+          "System.Resources.ResourceManager": "4.0.1-beta-23506",
+          "System.Runtime": "4.0.21-beta-23506",
+          "System.Runtime.Extensions": "4.0.11-beta-23506",
+          "System.Runtime.Handles": "4.0.1-beta-23506",
+          "System.Runtime.InteropServices": "4.0.21-beta-23506",
+          "System.Runtime.Numerics": "4.0.1-beta-23506",
+          "System.Security.Claims": "4.0.1-beta-23506",
+          "System.Security.Principal": "4.0.1-beta-23506",
+          "System.Text.Encoding": "4.0.11-beta-23506",
+          "System.Text.Encoding.Extensions": "4.0.11-beta-23506",
+          "System.Text.RegularExpressions": "4.0.11-beta-23506",
+          "System.Threading": "4.0.11-beta-23506",
+          "System.Threading.Tasks": "4.0.11-beta-23506",
+          "System.Threading.Tasks.Dataflow": "4.5.26-beta-23506",
+          "System.Threading.Tasks.Parallel": "4.0.1-beta-23506",
+          "System.Threading.Timer": "4.0.1-beta-23506",
+          "System.Xml.ReaderWriter": "4.0.11-beta-23506",
+          "System.Xml.XDocument": "4.0.11-beta-23506"
         }
       },
-      "Microsoft.NETCore.Console/1.0.0-beta-23429": {
+      "Microsoft.NETCore.Console/1.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore": "5.0.1-beta-23429",
-          "Microsoft.NETCore.ConsoleHost": "1.0.0-beta-23429",
-          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23429",
-          "Microsoft.Win32.Primitives": "4.0.1-beta-23429",
-          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23429",
-          "System.Console": "4.0.0-beta-23429",
-          "System.Data.Common": "4.0.1-beta-23429",
-          "System.Data.SqlClient": "4.0.0-beta-23429",
-          "System.Diagnostics.Contracts": "4.0.1-beta-23429",
-          "System.Diagnostics.FileVersionInfo": "4.0.0-beta-23429",
-          "System.Diagnostics.Process": "4.1.0-beta-23429",
-          "System.Diagnostics.StackTrace": "4.0.1-beta-23429",
-          "System.IO.FileSystem.DriveInfo": "4.0.0-beta-23429",
-          "System.IO.FileSystem.Watcher": "4.0.0-beta-23429",
-          "System.IO.MemoryMappedFiles": "4.0.0-beta-23429",
-          "System.IO.Pipes": "4.0.0-beta-23429",
-          "System.Net.NameResolution": "4.0.0-beta-23429",
-          "System.Net.NetworkInformation": "4.1.0-beta-23429",
-          "System.Net.Requests": "4.0.11-beta-23429",
-          "System.Net.Security": "4.0.0-beta-23429",
-          "System.Net.Sockets": "4.1.0-beta-23429",
-          "System.Net.Utilities": "4.0.0-beta-23429",
-          "System.Net.WebHeaderCollection": "4.0.1-beta-23429",
-          "System.Net.WebSockets": "4.0.0-beta-23429",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23429",
-          "System.Reflection.Emit": "4.0.1-beta-23429",
-          "System.Reflection.Emit.ILGeneration": "4.0.1-beta-23429",
-          "System.Reflection.Emit.Lightweight": "4.0.1-beta-23429",
-          "System.Resources.ReaderWriter": "4.0.0-beta-23429",
-          "System.Runtime.CompilerServices.VisualC": "4.0.0-beta-23429",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23429",
-          "System.Runtime.Loader": "4.0.0-beta-23429",
-          "System.Runtime.Serialization.Json": "4.0.1-beta-23429",
-          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23429",
-          "System.Runtime.Serialization.Xml": "4.1.0-beta-23429",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
-          "System.ServiceModel.Duplex": "4.0.1-beta-23429",
-          "System.ServiceModel.Http": "4.0.11-beta-23429",
-          "System.ServiceModel.NetTcp": "4.1.0-beta-23429",
-          "System.ServiceModel.Primitives": "4.1.0-beta-23429",
-          "System.ServiceModel.Security": "4.0.1-beta-23429",
-          "System.Xml.XmlSerializer": "4.0.11-beta-23429"
+          "Microsoft.NETCore": "5.0.1-beta-23506",
+          "Microsoft.NETCore.ConsoleHost": "1.0.0-beta-23506",
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23506",
+          "Microsoft.Win32.Primitives": "4.0.1-beta-23506",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23506",
+          "System.Console": "4.0.0-beta-23506",
+          "System.Data.Common": "4.0.1-beta-23506",
+          "System.Data.SqlClient": "4.0.0-beta-23506",
+          "System.Diagnostics.Contracts": "4.0.1-beta-23506",
+          "System.Diagnostics.FileVersionInfo": "4.0.0-beta-23506",
+          "System.Diagnostics.Process": "4.1.0-beta-23506",
+          "System.Diagnostics.StackTrace": "4.0.1-beta-23506",
+          "System.IO.FileSystem.DriveInfo": "4.0.0-beta-23506",
+          "System.IO.FileSystem.Watcher": "4.0.0-beta-23506",
+          "System.IO.MemoryMappedFiles": "4.0.0-beta-23506",
+          "System.IO.Pipes": "4.0.0-beta-23506",
+          "System.Net.NameResolution": "4.0.0-beta-23506",
+          "System.Net.NetworkInformation": "4.1.0-beta-23506",
+          "System.Net.Requests": "4.0.11-beta-23506",
+          "System.Net.Security": "4.0.0-beta-23506",
+          "System.Net.Sockets": "4.1.0-beta-23506",
+          "System.Net.Utilities": "4.0.0-beta-23506",
+          "System.Net.WebHeaderCollection": "4.0.1-beta-23506",
+          "System.Net.WebSockets": "4.0.0-beta-23506",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23506",
+          "System.Reflection.Emit": "4.0.1-beta-23506",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-beta-23506",
+          "System.Reflection.Emit.Lightweight": "4.0.1-beta-23506",
+          "System.Resources.ReaderWriter": "4.0.0-beta-23506",
+          "System.Runtime.CompilerServices.VisualC": "4.0.0-beta-23506",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23506",
+          "System.Runtime.Loader": "4.0.0-beta-23506",
+          "System.Runtime.Serialization.Json": "4.0.1-beta-23506",
+          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23506",
+          "System.Runtime.Serialization.Xml": "4.1.0-beta-23506",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
+          "System.ServiceModel.Duplex": "4.0.1-beta-23506",
+          "System.ServiceModel.Http": "4.0.11-beta-23506",
+          "System.ServiceModel.NetTcp": "4.1.0-beta-23506",
+          "System.ServiceModel.Primitives": "4.1.0-beta-23506",
+          "System.ServiceModel.Security": "4.0.1-beta-23506",
+          "System.Xml.XmlSerializer": "4.0.11-beta-23506"
         }
       },
-      "Microsoft.NETCore.ConsoleHost/1.0.0-beta-23429": {
+      "Microsoft.NETCore.ConsoleHost/1.0.0-beta-23506": {
         "type": "package"
       },
-      "Microsoft.NETCore.Platforms/1.0.1-beta-23429": {
-        "type": "package"
-      },
-      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23429": {
+      "Microsoft.NETCore.Platforms/1.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-beta-23429",
-          "System.Collections": "[4.0.11-beta-23429]",
-          "System.Diagnostics.Contracts": "[4.0.1-beta-23429]",
-          "System.Diagnostics.Debug": "[4.0.11-beta-23429]",
-          "System.Diagnostics.StackTrace": "[4.0.1-beta-23429]",
-          "System.Diagnostics.Tools": "[4.0.1-beta-23429]",
-          "System.Diagnostics.Tracing": "[4.0.21-beta-23429]",
-          "System.Globalization": "[4.0.11-beta-23429]",
-          "System.Globalization.Calendars": "[4.0.1-beta-23429]",
-          "System.IO": "[4.0.11-beta-23429]",
-          "System.ObjectModel": "[4.0.11-beta-23429]",
-          "System.Private.Uri": "[4.0.1-beta-23429]",
-          "System.Reflection": "[4.1.0-beta-23429]",
-          "System.Reflection.Extensions": "[4.0.1-beta-23429]",
-          "System.Reflection.Primitives": "[4.0.1-beta-23429]",
-          "System.Resources.ResourceManager": "[4.0.1-beta-23429]",
-          "System.Runtime": "[4.0.21-beta-23429]",
-          "System.Runtime.Extensions": "[4.0.11-beta-23429]",
-          "System.Runtime.Handles": "[4.0.1-beta-23429]",
-          "System.Runtime.InteropServices": "[4.0.21-beta-23429]",
-          "System.Text.Encoding": "[4.0.11-beta-23429]",
-          "System.Text.Encoding.Extensions": "[4.0.11-beta-23429]",
-          "System.Threading": "[4.0.11-beta-23429]",
-          "System.Threading.Tasks": "[4.0.11-beta-23429]",
-          "System.Threading.Timer": "[4.0.1-beta-23429]"
+          "Microsoft.NETCore.Targets": "1.0.1-beta-23506"
         }
       },
-      "Microsoft.NETCore.Targets/1.0.1-beta-23429": {
+      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1-beta-23429",
-          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-beta-23429"
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-beta-23506"
         }
       },
-      "Microsoft.NETCore.Targets.DNXCore/5.0.0-beta-23429": {
+      "Microsoft.NETCore.Targets/1.0.1-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-beta-23506"
+        }
+      },
+      "Microsoft.NETCore.Targets.DNXCore/5.0.0-beta-23506": {
         "type": "package"
       },
-      "Microsoft.NETCore.TestHost/1.0.0-beta-23429": {
+      "Microsoft.NETCore.TestHost/1.0.0-beta-23506": {
         "type": "package"
       },
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23429": {
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23506": {
         "type": "package"
       },
-      "Microsoft.VisualBasic/10.0.1-beta-23429": {
+      "Microsoft.VisualBasic/10.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -2184,16 +2074,16 @@
           "lib/dotnet5.4/Microsoft.VisualBasic.dll": {}
         }
       },
-      "Microsoft.Win32.Primitives/4.0.1-beta-23429": {
+      "Microsoft.Win32.Primitives/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/Microsoft.Win32.Primitives.dll": {}
+          "ref/dotnet5.4/Microsoft.Win32.Primitives.dll": {}
         }
       },
-      "Microsoft.Win32.Registry/4.0.0-beta-23429": {
+      "Microsoft.Win32.Registry/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -2205,7 +2095,7 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet5.2/Microsoft.Win32.Registry.dll": {}
+          "ref/dotnet5.4/Microsoft.Win32.Registry.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/Microsoft.Win32.Registry.dll": {}
@@ -2217,7 +2107,118 @@
       "ReportGenerator/2.3.1": {
         "type": "package"
       },
-      "runtime.win.System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23429": {
+      "runtime.any.System.Linq.Expressions/4.0.11-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Linq.Expressions.dll": {}
+        }
+      },
+      "runtime.any.System.Private.DataContractSerialization/4.1.0-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23506",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection.DispatchProxy/4.0.1-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.DispatchProxy.dll": {}
+        }
+      },
+      "runtime.any.System.Xml.XmlSerializer/4.0.11-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
+        }
+      },
+      "runtime.win.System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -2230,7 +2231,29 @@
           "runtimes/win/lib/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "runtime.win7.Microsoft.Win32.Primitives/4.0.1-beta-23429": {
+      "runtime.win.System.Text.Encoding.CodePages/4.0.1-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/dotnet5.4/System.Text.Encoding.CodePages.dll": {}
+        }
+      },
+      "runtime.win7.Microsoft.Win32.Primitives/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20",
@@ -2243,7 +2266,7 @@
           "runtimes/win7/lib/dotnet5.4/Microsoft.Win32.Primitives.dll": {}
         }
       },
-      "runtime.win7.System.Console/4.0.0-beta-23429": {
+      "runtime.win7.System.Console/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -2263,7 +2286,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Console.dll": {}
         }
       },
-      "runtime.win7.System.Data.SqlClient/4.0.0-beta-23429": {
+      "runtime.win7.System.Data.SqlClient/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -2275,10 +2298,10 @@
           "System.Globalization": "4.0.10",
           "System.IO": "4.0.10",
           "System.Linq": "4.0.0",
-          "System.Net.NameResolution": "4.0.0-beta-23429",
+          "System.Net.NameResolution": "4.0.0-beta-23506",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23429",
-          "System.Net.Sockets": "4.0.10-beta-23429",
+          "System.Net.Security": "4.0.0-beta-23506",
+          "System.Net.Sockets": "4.0.10-beta-23506",
           "System.Reflection": "4.0.0",
           "System.Reflection.TypeExtensions": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
@@ -2286,16 +2309,17 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
-          "System.Security.Principal.Windows": "4.0.0-beta-23429",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23506",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
+          "System.Security.Principal.Windows": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.10",
           "System.Text.Encoding.CodePages": "4.0.0",
           "System.Text.Encoding.Extensions": "4.0.0",
           "System.Text.RegularExpressions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.Thread": "4.0.0-beta-23429",
-          "System.Threading.ThreadPool": "4.0.0-beta-23429",
+          "System.Threading.Thread": "4.0.0-beta-23506",
+          "System.Threading.ThreadPool": "4.0.0-beta-23506",
           "System.Threading.Timer": "4.0.0",
           "System.Xml.ReaderWriter": "4.0.0"
         },
@@ -2306,7 +2330,7 @@
           "runtimes/win7/lib/DNXCore50/System.Data.SqlClient.dll": {}
         }
       },
-      "runtime.win7.System.Diagnostics.Debug/4.0.11-beta-23429": {
+      "runtime.win7.System.Diagnostics.Debug/4.0.11-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -2315,7 +2339,7 @@
           "runtimes/win7/lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "runtime.win7.System.Diagnostics.FileVersionInfo/4.0.0-beta-23429": {
+      "runtime.win7.System.Diagnostics.FileVersionInfo/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -2330,11 +2354,11 @@
           "runtimes/win7/lib/dotnet5.4/System.Diagnostics.FileVersionInfo.dll": {}
         }
       },
-      "runtime.win7.System.Diagnostics.Process/4.1.0-beta-23429": {
+      "runtime.win7.System.Diagnostics.Process/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
-          "Microsoft.Win32.Registry": "4.0.0-beta-23429",
+          "Microsoft.Win32.Registry": "4.0.0-beta-23506",
           "System.Collections": "4.0.10",
           "System.Diagnostics.Debug": "4.0.10",
           "System.Globalization": "4.0.10",
@@ -2350,8 +2374,8 @@
           "System.Text.Encoding.Extensions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.Thread": "4.0.0-beta-23429",
-          "System.Threading.ThreadPool": "4.0.10-beta-23429"
+          "System.Threading.Thread": "4.0.0-beta-23506",
+          "System.Threading.ThreadPool": "4.0.10-beta-23506"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -2360,7 +2384,7 @@
           "runtimes/win7/lib/dotnet5.5/System.Diagnostics.Process.dll": {}
         }
       },
-      "runtime.win7.System.Globalization.Extensions/4.0.1-beta-23429": {
+      "runtime.win7.System.Globalization.Extensions/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -2376,7 +2400,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Globalization.Extensions.dll": {}
         }
       },
-      "runtime.win7.System.IO.Compression/4.1.0-beta-23429": {
+      "runtime.win7.System.IO.Compression/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -2398,7 +2422,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.Compression.dll": {}
         }
       },
-      "runtime.win7.System.IO.FileSystem/4.0.1-beta-23429": {
+      "runtime.win7.System.IO.FileSystem/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -2422,7 +2446,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.FileSystem.dll": {}
         }
       },
-      "runtime.win7.System.IO.FileSystem.DriveInfo/4.0.0-beta-23429": {
+      "runtime.win7.System.IO.FileSystem.DriveInfo/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO.FileSystem": "4.0.0",
@@ -2440,7 +2464,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
-      "runtime.win7.System.IO.FileSystem.Watcher/4.0.0-beta-23429": {
+      "runtime.win7.System.IO.FileSystem.Watcher/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -2460,7 +2484,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.FileSystem.Watcher.dll": {}
         }
       },
-      "runtime.win7.System.IO.MemoryMappedFiles/4.0.0-beta-23429": {
+      "runtime.win7.System.IO.MemoryMappedFiles/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -2481,7 +2505,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.MemoryMappedFiles.dll": {}
         }
       },
-      "runtime.win7.System.IO.Pipes/4.0.0-beta-23429": {
+      "runtime.win7.System.IO.Pipes/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -2503,7 +2527,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.Pipes.dll": {}
         }
       },
-      "runtime.win7.System.Net.Http/4.0.1-beta-23429": {
+      "runtime.win7.System.Net.Http/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -2518,7 +2542,7 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.0",
           "System.Threading.Tasks": "4.0.10"
@@ -2530,10 +2554,10 @@
           "runtimes/win7/lib/DNXCore50/System.Net.Http.dll": {}
         }
       },
-      "runtime.win7.System.Net.NameResolution/4.0.0-beta-23429": {
+      "runtime.win7.System.Net.NameResolution/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23429"
+          "System.Private.Networking": "4.0.1-beta-23506"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -2542,10 +2566,10 @@
           "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
-      "runtime.win7.System.Net.NetworkInformation/4.1.0-beta-23429": {
+      "runtime.win7.System.Net.NetworkInformation/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23429",
+          "System.Private.Networking": "4.0.1-beta-23506",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -2555,10 +2579,10 @@
           "lib/DNXCore50/System.Net.NetworkInformation.dll": {}
         }
       },
-      "runtime.win7.System.Net.Primitives/4.0.11-beta-23429": {
+      "runtime.win7.System.Net.Primitives/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23429"
+          "System.Private.Networking": "4.0.1-beta-23506"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -2567,7 +2591,7 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "runtime.win7.System.Net.Requests/4.0.11-beta-23429": {
+      "runtime.win7.System.Net.Requests/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -2588,10 +2612,10 @@
           "runtimes/win7/lib/dotnet5.4/System.Net.Requests.dll": {}
         }
       },
-      "runtime.win7.System.Net.Security/4.0.0-beta-23429": {
+      "runtime.win7.System.Net.Security/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23429"
+          "System.Private.Networking": "4.0.1-beta-23506"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -2600,10 +2624,10 @@
           "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
-      "runtime.win7.System.Net.Sockets/4.1.0-beta-23429": {
+      "runtime.win7.System.Net.Sockets/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23429",
+          "System.Private.Networking": "4.0.1-beta-23506",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -2613,7 +2637,7 @@
           "lib/DNXCore50/System.Net.Sockets.dll": {}
         }
       },
-      "runtime.win7.System.Net.WebSockets.Client/4.0.0-beta-23429": {
+      "runtime.win7.System.Net.WebSockets.Client/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -2623,13 +2647,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23429",
+          "System.Net.WebSockets": "4.0.0-beta-23506",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -2641,7 +2665,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Net.WebSockets.Client.dll": {}
         }
       },
-      "runtime.win7.System.Private.Uri/4.0.1-beta-23429": {
+      "runtime.win7.System.Private.Uri/4.0.1-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -2650,7 +2674,7 @@
           "runtimes/win7/lib/DNXCore50/System.Private.Uri.dll": {}
         }
       },
-      "runtime.win7.System.Runtime.Extensions/4.0.11-beta-23429": {
+      "runtime.win7.System.Runtime.Extensions/4.0.11-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -2659,7 +2683,7 @@
           "lib/DNXCore50/System.Runtime.Extensions.dll": {}
         }
       },
-      "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-beta-23429": {
+      "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -2667,7 +2691,7 @@
           "System.Runtime": "4.0.20",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.0",
           "System.Text.Encoding.Extensions": "4.0.0"
         },
@@ -2678,7 +2702,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-beta-23429": {
+      "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -2690,7 +2714,7 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -2699,7 +2723,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-beta-23429": {
+      "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -2713,11 +2737,11 @@
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
           "System.Runtime.Numerics": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Cng": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Csp": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Cng": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Csp": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10"
         },
@@ -2728,7 +2752,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
-      "runtime.win7.System.Threading/4.0.11-beta-23429": {
+      "runtime.win7.System.Threading/4.0.11-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -2737,13 +2761,13 @@
           "runtimes/win7/lib/DNXCore50/System.Threading.dll": {}
         }
       },
-      "runtime.win7-x64.Microsoft.NETCore.ConsoleHost/1.0.0-beta-23429": {
+      "runtime.win7-x64.Microsoft.NETCore.ConsoleHost/1.0.0-beta-23506": {
         "type": "package",
         "native": {
           "runtimes/win7-x64/native/CoreConsole.exe": {}
         }
       },
-      "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23429": {
+      "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -2761,13 +2785,13 @@
           "runtimes/win7-x64/native/mscorrc.dll": {}
         }
       },
-      "runtime.win7-x64.Microsoft.NETCore.TestHost/1.0.0-beta-23429": {
+      "runtime.win7-x64.Microsoft.NETCore.TestHost/1.0.0-beta-23506": {
         "type": "package",
         "native": {
           "runtimes/win7-x64/native/CoreRun.exe": {}
         }
       },
-      "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23429": {
+      "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23506": {
         "type": "package",
         "native": {
           "runtimes/win7-x64/native/API-MS-Win-Base-Util-L1-1-0.dll": {},
@@ -2894,34 +2918,34 @@
           "runtimes/win7-x64/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll": {}
         }
       },
-      "runtime.win7-x64.System.Data.SqlClient.sni/4.0.0-beta-23429": {
+      "runtime.win7-x64.System.Data.SqlClient.sni/4.0.0-beta-23506": {
         "type": "package",
         "native": {
           "runtimes/win7-x64/native/sni.dll": {}
         }
       },
-      "runtime.win7-x64.System.IO.Compression.clrcompression/4.0.1-beta-23429": {
+      "runtime.win7-x64.System.IO.Compression.clrcompression/4.0.1-beta-23506": {
         "type": "package",
         "native": {
           "runtimes/win7-x64/native/clrcompression.dll": {}
         }
       },
-      "System.AppContext/4.0.1-beta-23429": {
+      "System.AppContext/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.AppContext.dll": {}
+          "ref/dotnet5.4/System.AppContext.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.AppContext.dll": {}
         }
       },
-      "System.Collections/4.0.11-beta-23429": {
+      "System.Collections/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Runtime": "4.0.21-beta-23429"
+          "System.Runtime": "4.0.21-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Collections.dll": {}
@@ -2930,7 +2954,7 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Collections.Concurrent/4.0.11-beta-23429": {
+      "System.Collections.Concurrent/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -2950,7 +2974,7 @@
           "lib/dotnet5.4/System.Collections.Concurrent.dll": {}
         }
       },
-      "System.Collections.Immutable/1.1.38-beta-23429": {
+      "System.Collections.Immutable/1.1.38-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -2969,7 +2993,7 @@
           "lib/dotnet5.1/System.Collections.Immutable.dll": {}
         }
       },
-      "System.Collections.NonGeneric/4.0.1-beta-23429": {
+      "System.Collections.NonGeneric/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -2980,13 +3004,13 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Collections.NonGeneric.dll": {}
+          "ref/dotnet5.4/System.Collections.NonGeneric.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Collections.NonGeneric.dll": {}
         }
       },
-      "System.Collections.Specialized/4.0.1-beta-23429": {
+      "System.Collections.Specialized/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections.NonGeneric": "4.0.0",
@@ -2998,13 +3022,13 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Collections.Specialized.dll": {}
+          "ref/dotnet5.4/System.Collections.Specialized.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Collections.Specialized.dll": {}
         }
       },
-      "System.ComponentModel/4.0.1-beta-23429": {
+      "System.ComponentModel/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -3016,7 +3040,7 @@
           "lib/dotnet5.4/System.ComponentModel.dll": {}
         }
       },
-      "System.ComponentModel.Annotations/4.0.11-beta-23429": {
+      "System.ComponentModel.Annotations/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -3038,7 +3062,7 @@
           "lib/dotnet5.4/System.ComponentModel.Annotations.dll": {}
         }
       },
-      "System.ComponentModel.EventBasedAsync/4.0.11-beta-23429": {
+      "System.ComponentModel.EventBasedAsync/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -3053,17 +3077,17 @@
           "lib/dotnet5.4/System.ComponentModel.EventBasedAsync.dll": {}
         }
       },
-      "System.Console/4.0.0-beta-23429": {
+      "System.Console/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Console.dll": {}
+          "ref/dotnet5.4/System.Console.dll": {}
         }
       },
-      "System.Data.Common/4.0.1-beta-23429": {
+      "System.Data.Common/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -3077,13 +3101,13 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Data.Common.dll": {}
+          "ref/dotnet5.4/System.Data.Common.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Data.Common.dll": {}
         }
       },
-      "System.Data.SqlClient/4.0.0-beta-23429": {
+      "System.Data.SqlClient/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Data.Common": "4.0.0",
@@ -3094,10 +3118,10 @@
           "System.Xml.ReaderWriter": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Data.SqlClient.dll": {}
+          "ref/dotnet5.4/System.Data.SqlClient.dll": {}
         }
       },
-      "System.Diagnostics.Contracts/4.0.1-beta-23429": {
+      "System.Diagnostics.Contracts/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -3109,7 +3133,7 @@
           "lib/DNXCore50/System.Diagnostics.Contracts.dll": {}
         }
       },
-      "System.Diagnostics.Debug/4.0.11-beta-23429": {
+      "System.Diagnostics.Debug/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -3118,16 +3142,16 @@
           "ref/dotnet5.4/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.FileVersionInfo/4.0.0-beta-23429": {
+      "System.Diagnostics.FileVersionInfo/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Diagnostics.FileVersionInfo.dll": {}
+          "ref/dotnet5.4/System.Diagnostics.FileVersionInfo.dll": {}
         }
       },
-      "System.Diagnostics.Process/4.1.0-beta-23429": {
+      "System.Diagnostics.Process/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3139,20 +3163,20 @@
           "ref/dotnet5.5/System.Diagnostics.Process.dll": {}
         }
       },
-      "System.Diagnostics.StackTrace/4.0.1-beta-23429": {
+      "System.Diagnostics.StackTrace/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Diagnostics.StackTrace.dll": {}
+          "ref/dotnet5.4/System.Diagnostics.StackTrace.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Diagnostics.StackTrace.dll": {}
         }
       },
-      "System.Diagnostics.Tools/4.0.1-beta-23429": {
+      "System.Diagnostics.Tools/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -3164,7 +3188,7 @@
           "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
         }
       },
-      "System.Diagnostics.Tracing/4.0.21-beta-23429": {
+      "System.Diagnostics.Tracing/4.0.21-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -3176,7 +3200,7 @@
           "lib/DNXCore50/System.Diagnostics.Tracing.dll": {}
         }
       },
-      "System.Dynamic.Runtime/4.0.11-beta-23429": {
+      "System.Dynamic.Runtime/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -3202,7 +3226,7 @@
           "lib/DNXCore50/System.Dynamic.Runtime.dll": {}
         }
       },
-      "System.Globalization/4.0.11-beta-23429": {
+      "System.Globalization/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -3214,20 +3238,20 @@
           "lib/DNXCore50/System.Globalization.dll": {}
         }
       },
-      "System.Globalization.Calendars/4.0.1-beta-23429": {
+      "System.Globalization.Calendars/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Globalization.Calendars.dll": {}
+          "ref/dotnet5.4/System.Globalization.Calendars.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Globalization.Calendars.dll": {}
         }
       },
-      "System.Globalization.Extensions/4.0.1-beta-23429": {
+      "System.Globalization.Extensions/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -3235,10 +3259,10 @@
           "System.Runtime.Extensions": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Globalization.Extensions.dll": {}
+          "ref/dotnet5.4/System.Globalization.Extensions.dll": {}
         }
       },
-      "System.IO/4.0.11-beta-23429": {
+      "System.IO/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20",
@@ -3252,7 +3276,7 @@
           "lib/DNXCore50/System.IO.dll": {}
         }
       },
-      "System.IO.Compression/4.1.0-beta-23429": {
+      "System.IO.Compression/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3264,7 +3288,7 @@
           "ref/dotnet5.4/System.IO.Compression.dll": {}
         }
       },
-      "System.IO.Compression.ZipFile/4.0.1-beta-23429": {
+      "System.IO.Compression.ZipFile/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -3277,13 +3301,13 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.2/System.IO.Compression.ZipFile.dll": {}
+          "ref/dotnet5.4/System.IO.Compression.ZipFile.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.IO.Compression.ZipFile.dll": {}
         }
       },
-      "System.IO.FileSystem/4.0.1-beta-23429": {
+      "System.IO.FileSystem/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3297,7 +3321,7 @@
           "ref/dotnet5.4/System.IO.FileSystem.dll": {}
         }
       },
-      "System.IO.FileSystem.DriveInfo/4.0.0-beta-23429": {
+      "System.IO.FileSystem.DriveInfo/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3308,28 +3332,28 @@
           "ref/dotnet5.4/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
-      "System.IO.FileSystem.Primitives/4.0.1-beta-23429": {
+      "System.IO.FileSystem.Primitives/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet5.1/System.IO.FileSystem.Primitives.dll": {}
+          "ref/dotnet5.4/System.IO.FileSystem.Primitives.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.IO.FileSystem.Primitives.dll": {}
         }
       },
-      "System.IO.FileSystem.Watcher/4.0.0-beta-23429": {
+      "System.IO.FileSystem.Watcher/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.IO.FileSystem.Watcher.dll": {}
+          "ref/dotnet5.4/System.IO.FileSystem.Watcher.dll": {}
         }
       },
-      "System.IO.MemoryMappedFiles/4.0.0-beta-23429": {
+      "System.IO.MemoryMappedFiles/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO.FileSystem": "4.0.0",
@@ -3343,7 +3367,7 @@
           "ref/dotnet5.4/System.IO.MemoryMappedFiles.dll": {}
         }
       },
-      "System.IO.Pipes/4.0.0-beta-23429": {
+      "System.IO.Pipes/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3356,7 +3380,7 @@
           "ref/dotnet5.4/System.IO.Pipes.dll": {}
         }
       },
-      "System.IO.UnmanagedMemoryStream/4.0.1-beta-23429": {
+      "System.IO.UnmanagedMemoryStream/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -3368,13 +3392,13 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.2/System.IO.UnmanagedMemoryStream.dll": {}
+          "ref/dotnet5.4/System.IO.UnmanagedMemoryStream.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.IO.UnmanagedMemoryStream.dll": {}
         }
       },
-      "System.Linq/4.0.1-beta-23429": {
+      "System.Linq/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -3390,33 +3414,17 @@
           "lib/dotnet5.4/System.Linq.dll": {}
         }
       },
-      "System.Linq.Expressions/4.0.11-beta-23429": {
+      "System.Linq.Expressions/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.Linq": "4.0.0",
-          "System.ObjectModel": "4.0.10",
-          "System.Reflection": "4.0.10",
-          "System.Reflection.Emit": "4.0.0",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Reflection.TypeExtensions": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Threading": "4.0.10"
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Linq.Expressions.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Linq.Expressions.dll": {}
         }
       },
-      "System.Linq.Parallel/4.0.1-beta-23429": {
+      "System.Linq.Parallel/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -3437,7 +3445,7 @@
           "lib/dotnet5.4/System.Linq.Parallel.dll": {}
         }
       },
-      "System.Linq.Queryable/4.0.1-beta-23429": {
+      "System.Linq.Queryable/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -3455,7 +3463,7 @@
           "lib/dotnet5.4/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23429": {
+      "System.Net.Http/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3468,7 +3476,7 @@
           "ref/dotnet5.2/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23429": {
+      "System.Net.NameResolution/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -3479,7 +3487,7 @@
           "ref/dotnet5.4/System.Net.NameResolution.dll": {}
         }
       },
-      "System.Net.NetworkInformation/4.1.0-beta-23429": {
+      "System.Net.NetworkInformation/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -3490,7 +3498,7 @@
           "ref/dotnet5.4/System.Net.NetworkInformation.dll": {}
         }
       },
-      "System.Net.Primitives/4.0.11-beta-23429": {
+      "System.Net.Primitives/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -3500,7 +3508,7 @@
           "ref/dotnet5.4/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Requests/4.0.11-beta-23429": {
+      "System.Net.Requests/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3513,20 +3521,20 @@
           "ref/dotnet5.4/System.Net.Requests.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23429": {
+      "System.Net.Security/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Net.Primitives": "4.0.10",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.Security.dll": {}
         }
       },
-      "System.Net.Sockets/4.1.0-beta-23429": {
+      "System.Net.Sockets/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3535,13 +3543,13 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.5/System.Net.Sockets.dll": {}
+          "ref/dotnet5.4/System.Net.Sockets.dll": {}
         }
       },
-      "System.Net.Utilities/4.0.0-beta-23429": {
+      "System.Net.Utilities/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23429"
+          "System.Private.Networking": "4.0.1-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.Utilities.dll": {}
@@ -3550,7 +3558,7 @@
           "lib/DNXCore50/System.Net.Utilities.dll": {}
         }
       },
-      "System.Net.WebHeaderCollection/4.0.1-beta-23429": {
+      "System.Net.WebHeaderCollection/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -3566,35 +3574,35 @@
           "lib/dotnet5.4/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23429": {
+      "System.Net.WebSockets/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
-          "System.Threading.Tasks": "4.0.0"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Net.WebSockets.dll": {}
+          "ref/dotnet5.4/System.Net.WebSockets.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23429": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
-          "System.Net.WebSockets": "4.0.0-beta-23429",
+          "System.Net.WebSockets": "4.0.0-beta-23506",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.WebSockets.Client.dll": {}
         }
       },
-      "System.Numerics.Vectors/4.1.1-beta-23429": {
+      "System.Numerics.Vectors/4.1.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -3609,7 +3617,7 @@
           "lib/dotnet5.4/System.Numerics.Vectors.dll": {}
         }
       },
-      "System.ObjectModel/4.0.11-beta-23429": {
+      "System.ObjectModel/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -3625,38 +3633,13 @@
           "lib/dotnet5.4/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.DataContractSerialization/4.1.0-beta-23429": {
+      "System.Private.DataContractSerialization/4.1.0-beta-23506": {
         "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.10",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Reflection.TypeExtensions": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23429",
-          "System.Text.Encoding": "4.0.10",
-          "System.Text.Encoding.Extensions": "4.0.10",
-          "System.Text.RegularExpressions": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Xml.ReaderWriter": "4.0.10",
-          "System.Xml.XmlSerializer": "4.0.10"
-        },
         "compile": {
           "ref/dnxcore50/_._": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23429": {
+      "System.Private.Networking/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -3675,14 +3658,14 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23429",
+          "System.Security.Principal.Windows": "4.0.0-beta-23506",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23429"
+          "System.Threading.ThreadPool": "4.0.10-beta-23506"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -3691,53 +3674,53 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23429": {
+      "System.Private.ServiceModel/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.11-beta-23429",
-          "System.Collections.Concurrent": "4.0.11-beta-23429",
-          "System.Collections.NonGeneric": "4.0.1-beta-23429",
-          "System.Collections.Specialized": "4.0.1-beta-23429",
-          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23429",
-          "System.Diagnostics.Debug": "4.0.11-beta-23429",
-          "System.Diagnostics.Tracing": "4.0.21-beta-23429",
-          "System.Globalization": "4.0.11-beta-23429",
-          "System.IO": "4.0.11-beta-23429",
-          "System.IO.Compression": "4.1.0-beta-23429",
-          "System.Linq": "4.0.1-beta-23429",
-          "System.Linq.Expressions": "4.0.11-beta-23429",
-          "System.Linq.Queryable": "4.0.1-beta-23429",
-          "System.Net.Http": "4.0.1-beta-23429",
-          "System.Net.NameResolution": "4.0.0-beta-23429",
-          "System.Net.Primitives": "4.0.11-beta-23429",
-          "System.Net.Security": "4.0.0-beta-23429",
-          "System.Net.Sockets": "4.1.0-beta-23429",
-          "System.Net.WebHeaderCollection": "4.0.1-beta-23429",
-          "System.Net.WebSockets": "4.0.0-beta-23429",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23429",
-          "System.ObjectModel": "4.0.11-beta-23429",
-          "System.Reflection": "4.1.0-beta-23429",
-          "System.Reflection.DispatchProxy": "4.0.1-beta-23429",
-          "System.Reflection.Extensions": "4.0.1-beta-23429",
-          "System.Reflection.Primitives": "4.0.1-beta-23429",
-          "System.Reflection.TypeExtensions": "4.0.1-beta-23429",
-          "System.Resources.ResourceManager": "4.0.1-beta-23429",
-          "System.Runtime": "4.0.21-beta-23429",
-          "System.Runtime.Extensions": "4.0.11-beta-23429",
-          "System.Runtime.InteropServices": "4.0.21-beta-23429",
+          "System.Collections": "4.0.11-beta-23506",
+          "System.Collections.Concurrent": "4.0.11-beta-23506",
+          "System.Collections.NonGeneric": "4.0.1-beta-23506",
+          "System.Collections.Specialized": "4.0.1-beta-23506",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23506",
+          "System.Diagnostics.Debug": "4.0.11-beta-23506",
+          "System.Diagnostics.Tracing": "4.0.21-beta-23506",
+          "System.Globalization": "4.0.11-beta-23506",
+          "System.IO": "4.0.11-beta-23506",
+          "System.IO.Compression": "4.1.0-beta-23506",
+          "System.Linq": "4.0.1-beta-23506",
+          "System.Linq.Expressions": "4.0.11-beta-23506",
+          "System.Linq.Queryable": "4.0.1-beta-23506",
+          "System.Net.Http": "4.0.1-beta-23506",
+          "System.Net.NameResolution": "4.0.0-beta-23506",
+          "System.Net.Primitives": "4.0.11-beta-23506",
+          "System.Net.Security": "4.0.0-beta-23506",
+          "System.Net.Sockets": "4.1.0-beta-23506",
+          "System.Net.WebHeaderCollection": "4.0.1-beta-23506",
+          "System.Net.WebSockets": "4.0.0-beta-23506",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23506",
+          "System.ObjectModel": "4.0.11-beta-23506",
+          "System.Reflection": "4.1.0-beta-23506",
+          "System.Reflection.DispatchProxy": "4.0.1-beta-23506",
+          "System.Reflection.Extensions": "4.0.1-beta-23506",
+          "System.Reflection.Primitives": "4.0.1-beta-23506",
+          "System.Reflection.TypeExtensions": "4.0.1-beta-23506",
+          "System.Resources.ResourceManager": "4.0.1-beta-23506",
+          "System.Runtime": "4.0.21-beta-23506",
+          "System.Runtime.Extensions": "4.0.11-beta-23506",
+          "System.Runtime.InteropServices": "4.0.21-beta-23506",
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
-          "System.Security.Claims": "4.0.1-beta-23429",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
-          "System.Security.Principal": "4.0.1-beta-23429",
-          "System.Security.Principal.Windows": "4.0.0-beta-23429",
-          "System.Text.Encoding": "4.0.11-beta-23429",
-          "System.Threading": "4.0.11-beta-23429",
-          "System.Threading.Tasks": "4.0.11-beta-23429",
-          "System.Threading.Timer": "4.0.1-beta-23429",
-          "System.Xml.ReaderWriter": "4.0.11-beta-23429",
-          "System.Xml.XmlDocument": "4.0.1-beta-23429",
-          "System.Xml.XmlSerializer": "4.0.11-beta-23429"
+          "System.Security.Claims": "4.0.1-beta-23506",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
+          "System.Security.Principal": "4.0.1-beta-23506",
+          "System.Security.Principal.Windows": "4.0.0-beta-23506",
+          "System.Text.Encoding": "4.0.11-beta-23506",
+          "System.Threading": "4.0.11-beta-23506",
+          "System.Threading.Tasks": "4.0.11-beta-23506",
+          "System.Threading.Timer": "4.0.1-beta-23506",
+          "System.Xml.ReaderWriter": "4.0.11-beta-23506",
+          "System.Xml.XmlDocument": "4.0.1-beta-23506",
+          "System.Xml.XmlSerializer": "4.0.11-beta-23506"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -3746,13 +3729,13 @@
           "lib/DNXCore50/System.Private.ServiceModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.1-beta-23429": {
+      "System.Private.Uri/4.0.1-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
         }
       },
-      "System.Reflection/4.1.0-beta-23429": {
+      "System.Reflection/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3766,26 +3749,17 @@
           "lib/DNXCore50/System.Reflection.dll": {}
         }
       },
-      "System.Reflection.DispatchProxy/4.0.1-beta-23429": {
+      "System.Reflection.DispatchProxy/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.10",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Threading": "4.0.10"
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Reflection.DispatchProxy.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Reflection.DispatchProxy.dll": {}
+          "ref/dotnet5.4/System.Reflection.DispatchProxy.dll": {}
         }
       },
-      "System.Reflection.Emit/4.0.1-beta-23429": {
+      "System.Reflection.Emit/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3801,7 +3775,7 @@
           "lib/DNXCore50/System.Reflection.Emit.dll": {}
         }
       },
-      "System.Reflection.Emit.ILGeneration/4.0.1-beta-23429": {
+      "System.Reflection.Emit.ILGeneration/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -3815,7 +3789,7 @@
           "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
         }
       },
-      "System.Reflection.Emit.Lightweight/4.0.1-beta-23429": {
+      "System.Reflection.Emit.Lightweight/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -3830,7 +3804,7 @@
           "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll": {}
         }
       },
-      "System.Reflection.Extensions/4.0.1-beta-23429": {
+      "System.Reflection.Extensions/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -3843,7 +3817,7 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.1.1-beta-23429": {
+      "System.Reflection.Metadata/1.1.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -3868,7 +3842,7 @@
           "lib/dotnet5.2/System.Reflection.Metadata.dll": {}
         }
       },
-      "System.Reflection.Primitives/4.0.1-beta-23429": {
+      "System.Reflection.Primitives/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -3880,20 +3854,20 @@
           "lib/DNXCore50/System.Reflection.Primitives.dll": {}
         }
       },
-      "System.Reflection.TypeExtensions/4.1.0-beta-23429": {
+      "System.Reflection.TypeExtensions/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Reflection.TypeExtensions.dll": {}
+          "ref/dotnet5.4/System.Reflection.TypeExtensions.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
         }
       },
-      "System.Resources.ReaderWriter/4.0.0-beta-23429": {
+      "System.Resources.ReaderWriter/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -3905,13 +3879,13 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Resources.ReaderWriter.dll": {}
+          "ref/dotnet5.4/System.Resources.ReaderWriter.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Resources.ReaderWriter.dll": {}
         }
       },
-      "System.Resources.ResourceManager/4.0.1-beta-23429": {
+      "System.Resources.ResourceManager/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -3925,10 +3899,10 @@
           "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
         }
       },
-      "System.Runtime/4.0.21-beta-23429": {
+      "System.Runtime/4.0.21-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.Uri": "4.0.1-beta-23429"
+          "System.Private.Uri": "4.0.1-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Runtime.dll": {}
@@ -3937,19 +3911,19 @@
           "lib/DNXCore50/System.Runtime.dll": {}
         }
       },
-      "System.Runtime.CompilerServices.VisualC/4.0.0-beta-23429": {
+      "System.Runtime.CompilerServices.VisualC/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Runtime.CompilerServices.VisualC.dll": {}
+          "ref/dotnet5.4/System.Runtime.CompilerServices.VisualC.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Runtime.CompilerServices.VisualC.dll": {}
         }
       },
-      "System.Runtime.Extensions/4.0.11-beta-23429": {
+      "System.Runtime.Extensions/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -3958,7 +3932,7 @@
           "ref/dotnet5.4/System.Runtime.Extensions.dll": {}
         }
       },
-      "System.Runtime.Handles/4.0.1-beta-23429": {
+      "System.Runtime.Handles/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -3970,7 +3944,7 @@
           "lib/DNXCore50/System.Runtime.Handles.dll": {}
         }
       },
-      "System.Runtime.InteropServices/4.0.21-beta-23429": {
+      "System.Runtime.InteropServices/4.0.21-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -3985,16 +3959,16 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23429": {
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+          "ref/dotnet5.2/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "System.Runtime.Loader/4.0.0-beta-23429": {
+      "System.Runtime.Loader/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -4008,7 +3982,7 @@
           "lib/DNXCore50/System.Runtime.Loader.dll": {}
         }
       },
-      "System.Runtime.Numerics/4.0.1-beta-23429": {
+      "System.Runtime.Numerics/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -4023,10 +3997,10 @@
           "lib/dotnet5.4/System.Runtime.Numerics.dll": {}
         }
       },
-      "System.Runtime.Serialization.Json/4.0.1-beta-23429": {
+      "System.Runtime.Serialization.Json/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.1.0-beta-23429"
+          "System.Private.DataContractSerialization": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.1/System.Runtime.Serialization.Json.dll": {}
@@ -4035,7 +4009,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Json.dll": {}
         }
       },
-      "System.Runtime.Serialization.Primitives/4.1.0-beta-23429": {
+      "System.Runtime.Serialization.Primitives/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -4048,11 +4022,11 @@
           "lib/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
         }
       },
-      "System.Runtime.Serialization.Xml/4.1.0-beta-23429": {
+      "System.Runtime.Serialization.Xml/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.1.0-beta-23429",
-          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23429"
+          "System.Private.DataContractSerialization": "4.1.0-beta-23506",
+          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Runtime.Serialization.Xml.dll": {}
@@ -4061,7 +4035,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Xml.dll": {}
         }
       },
-      "System.Security.Claims/4.0.1-beta-23429": {
+      "System.Security.Claims/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -4074,24 +4048,24 @@
           "System.Security.Principal": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Claims.dll": {}
+          "ref/dotnet5.4/System.Security.Claims.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23429": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Cryptography.Algorithms.dll": {}
+          "ref/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Cng/4.0.0-beta-23429": {
+      "System.Security.Cryptography.Cng/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -4100,18 +4074,18 @@
           "System.Runtime.Extensions": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.2/System.Security.Cryptography.Cng.dll": {}
+          "ref/dotnet5.4/System.Security.Cryptography.Cng.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Security.Cryptography.Cng.dll": {}
         }
       },
-      "System.Security.Cryptography.Csp/4.0.0-beta-23429": {
+      "System.Security.Cryptography.Csp/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -4121,29 +4095,29 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Cryptography.Csp.dll": {}
+          "ref/dotnet5.4/System.Security.Cryptography.Csp.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Security.Cryptography.Csp.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23429": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Cryptography.Encoding.dll": {}
+          "ref/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23429": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -4155,25 +4129,25 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Cryptography.Primitives.dll": {}
+          "ref/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23429": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23429"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
-      "System.Security.Principal/4.0.1-beta-23429": {
+      "System.Security.Principal/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -4185,7 +4159,7 @@
           "lib/dotnet5.1/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23429": {
+      "System.Security.Principal.Windows/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -4208,10 +4182,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23429": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429"
+          "System.Private.ServiceModel": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.2/System.ServiceModel.Duplex.dll": {}
@@ -4220,10 +4194,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23429": {
+      "System.ServiceModel.Http/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429",
+          "System.Private.ServiceModel": "4.1.0-beta-23506",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -4233,10 +4207,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.1.0-beta-23429": {
+      "System.ServiceModel.NetTcp/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429"
+          "System.Private.ServiceModel": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.ServiceModel.NetTcp.dll": {}
@@ -4245,10 +4219,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.1.0-beta-23429": {
+      "System.ServiceModel.Primitives/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429"
+          "System.Private.ServiceModel": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.ServiceModel.Primitives.dll": {}
@@ -4257,10 +4231,10 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
-      "System.ServiceModel.Security/4.0.1-beta-23429": {
+      "System.ServiceModel.Security/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429"
+          "System.Private.ServiceModel": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.2/System.ServiceModel.Security.dll": {}
@@ -4269,7 +4243,7 @@
           "lib/DNXCore50/System.ServiceModel.Security.dll": {}
         }
       },
-      "System.Text.Encoding/4.0.11-beta-23429": {
+      "System.Text.Encoding/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -4281,29 +4255,17 @@
           "lib/DNXCore50/System.Text.Encoding.dll": {}
         }
       },
-      "System.Text.Encoding.CodePages/4.0.0": {
+      "System.Text.Encoding.CodePages/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.Reflection": "4.0.10",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Runtime.Handles": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Text.Encoding": "4.0.10",
-          "System.Threading": "4.0.10"
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/System.Text.Encoding.CodePages.dll": {}
+          "ref/dotnet5.4/System.Text.Encoding.CodePages.dll": {}
         }
       },
-      "System.Text.Encoding.Extensions/4.0.11-beta-23429": {
+      "System.Text.Encoding.Extensions/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -4316,7 +4278,7 @@
           "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
         }
       },
-      "System.Text.RegularExpressions/4.0.11-beta-23429": {
+      "System.Text.RegularExpressions/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -4333,7 +4295,7 @@
           "lib/dotnet5.4/System.Text.RegularExpressions.dll": {}
         }
       },
-      "System.Threading/4.0.11-beta-23429": {
+      "System.Threading/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -4343,20 +4305,20 @@
           "ref/dotnet5.4/System.Threading.dll": {}
         }
       },
-      "System.Threading.Overlapped/4.0.0": {
+      "System.Threading.Overlapped/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Overlapped.dll": {}
+          "ref/dotnet5.4/System.Threading.Overlapped.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Overlapped.dll": {}
         }
       },
-      "System.Threading.Tasks/4.0.11-beta-23429": {
+      "System.Threading.Tasks/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -4368,7 +4330,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.Tasks.Dataflow/4.5.26-beta-23429": {
+      "System.Threading.Tasks.Dataflow/4.5.26-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -4390,7 +4352,7 @@
           "lib/dotnet5.2/System.Threading.Tasks.Dataflow.dll": {}
         }
       },
-      "System.Threading.Tasks.Parallel/4.0.1-beta-23429": {
+      "System.Threading.Tasks.Parallel/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections.Concurrent": "4.0.10",
@@ -4409,32 +4371,32 @@
           "lib/dotnet5.4/System.Threading.Tasks.Parallel.dll": {}
         }
       },
-      "System.Threading.Thread/4.0.0-beta-23429": {
+      "System.Threading.Thread/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Threading.Thread.dll": {}
+          "ref/dotnet5.4/System.Threading.Thread.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Thread.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23429": {
+      "System.Threading.ThreadPool/4.0.10-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.InteropServices": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.2/System.Threading.ThreadPool.dll": {}
+          "ref/dotnet5.4/System.Threading.ThreadPool.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
-      "System.Threading.Timer/4.0.1-beta-23429": {
+      "System.Threading.Timer/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -4446,7 +4408,7 @@
           "lib/DNXCore50/System.Threading.Timer.dll": {}
         }
       },
-      "System.Xml.ReaderWriter/4.0.11-beta-23429": {
+      "System.Xml.ReaderWriter/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -4471,7 +4433,7 @@
           "lib/dotnet5.4/System.Xml.ReaderWriter.dll": {}
         }
       },
-      "System.Xml.XDocument/4.0.11-beta-23429": {
+      "System.Xml.XDocument/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -4494,7 +4456,7 @@
           "lib/dotnet5.4/System.Xml.XDocument.dll": {}
         }
       },
-      "System.Xml.XmlDocument/4.0.1-beta-23429": {
+      "System.Xml.XmlDocument/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -4509,37 +4471,21 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Xml.XmlDocument.dll": {}
+          "ref/dotnet5.4/System.Xml.XmlDocument.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Xml.XmlDocument.dll": {}
         }
       },
-      "System.Xml.XmlSerializer/4.0.11-beta-23429": {
+      "System.Xml.XmlSerializer/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.10",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Reflection.TypeExtensions": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Text.RegularExpressions": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Xml.ReaderWriter": "4.0.10",
-          "System.Xml.XmlDocument": "4.0.0"
+          "System.IO": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet5.4/System.Xml.XmlSerializer.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
         }
       },
       "xunit/2.1.0": {
@@ -4699,7 +4645,7 @@
       "coveralls.io/1.4.0": {
         "type": "package"
       },
-      "Microsoft.CSharp/4.0.1-beta-23429": {
+      "Microsoft.CSharp/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -4735,169 +4681,147 @@
           "xunit.runner.console": "2.1.0"
         }
       },
-      "Microsoft.NETCore/5.0.1-beta-23429": {
+      "Microsoft.NETCore/5.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "Microsoft.CSharp": "4.0.1-beta-23429",
-          "Microsoft.NETCore.Targets": "1.0.1-beta-23429",
-          "Microsoft.VisualBasic": "10.0.1-beta-23429",
-          "System.AppContext": "4.0.1-beta-23429",
-          "System.Collections": "4.0.11-beta-23429",
-          "System.Collections.Concurrent": "4.0.11-beta-23429",
-          "System.Collections.Immutable": "1.1.38-beta-23429",
-          "System.ComponentModel": "4.0.1-beta-23429",
-          "System.ComponentModel.Annotations": "4.0.11-beta-23429",
-          "System.Diagnostics.Debug": "4.0.11-beta-23429",
-          "System.Diagnostics.Tools": "4.0.1-beta-23429",
-          "System.Diagnostics.Tracing": "4.0.21-beta-23429",
-          "System.Dynamic.Runtime": "4.0.11-beta-23429",
-          "System.Globalization": "4.0.11-beta-23429",
-          "System.Globalization.Calendars": "4.0.1-beta-23429",
-          "System.Globalization.Extensions": "4.0.1-beta-23429",
-          "System.IO": "4.0.11-beta-23429",
-          "System.IO.Compression": "4.1.0-beta-23429",
-          "System.IO.Compression.ZipFile": "4.0.1-beta-23429",
-          "System.IO.FileSystem": "4.0.1-beta-23429",
-          "System.IO.FileSystem.Primitives": "4.0.1-beta-23429",
-          "System.IO.UnmanagedMemoryStream": "4.0.1-beta-23429",
-          "System.Linq": "4.0.1-beta-23429",
-          "System.Linq.Expressions": "4.0.11-beta-23429",
-          "System.Linq.Parallel": "4.0.1-beta-23429",
-          "System.Linq.Queryable": "4.0.1-beta-23429",
-          "System.Net.Http": "4.0.1-beta-23429",
-          "System.Net.NetworkInformation": "4.1.0-beta-23429",
-          "System.Net.Primitives": "4.0.11-beta-23429",
-          "System.Numerics.Vectors": "4.1.1-beta-23429",
-          "System.ObjectModel": "4.0.11-beta-23429",
-          "System.Reflection": "4.1.0-beta-23429",
-          "System.Reflection.DispatchProxy": "4.0.1-beta-23429",
-          "System.Reflection.Extensions": "4.0.1-beta-23429",
-          "System.Reflection.Metadata": "1.1.1-beta-23429",
-          "System.Reflection.Primitives": "4.0.1-beta-23429",
-          "System.Reflection.TypeExtensions": "4.1.0-beta-23429",
-          "System.Resources.ResourceManager": "4.0.1-beta-23429",
-          "System.Runtime": "4.0.21-beta-23429",
-          "System.Runtime.Extensions": "4.0.11-beta-23429",
-          "System.Runtime.Handles": "4.0.1-beta-23429",
-          "System.Runtime.InteropServices": "4.0.21-beta-23429",
-          "System.Runtime.Numerics": "4.0.1-beta-23429",
-          "System.Security.Claims": "4.0.1-beta-23429",
-          "System.Security.Principal": "4.0.1-beta-23429",
-          "System.Text.Encoding": "4.0.11-beta-23429",
-          "System.Text.Encoding.Extensions": "4.0.11-beta-23429",
-          "System.Text.RegularExpressions": "4.0.11-beta-23429",
-          "System.Threading": "4.0.11-beta-23429",
-          "System.Threading.Tasks": "4.0.11-beta-23429",
-          "System.Threading.Tasks.Dataflow": "4.5.26-beta-23429",
-          "System.Threading.Tasks.Parallel": "4.0.1-beta-23429",
-          "System.Threading.Timer": "4.0.1-beta-23429",
-          "System.Xml.ReaderWriter": "4.0.11-beta-23429",
-          "System.Xml.XDocument": "4.0.11-beta-23429"
+          "Microsoft.CSharp": "4.0.1-beta-23506",
+          "Microsoft.NETCore.Platforms": "1.0.1-beta-23506",
+          "Microsoft.VisualBasic": "10.0.1-beta-23506",
+          "System.AppContext": "4.0.1-beta-23506",
+          "System.Collections": "4.0.11-beta-23506",
+          "System.Collections.Concurrent": "4.0.11-beta-23506",
+          "System.Collections.Immutable": "1.1.38-beta-23506",
+          "System.ComponentModel": "4.0.1-beta-23506",
+          "System.ComponentModel.Annotations": "4.0.11-beta-23506",
+          "System.Diagnostics.Debug": "4.0.11-beta-23506",
+          "System.Diagnostics.Tools": "4.0.1-beta-23506",
+          "System.Diagnostics.Tracing": "4.0.21-beta-23506",
+          "System.Dynamic.Runtime": "4.0.11-beta-23506",
+          "System.Globalization": "4.0.11-beta-23506",
+          "System.Globalization.Calendars": "4.0.1-beta-23506",
+          "System.Globalization.Extensions": "4.0.1-beta-23506",
+          "System.IO": "4.0.11-beta-23506",
+          "System.IO.Compression": "4.1.0-beta-23506",
+          "System.IO.Compression.ZipFile": "4.0.1-beta-23506",
+          "System.IO.FileSystem": "4.0.1-beta-23506",
+          "System.IO.FileSystem.Primitives": "4.0.1-beta-23506",
+          "System.IO.UnmanagedMemoryStream": "4.0.1-beta-23506",
+          "System.Linq": "4.0.1-beta-23506",
+          "System.Linq.Expressions": "4.0.11-beta-23506",
+          "System.Linq.Parallel": "4.0.1-beta-23506",
+          "System.Linq.Queryable": "4.0.1-beta-23506",
+          "System.Net.Http": "4.0.1-beta-23506",
+          "System.Net.NetworkInformation": "4.1.0-beta-23506",
+          "System.Net.Primitives": "4.0.11-beta-23506",
+          "System.Numerics.Vectors": "4.1.1-beta-23506",
+          "System.ObjectModel": "4.0.11-beta-23506",
+          "System.Reflection": "4.1.0-beta-23506",
+          "System.Reflection.DispatchProxy": "4.0.1-beta-23506",
+          "System.Reflection.Extensions": "4.0.1-beta-23506",
+          "System.Reflection.Metadata": "1.1.1-beta-23506",
+          "System.Reflection.Primitives": "4.0.1-beta-23506",
+          "System.Reflection.TypeExtensions": "4.1.0-beta-23506",
+          "System.Resources.ResourceManager": "4.0.1-beta-23506",
+          "System.Runtime": "4.0.21-beta-23506",
+          "System.Runtime.Extensions": "4.0.11-beta-23506",
+          "System.Runtime.Handles": "4.0.1-beta-23506",
+          "System.Runtime.InteropServices": "4.0.21-beta-23506",
+          "System.Runtime.Numerics": "4.0.1-beta-23506",
+          "System.Security.Claims": "4.0.1-beta-23506",
+          "System.Security.Principal": "4.0.1-beta-23506",
+          "System.Text.Encoding": "4.0.11-beta-23506",
+          "System.Text.Encoding.Extensions": "4.0.11-beta-23506",
+          "System.Text.RegularExpressions": "4.0.11-beta-23506",
+          "System.Threading": "4.0.11-beta-23506",
+          "System.Threading.Tasks": "4.0.11-beta-23506",
+          "System.Threading.Tasks.Dataflow": "4.5.26-beta-23506",
+          "System.Threading.Tasks.Parallel": "4.0.1-beta-23506",
+          "System.Threading.Timer": "4.0.1-beta-23506",
+          "System.Xml.ReaderWriter": "4.0.11-beta-23506",
+          "System.Xml.XDocument": "4.0.11-beta-23506"
         }
       },
-      "Microsoft.NETCore.Console/1.0.0-beta-23429": {
+      "Microsoft.NETCore.Console/1.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore": "5.0.1-beta-23429",
-          "Microsoft.NETCore.ConsoleHost": "1.0.0-beta-23429",
-          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23429",
-          "Microsoft.Win32.Primitives": "4.0.1-beta-23429",
-          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23429",
-          "System.Console": "4.0.0-beta-23429",
-          "System.Data.Common": "4.0.1-beta-23429",
-          "System.Data.SqlClient": "4.0.0-beta-23429",
-          "System.Diagnostics.Contracts": "4.0.1-beta-23429",
-          "System.Diagnostics.FileVersionInfo": "4.0.0-beta-23429",
-          "System.Diagnostics.Process": "4.1.0-beta-23429",
-          "System.Diagnostics.StackTrace": "4.0.1-beta-23429",
-          "System.IO.FileSystem.DriveInfo": "4.0.0-beta-23429",
-          "System.IO.FileSystem.Watcher": "4.0.0-beta-23429",
-          "System.IO.MemoryMappedFiles": "4.0.0-beta-23429",
-          "System.IO.Pipes": "4.0.0-beta-23429",
-          "System.Net.NameResolution": "4.0.0-beta-23429",
-          "System.Net.NetworkInformation": "4.1.0-beta-23429",
-          "System.Net.Requests": "4.0.11-beta-23429",
-          "System.Net.Security": "4.0.0-beta-23429",
-          "System.Net.Sockets": "4.1.0-beta-23429",
-          "System.Net.Utilities": "4.0.0-beta-23429",
-          "System.Net.WebHeaderCollection": "4.0.1-beta-23429",
-          "System.Net.WebSockets": "4.0.0-beta-23429",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23429",
-          "System.Reflection.Emit": "4.0.1-beta-23429",
-          "System.Reflection.Emit.ILGeneration": "4.0.1-beta-23429",
-          "System.Reflection.Emit.Lightweight": "4.0.1-beta-23429",
-          "System.Resources.ReaderWriter": "4.0.0-beta-23429",
-          "System.Runtime.CompilerServices.VisualC": "4.0.0-beta-23429",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23429",
-          "System.Runtime.Loader": "4.0.0-beta-23429",
-          "System.Runtime.Serialization.Json": "4.0.1-beta-23429",
-          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23429",
-          "System.Runtime.Serialization.Xml": "4.1.0-beta-23429",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
-          "System.ServiceModel.Duplex": "4.0.1-beta-23429",
-          "System.ServiceModel.Http": "4.0.11-beta-23429",
-          "System.ServiceModel.NetTcp": "4.1.0-beta-23429",
-          "System.ServiceModel.Primitives": "4.1.0-beta-23429",
-          "System.ServiceModel.Security": "4.0.1-beta-23429",
-          "System.Xml.XmlSerializer": "4.0.11-beta-23429"
+          "Microsoft.NETCore": "5.0.1-beta-23506",
+          "Microsoft.NETCore.ConsoleHost": "1.0.0-beta-23506",
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23506",
+          "Microsoft.Win32.Primitives": "4.0.1-beta-23506",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23506",
+          "System.Console": "4.0.0-beta-23506",
+          "System.Data.Common": "4.0.1-beta-23506",
+          "System.Data.SqlClient": "4.0.0-beta-23506",
+          "System.Diagnostics.Contracts": "4.0.1-beta-23506",
+          "System.Diagnostics.FileVersionInfo": "4.0.0-beta-23506",
+          "System.Diagnostics.Process": "4.1.0-beta-23506",
+          "System.Diagnostics.StackTrace": "4.0.1-beta-23506",
+          "System.IO.FileSystem.DriveInfo": "4.0.0-beta-23506",
+          "System.IO.FileSystem.Watcher": "4.0.0-beta-23506",
+          "System.IO.MemoryMappedFiles": "4.0.0-beta-23506",
+          "System.IO.Pipes": "4.0.0-beta-23506",
+          "System.Net.NameResolution": "4.0.0-beta-23506",
+          "System.Net.NetworkInformation": "4.1.0-beta-23506",
+          "System.Net.Requests": "4.0.11-beta-23506",
+          "System.Net.Security": "4.0.0-beta-23506",
+          "System.Net.Sockets": "4.1.0-beta-23506",
+          "System.Net.Utilities": "4.0.0-beta-23506",
+          "System.Net.WebHeaderCollection": "4.0.1-beta-23506",
+          "System.Net.WebSockets": "4.0.0-beta-23506",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23506",
+          "System.Reflection.Emit": "4.0.1-beta-23506",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-beta-23506",
+          "System.Reflection.Emit.Lightweight": "4.0.1-beta-23506",
+          "System.Resources.ReaderWriter": "4.0.0-beta-23506",
+          "System.Runtime.CompilerServices.VisualC": "4.0.0-beta-23506",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23506",
+          "System.Runtime.Loader": "4.0.0-beta-23506",
+          "System.Runtime.Serialization.Json": "4.0.1-beta-23506",
+          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23506",
+          "System.Runtime.Serialization.Xml": "4.1.0-beta-23506",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
+          "System.ServiceModel.Duplex": "4.0.1-beta-23506",
+          "System.ServiceModel.Http": "4.0.11-beta-23506",
+          "System.ServiceModel.NetTcp": "4.1.0-beta-23506",
+          "System.ServiceModel.Primitives": "4.1.0-beta-23506",
+          "System.ServiceModel.Security": "4.0.1-beta-23506",
+          "System.Xml.XmlSerializer": "4.0.11-beta-23506"
         }
       },
-      "Microsoft.NETCore.ConsoleHost/1.0.0-beta-23429": {
+      "Microsoft.NETCore.ConsoleHost/1.0.0-beta-23506": {
         "type": "package"
       },
-      "Microsoft.NETCore.Platforms/1.0.1-beta-23429": {
-        "type": "package"
-      },
-      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23429": {
+      "Microsoft.NETCore.Platforms/1.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-beta-23429",
-          "System.Collections": "[4.0.11-beta-23429]",
-          "System.Diagnostics.Contracts": "[4.0.1-beta-23429]",
-          "System.Diagnostics.Debug": "[4.0.11-beta-23429]",
-          "System.Diagnostics.StackTrace": "[4.0.1-beta-23429]",
-          "System.Diagnostics.Tools": "[4.0.1-beta-23429]",
-          "System.Diagnostics.Tracing": "[4.0.21-beta-23429]",
-          "System.Globalization": "[4.0.11-beta-23429]",
-          "System.Globalization.Calendars": "[4.0.1-beta-23429]",
-          "System.IO": "[4.0.11-beta-23429]",
-          "System.ObjectModel": "[4.0.11-beta-23429]",
-          "System.Private.Uri": "[4.0.1-beta-23429]",
-          "System.Reflection": "[4.1.0-beta-23429]",
-          "System.Reflection.Extensions": "[4.0.1-beta-23429]",
-          "System.Reflection.Primitives": "[4.0.1-beta-23429]",
-          "System.Resources.ResourceManager": "[4.0.1-beta-23429]",
-          "System.Runtime": "[4.0.21-beta-23429]",
-          "System.Runtime.Extensions": "[4.0.11-beta-23429]",
-          "System.Runtime.Handles": "[4.0.1-beta-23429]",
-          "System.Runtime.InteropServices": "[4.0.21-beta-23429]",
-          "System.Text.Encoding": "[4.0.11-beta-23429]",
-          "System.Text.Encoding.Extensions": "[4.0.11-beta-23429]",
-          "System.Threading": "[4.0.11-beta-23429]",
-          "System.Threading.Tasks": "[4.0.11-beta-23429]",
-          "System.Threading.Timer": "[4.0.1-beta-23429]"
+          "Microsoft.NETCore.Targets": "1.0.1-beta-23506"
         }
       },
-      "Microsoft.NETCore.Targets/1.0.1-beta-23429": {
+      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1-beta-23429",
-          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-beta-23429"
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-beta-23506"
         }
       },
-      "Microsoft.NETCore.Targets.DNXCore/5.0.0-beta-23429": {
+      "Microsoft.NETCore.Targets/1.0.1-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-beta-23506"
+        }
+      },
+      "Microsoft.NETCore.Targets.DNXCore/5.0.0-beta-23506": {
         "type": "package"
       },
-      "Microsoft.NETCore.TestHost/1.0.0-beta-23429": {
+      "Microsoft.NETCore.TestHost/1.0.0-beta-23506": {
         "type": "package"
       },
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23429": {
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23506": {
         "type": "package"
       },
-      "Microsoft.VisualBasic/10.0.1-beta-23429": {
+      "Microsoft.VisualBasic/10.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -4924,16 +4848,16 @@
           "lib/dotnet5.4/Microsoft.VisualBasic.dll": {}
         }
       },
-      "Microsoft.Win32.Primitives/4.0.1-beta-23429": {
+      "Microsoft.Win32.Primitives/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/Microsoft.Win32.Primitives.dll": {}
+          "ref/dotnet5.4/Microsoft.Win32.Primitives.dll": {}
         }
       },
-      "Microsoft.Win32.Registry/4.0.0-beta-23429": {
+      "Microsoft.Win32.Registry/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -4945,7 +4869,7 @@
           "System.Runtime.InteropServices": "4.0.20"
         },
         "compile": {
-          "ref/dotnet5.2/Microsoft.Win32.Registry.dll": {}
+          "ref/dotnet5.4/Microsoft.Win32.Registry.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/Microsoft.Win32.Registry.dll": {}
@@ -4957,7 +4881,118 @@
       "ReportGenerator/2.3.1": {
         "type": "package"
       },
-      "runtime.win.System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23429": {
+      "runtime.any.System.Linq.Expressions/4.0.11-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Linq.Expressions.dll": {}
+        }
+      },
+      "runtime.any.System.Private.DataContractSerialization/4.1.0-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23506",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection.DispatchProxy/4.0.1-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.DispatchProxy.dll": {}
+        }
+      },
+      "runtime.any.System.Xml.XmlSerializer/4.0.11-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
+        }
+      },
+      "runtime.win.System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -4970,7 +5005,29 @@
           "runtimes/win/lib/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "runtime.win7.Microsoft.Win32.Primitives/4.0.1-beta-23429": {
+      "runtime.win.System.Text.Encoding.CodePages/4.0.1-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/win/lib/dotnet5.4/System.Text.Encoding.CodePages.dll": {}
+        }
+      },
+      "runtime.win7.Microsoft.Win32.Primitives/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20",
@@ -4983,7 +5040,7 @@
           "runtimes/win7/lib/dotnet5.4/Microsoft.Win32.Primitives.dll": {}
         }
       },
-      "runtime.win7.System.Console/4.0.0-beta-23429": {
+      "runtime.win7.System.Console/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -5003,7 +5060,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Console.dll": {}
         }
       },
-      "runtime.win7.System.Data.SqlClient/4.0.0-beta-23429": {
+      "runtime.win7.System.Data.SqlClient/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -5015,10 +5072,10 @@
           "System.Globalization": "4.0.10",
           "System.IO": "4.0.10",
           "System.Linq": "4.0.0",
-          "System.Net.NameResolution": "4.0.0-beta-23429",
+          "System.Net.NameResolution": "4.0.0-beta-23506",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23429",
-          "System.Net.Sockets": "4.0.10-beta-23429",
+          "System.Net.Security": "4.0.0-beta-23506",
+          "System.Net.Sockets": "4.0.10-beta-23506",
           "System.Reflection": "4.0.0",
           "System.Reflection.TypeExtensions": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
@@ -5026,16 +5083,17 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
-          "System.Security.Principal.Windows": "4.0.0-beta-23429",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23506",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
+          "System.Security.Principal.Windows": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.10",
           "System.Text.Encoding.CodePages": "4.0.0",
           "System.Text.Encoding.Extensions": "4.0.0",
           "System.Text.RegularExpressions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.Thread": "4.0.0-beta-23429",
-          "System.Threading.ThreadPool": "4.0.0-beta-23429",
+          "System.Threading.Thread": "4.0.0-beta-23506",
+          "System.Threading.ThreadPool": "4.0.0-beta-23506",
           "System.Threading.Timer": "4.0.0",
           "System.Xml.ReaderWriter": "4.0.0"
         },
@@ -5046,7 +5104,7 @@
           "runtimes/win7/lib/DNXCore50/System.Data.SqlClient.dll": {}
         }
       },
-      "runtime.win7.System.Diagnostics.Debug/4.0.11-beta-23429": {
+      "runtime.win7.System.Diagnostics.Debug/4.0.11-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -5055,7 +5113,7 @@
           "runtimes/win7/lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "runtime.win7.System.Diagnostics.FileVersionInfo/4.0.0-beta-23429": {
+      "runtime.win7.System.Diagnostics.FileVersionInfo/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -5070,11 +5128,11 @@
           "runtimes/win7/lib/dotnet5.4/System.Diagnostics.FileVersionInfo.dll": {}
         }
       },
-      "runtime.win7.System.Diagnostics.Process/4.1.0-beta-23429": {
+      "runtime.win7.System.Diagnostics.Process/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
-          "Microsoft.Win32.Registry": "4.0.0-beta-23429",
+          "Microsoft.Win32.Registry": "4.0.0-beta-23506",
           "System.Collections": "4.0.10",
           "System.Diagnostics.Debug": "4.0.10",
           "System.Globalization": "4.0.10",
@@ -5090,8 +5148,8 @@
           "System.Text.Encoding.Extensions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.Thread": "4.0.0-beta-23429",
-          "System.Threading.ThreadPool": "4.0.10-beta-23429"
+          "System.Threading.Thread": "4.0.0-beta-23506",
+          "System.Threading.ThreadPool": "4.0.10-beta-23506"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -5100,7 +5158,7 @@
           "runtimes/win7/lib/dotnet5.5/System.Diagnostics.Process.dll": {}
         }
       },
-      "runtime.win7.System.Globalization.Extensions/4.0.1-beta-23429": {
+      "runtime.win7.System.Globalization.Extensions/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -5116,7 +5174,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Globalization.Extensions.dll": {}
         }
       },
-      "runtime.win7.System.IO.Compression/4.1.0-beta-23429": {
+      "runtime.win7.System.IO.Compression/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -5138,7 +5196,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.Compression.dll": {}
         }
       },
-      "runtime.win7.System.IO.FileSystem/4.0.1-beta-23429": {
+      "runtime.win7.System.IO.FileSystem/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -5162,7 +5220,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.FileSystem.dll": {}
         }
       },
-      "runtime.win7.System.IO.FileSystem.DriveInfo/4.0.0-beta-23429": {
+      "runtime.win7.System.IO.FileSystem.DriveInfo/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO.FileSystem": "4.0.0",
@@ -5180,7 +5238,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
-      "runtime.win7.System.IO.FileSystem.Watcher/4.0.0-beta-23429": {
+      "runtime.win7.System.IO.FileSystem.Watcher/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -5200,7 +5258,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.FileSystem.Watcher.dll": {}
         }
       },
-      "runtime.win7.System.IO.MemoryMappedFiles/4.0.0-beta-23429": {
+      "runtime.win7.System.IO.MemoryMappedFiles/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -5221,7 +5279,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.MemoryMappedFiles.dll": {}
         }
       },
-      "runtime.win7.System.IO.Pipes/4.0.0-beta-23429": {
+      "runtime.win7.System.IO.Pipes/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -5243,7 +5301,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.Pipes.dll": {}
         }
       },
-      "runtime.win7.System.Net.Http/4.0.1-beta-23429": {
+      "runtime.win7.System.Net.Http/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -5258,7 +5316,7 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.0",
           "System.Threading.Tasks": "4.0.10"
@@ -5270,10 +5328,10 @@
           "runtimes/win7/lib/DNXCore50/System.Net.Http.dll": {}
         }
       },
-      "runtime.win7.System.Net.NameResolution/4.0.0-beta-23429": {
+      "runtime.win7.System.Net.NameResolution/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23429"
+          "System.Private.Networking": "4.0.1-beta-23506"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -5282,10 +5340,10 @@
           "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
-      "runtime.win7.System.Net.NetworkInformation/4.1.0-beta-23429": {
+      "runtime.win7.System.Net.NetworkInformation/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23429",
+          "System.Private.Networking": "4.0.1-beta-23506",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -5295,10 +5353,10 @@
           "lib/DNXCore50/System.Net.NetworkInformation.dll": {}
         }
       },
-      "runtime.win7.System.Net.Primitives/4.0.11-beta-23429": {
+      "runtime.win7.System.Net.Primitives/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23429"
+          "System.Private.Networking": "4.0.1-beta-23506"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -5307,7 +5365,7 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "runtime.win7.System.Net.Requests/4.0.11-beta-23429": {
+      "runtime.win7.System.Net.Requests/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -5328,10 +5386,10 @@
           "runtimes/win7/lib/dotnet5.4/System.Net.Requests.dll": {}
         }
       },
-      "runtime.win7.System.Net.Security/4.0.0-beta-23429": {
+      "runtime.win7.System.Net.Security/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23429"
+          "System.Private.Networking": "4.0.1-beta-23506"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -5340,10 +5398,10 @@
           "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
-      "runtime.win7.System.Net.Sockets/4.1.0-beta-23429": {
+      "runtime.win7.System.Net.Sockets/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23429",
+          "System.Private.Networking": "4.0.1-beta-23506",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -5353,7 +5411,7 @@
           "lib/DNXCore50/System.Net.Sockets.dll": {}
         }
       },
-      "runtime.win7.System.Net.WebSockets.Client/4.0.0-beta-23429": {
+      "runtime.win7.System.Net.WebSockets.Client/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -5363,13 +5421,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23429",
+          "System.Net.WebSockets": "4.0.0-beta-23506",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -5381,7 +5439,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Net.WebSockets.Client.dll": {}
         }
       },
-      "runtime.win7.System.Private.Uri/4.0.1-beta-23429": {
+      "runtime.win7.System.Private.Uri/4.0.1-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -5390,7 +5448,7 @@
           "runtimes/win7/lib/DNXCore50/System.Private.Uri.dll": {}
         }
       },
-      "runtime.win7.System.Runtime.Extensions/4.0.11-beta-23429": {
+      "runtime.win7.System.Runtime.Extensions/4.0.11-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -5399,7 +5457,7 @@
           "lib/DNXCore50/System.Runtime.Extensions.dll": {}
         }
       },
-      "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-beta-23429": {
+      "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -5407,7 +5465,7 @@
           "System.Runtime": "4.0.20",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.0",
           "System.Text.Encoding.Extensions": "4.0.0"
         },
@@ -5418,7 +5476,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-beta-23429": {
+      "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -5430,7 +5488,7 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -5439,7 +5497,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-beta-23429": {
+      "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -5453,11 +5511,11 @@
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
           "System.Runtime.Numerics": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Cng": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Csp": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Cng": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Csp": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10"
         },
@@ -5468,7 +5526,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
-      "runtime.win7.System.Threading/4.0.11-beta-23429": {
+      "runtime.win7.System.Threading/4.0.11-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -5477,13 +5535,13 @@
           "runtimes/win7/lib/DNXCore50/System.Threading.dll": {}
         }
       },
-      "runtime.win7-x86.Microsoft.NETCore.ConsoleHost/1.0.0-beta-23429": {
+      "runtime.win7-x86.Microsoft.NETCore.ConsoleHost/1.0.0-beta-23506": {
         "type": "package",
         "native": {
           "runtimes/win7-x86/native/CoreConsole.exe": {}
         }
       },
-      "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23429": {
+      "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -5501,13 +5559,13 @@
           "runtimes/win7-x86/native/mscorrc.dll": {}
         }
       },
-      "runtime.win7-x86.Microsoft.NETCore.TestHost/1.0.0-beta-23429": {
+      "runtime.win7-x86.Microsoft.NETCore.TestHost/1.0.0-beta-23506": {
         "type": "package",
         "native": {
           "runtimes/win7-x86/native/CoreRun.exe": {}
         }
       },
-      "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23429": {
+      "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23506": {
         "type": "package",
         "native": {
           "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll": {},
@@ -5634,34 +5692,34 @@
           "runtimes/win7-x86/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll": {}
         }
       },
-      "runtime.win7-x86.System.Data.SqlClient.sni/4.0.0-beta-23429": {
+      "runtime.win7-x86.System.Data.SqlClient.sni/4.0.0-beta-23506": {
         "type": "package",
         "native": {
           "runtimes/win7-x86/native/sni.dll": {}
         }
       },
-      "runtime.win7-x86.System.IO.Compression.clrcompression/4.0.1-beta-23429": {
+      "runtime.win7-x86.System.IO.Compression.clrcompression/4.0.1-beta-23506": {
         "type": "package",
         "native": {
           "runtimes/win7-x86/native/clrcompression.dll": {}
         }
       },
-      "System.AppContext/4.0.1-beta-23429": {
+      "System.AppContext/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.AppContext.dll": {}
+          "ref/dotnet5.4/System.AppContext.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.AppContext.dll": {}
         }
       },
-      "System.Collections/4.0.11-beta-23429": {
+      "System.Collections/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Runtime": "4.0.21-beta-23429"
+          "System.Runtime": "4.0.21-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Collections.dll": {}
@@ -5670,7 +5728,7 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Collections.Concurrent/4.0.11-beta-23429": {
+      "System.Collections.Concurrent/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -5690,7 +5748,7 @@
           "lib/dotnet5.4/System.Collections.Concurrent.dll": {}
         }
       },
-      "System.Collections.Immutable/1.1.38-beta-23429": {
+      "System.Collections.Immutable/1.1.38-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -5709,7 +5767,7 @@
           "lib/dotnet5.1/System.Collections.Immutable.dll": {}
         }
       },
-      "System.Collections.NonGeneric/4.0.1-beta-23429": {
+      "System.Collections.NonGeneric/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -5720,13 +5778,13 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Collections.NonGeneric.dll": {}
+          "ref/dotnet5.4/System.Collections.NonGeneric.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Collections.NonGeneric.dll": {}
         }
       },
-      "System.Collections.Specialized/4.0.1-beta-23429": {
+      "System.Collections.Specialized/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections.NonGeneric": "4.0.0",
@@ -5738,13 +5796,13 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Collections.Specialized.dll": {}
+          "ref/dotnet5.4/System.Collections.Specialized.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Collections.Specialized.dll": {}
         }
       },
-      "System.ComponentModel/4.0.1-beta-23429": {
+      "System.ComponentModel/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -5756,7 +5814,7 @@
           "lib/dotnet5.4/System.ComponentModel.dll": {}
         }
       },
-      "System.ComponentModel.Annotations/4.0.11-beta-23429": {
+      "System.ComponentModel.Annotations/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -5778,7 +5836,7 @@
           "lib/dotnet5.4/System.ComponentModel.Annotations.dll": {}
         }
       },
-      "System.ComponentModel.EventBasedAsync/4.0.11-beta-23429": {
+      "System.ComponentModel.EventBasedAsync/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -5793,17 +5851,17 @@
           "lib/dotnet5.4/System.ComponentModel.EventBasedAsync.dll": {}
         }
       },
-      "System.Console/4.0.0-beta-23429": {
+      "System.Console/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Console.dll": {}
+          "ref/dotnet5.4/System.Console.dll": {}
         }
       },
-      "System.Data.Common/4.0.1-beta-23429": {
+      "System.Data.Common/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -5817,13 +5875,13 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Data.Common.dll": {}
+          "ref/dotnet5.4/System.Data.Common.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Data.Common.dll": {}
         }
       },
-      "System.Data.SqlClient/4.0.0-beta-23429": {
+      "System.Data.SqlClient/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Data.Common": "4.0.0",
@@ -5834,10 +5892,10 @@
           "System.Xml.ReaderWriter": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Data.SqlClient.dll": {}
+          "ref/dotnet5.4/System.Data.SqlClient.dll": {}
         }
       },
-      "System.Diagnostics.Contracts/4.0.1-beta-23429": {
+      "System.Diagnostics.Contracts/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -5849,7 +5907,7 @@
           "lib/DNXCore50/System.Diagnostics.Contracts.dll": {}
         }
       },
-      "System.Diagnostics.Debug/4.0.11-beta-23429": {
+      "System.Diagnostics.Debug/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -5858,16 +5916,16 @@
           "ref/dotnet5.4/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.FileVersionInfo/4.0.0-beta-23429": {
+      "System.Diagnostics.FileVersionInfo/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Diagnostics.FileVersionInfo.dll": {}
+          "ref/dotnet5.4/System.Diagnostics.FileVersionInfo.dll": {}
         }
       },
-      "System.Diagnostics.Process/4.1.0-beta-23429": {
+      "System.Diagnostics.Process/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -5879,20 +5937,20 @@
           "ref/dotnet5.5/System.Diagnostics.Process.dll": {}
         }
       },
-      "System.Diagnostics.StackTrace/4.0.1-beta-23429": {
+      "System.Diagnostics.StackTrace/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Diagnostics.StackTrace.dll": {}
+          "ref/dotnet5.4/System.Diagnostics.StackTrace.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Diagnostics.StackTrace.dll": {}
         }
       },
-      "System.Diagnostics.Tools/4.0.1-beta-23429": {
+      "System.Diagnostics.Tools/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -5904,7 +5962,7 @@
           "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
         }
       },
-      "System.Diagnostics.Tracing/4.0.21-beta-23429": {
+      "System.Diagnostics.Tracing/4.0.21-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -5916,7 +5974,7 @@
           "lib/DNXCore50/System.Diagnostics.Tracing.dll": {}
         }
       },
-      "System.Dynamic.Runtime/4.0.11-beta-23429": {
+      "System.Dynamic.Runtime/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -5942,7 +6000,7 @@
           "lib/DNXCore50/System.Dynamic.Runtime.dll": {}
         }
       },
-      "System.Globalization/4.0.11-beta-23429": {
+      "System.Globalization/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -5954,20 +6012,20 @@
           "lib/DNXCore50/System.Globalization.dll": {}
         }
       },
-      "System.Globalization.Calendars/4.0.1-beta-23429": {
+      "System.Globalization.Calendars/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Globalization.Calendars.dll": {}
+          "ref/dotnet5.4/System.Globalization.Calendars.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Globalization.Calendars.dll": {}
         }
       },
-      "System.Globalization.Extensions/4.0.1-beta-23429": {
+      "System.Globalization.Extensions/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -5975,10 +6033,10 @@
           "System.Runtime.Extensions": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Globalization.Extensions.dll": {}
+          "ref/dotnet5.4/System.Globalization.Extensions.dll": {}
         }
       },
-      "System.IO/4.0.11-beta-23429": {
+      "System.IO/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20",
@@ -5992,7 +6050,7 @@
           "lib/DNXCore50/System.IO.dll": {}
         }
       },
-      "System.IO.Compression/4.1.0-beta-23429": {
+      "System.IO.Compression/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -6004,7 +6062,7 @@
           "ref/dotnet5.4/System.IO.Compression.dll": {}
         }
       },
-      "System.IO.Compression.ZipFile/4.0.1-beta-23429": {
+      "System.IO.Compression.ZipFile/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -6017,13 +6075,13 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.2/System.IO.Compression.ZipFile.dll": {}
+          "ref/dotnet5.4/System.IO.Compression.ZipFile.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.IO.Compression.ZipFile.dll": {}
         }
       },
-      "System.IO.FileSystem/4.0.1-beta-23429": {
+      "System.IO.FileSystem/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -6037,7 +6095,7 @@
           "ref/dotnet5.4/System.IO.FileSystem.dll": {}
         }
       },
-      "System.IO.FileSystem.DriveInfo/4.0.0-beta-23429": {
+      "System.IO.FileSystem.DriveInfo/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -6048,28 +6106,28 @@
           "ref/dotnet5.4/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
-      "System.IO.FileSystem.Primitives/4.0.1-beta-23429": {
+      "System.IO.FileSystem.Primitives/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet5.1/System.IO.FileSystem.Primitives.dll": {}
+          "ref/dotnet5.4/System.IO.FileSystem.Primitives.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.IO.FileSystem.Primitives.dll": {}
         }
       },
-      "System.IO.FileSystem.Watcher/4.0.0-beta-23429": {
+      "System.IO.FileSystem.Watcher/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.IO.FileSystem.Watcher.dll": {}
+          "ref/dotnet5.4/System.IO.FileSystem.Watcher.dll": {}
         }
       },
-      "System.IO.MemoryMappedFiles/4.0.0-beta-23429": {
+      "System.IO.MemoryMappedFiles/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO.FileSystem": "4.0.0",
@@ -6083,7 +6141,7 @@
           "ref/dotnet5.4/System.IO.MemoryMappedFiles.dll": {}
         }
       },
-      "System.IO.Pipes/4.0.0-beta-23429": {
+      "System.IO.Pipes/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -6096,7 +6154,7 @@
           "ref/dotnet5.4/System.IO.Pipes.dll": {}
         }
       },
-      "System.IO.UnmanagedMemoryStream/4.0.1-beta-23429": {
+      "System.IO.UnmanagedMemoryStream/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -6108,13 +6166,13 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.2/System.IO.UnmanagedMemoryStream.dll": {}
+          "ref/dotnet5.4/System.IO.UnmanagedMemoryStream.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.IO.UnmanagedMemoryStream.dll": {}
         }
       },
-      "System.Linq/4.0.1-beta-23429": {
+      "System.Linq/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -6130,33 +6188,17 @@
           "lib/dotnet5.4/System.Linq.dll": {}
         }
       },
-      "System.Linq.Expressions/4.0.11-beta-23429": {
+      "System.Linq.Expressions/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.Linq": "4.0.0",
-          "System.ObjectModel": "4.0.10",
-          "System.Reflection": "4.0.10",
-          "System.Reflection.Emit": "4.0.0",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Reflection.TypeExtensions": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Threading": "4.0.10"
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Linq.Expressions.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Linq.Expressions.dll": {}
         }
       },
-      "System.Linq.Parallel/4.0.1-beta-23429": {
+      "System.Linq.Parallel/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -6177,7 +6219,7 @@
           "lib/dotnet5.4/System.Linq.Parallel.dll": {}
         }
       },
-      "System.Linq.Queryable/4.0.1-beta-23429": {
+      "System.Linq.Queryable/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -6195,7 +6237,7 @@
           "lib/dotnet5.4/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23429": {
+      "System.Net.Http/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -6208,7 +6250,7 @@
           "ref/dotnet5.2/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23429": {
+      "System.Net.NameResolution/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -6219,7 +6261,7 @@
           "ref/dotnet5.4/System.Net.NameResolution.dll": {}
         }
       },
-      "System.Net.NetworkInformation/4.1.0-beta-23429": {
+      "System.Net.NetworkInformation/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -6230,7 +6272,7 @@
           "ref/dotnet5.4/System.Net.NetworkInformation.dll": {}
         }
       },
-      "System.Net.Primitives/4.0.11-beta-23429": {
+      "System.Net.Primitives/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -6240,7 +6282,7 @@
           "ref/dotnet5.4/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Requests/4.0.11-beta-23429": {
+      "System.Net.Requests/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -6253,20 +6295,20 @@
           "ref/dotnet5.4/System.Net.Requests.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23429": {
+      "System.Net.Security/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Net.Primitives": "4.0.10",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.Security.dll": {}
         }
       },
-      "System.Net.Sockets/4.1.0-beta-23429": {
+      "System.Net.Sockets/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -6275,13 +6317,13 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.5/System.Net.Sockets.dll": {}
+          "ref/dotnet5.4/System.Net.Sockets.dll": {}
         }
       },
-      "System.Net.Utilities/4.0.0-beta-23429": {
+      "System.Net.Utilities/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23429"
+          "System.Private.Networking": "4.0.1-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.Utilities.dll": {}
@@ -6290,7 +6332,7 @@
           "lib/DNXCore50/System.Net.Utilities.dll": {}
         }
       },
-      "System.Net.WebHeaderCollection/4.0.1-beta-23429": {
+      "System.Net.WebHeaderCollection/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -6306,35 +6348,35 @@
           "lib/dotnet5.4/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23429": {
+      "System.Net.WebSockets/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
-          "System.Threading.Tasks": "4.0.0"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Net.WebSockets.dll": {}
+          "ref/dotnet5.4/System.Net.WebSockets.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23429": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
-          "System.Net.WebSockets": "4.0.0-beta-23429",
+          "System.Net.WebSockets": "4.0.0-beta-23506",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.WebSockets.Client.dll": {}
         }
       },
-      "System.Numerics.Vectors/4.1.1-beta-23429": {
+      "System.Numerics.Vectors/4.1.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -6349,7 +6391,7 @@
           "lib/dotnet5.4/System.Numerics.Vectors.dll": {}
         }
       },
-      "System.ObjectModel/4.0.11-beta-23429": {
+      "System.ObjectModel/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -6365,38 +6407,13 @@
           "lib/dotnet5.4/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.DataContractSerialization/4.1.0-beta-23429": {
+      "System.Private.DataContractSerialization/4.1.0-beta-23506": {
         "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.10",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Reflection.TypeExtensions": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23429",
-          "System.Text.Encoding": "4.0.10",
-          "System.Text.Encoding.Extensions": "4.0.10",
-          "System.Text.RegularExpressions": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Xml.ReaderWriter": "4.0.10",
-          "System.Xml.XmlSerializer": "4.0.10"
-        },
         "compile": {
           "ref/dnxcore50/_._": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23429": {
+      "System.Private.Networking/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -6415,14 +6432,14 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23429",
+          "System.Security.Principal.Windows": "4.0.0-beta-23506",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23429"
+          "System.Threading.ThreadPool": "4.0.10-beta-23506"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -6431,53 +6448,53 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23429": {
+      "System.Private.ServiceModel/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.11-beta-23429",
-          "System.Collections.Concurrent": "4.0.11-beta-23429",
-          "System.Collections.NonGeneric": "4.0.1-beta-23429",
-          "System.Collections.Specialized": "4.0.1-beta-23429",
-          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23429",
-          "System.Diagnostics.Debug": "4.0.11-beta-23429",
-          "System.Diagnostics.Tracing": "4.0.21-beta-23429",
-          "System.Globalization": "4.0.11-beta-23429",
-          "System.IO": "4.0.11-beta-23429",
-          "System.IO.Compression": "4.1.0-beta-23429",
-          "System.Linq": "4.0.1-beta-23429",
-          "System.Linq.Expressions": "4.0.11-beta-23429",
-          "System.Linq.Queryable": "4.0.1-beta-23429",
-          "System.Net.Http": "4.0.1-beta-23429",
-          "System.Net.NameResolution": "4.0.0-beta-23429",
-          "System.Net.Primitives": "4.0.11-beta-23429",
-          "System.Net.Security": "4.0.0-beta-23429",
-          "System.Net.Sockets": "4.1.0-beta-23429",
-          "System.Net.WebHeaderCollection": "4.0.1-beta-23429",
-          "System.Net.WebSockets": "4.0.0-beta-23429",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23429",
-          "System.ObjectModel": "4.0.11-beta-23429",
-          "System.Reflection": "4.1.0-beta-23429",
-          "System.Reflection.DispatchProxy": "4.0.1-beta-23429",
-          "System.Reflection.Extensions": "4.0.1-beta-23429",
-          "System.Reflection.Primitives": "4.0.1-beta-23429",
-          "System.Reflection.TypeExtensions": "4.0.1-beta-23429",
-          "System.Resources.ResourceManager": "4.0.1-beta-23429",
-          "System.Runtime": "4.0.21-beta-23429",
-          "System.Runtime.Extensions": "4.0.11-beta-23429",
-          "System.Runtime.InteropServices": "4.0.21-beta-23429",
+          "System.Collections": "4.0.11-beta-23506",
+          "System.Collections.Concurrent": "4.0.11-beta-23506",
+          "System.Collections.NonGeneric": "4.0.1-beta-23506",
+          "System.Collections.Specialized": "4.0.1-beta-23506",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23506",
+          "System.Diagnostics.Debug": "4.0.11-beta-23506",
+          "System.Diagnostics.Tracing": "4.0.21-beta-23506",
+          "System.Globalization": "4.0.11-beta-23506",
+          "System.IO": "4.0.11-beta-23506",
+          "System.IO.Compression": "4.1.0-beta-23506",
+          "System.Linq": "4.0.1-beta-23506",
+          "System.Linq.Expressions": "4.0.11-beta-23506",
+          "System.Linq.Queryable": "4.0.1-beta-23506",
+          "System.Net.Http": "4.0.1-beta-23506",
+          "System.Net.NameResolution": "4.0.0-beta-23506",
+          "System.Net.Primitives": "4.0.11-beta-23506",
+          "System.Net.Security": "4.0.0-beta-23506",
+          "System.Net.Sockets": "4.1.0-beta-23506",
+          "System.Net.WebHeaderCollection": "4.0.1-beta-23506",
+          "System.Net.WebSockets": "4.0.0-beta-23506",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23506",
+          "System.ObjectModel": "4.0.11-beta-23506",
+          "System.Reflection": "4.1.0-beta-23506",
+          "System.Reflection.DispatchProxy": "4.0.1-beta-23506",
+          "System.Reflection.Extensions": "4.0.1-beta-23506",
+          "System.Reflection.Primitives": "4.0.1-beta-23506",
+          "System.Reflection.TypeExtensions": "4.0.1-beta-23506",
+          "System.Resources.ResourceManager": "4.0.1-beta-23506",
+          "System.Runtime": "4.0.21-beta-23506",
+          "System.Runtime.Extensions": "4.0.11-beta-23506",
+          "System.Runtime.InteropServices": "4.0.21-beta-23506",
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
-          "System.Security.Claims": "4.0.1-beta-23429",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
-          "System.Security.Principal": "4.0.1-beta-23429",
-          "System.Security.Principal.Windows": "4.0.0-beta-23429",
-          "System.Text.Encoding": "4.0.11-beta-23429",
-          "System.Threading": "4.0.11-beta-23429",
-          "System.Threading.Tasks": "4.0.11-beta-23429",
-          "System.Threading.Timer": "4.0.1-beta-23429",
-          "System.Xml.ReaderWriter": "4.0.11-beta-23429",
-          "System.Xml.XmlDocument": "4.0.1-beta-23429",
-          "System.Xml.XmlSerializer": "4.0.11-beta-23429"
+          "System.Security.Claims": "4.0.1-beta-23506",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
+          "System.Security.Principal": "4.0.1-beta-23506",
+          "System.Security.Principal.Windows": "4.0.0-beta-23506",
+          "System.Text.Encoding": "4.0.11-beta-23506",
+          "System.Threading": "4.0.11-beta-23506",
+          "System.Threading.Tasks": "4.0.11-beta-23506",
+          "System.Threading.Timer": "4.0.1-beta-23506",
+          "System.Xml.ReaderWriter": "4.0.11-beta-23506",
+          "System.Xml.XmlDocument": "4.0.1-beta-23506",
+          "System.Xml.XmlSerializer": "4.0.11-beta-23506"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -6486,13 +6503,13 @@
           "lib/DNXCore50/System.Private.ServiceModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.1-beta-23429": {
+      "System.Private.Uri/4.0.1-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
         }
       },
-      "System.Reflection/4.1.0-beta-23429": {
+      "System.Reflection/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -6506,26 +6523,17 @@
           "lib/DNXCore50/System.Reflection.dll": {}
         }
       },
-      "System.Reflection.DispatchProxy/4.0.1-beta-23429": {
+      "System.Reflection.DispatchProxy/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.10",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Threading": "4.0.10"
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Reflection.DispatchProxy.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Reflection.DispatchProxy.dll": {}
+          "ref/dotnet5.4/System.Reflection.DispatchProxy.dll": {}
         }
       },
-      "System.Reflection.Emit/4.0.1-beta-23429": {
+      "System.Reflection.Emit/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -6541,7 +6549,7 @@
           "lib/DNXCore50/System.Reflection.Emit.dll": {}
         }
       },
-      "System.Reflection.Emit.ILGeneration/4.0.1-beta-23429": {
+      "System.Reflection.Emit.ILGeneration/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -6555,7 +6563,7 @@
           "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
         }
       },
-      "System.Reflection.Emit.Lightweight/4.0.1-beta-23429": {
+      "System.Reflection.Emit.Lightweight/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -6570,7 +6578,7 @@
           "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll": {}
         }
       },
-      "System.Reflection.Extensions/4.0.1-beta-23429": {
+      "System.Reflection.Extensions/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -6583,7 +6591,7 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.1.1-beta-23429": {
+      "System.Reflection.Metadata/1.1.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -6608,7 +6616,7 @@
           "lib/dotnet5.2/System.Reflection.Metadata.dll": {}
         }
       },
-      "System.Reflection.Primitives/4.0.1-beta-23429": {
+      "System.Reflection.Primitives/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -6620,20 +6628,20 @@
           "lib/DNXCore50/System.Reflection.Primitives.dll": {}
         }
       },
-      "System.Reflection.TypeExtensions/4.1.0-beta-23429": {
+      "System.Reflection.TypeExtensions/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Reflection.TypeExtensions.dll": {}
+          "ref/dotnet5.4/System.Reflection.TypeExtensions.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
         }
       },
-      "System.Resources.ReaderWriter/4.0.0-beta-23429": {
+      "System.Resources.ReaderWriter/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -6645,13 +6653,13 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Resources.ReaderWriter.dll": {}
+          "ref/dotnet5.4/System.Resources.ReaderWriter.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Resources.ReaderWriter.dll": {}
         }
       },
-      "System.Resources.ResourceManager/4.0.1-beta-23429": {
+      "System.Resources.ResourceManager/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -6665,10 +6673,10 @@
           "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
         }
       },
-      "System.Runtime/4.0.21-beta-23429": {
+      "System.Runtime/4.0.21-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.Uri": "4.0.1-beta-23429"
+          "System.Private.Uri": "4.0.1-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Runtime.dll": {}
@@ -6677,19 +6685,19 @@
           "lib/DNXCore50/System.Runtime.dll": {}
         }
       },
-      "System.Runtime.CompilerServices.VisualC/4.0.0-beta-23429": {
+      "System.Runtime.CompilerServices.VisualC/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Runtime.CompilerServices.VisualC.dll": {}
+          "ref/dotnet5.4/System.Runtime.CompilerServices.VisualC.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Runtime.CompilerServices.VisualC.dll": {}
         }
       },
-      "System.Runtime.Extensions/4.0.11-beta-23429": {
+      "System.Runtime.Extensions/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -6698,7 +6706,7 @@
           "ref/dotnet5.4/System.Runtime.Extensions.dll": {}
         }
       },
-      "System.Runtime.Handles/4.0.1-beta-23429": {
+      "System.Runtime.Handles/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -6710,7 +6718,7 @@
           "lib/DNXCore50/System.Runtime.Handles.dll": {}
         }
       },
-      "System.Runtime.InteropServices/4.0.21-beta-23429": {
+      "System.Runtime.InteropServices/4.0.21-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -6725,16 +6733,16 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23429": {
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+          "ref/dotnet5.2/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "System.Runtime.Loader/4.0.0-beta-23429": {
+      "System.Runtime.Loader/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -6748,7 +6756,7 @@
           "lib/DNXCore50/System.Runtime.Loader.dll": {}
         }
       },
-      "System.Runtime.Numerics/4.0.1-beta-23429": {
+      "System.Runtime.Numerics/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -6763,10 +6771,10 @@
           "lib/dotnet5.4/System.Runtime.Numerics.dll": {}
         }
       },
-      "System.Runtime.Serialization.Json/4.0.1-beta-23429": {
+      "System.Runtime.Serialization.Json/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.1.0-beta-23429"
+          "System.Private.DataContractSerialization": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.1/System.Runtime.Serialization.Json.dll": {}
@@ -6775,7 +6783,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Json.dll": {}
         }
       },
-      "System.Runtime.Serialization.Primitives/4.1.0-beta-23429": {
+      "System.Runtime.Serialization.Primitives/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -6788,11 +6796,11 @@
           "lib/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
         }
       },
-      "System.Runtime.Serialization.Xml/4.1.0-beta-23429": {
+      "System.Runtime.Serialization.Xml/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.1.0-beta-23429",
-          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23429"
+          "System.Private.DataContractSerialization": "4.1.0-beta-23506",
+          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Runtime.Serialization.Xml.dll": {}
@@ -6801,7 +6809,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Xml.dll": {}
         }
       },
-      "System.Security.Claims/4.0.1-beta-23429": {
+      "System.Security.Claims/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -6814,24 +6822,24 @@
           "System.Security.Principal": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Claims.dll": {}
+          "ref/dotnet5.4/System.Security.Claims.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23429": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Cryptography.Algorithms.dll": {}
+          "ref/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Cng/4.0.0-beta-23429": {
+      "System.Security.Cryptography.Cng/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -6840,18 +6848,18 @@
           "System.Runtime.Extensions": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.2/System.Security.Cryptography.Cng.dll": {}
+          "ref/dotnet5.4/System.Security.Cryptography.Cng.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Security.Cryptography.Cng.dll": {}
         }
       },
-      "System.Security.Cryptography.Csp/4.0.0-beta-23429": {
+      "System.Security.Cryptography.Csp/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -6861,29 +6869,29 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Cryptography.Csp.dll": {}
+          "ref/dotnet5.4/System.Security.Cryptography.Csp.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Security.Cryptography.Csp.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23429": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Cryptography.Encoding.dll": {}
+          "ref/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23429": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -6895,25 +6903,25 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Cryptography.Primitives.dll": {}
+          "ref/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23429": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23429"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
-      "System.Security.Principal/4.0.1-beta-23429": {
+      "System.Security.Principal/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -6925,7 +6933,7 @@
           "lib/dotnet5.1/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23429": {
+      "System.Security.Principal.Windows/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -6948,10 +6956,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23429": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429"
+          "System.Private.ServiceModel": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.2/System.ServiceModel.Duplex.dll": {}
@@ -6960,10 +6968,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23429": {
+      "System.ServiceModel.Http/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429",
+          "System.Private.ServiceModel": "4.1.0-beta-23506",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -6973,10 +6981,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.1.0-beta-23429": {
+      "System.ServiceModel.NetTcp/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429"
+          "System.Private.ServiceModel": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.ServiceModel.NetTcp.dll": {}
@@ -6985,10 +6993,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.1.0-beta-23429": {
+      "System.ServiceModel.Primitives/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429"
+          "System.Private.ServiceModel": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.ServiceModel.Primitives.dll": {}
@@ -6997,10 +7005,10 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
-      "System.ServiceModel.Security/4.0.1-beta-23429": {
+      "System.ServiceModel.Security/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429"
+          "System.Private.ServiceModel": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.2/System.ServiceModel.Security.dll": {}
@@ -7009,7 +7017,7 @@
           "lib/DNXCore50/System.ServiceModel.Security.dll": {}
         }
       },
-      "System.Text.Encoding/4.0.11-beta-23429": {
+      "System.Text.Encoding/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -7021,29 +7029,17 @@
           "lib/DNXCore50/System.Text.Encoding.dll": {}
         }
       },
-      "System.Text.Encoding.CodePages/4.0.0": {
+      "System.Text.Encoding.CodePages/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.Reflection": "4.0.10",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Runtime.Handles": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Text.Encoding": "4.0.10",
-          "System.Threading": "4.0.10"
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/System.Text.Encoding.CodePages.dll": {}
+          "ref/dotnet5.4/System.Text.Encoding.CodePages.dll": {}
         }
       },
-      "System.Text.Encoding.Extensions/4.0.11-beta-23429": {
+      "System.Text.Encoding.Extensions/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -7056,7 +7052,7 @@
           "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
         }
       },
-      "System.Text.RegularExpressions/4.0.11-beta-23429": {
+      "System.Text.RegularExpressions/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7073,7 +7069,7 @@
           "lib/dotnet5.4/System.Text.RegularExpressions.dll": {}
         }
       },
-      "System.Threading/4.0.11-beta-23429": {
+      "System.Threading/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -7083,20 +7079,20 @@
           "ref/dotnet5.4/System.Threading.dll": {}
         }
       },
-      "System.Threading.Overlapped/4.0.0": {
+      "System.Threading.Overlapped/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Overlapped.dll": {}
+          "ref/dotnet5.4/System.Threading.Overlapped.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Overlapped.dll": {}
         }
       },
-      "System.Threading.Tasks/4.0.11-beta-23429": {
+      "System.Threading.Tasks/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -7108,7 +7104,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.Tasks.Dataflow/4.5.26-beta-23429": {
+      "System.Threading.Tasks.Dataflow/4.5.26-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -7130,7 +7126,7 @@
           "lib/dotnet5.2/System.Threading.Tasks.Dataflow.dll": {}
         }
       },
-      "System.Threading.Tasks.Parallel/4.0.1-beta-23429": {
+      "System.Threading.Tasks.Parallel/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections.Concurrent": "4.0.10",
@@ -7149,32 +7145,32 @@
           "lib/dotnet5.4/System.Threading.Tasks.Parallel.dll": {}
         }
       },
-      "System.Threading.Thread/4.0.0-beta-23429": {
+      "System.Threading.Thread/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Threading.Thread.dll": {}
+          "ref/dotnet5.4/System.Threading.Thread.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Thread.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23429": {
+      "System.Threading.ThreadPool/4.0.10-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.InteropServices": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.2/System.Threading.ThreadPool.dll": {}
+          "ref/dotnet5.4/System.Threading.ThreadPool.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
-      "System.Threading.Timer/4.0.1-beta-23429": {
+      "System.Threading.Timer/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -7186,7 +7182,7 @@
           "lib/DNXCore50/System.Threading.Timer.dll": {}
         }
       },
-      "System.Xml.ReaderWriter/4.0.11-beta-23429": {
+      "System.Xml.ReaderWriter/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7211,7 +7207,7 @@
           "lib/dotnet5.4/System.Xml.ReaderWriter.dll": {}
         }
       },
-      "System.Xml.XDocument/4.0.11-beta-23429": {
+      "System.Xml.XDocument/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7234,7 +7230,7 @@
           "lib/dotnet5.4/System.Xml.XDocument.dll": {}
         }
       },
-      "System.Xml.XmlDocument/4.0.1-beta-23429": {
+      "System.Xml.XmlDocument/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7249,37 +7245,21 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Xml.XmlDocument.dll": {}
+          "ref/dotnet5.4/System.Xml.XmlDocument.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Xml.XmlDocument.dll": {}
         }
       },
-      "System.Xml.XmlSerializer/4.0.11-beta-23429": {
+      "System.Xml.XmlSerializer/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.10",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Reflection.TypeExtensions": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Text.RegularExpressions": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Xml.ReaderWriter": "4.0.10",
-          "System.Xml.XmlDocument": "4.0.0"
+          "System.IO": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet5.4/System.Xml.XmlSerializer.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
         }
       },
       "xunit/2.1.0": {
@@ -7439,7 +7419,7 @@
       "coveralls.io/1.4.0": {
         "type": "package"
       },
-      "Microsoft.CSharp/4.0.1-beta-23429": {
+      "Microsoft.CSharp/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7475,169 +7455,147 @@
           "xunit.runner.console": "2.1.0"
         }
       },
-      "Microsoft.NETCore/5.0.1-beta-23429": {
+      "Microsoft.NETCore/5.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "Microsoft.CSharp": "4.0.1-beta-23429",
-          "Microsoft.NETCore.Targets": "1.0.1-beta-23429",
-          "Microsoft.VisualBasic": "10.0.1-beta-23429",
-          "System.AppContext": "4.0.1-beta-23429",
-          "System.Collections": "4.0.11-beta-23429",
-          "System.Collections.Concurrent": "4.0.11-beta-23429",
-          "System.Collections.Immutable": "1.1.38-beta-23429",
-          "System.ComponentModel": "4.0.1-beta-23429",
-          "System.ComponentModel.Annotations": "4.0.11-beta-23429",
-          "System.Diagnostics.Debug": "4.0.11-beta-23429",
-          "System.Diagnostics.Tools": "4.0.1-beta-23429",
-          "System.Diagnostics.Tracing": "4.0.21-beta-23429",
-          "System.Dynamic.Runtime": "4.0.11-beta-23429",
-          "System.Globalization": "4.0.11-beta-23429",
-          "System.Globalization.Calendars": "4.0.1-beta-23429",
-          "System.Globalization.Extensions": "4.0.1-beta-23429",
-          "System.IO": "4.0.11-beta-23429",
-          "System.IO.Compression": "4.1.0-beta-23429",
-          "System.IO.Compression.ZipFile": "4.0.1-beta-23429",
-          "System.IO.FileSystem": "4.0.1-beta-23429",
-          "System.IO.FileSystem.Primitives": "4.0.1-beta-23429",
-          "System.IO.UnmanagedMemoryStream": "4.0.1-beta-23429",
-          "System.Linq": "4.0.1-beta-23429",
-          "System.Linq.Expressions": "4.0.11-beta-23429",
-          "System.Linq.Parallel": "4.0.1-beta-23429",
-          "System.Linq.Queryable": "4.0.1-beta-23429",
-          "System.Net.Http": "4.0.1-beta-23429",
-          "System.Net.NetworkInformation": "4.1.0-beta-23429",
-          "System.Net.Primitives": "4.0.11-beta-23429",
-          "System.Numerics.Vectors": "4.1.1-beta-23429",
-          "System.ObjectModel": "4.0.11-beta-23429",
-          "System.Reflection": "4.1.0-beta-23429",
-          "System.Reflection.DispatchProxy": "4.0.1-beta-23429",
-          "System.Reflection.Extensions": "4.0.1-beta-23429",
-          "System.Reflection.Metadata": "1.1.1-beta-23429",
-          "System.Reflection.Primitives": "4.0.1-beta-23429",
-          "System.Reflection.TypeExtensions": "4.1.0-beta-23429",
-          "System.Resources.ResourceManager": "4.0.1-beta-23429",
-          "System.Runtime": "4.0.21-beta-23429",
-          "System.Runtime.Extensions": "4.0.11-beta-23429",
-          "System.Runtime.Handles": "4.0.1-beta-23429",
-          "System.Runtime.InteropServices": "4.0.21-beta-23429",
-          "System.Runtime.Numerics": "4.0.1-beta-23429",
-          "System.Security.Claims": "4.0.1-beta-23429",
-          "System.Security.Principal": "4.0.1-beta-23429",
-          "System.Text.Encoding": "4.0.11-beta-23429",
-          "System.Text.Encoding.Extensions": "4.0.11-beta-23429",
-          "System.Text.RegularExpressions": "4.0.11-beta-23429",
-          "System.Threading": "4.0.11-beta-23429",
-          "System.Threading.Tasks": "4.0.11-beta-23429",
-          "System.Threading.Tasks.Dataflow": "4.5.26-beta-23429",
-          "System.Threading.Tasks.Parallel": "4.0.1-beta-23429",
-          "System.Threading.Timer": "4.0.1-beta-23429",
-          "System.Xml.ReaderWriter": "4.0.11-beta-23429",
-          "System.Xml.XDocument": "4.0.11-beta-23429"
+          "Microsoft.CSharp": "4.0.1-beta-23506",
+          "Microsoft.NETCore.Platforms": "1.0.1-beta-23506",
+          "Microsoft.VisualBasic": "10.0.1-beta-23506",
+          "System.AppContext": "4.0.1-beta-23506",
+          "System.Collections": "4.0.11-beta-23506",
+          "System.Collections.Concurrent": "4.0.11-beta-23506",
+          "System.Collections.Immutable": "1.1.38-beta-23506",
+          "System.ComponentModel": "4.0.1-beta-23506",
+          "System.ComponentModel.Annotations": "4.0.11-beta-23506",
+          "System.Diagnostics.Debug": "4.0.11-beta-23506",
+          "System.Diagnostics.Tools": "4.0.1-beta-23506",
+          "System.Diagnostics.Tracing": "4.0.21-beta-23506",
+          "System.Dynamic.Runtime": "4.0.11-beta-23506",
+          "System.Globalization": "4.0.11-beta-23506",
+          "System.Globalization.Calendars": "4.0.1-beta-23506",
+          "System.Globalization.Extensions": "4.0.1-beta-23506",
+          "System.IO": "4.0.11-beta-23506",
+          "System.IO.Compression": "4.1.0-beta-23506",
+          "System.IO.Compression.ZipFile": "4.0.1-beta-23506",
+          "System.IO.FileSystem": "4.0.1-beta-23506",
+          "System.IO.FileSystem.Primitives": "4.0.1-beta-23506",
+          "System.IO.UnmanagedMemoryStream": "4.0.1-beta-23506",
+          "System.Linq": "4.0.1-beta-23506",
+          "System.Linq.Expressions": "4.0.11-beta-23506",
+          "System.Linq.Parallel": "4.0.1-beta-23506",
+          "System.Linq.Queryable": "4.0.1-beta-23506",
+          "System.Net.Http": "4.0.1-beta-23506",
+          "System.Net.NetworkInformation": "4.1.0-beta-23506",
+          "System.Net.Primitives": "4.0.11-beta-23506",
+          "System.Numerics.Vectors": "4.1.1-beta-23506",
+          "System.ObjectModel": "4.0.11-beta-23506",
+          "System.Reflection": "4.1.0-beta-23506",
+          "System.Reflection.DispatchProxy": "4.0.1-beta-23506",
+          "System.Reflection.Extensions": "4.0.1-beta-23506",
+          "System.Reflection.Metadata": "1.1.1-beta-23506",
+          "System.Reflection.Primitives": "4.0.1-beta-23506",
+          "System.Reflection.TypeExtensions": "4.1.0-beta-23506",
+          "System.Resources.ResourceManager": "4.0.1-beta-23506",
+          "System.Runtime": "4.0.21-beta-23506",
+          "System.Runtime.Extensions": "4.0.11-beta-23506",
+          "System.Runtime.Handles": "4.0.1-beta-23506",
+          "System.Runtime.InteropServices": "4.0.21-beta-23506",
+          "System.Runtime.Numerics": "4.0.1-beta-23506",
+          "System.Security.Claims": "4.0.1-beta-23506",
+          "System.Security.Principal": "4.0.1-beta-23506",
+          "System.Text.Encoding": "4.0.11-beta-23506",
+          "System.Text.Encoding.Extensions": "4.0.11-beta-23506",
+          "System.Text.RegularExpressions": "4.0.11-beta-23506",
+          "System.Threading": "4.0.11-beta-23506",
+          "System.Threading.Tasks": "4.0.11-beta-23506",
+          "System.Threading.Tasks.Dataflow": "4.5.26-beta-23506",
+          "System.Threading.Tasks.Parallel": "4.0.1-beta-23506",
+          "System.Threading.Timer": "4.0.1-beta-23506",
+          "System.Xml.ReaderWriter": "4.0.11-beta-23506",
+          "System.Xml.XDocument": "4.0.11-beta-23506"
         }
       },
-      "Microsoft.NETCore.Console/1.0.0-beta-23429": {
+      "Microsoft.NETCore.Console/1.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore": "5.0.1-beta-23429",
-          "Microsoft.NETCore.ConsoleHost": "1.0.0-beta-23429",
-          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23429",
-          "Microsoft.Win32.Primitives": "4.0.1-beta-23429",
-          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23429",
-          "System.Console": "4.0.0-beta-23429",
-          "System.Data.Common": "4.0.1-beta-23429",
-          "System.Data.SqlClient": "4.0.0-beta-23429",
-          "System.Diagnostics.Contracts": "4.0.1-beta-23429",
-          "System.Diagnostics.FileVersionInfo": "4.0.0-beta-23429",
-          "System.Diagnostics.Process": "4.1.0-beta-23429",
-          "System.Diagnostics.StackTrace": "4.0.1-beta-23429",
-          "System.IO.FileSystem.DriveInfo": "4.0.0-beta-23429",
-          "System.IO.FileSystem.Watcher": "4.0.0-beta-23429",
-          "System.IO.MemoryMappedFiles": "4.0.0-beta-23429",
-          "System.IO.Pipes": "4.0.0-beta-23429",
-          "System.Net.NameResolution": "4.0.0-beta-23429",
-          "System.Net.NetworkInformation": "4.1.0-beta-23429",
-          "System.Net.Requests": "4.0.11-beta-23429",
-          "System.Net.Security": "4.0.0-beta-23429",
-          "System.Net.Sockets": "4.1.0-beta-23429",
-          "System.Net.Utilities": "4.0.0-beta-23429",
-          "System.Net.WebHeaderCollection": "4.0.1-beta-23429",
-          "System.Net.WebSockets": "4.0.0-beta-23429",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23429",
-          "System.Reflection.Emit": "4.0.1-beta-23429",
-          "System.Reflection.Emit.ILGeneration": "4.0.1-beta-23429",
-          "System.Reflection.Emit.Lightweight": "4.0.1-beta-23429",
-          "System.Resources.ReaderWriter": "4.0.0-beta-23429",
-          "System.Runtime.CompilerServices.VisualC": "4.0.0-beta-23429",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23429",
-          "System.Runtime.Loader": "4.0.0-beta-23429",
-          "System.Runtime.Serialization.Json": "4.0.1-beta-23429",
-          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23429",
-          "System.Runtime.Serialization.Xml": "4.1.0-beta-23429",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
-          "System.ServiceModel.Duplex": "4.0.1-beta-23429",
-          "System.ServiceModel.Http": "4.0.11-beta-23429",
-          "System.ServiceModel.NetTcp": "4.1.0-beta-23429",
-          "System.ServiceModel.Primitives": "4.1.0-beta-23429",
-          "System.ServiceModel.Security": "4.0.1-beta-23429",
-          "System.Xml.XmlSerializer": "4.0.11-beta-23429"
+          "Microsoft.NETCore": "5.0.1-beta-23506",
+          "Microsoft.NETCore.ConsoleHost": "1.0.0-beta-23506",
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23506",
+          "Microsoft.Win32.Primitives": "4.0.1-beta-23506",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23506",
+          "System.Console": "4.0.0-beta-23506",
+          "System.Data.Common": "4.0.1-beta-23506",
+          "System.Data.SqlClient": "4.0.0-beta-23506",
+          "System.Diagnostics.Contracts": "4.0.1-beta-23506",
+          "System.Diagnostics.FileVersionInfo": "4.0.0-beta-23506",
+          "System.Diagnostics.Process": "4.1.0-beta-23506",
+          "System.Diagnostics.StackTrace": "4.0.1-beta-23506",
+          "System.IO.FileSystem.DriveInfo": "4.0.0-beta-23506",
+          "System.IO.FileSystem.Watcher": "4.0.0-beta-23506",
+          "System.IO.MemoryMappedFiles": "4.0.0-beta-23506",
+          "System.IO.Pipes": "4.0.0-beta-23506",
+          "System.Net.NameResolution": "4.0.0-beta-23506",
+          "System.Net.NetworkInformation": "4.1.0-beta-23506",
+          "System.Net.Requests": "4.0.11-beta-23506",
+          "System.Net.Security": "4.0.0-beta-23506",
+          "System.Net.Sockets": "4.1.0-beta-23506",
+          "System.Net.Utilities": "4.0.0-beta-23506",
+          "System.Net.WebHeaderCollection": "4.0.1-beta-23506",
+          "System.Net.WebSockets": "4.0.0-beta-23506",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23506",
+          "System.Reflection.Emit": "4.0.1-beta-23506",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-beta-23506",
+          "System.Reflection.Emit.Lightweight": "4.0.1-beta-23506",
+          "System.Resources.ReaderWriter": "4.0.0-beta-23506",
+          "System.Runtime.CompilerServices.VisualC": "4.0.0-beta-23506",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23506",
+          "System.Runtime.Loader": "4.0.0-beta-23506",
+          "System.Runtime.Serialization.Json": "4.0.1-beta-23506",
+          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23506",
+          "System.Runtime.Serialization.Xml": "4.1.0-beta-23506",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
+          "System.ServiceModel.Duplex": "4.0.1-beta-23506",
+          "System.ServiceModel.Http": "4.0.11-beta-23506",
+          "System.ServiceModel.NetTcp": "4.1.0-beta-23506",
+          "System.ServiceModel.Primitives": "4.1.0-beta-23506",
+          "System.ServiceModel.Security": "4.0.1-beta-23506",
+          "System.Xml.XmlSerializer": "4.0.11-beta-23506"
         }
       },
-      "Microsoft.NETCore.ConsoleHost/1.0.0-beta-23429": {
+      "Microsoft.NETCore.ConsoleHost/1.0.0-beta-23506": {
         "type": "package"
       },
-      "Microsoft.NETCore.Platforms/1.0.1-beta-23429": {
-        "type": "package"
-      },
-      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23429": {
+      "Microsoft.NETCore.Platforms/1.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-beta-23429",
-          "System.Collections": "[4.0.11-beta-23429]",
-          "System.Diagnostics.Contracts": "[4.0.1-beta-23429]",
-          "System.Diagnostics.Debug": "[4.0.11-beta-23429]",
-          "System.Diagnostics.StackTrace": "[4.0.1-beta-23429]",
-          "System.Diagnostics.Tools": "[4.0.1-beta-23429]",
-          "System.Diagnostics.Tracing": "[4.0.21-beta-23429]",
-          "System.Globalization": "[4.0.11-beta-23429]",
-          "System.Globalization.Calendars": "[4.0.1-beta-23429]",
-          "System.IO": "[4.0.11-beta-23429]",
-          "System.ObjectModel": "[4.0.11-beta-23429]",
-          "System.Private.Uri": "[4.0.1-beta-23429]",
-          "System.Reflection": "[4.1.0-beta-23429]",
-          "System.Reflection.Extensions": "[4.0.1-beta-23429]",
-          "System.Reflection.Primitives": "[4.0.1-beta-23429]",
-          "System.Resources.ResourceManager": "[4.0.1-beta-23429]",
-          "System.Runtime": "[4.0.21-beta-23429]",
-          "System.Runtime.Extensions": "[4.0.11-beta-23429]",
-          "System.Runtime.Handles": "[4.0.1-beta-23429]",
-          "System.Runtime.InteropServices": "[4.0.21-beta-23429]",
-          "System.Text.Encoding": "[4.0.11-beta-23429]",
-          "System.Text.Encoding.Extensions": "[4.0.11-beta-23429]",
-          "System.Threading": "[4.0.11-beta-23429]",
-          "System.Threading.Tasks": "[4.0.11-beta-23429]",
-          "System.Threading.Timer": "[4.0.1-beta-23429]"
+          "Microsoft.NETCore.Targets": "1.0.1-beta-23506"
         }
       },
-      "Microsoft.NETCore.Targets/1.0.1-beta-23429": {
+      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1-beta-23429",
-          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-beta-23429"
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-beta-23506"
         }
       },
-      "Microsoft.NETCore.Targets.DNXCore/5.0.0-beta-23429": {
+      "Microsoft.NETCore.Targets/1.0.1-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-beta-23506"
+        }
+      },
+      "Microsoft.NETCore.Targets.DNXCore/5.0.0-beta-23506": {
         "type": "package"
       },
-      "Microsoft.NETCore.TestHost/1.0.0-beta-23429": {
+      "Microsoft.NETCore.TestHost/1.0.0-beta-23506": {
         "type": "package"
       },
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23429": {
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23506": {
         "type": "package"
       },
-      "Microsoft.VisualBasic/10.0.1-beta-23429": {
+      "Microsoft.VisualBasic/10.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7664,13 +7622,13 @@
           "lib/dotnet5.4/Microsoft.VisualBasic.dll": {}
         }
       },
-      "Microsoft.Win32.Primitives/4.0.1-beta-23429": {
+      "Microsoft.Win32.Primitives/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/Microsoft.Win32.Primitives.dll": {}
+          "ref/dotnet5.4/Microsoft.Win32.Primitives.dll": {}
         }
       },
       "OpenCover/4.6.166": {
@@ -7679,7 +7637,118 @@
       "ReportGenerator/2.3.1": {
         "type": "package"
       },
-      "runtime.linux.System.Diagnostics.Process/4.1.0-beta-23429": {
+      "runtime.any.System.Linq.Expressions/4.0.11-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Linq.Expressions.dll": {}
+        }
+      },
+      "runtime.any.System.Private.DataContractSerialization/4.1.0-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23506",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection.DispatchProxy/4.0.1-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.DispatchProxy.dll": {}
+        }
+      },
+      "runtime.any.System.Xml.XmlSerializer/4.0.11-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
+        }
+      },
+      "runtime.linux.System.Diagnostics.Process/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -7698,7 +7767,7 @@
           "System.Text.Encoding.Extensions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23429"
+          "System.Threading.ThreadPool": "4.0.10-beta-23506"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -7707,7 +7776,7 @@
           "runtimes/unix/lib/dotnet5.5/System.Diagnostics.Process.dll": {}
         }
       },
-      "runtime.linux.System.IO.FileSystem/4.0.1-beta-23429": {
+      "runtime.linux.System.IO.FileSystem/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7731,7 +7800,7 @@
           "runtimes/linux/lib/dotnet5.4/System.IO.FileSystem.dll": {}
         }
       },
-      "runtime.linux.System.IO.FileSystem.DriveInfo/4.0.0-beta-23429": {
+      "runtime.linux.System.IO.FileSystem.DriveInfo/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7750,7 +7819,7 @@
           "runtimes/unix/lib/dotnet5.4/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
-      "runtime.linux.System.IO.FileSystem.Watcher/4.0.0-beta-23429": {
+      "runtime.linux.System.IO.FileSystem.Watcher/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7772,7 +7841,7 @@
           "runtimes/unix/lib/dotnet5.4/System.IO.FileSystem.Watcher.dll": {}
         }
       },
-      "runtime.linux.System.IO.MemoryMappedFiles/4.0.0-beta-23429": {
+      "runtime.linux.System.IO.MemoryMappedFiles/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -7794,7 +7863,7 @@
           "runtimes/unix/lib/dotnet5.4/System.IO.MemoryMappedFiles.dll": {}
         }
       },
-      "runtime.linux.System.Net.Http/4.0.1-beta-23429": {
+      "runtime.linux.System.Net.Http/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7807,7 +7876,7 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.0",
           "System.Threading.Tasks": "4.0.10"
@@ -7819,7 +7888,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Net.Http.dll": {}
         }
       },
-      "runtime.linux.System.Net.NameResolution/4.0.0-beta-23429": {
+      "runtime.linux.System.Net.NameResolution/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -7830,7 +7899,7 @@
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Principal.Windows": "4.0.0-beta-23429",
+          "System.Security.Principal.Windows": "4.0.0-beta-23506",
           "System.Threading": "4.0.0",
           "System.Threading.Tasks": "4.0.0"
         },
@@ -7841,7 +7910,7 @@
           "runtimes/unix/lib/dnxcore50/System.Net.NameResolution.dll": {}
         }
       },
-      "runtime.linux.System.Net.NetworkInformation/4.1.0-beta-23429": {
+      "runtime.linux.System.Net.NetworkInformation/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -7865,24 +7934,24 @@
           "runtimes/unix/lib/dotnet5.4/System.Net.NetworkInformation.dll": {}
         }
       },
-      "runtime.linux.System.Net.Sockets/4.1.0-beta-23429": {
+      "runtime.linux.System.Net.Sockets/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
           "System.Diagnostics.Tracing": "4.0.20",
           "System.Globalization": "4.0.0",
           "System.IO": "4.0.10",
-          "System.Net.NameResolution": "4.0.0-beta-23429",
+          "System.Net.NameResolution": "4.0.0-beta-23506",
           "System.Net.Primitives": "4.0.10",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Principal.Windows": "4.0.0-beta-23429",
+          "System.Security.Principal.Windows": "4.0.0-beta-23506",
           "System.Threading": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23429"
+          "System.Threading.ThreadPool": "4.0.10-beta-23506"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -7891,7 +7960,7 @@
           "runtimes/linux/lib/dotnet5.5/System.Net.Sockets.dll": {}
         }
       },
-      "runtime.linux.System.Runtime.Extensions/4.0.11-beta-23429": {
+      "runtime.linux.System.Runtime.Extensions/4.0.11-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -7900,7 +7969,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Runtime.Extensions.dll": {}
         }
       },
-      "runtime.linux.System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23429": {
+      "runtime.linux.System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -7913,7 +7982,7 @@
           "runtimes/unix/lib/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "runtime.linux.System.Security.Cryptography.Algorithms/4.0.0-beta-23429": {
+      "runtime.linux.System.Security.Cryptography.Algorithms/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -7921,7 +7990,7 @@
           "System.Runtime": "4.0.20",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.0",
           "System.Text.Encoding.Extensions": "4.0.0"
         },
@@ -7932,13 +8001,13 @@
           "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "runtime.ubuntu.14.04-x64.Microsoft.NETCore.ConsoleHost/1.0.0-beta-23429": {
+      "runtime.ubuntu.14.04-x64.Microsoft.NETCore.ConsoleHost/1.0.0-beta-23506": {
         "type": "package",
         "native": {
           "runtimes/ubuntu.14.04-x64/native/coreconsole": {}
         }
       },
-      "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23429": {
+      "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -7961,13 +8030,13 @@
           "runtimes/ubuntu.14.04-x64/native/System.Security.Cryptography.Native.so": {}
         }
       },
-      "runtime.ubuntu.14.04-x64.Microsoft.NETCore.TestHost/1.0.0-beta-23429": {
+      "runtime.ubuntu.14.04-x64.Microsoft.NETCore.TestHost/1.0.0-beta-23506": {
         "type": "package",
         "native": {
           "runtimes/ubuntu.14.04-x64/native/corerun": {}
         }
       },
-      "runtime.unix.Microsoft.Win32.Primitives/4.0.1-beta-23429": {
+      "runtime.unix.Microsoft.Win32.Primitives/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20",
@@ -7980,7 +8049,7 @@
           "runtimes/unix/lib/dotnet5.4/Microsoft.Win32.Primitives.dll": {}
         }
       },
-      "runtime.unix.System.Console/4.0.0-beta-23429": {
+      "runtime.unix.System.Console/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8004,7 +8073,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Console.dll": {}
         }
       },
-      "runtime.unix.System.Data.SqlClient/4.0.0-beta-23429": {
+      "runtime.unix.System.Data.SqlClient/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -8016,10 +8085,10 @@
           "System.Globalization": "4.0.10",
           "System.IO": "4.0.10",
           "System.Linq": "4.0.0",
-          "System.Net.NameResolution": "4.0.0-beta-23429",
+          "System.Net.NameResolution": "4.0.0-beta-23506",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23429",
-          "System.Net.Sockets": "4.1.0-beta-23429",
+          "System.Net.Security": "4.0.0-beta-23506",
+          "System.Net.Sockets": "4.1.0-beta-23506",
           "System.Reflection": "4.0.0",
           "System.Reflection.TypeExtensions": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
@@ -8027,17 +8096,17 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23429",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
-          "System.Security.Principal.Windows": "4.0.0-beta-23429",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23506",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
+          "System.Security.Principal.Windows": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.10",
           "System.Text.Encoding.CodePages": "4.0.0",
           "System.Text.Encoding.Extensions": "4.0.10",
           "System.Text.RegularExpressions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.Thread": "4.0.0-beta-23429",
-          "System.Threading.ThreadPool": "4.0.10-beta-23429",
+          "System.Threading.Thread": "4.0.0-beta-23506",
+          "System.Threading.ThreadPool": "4.0.10-beta-23506",
           "System.Threading.Timer": "4.0.0",
           "System.Xml.ReaderWriter": "4.0.0"
         },
@@ -8048,7 +8117,7 @@
           "runtimes/unix/lib/dotnet5.5/System.Data.SqlClient.dll": {}
         }
       },
-      "runtime.unix.System.Diagnostics.Debug/4.0.11-beta-23429": {
+      "runtime.unix.System.Diagnostics.Debug/4.0.11-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -8057,7 +8126,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Diagnostics.Debug.dll": {}
         }
       },
-      "runtime.unix.System.Diagnostics.FileVersionInfo/4.0.0-beta-23429": {
+      "runtime.unix.System.Diagnostics.FileVersionInfo/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -8073,7 +8142,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Diagnostics.FileVersionInfo.dll": {}
         }
       },
-      "runtime.unix.System.Globalization.Extensions/4.0.1-beta-23429": {
+      "runtime.unix.System.Globalization.Extensions/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -8088,7 +8157,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Globalization.Extensions.dll": {}
         }
       },
-      "runtime.unix.System.IO.Compression/4.1.0-beta-23429": {
+      "runtime.unix.System.IO.Compression/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8110,7 +8179,7 @@
           "runtimes/unix/lib/dotnet5.4/System.IO.Compression.dll": {}
         }
       },
-      "runtime.unix.System.IO.Pipes/4.0.0-beta-23429": {
+      "runtime.unix.System.IO.Pipes/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -8131,7 +8200,7 @@
           "runtimes/unix/lib/dotnet5.4/System.IO.Pipes.dll": {}
         }
       },
-      "runtime.unix.System.Net.Primitives/4.0.11-beta-23429": {
+      "runtime.unix.System.Net.Primitives/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -8153,7 +8222,7 @@
           "runtimes/unix/lib/dnxcore50/System.Net.Primitives.dll": {}
         }
       },
-      "runtime.unix.System.Net.Requests/4.0.11-beta-23429": {
+      "runtime.unix.System.Net.Requests/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8174,7 +8243,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Net.Requests.dll": {}
         }
       },
-      "runtime.unix.System.Net.Security/4.0.0-beta-23429": {
+      "runtime.unix.System.Net.Security/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -8190,15 +8259,17 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.OpenSsl": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23506",
+          "System.Security.Cryptography.OpenSsl": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23429",
+          "System.Security.Principal.Windows": "4.0.0-beta-23506",
+          "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23429"
+          "System.Threading.ThreadPool": "4.0.10-beta-23506"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -8207,7 +8278,7 @@
           "runtimes/unix/lib/dnxcore50/System.Net.Security.dll": {}
         }
       },
-      "runtime.unix.System.Net.WebSockets.Client/4.0.0-beta-23429": {
+      "runtime.unix.System.Net.WebSockets.Client/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8215,10 +8286,10 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.0",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23429",
+          "System.Net.WebSockets": "4.0.0-beta-23506",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.0",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -8230,7 +8301,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Net.WebSockets.Client.dll": {}
         }
       },
-      "runtime.unix.System.Private.Uri/4.0.1-beta-23429": {
+      "runtime.unix.System.Private.Uri/4.0.1-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -8239,7 +8310,7 @@
           "runtimes/unix/lib/dotnet5.1/System.Private.Uri.dll": {}
         }
       },
-      "runtime.unix.System.Security.Cryptography.Encoding/4.0.0-beta-23429": {
+      "runtime.unix.System.Security.Cryptography.Encoding/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -8251,7 +8322,7 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.0"
         },
         "compile": {
@@ -8261,7 +8332,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "runtime.unix.System.Security.Cryptography.X509Certificates/4.0.0-beta-23429": {
+      "runtime.unix.System.Security.Cryptography.X509Certificates/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8270,17 +8341,17 @@
           "System.IO": "4.0.10",
           "System.IO.FileSystem": "4.0.0",
           "System.IO.FileSystem.Primitives": "4.0.0",
-          "System.IO.FileSystem.Watcher": "4.0.0-beta-23429",
+          "System.IO.FileSystem.Watcher": "4.0.0-beta-23506",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
           "System.Runtime.Numerics": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23429",
-          "System.Security.Cryptography.OpenSsl": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23506",
+          "System.Security.Cryptography.OpenSsl": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10"
         },
@@ -8291,7 +8362,29 @@
           "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
-      "runtime.unix.System.Threading/4.0.11-beta-23429": {
+      "runtime.unix.System.Text.Encoding.CodePages/4.0.1-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/dotnet5.4/System.Text.Encoding.CodePages.dll": {}
+        }
+      },
+      "runtime.unix.System.Threading/4.0.11-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -8300,22 +8393,22 @@
           "runtimes/unix/lib/dotnet5.4/System.Threading.dll": {}
         }
       },
-      "System.AppContext/4.0.1-beta-23429": {
+      "System.AppContext/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.AppContext.dll": {}
+          "ref/dotnet5.4/System.AppContext.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.AppContext.dll": {}
         }
       },
-      "System.Collections/4.0.11-beta-23429": {
+      "System.Collections/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Runtime": "4.0.21-beta-23429"
+          "System.Runtime": "4.0.21-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Collections.dll": {}
@@ -8324,7 +8417,7 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Collections.Concurrent/4.0.11-beta-23429": {
+      "System.Collections.Concurrent/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8344,7 +8437,7 @@
           "lib/dotnet5.4/System.Collections.Concurrent.dll": {}
         }
       },
-      "System.Collections.Immutable/1.1.38-beta-23429": {
+      "System.Collections.Immutable/1.1.38-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -8363,7 +8456,7 @@
           "lib/dotnet5.1/System.Collections.Immutable.dll": {}
         }
       },
-      "System.Collections.NonGeneric/4.0.1-beta-23429": {
+      "System.Collections.NonGeneric/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -8374,13 +8467,13 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Collections.NonGeneric.dll": {}
+          "ref/dotnet5.4/System.Collections.NonGeneric.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Collections.NonGeneric.dll": {}
         }
       },
-      "System.Collections.Specialized/4.0.1-beta-23429": {
+      "System.Collections.Specialized/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections.NonGeneric": "4.0.0",
@@ -8392,13 +8485,13 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Collections.Specialized.dll": {}
+          "ref/dotnet5.4/System.Collections.Specialized.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Collections.Specialized.dll": {}
         }
       },
-      "System.ComponentModel/4.0.1-beta-23429": {
+      "System.ComponentModel/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -8410,7 +8503,7 @@
           "lib/dotnet5.4/System.ComponentModel.dll": {}
         }
       },
-      "System.ComponentModel.Annotations/4.0.11-beta-23429": {
+      "System.ComponentModel.Annotations/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8432,7 +8525,7 @@
           "lib/dotnet5.4/System.ComponentModel.Annotations.dll": {}
         }
       },
-      "System.ComponentModel.EventBasedAsync/4.0.11-beta-23429": {
+      "System.ComponentModel.EventBasedAsync/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -8447,17 +8540,17 @@
           "lib/dotnet5.4/System.ComponentModel.EventBasedAsync.dll": {}
         }
       },
-      "System.Console/4.0.0-beta-23429": {
+      "System.Console/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Console.dll": {}
+          "ref/dotnet5.4/System.Console.dll": {}
         }
       },
-      "System.Data.Common/4.0.1-beta-23429": {
+      "System.Data.Common/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8471,13 +8564,13 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Data.Common.dll": {}
+          "ref/dotnet5.4/System.Data.Common.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Data.Common.dll": {}
         }
       },
-      "System.Data.SqlClient/4.0.0-beta-23429": {
+      "System.Data.SqlClient/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Data.Common": "4.0.0",
@@ -8488,10 +8581,10 @@
           "System.Xml.ReaderWriter": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Data.SqlClient.dll": {}
+          "ref/dotnet5.4/System.Data.SqlClient.dll": {}
         }
       },
-      "System.Diagnostics.Contracts/4.0.1-beta-23429": {
+      "System.Diagnostics.Contracts/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -8503,7 +8596,7 @@
           "lib/DNXCore50/System.Diagnostics.Contracts.dll": {}
         }
       },
-      "System.Diagnostics.Debug/4.0.11-beta-23429": {
+      "System.Diagnostics.Debug/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -8512,16 +8605,16 @@
           "ref/dotnet5.4/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.FileVersionInfo/4.0.0-beta-23429": {
+      "System.Diagnostics.FileVersionInfo/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Diagnostics.FileVersionInfo.dll": {}
+          "ref/dotnet5.4/System.Diagnostics.FileVersionInfo.dll": {}
         }
       },
-      "System.Diagnostics.Process/4.1.0-beta-23429": {
+      "System.Diagnostics.Process/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -8533,20 +8626,20 @@
           "ref/dotnet5.5/System.Diagnostics.Process.dll": {}
         }
       },
-      "System.Diagnostics.StackTrace/4.0.1-beta-23429": {
+      "System.Diagnostics.StackTrace/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Diagnostics.StackTrace.dll": {}
+          "ref/dotnet5.4/System.Diagnostics.StackTrace.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Diagnostics.StackTrace.dll": {}
         }
       },
-      "System.Diagnostics.Tools/4.0.1-beta-23429": {
+      "System.Diagnostics.Tools/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -8558,7 +8651,7 @@
           "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
         }
       },
-      "System.Diagnostics.Tracing/4.0.21-beta-23429": {
+      "System.Diagnostics.Tracing/4.0.21-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -8570,7 +8663,7 @@
           "lib/DNXCore50/System.Diagnostics.Tracing.dll": {}
         }
       },
-      "System.Dynamic.Runtime/4.0.11-beta-23429": {
+      "System.Dynamic.Runtime/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8596,7 +8689,7 @@
           "lib/DNXCore50/System.Dynamic.Runtime.dll": {}
         }
       },
-      "System.Globalization/4.0.11-beta-23429": {
+      "System.Globalization/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -8608,20 +8701,20 @@
           "lib/DNXCore50/System.Globalization.dll": {}
         }
       },
-      "System.Globalization.Calendars/4.0.1-beta-23429": {
+      "System.Globalization.Calendars/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Globalization.Calendars.dll": {}
+          "ref/dotnet5.4/System.Globalization.Calendars.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Globalization.Calendars.dll": {}
         }
       },
-      "System.Globalization.Extensions/4.0.1-beta-23429": {
+      "System.Globalization.Extensions/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -8629,10 +8722,10 @@
           "System.Runtime.Extensions": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Globalization.Extensions.dll": {}
+          "ref/dotnet5.4/System.Globalization.Extensions.dll": {}
         }
       },
-      "System.IO/4.0.11-beta-23429": {
+      "System.IO/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20",
@@ -8646,7 +8739,7 @@
           "lib/DNXCore50/System.IO.dll": {}
         }
       },
-      "System.IO.Compression/4.1.0-beta-23429": {
+      "System.IO.Compression/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -8658,7 +8751,7 @@
           "ref/dotnet5.4/System.IO.Compression.dll": {}
         }
       },
-      "System.IO.Compression.ZipFile/4.0.1-beta-23429": {
+      "System.IO.Compression.ZipFile/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -8671,13 +8764,13 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.2/System.IO.Compression.ZipFile.dll": {}
+          "ref/dotnet5.4/System.IO.Compression.ZipFile.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.IO.Compression.ZipFile.dll": {}
         }
       },
-      "System.IO.FileSystem/4.0.1-beta-23429": {
+      "System.IO.FileSystem/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -8691,7 +8784,7 @@
           "ref/dotnet5.4/System.IO.FileSystem.dll": {}
         }
       },
-      "System.IO.FileSystem.DriveInfo/4.0.0-beta-23429": {
+      "System.IO.FileSystem.DriveInfo/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -8702,28 +8795,28 @@
           "ref/dotnet5.4/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
-      "System.IO.FileSystem.Primitives/4.0.1-beta-23429": {
+      "System.IO.FileSystem.Primitives/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet5.1/System.IO.FileSystem.Primitives.dll": {}
+          "ref/dotnet5.4/System.IO.FileSystem.Primitives.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.IO.FileSystem.Primitives.dll": {}
         }
       },
-      "System.IO.FileSystem.Watcher/4.0.0-beta-23429": {
+      "System.IO.FileSystem.Watcher/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.IO.FileSystem.Watcher.dll": {}
+          "ref/dotnet5.4/System.IO.FileSystem.Watcher.dll": {}
         }
       },
-      "System.IO.MemoryMappedFiles/4.0.0-beta-23429": {
+      "System.IO.MemoryMappedFiles/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO.FileSystem": "4.0.0",
@@ -8737,7 +8830,7 @@
           "ref/dotnet5.4/System.IO.MemoryMappedFiles.dll": {}
         }
       },
-      "System.IO.Pipes/4.0.0-beta-23429": {
+      "System.IO.Pipes/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -8750,7 +8843,7 @@
           "ref/dotnet5.4/System.IO.Pipes.dll": {}
         }
       },
-      "System.IO.UnmanagedMemoryStream/4.0.1-beta-23429": {
+      "System.IO.UnmanagedMemoryStream/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -8762,13 +8855,13 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.2/System.IO.UnmanagedMemoryStream.dll": {}
+          "ref/dotnet5.4/System.IO.UnmanagedMemoryStream.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.IO.UnmanagedMemoryStream.dll": {}
         }
       },
-      "System.Linq/4.0.1-beta-23429": {
+      "System.Linq/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8784,33 +8877,17 @@
           "lib/dotnet5.4/System.Linq.dll": {}
         }
       },
-      "System.Linq.Expressions/4.0.11-beta-23429": {
+      "System.Linq.Expressions/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.Linq": "4.0.0",
-          "System.ObjectModel": "4.0.10",
-          "System.Reflection": "4.0.10",
-          "System.Reflection.Emit": "4.0.0",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Reflection.TypeExtensions": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Threading": "4.0.10"
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Linq.Expressions.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Linq.Expressions.dll": {}
         }
       },
-      "System.Linq.Parallel/4.0.1-beta-23429": {
+      "System.Linq.Parallel/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8831,7 +8908,7 @@
           "lib/dotnet5.4/System.Linq.Parallel.dll": {}
         }
       },
-      "System.Linq.Queryable/4.0.1-beta-23429": {
+      "System.Linq.Queryable/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8849,7 +8926,7 @@
           "lib/dotnet5.4/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23429": {
+      "System.Net.Http/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -8862,7 +8939,7 @@
           "ref/dotnet5.2/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23429": {
+      "System.Net.NameResolution/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -8873,7 +8950,7 @@
           "ref/dotnet5.4/System.Net.NameResolution.dll": {}
         }
       },
-      "System.Net.NetworkInformation/4.1.0-beta-23429": {
+      "System.Net.NetworkInformation/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -8884,7 +8961,7 @@
           "ref/dotnet5.4/System.Net.NetworkInformation.dll": {}
         }
       },
-      "System.Net.Primitives/4.0.11-beta-23429": {
+      "System.Net.Primitives/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -8894,7 +8971,7 @@
           "ref/dotnet5.4/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Requests/4.0.11-beta-23429": {
+      "System.Net.Requests/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -8907,20 +8984,20 @@
           "ref/dotnet5.4/System.Net.Requests.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23429": {
+      "System.Net.Security/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Net.Primitives": "4.0.10",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.Security.dll": {}
         }
       },
-      "System.Net.Sockets/4.1.0-beta-23429": {
+      "System.Net.Sockets/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -8929,13 +9006,13 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.5/System.Net.Sockets.dll": {}
+          "ref/dotnet5.4/System.Net.Sockets.dll": {}
         }
       },
-      "System.Net.Utilities/4.0.0-beta-23429": {
+      "System.Net.Utilities/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23429"
+          "System.Private.Networking": "4.0.1-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.Utilities.dll": {}
@@ -8944,7 +9021,7 @@
           "lib/DNXCore50/System.Net.Utilities.dll": {}
         }
       },
-      "System.Net.WebHeaderCollection/4.0.1-beta-23429": {
+      "System.Net.WebHeaderCollection/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8960,35 +9037,35 @@
           "lib/dotnet5.4/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23429": {
+      "System.Net.WebSockets/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
-          "System.Threading.Tasks": "4.0.0"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Net.WebSockets.dll": {}
+          "ref/dotnet5.4/System.Net.WebSockets.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23429": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
-          "System.Net.WebSockets": "4.0.0-beta-23429",
+          "System.Net.WebSockets": "4.0.0-beta-23506",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.WebSockets.Client.dll": {}
         }
       },
-      "System.Numerics.Vectors/4.1.1-beta-23429": {
+      "System.Numerics.Vectors/4.1.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -9003,7 +9080,7 @@
           "lib/dotnet5.4/System.Numerics.Vectors.dll": {}
         }
       },
-      "System.ObjectModel/4.0.11-beta-23429": {
+      "System.ObjectModel/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -9019,38 +9096,13 @@
           "lib/dotnet5.4/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.DataContractSerialization/4.1.0-beta-23429": {
+      "System.Private.DataContractSerialization/4.1.0-beta-23506": {
         "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.10",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Reflection.TypeExtensions": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23429",
-          "System.Text.Encoding": "4.0.10",
-          "System.Text.Encoding.Extensions": "4.0.10",
-          "System.Text.RegularExpressions": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Xml.ReaderWriter": "4.0.10",
-          "System.Xml.XmlSerializer": "4.0.10"
-        },
         "compile": {
           "ref/dnxcore50/_._": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23429": {
+      "System.Private.Networking/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -9069,14 +9121,14 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23429",
+          "System.Security.Principal.Windows": "4.0.0-beta-23506",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23429"
+          "System.Threading.ThreadPool": "4.0.10-beta-23506"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -9085,53 +9137,53 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23429": {
+      "System.Private.ServiceModel/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.11-beta-23429",
-          "System.Collections.Concurrent": "4.0.11-beta-23429",
-          "System.Collections.NonGeneric": "4.0.1-beta-23429",
-          "System.Collections.Specialized": "4.0.1-beta-23429",
-          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23429",
-          "System.Diagnostics.Debug": "4.0.11-beta-23429",
-          "System.Diagnostics.Tracing": "4.0.21-beta-23429",
-          "System.Globalization": "4.0.11-beta-23429",
-          "System.IO": "4.0.11-beta-23429",
-          "System.IO.Compression": "4.1.0-beta-23429",
-          "System.Linq": "4.0.1-beta-23429",
-          "System.Linq.Expressions": "4.0.11-beta-23429",
-          "System.Linq.Queryable": "4.0.1-beta-23429",
-          "System.Net.Http": "4.0.1-beta-23429",
-          "System.Net.NameResolution": "4.0.0-beta-23429",
-          "System.Net.Primitives": "4.0.11-beta-23429",
-          "System.Net.Security": "4.0.0-beta-23429",
-          "System.Net.Sockets": "4.1.0-beta-23429",
-          "System.Net.WebHeaderCollection": "4.0.1-beta-23429",
-          "System.Net.WebSockets": "4.0.0-beta-23429",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23429",
-          "System.ObjectModel": "4.0.11-beta-23429",
-          "System.Reflection": "4.1.0-beta-23429",
-          "System.Reflection.DispatchProxy": "4.0.1-beta-23429",
-          "System.Reflection.Extensions": "4.0.1-beta-23429",
-          "System.Reflection.Primitives": "4.0.1-beta-23429",
-          "System.Reflection.TypeExtensions": "4.0.1-beta-23429",
-          "System.Resources.ResourceManager": "4.0.1-beta-23429",
-          "System.Runtime": "4.0.21-beta-23429",
-          "System.Runtime.Extensions": "4.0.11-beta-23429",
-          "System.Runtime.InteropServices": "4.0.21-beta-23429",
+          "System.Collections": "4.0.11-beta-23506",
+          "System.Collections.Concurrent": "4.0.11-beta-23506",
+          "System.Collections.NonGeneric": "4.0.1-beta-23506",
+          "System.Collections.Specialized": "4.0.1-beta-23506",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23506",
+          "System.Diagnostics.Debug": "4.0.11-beta-23506",
+          "System.Diagnostics.Tracing": "4.0.21-beta-23506",
+          "System.Globalization": "4.0.11-beta-23506",
+          "System.IO": "4.0.11-beta-23506",
+          "System.IO.Compression": "4.1.0-beta-23506",
+          "System.Linq": "4.0.1-beta-23506",
+          "System.Linq.Expressions": "4.0.11-beta-23506",
+          "System.Linq.Queryable": "4.0.1-beta-23506",
+          "System.Net.Http": "4.0.1-beta-23506",
+          "System.Net.NameResolution": "4.0.0-beta-23506",
+          "System.Net.Primitives": "4.0.11-beta-23506",
+          "System.Net.Security": "4.0.0-beta-23506",
+          "System.Net.Sockets": "4.1.0-beta-23506",
+          "System.Net.WebHeaderCollection": "4.0.1-beta-23506",
+          "System.Net.WebSockets": "4.0.0-beta-23506",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23506",
+          "System.ObjectModel": "4.0.11-beta-23506",
+          "System.Reflection": "4.1.0-beta-23506",
+          "System.Reflection.DispatchProxy": "4.0.1-beta-23506",
+          "System.Reflection.Extensions": "4.0.1-beta-23506",
+          "System.Reflection.Primitives": "4.0.1-beta-23506",
+          "System.Reflection.TypeExtensions": "4.0.1-beta-23506",
+          "System.Resources.ResourceManager": "4.0.1-beta-23506",
+          "System.Runtime": "4.0.21-beta-23506",
+          "System.Runtime.Extensions": "4.0.11-beta-23506",
+          "System.Runtime.InteropServices": "4.0.21-beta-23506",
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
-          "System.Security.Claims": "4.0.1-beta-23429",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
-          "System.Security.Principal": "4.0.1-beta-23429",
-          "System.Security.Principal.Windows": "4.0.0-beta-23429",
-          "System.Text.Encoding": "4.0.11-beta-23429",
-          "System.Threading": "4.0.11-beta-23429",
-          "System.Threading.Tasks": "4.0.11-beta-23429",
-          "System.Threading.Timer": "4.0.1-beta-23429",
-          "System.Xml.ReaderWriter": "4.0.11-beta-23429",
-          "System.Xml.XmlDocument": "4.0.1-beta-23429",
-          "System.Xml.XmlSerializer": "4.0.11-beta-23429"
+          "System.Security.Claims": "4.0.1-beta-23506",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
+          "System.Security.Principal": "4.0.1-beta-23506",
+          "System.Security.Principal.Windows": "4.0.0-beta-23506",
+          "System.Text.Encoding": "4.0.11-beta-23506",
+          "System.Threading": "4.0.11-beta-23506",
+          "System.Threading.Tasks": "4.0.11-beta-23506",
+          "System.Threading.Timer": "4.0.1-beta-23506",
+          "System.Xml.ReaderWriter": "4.0.11-beta-23506",
+          "System.Xml.XmlDocument": "4.0.1-beta-23506",
+          "System.Xml.XmlSerializer": "4.0.11-beta-23506"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -9140,13 +9192,13 @@
           "lib/DNXCore50/System.Private.ServiceModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.1-beta-23429": {
+      "System.Private.Uri/4.0.1-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
         }
       },
-      "System.Reflection/4.1.0-beta-23429": {
+      "System.Reflection/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -9160,26 +9212,17 @@
           "lib/DNXCore50/System.Reflection.dll": {}
         }
       },
-      "System.Reflection.DispatchProxy/4.0.1-beta-23429": {
+      "System.Reflection.DispatchProxy/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.10",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Threading": "4.0.10"
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Reflection.DispatchProxy.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Reflection.DispatchProxy.dll": {}
+          "ref/dotnet5.4/System.Reflection.DispatchProxy.dll": {}
         }
       },
-      "System.Reflection.Emit/4.0.1-beta-23429": {
+      "System.Reflection.Emit/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -9195,7 +9238,7 @@
           "lib/DNXCore50/System.Reflection.Emit.dll": {}
         }
       },
-      "System.Reflection.Emit.ILGeneration/4.0.1-beta-23429": {
+      "System.Reflection.Emit.ILGeneration/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -9209,7 +9252,7 @@
           "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
         }
       },
-      "System.Reflection.Emit.Lightweight/4.0.1-beta-23429": {
+      "System.Reflection.Emit.Lightweight/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -9224,7 +9267,7 @@
           "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll": {}
         }
       },
-      "System.Reflection.Extensions/4.0.1-beta-23429": {
+      "System.Reflection.Extensions/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -9237,7 +9280,7 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.1.1-beta-23429": {
+      "System.Reflection.Metadata/1.1.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -9262,7 +9305,7 @@
           "lib/dotnet5.2/System.Reflection.Metadata.dll": {}
         }
       },
-      "System.Reflection.Primitives/4.0.1-beta-23429": {
+      "System.Reflection.Primitives/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -9274,20 +9317,20 @@
           "lib/DNXCore50/System.Reflection.Primitives.dll": {}
         }
       },
-      "System.Reflection.TypeExtensions/4.1.0-beta-23429": {
+      "System.Reflection.TypeExtensions/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Reflection.TypeExtensions.dll": {}
+          "ref/dotnet5.4/System.Reflection.TypeExtensions.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
         }
       },
-      "System.Resources.ReaderWriter/4.0.0-beta-23429": {
+      "System.Resources.ReaderWriter/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -9299,13 +9342,13 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Resources.ReaderWriter.dll": {}
+          "ref/dotnet5.4/System.Resources.ReaderWriter.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Resources.ReaderWriter.dll": {}
         }
       },
-      "System.Resources.ResourceManager/4.0.1-beta-23429": {
+      "System.Resources.ResourceManager/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -9319,10 +9362,10 @@
           "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
         }
       },
-      "System.Runtime/4.0.21-beta-23429": {
+      "System.Runtime/4.0.21-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.Uri": "4.0.1-beta-23429"
+          "System.Private.Uri": "4.0.1-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Runtime.dll": {}
@@ -9331,19 +9374,19 @@
           "lib/DNXCore50/System.Runtime.dll": {}
         }
       },
-      "System.Runtime.CompilerServices.VisualC/4.0.0-beta-23429": {
+      "System.Runtime.CompilerServices.VisualC/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Runtime.CompilerServices.VisualC.dll": {}
+          "ref/dotnet5.4/System.Runtime.CompilerServices.VisualC.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Runtime.CompilerServices.VisualC.dll": {}
         }
       },
-      "System.Runtime.Extensions/4.0.11-beta-23429": {
+      "System.Runtime.Extensions/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -9352,7 +9395,7 @@
           "ref/dotnet5.4/System.Runtime.Extensions.dll": {}
         }
       },
-      "System.Runtime.Handles/4.0.1-beta-23429": {
+      "System.Runtime.Handles/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -9364,7 +9407,7 @@
           "lib/DNXCore50/System.Runtime.Handles.dll": {}
         }
       },
-      "System.Runtime.InteropServices/4.0.21-beta-23429": {
+      "System.Runtime.InteropServices/4.0.21-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -9379,16 +9422,16 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23429": {
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+          "ref/dotnet5.2/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "System.Runtime.Loader/4.0.0-beta-23429": {
+      "System.Runtime.Loader/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -9402,7 +9445,7 @@
           "lib/DNXCore50/System.Runtime.Loader.dll": {}
         }
       },
-      "System.Runtime.Numerics/4.0.1-beta-23429": {
+      "System.Runtime.Numerics/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -9417,10 +9460,10 @@
           "lib/dotnet5.4/System.Runtime.Numerics.dll": {}
         }
       },
-      "System.Runtime.Serialization.Json/4.0.1-beta-23429": {
+      "System.Runtime.Serialization.Json/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.1.0-beta-23429"
+          "System.Private.DataContractSerialization": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.1/System.Runtime.Serialization.Json.dll": {}
@@ -9429,7 +9472,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Json.dll": {}
         }
       },
-      "System.Runtime.Serialization.Primitives/4.1.0-beta-23429": {
+      "System.Runtime.Serialization.Primitives/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -9442,11 +9485,11 @@
           "lib/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
         }
       },
-      "System.Runtime.Serialization.Xml/4.1.0-beta-23429": {
+      "System.Runtime.Serialization.Xml/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.1.0-beta-23429",
-          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23429"
+          "System.Private.DataContractSerialization": "4.1.0-beta-23506",
+          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Runtime.Serialization.Xml.dll": {}
@@ -9455,7 +9498,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Xml.dll": {}
         }
       },
-      "System.Security.Claims/4.0.1-beta-23429": {
+      "System.Security.Claims/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -9468,35 +9511,36 @@
           "System.Security.Principal": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Claims.dll": {}
+          "ref/dotnet5.4/System.Security.Claims.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23429": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Cryptography.Algorithms.dll": {}
+          "ref/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23429": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Cryptography.Encoding.dll": {}
+          "ref/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.OpenSsl/4.0.0-beta-23429": {
+      "System.Security.Cryptography.OpenSsl/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
+          "System.Collections": "4.0.0",
           "System.IO": "4.0.10",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
@@ -9504,9 +9548,9 @@
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
           "System.Runtime.Numerics": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
@@ -9516,7 +9560,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.OpenSsl.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23429": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -9528,25 +9572,25 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Cryptography.Primitives.dll": {}
+          "ref/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23429": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23429"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
-      "System.Security.Principal/4.0.1-beta-23429": {
+      "System.Security.Principal/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -9558,7 +9602,7 @@
           "lib/dotnet5.1/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23429": {
+      "System.Security.Principal.Windows/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -9581,10 +9625,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23429": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429"
+          "System.Private.ServiceModel": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.2/System.ServiceModel.Duplex.dll": {}
@@ -9593,10 +9637,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23429": {
+      "System.ServiceModel.Http/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429",
+          "System.Private.ServiceModel": "4.1.0-beta-23506",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -9606,10 +9650,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.1.0-beta-23429": {
+      "System.ServiceModel.NetTcp/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429"
+          "System.Private.ServiceModel": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.ServiceModel.NetTcp.dll": {}
@@ -9618,10 +9662,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.1.0-beta-23429": {
+      "System.ServiceModel.Primitives/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429"
+          "System.Private.ServiceModel": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.ServiceModel.Primitives.dll": {}
@@ -9630,10 +9674,10 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
-      "System.ServiceModel.Security/4.0.1-beta-23429": {
+      "System.ServiceModel.Security/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429"
+          "System.Private.ServiceModel": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.2/System.ServiceModel.Security.dll": {}
@@ -9642,7 +9686,7 @@
           "lib/DNXCore50/System.ServiceModel.Security.dll": {}
         }
       },
-      "System.Text.Encoding/4.0.11-beta-23429": {
+      "System.Text.Encoding/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -9654,29 +9698,17 @@
           "lib/DNXCore50/System.Text.Encoding.dll": {}
         }
       },
-      "System.Text.Encoding.CodePages/4.0.0": {
+      "System.Text.Encoding.CodePages/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.Reflection": "4.0.10",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Runtime.Handles": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Text.Encoding": "4.0.10",
-          "System.Threading": "4.0.10"
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/System.Text.Encoding.CodePages.dll": {}
+          "ref/dotnet5.4/System.Text.Encoding.CodePages.dll": {}
         }
       },
-      "System.Text.Encoding.Extensions/4.0.11-beta-23429": {
+      "System.Text.Encoding.Extensions/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -9689,7 +9721,7 @@
           "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
         }
       },
-      "System.Text.RegularExpressions/4.0.11-beta-23429": {
+      "System.Text.RegularExpressions/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -9706,7 +9738,7 @@
           "lib/dotnet5.4/System.Text.RegularExpressions.dll": {}
         }
       },
-      "System.Threading/4.0.11-beta-23429": {
+      "System.Threading/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -9716,20 +9748,20 @@
           "ref/dotnet5.4/System.Threading.dll": {}
         }
       },
-      "System.Threading.Overlapped/4.0.0": {
+      "System.Threading.Overlapped/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Overlapped.dll": {}
+          "ref/dotnet5.4/System.Threading.Overlapped.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Overlapped.dll": {}
         }
       },
-      "System.Threading.Tasks/4.0.11-beta-23429": {
+      "System.Threading.Tasks/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -9741,7 +9773,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.Tasks.Dataflow/4.5.26-beta-23429": {
+      "System.Threading.Tasks.Dataflow/4.5.26-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -9763,7 +9795,7 @@
           "lib/dotnet5.2/System.Threading.Tasks.Dataflow.dll": {}
         }
       },
-      "System.Threading.Tasks.Parallel/4.0.1-beta-23429": {
+      "System.Threading.Tasks.Parallel/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections.Concurrent": "4.0.10",
@@ -9782,32 +9814,32 @@
           "lib/dotnet5.4/System.Threading.Tasks.Parallel.dll": {}
         }
       },
-      "System.Threading.Thread/4.0.0-beta-23429": {
+      "System.Threading.Thread/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Threading.Thread.dll": {}
+          "ref/dotnet5.4/System.Threading.Thread.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Thread.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23429": {
+      "System.Threading.ThreadPool/4.0.10-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.InteropServices": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.2/System.Threading.ThreadPool.dll": {}
+          "ref/dotnet5.4/System.Threading.ThreadPool.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
-      "System.Threading.Timer/4.0.1-beta-23429": {
+      "System.Threading.Timer/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -9819,7 +9851,7 @@
           "lib/DNXCore50/System.Threading.Timer.dll": {}
         }
       },
-      "System.Xml.ReaderWriter/4.0.11-beta-23429": {
+      "System.Xml.ReaderWriter/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -9844,7 +9876,7 @@
           "lib/dotnet5.4/System.Xml.ReaderWriter.dll": {}
         }
       },
-      "System.Xml.XDocument/4.0.11-beta-23429": {
+      "System.Xml.XDocument/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -9867,7 +9899,7 @@
           "lib/dotnet5.4/System.Xml.XDocument.dll": {}
         }
       },
-      "System.Xml.XmlDocument/4.0.1-beta-23429": {
+      "System.Xml.XmlDocument/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -9882,37 +9914,21 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Xml.XmlDocument.dll": {}
+          "ref/dotnet5.4/System.Xml.XmlDocument.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Xml.XmlDocument.dll": {}
         }
       },
-      "System.Xml.XmlSerializer/4.0.11-beta-23429": {
+      "System.Xml.XmlSerializer/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.10",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Reflection.TypeExtensions": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Text.RegularExpressions": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Xml.ReaderWriter": "4.0.10",
-          "System.Xml.XmlDocument": "4.0.0"
+          "System.IO": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet5.4/System.Xml.XmlSerializer.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
         }
       },
       "xunit/2.1.0": {
@@ -10072,7 +10088,7 @@
       "coveralls.io/1.4.0": {
         "type": "package"
       },
-      "Microsoft.CSharp/4.0.1-beta-23429": {
+      "Microsoft.CSharp/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10108,169 +10124,147 @@
           "xunit.runner.console": "2.1.0"
         }
       },
-      "Microsoft.NETCore/5.0.1-beta-23429": {
+      "Microsoft.NETCore/5.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "Microsoft.CSharp": "4.0.1-beta-23429",
-          "Microsoft.NETCore.Targets": "1.0.1-beta-23429",
-          "Microsoft.VisualBasic": "10.0.1-beta-23429",
-          "System.AppContext": "4.0.1-beta-23429",
-          "System.Collections": "4.0.11-beta-23429",
-          "System.Collections.Concurrent": "4.0.11-beta-23429",
-          "System.Collections.Immutable": "1.1.38-beta-23429",
-          "System.ComponentModel": "4.0.1-beta-23429",
-          "System.ComponentModel.Annotations": "4.0.11-beta-23429",
-          "System.Diagnostics.Debug": "4.0.11-beta-23429",
-          "System.Diagnostics.Tools": "4.0.1-beta-23429",
-          "System.Diagnostics.Tracing": "4.0.21-beta-23429",
-          "System.Dynamic.Runtime": "4.0.11-beta-23429",
-          "System.Globalization": "4.0.11-beta-23429",
-          "System.Globalization.Calendars": "4.0.1-beta-23429",
-          "System.Globalization.Extensions": "4.0.1-beta-23429",
-          "System.IO": "4.0.11-beta-23429",
-          "System.IO.Compression": "4.1.0-beta-23429",
-          "System.IO.Compression.ZipFile": "4.0.1-beta-23429",
-          "System.IO.FileSystem": "4.0.1-beta-23429",
-          "System.IO.FileSystem.Primitives": "4.0.1-beta-23429",
-          "System.IO.UnmanagedMemoryStream": "4.0.1-beta-23429",
-          "System.Linq": "4.0.1-beta-23429",
-          "System.Linq.Expressions": "4.0.11-beta-23429",
-          "System.Linq.Parallel": "4.0.1-beta-23429",
-          "System.Linq.Queryable": "4.0.1-beta-23429",
-          "System.Net.Http": "4.0.1-beta-23429",
-          "System.Net.NetworkInformation": "4.1.0-beta-23429",
-          "System.Net.Primitives": "4.0.11-beta-23429",
-          "System.Numerics.Vectors": "4.1.1-beta-23429",
-          "System.ObjectModel": "4.0.11-beta-23429",
-          "System.Reflection": "4.1.0-beta-23429",
-          "System.Reflection.DispatchProxy": "4.0.1-beta-23429",
-          "System.Reflection.Extensions": "4.0.1-beta-23429",
-          "System.Reflection.Metadata": "1.1.1-beta-23429",
-          "System.Reflection.Primitives": "4.0.1-beta-23429",
-          "System.Reflection.TypeExtensions": "4.1.0-beta-23429",
-          "System.Resources.ResourceManager": "4.0.1-beta-23429",
-          "System.Runtime": "4.0.21-beta-23429",
-          "System.Runtime.Extensions": "4.0.11-beta-23429",
-          "System.Runtime.Handles": "4.0.1-beta-23429",
-          "System.Runtime.InteropServices": "4.0.21-beta-23429",
-          "System.Runtime.Numerics": "4.0.1-beta-23429",
-          "System.Security.Claims": "4.0.1-beta-23429",
-          "System.Security.Principal": "4.0.1-beta-23429",
-          "System.Text.Encoding": "4.0.11-beta-23429",
-          "System.Text.Encoding.Extensions": "4.0.11-beta-23429",
-          "System.Text.RegularExpressions": "4.0.11-beta-23429",
-          "System.Threading": "4.0.11-beta-23429",
-          "System.Threading.Tasks": "4.0.11-beta-23429",
-          "System.Threading.Tasks.Dataflow": "4.5.26-beta-23429",
-          "System.Threading.Tasks.Parallel": "4.0.1-beta-23429",
-          "System.Threading.Timer": "4.0.1-beta-23429",
-          "System.Xml.ReaderWriter": "4.0.11-beta-23429",
-          "System.Xml.XDocument": "4.0.11-beta-23429"
+          "Microsoft.CSharp": "4.0.1-beta-23506",
+          "Microsoft.NETCore.Platforms": "1.0.1-beta-23506",
+          "Microsoft.VisualBasic": "10.0.1-beta-23506",
+          "System.AppContext": "4.0.1-beta-23506",
+          "System.Collections": "4.0.11-beta-23506",
+          "System.Collections.Concurrent": "4.0.11-beta-23506",
+          "System.Collections.Immutable": "1.1.38-beta-23506",
+          "System.ComponentModel": "4.0.1-beta-23506",
+          "System.ComponentModel.Annotations": "4.0.11-beta-23506",
+          "System.Diagnostics.Debug": "4.0.11-beta-23506",
+          "System.Diagnostics.Tools": "4.0.1-beta-23506",
+          "System.Diagnostics.Tracing": "4.0.21-beta-23506",
+          "System.Dynamic.Runtime": "4.0.11-beta-23506",
+          "System.Globalization": "4.0.11-beta-23506",
+          "System.Globalization.Calendars": "4.0.1-beta-23506",
+          "System.Globalization.Extensions": "4.0.1-beta-23506",
+          "System.IO": "4.0.11-beta-23506",
+          "System.IO.Compression": "4.1.0-beta-23506",
+          "System.IO.Compression.ZipFile": "4.0.1-beta-23506",
+          "System.IO.FileSystem": "4.0.1-beta-23506",
+          "System.IO.FileSystem.Primitives": "4.0.1-beta-23506",
+          "System.IO.UnmanagedMemoryStream": "4.0.1-beta-23506",
+          "System.Linq": "4.0.1-beta-23506",
+          "System.Linq.Expressions": "4.0.11-beta-23506",
+          "System.Linq.Parallel": "4.0.1-beta-23506",
+          "System.Linq.Queryable": "4.0.1-beta-23506",
+          "System.Net.Http": "4.0.1-beta-23506",
+          "System.Net.NetworkInformation": "4.1.0-beta-23506",
+          "System.Net.Primitives": "4.0.11-beta-23506",
+          "System.Numerics.Vectors": "4.1.1-beta-23506",
+          "System.ObjectModel": "4.0.11-beta-23506",
+          "System.Reflection": "4.1.0-beta-23506",
+          "System.Reflection.DispatchProxy": "4.0.1-beta-23506",
+          "System.Reflection.Extensions": "4.0.1-beta-23506",
+          "System.Reflection.Metadata": "1.1.1-beta-23506",
+          "System.Reflection.Primitives": "4.0.1-beta-23506",
+          "System.Reflection.TypeExtensions": "4.1.0-beta-23506",
+          "System.Resources.ResourceManager": "4.0.1-beta-23506",
+          "System.Runtime": "4.0.21-beta-23506",
+          "System.Runtime.Extensions": "4.0.11-beta-23506",
+          "System.Runtime.Handles": "4.0.1-beta-23506",
+          "System.Runtime.InteropServices": "4.0.21-beta-23506",
+          "System.Runtime.Numerics": "4.0.1-beta-23506",
+          "System.Security.Claims": "4.0.1-beta-23506",
+          "System.Security.Principal": "4.0.1-beta-23506",
+          "System.Text.Encoding": "4.0.11-beta-23506",
+          "System.Text.Encoding.Extensions": "4.0.11-beta-23506",
+          "System.Text.RegularExpressions": "4.0.11-beta-23506",
+          "System.Threading": "4.0.11-beta-23506",
+          "System.Threading.Tasks": "4.0.11-beta-23506",
+          "System.Threading.Tasks.Dataflow": "4.5.26-beta-23506",
+          "System.Threading.Tasks.Parallel": "4.0.1-beta-23506",
+          "System.Threading.Timer": "4.0.1-beta-23506",
+          "System.Xml.ReaderWriter": "4.0.11-beta-23506",
+          "System.Xml.XDocument": "4.0.11-beta-23506"
         }
       },
-      "Microsoft.NETCore.Console/1.0.0-beta-23429": {
+      "Microsoft.NETCore.Console/1.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore": "5.0.1-beta-23429",
-          "Microsoft.NETCore.ConsoleHost": "1.0.0-beta-23429",
-          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23429",
-          "Microsoft.Win32.Primitives": "4.0.1-beta-23429",
-          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23429",
-          "System.Console": "4.0.0-beta-23429",
-          "System.Data.Common": "4.0.1-beta-23429",
-          "System.Data.SqlClient": "4.0.0-beta-23429",
-          "System.Diagnostics.Contracts": "4.0.1-beta-23429",
-          "System.Diagnostics.FileVersionInfo": "4.0.0-beta-23429",
-          "System.Diagnostics.Process": "4.1.0-beta-23429",
-          "System.Diagnostics.StackTrace": "4.0.1-beta-23429",
-          "System.IO.FileSystem.DriveInfo": "4.0.0-beta-23429",
-          "System.IO.FileSystem.Watcher": "4.0.0-beta-23429",
-          "System.IO.MemoryMappedFiles": "4.0.0-beta-23429",
-          "System.IO.Pipes": "4.0.0-beta-23429",
-          "System.Net.NameResolution": "4.0.0-beta-23429",
-          "System.Net.NetworkInformation": "4.1.0-beta-23429",
-          "System.Net.Requests": "4.0.11-beta-23429",
-          "System.Net.Security": "4.0.0-beta-23429",
-          "System.Net.Sockets": "4.1.0-beta-23429",
-          "System.Net.Utilities": "4.0.0-beta-23429",
-          "System.Net.WebHeaderCollection": "4.0.1-beta-23429",
-          "System.Net.WebSockets": "4.0.0-beta-23429",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23429",
-          "System.Reflection.Emit": "4.0.1-beta-23429",
-          "System.Reflection.Emit.ILGeneration": "4.0.1-beta-23429",
-          "System.Reflection.Emit.Lightweight": "4.0.1-beta-23429",
-          "System.Resources.ReaderWriter": "4.0.0-beta-23429",
-          "System.Runtime.CompilerServices.VisualC": "4.0.0-beta-23429",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23429",
-          "System.Runtime.Loader": "4.0.0-beta-23429",
-          "System.Runtime.Serialization.Json": "4.0.1-beta-23429",
-          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23429",
-          "System.Runtime.Serialization.Xml": "4.1.0-beta-23429",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
-          "System.ServiceModel.Duplex": "4.0.1-beta-23429",
-          "System.ServiceModel.Http": "4.0.11-beta-23429",
-          "System.ServiceModel.NetTcp": "4.1.0-beta-23429",
-          "System.ServiceModel.Primitives": "4.1.0-beta-23429",
-          "System.ServiceModel.Security": "4.0.1-beta-23429",
-          "System.Xml.XmlSerializer": "4.0.11-beta-23429"
+          "Microsoft.NETCore": "5.0.1-beta-23506",
+          "Microsoft.NETCore.ConsoleHost": "1.0.0-beta-23506",
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-beta-23506",
+          "Microsoft.Win32.Primitives": "4.0.1-beta-23506",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23506",
+          "System.Console": "4.0.0-beta-23506",
+          "System.Data.Common": "4.0.1-beta-23506",
+          "System.Data.SqlClient": "4.0.0-beta-23506",
+          "System.Diagnostics.Contracts": "4.0.1-beta-23506",
+          "System.Diagnostics.FileVersionInfo": "4.0.0-beta-23506",
+          "System.Diagnostics.Process": "4.1.0-beta-23506",
+          "System.Diagnostics.StackTrace": "4.0.1-beta-23506",
+          "System.IO.FileSystem.DriveInfo": "4.0.0-beta-23506",
+          "System.IO.FileSystem.Watcher": "4.0.0-beta-23506",
+          "System.IO.MemoryMappedFiles": "4.0.0-beta-23506",
+          "System.IO.Pipes": "4.0.0-beta-23506",
+          "System.Net.NameResolution": "4.0.0-beta-23506",
+          "System.Net.NetworkInformation": "4.1.0-beta-23506",
+          "System.Net.Requests": "4.0.11-beta-23506",
+          "System.Net.Security": "4.0.0-beta-23506",
+          "System.Net.Sockets": "4.1.0-beta-23506",
+          "System.Net.Utilities": "4.0.0-beta-23506",
+          "System.Net.WebHeaderCollection": "4.0.1-beta-23506",
+          "System.Net.WebSockets": "4.0.0-beta-23506",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23506",
+          "System.Reflection.Emit": "4.0.1-beta-23506",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-beta-23506",
+          "System.Reflection.Emit.Lightweight": "4.0.1-beta-23506",
+          "System.Resources.ReaderWriter": "4.0.0-beta-23506",
+          "System.Runtime.CompilerServices.VisualC": "4.0.0-beta-23506",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23506",
+          "System.Runtime.Loader": "4.0.0-beta-23506",
+          "System.Runtime.Serialization.Json": "4.0.1-beta-23506",
+          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23506",
+          "System.Runtime.Serialization.Xml": "4.1.0-beta-23506",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
+          "System.ServiceModel.Duplex": "4.0.1-beta-23506",
+          "System.ServiceModel.Http": "4.0.11-beta-23506",
+          "System.ServiceModel.NetTcp": "4.1.0-beta-23506",
+          "System.ServiceModel.Primitives": "4.1.0-beta-23506",
+          "System.ServiceModel.Security": "4.0.1-beta-23506",
+          "System.Xml.XmlSerializer": "4.0.11-beta-23506"
         }
       },
-      "Microsoft.NETCore.ConsoleHost/1.0.0-beta-23429": {
+      "Microsoft.NETCore.ConsoleHost/1.0.0-beta-23506": {
         "type": "package"
       },
-      "Microsoft.NETCore.Platforms/1.0.1-beta-23429": {
-        "type": "package"
-      },
-      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23429": {
+      "Microsoft.NETCore.Platforms/1.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-beta-23429",
-          "System.Collections": "[4.0.11-beta-23429]",
-          "System.Diagnostics.Contracts": "[4.0.1-beta-23429]",
-          "System.Diagnostics.Debug": "[4.0.11-beta-23429]",
-          "System.Diagnostics.StackTrace": "[4.0.1-beta-23429]",
-          "System.Diagnostics.Tools": "[4.0.1-beta-23429]",
-          "System.Diagnostics.Tracing": "[4.0.21-beta-23429]",
-          "System.Globalization": "[4.0.11-beta-23429]",
-          "System.Globalization.Calendars": "[4.0.1-beta-23429]",
-          "System.IO": "[4.0.11-beta-23429]",
-          "System.ObjectModel": "[4.0.11-beta-23429]",
-          "System.Private.Uri": "[4.0.1-beta-23429]",
-          "System.Reflection": "[4.1.0-beta-23429]",
-          "System.Reflection.Extensions": "[4.0.1-beta-23429]",
-          "System.Reflection.Primitives": "[4.0.1-beta-23429]",
-          "System.Resources.ResourceManager": "[4.0.1-beta-23429]",
-          "System.Runtime": "[4.0.21-beta-23429]",
-          "System.Runtime.Extensions": "[4.0.11-beta-23429]",
-          "System.Runtime.Handles": "[4.0.1-beta-23429]",
-          "System.Runtime.InteropServices": "[4.0.21-beta-23429]",
-          "System.Text.Encoding": "[4.0.11-beta-23429]",
-          "System.Text.Encoding.Extensions": "[4.0.11-beta-23429]",
-          "System.Threading": "[4.0.11-beta-23429]",
-          "System.Threading.Tasks": "[4.0.11-beta-23429]",
-          "System.Threading.Timer": "[4.0.1-beta-23429]"
+          "Microsoft.NETCore.Targets": "1.0.1-beta-23506"
         }
       },
-      "Microsoft.NETCore.Targets/1.0.1-beta-23429": {
+      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.0.1-beta-23429",
-          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-beta-23429"
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-beta-23506"
         }
       },
-      "Microsoft.NETCore.Targets.DNXCore/5.0.0-beta-23429": {
+      "Microsoft.NETCore.Targets/1.0.1-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-beta-23506"
+        }
+      },
+      "Microsoft.NETCore.Targets.DNXCore/5.0.0-beta-23506": {
         "type": "package"
       },
-      "Microsoft.NETCore.TestHost/1.0.0-beta-23429": {
+      "Microsoft.NETCore.TestHost/1.0.0-beta-23506": {
         "type": "package"
       },
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23429": {
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23506": {
         "type": "package"
       },
-      "Microsoft.VisualBasic/10.0.1-beta-23429": {
+      "Microsoft.VisualBasic/10.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10297,13 +10291,13 @@
           "lib/dotnet5.4/Microsoft.VisualBasic.dll": {}
         }
       },
-      "Microsoft.Win32.Primitives/4.0.1-beta-23429": {
+      "Microsoft.Win32.Primitives/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/Microsoft.Win32.Primitives.dll": {}
+          "ref/dotnet5.4/Microsoft.Win32.Primitives.dll": {}
         }
       },
       "OpenCover/4.6.166": {
@@ -10312,7 +10306,118 @@
       "ReportGenerator/2.3.1": {
         "type": "package"
       },
-      "runtime.osx.10.10.System.Diagnostics.Process/4.1.0-beta-23429": {
+      "runtime.any.System.Linq.Expressions/4.0.11-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.ObjectModel": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Linq.Expressions.dll": {}
+        }
+      },
+      "runtime.any.System.Private.DataContractSerialization/4.1.0-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Emit.Lightweight": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23506",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlSerializer": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
+        }
+      },
+      "runtime.any.System.Reflection.DispatchProxy/4.0.1-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.DispatchProxy.dll": {}
+        }
+      },
+      "runtime.any.System.Xml.XmlSerializer/4.0.11-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Emit": "4.0.0",
+          "System.Reflection.Emit.ILGeneration": "4.0.0",
+          "System.Reflection.Extensions": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Text.RegularExpressions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Xml.ReaderWriter": "4.0.10",
+          "System.Xml.XmlDocument": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
+        }
+      },
+      "runtime.osx.10.10.System.Diagnostics.Process/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -10331,7 +10436,7 @@
           "System.Text.Encoding.Extensions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23429"
+          "System.Threading.ThreadPool": "4.0.10-beta-23506"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -10340,7 +10445,7 @@
           "runtimes/unix/lib/dotnet5.5/System.Diagnostics.Process.dll": {}
         }
       },
-      "runtime.osx.10.10.System.IO.FileSystem/4.0.1-beta-23429": {
+      "runtime.osx.10.10.System.IO.FileSystem/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10364,7 +10469,7 @@
           "runtimes/osx.10.10/lib/dotnet5.4/System.IO.FileSystem.dll": {}
         }
       },
-      "runtime.osx.10.10.System.IO.FileSystem.DriveInfo/4.0.0-beta-23429": {
+      "runtime.osx.10.10.System.IO.FileSystem.DriveInfo/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10383,7 +10488,7 @@
           "runtimes/unix/lib/dotnet5.4/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
-      "runtime.osx.10.10.System.IO.FileSystem.Watcher/4.0.0-beta-23429": {
+      "runtime.osx.10.10.System.IO.FileSystem.Watcher/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10396,7 +10501,7 @@
           "System.Runtime.InteropServices": "4.0.20",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.Thread": "4.0.0-beta-23429"
+          "System.Threading.Thread": "4.0.0-beta-23506"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -10405,7 +10510,7 @@
           "runtimes/unix/lib/dotnet5.4/System.IO.FileSystem.Watcher.dll": {}
         }
       },
-      "runtime.osx.10.10.System.IO.MemoryMappedFiles/4.0.0-beta-23429": {
+      "runtime.osx.10.10.System.IO.MemoryMappedFiles/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -10427,7 +10532,7 @@
           "runtimes/unix/lib/dotnet5.4/System.IO.MemoryMappedFiles.dll": {}
         }
       },
-      "runtime.osx.10.10.System.Net.Http/4.0.1-beta-23429": {
+      "runtime.osx.10.10.System.Net.Http/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10440,7 +10545,7 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.0",
           "System.Threading.Tasks": "4.0.10"
@@ -10452,7 +10557,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Net.Http.dll": {}
         }
       },
-      "runtime.osx.10.10.System.Net.NameResolution/4.0.0-beta-23429": {
+      "runtime.osx.10.10.System.Net.NameResolution/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -10463,7 +10568,7 @@
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Principal.Windows": "4.0.0-beta-23429",
+          "System.Security.Principal.Windows": "4.0.0-beta-23506",
           "System.Threading": "4.0.0",
           "System.Threading.Tasks": "4.0.0"
         },
@@ -10474,7 +10579,7 @@
           "runtimes/unix/lib/dnxcore50/System.Net.NameResolution.dll": {}
         }
       },
-      "runtime.osx.10.10.System.Net.NetworkInformation/4.1.0-beta-23429": {
+      "runtime.osx.10.10.System.Net.NetworkInformation/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -10485,8 +10590,11 @@
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Threading.Tasks": "4.0.10"
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.10",
+          "System.Threading.Thread": "4.0.0-beta-23506"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -10495,7 +10603,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Net.NetworkInformation.dll": {}
         }
       },
-      "runtime.osx.10.10.System.Net.Primitives/4.0.11-beta-23429": {
+      "runtime.osx.10.10.System.Net.Primitives/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -10517,24 +10625,24 @@
           "runtimes/unix/lib/dnxcore50/System.Net.Primitives.dll": {}
         }
       },
-      "runtime.osx.10.10.System.Net.Sockets/4.1.0-beta-23429": {
+      "runtime.osx.10.10.System.Net.Sockets/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
           "System.Diagnostics.Tracing": "4.0.20",
           "System.Globalization": "4.0.0",
           "System.IO": "4.0.10",
-          "System.Net.NameResolution": "4.0.0-beta-23429",
+          "System.Net.NameResolution": "4.0.0-beta-23506",
           "System.Net.Primitives": "4.0.10",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Principal.Windows": "4.0.0-beta-23429",
+          "System.Security.Principal.Windows": "4.0.0-beta-23506",
           "System.Threading": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23429"
+          "System.Threading.ThreadPool": "4.0.10-beta-23506"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -10543,7 +10651,7 @@
           "runtimes/osx.10.10/lib/dotnet5.5/System.Net.Sockets.dll": {}
         }
       },
-      "runtime.osx.10.10.System.Runtime.Extensions/4.0.11-beta-23429": {
+      "runtime.osx.10.10.System.Runtime.Extensions/4.0.11-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -10552,7 +10660,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Runtime.Extensions.dll": {}
         }
       },
-      "runtime.osx.10.10.System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23429": {
+      "runtime.osx.10.10.System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -10565,7 +10673,7 @@
           "runtimes/unix/lib/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "runtime.osx.10.10.System.Security.Cryptography.Algorithms/4.0.0-beta-23429": {
+      "runtime.osx.10.10.System.Security.Cryptography.Algorithms/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -10573,7 +10681,7 @@
           "System.Runtime": "4.0.20",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.0",
           "System.Text.Encoding.Extensions": "4.0.0"
         },
@@ -10584,13 +10692,13 @@
           "runtimes/osx.10.10/lib/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "runtime.osx.10.10-x64.Microsoft.NETCore.ConsoleHost/1.0.0-beta-23429": {
+      "runtime.osx.10.10-x64.Microsoft.NETCore.ConsoleHost/1.0.0-beta-23506": {
         "type": "package",
         "native": {
           "runtimes/osx.10.10-x64/native/coreconsole": {}
         }
       },
-      "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23429": {
+      "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -10611,13 +10719,13 @@
           "runtimes/osx.10.10-x64/native/System.Security.Cryptography.Native.dylib": {}
         }
       },
-      "runtime.osx.10.10-x64.Microsoft.NETCore.TestHost/1.0.0-beta-23429": {
+      "runtime.osx.10.10-x64.Microsoft.NETCore.TestHost/1.0.0-beta-23506": {
         "type": "package",
         "native": {
           "runtimes/osx.10.10-x64/native/corerun": {}
         }
       },
-      "runtime.unix.Microsoft.Win32.Primitives/4.0.1-beta-23429": {
+      "runtime.unix.Microsoft.Win32.Primitives/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20",
@@ -10630,7 +10738,7 @@
           "runtimes/unix/lib/dotnet5.4/Microsoft.Win32.Primitives.dll": {}
         }
       },
-      "runtime.unix.System.Console/4.0.0-beta-23429": {
+      "runtime.unix.System.Console/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10654,7 +10762,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Console.dll": {}
         }
       },
-      "runtime.unix.System.Data.SqlClient/4.0.0-beta-23429": {
+      "runtime.unix.System.Data.SqlClient/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -10666,10 +10774,10 @@
           "System.Globalization": "4.0.10",
           "System.IO": "4.0.10",
           "System.Linq": "4.0.0",
-          "System.Net.NameResolution": "4.0.0-beta-23429",
+          "System.Net.NameResolution": "4.0.0-beta-23506",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-beta-23429",
-          "System.Net.Sockets": "4.1.0-beta-23429",
+          "System.Net.Security": "4.0.0-beta-23506",
+          "System.Net.Sockets": "4.1.0-beta-23506",
           "System.Reflection": "4.0.0",
           "System.Reflection.TypeExtensions": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
@@ -10677,17 +10785,17 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23429",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
-          "System.Security.Principal.Windows": "4.0.0-beta-23429",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-beta-23506",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
+          "System.Security.Principal.Windows": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.10",
           "System.Text.Encoding.CodePages": "4.0.0",
           "System.Text.Encoding.Extensions": "4.0.10",
           "System.Text.RegularExpressions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.Thread": "4.0.0-beta-23429",
-          "System.Threading.ThreadPool": "4.0.10-beta-23429",
+          "System.Threading.Thread": "4.0.0-beta-23506",
+          "System.Threading.ThreadPool": "4.0.10-beta-23506",
           "System.Threading.Timer": "4.0.0",
           "System.Xml.ReaderWriter": "4.0.0"
         },
@@ -10698,7 +10806,7 @@
           "runtimes/unix/lib/dotnet5.5/System.Data.SqlClient.dll": {}
         }
       },
-      "runtime.unix.System.Diagnostics.Debug/4.0.11-beta-23429": {
+      "runtime.unix.System.Diagnostics.Debug/4.0.11-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -10707,7 +10815,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Diagnostics.Debug.dll": {}
         }
       },
-      "runtime.unix.System.Diagnostics.FileVersionInfo/4.0.0-beta-23429": {
+      "runtime.unix.System.Diagnostics.FileVersionInfo/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -10723,7 +10831,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Diagnostics.FileVersionInfo.dll": {}
         }
       },
-      "runtime.unix.System.Globalization.Extensions/4.0.1-beta-23429": {
+      "runtime.unix.System.Globalization.Extensions/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -10738,7 +10846,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Globalization.Extensions.dll": {}
         }
       },
-      "runtime.unix.System.IO.Compression/4.1.0-beta-23429": {
+      "runtime.unix.System.IO.Compression/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10760,7 +10868,7 @@
           "runtimes/unix/lib/dotnet5.4/System.IO.Compression.dll": {}
         }
       },
-      "runtime.unix.System.IO.Pipes/4.0.0-beta-23429": {
+      "runtime.unix.System.IO.Pipes/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -10781,7 +10889,7 @@
           "runtimes/unix/lib/dotnet5.4/System.IO.Pipes.dll": {}
         }
       },
-      "runtime.unix.System.Net.Requests/4.0.11-beta-23429": {
+      "runtime.unix.System.Net.Requests/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10802,7 +10910,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Net.Requests.dll": {}
         }
       },
-      "runtime.unix.System.Net.Security/4.0.0-beta-23429": {
+      "runtime.unix.System.Net.Security/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -10818,15 +10926,17 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.OpenSsl": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23506",
+          "System.Security.Cryptography.OpenSsl": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23429",
+          "System.Security.Principal.Windows": "4.0.0-beta-23506",
+          "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23429"
+          "System.Threading.ThreadPool": "4.0.10-beta-23506"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -10835,7 +10945,7 @@
           "runtimes/unix/lib/dnxcore50/System.Net.Security.dll": {}
         }
       },
-      "runtime.unix.System.Net.WebSockets.Client/4.0.0-beta-23429": {
+      "runtime.unix.System.Net.WebSockets.Client/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10843,10 +10953,10 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.0",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-beta-23429",
+          "System.Net.WebSockets": "4.0.0-beta-23506",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.0",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -10858,7 +10968,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Net.WebSockets.Client.dll": {}
         }
       },
-      "runtime.unix.System.Private.Uri/4.0.1-beta-23429": {
+      "runtime.unix.System.Private.Uri/4.0.1-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -10867,7 +10977,7 @@
           "runtimes/unix/lib/dotnet5.1/System.Private.Uri.dll": {}
         }
       },
-      "runtime.unix.System.Security.Cryptography.Encoding/4.0.0-beta-23429": {
+      "runtime.unix.System.Security.Cryptography.Encoding/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -10879,7 +10989,7 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.0"
         },
         "compile": {
@@ -10889,7 +10999,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "runtime.unix.System.Security.Cryptography.X509Certificates/4.0.0-beta-23429": {
+      "runtime.unix.System.Security.Cryptography.X509Certificates/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10898,17 +11008,17 @@
           "System.IO": "4.0.10",
           "System.IO.FileSystem": "4.0.0",
           "System.IO.FileSystem.Primitives": "4.0.0",
-          "System.IO.FileSystem.Watcher": "4.0.0-beta-23429",
+          "System.IO.FileSystem.Watcher": "4.0.0-beta-23506",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
           "System.Runtime.Numerics": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23429",
-          "System.Security.Cryptography.OpenSsl": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23506",
+          "System.Security.Cryptography.OpenSsl": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10"
         },
@@ -10919,7 +11029,29 @@
           "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
-      "runtime.unix.System.Threading/4.0.11-beta-23429": {
+      "runtime.unix.System.Text.Encoding.CodePages/4.0.1-beta-23506": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/_._": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/dotnet5.4/System.Text.Encoding.CodePages.dll": {}
+        }
+      },
+      "runtime.unix.System.Threading/4.0.11-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -10928,22 +11060,22 @@
           "runtimes/unix/lib/dotnet5.4/System.Threading.dll": {}
         }
       },
-      "System.AppContext/4.0.1-beta-23429": {
+      "System.AppContext/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.AppContext.dll": {}
+          "ref/dotnet5.4/System.AppContext.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.AppContext.dll": {}
         }
       },
-      "System.Collections/4.0.11-beta-23429": {
+      "System.Collections/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Runtime": "4.0.21-beta-23429"
+          "System.Runtime": "4.0.21-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Collections.dll": {}
@@ -10952,7 +11084,7 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Collections.Concurrent/4.0.11-beta-23429": {
+      "System.Collections.Concurrent/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10972,7 +11104,7 @@
           "lib/dotnet5.4/System.Collections.Concurrent.dll": {}
         }
       },
-      "System.Collections.Immutable/1.1.38-beta-23429": {
+      "System.Collections.Immutable/1.1.38-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -10991,7 +11123,7 @@
           "lib/dotnet5.1/System.Collections.Immutable.dll": {}
         }
       },
-      "System.Collections.NonGeneric/4.0.1-beta-23429": {
+      "System.Collections.NonGeneric/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -11002,13 +11134,13 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Collections.NonGeneric.dll": {}
+          "ref/dotnet5.4/System.Collections.NonGeneric.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Collections.NonGeneric.dll": {}
         }
       },
-      "System.Collections.Specialized/4.0.1-beta-23429": {
+      "System.Collections.Specialized/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections.NonGeneric": "4.0.0",
@@ -11020,13 +11152,13 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Collections.Specialized.dll": {}
+          "ref/dotnet5.4/System.Collections.Specialized.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Collections.Specialized.dll": {}
         }
       },
-      "System.ComponentModel/4.0.1-beta-23429": {
+      "System.ComponentModel/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -11038,7 +11170,7 @@
           "lib/dotnet5.4/System.ComponentModel.dll": {}
         }
       },
-      "System.ComponentModel.Annotations/4.0.11-beta-23429": {
+      "System.ComponentModel.Annotations/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11060,7 +11192,7 @@
           "lib/dotnet5.4/System.ComponentModel.Annotations.dll": {}
         }
       },
-      "System.ComponentModel.EventBasedAsync/4.0.11-beta-23429": {
+      "System.ComponentModel.EventBasedAsync/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -11075,17 +11207,17 @@
           "lib/dotnet5.4/System.ComponentModel.EventBasedAsync.dll": {}
         }
       },
-      "System.Console/4.0.0-beta-23429": {
+      "System.Console/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Console.dll": {}
+          "ref/dotnet5.4/System.Console.dll": {}
         }
       },
-      "System.Data.Common/4.0.1-beta-23429": {
+      "System.Data.Common/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11099,13 +11231,13 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Data.Common.dll": {}
+          "ref/dotnet5.4/System.Data.Common.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Data.Common.dll": {}
         }
       },
-      "System.Data.SqlClient/4.0.0-beta-23429": {
+      "System.Data.SqlClient/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Data.Common": "4.0.0",
@@ -11116,10 +11248,10 @@
           "System.Xml.ReaderWriter": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Data.SqlClient.dll": {}
+          "ref/dotnet5.4/System.Data.SqlClient.dll": {}
         }
       },
-      "System.Diagnostics.Contracts/4.0.1-beta-23429": {
+      "System.Diagnostics.Contracts/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -11131,7 +11263,7 @@
           "lib/DNXCore50/System.Diagnostics.Contracts.dll": {}
         }
       },
-      "System.Diagnostics.Debug/4.0.11-beta-23429": {
+      "System.Diagnostics.Debug/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -11140,16 +11272,16 @@
           "ref/dotnet5.4/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.FileVersionInfo/4.0.0-beta-23429": {
+      "System.Diagnostics.FileVersionInfo/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Diagnostics.FileVersionInfo.dll": {}
+          "ref/dotnet5.4/System.Diagnostics.FileVersionInfo.dll": {}
         }
       },
-      "System.Diagnostics.Process/4.1.0-beta-23429": {
+      "System.Diagnostics.Process/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -11161,20 +11293,20 @@
           "ref/dotnet5.5/System.Diagnostics.Process.dll": {}
         }
       },
-      "System.Diagnostics.StackTrace/4.0.1-beta-23429": {
+      "System.Diagnostics.StackTrace/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Diagnostics.StackTrace.dll": {}
+          "ref/dotnet5.4/System.Diagnostics.StackTrace.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Diagnostics.StackTrace.dll": {}
         }
       },
-      "System.Diagnostics.Tools/4.0.1-beta-23429": {
+      "System.Diagnostics.Tools/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -11186,7 +11318,7 @@
           "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
         }
       },
-      "System.Diagnostics.Tracing/4.0.21-beta-23429": {
+      "System.Diagnostics.Tracing/4.0.21-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -11198,7 +11330,7 @@
           "lib/DNXCore50/System.Diagnostics.Tracing.dll": {}
         }
       },
-      "System.Dynamic.Runtime/4.0.11-beta-23429": {
+      "System.Dynamic.Runtime/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11224,7 +11356,7 @@
           "lib/DNXCore50/System.Dynamic.Runtime.dll": {}
         }
       },
-      "System.Globalization/4.0.11-beta-23429": {
+      "System.Globalization/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -11236,20 +11368,20 @@
           "lib/DNXCore50/System.Globalization.dll": {}
         }
       },
-      "System.Globalization.Calendars/4.0.1-beta-23429": {
+      "System.Globalization.Calendars/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Globalization.Calendars.dll": {}
+          "ref/dotnet5.4/System.Globalization.Calendars.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Globalization.Calendars.dll": {}
         }
       },
-      "System.Globalization.Extensions/4.0.1-beta-23429": {
+      "System.Globalization.Extensions/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -11257,10 +11389,10 @@
           "System.Runtime.Extensions": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Globalization.Extensions.dll": {}
+          "ref/dotnet5.4/System.Globalization.Extensions.dll": {}
         }
       },
-      "System.IO/4.0.11-beta-23429": {
+      "System.IO/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20",
@@ -11274,7 +11406,7 @@
           "lib/DNXCore50/System.IO.dll": {}
         }
       },
-      "System.IO.Compression/4.1.0-beta-23429": {
+      "System.IO.Compression/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -11286,7 +11418,7 @@
           "ref/dotnet5.4/System.IO.Compression.dll": {}
         }
       },
-      "System.IO.Compression.ZipFile/4.0.1-beta-23429": {
+      "System.IO.Compression.ZipFile/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -11299,13 +11431,13 @@
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.2/System.IO.Compression.ZipFile.dll": {}
+          "ref/dotnet5.4/System.IO.Compression.ZipFile.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.IO.Compression.ZipFile.dll": {}
         }
       },
-      "System.IO.FileSystem/4.0.1-beta-23429": {
+      "System.IO.FileSystem/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -11319,7 +11451,7 @@
           "ref/dotnet5.4/System.IO.FileSystem.dll": {}
         }
       },
-      "System.IO.FileSystem.DriveInfo/4.0.0-beta-23429": {
+      "System.IO.FileSystem.DriveInfo/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -11330,28 +11462,28 @@
           "ref/dotnet5.4/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
-      "System.IO.FileSystem.Primitives/4.0.1-beta-23429": {
+      "System.IO.FileSystem.Primitives/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
         },
         "compile": {
-          "ref/dotnet5.1/System.IO.FileSystem.Primitives.dll": {}
+          "ref/dotnet5.4/System.IO.FileSystem.Primitives.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.IO.FileSystem.Primitives.dll": {}
         }
       },
-      "System.IO.FileSystem.Watcher/4.0.0-beta-23429": {
+      "System.IO.FileSystem.Watcher/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.IO.FileSystem.Watcher.dll": {}
+          "ref/dotnet5.4/System.IO.FileSystem.Watcher.dll": {}
         }
       },
-      "System.IO.MemoryMappedFiles/4.0.0-beta-23429": {
+      "System.IO.MemoryMappedFiles/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO.FileSystem": "4.0.0",
@@ -11365,7 +11497,7 @@
           "ref/dotnet5.4/System.IO.MemoryMappedFiles.dll": {}
         }
       },
-      "System.IO.Pipes/4.0.0-beta-23429": {
+      "System.IO.Pipes/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -11378,7 +11510,7 @@
           "ref/dotnet5.4/System.IO.Pipes.dll": {}
         }
       },
-      "System.IO.UnmanagedMemoryStream/4.0.1-beta-23429": {
+      "System.IO.UnmanagedMemoryStream/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -11390,13 +11522,13 @@
           "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.2/System.IO.UnmanagedMemoryStream.dll": {}
+          "ref/dotnet5.4/System.IO.UnmanagedMemoryStream.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.IO.UnmanagedMemoryStream.dll": {}
         }
       },
-      "System.Linq/4.0.1-beta-23429": {
+      "System.Linq/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11412,33 +11544,17 @@
           "lib/dotnet5.4/System.Linq.dll": {}
         }
       },
-      "System.Linq.Expressions/4.0.11-beta-23429": {
+      "System.Linq.Expressions/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.Linq": "4.0.0",
-          "System.ObjectModel": "4.0.10",
-          "System.Reflection": "4.0.10",
-          "System.Reflection.Emit": "4.0.0",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Reflection.TypeExtensions": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Threading": "4.0.10"
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Linq.Expressions.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Linq.Expressions.dll": {}
         }
       },
-      "System.Linq.Parallel/4.0.1-beta-23429": {
+      "System.Linq.Parallel/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11459,7 +11575,7 @@
           "lib/dotnet5.4/System.Linq.Parallel.dll": {}
         }
       },
-      "System.Linq.Queryable/4.0.1-beta-23429": {
+      "System.Linq.Queryable/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11477,7 +11593,7 @@
           "lib/dotnet5.4/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-beta-23429": {
+      "System.Net.Http/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -11490,7 +11606,7 @@
           "ref/dotnet5.2/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-beta-23429": {
+      "System.Net.NameResolution/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -11501,7 +11617,7 @@
           "ref/dotnet5.4/System.Net.NameResolution.dll": {}
         }
       },
-      "System.Net.NetworkInformation/4.1.0-beta-23429": {
+      "System.Net.NetworkInformation/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -11512,7 +11628,7 @@
           "ref/dotnet5.4/System.Net.NetworkInformation.dll": {}
         }
       },
-      "System.Net.Primitives/4.0.11-beta-23429": {
+      "System.Net.Primitives/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -11522,7 +11638,7 @@
           "ref/dotnet5.4/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Requests/4.0.11-beta-23429": {
+      "System.Net.Requests/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -11535,20 +11651,20 @@
           "ref/dotnet5.4/System.Net.Requests.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-beta-23429": {
+      "System.Net.Security/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Net.Primitives": "4.0.10",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.Security.dll": {}
         }
       },
-      "System.Net.Sockets/4.1.0-beta-23429": {
+      "System.Net.Sockets/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -11557,13 +11673,13 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.5/System.Net.Sockets.dll": {}
+          "ref/dotnet5.4/System.Net.Sockets.dll": {}
         }
       },
-      "System.Net.Utilities/4.0.0-beta-23429": {
+      "System.Net.Utilities/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23429"
+          "System.Private.Networking": "4.0.1-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.Utilities.dll": {}
@@ -11572,7 +11688,7 @@
           "lib/DNXCore50/System.Net.Utilities.dll": {}
         }
       },
-      "System.Net.WebHeaderCollection/4.0.1-beta-23429": {
+      "System.Net.WebHeaderCollection/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11588,35 +11704,35 @@
           "lib/dotnet5.4/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-beta-23429": {
+      "System.Net.WebSockets/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
-          "System.Threading.Tasks": "4.0.0"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Net.WebSockets.dll": {}
+          "ref/dotnet5.4/System.Net.WebSockets.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-beta-23429": {
+      "System.Net.WebSockets.Client/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
-          "System.Net.WebSockets": "4.0.0-beta-23429",
+          "System.Net.WebSockets": "4.0.0-beta-23506",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.WebSockets.Client.dll": {}
         }
       },
-      "System.Numerics.Vectors/4.1.1-beta-23429": {
+      "System.Numerics.Vectors/4.1.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -11631,7 +11747,7 @@
           "lib/dotnet5.4/System.Numerics.Vectors.dll": {}
         }
       },
-      "System.ObjectModel/4.0.11-beta-23429": {
+      "System.ObjectModel/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11647,38 +11763,13 @@
           "lib/dotnet5.4/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.DataContractSerialization/4.1.0-beta-23429": {
+      "System.Private.DataContractSerialization/4.1.0-beta-23506": {
         "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.10",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Reflection.TypeExtensions": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23429",
-          "System.Text.Encoding": "4.0.10",
-          "System.Text.Encoding.Extensions": "4.0.10",
-          "System.Text.RegularExpressions": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Xml.ReaderWriter": "4.0.10",
-          "System.Xml.XmlSerializer": "4.0.10"
-        },
         "compile": {
           "ref/dnxcore50/_._": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23429": {
+      "System.Private.Networking/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -11697,14 +11788,14 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23429",
+          "System.Security.Principal.Windows": "4.0.0-beta-23506",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23429"
+          "System.Threading.ThreadPool": "4.0.10-beta-23506"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -11713,53 +11804,53 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-beta-23429": {
+      "System.Private.ServiceModel/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.11-beta-23429",
-          "System.Collections.Concurrent": "4.0.11-beta-23429",
-          "System.Collections.NonGeneric": "4.0.1-beta-23429",
-          "System.Collections.Specialized": "4.0.1-beta-23429",
-          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23429",
-          "System.Diagnostics.Debug": "4.0.11-beta-23429",
-          "System.Diagnostics.Tracing": "4.0.21-beta-23429",
-          "System.Globalization": "4.0.11-beta-23429",
-          "System.IO": "4.0.11-beta-23429",
-          "System.IO.Compression": "4.1.0-beta-23429",
-          "System.Linq": "4.0.1-beta-23429",
-          "System.Linq.Expressions": "4.0.11-beta-23429",
-          "System.Linq.Queryable": "4.0.1-beta-23429",
-          "System.Net.Http": "4.0.1-beta-23429",
-          "System.Net.NameResolution": "4.0.0-beta-23429",
-          "System.Net.Primitives": "4.0.11-beta-23429",
-          "System.Net.Security": "4.0.0-beta-23429",
-          "System.Net.Sockets": "4.1.0-beta-23429",
-          "System.Net.WebHeaderCollection": "4.0.1-beta-23429",
-          "System.Net.WebSockets": "4.0.0-beta-23429",
-          "System.Net.WebSockets.Client": "4.0.0-beta-23429",
-          "System.ObjectModel": "4.0.11-beta-23429",
-          "System.Reflection": "4.1.0-beta-23429",
-          "System.Reflection.DispatchProxy": "4.0.1-beta-23429",
-          "System.Reflection.Extensions": "4.0.1-beta-23429",
-          "System.Reflection.Primitives": "4.0.1-beta-23429",
-          "System.Reflection.TypeExtensions": "4.0.1-beta-23429",
-          "System.Resources.ResourceManager": "4.0.1-beta-23429",
-          "System.Runtime": "4.0.21-beta-23429",
-          "System.Runtime.Extensions": "4.0.11-beta-23429",
-          "System.Runtime.InteropServices": "4.0.21-beta-23429",
+          "System.Collections": "4.0.11-beta-23506",
+          "System.Collections.Concurrent": "4.0.11-beta-23506",
+          "System.Collections.NonGeneric": "4.0.1-beta-23506",
+          "System.Collections.Specialized": "4.0.1-beta-23506",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-beta-23506",
+          "System.Diagnostics.Debug": "4.0.11-beta-23506",
+          "System.Diagnostics.Tracing": "4.0.21-beta-23506",
+          "System.Globalization": "4.0.11-beta-23506",
+          "System.IO": "4.0.11-beta-23506",
+          "System.IO.Compression": "4.1.0-beta-23506",
+          "System.Linq": "4.0.1-beta-23506",
+          "System.Linq.Expressions": "4.0.11-beta-23506",
+          "System.Linq.Queryable": "4.0.1-beta-23506",
+          "System.Net.Http": "4.0.1-beta-23506",
+          "System.Net.NameResolution": "4.0.0-beta-23506",
+          "System.Net.Primitives": "4.0.11-beta-23506",
+          "System.Net.Security": "4.0.0-beta-23506",
+          "System.Net.Sockets": "4.1.0-beta-23506",
+          "System.Net.WebHeaderCollection": "4.0.1-beta-23506",
+          "System.Net.WebSockets": "4.0.0-beta-23506",
+          "System.Net.WebSockets.Client": "4.0.0-beta-23506",
+          "System.ObjectModel": "4.0.11-beta-23506",
+          "System.Reflection": "4.1.0-beta-23506",
+          "System.Reflection.DispatchProxy": "4.0.1-beta-23506",
+          "System.Reflection.Extensions": "4.0.1-beta-23506",
+          "System.Reflection.Primitives": "4.0.1-beta-23506",
+          "System.Reflection.TypeExtensions": "4.0.1-beta-23506",
+          "System.Resources.ResourceManager": "4.0.1-beta-23506",
+          "System.Runtime": "4.0.21-beta-23506",
+          "System.Runtime.Extensions": "4.0.11-beta-23506",
+          "System.Runtime.InteropServices": "4.0.21-beta-23506",
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
-          "System.Security.Claims": "4.0.1-beta-23429",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23429",
-          "System.Security.Principal": "4.0.1-beta-23429",
-          "System.Security.Principal.Windows": "4.0.0-beta-23429",
-          "System.Text.Encoding": "4.0.11-beta-23429",
-          "System.Threading": "4.0.11-beta-23429",
-          "System.Threading.Tasks": "4.0.11-beta-23429",
-          "System.Threading.Timer": "4.0.1-beta-23429",
-          "System.Xml.ReaderWriter": "4.0.11-beta-23429",
-          "System.Xml.XmlDocument": "4.0.1-beta-23429",
-          "System.Xml.XmlSerializer": "4.0.11-beta-23429"
+          "System.Security.Claims": "4.0.1-beta-23506",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23506",
+          "System.Security.Principal": "4.0.1-beta-23506",
+          "System.Security.Principal.Windows": "4.0.0-beta-23506",
+          "System.Text.Encoding": "4.0.11-beta-23506",
+          "System.Threading": "4.0.11-beta-23506",
+          "System.Threading.Tasks": "4.0.11-beta-23506",
+          "System.Threading.Timer": "4.0.1-beta-23506",
+          "System.Xml.ReaderWriter": "4.0.11-beta-23506",
+          "System.Xml.XmlDocument": "4.0.1-beta-23506",
+          "System.Xml.XmlSerializer": "4.0.11-beta-23506"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -11768,13 +11859,13 @@
           "lib/DNXCore50/System.Private.ServiceModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.1-beta-23429": {
+      "System.Private.Uri/4.0.1-beta-23506": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
         }
       },
-      "System.Reflection/4.1.0-beta-23429": {
+      "System.Reflection/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -11788,26 +11879,17 @@
           "lib/DNXCore50/System.Reflection.dll": {}
         }
       },
-      "System.Reflection.DispatchProxy/4.0.1-beta-23429": {
+      "System.Reflection.DispatchProxy/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.10",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Threading": "4.0.10"
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Reflection.DispatchProxy.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Reflection.DispatchProxy.dll": {}
+          "ref/dotnet5.4/System.Reflection.DispatchProxy.dll": {}
         }
       },
-      "System.Reflection.Emit/4.0.1-beta-23429": {
+      "System.Reflection.Emit/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -11823,7 +11905,7 @@
           "lib/DNXCore50/System.Reflection.Emit.dll": {}
         }
       },
-      "System.Reflection.Emit.ILGeneration/4.0.1-beta-23429": {
+      "System.Reflection.Emit.ILGeneration/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -11837,7 +11919,7 @@
           "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
         }
       },
-      "System.Reflection.Emit.Lightweight/4.0.1-beta-23429": {
+      "System.Reflection.Emit.Lightweight/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -11852,7 +11934,7 @@
           "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll": {}
         }
       },
-      "System.Reflection.Extensions/4.0.1-beta-23429": {
+      "System.Reflection.Extensions/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -11865,7 +11947,7 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.1.1-beta-23429": {
+      "System.Reflection.Metadata/1.1.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -11890,7 +11972,7 @@
           "lib/dotnet5.2/System.Reflection.Metadata.dll": {}
         }
       },
-      "System.Reflection.Primitives/4.0.1-beta-23429": {
+      "System.Reflection.Primitives/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -11902,20 +11984,20 @@
           "lib/DNXCore50/System.Reflection.Primitives.dll": {}
         }
       },
-      "System.Reflection.TypeExtensions/4.1.0-beta-23429": {
+      "System.Reflection.TypeExtensions/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Reflection.TypeExtensions.dll": {}
+          "ref/dotnet5.4/System.Reflection.TypeExtensions.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
         }
       },
-      "System.Resources.ReaderWriter/4.0.0-beta-23429": {
+      "System.Resources.ReaderWriter/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11927,13 +12009,13 @@
           "System.Threading": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Resources.ReaderWriter.dll": {}
+          "ref/dotnet5.4/System.Resources.ReaderWriter.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Resources.ReaderWriter.dll": {}
         }
       },
-      "System.Resources.ResourceManager/4.0.1-beta-23429": {
+      "System.Resources.ResourceManager/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -11947,10 +12029,10 @@
           "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
         }
       },
-      "System.Runtime/4.0.21-beta-23429": {
+      "System.Runtime/4.0.21-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.Uri": "4.0.1-beta-23429"
+          "System.Private.Uri": "4.0.1-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Runtime.dll": {}
@@ -11959,19 +12041,19 @@
           "lib/DNXCore50/System.Runtime.dll": {}
         }
       },
-      "System.Runtime.CompilerServices.VisualC/4.0.0-beta-23429": {
+      "System.Runtime.CompilerServices.VisualC/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Runtime.CompilerServices.VisualC.dll": {}
+          "ref/dotnet5.4/System.Runtime.CompilerServices.VisualC.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Runtime.CompilerServices.VisualC.dll": {}
         }
       },
-      "System.Runtime.Extensions/4.0.11-beta-23429": {
+      "System.Runtime.Extensions/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -11980,7 +12062,7 @@
           "ref/dotnet5.4/System.Runtime.Extensions.dll": {}
         }
       },
-      "System.Runtime.Handles/4.0.1-beta-23429": {
+      "System.Runtime.Handles/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -11992,7 +12074,7 @@
           "lib/DNXCore50/System.Runtime.Handles.dll": {}
         }
       },
-      "System.Runtime.InteropServices/4.0.21-beta-23429": {
+      "System.Runtime.InteropServices/4.0.21-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -12007,16 +12089,16 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23429": {
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
+          "ref/dotnet5.2/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "System.Runtime.Loader/4.0.0-beta-23429": {
+      "System.Runtime.Loader/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -12030,7 +12112,7 @@
           "lib/DNXCore50/System.Runtime.Loader.dll": {}
         }
       },
-      "System.Runtime.Numerics/4.0.1-beta-23429": {
+      "System.Runtime.Numerics/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -12045,10 +12127,10 @@
           "lib/dotnet5.4/System.Runtime.Numerics.dll": {}
         }
       },
-      "System.Runtime.Serialization.Json/4.0.1-beta-23429": {
+      "System.Runtime.Serialization.Json/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.1.0-beta-23429"
+          "System.Private.DataContractSerialization": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.1/System.Runtime.Serialization.Json.dll": {}
@@ -12057,7 +12139,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Json.dll": {}
         }
       },
-      "System.Runtime.Serialization.Primitives/4.1.0-beta-23429": {
+      "System.Runtime.Serialization.Primitives/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -12070,11 +12152,11 @@
           "lib/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
         }
       },
-      "System.Runtime.Serialization.Xml/4.1.0-beta-23429": {
+      "System.Runtime.Serialization.Xml/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.1.0-beta-23429",
-          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23429"
+          "System.Private.DataContractSerialization": "4.1.0-beta-23506",
+          "System.Runtime.Serialization.Primitives": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Runtime.Serialization.Xml.dll": {}
@@ -12083,7 +12165,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Xml.dll": {}
         }
       },
-      "System.Security.Claims/4.0.1-beta-23429": {
+      "System.Security.Claims/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -12096,35 +12178,36 @@
           "System.Security.Principal": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Claims.dll": {}
+          "ref/dotnet5.4/System.Security.Claims.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23429": {
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Cryptography.Algorithms.dll": {}
+          "ref/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23429": {
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Cryptography.Encoding.dll": {}
+          "ref/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.OpenSsl/4.0.0-beta-23429": {
+      "System.Security.Cryptography.OpenSsl/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
+          "System.Collections": "4.0.0",
           "System.IO": "4.0.10",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
@@ -12132,9 +12215,9 @@
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
           "System.Runtime.Numerics": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23429",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23506",
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
@@ -12144,7 +12227,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.OpenSsl.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23429": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -12156,25 +12239,25 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Security.Cryptography.Primitives.dll": {}
+          "ref/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23429": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23429",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23429"
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23506",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
-      "System.Security.Principal/4.0.1-beta-23429": {
+      "System.Security.Principal/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -12186,7 +12269,7 @@
           "lib/dotnet5.1/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-beta-23429": {
+      "System.Security.Principal.Windows/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -12209,10 +12292,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-beta-23429": {
+      "System.ServiceModel.Duplex/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429"
+          "System.Private.ServiceModel": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.2/System.ServiceModel.Duplex.dll": {}
@@ -12221,10 +12304,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-beta-23429": {
+      "System.ServiceModel.Http/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429",
+          "System.Private.ServiceModel": "4.1.0-beta-23506",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -12234,10 +12317,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.1.0-beta-23429": {
+      "System.ServiceModel.NetTcp/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429"
+          "System.Private.ServiceModel": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.ServiceModel.NetTcp.dll": {}
@@ -12246,10 +12329,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.1.0-beta-23429": {
+      "System.ServiceModel.Primitives/4.1.0-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429"
+          "System.Private.ServiceModel": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.4/System.ServiceModel.Primitives.dll": {}
@@ -12258,10 +12341,10 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
-      "System.ServiceModel.Security/4.0.1-beta-23429": {
+      "System.ServiceModel.Security/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-beta-23429"
+          "System.Private.ServiceModel": "4.1.0-beta-23506"
         },
         "compile": {
           "ref/dotnet5.2/System.ServiceModel.Security.dll": {}
@@ -12270,7 +12353,7 @@
           "lib/DNXCore50/System.ServiceModel.Security.dll": {}
         }
       },
-      "System.Text.Encoding/4.0.11-beta-23429": {
+      "System.Text.Encoding/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -12282,29 +12365,17 @@
           "lib/DNXCore50/System.Text.Encoding.dll": {}
         }
       },
-      "System.Text.Encoding.CodePages/4.0.0": {
+      "System.Text.Encoding.CodePages/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.Reflection": "4.0.10",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Runtime.Handles": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Text.Encoding": "4.0.10",
-          "System.Threading": "4.0.10"
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/System.Text.Encoding.CodePages.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/System.Text.Encoding.CodePages.dll": {}
+          "ref/dotnet5.4/System.Text.Encoding.CodePages.dll": {}
         }
       },
-      "System.Text.Encoding.Extensions/4.0.11-beta-23429": {
+      "System.Text.Encoding.Extensions/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -12317,7 +12388,7 @@
           "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
         }
       },
-      "System.Text.RegularExpressions/4.0.11-beta-23429": {
+      "System.Text.RegularExpressions/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -12334,7 +12405,7 @@
           "lib/dotnet5.4/System.Text.RegularExpressions.dll": {}
         }
       },
-      "System.Threading/4.0.11-beta-23429": {
+      "System.Threading/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -12344,20 +12415,20 @@
           "ref/dotnet5.4/System.Threading.dll": {}
         }
       },
-      "System.Threading.Overlapped/4.0.0": {
+      "System.Threading.Overlapped/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
-          "ref/dotnet/System.Threading.Overlapped.dll": {}
+          "ref/dotnet5.4/System.Threading.Overlapped.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Overlapped.dll": {}
         }
       },
-      "System.Threading.Tasks/4.0.11-beta-23429": {
+      "System.Threading.Tasks/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -12369,7 +12440,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.Tasks.Dataflow/4.5.26-beta-23429": {
+      "System.Threading.Tasks.Dataflow/4.5.26-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -12391,7 +12462,7 @@
           "lib/dotnet5.2/System.Threading.Tasks.Dataflow.dll": {}
         }
       },
-      "System.Threading.Tasks.Parallel/4.0.1-beta-23429": {
+      "System.Threading.Tasks.Parallel/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections.Concurrent": "4.0.10",
@@ -12410,32 +12481,32 @@
           "lib/dotnet5.4/System.Threading.Tasks.Parallel.dll": {}
         }
       },
-      "System.Threading.Thread/4.0.0-beta-23429": {
+      "System.Threading.Thread/4.0.0-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Threading.Thread.dll": {}
+          "ref/dotnet5.4/System.Threading.Thread.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Thread.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-beta-23429": {
+      "System.Threading.ThreadPool/4.0.10-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.InteropServices": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.2/System.Threading.ThreadPool.dll": {}
+          "ref/dotnet5.4/System.Threading.ThreadPool.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
-      "System.Threading.Timer/4.0.1-beta-23429": {
+      "System.Threading.Timer/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -12447,7 +12518,7 @@
           "lib/DNXCore50/System.Threading.Timer.dll": {}
         }
       },
-      "System.Xml.ReaderWriter/4.0.11-beta-23429": {
+      "System.Xml.ReaderWriter/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -12472,7 +12543,7 @@
           "lib/dotnet5.4/System.Xml.ReaderWriter.dll": {}
         }
       },
-      "System.Xml.XDocument/4.0.11-beta-23429": {
+      "System.Xml.XDocument/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -12495,7 +12566,7 @@
           "lib/dotnet5.4/System.Xml.XDocument.dll": {}
         }
       },
-      "System.Xml.XmlDocument/4.0.1-beta-23429": {
+      "System.Xml.XmlDocument/4.0.1-beta-23506": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -12510,37 +12581,21 @@
           "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
-          "ref/dotnet5.1/System.Xml.XmlDocument.dll": {}
+          "ref/dotnet5.4/System.Xml.XmlDocument.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Xml.XmlDocument.dll": {}
         }
       },
-      "System.Xml.XmlSerializer/4.0.11-beta-23429": {
+      "System.Xml.XmlSerializer/4.0.11-beta-23506": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.Linq": "4.0.0",
-          "System.Reflection": "4.0.10",
-          "System.Reflection.Extensions": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Reflection.TypeExtensions": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Text.RegularExpressions": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Xml.ReaderWriter": "4.0.10",
-          "System.Xml.XmlDocument": "4.0.0"
+          "System.IO": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Xml.ReaderWriter": "4.0.10"
         },
         "compile": {
           "ref/dotnet5.4/System.Xml.XmlSerializer.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
         }
       },
       "xunit/2.1.0": {
@@ -12722,10 +12777,10 @@
         "tools/Newtonsoft.Json.xml"
       ]
     },
-    "Microsoft.CSharp/4.0.1-beta-23429": {
+    "Microsoft.CSharp/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "s1Q0UXlW4kI2wOUJGlBPiysyjt34LpWlzZ7Zy0hhrqohuzkQpiX7Tieb7RQT+7PucOuT25O0e6J/oXliLQZKFQ==",
+      "sha512": "3vssehqBuPp0p245YPnVdYAwCMqG5Vb5pGVh8Rf/nEhVrzygcWk+qJ7Iybw2IQ85DbFn8nlFMz7EMGirY8hr8A==",
       "files": [
         "lib/dotnet5.4/Microsoft.CSharp.dll",
         "lib/MonoAndroid10/_._",
@@ -12737,8 +12792,8 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "Microsoft.CSharp.4.0.1-beta-23429.nupkg",
-        "Microsoft.CSharp.4.0.1-beta-23429.nupkg.sha512",
+        "Microsoft.CSharp.4.0.1-beta-23506.nupkg",
+        "Microsoft.CSharp.4.0.1-beta-23506.nupkg.sha512",
         "Microsoft.CSharp.nuspec",
         "ref/dotnet5.1/de/Microsoft.CSharp.xml",
         "ref/dotnet5.1/es/Microsoft.CSharp.xml",
@@ -12816,108 +12871,108 @@
         "tools/xunit.runner.utility.desktop.pdb"
       ]
     },
-    "Microsoft.NETCore/5.0.1-beta-23429": {
+    "Microsoft.NETCore/5.0.1-beta-23506": {
       "type": "package",
-      "sha512": "S7vdvg+Dczc+5O0bdiBcdQ60d/lAM9tlh59Y3WNNt2wWBc6yx14A4VAVHV0p1MnNU4m68aNsw6VSKr7t3uPSvA==",
+      "sha512": "9MuXBhnHv/zROyGT+CD3hXBhBMAZjKyAef9ms+AF8mHbjcvUfP2cCN0SsuM8nnlGtFSFpVUmK5tyHX3idH+eKg==",
       "files": [
         "_._",
-        "Microsoft.NETCore.5.0.1-beta-23429.nupkg",
-        "Microsoft.NETCore.5.0.1-beta-23429.nupkg.sha512",
+        "Microsoft.NETCore.5.0.1-beta-23506.nupkg",
+        "Microsoft.NETCore.5.0.1-beta-23506.nupkg.sha512",
         "Microsoft.NETCore.nuspec"
       ]
     },
-    "Microsoft.NETCore.Console/1.0.0-beta-23429": {
+    "Microsoft.NETCore.Console/1.0.0-beta-23506": {
       "type": "package",
-      "sha512": "Kr2nruwh5g4pzvEkwGp4RG5DmmFBhTdAdiv5rmQ36AjdyV/hOY0t1EyAPD0V4YzJZaGEBVfWtMoE/dtol9SSAg==",
+      "sha512": "5YxvnIY0i5Q/wluLwaRCKg6zuCqWQli2foeBz/Ic59RCBa/dshTZR767tns3hhP+kzIvXKIpZ0EgzurQCq3tdg==",
       "files": [
         "_._",
-        "Microsoft.NETCore.Console.1.0.0-beta-23429.nupkg",
-        "Microsoft.NETCore.Console.1.0.0-beta-23429.nupkg.sha512",
+        "Microsoft.NETCore.Console.1.0.0-beta-23506.nupkg",
+        "Microsoft.NETCore.Console.1.0.0-beta-23506.nupkg.sha512",
         "Microsoft.NETCore.Console.nuspec"
       ]
     },
-    "Microsoft.NETCore.ConsoleHost/1.0.0-beta-23429": {
+    "Microsoft.NETCore.ConsoleHost/1.0.0-beta-23506": {
       "type": "package",
-      "sha512": "L/LZgbzU7HsQUh9bDZ9dMgcfNOG9l8Zq5FQOgNuUrK0zH2bwVNcYY4qNw/mJb4HhNyjO0h/FEJLeUklk7A4yqA==",
+      "sha512": "IGkWAT0xnKDKuo/JUK/H2B7qp4VFr2jyF/8c5jz3EE5URjTY0O0JQveO0ArLlpWTyGA5DpKKZ0zMmsZgeq1OBQ==",
       "files": [
-        "Microsoft.NETCore.ConsoleHost.1.0.0-beta-23429.nupkg",
-        "Microsoft.NETCore.ConsoleHost.1.0.0-beta-23429.nupkg.sha512",
+        "Microsoft.NETCore.ConsoleHost.1.0.0-beta-23506.nupkg",
+        "Microsoft.NETCore.ConsoleHost.1.0.0-beta-23506.nupkg.sha512",
         "Microsoft.NETCore.ConsoleHost.nuspec",
         "runtime.json"
       ]
     },
-    "Microsoft.NETCore.Platforms/1.0.1-beta-23429": {
+    "Microsoft.NETCore.Platforms/1.0.1-beta-23506": {
       "type": "package",
-      "sha512": "s40F1jj7REHgL4SoDFwHpvexXoxYwTS6RGuimCmipjqDZdmA/aEFDZwZFJLlkMaP2L0WcWSfozPrdxn2gpN/Uw==",
+      "sha512": "cFGYFbXYnDa9rRLDxYaTqrpyigDRtwX29LZHwyaDM/hTinK6Xbf8zkOcRl5Y439oXHWyWQHGtOgfyWp42y4Ssw==",
       "files": [
-        "Microsoft.NETCore.Platforms.1.0.1-beta-23429.nupkg",
-        "Microsoft.NETCore.Platforms.1.0.1-beta-23429.nupkg.sha512",
+        "Microsoft.NETCore.Platforms.1.0.1-beta-23506.nupkg",
+        "Microsoft.NETCore.Platforms.1.0.1-beta-23506.nupkg.sha512",
         "Microsoft.NETCore.Platforms.nuspec",
         "runtime.json"
       ]
     },
-    "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23429": {
+    "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23506": {
       "type": "package",
-      "sha512": "zx5PMX7TwlgCFalfxFx7hU94qI+iRVpv74dQ1VhtoGb7ZUOSaKyz5zwlXvQ6Euzp/5stQ+1ILbLZt5i8bTEMfQ==",
+      "sha512": "6Z3BRxZ9BjPnG7DuhYu+zfR5hWB0xwrdjqZfDuXtDdbuB9RxWn08ujKZKQk9rwIACfo+CRCx0hX41tIlIUZFyw==",
       "files": [
-        "Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23429.nupkg",
-        "Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23429.nupkg.sha512",
+        "Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23506.nupkg",
+        "Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23506.nupkg.sha512",
         "Microsoft.NETCore.Runtime.CoreCLR.nuspec",
         "runtime.json"
       ]
     },
-    "Microsoft.NETCore.Targets/1.0.1-beta-23429": {
+    "Microsoft.NETCore.Targets/1.0.1-beta-23506": {
       "type": "package",
-      "sha512": "0cHyGxSkMEM51TS8BwBtL5LFq2OhSTO1rse5w6357MIjjwnQV0j31Osq8mGhV0pr6BFQdjfdrTcm0vpqY0PRrw==",
+      "sha512": "GIcdFGIXJNINj/ZkkqT3pE/IE6ryrRwvicQiCGqFuacfg70atZrczaNjnRwi7ZVsuz9a9TWy7yWKAgMKMe42Nw==",
       "files": [
-        "Microsoft.NETCore.Targets.1.0.1-beta-23429.nupkg",
-        "Microsoft.NETCore.Targets.1.0.1-beta-23429.nupkg.sha512",
+        "Microsoft.NETCore.Targets.1.0.1-beta-23506.nupkg",
+        "Microsoft.NETCore.Targets.1.0.1-beta-23506.nupkg.sha512",
         "Microsoft.NETCore.Targets.nuspec",
         "runtime.json"
       ]
     },
-    "Microsoft.NETCore.Targets.DNXCore/5.0.0-beta-23429": {
+    "Microsoft.NETCore.Targets.DNXCore/5.0.0-beta-23506": {
       "type": "package",
-      "sha512": "YKNdtk2VG8x+5L/QVTz/F1gJZ6At+0NBgza5d70ycSOrekCbsypIGIBqpauqXeU9XtBb1yyhHUWCCeNWuPiTyA==",
+      "sha512": "RPUu5d8qdnkMqwvTEgoUB4eqM3w8OQxvh4dDvv3+nBphIDRMrCeHDw2bd8tr6yieHO/msa0MGqy3EdTbU34lgw==",
       "files": [
-        "Microsoft.NETCore.Targets.DNXCore.5.0.0-beta-23429.nupkg",
-        "Microsoft.NETCore.Targets.DNXCore.5.0.0-beta-23429.nupkg.sha512",
+        "Microsoft.NETCore.Targets.DNXCore.5.0.0-beta-23506.nupkg",
+        "Microsoft.NETCore.Targets.DNXCore.5.0.0-beta-23506.nupkg.sha512",
         "Microsoft.NETCore.Targets.DNXCore.nuspec",
         "runtime.json"
       ]
     },
-    "Microsoft.NETCore.TestHost/1.0.0-beta-23429": {
+    "Microsoft.NETCore.TestHost/1.0.0-beta-23506": {
       "type": "package",
-      "sha512": "HNoXogXwU9J98Lk6q95PoNrVg8k2xFiBZiWvTaJap7F0jYjhBoPrHNYptjbWMFqsTgw5S/7+e8+6VPE2T/trew==",
+      "sha512": "/yJVosLlvWO1UQb/Nx8zb+UQUAauzCwhnNPdgPtce2OZ59ek5SC8RnU7jlWT5lodNEKMaBd7r00NLX7FUQt3zw==",
       "files": [
-        "Microsoft.NETCore.TestHost.1.0.0-beta-23429.nupkg",
-        "Microsoft.NETCore.TestHost.1.0.0-beta-23429.nupkg.sha512",
+        "Microsoft.NETCore.TestHost.1.0.0-beta-23506.nupkg",
+        "Microsoft.NETCore.TestHost.1.0.0-beta-23506.nupkg.sha512",
         "Microsoft.NETCore.TestHost.nuspec",
         "runtime.json"
       ]
     },
-    "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23429": {
+    "Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23506": {
       "type": "package",
-      "sha512": "n8e/j34E2Qy6wY0/sVR/RGBBkZLqhjNlNLAdtDG3TtnY8yQgA0gL0FX5HpqnMOqbX7dx2sggoSnPP6q3lcLjkg==",
+      "sha512": "A4CIlkH1sWlXkaFNx8RqS/hphkbp3Jv7Sm3DyG7aBQRCegWUgF96QfEuKP7PdbPYTmKJQ7JXMUr6HctwAmVwqw==",
       "files": [
-        "Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23429.nupkg",
-        "Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23429.nupkg.sha512",
+        "Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23506.nupkg",
+        "Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23506.nupkg.sha512",
         "Microsoft.NETCore.Windows.ApiSets.nuspec",
         "runtime.json"
       ]
     },
-    "Microsoft.VisualBasic/10.0.1-beta-23429": {
+    "Microsoft.VisualBasic/10.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FXQGJT67Hl+pLukg4sxAkcWdZnPjeC2zLo6aPJcmuiJri94zUmqU6MIXSstt5SgjdW8WIr0+f/EX8VJxr0QMFQ==",
+      "sha512": "wLNkpf8wBPEkmgwjERv5a9MG9fohTV7XmJ2blj67BZ4esxfXtBeMeLbtrf3B64zYHC9aoA/uBPdRgrkEuUcelg==",
       "files": [
         "lib/dotnet5.4/Microsoft.VisualBasic.dll",
         "lib/net45/_._",
         "lib/netcore50/Microsoft.VisualBasic.dll",
         "lib/win8/_._",
         "lib/wpa81/_._",
-        "Microsoft.VisualBasic.10.0.1-beta-23429.nupkg",
-        "Microsoft.VisualBasic.10.0.1-beta-23429.nupkg.sha512",
+        "Microsoft.VisualBasic.10.0.1-beta-23506.nupkg",
+        "Microsoft.VisualBasic.10.0.1-beta-23506.nupkg.sha512",
         "Microsoft.VisualBasic.nuspec",
         "ref/dotnet5.2/de/Microsoft.VisualBasic.xml",
         "ref/dotnet5.2/es/Microsoft.VisualBasic.xml",
@@ -12946,30 +13001,30 @@
         "ref/wpa81/_._"
       ]
     },
-    "Microsoft.Win32.Primitives/4.0.1-beta-23429": {
+    "Microsoft.Win32.Primitives/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "X+0xbDVnKyFuSD3OJnZrR8FgfuWmzt3TtlBWMD2DzJyTjavtav3DEIGm8ccY8bxKXQUn+lth0o1X8mMzJx1sdQ==",
+      "sha512": "EFGMc2HEEe34NFXkjUIijloaLWa/CHNPRVpFvZG0VC2qXanuuBGOhL3sfoseXpT7iwdFcQZoib9y3kQHEVisZg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/Microsoft.Win32.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "Microsoft.Win32.Primitives.4.0.1-beta-23429.nupkg",
-        "Microsoft.Win32.Primitives.4.0.1-beta-23429.nupkg.sha512",
+        "Microsoft.Win32.Primitives.4.0.1-beta-23506.nupkg",
+        "Microsoft.Win32.Primitives.4.0.1-beta-23506.nupkg.sha512",
         "Microsoft.Win32.Primitives.nuspec",
-        "ref/dotnet5.1/de/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet5.1/es/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet5.1/fr/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet5.1/it/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet5.1/ja/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet5.1/ko/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet5.1/Microsoft.Win32.Primitives.dll",
-        "ref/dotnet5.1/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet5.1/ru/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet5.1/zh-hans/Microsoft.Win32.Primitives.xml",
-        "ref/dotnet5.1/zh-hant/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet5.4/de/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet5.4/es/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet5.4/fr/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet5.4/it/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet5.4/ja/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet5.4/ko/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet5.4/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet5.4/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet5.4/ru/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet5.4/zh-hans/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet5.4/zh-hant/Microsoft.Win32.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/Microsoft.Win32.Primitives.dll",
@@ -12978,27 +13033,27 @@
         "runtime.json"
       ]
     },
-    "Microsoft.Win32.Registry/4.0.0-beta-23429": {
+    "Microsoft.Win32.Registry/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "udt7VwcXv6wGq+Nb/0HLhu0+8aTOEyrrQrQ/fZgG7IqZ9AprYY5gbAt+BohNz47HqJjeH4zWsNTwcW0bBtrpjQ==",
+      "sha512": "/nVvFIZCHWkHRnkiR9NGjNn5/JdCNG6lFP5pA5Io6nJYDDoDlUpo/RtNmNLfWmT2xJgsUTTLoWY24CNs7DgqgQ==",
       "files": [
         "lib/DNXCore50/Microsoft.Win32.Registry.dll",
         "lib/net46/Microsoft.Win32.Registry.dll",
-        "Microsoft.Win32.Registry.4.0.0-beta-23429.nupkg",
-        "Microsoft.Win32.Registry.4.0.0-beta-23429.nupkg.sha512",
+        "Microsoft.Win32.Registry.4.0.0-beta-23506.nupkg",
+        "Microsoft.Win32.Registry.4.0.0-beta-23506.nupkg.sha512",
         "Microsoft.Win32.Registry.nuspec",
-        "ref/dotnet5.2/de/Microsoft.Win32.Registry.xml",
-        "ref/dotnet5.2/es/Microsoft.Win32.Registry.xml",
-        "ref/dotnet5.2/fr/Microsoft.Win32.Registry.xml",
-        "ref/dotnet5.2/it/Microsoft.Win32.Registry.xml",
-        "ref/dotnet5.2/ja/Microsoft.Win32.Registry.xml",
-        "ref/dotnet5.2/ko/Microsoft.Win32.Registry.xml",
-        "ref/dotnet5.2/Microsoft.Win32.Registry.dll",
-        "ref/dotnet5.2/Microsoft.Win32.Registry.xml",
-        "ref/dotnet5.2/ru/Microsoft.Win32.Registry.xml",
-        "ref/dotnet5.2/zh-hans/Microsoft.Win32.Registry.xml",
-        "ref/dotnet5.2/zh-hant/Microsoft.Win32.Registry.xml",
+        "ref/dotnet5.4/de/Microsoft.Win32.Registry.xml",
+        "ref/dotnet5.4/es/Microsoft.Win32.Registry.xml",
+        "ref/dotnet5.4/fr/Microsoft.Win32.Registry.xml",
+        "ref/dotnet5.4/it/Microsoft.Win32.Registry.xml",
+        "ref/dotnet5.4/ja/Microsoft.Win32.Registry.xml",
+        "ref/dotnet5.4/ko/Microsoft.Win32.Registry.xml",
+        "ref/dotnet5.4/Microsoft.Win32.Registry.dll",
+        "ref/dotnet5.4/Microsoft.Win32.Registry.xml",
+        "ref/dotnet5.4/ru/Microsoft.Win32.Registry.xml",
+        "ref/dotnet5.4/zh-hans/Microsoft.Win32.Registry.xml",
+        "ref/dotnet5.4/zh-hant/Microsoft.Win32.Registry.xml",
         "ref/net46/Microsoft.Win32.Registry.dll"
       ]
     },
@@ -13069,323 +13124,400 @@
         "tools/ReportGenerator.XML"
       ]
     },
-    "runtime.linux.System.Diagnostics.Process/4.1.0-beta-23429": {
+    "runtime.any.System.Linq.Expressions/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "cPDT1PQMo/h51l6sNakVfStlw1N/ioBemk1scZepv3Ykrb0L/mowT+J6QN2Ksb5vtv/CdRhlswMi8J2G3Ihnyg==",
+      "sha512": "LMZ0wCfub5v1VrX8WI4R0q1H1MoRwCbprYUyYW4xzstU0qykxHXjvaRnPZIxJiDYdY9oVjtOGHV5aSx7NQgjTg==",
+      "files": [
+        "lib/DNXCore50/System.Linq.Expressions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/netcore50/System.Linq.Expressions.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/_._",
+        "runtime.any.System.Linq.Expressions.4.0.11-beta-23506.nupkg",
+        "runtime.any.System.Linq.Expressions.4.0.11-beta-23506.nupkg.sha512",
+        "runtime.any.System.Linq.Expressions.nuspec",
+        "runtimes/aot/lib/netcore50/_._"
+      ]
+    },
+    "runtime.any.System.Private.DataContractSerialization/4.1.0-beta-23506": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "8pTEBy4Z67pBJALPSlIr85wrvJrCQtE9gLquX1C8Ptskb7ZrBUVMumFDYfrqWLUEl17EU8hPhp16BZWDQ+TOBA==",
+      "files": [
+        "lib/DNXCore50/System.Private.DataContractSerialization.dll",
+        "lib/netcore50/System.Private.DataContractSerialization.dll",
+        "ref/dotnet/_._",
+        "runtime.any.System.Private.DataContractSerialization.4.1.0-beta-23506.nupkg",
+        "runtime.any.System.Private.DataContractSerialization.4.1.0-beta-23506.nupkg.sha512",
+        "runtime.any.System.Private.DataContractSerialization.nuspec",
+        "runtimes/aot/lib/netcore50/_._"
+      ]
+    },
+    "runtime.any.System.Reflection.DispatchProxy/4.0.1-beta-23506": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "VNrua2JbDPigx11exzLG5vGCBm8bjrMijObPX+aLPsegfSv19m9a8bo3YLbN1P7Ssxll4G4b14nncQXbipXQtQ==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.DispatchProxy.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.DispatchProxy.dll",
+        "lib/netcore50/System.Reflection.DispatchProxy.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/_._",
+        "runtime.any.System.Reflection.DispatchProxy.4.0.1-beta-23506.nupkg",
+        "runtime.any.System.Reflection.DispatchProxy.4.0.1-beta-23506.nupkg.sha512",
+        "runtime.any.System.Reflection.DispatchProxy.nuspec",
+        "runtimes/aot/lib/netcore50/_._"
+      ]
+    },
+    "runtime.any.System.Xml.XmlSerializer/4.0.11-beta-23506": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "c7wbiRN2Cphn+1jUQPgS0kxpIVfFuCbdr97Z3SoKWI7fFtSCaIqAHccm9Av9tsr52O93RoM+3tEq6aN282fBqg==",
+      "files": [
+        "lib/DNXCore50/System.Xml.XmlSerializer.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/netcore50/System.Xml.XmlSerializer.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/_._",
+        "runtime.any.System.Xml.XmlSerializer.4.0.11-beta-23506.nupkg",
+        "runtime.any.System.Xml.XmlSerializer.4.0.11-beta-23506.nupkg.sha512",
+        "runtime.any.System.Xml.XmlSerializer.nuspec",
+        "runtimes/aot/lib/netcore50/_._"
+      ]
+    },
+    "runtime.linux.System.Diagnostics.Process/4.1.0-beta-23506": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "xGkkVgR67SKjAvCwhHEXlFKIvSRNDM7CfPtv+muiTk1Pinwim1x9ICBGUQ5DlrjCjWFOAvnF2GhP3Q+e/CuDFQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.Diagnostics.Process.4.1.0-beta-23429.nupkg",
-        "runtime.linux.System.Diagnostics.Process.4.1.0-beta-23429.nupkg.sha512",
+        "runtime.linux.System.Diagnostics.Process.4.1.0-beta-23506.nupkg",
+        "runtime.linux.System.Diagnostics.Process.4.1.0-beta-23506.nupkg.sha512",
         "runtime.linux.System.Diagnostics.Process.nuspec",
         "runtimes/unix/lib/dotnet5.5/System.Diagnostics.Process.dll"
       ]
     },
-    "runtime.linux.System.IO.FileSystem/4.0.1-beta-23429": {
+    "runtime.linux.System.IO.FileSystem/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "3cWHasW4pON1aVOidmI4rKLTnrKczdl5gMM13hb256XlYYKoUbwHWF9aQZU7lTexK5FnX7NiWKrB8+WxCvtWDQ==",
+      "sha512": "LHtzSypkkXEI6R4EjM15SiKcbM0YxkB7U0z1upPfTWj7U470+Y6oBgl3brSb3aXkk08MZ2KRQV/FNEtLVINIrg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.IO.FileSystem.4.0.1-beta-23429.nupkg",
-        "runtime.linux.System.IO.FileSystem.4.0.1-beta-23429.nupkg.sha512",
+        "runtime.linux.System.IO.FileSystem.4.0.1-beta-23506.nupkg",
+        "runtime.linux.System.IO.FileSystem.4.0.1-beta-23506.nupkg.sha512",
         "runtime.linux.System.IO.FileSystem.nuspec",
         "runtimes/linux/lib/dotnet5.4/System.IO.FileSystem.dll"
       ]
     },
-    "runtime.linux.System.IO.FileSystem.DriveInfo/4.0.0-beta-23429": {
+    "runtime.linux.System.IO.FileSystem.DriveInfo/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "4c1jl7svnNadlsolPQ0g0nuOLXsAxY73DRjE77xBZxbd0Zn2GjD05FYBW90rOccF1xEspytkvQeZ5s3bGwMj2g==",
+      "sha512": "0AVTPGdRn7Nbpx8grc4ErYectGjXIZ2GevH5OcVcgohVi1pkXuHjeLtzIoaKDLyovB6bDz6tejoSffWr3FZ63Q==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.IO.FileSystem.DriveInfo.4.0.0-beta-23429.nupkg",
-        "runtime.linux.System.IO.FileSystem.DriveInfo.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.linux.System.IO.FileSystem.DriveInfo.4.0.0-beta-23506.nupkg",
+        "runtime.linux.System.IO.FileSystem.DriveInfo.4.0.0-beta-23506.nupkg.sha512",
         "runtime.linux.System.IO.FileSystem.DriveInfo.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.IO.FileSystem.DriveInfo.dll"
       ]
     },
-    "runtime.linux.System.IO.FileSystem.Watcher/4.0.0-beta-23429": {
+    "runtime.linux.System.IO.FileSystem.Watcher/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "1Q/qb2ntN2CP9n6yo9DjURENZpLFs8Iro87VG0FG0UixdW8E9jKH++hBgRT5rSxoEGL5ZyZbkSmTmWnbAeCvRw==",
+      "sha512": "QW+UsRBnibpgjsvGzDOP3alRtIpwaYLqmTAQVgWc7r5Tj7GyKeOE+D+eDC93Jgc20hIeB30HN5s7x9dvoN3v+Q==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.IO.FileSystem.Watcher.4.0.0-beta-23429.nupkg",
-        "runtime.linux.System.IO.FileSystem.Watcher.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.linux.System.IO.FileSystem.Watcher.4.0.0-beta-23506.nupkg",
+        "runtime.linux.System.IO.FileSystem.Watcher.4.0.0-beta-23506.nupkg.sha512",
         "runtime.linux.System.IO.FileSystem.Watcher.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.IO.FileSystem.Watcher.dll"
       ]
     },
-    "runtime.linux.System.IO.MemoryMappedFiles/4.0.0-beta-23429": {
+    "runtime.linux.System.IO.MemoryMappedFiles/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "CtWgEH6G7TFiDbQInd+LWbTUsAVgrhISpO9ym/jWhHcmuezb9Xl+VoYRZZZZnhIZ9f+yku/wwCX89D+8UBHHoA==",
+      "sha512": "V/AbI6lO882JFGWgPZOQCNlgy+ZsEQpMJ2LQfKZmnugfZX3qpNx5TGPJC2ToeqAVNmmZ3GglPjlFHYZhDX+Qtw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.IO.MemoryMappedFiles.4.0.0-beta-23429.nupkg",
-        "runtime.linux.System.IO.MemoryMappedFiles.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.linux.System.IO.MemoryMappedFiles.4.0.0-beta-23506.nupkg",
+        "runtime.linux.System.IO.MemoryMappedFiles.4.0.0-beta-23506.nupkg.sha512",
         "runtime.linux.System.IO.MemoryMappedFiles.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.IO.MemoryMappedFiles.dll"
       ]
     },
-    "runtime.linux.System.Net.Http/4.0.1-beta-23429": {
+    "runtime.linux.System.Net.Http/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "h9PpKAcfdjQGDT/Y8yd4ksFsSWFi9yyYqbExmCcPg7DdXMN/T0eTbEYAOe2UZlaU2XNrfmMQ3+H2okNsFmAkCg==",
+      "sha512": "bdougJm6yuTZk4Nc5ceJUIA3HVEI/Q7GIOjN1vjMsTWmHnxGl0b1p7WEo6zUoRa3fIwasLM67Gm1XupB3PnWmw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.Net.Http.4.0.1-beta-23429.nupkg",
-        "runtime.linux.System.Net.Http.4.0.1-beta-23429.nupkg.sha512",
+        "runtime.linux.System.Net.Http.4.0.1-beta-23506.nupkg",
+        "runtime.linux.System.Net.Http.4.0.1-beta-23506.nupkg.sha512",
         "runtime.linux.System.Net.Http.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Net.Http.dll"
       ]
     },
-    "runtime.linux.System.Net.NameResolution/4.0.0-beta-23429": {
+    "runtime.linux.System.Net.NameResolution/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "zQtjCsg0fu4LWwv+V819ZVAnPXj5bZQm3WiV0t98jwdcGzKf30s4z0Zn5LL97b1S7cCtFmEhKCnzlpbzzoC6Xg==",
+      "sha512": "6i60tV/bDHreGr2vlBegdco3fu5CEr7llM9ITE+yB9UshdR+6Xh7a4rkygD+Q1CK6YMGZ0TMAgENloQOv4GRPg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.Net.NameResolution.4.0.0-beta-23429.nupkg",
-        "runtime.linux.System.Net.NameResolution.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.linux.System.Net.NameResolution.4.0.0-beta-23506.nupkg",
+        "runtime.linux.System.Net.NameResolution.4.0.0-beta-23506.nupkg.sha512",
         "runtime.linux.System.Net.NameResolution.nuspec",
         "runtimes/unix/lib/dnxcore50/System.Net.NameResolution.dll"
       ]
     },
-    "runtime.linux.System.Net.NetworkInformation/4.1.0-beta-23429": {
+    "runtime.linux.System.Net.NetworkInformation/4.1.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "1MSmGKue4aEQkJczbkfCJ3GdKYQPAfx2Pz4qFsB8i20oOh2d/8t7IjdVRb9M9PNtomGMtN8biQMHo7Wm4D2BPA==",
+      "sha512": "ptKOydR/Tf3xqgghwzWvBwMrNuKVf4TTV3ihnJ1ztr/EDxRTCyMs7qZnAN/fLYFkL4aEl+IwU5i95oxM/PbI+w==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.Net.NetworkInformation.4.1.0-beta-23429.nupkg",
-        "runtime.linux.System.Net.NetworkInformation.4.1.0-beta-23429.nupkg.sha512",
+        "runtime.linux.System.Net.NetworkInformation.4.1.0-beta-23506.nupkg",
+        "runtime.linux.System.Net.NetworkInformation.4.1.0-beta-23506.nupkg.sha512",
         "runtime.linux.System.Net.NetworkInformation.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Net.NetworkInformation.dll"
       ]
     },
-    "runtime.linux.System.Net.Sockets/4.1.0-beta-23429": {
+    "runtime.linux.System.Net.Sockets/4.1.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "QAf6CP9JEo6670QlBV7/XVlMNBq1qQJnFytvgZNosxlFp+MkBNcUm3CUDupU3K7qbc+EbPuI3WXWVfZQo6ar4Q==",
+      "sha512": "XUpHbj9+tjxxPNjKvLJ6Xt2zL5tDE0rVInmLi8OlquP7MqdgMxI5/Gc8G3IUoW39ZbyFdhfY36a0PPoRWXrxGw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.Net.Sockets.4.1.0-beta-23429.nupkg",
-        "runtime.linux.System.Net.Sockets.4.1.0-beta-23429.nupkg.sha512",
+        "runtime.linux.System.Net.Sockets.4.1.0-beta-23506.nupkg",
+        "runtime.linux.System.Net.Sockets.4.1.0-beta-23506.nupkg.sha512",
         "runtime.linux.System.Net.Sockets.nuspec",
         "runtimes/linux/lib/dotnet5.5/System.Net.Sockets.dll"
       ]
     },
-    "runtime.linux.System.Runtime.Extensions/4.0.11-beta-23429": {
+    "runtime.linux.System.Runtime.Extensions/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "dfZJTk0FIw0pv05s+GMFA9+4tvqLlAFUyyGP0SEp1LmZ8mszRXMo4ZWfZl1lf5pU6i5qr+XRYffYEXO0NGCTlw==",
+      "sha512": "Ke/JOXVCcVBOdI8wjc1FkY7KQlpo+KFp+Ws2OPL5T1d6H3CPqbKxYWvaba1QyfIEPBkHEsbfA0Nz5pRFLJvWXw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.Runtime.Extensions.4.0.11-beta-23429.nupkg",
-        "runtime.linux.System.Runtime.Extensions.4.0.11-beta-23429.nupkg.sha512",
+        "runtime.linux.System.Runtime.Extensions.4.0.11-beta-23506.nupkg",
+        "runtime.linux.System.Runtime.Extensions.4.0.11-beta-23506.nupkg.sha512",
         "runtime.linux.System.Runtime.Extensions.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Runtime.Extensions.dll"
       ]
     },
-    "runtime.linux.System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23429": {
+    "runtime.linux.System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "E+VsAs/hNAQpUUkDepJ6x5ZaZwobhXVIHbaqD10iBkhGG3Nsu8gk6c1RF1BVpLFqzH/gEiPcF4FbebbB7vwc5g==",
+      "sha512": "csSBa51sdzc7th+H8CyEFRyk/GF4BdVuc/p/b2Bmav7lIZhpqpu4SWqAYj9PpT8UzPVTrD4ZF+VesDMG740RIA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23429.nupkg",
-        "runtime.linux.System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.linux.System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23506.nupkg",
+        "runtime.linux.System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23506.nupkg.sha512",
         "runtime.linux.System.Runtime.InteropServices.RuntimeInformation.nuspec",
         "runtimes/unix/lib/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll"
       ]
     },
-    "runtime.linux.System.Security.Cryptography.Algorithms/4.0.0-beta-23429": {
+    "runtime.linux.System.Security.Cryptography.Algorithms/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "HU9g5vQznM9yFd9vX2CijV/fIh7UCfGOkaJfk9KxpHY8054aVWWy4ikYLFUWz4r2h3CaBnJsvatQ+/+uCA2Yng==",
+      "sha512": "T0blGuVlSVs5iFn2Rb5HBCm8DIAakCMO84EUexKA9D8ilRPqMB2qjNQ+STzPcR9yi1NlU8h5krcKoNMkcd2NLA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.Security.Cryptography.Algorithms.4.0.0-beta-23429.nupkg",
-        "runtime.linux.System.Security.Cryptography.Algorithms.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.linux.System.Security.Cryptography.Algorithms.4.0.0-beta-23506.nupkg",
+        "runtime.linux.System.Security.Cryptography.Algorithms.4.0.0-beta-23506.nupkg.sha512",
         "runtime.linux.System.Security.Cryptography.Algorithms.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.Algorithms.dll"
       ]
     },
-    "runtime.osx.10.10.System.Diagnostics.Process/4.1.0-beta-23429": {
+    "runtime.osx.10.10.System.Diagnostics.Process/4.1.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "41x0xl60bOCLuxvfjVkRvdfvdRtcHD7oek6z5prL/AsUFGw1fBD7qXFtBwzYCdlo5aC2oqPUftYHWo0D8mT2dg==",
+      "sha512": "E5kDF3HDvTaT6ejE+lyK0R1p/WuFprdWK0UgR0gQaZYapX4OZuGxD5HSk864FWmFHhe1eqIubfWeeTAYOov1Tg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.Diagnostics.Process.4.1.0-beta-23429.nupkg",
-        "runtime.osx.10.10.System.Diagnostics.Process.4.1.0-beta-23429.nupkg.sha512",
+        "runtime.osx.10.10.System.Diagnostics.Process.4.1.0-beta-23506.nupkg",
+        "runtime.osx.10.10.System.Diagnostics.Process.4.1.0-beta-23506.nupkg.sha512",
         "runtime.osx.10.10.System.Diagnostics.Process.nuspec",
         "runtimes/unix/lib/dotnet5.5/System.Diagnostics.Process.dll"
       ]
     },
-    "runtime.osx.10.10.System.IO.FileSystem/4.0.1-beta-23429": {
+    "runtime.osx.10.10.System.IO.FileSystem/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "1IfcZCMzmuVh1xY/EEoscXJNCSZYdNt1z01P1c7I9jhID+iqMOJ+slIeLLFAz+4FPAxLVpsmetmo8cLSFMwEzg==",
+      "sha512": "3/ocYDngNUC00mo2iBkMIlAV8/CWNHTkzmM0XPNAOrE+seJOVd00URdLzuzsPJffIfwMztC4fGUBnPdCBjEuZw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.IO.FileSystem.4.0.1-beta-23429.nupkg",
-        "runtime.osx.10.10.System.IO.FileSystem.4.0.1-beta-23429.nupkg.sha512",
+        "runtime.osx.10.10.System.IO.FileSystem.4.0.1-beta-23506.nupkg",
+        "runtime.osx.10.10.System.IO.FileSystem.4.0.1-beta-23506.nupkg.sha512",
         "runtime.osx.10.10.System.IO.FileSystem.nuspec",
         "runtimes/osx.10.10/lib/dotnet5.4/System.IO.FileSystem.dll"
       ]
     },
-    "runtime.osx.10.10.System.IO.FileSystem.DriveInfo/4.0.0-beta-23429": {
+    "runtime.osx.10.10.System.IO.FileSystem.DriveInfo/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "NjEWSHyoDgxdlOEY//sY3utWdC51xVvAS96gcPTOvBN6/+OY3hmvGMhHjWmbZlvD+I4kTLZmLbZ1AreH8HCeRA==",
+      "sha512": "apaLsq0wICLSWMgCvfC6CeapL4m/rVkI/WAQncMLBHF9PauGVoDjYeqRkHqxBa2kWz/2S0YB/3u/ozEwOtGctA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.IO.FileSystem.DriveInfo.4.0.0-beta-23429.nupkg",
-        "runtime.osx.10.10.System.IO.FileSystem.DriveInfo.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.osx.10.10.System.IO.FileSystem.DriveInfo.4.0.0-beta-23506.nupkg",
+        "runtime.osx.10.10.System.IO.FileSystem.DriveInfo.4.0.0-beta-23506.nupkg.sha512",
         "runtime.osx.10.10.System.IO.FileSystem.DriveInfo.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.IO.FileSystem.DriveInfo.dll"
       ]
     },
-    "runtime.osx.10.10.System.IO.FileSystem.Watcher/4.0.0-beta-23429": {
+    "runtime.osx.10.10.System.IO.FileSystem.Watcher/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "iyRiiyg0Dr1onkAq42bkgZizDySB+YsVr49qrO2RpeJbsKCIbSGbVmOCZVu4tpB6Qw70k/+nQqMw1F4qRZpxGA==",
+      "sha512": "oGPWInX9QJhwgAS7tvSOPUgyKHUl55uUyLpisfxkprUwy9AFD9hcFdPxwh74ILMmcxEXgm8Gdj6ubmEi0r0HaA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.IO.FileSystem.Watcher.4.0.0-beta-23429.nupkg",
-        "runtime.osx.10.10.System.IO.FileSystem.Watcher.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.osx.10.10.System.IO.FileSystem.Watcher.4.0.0-beta-23506.nupkg",
+        "runtime.osx.10.10.System.IO.FileSystem.Watcher.4.0.0-beta-23506.nupkg.sha512",
         "runtime.osx.10.10.System.IO.FileSystem.Watcher.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.IO.FileSystem.Watcher.dll"
       ]
     },
-    "runtime.osx.10.10.System.IO.MemoryMappedFiles/4.0.0-beta-23429": {
+    "runtime.osx.10.10.System.IO.MemoryMappedFiles/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lyvU4YikABJfcf1Awr3Q+aiUvqbpKT0+IgleYlEAsIkyrasq7SdPJMhz8sA3qvVXoj+460lLRUue1MKGn9ZQ/A==",
+      "sha512": "52A9j49Z7fyUBGNZ8rtCBtCE3IJHIqLeh1owpEnpQm2Uej0/P2Nmc60QCsO2Rua2q67B31VzyFDJucVZRidpFw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.IO.MemoryMappedFiles.4.0.0-beta-23429.nupkg",
-        "runtime.osx.10.10.System.IO.MemoryMappedFiles.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.osx.10.10.System.IO.MemoryMappedFiles.4.0.0-beta-23506.nupkg",
+        "runtime.osx.10.10.System.IO.MemoryMappedFiles.4.0.0-beta-23506.nupkg.sha512",
         "runtime.osx.10.10.System.IO.MemoryMappedFiles.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.IO.MemoryMappedFiles.dll"
       ]
     },
-    "runtime.osx.10.10.System.Net.Http/4.0.1-beta-23429": {
+    "runtime.osx.10.10.System.Net.Http/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "AUbq7zmM2Suv2g7+38unrA1sCJx62fTyTTkpwg3Ox6XDfZ7iDUHplZ502zPvFkD3dwASDZHYQaeV5K18JCl/5Q==",
+      "sha512": "GHgtuiS63TFbLnybR8tGtWIBqhsLmFdHWCFdI3Rho5E81amUL77k8jeFc4Rje9jkvC8svW5A67kMT2CX7o6TDA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.Net.Http.4.0.1-beta-23429.nupkg",
-        "runtime.osx.10.10.System.Net.Http.4.0.1-beta-23429.nupkg.sha512",
+        "runtime.osx.10.10.System.Net.Http.4.0.1-beta-23506.nupkg",
+        "runtime.osx.10.10.System.Net.Http.4.0.1-beta-23506.nupkg.sha512",
         "runtime.osx.10.10.System.Net.Http.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Net.Http.dll"
       ]
     },
-    "runtime.osx.10.10.System.Net.NameResolution/4.0.0-beta-23429": {
+    "runtime.osx.10.10.System.Net.NameResolution/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RREadU/JvryuaOHSBP7vK1Dhn2K5ibsUM9mkquN3WgPUK9dJZQ2deMcs9clwpHj4jssow8NuRkWajy2T2ZrHUw==",
+      "sha512": "49NhEM8jHuo0Snd84Stm8O5gCGZiYOdtf+xq0bBUI8o1rIwfdiTjC/YtMQ7Eq7U6li4KAxRd9V7qGWnM3ML+kA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.Net.NameResolution.4.0.0-beta-23429.nupkg",
-        "runtime.osx.10.10.System.Net.NameResolution.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.osx.10.10.System.Net.NameResolution.4.0.0-beta-23506.nupkg",
+        "runtime.osx.10.10.System.Net.NameResolution.4.0.0-beta-23506.nupkg.sha512",
         "runtime.osx.10.10.System.Net.NameResolution.nuspec",
         "runtimes/unix/lib/dnxcore50/System.Net.NameResolution.dll"
       ]
     },
-    "runtime.osx.10.10.System.Net.NetworkInformation/4.1.0-beta-23429": {
+    "runtime.osx.10.10.System.Net.NetworkInformation/4.1.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "McjqwLUfJaA2jf2m/fI98qkNchqLhCj1Xp6EwNIEgk6OOSnQAI5tMV/r/d+gRFQm+8cT4YRfGus5GuIg+/T7kw==",
+      "sha512": "uBzC1YGK4OdjkMTIxh3tZdcDuQ1wD9jNwks3WyVFYpHSKaU3tZMoMGXj2s3kaa7g+lWLRzpkbCrc4bFau2sS8Q==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.Net.NetworkInformation.4.1.0-beta-23429.nupkg",
-        "runtime.osx.10.10.System.Net.NetworkInformation.4.1.0-beta-23429.nupkg.sha512",
+        "runtime.osx.10.10.System.Net.NetworkInformation.4.1.0-beta-23506.nupkg",
+        "runtime.osx.10.10.System.Net.NetworkInformation.4.1.0-beta-23506.nupkg.sha512",
         "runtime.osx.10.10.System.Net.NetworkInformation.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Net.NetworkInformation.dll"
       ]
     },
-    "runtime.osx.10.10.System.Net.Primitives/4.0.11-beta-23429": {
+    "runtime.osx.10.10.System.Net.Primitives/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RVU+MnBvERhka7N1Tb99LtH9hFi29fkCbMeGDtIknYz2+zt+2dQaET+U1kpyHi6z6mzmyYLD7aVKa5z3hIZGDA==",
+      "sha512": "qWJEzPyzKJq6Vz6mP11F+r9yoa/UsMcsPcXeRKT/Q7hguq5//CCW36Z1f4NL7aoAdV9mHgg8/E30O15W+Bbipw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.Net.Primitives.4.0.11-beta-23429.nupkg",
-        "runtime.osx.10.10.System.Net.Primitives.4.0.11-beta-23429.nupkg.sha512",
+        "runtime.osx.10.10.System.Net.Primitives.4.0.11-beta-23506.nupkg",
+        "runtime.osx.10.10.System.Net.Primitives.4.0.11-beta-23506.nupkg.sha512",
         "runtime.osx.10.10.System.Net.Primitives.nuspec",
         "runtimes/unix/lib/dnxcore50/System.Net.Primitives.dll"
       ]
     },
-    "runtime.osx.10.10.System.Net.Sockets/4.1.0-beta-23429": {
+    "runtime.osx.10.10.System.Net.Sockets/4.1.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "U2k4t4HwZEGcm8v5WU7C8lO8r7pXQm+qD8rVWd6UWjnbBHLZ3OeEYzgN5RMdaEF8jbSdeHa2yaLVeZRlzLVBww==",
+      "sha512": "ZqA3mdtQjRn/7dzifE5qWB375UbUX+TxdzVnMWwtBo++hUvMK+4YR5dmggiJNYE3BJt6WKcsF/1kYV1cqZfHjA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.Net.Sockets.4.1.0-beta-23429.nupkg",
-        "runtime.osx.10.10.System.Net.Sockets.4.1.0-beta-23429.nupkg.sha512",
+        "runtime.osx.10.10.System.Net.Sockets.4.1.0-beta-23506.nupkg",
+        "runtime.osx.10.10.System.Net.Sockets.4.1.0-beta-23506.nupkg.sha512",
         "runtime.osx.10.10.System.Net.Sockets.nuspec",
         "runtimes/osx.10.10/lib/dotnet5.5/System.Net.Sockets.dll"
       ]
     },
-    "runtime.osx.10.10.System.Runtime.Extensions/4.0.11-beta-23429": {
+    "runtime.osx.10.10.System.Runtime.Extensions/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "TJmSzso5ApFiEeKw+kLjToujebXSEAYMHoE2sFzos3klCfEsAUIQbI+DWpasYQy4YaRpxmRIGPfi59NTI8eFbQ==",
+      "sha512": "qEQHWSAgeF5ANtGXIYIKdRrJ0S5XN1DvTLKpzvY578eiunGrgPmaBCLw6FYA3JI+50uruFIJs6h3QTOdwBDmHw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.Runtime.Extensions.4.0.11-beta-23429.nupkg",
-        "runtime.osx.10.10.System.Runtime.Extensions.4.0.11-beta-23429.nupkg.sha512",
+        "runtime.osx.10.10.System.Runtime.Extensions.4.0.11-beta-23506.nupkg",
+        "runtime.osx.10.10.System.Runtime.Extensions.4.0.11-beta-23506.nupkg.sha512",
         "runtime.osx.10.10.System.Runtime.Extensions.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Runtime.Extensions.dll"
       ]
     },
-    "runtime.osx.10.10.System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23429": {
+    "runtime.osx.10.10.System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "CH05UovLrHvpxFu19eTSsASKdUgV7kSgVow69hMK/EqxTHzOQg3a61mzc41cl4P2MrEMh+qao8NwnqU4PlQqQA==",
+      "sha512": "t24DNqKvLbXCJYF3wxGqZ6+zcIFOIW4FzTsOqVtwiCoGN0iVZPlnPblKF7033D8YpoAnzUasnx6an5FwKp7nhA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23429.nupkg",
-        "runtime.osx.10.10.System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.osx.10.10.System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23506.nupkg",
+        "runtime.osx.10.10.System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23506.nupkg.sha512",
         "runtime.osx.10.10.System.Runtime.InteropServices.RuntimeInformation.nuspec",
         "runtimes/unix/lib/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll"
       ]
     },
-    "runtime.osx.10.10.System.Security.Cryptography.Algorithms/4.0.0-beta-23429": {
+    "runtime.osx.10.10.System.Security.Cryptography.Algorithms/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "zulRRuC/XRfMzggevi6OnEpXyDZNRdqcflfDfJxsicbOzXS67bIHnhlvedwX+/f+oeumrqQkH6ot6qzdO/CXAA==",
+      "sha512": "IWG82rzfiWMJs54/c5Q5Re80cXCq+prjd8bfovsav6fUysYIz+tNOQCHqqlMsyzjuVMGyOXi+A6bnXEZ/xYRTA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.Security.Cryptography.Algorithms.4.0.0-beta-23429.nupkg",
-        "runtime.osx.10.10.System.Security.Cryptography.Algorithms.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.osx.10.10.System.Security.Cryptography.Algorithms.4.0.0-beta-23506.nupkg",
+        "runtime.osx.10.10.System.Security.Cryptography.Algorithms.4.0.0-beta-23506.nupkg.sha512",
         "runtime.osx.10.10.System.Security.Cryptography.Algorithms.nuspec",
         "runtimes/osx.10.10/lib/dotnet5.4/System.Security.Cryptography.Algorithms.dll"
       ]
     },
-    "runtime.osx.10.10-x64.Microsoft.NETCore.ConsoleHost/1.0.0-beta-23429": {
+    "runtime.osx.10.10-x64.Microsoft.NETCore.ConsoleHost/1.0.0-beta-23506": {
       "type": "package",
-      "sha512": "n/v9a/Gjq6ZDL+4J+VrLP1McF+YzELQM0yNiNgX05R8TgvEt/DPVEee8Q7ESN9IesuAHisKg/eSVd6WbMDwQZQ==",
+      "sha512": "XCiyBfv1qWLVRVZLS40aQCDKwXkTIpTZspdCXRNeOF4Yw6nGMRZRp3yinBQTc6i0+MalvGr1QeCjYka2nbqxhA==",
       "files": [
-        "runtime.osx.10.10-x64.Microsoft.NETCore.ConsoleHost.1.0.0-beta-23429.nupkg",
-        "runtime.osx.10.10-x64.Microsoft.NETCore.ConsoleHost.1.0.0-beta-23429.nupkg.sha512",
+        "runtime.osx.10.10-x64.Microsoft.NETCore.ConsoleHost.1.0.0-beta-23506.nupkg",
+        "runtime.osx.10.10-x64.Microsoft.NETCore.ConsoleHost.1.0.0-beta-23506.nupkg.sha512",
         "runtime.osx.10.10-x64.Microsoft.NETCore.ConsoleHost.nuspec",
         "runtimes/osx.10.10-x64/native/coreconsole"
       ]
     },
-    "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23429": {
+    "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23506": {
       "type": "package",
-      "sha512": "GwjaATRyyxqMSEGysrpK7NPj9aJloDSLt1T1RVeL/rWa9L9m2zatJ3yW1Fbp7TpsCpKjMbWwZEAFbz2og8EEzw==",
+      "sha512": "1gaetzKdS6HsukFVGa9am9bd9bXXQtL2srUlI8l5dk2OSM5FdPXbgg7p5GRl8yjgg/uOd8E5SN5DvibcrZ9ldQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23429.nupkg",
-        "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23429.nupkg.sha512",
+        "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23506.nupkg",
+        "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23506.nupkg.sha512",
         "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR.nuspec",
         "runtimes/osx.10.10-x64/lib/dotnet/mscorlib.dll",
         "runtimes/osx.10.10-x64/native/libcoreclr.dylib",
@@ -13397,36 +13529,37 @@
         "runtimes/osx.10.10-x64/native/System.Globalization.Native.dylib",
         "runtimes/osx.10.10-x64/native/System.Native.dylib",
         "runtimes/osx.10.10-x64/native/System.Net.Http.Native.dylib",
-        "runtimes/osx.10.10-x64/native/System.Security.Cryptography.Native.dylib"
+        "runtimes/osx.10.10-x64/native/System.Security.Cryptography.Native.dylib",
+        "tools/crossgen"
       ]
     },
-    "runtime.osx.10.10-x64.Microsoft.NETCore.TestHost/1.0.0-beta-23429": {
+    "runtime.osx.10.10-x64.Microsoft.NETCore.TestHost/1.0.0-beta-23506": {
       "type": "package",
-      "sha512": "sIvElhLJkh+n7aPEPFNJx3GFmpTuHJr1pKeBNU9eJdPkfYkWrpigpgIrpY4fMuc5nNXw+QnJxP8U04tpphzGPg==",
+      "sha512": "F4V/1NcSCLN5E664WVuhNDdKcRGAqbNUKDdkGbzxGhf/DHRsGsDbh0fTqUnIc8768K60ks+3XnTWcy0SrERFjQ==",
       "files": [
-        "runtime.osx.10.10-x64.Microsoft.NETCore.TestHost.1.0.0-beta-23429.nupkg",
-        "runtime.osx.10.10-x64.Microsoft.NETCore.TestHost.1.0.0-beta-23429.nupkg.sha512",
+        "runtime.osx.10.10-x64.Microsoft.NETCore.TestHost.1.0.0-beta-23506.nupkg",
+        "runtime.osx.10.10-x64.Microsoft.NETCore.TestHost.1.0.0-beta-23506.nupkg.sha512",
         "runtime.osx.10.10-x64.Microsoft.NETCore.TestHost.nuspec",
         "runtimes/osx.10.10-x64/native/corerun"
       ]
     },
-    "runtime.ubuntu.14.04-x64.Microsoft.NETCore.ConsoleHost/1.0.0-beta-23429": {
+    "runtime.ubuntu.14.04-x64.Microsoft.NETCore.ConsoleHost/1.0.0-beta-23506": {
       "type": "package",
-      "sha512": "L2VT6XxLTloQevr8H7wQLJvV56/ntnrPoSTw36Km4kobyv7gjJPC+7qE7yiIWamW2Is+gJonFEQHaGwKoZ0J1g==",
+      "sha512": "4U7+QhBMHb6z4AcsF00JwOhkuC0Y947T0Jwvr/S3AfuF8DmVNqkQern3+ruFLMDIMnAAy0PZYyDK8fHJL6tElQ==",
       "files": [
-        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.ConsoleHost.1.0.0-beta-23429.nupkg",
-        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.ConsoleHost.1.0.0-beta-23429.nupkg.sha512",
+        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.ConsoleHost.1.0.0-beta-23506.nupkg",
+        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.ConsoleHost.1.0.0-beta-23506.nupkg.sha512",
         "runtime.ubuntu.14.04-x64.Microsoft.NETCore.ConsoleHost.nuspec",
         "runtimes/ubuntu.14.04-x64/native/coreconsole"
       ]
     },
-    "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23429": {
+    "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23506": {
       "type": "package",
-      "sha512": "W/8dMc/DbGMRSfOgihgFu8jULdjjUKYczEPIfqOKlGEtqHAe7zi/9kNa7aWFvOBkJiXmixiqXLAJLVLkoURpaA==",
+      "sha512": "vTJCzp4gsk/UsIw9TbgADf3uckjFKi8tz4tQ5YhANkIapApQo7ksu/COkZ45Oz6sq+ibt1cD+yXgZFAHiPYagQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23429.nupkg",
-        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23429.nupkg.sha512",
+        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23506.nupkg",
+        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23506.nupkg.sha512",
         "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR.nuspec",
         "runtimes/ubuntu.14.04-x64/lib/dotnet/mscorlib.dll",
         "runtimes/ubuntu.14.04-x64/native/libcoreclr.so",
@@ -13440,258 +13573,287 @@
         "runtimes/ubuntu.14.04-x64/native/System.Globalization.Native.so",
         "runtimes/ubuntu.14.04-x64/native/System.Native.so",
         "runtimes/ubuntu.14.04-x64/native/System.Net.Http.Native.so",
-        "runtimes/ubuntu.14.04-x64/native/System.Security.Cryptography.Native.so"
+        "runtimes/ubuntu.14.04-x64/native/System.Security.Cryptography.Native.so",
+        "tools/crossgen"
       ]
     },
-    "runtime.ubuntu.14.04-x64.Microsoft.NETCore.TestHost/1.0.0-beta-23429": {
+    "runtime.ubuntu.14.04-x64.Microsoft.NETCore.TestHost/1.0.0-beta-23506": {
       "type": "package",
-      "sha512": "OlndcHFMINIATBR5fqdFbbibCDMSTwoYnh7X1gX59rm6/f8VoVyPQa/XrqLIAiAaLKHnHA90sEb30pd9aZVVCQ==",
+      "sha512": "pfH1g9dUzM9aVH225dY3612umTJGmrxS3wWkXaQoJz7dHa0DSMaUy5xADS3tylJVSjq9A7OW0SJi7H5Go8c3Jg==",
       "files": [
-        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.TestHost.1.0.0-beta-23429.nupkg",
-        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.TestHost.1.0.0-beta-23429.nupkg.sha512",
+        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.TestHost.1.0.0-beta-23506.nupkg",
+        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.TestHost.1.0.0-beta-23506.nupkg.sha512",
         "runtime.ubuntu.14.04-x64.Microsoft.NETCore.TestHost.nuspec",
         "runtimes/ubuntu.14.04-x64/native/corerun"
       ]
     },
-    "runtime.unix.Microsoft.Win32.Primitives/4.0.1-beta-23429": {
+    "runtime.unix.Microsoft.Win32.Primitives/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "J51NKf1g+ArxQS3zQRWJjaJZnqCo+5uUi8T1/WG2cBOrZRALPPEB6JGwJSCaWsEC6DNKY5zZk8bGiltPkGfqtA==",
+      "sha512": "VEzQrFbrvZBmXC0WFpEWhAkF86VSJF8Z4oJ3jzHed70RXoIU2+Mv0Tdo2SiIjkpiaKv7OU8N+vK07iKYdkDr7A==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.Microsoft.Win32.Primitives.4.0.1-beta-23429.nupkg",
-        "runtime.unix.Microsoft.Win32.Primitives.4.0.1-beta-23429.nupkg.sha512",
+        "runtime.unix.Microsoft.Win32.Primitives.4.0.1-beta-23506.nupkg",
+        "runtime.unix.Microsoft.Win32.Primitives.4.0.1-beta-23506.nupkg.sha512",
         "runtime.unix.Microsoft.Win32.Primitives.nuspec",
         "runtimes/unix/lib/dotnet5.4/Microsoft.Win32.Primitives.dll"
       ]
     },
-    "runtime.unix.System.Console/4.0.0-beta-23429": {
+    "runtime.unix.System.Console/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "z5gtoF9UbuLF1WFhcYBLo/ZJGK4b/6Z0q++d/jVmRWKDOW81EV0sBxXjg8cJql0Stukx6xDLRvCpXWHlJo1E/Q==",
+      "sha512": "OQfoV70s4VBR2B3Yv4DejmcOmt9LDw4LvLN5NH7njc9TwxYALKE+1K9Zs03T/5jXb7/57dUuxgKW1VTuEiYDYg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Console.4.0.0-beta-23429.nupkg",
-        "runtime.unix.System.Console.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.unix.System.Console.4.0.0-beta-23506.nupkg",
+        "runtime.unix.System.Console.4.0.0-beta-23506.nupkg.sha512",
         "runtime.unix.System.Console.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Console.dll"
       ]
     },
-    "runtime.unix.System.Data.SqlClient/4.0.0-beta-23429": {
+    "runtime.unix.System.Data.SqlClient/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "e/CcaQm+enBEIMgUIH77RbZhDNP7hTod+Cs3GaOh0VoJjF/FdSIjXoJUEbJkUS6PPNQinSwjXgxba2iCNv6KUQ==",
+      "sha512": "vDIqop/3nMYVxuHunSL836zCoLxwyWfqQFPSdjhwk8DPi48xkbU8KQe791opOUfvkNPlM4CJVGZfMbRd740yKg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Data.SqlClient.4.0.0-beta-23429.nupkg",
-        "runtime.unix.System.Data.SqlClient.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.unix.System.Data.SqlClient.4.0.0-beta-23506.nupkg",
+        "runtime.unix.System.Data.SqlClient.4.0.0-beta-23506.nupkg.sha512",
         "runtime.unix.System.Data.SqlClient.nuspec",
         "runtimes/unix/lib/dotnet5.5/System.Data.SqlClient.dll"
       ]
     },
-    "runtime.unix.System.Diagnostics.Debug/4.0.11-beta-23429": {
+    "runtime.unix.System.Diagnostics.Debug/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Li2DaD9wyqbNwBRXAZztd4VSMv9I6kFO5MZWxLJYpH7P11f6jrZRfmrpKd7v+iL3Ng+i1ruQijIiWlFS/zaH/g==",
+      "sha512": "Xx2XfZ+hnY043omB6Qi0iJVhIj2d4t8tNPaIDJ9H4ftD29iMJt8SYyqieAxzLkugRlvoddrWb872Fic1QhgrEQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Diagnostics.Debug.4.0.11-beta-23429.nupkg",
-        "runtime.unix.System.Diagnostics.Debug.4.0.11-beta-23429.nupkg.sha512",
+        "runtime.unix.System.Diagnostics.Debug.4.0.11-beta-23506.nupkg",
+        "runtime.unix.System.Diagnostics.Debug.4.0.11-beta-23506.nupkg.sha512",
         "runtime.unix.System.Diagnostics.Debug.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Diagnostics.Debug.dll"
       ]
     },
-    "runtime.unix.System.Diagnostics.FileVersionInfo/4.0.0-beta-23429": {
+    "runtime.unix.System.Diagnostics.FileVersionInfo/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Flaeh2Qbrsids9vzNRVka4JUNDBXIciTSwKvC/meYaxPR3APfZR207pZMQECLzM/8EyOqlDociJDpt2qe5CehA==",
+      "sha512": "EGssvOVpBhasYpzhrs/NsdRnIp+r8b2HTpFcLblh++1t8ihgiliC0+O7dF4JmZ1zl/qgBHGEkYA4wk/28HxaSg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Diagnostics.FileVersionInfo.4.0.0-beta-23429.nupkg",
-        "runtime.unix.System.Diagnostics.FileVersionInfo.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.unix.System.Diagnostics.FileVersionInfo.4.0.0-beta-23506.nupkg",
+        "runtime.unix.System.Diagnostics.FileVersionInfo.4.0.0-beta-23506.nupkg.sha512",
         "runtime.unix.System.Diagnostics.FileVersionInfo.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Diagnostics.FileVersionInfo.dll"
       ]
     },
-    "runtime.unix.System.Globalization.Extensions/4.0.1-beta-23429": {
+    "runtime.unix.System.Globalization.Extensions/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "HWP8MHor7BLX/RKFzk8W08ajwnOHSnmWi+XBwG2HdY6K764rcyhd1yUMlkI3W0yjlNU/3yjEU+nSOmMA3lo8sw==",
+      "sha512": "IU3cIQ+zlisirM+fhdEMYuNNOSmYd4FacG7z51bQ0yyWMviKx6ao+I1yVmFBOXrED8NZ4m/JZ2GxfaDNCtHR7g==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Globalization.Extensions.4.0.1-beta-23429.nupkg",
-        "runtime.unix.System.Globalization.Extensions.4.0.1-beta-23429.nupkg.sha512",
+        "runtime.unix.System.Globalization.Extensions.4.0.1-beta-23506.nupkg",
+        "runtime.unix.System.Globalization.Extensions.4.0.1-beta-23506.nupkg.sha512",
         "runtime.unix.System.Globalization.Extensions.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Globalization.Extensions.dll"
       ]
     },
-    "runtime.unix.System.IO.Compression/4.1.0-beta-23429": {
+    "runtime.unix.System.IO.Compression/4.1.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "tn3zMeRLF9sXwAvM++6Pk4iYk4Qp20jdCXCVd+yETRjkHvO+CVtKcnf+VELgZ3xSe8a/BYtP82YRM+cK5kCc9w==",
+      "sha512": "rVcKacDjNOO6COyjn64hqAESwV+Qmg6iEMzMZSeVQfJ2MfF51JdOWRr0H0WFnBh+Jsh1Xc6FBqaqtozPjhGGPA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.IO.Compression.4.1.0-beta-23429.nupkg",
-        "runtime.unix.System.IO.Compression.4.1.0-beta-23429.nupkg.sha512",
+        "runtime.unix.System.IO.Compression.4.1.0-beta-23506.nupkg",
+        "runtime.unix.System.IO.Compression.4.1.0-beta-23506.nupkg.sha512",
         "runtime.unix.System.IO.Compression.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.IO.Compression.dll"
       ]
     },
-    "runtime.unix.System.IO.Pipes/4.0.0-beta-23429": {
+    "runtime.unix.System.IO.Pipes/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2txc5WLpXwhvfob5xRPtFcjM3jAeJeqdVhtoR0fR7YIBHJwrUOGHYiYrwWKZgIMazFR2a+O5wMhZTePD6EGoWg==",
+      "sha512": "V8V78N+WEoKmrbkvgERdkLJTIHX3zC+HePJjb63Rwd1d+uJFwlGRrQ6Fmx3CKlzR7YwTsPAhgwGvz5+Bs/AhAw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.IO.Pipes.4.0.0-beta-23429.nupkg",
-        "runtime.unix.System.IO.Pipes.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.unix.System.IO.Pipes.4.0.0-beta-23506.nupkg",
+        "runtime.unix.System.IO.Pipes.4.0.0-beta-23506.nupkg.sha512",
         "runtime.unix.System.IO.Pipes.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.IO.Pipes.dll"
       ]
     },
-    "runtime.unix.System.Net.Primitives/4.0.11-beta-23429": {
+    "runtime.unix.System.Net.Primitives/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZLZie/fMyijLvGrXhRngfPyvn6gV4GuvImpHSn1it3H9mws+F1ypK+Ccz4ow6qrl7FiwNBnNkaoSMbUfZZfaNA==",
+      "sha512": "xFgTM7dVTjnpplHRG8WClX8NC17rjpEPaymTxfW0S7OeyY1mL8258TD9M7wb/Jl59VZZ4WVdt6zzDZ7J9jgfig==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Net.Primitives.4.0.11-beta-23429.nupkg",
-        "runtime.unix.System.Net.Primitives.4.0.11-beta-23429.nupkg.sha512",
+        "runtime.unix.System.Net.Primitives.4.0.11-beta-23506.nupkg",
+        "runtime.unix.System.Net.Primitives.4.0.11-beta-23506.nupkg.sha512",
         "runtime.unix.System.Net.Primitives.nuspec",
         "runtimes/unix/lib/dnxcore50/System.Net.Primitives.dll"
       ]
     },
-    "runtime.unix.System.Net.Requests/4.0.11-beta-23429": {
+    "runtime.unix.System.Net.Requests/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "muXrbDru2YENnyl9nZ0H9EBWFql2ImOWcOhqHhCjH58GIlNQpdXraiHe/Tx1HjdOvpEFwbRF/syGGlWoscXwqA==",
+      "sha512": "45pEraC0avTv0NuwgiOAbHOoemx4qPglo4jZyU/edd6zvy5lsll7AJ71TF9Tgas3VVOmCX2rXMjvaMc+tJhHPA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Net.Requests.4.0.11-beta-23429.nupkg",
-        "runtime.unix.System.Net.Requests.4.0.11-beta-23429.nupkg.sha512",
+        "runtime.unix.System.Net.Requests.4.0.11-beta-23506.nupkg",
+        "runtime.unix.System.Net.Requests.4.0.11-beta-23506.nupkg.sha512",
         "runtime.unix.System.Net.Requests.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Net.Requests.dll"
       ]
     },
-    "runtime.unix.System.Net.Security/4.0.0-beta-23429": {
+    "runtime.unix.System.Net.Security/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bfpAzC4LKkJ0JNnbbU2+8CZ4ZOOT430M9gLH9EhsG3DFx5qlvMSSDJYRZlNWgQtwYKwdJgdEyFY89MDbRUdFxQ==",
+      "sha512": "DLvqj1WYPUWhE1+CI1C5I5SDNhrkCbKxCfM90iMprmvyyDgzFhJexbCxfm1zFjybG6L92Tj3UasQo/GJOWm4/Q==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Net.Security.4.0.0-beta-23429.nupkg",
-        "runtime.unix.System.Net.Security.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.unix.System.Net.Security.4.0.0-beta-23506.nupkg",
+        "runtime.unix.System.Net.Security.4.0.0-beta-23506.nupkg.sha512",
         "runtime.unix.System.Net.Security.nuspec",
         "runtimes/unix/lib/dnxcore50/System.Net.Security.dll"
       ]
     },
-    "runtime.unix.System.Net.WebSockets.Client/4.0.0-beta-23429": {
+    "runtime.unix.System.Net.WebSockets.Client/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "vh0E2v/RKt+IatmISiBVtfmIfWq6va2RpZQeOGCPb5WNx3IWWmuH1jIOKLZe0fhBnGx9qw+PYgoo74ps0UofHA==",
+      "sha512": "oTsVt4NdQDO++PWQZNWPnLCT0QOEbxo8zE3opDOjC2vbxpOWEAeAGjon0qfIP1p9QRDWkmw5OrLzEiZTsLidEw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Net.WebSockets.Client.4.0.0-beta-23429.nupkg",
-        "runtime.unix.System.Net.WebSockets.Client.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.unix.System.Net.WebSockets.Client.4.0.0-beta-23506.nupkg",
+        "runtime.unix.System.Net.WebSockets.Client.4.0.0-beta-23506.nupkg.sha512",
         "runtime.unix.System.Net.WebSockets.Client.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Net.WebSockets.Client.dll"
       ]
     },
-    "runtime.unix.System.Private.Uri/4.0.1-beta-23429": {
+    "runtime.unix.System.Private.Uri/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "y1OBSt/d3zB8XgHZp+WHPiukgyBRPJIyds5cKvQmhE6BhdoxehfW3BmMmXnnUfCrcQhVlusdz4p6zl1cW+XLpA==",
+      "sha512": "Rli7Ff/EE8z2x0N+6bujmklazDicG9e7koZt97mitgB7PNNc03jmyZZw71TsO6Tqj9MiuEQEN2xMxPHo0EZL8g==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Private.Uri.4.0.1-beta-23429.nupkg",
-        "runtime.unix.System.Private.Uri.4.0.1-beta-23429.nupkg.sha512",
+        "runtime.unix.System.Private.Uri.4.0.1-beta-23506.nupkg",
+        "runtime.unix.System.Private.Uri.4.0.1-beta-23506.nupkg.sha512",
         "runtime.unix.System.Private.Uri.nuspec",
         "runtimes/unix/lib/dotnet5.1/System.Private.Uri.dll"
       ]
     },
-    "runtime.unix.System.Security.Cryptography.Encoding/4.0.0-beta-23429": {
+    "runtime.unix.System.Security.Cryptography.Encoding/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "M7qjv9RzXvc33QsQ5L7KhRV02n8HuU0Hqk3n+aKHIxqv+qNl8nOa+PlZnXEc437NIzatEhYl7sipOkyDNcUq0g==",
+      "sha512": "WV54MaKhycIoOckpeqTEI6k1KcyS5QilOqN+YXzer71kX/A44S3fJbmDTzKoObLEJH6MS08bmpSmYexDwGoW4w==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Security.Cryptography.Encoding.4.0.0-beta-23429.nupkg",
-        "runtime.unix.System.Security.Cryptography.Encoding.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.unix.System.Security.Cryptography.Encoding.4.0.0-beta-23506.nupkg",
+        "runtime.unix.System.Security.Cryptography.Encoding.4.0.0-beta-23506.nupkg.sha512",
         "runtime.unix.System.Security.Cryptography.Encoding.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.Encoding.dll"
       ]
     },
-    "runtime.unix.System.Security.Cryptography.X509Certificates/4.0.0-beta-23429": {
+    "runtime.unix.System.Security.Cryptography.X509Certificates/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "g3/hoJOiROTMLvXxj/AfMUuM+UHats/QzqrQeDsZG4D38FFCrHQb7FP0iWbZ4myOi7KhM1eoMaTTfmy4KwiAcQ==",
+      "sha512": "ZNu5r7fLbRsC2uY9T6O2vFqVQ4hyT1bLOivBUP0VuPD1wi3H1BFAn7H6V40D0SsMwGHGPwPhdbKkXwwhUIC4Qw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Security.Cryptography.X509Certificates.4.0.0-beta-23429.nupkg",
-        "runtime.unix.System.Security.Cryptography.X509Certificates.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.unix.System.Security.Cryptography.X509Certificates.4.0.0-beta-23506.nupkg",
+        "runtime.unix.System.Security.Cryptography.X509Certificates.4.0.0-beta-23506.nupkg.sha512",
         "runtime.unix.System.Security.Cryptography.X509Certificates.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.X509Certificates.dll"
       ]
     },
-    "runtime.unix.System.Threading/4.0.11-beta-23429": {
+    "runtime.unix.System.Text.Encoding.CodePages/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "CanLreI7oHXa/iAVC/jSLOAf3NyJ5zBib0ouoWwl6WtG4ndW2Q/0qu2AVF+oW/R85PYJMqhv3Z1tiqrUFBc9zA==",
+      "sha512": "6Kk0CrAs8Cusp9V9lc0Hm1aTUG1B5C/SUv9nOZn+D0pyhl9AyGVNHRBK6GERYW41hHOOjpYb/rBEUQzx3KESGg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Threading.4.0.11-beta-23429.nupkg",
-        "runtime.unix.System.Threading.4.0.11-beta-23429.nupkg.sha512",
+        "runtime.unix.System.Text.Encoding.CodePages.4.0.1-beta-23506.nupkg",
+        "runtime.unix.System.Text.Encoding.CodePages.4.0.1-beta-23506.nupkg.sha512",
+        "runtime.unix.System.Text.Encoding.CodePages.nuspec",
+        "runtimes/unix/lib/dotnet5.4/System.Text.Encoding.CodePages.dll"
+      ]
+    },
+    "runtime.unix.System.Threading/4.0.11-beta-23506": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "OhOBO+kTddjcPDbsLwx47JajbYb3uDrjiynYFSRq8ORJ6kXYtPd+WvsvTEBR7RcHm9D3X+r60oM0DGnLFhuYmw==",
+      "files": [
+        "ref/dotnet/_._",
+        "runtime.unix.System.Threading.4.0.11-beta-23506.nupkg",
+        "runtime.unix.System.Threading.4.0.11-beta-23506.nupkg.sha512",
         "runtime.unix.System.Threading.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Threading.dll"
       ]
     },
-    "runtime.win.System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23429": {
+    "runtime.win.System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "wAWOenZT86f5+6JMYRSygKE66z3nz41Y4TUo9F4Gqi8v/y0c4gIFayQ+/YuOfX8nNWrCkHN989K3f9G7sIvwwg==",
+      "sha512": "QeVopRMPKLiA9xcZLkPnYLVPY7j9rnuT8PCrp5bM8P0tRyE8+Z4G7cs8vRCmc1/KZnDIYx4c37/gYS5OUYVgfg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win.System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23429.nupkg",
-        "runtime.win.System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.win.System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23506.nupkg",
+        "runtime.win.System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23506.nupkg.sha512",
         "runtime.win.System.Runtime.InteropServices.RuntimeInformation.nuspec",
         "runtimes/win/lib/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll"
       ]
     },
-    "runtime.win7.Microsoft.Win32.Primitives/4.0.1-beta-23429": {
+    "runtime.win.System.Text.Encoding.CodePages/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BwSSQ9IabMmsDK01N5WxjQZUYzc2APNhp8yzFXy2Fh6yJngcgl6nDNPW0JXeH182seg6wioXTchO5V0j1Wm2ag==",
+      "sha512": "DK6eAoHmPOQjllMR+tcAeBo5Roc6ozNZGElvlVTIz1r/pmTTgBsI73at8wYZJS75aHX8e2wqY4aLEmPruFQEVQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.Microsoft.Win32.Primitives.4.0.1-beta-23429.nupkg",
-        "runtime.win7.Microsoft.Win32.Primitives.4.0.1-beta-23429.nupkg.sha512",
+        "runtime.win.System.Text.Encoding.CodePages.4.0.1-beta-23506.nupkg",
+        "runtime.win.System.Text.Encoding.CodePages.4.0.1-beta-23506.nupkg.sha512",
+        "runtime.win.System.Text.Encoding.CodePages.nuspec",
+        "runtimes/win/lib/dotnet5.4/System.Text.Encoding.CodePages.dll",
+        "runtimes/win/lib/netcore50/System.Text.Encoding.CodePages.dll",
+        "runtimes/win/lib/win8/_._",
+        "runtimes/win/lib/wp8/_._",
+        "runtimes/win/lib/wpa81/_._"
+      ]
+    },
+    "runtime.win7.Microsoft.Win32.Primitives/4.0.1-beta-23506": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "dQdofNVIqdGX7H/GWzOVjhKm2rrbOK124jlLWNvdEamVmkYhDyv94ZubFaH4E9qke86nhIzol2jZT0IsC95PmA==",
+      "files": [
+        "ref/dotnet/_._",
+        "runtime.win7.Microsoft.Win32.Primitives.4.0.1-beta-23506.nupkg",
+        "runtime.win7.Microsoft.Win32.Primitives.4.0.1-beta-23506.nupkg.sha512",
         "runtime.win7.Microsoft.Win32.Primitives.nuspec",
         "runtimes/win7/lib/dotnet5.4/Microsoft.Win32.Primitives.dll",
         "runtimes/win7/lib/net/_._"
       ]
     },
-    "runtime.win7.System.Console/4.0.0-beta-23429": {
+    "runtime.win7.System.Console/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "mS5yZx2r86TW/p0nAumaYKyWt6tIWlchmLfGyDd6LXIlFz+VR0N6OjdKkCP3fDhPQqN0NbclPC15VSn8ztdavA==",
+      "sha512": "AKzJ2WO7Zbo0MHcuaQDl/h5HsWqIVtSR4jhk2OEjYhDUow0eUFXU+Hxe2ney3Ao4NbIQw0zzL7QcqpLAegF1cg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Console.4.0.0-beta-23429.nupkg",
-        "runtime.win7.System.Console.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.win7.System.Console.4.0.0-beta-23506.nupkg",
+        "runtime.win7.System.Console.4.0.0-beta-23506.nupkg.sha512",
         "runtime.win7.System.Console.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.Console.dll",
         "runtimes/win7/lib/net/_._"
       ]
     },
-    "runtime.win7.System.Data.SqlClient/4.0.0-beta-23429": {
+    "runtime.win7.System.Data.SqlClient/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "4fP9FUjTUobBKBquUyO3HzUvF6bPfwOlY3Zf6Xcr+1K2wd5XPufLlj8ZcdIeqqg975g0stAsiF6EuCpJB6/W/A==",
+      "sha512": "Fl6SDdMqTTwxJJ5ViWqzIs9Xv9GYBT1B9h9Rm4T7V56b1zZAFp36HkMb2cxmVcJLy3jFD/3f1d5Nu0JurhcAaQ==",
       "files": [
         "lib/net/_._",
         "ref/dotnet/_._",
-        "runtime.win7.System.Data.SqlClient.4.0.0-beta-23429.nupkg",
-        "runtime.win7.System.Data.SqlClient.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.win7.System.Data.SqlClient.4.0.0-beta-23506.nupkg",
+        "runtime.win7.System.Data.SqlClient.4.0.0-beta-23506.nupkg.sha512",
         "runtime.win7.System.Data.SqlClient.nuspec",
         "runtimes/win7/lib/DNXCore50/System.Data.SqlClient.dll",
         "runtimes/win7/lib/win8/_._",
@@ -13699,28 +13861,28 @@
         "runtimes/win7/lib/wpa81/_._"
       ]
     },
-    "runtime.win7.System.Diagnostics.Debug/4.0.11-beta-23429": {
+    "runtime.win7.System.Diagnostics.Debug/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "9i5aAvBzAcG8YYvgQvXxBw7Dzu7XofvnLz3oT9nUfYLCUsj5GpSgWLibDPPinmDo3+2bTAHrmnCx9vbMcQtdSQ==",
+      "sha512": "fp8Ax9bBlzH9LOAP3+gQ0bU4BxOZ92lgQ8WaR6SFZF3SxZowfaCY4CVDzya5VxtgyiSsblPE6hCvwgqHMsU0qQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Diagnostics.Debug.4.0.11-beta-23429.nupkg",
-        "runtime.win7.System.Diagnostics.Debug.4.0.11-beta-23429.nupkg.sha512",
+        "runtime.win7.System.Diagnostics.Debug.4.0.11-beta-23506.nupkg",
+        "runtime.win7.System.Diagnostics.Debug.4.0.11-beta-23506.nupkg.sha512",
         "runtime.win7.System.Diagnostics.Debug.nuspec",
         "runtimes/win7/lib/DNXCore50/System.Diagnostics.Debug.dll",
         "runtimes/win7/lib/netcore50/System.Diagnostics.Debug.dll",
         "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll"
       ]
     },
-    "runtime.win7.System.Diagnostics.FileVersionInfo/4.0.0-beta-23429": {
+    "runtime.win7.System.Diagnostics.FileVersionInfo/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xumyYSN4x3E4HMAgGw6EY12SuHpKr7slmGvej3KwP4VUOFEYXpEAHOv2Rlvs/5v8LQB8v9lshq2KC82ILo0Psw==",
+      "sha512": "iVAgYgsTDUKqdx77e/cMCKTN/V4fXZcuM9jiKnpGsmAR4ypmb7TrLQJMVEDqe5qUxnjyRifdy9p3RjIyPq+2Kw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Diagnostics.FileVersionInfo.4.0.0-beta-23429.nupkg",
-        "runtime.win7.System.Diagnostics.FileVersionInfo.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.win7.System.Diagnostics.FileVersionInfo.4.0.0-beta-23506.nupkg",
+        "runtime.win7.System.Diagnostics.FileVersionInfo.4.0.0-beta-23506.nupkg.sha512",
         "runtime.win7.System.Diagnostics.FileVersionInfo.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.Diagnostics.FileVersionInfo.dll",
         "runtimes/win7/lib/net/_._",
@@ -13730,14 +13892,14 @@
         "runtimes/win7/lib/wpa81/_._"
       ]
     },
-    "runtime.win7.System.Diagnostics.Process/4.1.0-beta-23429": {
+    "runtime.win7.System.Diagnostics.Process/4.1.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "QpQeIekM//jxjJJ1WLyp1XJ2eykVLwgPc+TzeeHsTvui1hn0XTWnqPH/WgQNeKlpQ3ii+YWs8z6YahOhDS2y7Q==",
+      "sha512": "2VGi+B/dAW3lsM7QixbJ2QgnNgUbNPNeqte/cJpLGfyq6FoB4Xec7oj6fm/A2ORZ9wc18tjkcHMqUeAK6a+ATg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Diagnostics.Process.4.1.0-beta-23429.nupkg",
-        "runtime.win7.System.Diagnostics.Process.4.1.0-beta-23429.nupkg.sha512",
+        "runtime.win7.System.Diagnostics.Process.4.1.0-beta-23506.nupkg",
+        "runtime.win7.System.Diagnostics.Process.4.1.0-beta-23506.nupkg.sha512",
         "runtime.win7.System.Diagnostics.Process.nuspec",
         "runtimes/win7/lib/dotnet5.5/System.Diagnostics.Process.dll",
         "runtimes/win7/lib/net/_._",
@@ -13747,27 +13909,27 @@
         "runtimes/win7/lib/wpa81/_._"
       ]
     },
-    "runtime.win7.System.Globalization.Extensions/4.0.1-beta-23429": {
+    "runtime.win7.System.Globalization.Extensions/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "+uB+TpIAOJBNEziJbktoDETpPnNAR8TdI9G+/+czpdClNv5lvw8fE538WsqijFt9FAZVCDOSTiUYrQm3qKaELw==",
+      "sha512": "otBN/+5IuwlDMqbLNyk3iSCTy6VCSqjE5Tb+AbMHASPifbagnNyxShQic5bw6zpRVkJkSS5Q+douXJDV6NhjsA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Globalization.Extensions.4.0.1-beta-23429.nupkg",
-        "runtime.win7.System.Globalization.Extensions.4.0.1-beta-23429.nupkg.sha512",
+        "runtime.win7.System.Globalization.Extensions.4.0.1-beta-23506.nupkg",
+        "runtime.win7.System.Globalization.Extensions.4.0.1-beta-23506.nupkg.sha512",
         "runtime.win7.System.Globalization.Extensions.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.Globalization.Extensions.dll",
         "runtimes/win7/lib/net/_._"
       ]
     },
-    "runtime.win7.System.IO.Compression/4.1.0-beta-23429": {
+    "runtime.win7.System.IO.Compression/4.1.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "qtV4M0WfQUgs8eGMObLq1mpnM6dkHfJLxZygzFAStSrk7P44ZrpS87gYw+ejlQqxtFmEx4ikNzzTza+RxvIkdA==",
+      "sha512": "AKms9bplgK/DBDz1nLRaHtMOdyR7N2bVywv258zA9wcCSNPT/5s+NTmrObJunSwnkJipQcnTgc7ReaReb06y9Q==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.IO.Compression.4.1.0-beta-23429.nupkg",
-        "runtime.win7.System.IO.Compression.4.1.0-beta-23429.nupkg.sha512",
+        "runtime.win7.System.IO.Compression.4.1.0-beta-23506.nupkg",
+        "runtime.win7.System.IO.Compression.4.1.0-beta-23506.nupkg.sha512",
         "runtime.win7.System.IO.Compression.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.IO.Compression.dll",
         "runtimes/win7/lib/net/_._",
@@ -13777,14 +13939,14 @@
         "runtimes/win7/lib/wpa81/_._"
       ]
     },
-    "runtime.win7.System.IO.FileSystem/4.0.1-beta-23429": {
+    "runtime.win7.System.IO.FileSystem/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "b5UoNzVnRWBq+QF/PYHWoaEKGsM8A5l0Blu3BPQjJVdhj8oCiEXFxmw0LBehVMtYGf8CwFR/Up1vv5uDoEDcHw==",
+      "sha512": "HWqM0jytDcBJPqaXOAomNUc5Qbn4zA/9XLAa8caDiNqewQI6bCVi5fSX9f3fBPqaVzJVVsbpTGpmr1wYGlCt6Q==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.IO.FileSystem.4.0.1-beta-23429.nupkg",
-        "runtime.win7.System.IO.FileSystem.4.0.1-beta-23429.nupkg.sha512",
+        "runtime.win7.System.IO.FileSystem.4.0.1-beta-23506.nupkg",
+        "runtime.win7.System.IO.FileSystem.4.0.1-beta-23506.nupkg.sha512",
         "runtime.win7.System.IO.FileSystem.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.IO.FileSystem.dll",
         "runtimes/win7/lib/net/_._",
@@ -13794,14 +13956,14 @@
         "runtimes/win7/lib/wpa81/_._"
       ]
     },
-    "runtime.win7.System.IO.FileSystem.DriveInfo/4.0.0-beta-23429": {
+    "runtime.win7.System.IO.FileSystem.DriveInfo/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZfriF9yI9yz1SMxNGN6koeq6l5oUKnKoJFrGHBqXzLqLtz1zhRlVy1jhJtG8oKsBd1ztwWqdJe6JZNjMNNn+Qg==",
+      "sha512": "wH/enNA4d0jeqJBhh4DE85yuac1lERITOlmdzfD2vMi3lLABwGVGN6gevD3zMvMvu75zvR+T9fSySBaOflhqQA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.IO.FileSystem.DriveInfo.4.0.0-beta-23429.nupkg",
-        "runtime.win7.System.IO.FileSystem.DriveInfo.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.win7.System.IO.FileSystem.DriveInfo.4.0.0-beta-23506.nupkg",
+        "runtime.win7.System.IO.FileSystem.DriveInfo.4.0.0-beta-23506.nupkg.sha512",
         "runtime.win7.System.IO.FileSystem.DriveInfo.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.IO.FileSystem.DriveInfo.dll",
         "runtimes/win7/lib/net/_._",
@@ -13811,14 +13973,14 @@
         "runtimes/win7/lib/wpa81/_._"
       ]
     },
-    "runtime.win7.System.IO.FileSystem.Watcher/4.0.0-beta-23429": {
+    "runtime.win7.System.IO.FileSystem.Watcher/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Jr731+yJzOSMcC0dmeF5BQp2JV2rjWMEt3MyqqKDVtR3icZkFg/fIZXZ8XLUFZkkFrhMZZ0/xi14c0dolGRdMw==",
+      "sha512": "vCIWHCls3I/QCGj4DxkvbTJwB4Ip042xBIUgjJbvn4oGohiUebWs7fCCtI+nykWz5CG4SVisM9tubhc1gZt7FQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.IO.FileSystem.Watcher.4.0.0-beta-23429.nupkg",
-        "runtime.win7.System.IO.FileSystem.Watcher.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.win7.System.IO.FileSystem.Watcher.4.0.0-beta-23506.nupkg",
+        "runtime.win7.System.IO.FileSystem.Watcher.4.0.0-beta-23506.nupkg.sha512",
         "runtime.win7.System.IO.FileSystem.Watcher.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.IO.FileSystem.Watcher.dll",
         "runtimes/win7/lib/net/_._",
@@ -13828,14 +13990,14 @@
         "runtimes/win7/lib/wpa81/_._"
       ]
     },
-    "runtime.win7.System.IO.MemoryMappedFiles/4.0.0-beta-23429": {
+    "runtime.win7.System.IO.MemoryMappedFiles/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "pKzdr68lhgHAYPVYpodRwlpUTx6sltShbgVLiOVJhGkjDgt3M7o0aoQJD9nAkoEB90OiPzUqYPjC/G6neWVnqg==",
+      "sha512": "j3AEEXqjsOSsivXxWfPREi6xu9DOvJFJUBIASbs26Mw+tCgkuCsmFVfVlpRHotuvGPwF6Nq31eini/uPqUaOSA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.IO.MemoryMappedFiles.4.0.0-beta-23429.nupkg",
-        "runtime.win7.System.IO.MemoryMappedFiles.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.win7.System.IO.MemoryMappedFiles.4.0.0-beta-23506.nupkg",
+        "runtime.win7.System.IO.MemoryMappedFiles.4.0.0-beta-23506.nupkg.sha512",
         "runtime.win7.System.IO.MemoryMappedFiles.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.IO.MemoryMappedFiles.dll",
         "runtimes/win7/lib/net/_._",
@@ -13845,223 +14007,223 @@
         "runtimes/win7/lib/wpa81/_._"
       ]
     },
-    "runtime.win7.System.IO.Pipes/4.0.0-beta-23429": {
+    "runtime.win7.System.IO.Pipes/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "CVGmqsX70rfkPeEFkQ++oyrEsYS8UeGDaDU5TXrPAFHOhSLBJ/ejfiHyw4KWRciTITvr3sdU0BbJVCzcKxLaDw==",
+      "sha512": "u9xhZeuG54Q8IeRSvsPBUIxwhE9CQ7IssNdsCqBd5+2geyjNOMaPZ0lMEEbo4Xz+WJZddMuUzqAghaxxXt6zqA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.IO.Pipes.4.0.0-beta-23429.nupkg",
-        "runtime.win7.System.IO.Pipes.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.win7.System.IO.Pipes.4.0.0-beta-23506.nupkg",
+        "runtime.win7.System.IO.Pipes.4.0.0-beta-23506.nupkg.sha512",
         "runtime.win7.System.IO.Pipes.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.IO.Pipes.dll",
         "runtimes/win7/lib/net/_._",
         "runtimes/win7/lib/netcore50/_._"
       ]
     },
-    "runtime.win7.System.Net.Http/4.0.1-beta-23429": {
+    "runtime.win7.System.Net.Http/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "UFk8B8Jyd/wPLpgfl4GprJ3M8xIvAFLW6H/k88EvgYpPEqgku9jmJvMIkhk+XPWijpjSmOsbZ6we5ucP3QNkhg==",
+      "sha512": "v/4SaIYYU1gJ/8ahqWp/jyRfjqFJbzWmG93P3Hqm3BsvNUQu0Ug/CZFbh0gWYVdCSiHW5ZA9Oy7RMP4orazkkQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Net.Http.4.0.1-beta-23429.nupkg",
-        "runtime.win7.System.Net.Http.4.0.1-beta-23429.nupkg.sha512",
+        "runtime.win7.System.Net.Http.4.0.1-beta-23506.nupkg",
+        "runtime.win7.System.Net.Http.4.0.1-beta-23506.nupkg.sha512",
         "runtime.win7.System.Net.Http.nuspec",
         "runtimes/win7/lib/DNXCore50/System.Net.Http.dll",
         "runtimes/win7/lib/netcore50/System.Net.Http.dll"
       ]
     },
-    "runtime.win7.System.Net.NameResolution/4.0.0-beta-23429": {
+    "runtime.win7.System.Net.NameResolution/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fI5VmQyd5VZHA+mm2+0dJ3MivyIsFWwyGttzTR54kPiFdoligzOptdGOMgILTgDMMDjF8GHSkEm6qoQDDxkbzQ==",
+      "sha512": "6yFpkImVRjnBBvullPQvPSkxi+hzAiI4OGt/HBbApmQY6llhkRrt0529ELWmMzAtOrsd7Ax218wDWPjx2ladww==",
       "files": [
         "lib/DNXCore50/System.Net.NameResolution.dll",
         "ref/dotnet/_._",
-        "runtime.win7.System.Net.NameResolution.4.0.0-beta-23429.nupkg",
-        "runtime.win7.System.Net.NameResolution.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.win7.System.Net.NameResolution.4.0.0-beta-23506.nupkg",
+        "runtime.win7.System.Net.NameResolution.4.0.0-beta-23506.nupkg.sha512",
         "runtime.win7.System.Net.NameResolution.nuspec"
       ]
     },
-    "runtime.win7.System.Net.NetworkInformation/4.1.0-beta-23429": {
+    "runtime.win7.System.Net.NetworkInformation/4.1.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RZV1cyhFVEZs1wlttUtqReMONdgxI4ZLIna5BA++7e0KG7gKasgi95jiGdqmYEu9yYInO0PhecWohqiGtEmLjQ==",
+      "sha512": "h3xSJPtNt4J71b0MCnkmPVgsSWwkLvLebayGIf6wnNWHodJ1Tu8QuMi1Wi9p85pR6xZPMmw/qtjzOAQnIwminw==",
       "files": [
         "lib/DNXCore50/System.Net.NetworkInformation.dll",
         "lib/netcore50/System.Net.NetworkInformation.dll",
         "ref/dotnet/_._",
-        "runtime.win7.System.Net.NetworkInformation.4.1.0-beta-23429.nupkg",
-        "runtime.win7.System.Net.NetworkInformation.4.1.0-beta-23429.nupkg.sha512",
+        "runtime.win7.System.Net.NetworkInformation.4.1.0-beta-23506.nupkg",
+        "runtime.win7.System.Net.NetworkInformation.4.1.0-beta-23506.nupkg.sha512",
         "runtime.win7.System.Net.NetworkInformation.nuspec",
         "runtimes/win7/lib/net/_._"
       ]
     },
-    "runtime.win7.System.Net.Primitives/4.0.11-beta-23429": {
+    "runtime.win7.System.Net.Primitives/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ehc5NKK6DpYWcbDbPQDmXzqjzl9XifVbCJzGsmqWoGSz+2zOe8FwHj0eJPy9f+u7CFkVmMKhFsmQhnm9TtqI6g==",
+      "sha512": "HIrZ6pOVEV8TdTV46Vb3E1rqEoAVAuMXp6mYT65OYhzEQa36nqTHQH0smjAu7NIfJXzM3DTDFG2sqbRBWYkxmw==",
       "files": [
         "lib/DNXCore50/System.Net.Primitives.dll",
         "ref/dotnet/_._",
-        "runtime.win7.System.Net.Primitives.4.0.11-beta-23429.nupkg",
-        "runtime.win7.System.Net.Primitives.4.0.11-beta-23429.nupkg.sha512",
+        "runtime.win7.System.Net.Primitives.4.0.11-beta-23506.nupkg",
+        "runtime.win7.System.Net.Primitives.4.0.11-beta-23506.nupkg.sha512",
         "runtime.win7.System.Net.Primitives.nuspec",
         "runtimes/win7/lib/netcore50/System.Net.Primitives.dll"
       ]
     },
-    "runtime.win7.System.Net.Requests/4.0.11-beta-23429": {
+    "runtime.win7.System.Net.Requests/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "vqtCqgI6Fr+ywCyrqWzBy2g+9RmkRLy+GGVu3BTS1cVRPF+mJExFroy4KcXmfYbiw7X+qGJ/1eIQNoSd58UXxA==",
+      "sha512": "QCZLVVNlX/XOBNnYDPexhvyg/KFIToIvo6+11VzqDs+fyJ0ctsZKUkwcx/wbSuBB5+byg+pVGGKIKgjUKis9Pw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Net.Requests.4.0.11-beta-23429.nupkg",
-        "runtime.win7.System.Net.Requests.4.0.11-beta-23429.nupkg.sha512",
+        "runtime.win7.System.Net.Requests.4.0.11-beta-23506.nupkg",
+        "runtime.win7.System.Net.Requests.4.0.11-beta-23506.nupkg.sha512",
         "runtime.win7.System.Net.Requests.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.Net.Requests.dll",
         "runtimes/win7/lib/net/_._"
       ]
     },
-    "runtime.win7.System.Net.Security/4.0.0-beta-23429": {
+    "runtime.win7.System.Net.Security/4.0.0-beta-23506": {
       "type": "package",
-      "sha512": "OcPJscYVrbToMAVGskbcV1nQpu8jacVvwUieHnsu/PhfX4GqUraYTmFy8jTkGQnuFyNIIkSPFLJ42T72T7sfbw==",
+      "sha512": "jggWnbqjazYLwD1p9FuN4yoadPOzdVT2DMmCYNOe1yfY6eMmFq0HI9yvKOJfFCaF8aj/1uojtwjzHskWJ0mRIg==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "ref/dotnet/_._",
-        "runtime.win7.System.Net.Security.4.0.0-beta-23429.nupkg",
-        "runtime.win7.System.Net.Security.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.win7.System.Net.Security.4.0.0-beta-23506.nupkg",
+        "runtime.win7.System.Net.Security.4.0.0-beta-23506.nupkg.sha512",
         "runtime.win7.System.Net.Security.nuspec"
       ]
     },
-    "runtime.win7.System.Net.Sockets/4.1.0-beta-23429": {
+    "runtime.win7.System.Net.Sockets/4.1.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i4p7khSLO6DUWDCGEUH4lvOTgaK/FGN51neDZiLEaKgaagx91rP1l1M+t8e8sng9JSRhTgmiyOBhleNUIc7f5w==",
+      "sha512": "Pg/JxHu7lRT0yKYYe9bRvNpZck3WApLcsYwQNX3VJA5IoDCV4ChH/2OeXk/lkVYlKtyvqPU1aw/CWzplQ7uRGA==",
       "files": [
         "lib/DNXCore50/System.Net.Sockets.dll",
         "lib/netcore50/System.Net.Sockets.dll",
         "ref/dotnet/_._",
-        "runtime.win7.System.Net.Sockets.4.1.0-beta-23429.nupkg",
-        "runtime.win7.System.Net.Sockets.4.1.0-beta-23429.nupkg.sha512",
+        "runtime.win7.System.Net.Sockets.4.1.0-beta-23506.nupkg",
+        "runtime.win7.System.Net.Sockets.4.1.0-beta-23506.nupkg.sha512",
         "runtime.win7.System.Net.Sockets.nuspec",
         "runtimes/win7/lib/net/_._"
       ]
     },
-    "runtime.win7.System.Net.WebSockets.Client/4.0.0-beta-23429": {
+    "runtime.win7.System.Net.WebSockets.Client/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "zZr0uNwzQNAf5A6QNyqTOGP5sWbNyBM7qpZxl8LRUhT652iU5iUURiCTUYx2N4F3+N0rK7eNJg1KEKnftfsQAg==",
+      "sha512": "JMeN9CDTrkeMa09vY5uZtdbmBaljOZI8RyoA77Y1habxIJZQDmRu7yMmjkZBCtv5id30YWBpYEvGtl0YcQwXYA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Net.WebSockets.Client.4.0.0-beta-23429.nupkg",
-        "runtime.win7.System.Net.WebSockets.Client.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.win7.System.Net.WebSockets.Client.4.0.0-beta-23506.nupkg",
+        "runtime.win7.System.Net.WebSockets.Client.4.0.0-beta-23506.nupkg.sha512",
         "runtime.win7.System.Net.WebSockets.Client.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.Net.WebSockets.Client.dll",
         "runtimes/win7/lib/net/_._",
         "runtimes/win7/lib/netcore50/System.Net.WebSockets.Client.dll"
       ]
     },
-    "runtime.win7.System.Private.Uri/4.0.1-beta-23429": {
+    "runtime.win7.System.Private.Uri/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "QVJ1JJJ0FERlsiD5KLmoUSD8FtcsDPqQQIspddQbIwcUIv5Gzkhdu+drtWSnVynYYiRXdvcssWOrLjYaxQL6ag==",
+      "sha512": "ZDGZhS38XFdK+pMOJE0ulCfB9NhHKIgiWhO6NCr8mVbS03K0GIvvC3cO5cSBFTiEQROA1+DqsLVm32axbwunwQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Private.Uri.4.0.1-beta-23429.nupkg",
-        "runtime.win7.System.Private.Uri.4.0.1-beta-23429.nupkg.sha512",
+        "runtime.win7.System.Private.Uri.4.0.1-beta-23506.nupkg",
+        "runtime.win7.System.Private.Uri.4.0.1-beta-23506.nupkg.sha512",
         "runtime.win7.System.Private.Uri.nuspec",
         "runtimes/win7/lib/DNXCore50/System.Private.Uri.dll",
         "runtimes/win7/lib/netcore50/System.Private.Uri.dll",
         "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll"
       ]
     },
-    "runtime.win7.System.Runtime.Extensions/4.0.11-beta-23429": {
+    "runtime.win7.System.Runtime.Extensions/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "KA5BJ/3jqONEZ5qduOu9zgweW/n4Ke7WxNCA7OCGPCrK4DRpqk6N/Vt14CNsT6X0YTjNCNmj4oLv8T9O7UjF6g==",
+      "sha512": "rjdX64iPXFJP9znsL/X0jdmytflheJLuL+8Vo6pv9Pl7jufLwRbTDuaxRaV9YQwrSDL98JlbaLuC1STptx5dvw==",
       "files": [
         "lib/DNXCore50/System.Runtime.Extensions.dll",
         "lib/netcore50/System.Runtime.Extensions.dll",
         "ref/dotnet/_._",
-        "runtime.win7.System.Runtime.Extensions.4.0.11-beta-23429.nupkg",
-        "runtime.win7.System.Runtime.Extensions.4.0.11-beta-23429.nupkg.sha512",
+        "runtime.win7.System.Runtime.Extensions.4.0.11-beta-23506.nupkg",
+        "runtime.win7.System.Runtime.Extensions.4.0.11-beta-23506.nupkg.sha512",
         "runtime.win7.System.Runtime.Extensions.nuspec",
         "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll"
       ]
     },
-    "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-beta-23429": {
+    "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FQg77MYC+5KS5APfhxI1zjLON4BN85/LIiVzHX2g9d2hjWe5QN0f81i5eueufkLcgozWbmXeep/Tpm3uDYdKKQ==",
+      "sha512": "5Pjl4j0x/5lvP2D3rgWsXo7RjWuNNzYB6SL4q+nFnrflvrH5xZOwtJ/w1MjsisQn8S5rqOAevtd5j8+Bkhfl+A==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Security.Cryptography.Algorithms.4.0.0-beta-23429.nupkg",
-        "runtime.win7.System.Security.Cryptography.Algorithms.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.win7.System.Security.Cryptography.Algorithms.4.0.0-beta-23506.nupkg",
+        "runtime.win7.System.Security.Cryptography.Algorithms.4.0.0-beta-23506.nupkg.sha512",
         "runtime.win7.System.Security.Cryptography.Algorithms.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.Algorithms.dll",
         "runtimes/win7/lib/net/_._"
       ]
     },
-    "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-beta-23429": {
+    "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "7KSps8UaXeri/mJKgKPSZW7/RXzJbJpIY4nFQh2m48LIzISwQI2jckaYgvP3LHQzL2qT+WC5LPchiAOjkgJdoA==",
+      "sha512": "9RAvACUVI+OenrK2Egww2ziXWnjvoBDyjHgjxv2BQRGVKxiiU70Vgj8fHQltBYork0AoPJ9UyMDSvuoZoI44Hg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Security.Cryptography.Encoding.4.0.0-beta-23429.nupkg",
-        "runtime.win7.System.Security.Cryptography.Encoding.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.win7.System.Security.Cryptography.Encoding.4.0.0-beta-23506.nupkg",
+        "runtime.win7.System.Security.Cryptography.Encoding.4.0.0-beta-23506.nupkg.sha512",
         "runtime.win7.System.Security.Cryptography.Encoding.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.Encoding.dll",
         "runtimes/win7/lib/net/_._"
       ]
     },
-    "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-beta-23429": {
+    "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Bt1mexum2bqfrXgpcGnmY3YVyfFYqexEdPD7HhxIvx/V2N1cODu4a5nVklTZ9MN22UbKyLve7BJRPBv2RUz4HQ==",
+      "sha512": "DdgW31Cwvdpb8641NHF/d3xpwye1gV3GnwSFM3RcLrf4a6EyEQyGw8j5Pi8YUKyuYa6qkPSV2SAh5gsvmgdhUw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Security.Cryptography.X509Certificates.4.0.0-beta-23429.nupkg",
-        "runtime.win7.System.Security.Cryptography.X509Certificates.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.win7.System.Security.Cryptography.X509Certificates.4.0.0-beta-23506.nupkg",
+        "runtime.win7.System.Security.Cryptography.X509Certificates.4.0.0-beta-23506.nupkg.sha512",
         "runtime.win7.System.Security.Cryptography.X509Certificates.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.X509Certificates.dll",
         "runtimes/win7/lib/net/_._",
         "runtimes/win7/lib/netcore50/System.Security.Cryptography.X509Certificates.dll"
       ]
     },
-    "runtime.win7.System.Threading/4.0.11-beta-23429": {
+    "runtime.win7.System.Threading/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OW8PSgNwD39G5y2Jh/V2KriQB/FAmyckHOF5OgcB9Ga0eYiqvFRhKVFqRD5A0XsS0NbqBLnD8+exLNDaRiazlg==",
+      "sha512": "ysa+t7T3gaTc/7dQUg8sSJAfxjg/VHgEE+s2hY3LsowrtFzZqJWeVLLEJup6k2NMR3PjCH92uPe6eGuWHykRBw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Threading.4.0.11-beta-23429.nupkg",
-        "runtime.win7.System.Threading.4.0.11-beta-23429.nupkg.sha512",
+        "runtime.win7.System.Threading.4.0.11-beta-23506.nupkg",
+        "runtime.win7.System.Threading.4.0.11-beta-23506.nupkg.sha512",
         "runtime.win7.System.Threading.nuspec",
         "runtimes/win7/lib/DNXCore50/System.Threading.dll",
         "runtimes/win7/lib/netcore50/System.Threading.dll",
         "runtimes/win8-aot/lib/netcore50/System.Threading.dll"
       ]
     },
-    "runtime.win7-x64.Microsoft.NETCore.ConsoleHost/1.0.0-beta-23429": {
+    "runtime.win7-x64.Microsoft.NETCore.ConsoleHost/1.0.0-beta-23506": {
       "type": "package",
-      "sha512": "1NBL5uyK21gf+ZwNR3URRgdieZ6WMWiejMpb6HezUiHNepZvW81RYYZZpxKCZhUjSAzkmzjs8LsJm4PFcxpbvw==",
+      "sha512": "v7do/9NlS6Y+67Q/8Q9luNegDv6f5YCCmp7IAzawVw8PF6Q/eWYJKjNxRjA4OY/fiDkXHguqDaTD34A+KudZng==",
       "files": [
-        "runtime.win7-x64.Microsoft.NETCore.ConsoleHost.1.0.0-beta-23429.nupkg",
-        "runtime.win7-x64.Microsoft.NETCore.ConsoleHost.1.0.0-beta-23429.nupkg.sha512",
+        "runtime.win7-x64.Microsoft.NETCore.ConsoleHost.1.0.0-beta-23506.nupkg",
+        "runtime.win7-x64.Microsoft.NETCore.ConsoleHost.1.0.0-beta-23506.nupkg.sha512",
         "runtime.win7-x64.Microsoft.NETCore.ConsoleHost.nuspec",
         "runtimes/win7-x64/native/CoreConsole.exe"
       ]
     },
-    "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23429": {
+    "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23506": {
       "type": "package",
-      "sha512": "IGVGjs4acLrd8Exb0KonVoWmtMBRC4yFZV3FloESnc24w3sQDIMUWwVDKutapvkJF3gk/5j2HA6JB1iwuoPzhQ==",
+      "sha512": "jW3EvmzVxa3M1urYCAuMLz2kZEc+YbUabfXfAlED0PsnaNszba3WMR1B6xR4HgtME6t002K0TwDiDnC2qVQgjA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23429.nupkg",
-        "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23429.nupkg.sha512",
+        "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23506.nupkg",
+        "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23506.nupkg.sha512",
         "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR.nuspec",
         "runtimes/win7-x64/lib/dotnet/mscorlib.ni.dll",
         "runtimes/win7-x64/native/clretwrc.dll",
@@ -14075,22 +14237,22 @@
         "tools/sos.dll"
       ]
     },
-    "runtime.win7-x64.Microsoft.NETCore.TestHost/1.0.0-beta-23429": {
+    "runtime.win7-x64.Microsoft.NETCore.TestHost/1.0.0-beta-23506": {
       "type": "package",
-      "sha512": "X/xGE/bYoDqsxwe/ejtbkF4c2IiQVYcDJo/qjLCFHW6AEQxmp5Rs+sbB6t2RwaJLmoi/CjmnwN3Og8GvjhgV9g==",
+      "sha512": "CPgg5SNWvT1ozaN2BqaVwzZYZomCg+H8F/+AUuxuKGxs9w7rQD6NOA9dt1c2zFCmmng6h6lSl1Tm9NXitQZzqQ==",
       "files": [
-        "runtime.win7-x64.Microsoft.NETCore.TestHost.1.0.0-beta-23429.nupkg",
-        "runtime.win7-x64.Microsoft.NETCore.TestHost.1.0.0-beta-23429.nupkg.sha512",
+        "runtime.win7-x64.Microsoft.NETCore.TestHost.1.0.0-beta-23506.nupkg",
+        "runtime.win7-x64.Microsoft.NETCore.TestHost.1.0.0-beta-23506.nupkg.sha512",
         "runtime.win7-x64.Microsoft.NETCore.TestHost.nuspec",
         "runtimes/win7-x64/native/CoreRun.exe"
       ]
     },
-    "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23429": {
+    "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23506": {
       "type": "package",
-      "sha512": "al+lfxv/8iBJBKdrLHCjkMa0nC91XxOHEe3A84SaleEfrhT5l64tl4yCEaUHdrWO5BbX8Yy9KLDM2zlAKLzYTA==",
+      "sha512": "EYuNcFY32w3LEY99K/KAuaVv1nGilk9Ga7d9LWsuQCliMiTpzd1/6hVpq4RvWiPem+3Jolcso/nhHqS6RLOoMw==",
       "files": [
-        "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23429.nupkg",
-        "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23429.nupkg.sha512",
+        "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23506.nupkg",
+        "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23506.nupkg.sha512",
         "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets.nuspec",
         "runtimes/win10-x64/native/_._",
         "runtimes/win7-x64/native/API-MS-Win-Base-Util-L1-1-0.dll",
@@ -14251,44 +14413,44 @@
         "runtimes/win8-x64/native/api-ms-win-service-private-l1-1-1.dll"
       ]
     },
-    "runtime.win7-x64.System.Data.SqlClient.sni/4.0.0-beta-23429": {
+    "runtime.win7-x64.System.Data.SqlClient.sni/4.0.0-beta-23506": {
       "type": "package",
-      "sha512": "rBimtTPvrRg5Gtoj5Qvxj64fHbGLNcbmuY0VtAfhHPIFE7+q8fMMKXaNA8974+CXjQosud6u2GtCmc4ovm4QLQ==",
+      "sha512": "Ku2BAuxMk4U8eTLvQD3lFCsMPuqMgpZdQqC/crXiUReLiqVUXbXJC4gyZjsKvTZ3xI7Y8XCfZGhhEKVIkECNug==",
       "files": [
-        "runtime.win7-x64.System.Data.SqlClient.sni.4.0.0-beta-23429.nupkg",
-        "runtime.win7-x64.System.Data.SqlClient.sni.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.win7-x64.System.Data.SqlClient.sni.4.0.0-beta-23506.nupkg",
+        "runtime.win7-x64.System.Data.SqlClient.sni.4.0.0-beta-23506.nupkg.sha512",
         "runtime.win7-x64.System.Data.SqlClient.sni.nuspec",
         "runtimes/win7-x64/native/sni.dll"
       ]
     },
-    "runtime.win7-x64.System.IO.Compression.clrcompression/4.0.1-beta-23429": {
+    "runtime.win7-x64.System.IO.Compression.clrcompression/4.0.1-beta-23506": {
       "type": "package",
-      "sha512": "NR0b7IFhMN2FOINrzTsgz8EiSUK4RpPcFod/7oRkA8zCPOPvlLce84sTzHharKigoYYU3ZGar6znDQi5paT/Vg==",
+      "sha512": "NTINt69mxBmoPIoMNVxdGDTzR4aE+4dOstJazmsp62G6t8ruzvkiIajPzHb2FCi2zAsEuBfF/aNC8CzvE+q9NQ==",
       "files": [
-        "runtime.win7-x64.System.IO.Compression.clrcompression.4.0.1-beta-23429.nupkg",
-        "runtime.win7-x64.System.IO.Compression.clrcompression.4.0.1-beta-23429.nupkg.sha512",
+        "runtime.win7-x64.System.IO.Compression.clrcompression.4.0.1-beta-23506.nupkg",
+        "runtime.win7-x64.System.IO.Compression.clrcompression.4.0.1-beta-23506.nupkg.sha512",
         "runtime.win7-x64.System.IO.Compression.clrcompression.nuspec",
         "runtimes/win10-x64/native/ClrCompression.dll",
         "runtimes/win7-x64/native/clrcompression.dll"
       ]
     },
-    "runtime.win7-x86.Microsoft.NETCore.ConsoleHost/1.0.0-beta-23429": {
+    "runtime.win7-x86.Microsoft.NETCore.ConsoleHost/1.0.0-beta-23506": {
       "type": "package",
-      "sha512": "vLZlmpYzLdswavR3757WTFI1jRnU1oYQNaqVi7L0YDFYV+qgAq5HNLyPUXDOL9eTT7fpCaWw8d/p56V4snZMSA==",
+      "sha512": "BAAeoaCKD2ZM3I7egsv6krBarD4z8Vn/KfFiCuDPtHQd+m/c4TOljaTN4Nb9vsYRDXg4iUZ2m8zSdS3HbmuL+A==",
       "files": [
-        "runtime.win7-x86.Microsoft.NETCore.ConsoleHost.1.0.0-beta-23429.nupkg",
-        "runtime.win7-x86.Microsoft.NETCore.ConsoleHost.1.0.0-beta-23429.nupkg.sha512",
+        "runtime.win7-x86.Microsoft.NETCore.ConsoleHost.1.0.0-beta-23506.nupkg",
+        "runtime.win7-x86.Microsoft.NETCore.ConsoleHost.1.0.0-beta-23506.nupkg.sha512",
         "runtime.win7-x86.Microsoft.NETCore.ConsoleHost.nuspec",
         "runtimes/win7-x86/native/CoreConsole.exe"
       ]
     },
-    "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23429": {
+    "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-beta-23506": {
       "type": "package",
-      "sha512": "VcVO5hihrEQSXqB4tCEl66mQCiNqs1dVbUA/Gvlc0Oe83+K/HNdndoJS1TC6Ez5755Djb8wiu3zzjJIzpztppA==",
+      "sha512": "VhwMfMbwi5qtl0pbIK9BDD1PqKAl96KwZYvJj3TCpXYfI0FF2XWyrzyPG8Z+Q3g0pF2cWNsmhsIIdab6yN87AQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23429.nupkg",
-        "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23429.nupkg.sha512",
+        "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23506.nupkg",
+        "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-beta-23506.nupkg.sha512",
         "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR.nuspec",
         "runtimes/win7-x86/lib/dotnet/mscorlib.ni.dll",
         "runtimes/win7-x86/native/clretwrc.dll",
@@ -14302,22 +14464,22 @@
         "tools/sos.dll"
       ]
     },
-    "runtime.win7-x86.Microsoft.NETCore.TestHost/1.0.0-beta-23429": {
+    "runtime.win7-x86.Microsoft.NETCore.TestHost/1.0.0-beta-23506": {
       "type": "package",
-      "sha512": "9M4L4zOc6b0+Ryr/e9pLIEZrCxfqmlMYZIOu5MJMOif5kQ9oeeazD11fU7O7CWLDRjNYTDouZbSpMXo0Q9XdZw==",
+      "sha512": "Xse1inviGIS870ldK8YM2b4aYa8+9LtX2rA6QnsFGw4fuTD4tNRuRXJUiK10AvBqi0v4UlF8FqM4HcKGt9L+qA==",
       "files": [
-        "runtime.win7-x86.Microsoft.NETCore.TestHost.1.0.0-beta-23429.nupkg",
-        "runtime.win7-x86.Microsoft.NETCore.TestHost.1.0.0-beta-23429.nupkg.sha512",
+        "runtime.win7-x86.Microsoft.NETCore.TestHost.1.0.0-beta-23506.nupkg",
+        "runtime.win7-x86.Microsoft.NETCore.TestHost.1.0.0-beta-23506.nupkg.sha512",
         "runtime.win7-x86.Microsoft.NETCore.TestHost.nuspec",
         "runtimes/win7-x86/native/CoreRun.exe"
       ]
     },
-    "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23429": {
+    "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets/1.0.1-beta-23506": {
       "type": "package",
-      "sha512": "1ApZrmPNM8n6bd83hPkz1cTH1eIc7xihHEOpkJAF68+f/lHBAi4wRGepEnWHcbXxHw5TEx9WWqTa11qZDInw4w==",
+      "sha512": "1+2MuDRf3XCfRw/kRwPejEvtzv/JFz3FxKmnZB570G2u3RkkRdLE1V8B1OH7KKHDEknuDvoQ35rRS0f/pELabQ==",
       "files": [
-        "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23429.nupkg",
-        "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23429.nupkg.sha512",
+        "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23506.nupkg",
+        "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets.1.0.1-beta-23506.nupkg.sha512",
         "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets.nuspec",
         "runtimes/win10-x86/native/_._",
         "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll",
@@ -14478,31 +14640,31 @@
         "runtimes/win8-x86/native/api-ms-win-service-private-l1-1-1.dll"
       ]
     },
-    "runtime.win7-x86.System.Data.SqlClient.sni/4.0.0-beta-23429": {
+    "runtime.win7-x86.System.Data.SqlClient.sni/4.0.0-beta-23506": {
       "type": "package",
-      "sha512": "noYd3Nin21rMS+qhlHnEjzhbxVsVJYE8ZN1Blj/PTwoC3AU2Ithycj9ALBL4resF39RahwWn+nesjYaqL7VPWQ==",
+      "sha512": "zJ1Lw3AJ/0iCQm+NnHaFKLF3QYbJvyFobTOf1fZU8MVH/RorXfqEm+z/mKVghfx/XToJtq4MkZRLqyS8uaAq7g==",
       "files": [
-        "runtime.win7-x86.System.Data.SqlClient.sni.4.0.0-beta-23429.nupkg",
-        "runtime.win7-x86.System.Data.SqlClient.sni.4.0.0-beta-23429.nupkg.sha512",
+        "runtime.win7-x86.System.Data.SqlClient.sni.4.0.0-beta-23506.nupkg",
+        "runtime.win7-x86.System.Data.SqlClient.sni.4.0.0-beta-23506.nupkg.sha512",
         "runtime.win7-x86.System.Data.SqlClient.sni.nuspec",
         "runtimes/win7-x86/native/sni.dll"
       ]
     },
-    "runtime.win7-x86.System.IO.Compression.clrcompression/4.0.1-beta-23429": {
+    "runtime.win7-x86.System.IO.Compression.clrcompression/4.0.1-beta-23506": {
       "type": "package",
-      "sha512": "5S4MptDSpv/eytnEdtXkr3+9n/WY3BnrvzrV2xPGn0ychTpJniscJNajNC8i7sPskkp9Q4l3IIgScTR9SI2F/Q==",
+      "sha512": "AqS3QMnRLiy4+XTtMeZW/vhgGPhHDai650GWJcYIFH4+D7S4X7OC+VFd4Jxy3xDtE9KTIlAStHp/n35PWHUhCQ==",
       "files": [
-        "runtime.win7-x86.System.IO.Compression.clrcompression.4.0.1-beta-23429.nupkg",
-        "runtime.win7-x86.System.IO.Compression.clrcompression.4.0.1-beta-23429.nupkg.sha512",
+        "runtime.win7-x86.System.IO.Compression.clrcompression.4.0.1-beta-23506.nupkg",
+        "runtime.win7-x86.System.IO.Compression.clrcompression.4.0.1-beta-23506.nupkg.sha512",
         "runtime.win7-x86.System.IO.Compression.clrcompression.nuspec",
         "runtimes/win10-x86/native/ClrCompression.dll",
         "runtimes/win7-x86/native/clrcompression.dll"
       ]
     },
-    "System.AppContext/4.0.1-beta-23429": {
+    "System.AppContext/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "HgMi3E/W6EG0Qe/LmqoRfb+cq3OFuNpU2ZjjiyEoisKN5X+/14jbPGc6sGkFTQa/3gHm4jZG8o2KzhvHb83SQQ==",
+      "sha512": "U8kbW0feZCbqvgO6ZWKWjMo3vV+SoUNsuIVtR19ob8OPG4D3P7ZuVg9oj+qbiaqYLK4Is/EmKpPyu+AXpZ7E9w==",
       "files": [
         "lib/DNXCore50/System.AppContext.dll",
         "lib/MonoAndroid10/_._",
@@ -14511,31 +14673,31 @@
         "lib/netcore50/System.AppContext.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.AppContext.xml",
-        "ref/dotnet5.1/es/System.AppContext.xml",
-        "ref/dotnet5.1/fr/System.AppContext.xml",
-        "ref/dotnet5.1/it/System.AppContext.xml",
-        "ref/dotnet5.1/ja/System.AppContext.xml",
-        "ref/dotnet5.1/ko/System.AppContext.xml",
-        "ref/dotnet5.1/ru/System.AppContext.xml",
-        "ref/dotnet5.1/System.AppContext.dll",
-        "ref/dotnet5.1/System.AppContext.xml",
-        "ref/dotnet5.1/zh-hans/System.AppContext.xml",
-        "ref/dotnet5.1/zh-hant/System.AppContext.xml",
+        "ref/dotnet5.4/de/System.AppContext.xml",
+        "ref/dotnet5.4/es/System.AppContext.xml",
+        "ref/dotnet5.4/fr/System.AppContext.xml",
+        "ref/dotnet5.4/it/System.AppContext.xml",
+        "ref/dotnet5.4/ja/System.AppContext.xml",
+        "ref/dotnet5.4/ko/System.AppContext.xml",
+        "ref/dotnet5.4/ru/System.AppContext.xml",
+        "ref/dotnet5.4/System.AppContext.dll",
+        "ref/dotnet5.4/System.AppContext.xml",
+        "ref/dotnet5.4/zh-hans/System.AppContext.xml",
+        "ref/dotnet5.4/zh-hant/System.AppContext.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.AppContext.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.AppContext.4.0.1-beta-23429.nupkg",
-        "System.AppContext.4.0.1-beta-23429.nupkg.sha512",
+        "System.AppContext.4.0.1-beta-23506.nupkg",
+        "System.AppContext.4.0.1-beta-23506.nupkg.sha512",
         "System.AppContext.nuspec"
       ]
     },
-    "System.Collections/4.0.11-beta-23429": {
+    "System.Collections/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8otwTxgJoKOpvIVz+j6yRszF+xwrgoS5lLm1Hen3bOl80u2Vq+qlxO6GX5fNyIRMNQPpduzrvl+WRVan+2zDSQ==",
+      "sha512": "y7uzlKKGgi7YHEE6NUA22l3/7Mx5m3NnzybwA096ji6YqpRFwa7LM5pemrV97abW0iiMw5c+8WbAtT64qR1/pw==",
       "files": [
         "lib/DNXCore50/System.Collections.dll",
         "lib/MonoAndroid10/_._",
@@ -14589,15 +14751,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
-        "System.Collections.4.0.11-beta-23429.nupkg",
-        "System.Collections.4.0.11-beta-23429.nupkg.sha512",
+        "System.Collections.4.0.11-beta-23506.nupkg",
+        "System.Collections.4.0.11-beta-23506.nupkg.sha512",
         "System.Collections.nuspec"
       ]
     },
-    "System.Collections.Concurrent/4.0.11-beta-23429": {
+    "System.Collections.Concurrent/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VQlWR8e6TLzWxQb+NcCuvupgDFNpyTJlodV4crSFOx9qRdAJGwIyMSzpFYm17qY9+HSct4dZL+ygxMp+UOEPng==",
+      "sha512": "XcAV3RY6CH8kKaHXJFnssKAgnf6ci5ogFZUpKkKqq86lUjOrCCiSk2sCQUkrT6TEvEUtJK6pNd1ChDQU2tPZrA==",
       "files": [
         "lib/dotnet5.4/System.Collections.Concurrent.dll",
         "lib/MonoAndroid10/_._",
@@ -14648,29 +14810,29 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Collections.Concurrent.4.0.11-beta-23429.nupkg",
-        "System.Collections.Concurrent.4.0.11-beta-23429.nupkg.sha512",
+        "System.Collections.Concurrent.4.0.11-beta-23506.nupkg",
+        "System.Collections.Concurrent.4.0.11-beta-23506.nupkg.sha512",
         "System.Collections.Concurrent.nuspec"
       ]
     },
-    "System.Collections.Immutable/1.1.38-beta-23429": {
+    "System.Collections.Immutable/1.1.38-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8+1qkT1W57fEMUm+Dj8qAUgc9ttPCw6hnrDbTUF5rTaJm8i/B+bGkFC9w66WZq7azNWihSpfMLb+UBejtqgSSA==",
+      "sha512": "soodLbSGVykqv9658f3CgwXO+7H2Ko53MmA+AUt3nD8+8SrqOWoX3KVTxuJ+H8sF9rE3rbA6MFykjBwO/cj7bQ==",
       "files": [
         "lib/dotnet5.1/System.Collections.Immutable.dll",
         "lib/dotnet5.1/System.Collections.Immutable.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
         "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
-        "System.Collections.Immutable.1.1.38-beta-23429.nupkg",
-        "System.Collections.Immutable.1.1.38-beta-23429.nupkg.sha512",
+        "System.Collections.Immutable.1.1.38-beta-23506.nupkg",
+        "System.Collections.Immutable.1.1.38-beta-23506.nupkg.sha512",
         "System.Collections.Immutable.nuspec"
       ]
     },
-    "System.Collections.NonGeneric/4.0.1-beta-23429": {
+    "System.Collections.NonGeneric/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "K54Hou3jcSgfxAPFcqbxYHAomq8rXxYKcx6eqXOXgdJ86M07TbgnZZYZJ4YZYI9kK0ORh3pmezNAdUMk9t9NIw==",
+      "sha512": "wI+7tvj8VWQKQnCDXVt7c2qkQtKPcsChtyxTekQxidFJbUMFwpoyjmiFSr9vjssSGPyBKO7YmukA0XhM3gBt0g==",
       "files": [
         "lib/dotnet5.4/System.Collections.NonGeneric.dll",
         "lib/MonoAndroid10/_._",
@@ -14678,31 +14840,31 @@
         "lib/net46/System.Collections.NonGeneric.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.Collections.NonGeneric.xml",
-        "ref/dotnet5.1/es/System.Collections.NonGeneric.xml",
-        "ref/dotnet5.1/fr/System.Collections.NonGeneric.xml",
-        "ref/dotnet5.1/it/System.Collections.NonGeneric.xml",
-        "ref/dotnet5.1/ja/System.Collections.NonGeneric.xml",
-        "ref/dotnet5.1/ko/System.Collections.NonGeneric.xml",
-        "ref/dotnet5.1/ru/System.Collections.NonGeneric.xml",
-        "ref/dotnet5.1/System.Collections.NonGeneric.dll",
-        "ref/dotnet5.1/System.Collections.NonGeneric.xml",
-        "ref/dotnet5.1/zh-hans/System.Collections.NonGeneric.xml",
-        "ref/dotnet5.1/zh-hant/System.Collections.NonGeneric.xml",
+        "ref/dotnet5.4/de/System.Collections.NonGeneric.xml",
+        "ref/dotnet5.4/es/System.Collections.NonGeneric.xml",
+        "ref/dotnet5.4/fr/System.Collections.NonGeneric.xml",
+        "ref/dotnet5.4/it/System.Collections.NonGeneric.xml",
+        "ref/dotnet5.4/ja/System.Collections.NonGeneric.xml",
+        "ref/dotnet5.4/ko/System.Collections.NonGeneric.xml",
+        "ref/dotnet5.4/ru/System.Collections.NonGeneric.xml",
+        "ref/dotnet5.4/System.Collections.NonGeneric.dll",
+        "ref/dotnet5.4/System.Collections.NonGeneric.xml",
+        "ref/dotnet5.4/zh-hans/System.Collections.NonGeneric.xml",
+        "ref/dotnet5.4/zh-hant/System.Collections.NonGeneric.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Collections.NonGeneric.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Collections.NonGeneric.4.0.1-beta-23429.nupkg",
-        "System.Collections.NonGeneric.4.0.1-beta-23429.nupkg.sha512",
+        "System.Collections.NonGeneric.4.0.1-beta-23506.nupkg",
+        "System.Collections.NonGeneric.4.0.1-beta-23506.nupkg.sha512",
         "System.Collections.NonGeneric.nuspec"
       ]
     },
-    "System.Collections.Specialized/4.0.1-beta-23429": {
+    "System.Collections.Specialized/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "7aMssbwBWsdteETxkEFgLXNlQ7+MhSfJBS3NwifsKsxKiGF1poEiXrJVbBxkcja/owq5daT66z8mbHgwTBAFuA==",
+      "sha512": "JYHrHwqmVkgPj/zo3XuCDvx1HAFWs8pxgM53AwPYAv9DUyc3uNyfIO4yl/+yyrsgy+oTQc10EMABk0yzqcx4Lw==",
       "files": [
         "lib/dotnet5.4/System.Collections.Specialized.dll",
         "lib/MonoAndroid10/_._",
@@ -14710,31 +14872,31 @@
         "lib/net46/System.Collections.Specialized.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.Collections.Specialized.xml",
-        "ref/dotnet5.1/es/System.Collections.Specialized.xml",
-        "ref/dotnet5.1/fr/System.Collections.Specialized.xml",
-        "ref/dotnet5.1/it/System.Collections.Specialized.xml",
-        "ref/dotnet5.1/ja/System.Collections.Specialized.xml",
-        "ref/dotnet5.1/ko/System.Collections.Specialized.xml",
-        "ref/dotnet5.1/ru/System.Collections.Specialized.xml",
-        "ref/dotnet5.1/System.Collections.Specialized.dll",
-        "ref/dotnet5.1/System.Collections.Specialized.xml",
-        "ref/dotnet5.1/zh-hans/System.Collections.Specialized.xml",
-        "ref/dotnet5.1/zh-hant/System.Collections.Specialized.xml",
+        "ref/dotnet5.4/de/System.Collections.Specialized.xml",
+        "ref/dotnet5.4/es/System.Collections.Specialized.xml",
+        "ref/dotnet5.4/fr/System.Collections.Specialized.xml",
+        "ref/dotnet5.4/it/System.Collections.Specialized.xml",
+        "ref/dotnet5.4/ja/System.Collections.Specialized.xml",
+        "ref/dotnet5.4/ko/System.Collections.Specialized.xml",
+        "ref/dotnet5.4/ru/System.Collections.Specialized.xml",
+        "ref/dotnet5.4/System.Collections.Specialized.dll",
+        "ref/dotnet5.4/System.Collections.Specialized.xml",
+        "ref/dotnet5.4/zh-hans/System.Collections.Specialized.xml",
+        "ref/dotnet5.4/zh-hant/System.Collections.Specialized.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Collections.Specialized.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Collections.Specialized.4.0.1-beta-23429.nupkg",
-        "System.Collections.Specialized.4.0.1-beta-23429.nupkg.sha512",
+        "System.Collections.Specialized.4.0.1-beta-23506.nupkg",
+        "System.Collections.Specialized.4.0.1-beta-23506.nupkg.sha512",
         "System.Collections.Specialized.nuspec"
       ]
     },
-    "System.ComponentModel/4.0.1-beta-23429": {
+    "System.ComponentModel/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "MDjn6qxgH07Ijbhx5zlhVbSrLKKENLgbHS3u5LjtTKDUwqnPTfwV4/shMnQgOIQGqSseRtk7LtkqzkYG5mNLyw==",
+      "sha512": "tFh0wgAX3BVsu//hHLWHmDMFnfeMfBGqJ4QzQJvefOSC5kYH5H+im1G//oNItjowM2q4MvC2XT8/apXqpcJ2zg==",
       "files": [
         "lib/dotnet5.4/System.ComponentModel.dll",
         "lib/net45/_._",
@@ -14768,15 +14930,15 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "System.ComponentModel.4.0.1-beta-23429.nupkg",
-        "System.ComponentModel.4.0.1-beta-23429.nupkg.sha512",
+        "System.ComponentModel.4.0.1-beta-23506.nupkg",
+        "System.ComponentModel.4.0.1-beta-23506.nupkg.sha512",
         "System.ComponentModel.nuspec"
       ]
     },
-    "System.ComponentModel.Annotations/4.0.11-beta-23429": {
+    "System.ComponentModel.Annotations/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xdG3BY/6hMIeQ+Z2wspz9grEaxOscDerQYriA8cF3yFSZ+5KFHbE7VhxSVCLA0qDHUeCfP2touHBJX5sTMel4A==",
+      "sha512": "Hrx72nyaQzJzQ5+tEUydlSjvTKgJlqSEK36RyKHiX4xiBpLWdYsnlh5WXTETcMT3lM7PTIuHT3+El3e2ZyBWdw==",
       "files": [
         "lib/dotnet5.4/System.ComponentModel.Annotations.dll",
         "lib/MonoAndroid10/_._",
@@ -14825,15 +14987,15 @@
         "ref/win8/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ComponentModel.Annotations.4.0.11-beta-23429.nupkg",
-        "System.ComponentModel.Annotations.4.0.11-beta-23429.nupkg.sha512",
+        "System.ComponentModel.Annotations.4.0.11-beta-23506.nupkg",
+        "System.ComponentModel.Annotations.4.0.11-beta-23506.nupkg.sha512",
         "System.ComponentModel.Annotations.nuspec"
       ]
     },
-    "System.ComponentModel.EventBasedAsync/4.0.11-beta-23429": {
+    "System.ComponentModel.EventBasedAsync/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VL8kgqIvxbRVfUkGrsjHwolVeF6IHz58bsUlrzo+fXPK7YaYCymMnHJoln5aWVG/NQAIRAnXg5Y6yR1Dn0Td4Q==",
+      "sha512": "aNeOfbWfW3YcPYOxGQbTbV6vRwO71hJ0dTBJAxt/WsvIUWYucojmsyR+ryMR6/EcEVdX6lv6BdlGLrlNKV0tGg==",
       "files": [
         "lib/dotnet5.4/System.ComponentModel.EventBasedAsync.dll",
         "lib/MonoAndroid10/_._",
@@ -14886,47 +15048,47 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ComponentModel.EventBasedAsync.4.0.11-beta-23429.nupkg",
-        "System.ComponentModel.EventBasedAsync.4.0.11-beta-23429.nupkg.sha512",
+        "System.ComponentModel.EventBasedAsync.4.0.11-beta-23506.nupkg",
+        "System.ComponentModel.EventBasedAsync.4.0.11-beta-23506.nupkg.sha512",
         "System.ComponentModel.EventBasedAsync.nuspec"
       ]
     },
-    "System.Console/4.0.0-beta-23429": {
+    "System.Console/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "vggna7ujKHX2txFF22sXU5oSZ47ze5bRzOBU9/pMdLxkMw26sUg7Hzh0vGZ6gT8un/XV3WCpXapuJWMMltF7Rg==",
+      "sha512": "ICGw38+F7q2PTxDJJZ+LCpBWt/shqg6ANAPpmFzq0s9xZPlFwN0U5OhyyzeNlSGoSzljwNngCnt6mn5jivFd3g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Console.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.Console.xml",
-        "ref/dotnet5.1/es/System.Console.xml",
-        "ref/dotnet5.1/fr/System.Console.xml",
-        "ref/dotnet5.1/it/System.Console.xml",
-        "ref/dotnet5.1/ja/System.Console.xml",
-        "ref/dotnet5.1/ko/System.Console.xml",
-        "ref/dotnet5.1/ru/System.Console.xml",
-        "ref/dotnet5.1/System.Console.dll",
-        "ref/dotnet5.1/System.Console.xml",
-        "ref/dotnet5.1/zh-hans/System.Console.xml",
-        "ref/dotnet5.1/zh-hant/System.Console.xml",
+        "ref/dotnet5.4/de/System.Console.xml",
+        "ref/dotnet5.4/es/System.Console.xml",
+        "ref/dotnet5.4/fr/System.Console.xml",
+        "ref/dotnet5.4/it/System.Console.xml",
+        "ref/dotnet5.4/ja/System.Console.xml",
+        "ref/dotnet5.4/ko/System.Console.xml",
+        "ref/dotnet5.4/ru/System.Console.xml",
+        "ref/dotnet5.4/System.Console.dll",
+        "ref/dotnet5.4/System.Console.xml",
+        "ref/dotnet5.4/zh-hans/System.Console.xml",
+        "ref/dotnet5.4/zh-hant/System.Console.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Console.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Console.4.0.0-beta-23429.nupkg",
-        "System.Console.4.0.0-beta-23429.nupkg.sha512",
+        "System.Console.4.0.0-beta-23506.nupkg",
+        "System.Console.4.0.0-beta-23506.nupkg.sha512",
         "System.Console.nuspec"
       ]
     },
-    "System.Data.Common/4.0.1-beta-23429": {
+    "System.Data.Common/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "4wfTHwX6NCxZFE4QRg4Fj626yqpPcE6j+7c4+7NvDUX4W5sjVYwVOprTqNLDpEIXECL4F0YXni1yDa9EWmSWfQ==",
+      "sha512": "Fo8fh1ziNEnnYKp0M9VCwp7lL/RTnmwa5ElBtUD45aaOopJ9y/d6a0kxHXHuLutF/7i8U3gsfUsryIxSIZe3QA==",
       "files": [
         "lib/dotnet5.4/System.Data.Common.dll",
         "lib/MonoAndroid10/_._",
@@ -14934,63 +15096,63 @@
         "lib/net46/System.Data.Common.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.Data.Common.xml",
-        "ref/dotnet5.1/es/System.Data.Common.xml",
-        "ref/dotnet5.1/fr/System.Data.Common.xml",
-        "ref/dotnet5.1/it/System.Data.Common.xml",
-        "ref/dotnet5.1/ja/System.Data.Common.xml",
-        "ref/dotnet5.1/ko/System.Data.Common.xml",
-        "ref/dotnet5.1/ru/System.Data.Common.xml",
-        "ref/dotnet5.1/System.Data.Common.dll",
-        "ref/dotnet5.1/System.Data.Common.xml",
-        "ref/dotnet5.1/zh-hans/System.Data.Common.xml",
-        "ref/dotnet5.1/zh-hant/System.Data.Common.xml",
+        "ref/dotnet5.4/de/System.Data.Common.xml",
+        "ref/dotnet5.4/es/System.Data.Common.xml",
+        "ref/dotnet5.4/fr/System.Data.Common.xml",
+        "ref/dotnet5.4/it/System.Data.Common.xml",
+        "ref/dotnet5.4/ja/System.Data.Common.xml",
+        "ref/dotnet5.4/ko/System.Data.Common.xml",
+        "ref/dotnet5.4/ru/System.Data.Common.xml",
+        "ref/dotnet5.4/System.Data.Common.dll",
+        "ref/dotnet5.4/System.Data.Common.xml",
+        "ref/dotnet5.4/zh-hans/System.Data.Common.xml",
+        "ref/dotnet5.4/zh-hant/System.Data.Common.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Data.Common.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Data.Common.4.0.1-beta-23429.nupkg",
-        "System.Data.Common.4.0.1-beta-23429.nupkg.sha512",
+        "System.Data.Common.4.0.1-beta-23506.nupkg",
+        "System.Data.Common.4.0.1-beta-23506.nupkg.sha512",
         "System.Data.Common.nuspec"
       ]
     },
-    "System.Data.SqlClient/4.0.0-beta-23429": {
+    "System.Data.SqlClient/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "nClKb6eknhaoG/XuYqPVSDr0qdiwvl+DirVVNCvwFhtwY9ILz01S43DcsfW4sTO3N2tFFhfxO/8zQaa99oVPUw==",
+      "sha512": "ILCSWMfdfLBF8/OeW7/ODu/E3s3l8Ir/pHoo6onuMFN0DklJiKhb6Iowm2S8LOh5jggpcyJdUnjE+5tU77qV8Q==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Data.SqlClient.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.Data.SqlClient.xml",
-        "ref/dotnet5.1/es/System.Data.SqlClient.xml",
-        "ref/dotnet5.1/fr/System.Data.SqlClient.xml",
-        "ref/dotnet5.1/it/System.Data.SqlClient.xml",
-        "ref/dotnet5.1/ja/System.Data.SqlClient.xml",
-        "ref/dotnet5.1/ko/System.Data.SqlClient.xml",
-        "ref/dotnet5.1/ru/System.Data.SqlClient.xml",
-        "ref/dotnet5.1/System.Data.SqlClient.dll",
-        "ref/dotnet5.1/System.Data.SqlClient.xml",
-        "ref/dotnet5.1/zh-hans/System.Data.SqlClient.xml",
-        "ref/dotnet5.1/zh-hant/System.Data.SqlClient.xml",
+        "ref/dotnet5.4/de/System.Data.SqlClient.xml",
+        "ref/dotnet5.4/es/System.Data.SqlClient.xml",
+        "ref/dotnet5.4/fr/System.Data.SqlClient.xml",
+        "ref/dotnet5.4/it/System.Data.SqlClient.xml",
+        "ref/dotnet5.4/ja/System.Data.SqlClient.xml",
+        "ref/dotnet5.4/ko/System.Data.SqlClient.xml",
+        "ref/dotnet5.4/ru/System.Data.SqlClient.xml",
+        "ref/dotnet5.4/System.Data.SqlClient.dll",
+        "ref/dotnet5.4/System.Data.SqlClient.xml",
+        "ref/dotnet5.4/zh-hans/System.Data.SqlClient.xml",
+        "ref/dotnet5.4/zh-hant/System.Data.SqlClient.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Data.SqlClient.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Data.SqlClient.4.0.0-beta-23429.nupkg",
-        "System.Data.SqlClient.4.0.0-beta-23429.nupkg.sha512",
+        "System.Data.SqlClient.4.0.0-beta-23506.nupkg",
+        "System.Data.SqlClient.4.0.0-beta-23506.nupkg.sha512",
         "System.Data.SqlClient.nuspec"
       ]
     },
-    "System.Diagnostics.Contracts/4.0.1-beta-23429": {
+    "System.Diagnostics.Contracts/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "7tjLCFdzeKnOxvVUKhBu494C320GXD7U0bWadzEJ18+hOxi+4kUSlym7Ogcd2OWZvyTCVXkU68ZZQa6GaYuhYA==",
+      "sha512": "ClAQWWJpuVp2e38cS43MLy/x/5crM3/0zPGjFeiKZHfea5BAlS3mOfXxMSa+hflbiRP1HxCsDkMhpsIiAZBpCw==",
       "files": [
         "lib/DNXCore50/System.Diagnostics.Contracts.dll",
         "lib/net45/_._",
@@ -15025,15 +15187,15 @@
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
-        "System.Diagnostics.Contracts.4.0.1-beta-23429.nupkg",
-        "System.Diagnostics.Contracts.4.0.1-beta-23429.nupkg.sha512",
+        "System.Diagnostics.Contracts.4.0.1-beta-23506.nupkg",
+        "System.Diagnostics.Contracts.4.0.1-beta-23506.nupkg.sha512",
         "System.Diagnostics.Contracts.nuspec"
       ]
     },
-    "System.Diagnostics.Debug/4.0.11-beta-23429": {
+    "System.Diagnostics.Debug/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "CR3SuzdP6mDzlHzCRAqpn7+nNs7CbtOFvMrFnw1aDVgf8XKD1PjJW5JMbWVsNDw1dtFuqBN6XinCH/sPz42VbQ==",
+      "sha512": "m8AEUY82jHb1CKx26CgRZdBGA8jnw7AuAtghregGnx55NeurtxIJrdXiiu4SGcGb6QZ5A+J3jIHWJwuGi9TGiQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15085,47 +15247,47 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Diagnostics.Debug.4.0.11-beta-23429.nupkg",
-        "System.Diagnostics.Debug.4.0.11-beta-23429.nupkg.sha512",
+        "System.Diagnostics.Debug.4.0.11-beta-23506.nupkg",
+        "System.Diagnostics.Debug.4.0.11-beta-23506.nupkg.sha512",
         "System.Diagnostics.Debug.nuspec"
       ]
     },
-    "System.Diagnostics.FileVersionInfo/4.0.0-beta-23429": {
+    "System.Diagnostics.FileVersionInfo/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "IZ6O7Mh+yMrHQyFZPgCWTi98CWAEDLginv72UTQ8flNL1qH79RqLCE8mhBNGTiFvtX3nHBCYmy4n/tre0z5CIg==",
+      "sha512": "oSttdkx4kMbG8bJoVDqVAnwUo6oPPT15gscLL6qKvmXI71n4irrTXbHttSUdRUNwnK/yeZa/zQl20xTsG5mftA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Diagnostics.FileVersionInfo.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.Diagnostics.FileVersionInfo.xml",
-        "ref/dotnet5.1/es/System.Diagnostics.FileVersionInfo.xml",
-        "ref/dotnet5.1/fr/System.Diagnostics.FileVersionInfo.xml",
-        "ref/dotnet5.1/it/System.Diagnostics.FileVersionInfo.xml",
-        "ref/dotnet5.1/ja/System.Diagnostics.FileVersionInfo.xml",
-        "ref/dotnet5.1/ko/System.Diagnostics.FileVersionInfo.xml",
-        "ref/dotnet5.1/ru/System.Diagnostics.FileVersionInfo.xml",
-        "ref/dotnet5.1/System.Diagnostics.FileVersionInfo.dll",
-        "ref/dotnet5.1/System.Diagnostics.FileVersionInfo.xml",
-        "ref/dotnet5.1/zh-hans/System.Diagnostics.FileVersionInfo.xml",
-        "ref/dotnet5.1/zh-hant/System.Diagnostics.FileVersionInfo.xml",
+        "ref/dotnet5.4/de/System.Diagnostics.FileVersionInfo.xml",
+        "ref/dotnet5.4/es/System.Diagnostics.FileVersionInfo.xml",
+        "ref/dotnet5.4/fr/System.Diagnostics.FileVersionInfo.xml",
+        "ref/dotnet5.4/it/System.Diagnostics.FileVersionInfo.xml",
+        "ref/dotnet5.4/ja/System.Diagnostics.FileVersionInfo.xml",
+        "ref/dotnet5.4/ko/System.Diagnostics.FileVersionInfo.xml",
+        "ref/dotnet5.4/ru/System.Diagnostics.FileVersionInfo.xml",
+        "ref/dotnet5.4/System.Diagnostics.FileVersionInfo.dll",
+        "ref/dotnet5.4/System.Diagnostics.FileVersionInfo.xml",
+        "ref/dotnet5.4/zh-hans/System.Diagnostics.FileVersionInfo.xml",
+        "ref/dotnet5.4/zh-hant/System.Diagnostics.FileVersionInfo.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Diagnostics.FileVersionInfo.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Diagnostics.FileVersionInfo.4.0.0-beta-23429.nupkg",
-        "System.Diagnostics.FileVersionInfo.4.0.0-beta-23429.nupkg.sha512",
+        "System.Diagnostics.FileVersionInfo.4.0.0-beta-23506.nupkg",
+        "System.Diagnostics.FileVersionInfo.4.0.0-beta-23506.nupkg.sha512",
         "System.Diagnostics.FileVersionInfo.nuspec"
       ]
     },
-    "System.Diagnostics.Process/4.1.0-beta-23429": {
+    "System.Diagnostics.Process/4.1.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "B4XkHqnO7Ou83te7y6looopPwLcgvyW71yOhe7wI3aehmxvHg3AaXYxeNp4QB6eREILsmyTqiD64mtPUyY2fww==",
+      "sha512": "Ulb8H64qYX9tUSo5xxoKo2jlJ0sFr/sV2YxrrCaMNDX5eX2iQkbus1nnZqxEencaijuB/F+NAFJ5CDgROg8Phw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15162,15 +15324,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Diagnostics.Process.4.1.0-beta-23429.nupkg",
-        "System.Diagnostics.Process.4.1.0-beta-23429.nupkg.sha512",
+        "System.Diagnostics.Process.4.1.0-beta-23506.nupkg",
+        "System.Diagnostics.Process.4.1.0-beta-23506.nupkg.sha512",
         "System.Diagnostics.Process.nuspec"
       ]
     },
-    "System.Diagnostics.StackTrace/4.0.1-beta-23429": {
+    "System.Diagnostics.StackTrace/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ygi2sTkd/GJkkTABVFvrDuGFK1BqSwfCYjFed4LcrRNhqaAV1Lub96+KvFpyuPB06FoRcfkaTT56jEYJbezx1w==",
+      "sha512": "qTT1JUxZN2a9WYufGW1kWNRHq/6nYYtmLQXBBee8JZZ8BFaLNvuwySsiIwz51/6Y0U6lQBUob2qfm1NVvqH+MA==",
       "files": [
         "lib/DNXCore50/System.Diagnostics.StackTrace.dll",
         "lib/MonoAndroid10/_._",
@@ -15179,32 +15341,32 @@
         "lib/netcore50/System.Diagnostics.StackTrace.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet5.1/es/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet5.1/fr/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet5.1/it/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet5.1/ja/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet5.1/ko/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet5.1/ru/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet5.1/System.Diagnostics.StackTrace.dll",
-        "ref/dotnet5.1/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet5.1/zh-hans/System.Diagnostics.StackTrace.xml",
-        "ref/dotnet5.1/zh-hant/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet5.4/de/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet5.4/es/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet5.4/fr/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet5.4/it/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet5.4/ja/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet5.4/ko/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet5.4/ru/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet5.4/System.Diagnostics.StackTrace.dll",
+        "ref/dotnet5.4/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet5.4/zh-hans/System.Diagnostics.StackTrace.xml",
+        "ref/dotnet5.4/zh-hant/System.Diagnostics.StackTrace.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Diagnostics.StackTrace.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll",
-        "System.Diagnostics.StackTrace.4.0.1-beta-23429.nupkg",
-        "System.Diagnostics.StackTrace.4.0.1-beta-23429.nupkg.sha512",
+        "System.Diagnostics.StackTrace.4.0.1-beta-23506.nupkg",
+        "System.Diagnostics.StackTrace.4.0.1-beta-23506.nupkg.sha512",
         "System.Diagnostics.StackTrace.nuspec"
       ]
     },
-    "System.Diagnostics.Tools/4.0.1-beta-23429": {
+    "System.Diagnostics.Tools/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "p9J4+07+toXzzqlK4kaa/5ytctQPFlBdCj4rv+kcN/XYdhjmj0v1fu0+3PlwDcCwoTHmwxINypClJyJe9RKEAA==",
+      "sha512": "GjaSR/OnFLnjxxnfLkBmIjqZs1SuhdKBZb7LMNLd4dHIpejuNs6KAF/UstUFXiA+ktPI/CgOs7jUFupTyEwySw==",
       "files": [
         "lib/DNXCore50/System.Diagnostics.Tools.dll",
         "lib/net45/_._",
@@ -15239,15 +15401,15 @@
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
-        "System.Diagnostics.Tools.4.0.1-beta-23429.nupkg",
-        "System.Diagnostics.Tools.4.0.1-beta-23429.nupkg.sha512",
+        "System.Diagnostics.Tools.4.0.1-beta-23506.nupkg",
+        "System.Diagnostics.Tools.4.0.1-beta-23506.nupkg.sha512",
         "System.Diagnostics.Tools.nuspec"
       ]
     },
-    "System.Diagnostics.Tracing/4.0.21-beta-23429": {
+    "System.Diagnostics.Tracing/4.0.21-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Jnfi6JNzq/7skF88+Jzvmvv/m9y4Nv5/aKSMBOS7nEC8CVYOMDfLFUBba/0Kfz2EeOsO2kf5JKSq1lo7c/Wr+w==",
+      "sha512": "6liKF8S2xoJ+V7dLX5bQJY5glhctU2RS/7gVmz8VW4x2bPoOdi8YXiuWYEpzN32cZy9PpCXUfgpleYwqEVqfOg==",
       "files": [
         "lib/DNXCore50/System.Diagnostics.Tracing.dll",
         "lib/MonoAndroid10/_._",
@@ -15310,15 +15472,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
-        "System.Diagnostics.Tracing.4.0.21-beta-23429.nupkg",
-        "System.Diagnostics.Tracing.4.0.21-beta-23429.nupkg.sha512",
+        "System.Diagnostics.Tracing.4.0.21-beta-23506.nupkg",
+        "System.Diagnostics.Tracing.4.0.21-beta-23506.nupkg.sha512",
         "System.Diagnostics.Tracing.nuspec"
       ]
     },
-    "System.Dynamic.Runtime/4.0.11-beta-23429": {
+    "System.Dynamic.Runtime/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "3+LHycPQF8cdNKh976IW3A8SlvY6SE1jSk4vf4gYlOytEvlJ59+a2x3+3wTbz1qnRd2sGAPhGBc1A82DDxs+cQ==",
+      "sha512": "CtR6YWr/GEVzDPV1h1Khn52SFPcamNPkbMVfcFi/RReVnIy5j+4tTru6B3T+XIEv6ZbFoJ7VQ+9g5jC7rQe5FA==",
       "files": [
         "lib/DNXCore50/System.Dynamic.Runtime.dll",
         "lib/MonoAndroid10/_._",
@@ -15372,15 +15534,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll",
-        "System.Dynamic.Runtime.4.0.11-beta-23429.nupkg",
-        "System.Dynamic.Runtime.4.0.11-beta-23429.nupkg.sha512",
+        "System.Dynamic.Runtime.4.0.11-beta-23506.nupkg",
+        "System.Dynamic.Runtime.4.0.11-beta-23506.nupkg.sha512",
         "System.Dynamic.Runtime.nuspec"
       ]
     },
-    "System.Globalization/4.0.11-beta-23429": {
+    "System.Globalization/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2e+xhvbi0j+XDjQIv2brleh5/sXvc58OEDgYt6G1nwq8WmXaAb+MwpAT21QSF5Gg/GlQ4boemagH7LvbL34boA==",
+      "sha512": "3mJ4fCJCiaapqzZP9ElkQLhmER/uyrCX7fO2KLf29rZ9rbcCr9lkbSUCJ22k1C2G2+MFpLeHYfPBO3l7sfCupQ==",
       "files": [
         "lib/DNXCore50/System.Globalization.dll",
         "lib/MonoAndroid10/_._",
@@ -15434,15 +15596,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
-        "System.Globalization.4.0.11-beta-23429.nupkg",
-        "System.Globalization.4.0.11-beta-23429.nupkg.sha512",
+        "System.Globalization.4.0.11-beta-23506.nupkg",
+        "System.Globalization.4.0.11-beta-23506.nupkg.sha512",
         "System.Globalization.nuspec"
       ]
     },
-    "System.Globalization.Calendars/4.0.1-beta-23429": {
+    "System.Globalization.Calendars/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "geqH8aMsqgqvAh6gE2d1t5SYGI9hjKQBFb6nj7it7An+evgLYqkL+s+dytvra3oHlK3DteMTrnyl02EJv5e9Ng==",
+      "sha512": "mXOfMk1MRzuK+RxHhaVXJRkleh0N60L7RoViopAKt4GT0BnuOJv4yRkYffCsfh5F9nTQbcZosR+Af0AOuPne9Q==",
       "files": [
         "lib/DNXCore50/System.Globalization.Calendars.dll",
         "lib/MonoAndroid10/_._",
@@ -15451,64 +15613,64 @@
         "lib/netcore50/System.Globalization.Calendars.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.Globalization.Calendars.xml",
-        "ref/dotnet5.1/es/System.Globalization.Calendars.xml",
-        "ref/dotnet5.1/fr/System.Globalization.Calendars.xml",
-        "ref/dotnet5.1/it/System.Globalization.Calendars.xml",
-        "ref/dotnet5.1/ja/System.Globalization.Calendars.xml",
-        "ref/dotnet5.1/ko/System.Globalization.Calendars.xml",
-        "ref/dotnet5.1/ru/System.Globalization.Calendars.xml",
-        "ref/dotnet5.1/System.Globalization.Calendars.dll",
-        "ref/dotnet5.1/System.Globalization.Calendars.xml",
-        "ref/dotnet5.1/zh-hans/System.Globalization.Calendars.xml",
-        "ref/dotnet5.1/zh-hant/System.Globalization.Calendars.xml",
+        "ref/dotnet5.4/de/System.Globalization.Calendars.xml",
+        "ref/dotnet5.4/es/System.Globalization.Calendars.xml",
+        "ref/dotnet5.4/fr/System.Globalization.Calendars.xml",
+        "ref/dotnet5.4/it/System.Globalization.Calendars.xml",
+        "ref/dotnet5.4/ja/System.Globalization.Calendars.xml",
+        "ref/dotnet5.4/ko/System.Globalization.Calendars.xml",
+        "ref/dotnet5.4/ru/System.Globalization.Calendars.xml",
+        "ref/dotnet5.4/System.Globalization.Calendars.dll",
+        "ref/dotnet5.4/System.Globalization.Calendars.xml",
+        "ref/dotnet5.4/zh-hans/System.Globalization.Calendars.xml",
+        "ref/dotnet5.4/zh-hant/System.Globalization.Calendars.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Globalization.Calendars.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
-        "System.Globalization.Calendars.4.0.1-beta-23429.nupkg",
-        "System.Globalization.Calendars.4.0.1-beta-23429.nupkg.sha512",
+        "System.Globalization.Calendars.4.0.1-beta-23506.nupkg",
+        "System.Globalization.Calendars.4.0.1-beta-23506.nupkg.sha512",
         "System.Globalization.Calendars.nuspec"
       ]
     },
-    "System.Globalization.Extensions/4.0.1-beta-23429": {
+    "System.Globalization.Extensions/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "+48zEcGRBaAW3HKDbHu3enhCyzdSH6vD8qdm6DHy63+opLdbM5hxZ+EfztCqpNxsfYKaMvOhxwhqbiD+yYtHtA==",
+      "sha512": "1PCS1AtWergmaI9uwhGHswZz+Q78RcnSjtsju+d7YJGTk/1y2Kn507B5C4Ls0EA01CxjBNXh/zjt6FU4llTJjQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Globalization.Extensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.Globalization.Extensions.xml",
-        "ref/dotnet5.1/es/System.Globalization.Extensions.xml",
-        "ref/dotnet5.1/fr/System.Globalization.Extensions.xml",
-        "ref/dotnet5.1/it/System.Globalization.Extensions.xml",
-        "ref/dotnet5.1/ja/System.Globalization.Extensions.xml",
-        "ref/dotnet5.1/ko/System.Globalization.Extensions.xml",
-        "ref/dotnet5.1/ru/System.Globalization.Extensions.xml",
-        "ref/dotnet5.1/System.Globalization.Extensions.dll",
-        "ref/dotnet5.1/System.Globalization.Extensions.xml",
-        "ref/dotnet5.1/zh-hans/System.Globalization.Extensions.xml",
-        "ref/dotnet5.1/zh-hant/System.Globalization.Extensions.xml",
+        "ref/dotnet5.4/de/System.Globalization.Extensions.xml",
+        "ref/dotnet5.4/es/System.Globalization.Extensions.xml",
+        "ref/dotnet5.4/fr/System.Globalization.Extensions.xml",
+        "ref/dotnet5.4/it/System.Globalization.Extensions.xml",
+        "ref/dotnet5.4/ja/System.Globalization.Extensions.xml",
+        "ref/dotnet5.4/ko/System.Globalization.Extensions.xml",
+        "ref/dotnet5.4/ru/System.Globalization.Extensions.xml",
+        "ref/dotnet5.4/System.Globalization.Extensions.dll",
+        "ref/dotnet5.4/System.Globalization.Extensions.xml",
+        "ref/dotnet5.4/zh-hans/System.Globalization.Extensions.xml",
+        "ref/dotnet5.4/zh-hant/System.Globalization.Extensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Globalization.Extensions.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Globalization.Extensions.4.0.1-beta-23429.nupkg",
-        "System.Globalization.Extensions.4.0.1-beta-23429.nupkg.sha512",
+        "System.Globalization.Extensions.4.0.1-beta-23506.nupkg",
+        "System.Globalization.Extensions.4.0.1-beta-23506.nupkg.sha512",
         "System.Globalization.Extensions.nuspec"
       ]
     },
-    "System.IO/4.0.11-beta-23429": {
+    "System.IO/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "KDXYQcC34TalAT4BqeJTqI+FpR94fBBTN/XRJr4XfYTdS561R+FTMFtTN4zL6Hujk9JzpTRsJDUZY6ix3sP05w==",
+      "sha512": "IBQV10ntGmWC2ZDVughFnC1cWD8nKHShm4TsyX1ig1T1FzletarBnVAw2w6FZuj00UaI1MvFzoY/J5A5c7ZzMw==",
       "files": [
         "lib/DNXCore50/System.IO.dll",
         "lib/MonoAndroid10/_._",
@@ -15562,15 +15724,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.IO.dll",
-        "System.IO.4.0.11-beta-23429.nupkg",
-        "System.IO.4.0.11-beta-23429.nupkg.sha512",
+        "System.IO.4.0.11-beta-23506.nupkg",
+        "System.IO.4.0.11-beta-23506.nupkg.sha512",
         "System.IO.nuspec"
       ]
     },
-    "System.IO.Compression/4.1.0-beta-23429": {
+    "System.IO.Compression/4.1.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "aYxfjvGHrpR5ZrSCYkmh77VGMRHXBHHuxryLK1ZajWyMSUJx0tCp2Zy6lB/QzXvokJkoz3qK9sh931Kqnk2AwQ==",
+      "sha512": "IH4LUs5AXLzoLOaDfPSOUWsCupPn5H/62MrRnEmj/iIokuW0kfdprOf/IBLwLw+G2mvy1YY3IC+BEAf79p1O0w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15622,15 +15784,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.IO.Compression.4.1.0-beta-23429.nupkg",
-        "System.IO.Compression.4.1.0-beta-23429.nupkg.sha512",
+        "System.IO.Compression.4.1.0-beta-23506.nupkg",
+        "System.IO.Compression.4.1.0-beta-23506.nupkg.sha512",
         "System.IO.Compression.nuspec"
       ]
     },
-    "System.IO.Compression.ZipFile/4.0.1-beta-23429": {
+    "System.IO.Compression.ZipFile/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "SN1JRFFwCcYzv62h8vpQGfqJuq3lG+HXMle+nrmUSoXKqTQojhQ9ikTLYR8tag0RWE7b3spSdpRCIoVCLUoldw==",
+      "sha512": "4lRWYQZe7P9vM+JIuTr9G9SISO8l29Tu9kKiF89PdSVI+DT+noZb40ubj0ifcuCTO2ygpA4u+2Q6UwJmEz2k6A==",
       "files": [
         "lib/dotnet5.4/System.IO.Compression.ZipFile.dll",
         "lib/MonoAndroid10/_._",
@@ -15638,31 +15800,31 @@
         "lib/net46/System.IO.Compression.ZipFile.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.2/de/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet5.2/es/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet5.2/fr/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet5.2/it/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet5.2/ja/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet5.2/ko/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet5.2/ru/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet5.2/System.IO.Compression.ZipFile.dll",
-        "ref/dotnet5.2/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet5.2/zh-hans/System.IO.Compression.ZipFile.xml",
-        "ref/dotnet5.2/zh-hant/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet5.4/de/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet5.4/es/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet5.4/fr/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet5.4/it/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet5.4/ja/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet5.4/ko/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet5.4/ru/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet5.4/System.IO.Compression.ZipFile.dll",
+        "ref/dotnet5.4/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet5.4/zh-hans/System.IO.Compression.ZipFile.xml",
+        "ref/dotnet5.4/zh-hant/System.IO.Compression.ZipFile.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.IO.Compression.ZipFile.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.IO.Compression.ZipFile.4.0.1-beta-23429.nupkg",
-        "System.IO.Compression.ZipFile.4.0.1-beta-23429.nupkg.sha512",
+        "System.IO.Compression.ZipFile.4.0.1-beta-23506.nupkg",
+        "System.IO.Compression.ZipFile.4.0.1-beta-23506.nupkg.sha512",
         "System.IO.Compression.ZipFile.nuspec"
       ]
     },
-    "System.IO.FileSystem/4.0.1-beta-23429": {
+    "System.IO.FileSystem/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "sDxQUlnQ4nwUDLHkS1+cC2bKHwwOrneqb+PUnpLuY0fKAxDBD5ZD3rqfNWbwaZEZCE+oJf/IAPPnT4D4wdnO/A==",
+      "sha512": "lhGjHB8YjbsMxA6rSrR5ZxNtAE7vEB/WbYn7Abu7fE0fYmID3EhGheHoJbqSxNhra8GnUWBYuiNPnEGP7C32pg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15686,15 +15848,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.IO.FileSystem.4.0.1-beta-23429.nupkg",
-        "System.IO.FileSystem.4.0.1-beta-23429.nupkg.sha512",
+        "System.IO.FileSystem.4.0.1-beta-23506.nupkg",
+        "System.IO.FileSystem.4.0.1-beta-23506.nupkg.sha512",
         "System.IO.FileSystem.nuspec"
       ]
     },
-    "System.IO.FileSystem.DriveInfo/4.0.0-beta-23429": {
+    "System.IO.FileSystem.DriveInfo/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "mb+9Vi2fmlO4TQKv/SyXt/NkVL1XR7ItDx/ePwWYKd0KSBrrzp7Xy7pYz9ciA2mNVD8VqPkFCgFbmKujoviP6A==",
+      "sha512": "qugrJKDvtEOgMEtFTPk6Zx34xbnYXH89bMb8TiirIszdXjLimGIVx8ys/eSTSQsY0eJRsxfwEyopKAwYlxREhA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15718,15 +15880,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.IO.FileSystem.DriveInfo.4.0.0-beta-23429.nupkg",
-        "System.IO.FileSystem.DriveInfo.4.0.0-beta-23429.nupkg.sha512",
+        "System.IO.FileSystem.DriveInfo.4.0.0-beta-23506.nupkg",
+        "System.IO.FileSystem.DriveInfo.4.0.0-beta-23506.nupkg.sha512",
         "System.IO.FileSystem.DriveInfo.nuspec"
       ]
     },
-    "System.IO.FileSystem.Primitives/4.0.1-beta-23429": {
+    "System.IO.FileSystem.Primitives/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "iEIIQYGPHJ09rG1COm1siqARBLdtX4HTW7YAmaZCKsW3mf657cqipN3y4RxfDRq3vsg8Bco1JtgWo8qvWYVCZQ==",
+      "sha512": "1Xm/5b4K41vT2xvB3+F1pDpnqwDDNJMG4Svvh/B4jfI7RhZj6r5UAe2LsaexJDaLPReUTcVh7GLPWW+bJtRzDw==",
       "files": [
         "lib/dotnet5.4/System.IO.FileSystem.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -15734,63 +15896,63 @@
         "lib/net46/System.IO.FileSystem.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet5.1/es/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet5.1/fr/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet5.1/it/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet5.1/ja/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet5.1/ko/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet5.1/ru/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet5.1/System.IO.FileSystem.Primitives.dll",
-        "ref/dotnet5.1/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet5.1/zh-hans/System.IO.FileSystem.Primitives.xml",
-        "ref/dotnet5.1/zh-hant/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet5.4/de/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet5.4/es/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet5.4/fr/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet5.4/it/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet5.4/ja/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet5.4/ko/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet5.4/ru/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet5.4/System.IO.FileSystem.Primitives.dll",
+        "ref/dotnet5.4/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet5.4/zh-hans/System.IO.FileSystem.Primitives.xml",
+        "ref/dotnet5.4/zh-hant/System.IO.FileSystem.Primitives.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.IO.FileSystem.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.IO.FileSystem.Primitives.4.0.1-beta-23429.nupkg",
-        "System.IO.FileSystem.Primitives.4.0.1-beta-23429.nupkg.sha512",
+        "System.IO.FileSystem.Primitives.4.0.1-beta-23506.nupkg",
+        "System.IO.FileSystem.Primitives.4.0.1-beta-23506.nupkg.sha512",
         "System.IO.FileSystem.Primitives.nuspec"
       ]
     },
-    "System.IO.FileSystem.Watcher/4.0.0-beta-23429": {
+    "System.IO.FileSystem.Watcher/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OGdh9UQWyOnRR3T5Nu5Rr79JOhsGYXZKJOQxY3hjV+MRX17aFmQQx9oM/p0VH+KErUErnGi72NeYOprUpRvgaw==",
+      "sha512": "M4Wenz00Zs/Li0WTwpI0O//nAV5+jjZDLdqphHItE6KGaMWUA8TXaGU8vQWla/0tZjPNrPv17oERCumUGM90+g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.IO.FileSystem.Watcher.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.IO.FileSystem.Watcher.xml",
-        "ref/dotnet5.1/es/System.IO.FileSystem.Watcher.xml",
-        "ref/dotnet5.1/fr/System.IO.FileSystem.Watcher.xml",
-        "ref/dotnet5.1/it/System.IO.FileSystem.Watcher.xml",
-        "ref/dotnet5.1/ja/System.IO.FileSystem.Watcher.xml",
-        "ref/dotnet5.1/ko/System.IO.FileSystem.Watcher.xml",
-        "ref/dotnet5.1/ru/System.IO.FileSystem.Watcher.xml",
-        "ref/dotnet5.1/System.IO.FileSystem.Watcher.dll",
-        "ref/dotnet5.1/System.IO.FileSystem.Watcher.xml",
-        "ref/dotnet5.1/zh-hans/System.IO.FileSystem.Watcher.xml",
-        "ref/dotnet5.1/zh-hant/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet5.4/de/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet5.4/es/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet5.4/fr/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet5.4/it/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet5.4/ja/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet5.4/ko/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet5.4/ru/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet5.4/System.IO.FileSystem.Watcher.dll",
+        "ref/dotnet5.4/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet5.4/zh-hans/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet5.4/zh-hant/System.IO.FileSystem.Watcher.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.IO.FileSystem.Watcher.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.IO.FileSystem.Watcher.4.0.0-beta-23429.nupkg",
-        "System.IO.FileSystem.Watcher.4.0.0-beta-23429.nupkg.sha512",
+        "System.IO.FileSystem.Watcher.4.0.0-beta-23506.nupkg",
+        "System.IO.FileSystem.Watcher.4.0.0-beta-23506.nupkg.sha512",
         "System.IO.FileSystem.Watcher.nuspec"
       ]
     },
-    "System.IO.MemoryMappedFiles/4.0.0-beta-23429": {
+    "System.IO.MemoryMappedFiles/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JPZfsISj5ZLfoHzg9mklSLYZQBv2AWmG5ipyqNdpb+p5JPTkP590qKAz9terD117/WJDP0JzV8GkkFructJbFA==",
+      "sha512": "6jVQQavFQ5F70MpWSW1CM/jsvPXEb42LNbVLXyTNkU7wO3FjYNMrKNa1eZmDy8g9SJGLSKbgP+kbJzE8PZ05SA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15814,15 +15976,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.IO.MemoryMappedFiles.4.0.0-beta-23429.nupkg",
-        "System.IO.MemoryMappedFiles.4.0.0-beta-23429.nupkg.sha512",
+        "System.IO.MemoryMappedFiles.4.0.0-beta-23506.nupkg",
+        "System.IO.MemoryMappedFiles.4.0.0-beta-23506.nupkg.sha512",
         "System.IO.MemoryMappedFiles.nuspec"
       ]
     },
-    "System.IO.Pipes/4.0.0-beta-23429": {
+    "System.IO.Pipes/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2LdhNqYX6aJtCVMwvU95Xt/AhfTj1X5w60u9ksVlDVx9C1z3hA/6CuLI3PMzlKXL4lyYpRSn0CHBku28o16VuQ==",
+      "sha512": "bDzXlfAcuvxJNOtKMb7xLqFMcjxLkrWykI7kc8SWpqANAp7fDfUkXMBhhtGFXBVRShYKvL+jMXoLlCuSJcwECw==",
       "files": [
         "lib/net46/System.IO.Pipes.dll",
         "ref/dotnet5.4/de/System.IO.Pipes.xml",
@@ -15838,15 +16000,15 @@
         "ref/dotnet5.4/zh-hant/System.IO.Pipes.xml",
         "ref/net46/System.IO.Pipes.dll",
         "runtime.json",
-        "System.IO.Pipes.4.0.0-beta-23429.nupkg",
-        "System.IO.Pipes.4.0.0-beta-23429.nupkg.sha512",
+        "System.IO.Pipes.4.0.0-beta-23506.nupkg",
+        "System.IO.Pipes.4.0.0-beta-23506.nupkg.sha512",
         "System.IO.Pipes.nuspec"
       ]
     },
-    "System.IO.UnmanagedMemoryStream/4.0.1-beta-23429": {
+    "System.IO.UnmanagedMemoryStream/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "z/90gW6aiAdTdwyL/N91ghUo0dsz1Uk//EtxC1P1wUwnto5yXSgqicfSplI4/6iwbr1yZOtcruN2hmEpMPVdWQ==",
+      "sha512": "wvnjID8Uy9VJL6qZe7WaVHfwAG0r6VsSkUte/jc14lCKe5TzoD89LTmnwxbZlUhmRV+QGGKl6bucsc6TAPQm6Q==",
       "files": [
         "lib/dotnet5.4/System.IO.UnmanagedMemoryStream.dll",
         "lib/MonoAndroid10/_._",
@@ -15854,31 +16016,31 @@
         "lib/net46/System.IO.UnmanagedMemoryStream.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.2/de/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet5.2/es/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet5.2/fr/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet5.2/it/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet5.2/ja/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet5.2/ko/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet5.2/ru/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet5.2/System.IO.UnmanagedMemoryStream.dll",
-        "ref/dotnet5.2/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet5.2/zh-hans/System.IO.UnmanagedMemoryStream.xml",
-        "ref/dotnet5.2/zh-hant/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet5.4/de/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet5.4/es/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet5.4/fr/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet5.4/it/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet5.4/ja/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet5.4/ko/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet5.4/ru/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet5.4/System.IO.UnmanagedMemoryStream.dll",
+        "ref/dotnet5.4/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet5.4/zh-hans/System.IO.UnmanagedMemoryStream.xml",
+        "ref/dotnet5.4/zh-hant/System.IO.UnmanagedMemoryStream.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.IO.UnmanagedMemoryStream.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.IO.UnmanagedMemoryStream.4.0.1-beta-23429.nupkg",
-        "System.IO.UnmanagedMemoryStream.4.0.1-beta-23429.nupkg.sha512",
+        "System.IO.UnmanagedMemoryStream.4.0.1-beta-23506.nupkg",
+        "System.IO.UnmanagedMemoryStream.4.0.1-beta-23506.nupkg.sha512",
         "System.IO.UnmanagedMemoryStream.nuspec"
       ]
     },
-    "System.Linq/4.0.1-beta-23429": {
+    "System.Linq/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Agh9BCkrdlPTOAwKzb5PHiqV74OrUV2uGPJ420zB0zP4GhW4fj3RXLho4XawD9tIyADWvhuOkjDsHjhV3ku/oA==",
+      "sha512": "ZhPwMcoHe7riRgHE8IDEIg7LllpM8C4OkYlH+po7fKDehqOa9WXS60h+BaXHLYy0L8OlSrMy1Z/2XKl9HZh9rg==",
       "files": [
         "lib/dotnet5.4/System.Linq.dll",
         "lib/net45/_._",
@@ -15912,21 +16074,19 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "System.Linq.4.0.1-beta-23429.nupkg",
-        "System.Linq.4.0.1-beta-23429.nupkg.sha512",
+        "System.Linq.4.0.1-beta-23506.nupkg",
+        "System.Linq.4.0.1-beta-23506.nupkg.sha512",
         "System.Linq.nuspec"
       ]
     },
-    "System.Linq.Expressions/4.0.11-beta-23429": {
+    "System.Linq.Expressions/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "EjlVpZCTlrqiS1EcsWKdMZ+UikwBWXsJXcD/UDKEbX3jsRdogFa2+0a3W5iXeiSSegYs0KyHKJN1S+thIovkIA==",
+      "sha512": "wEt7gWP49rlCsMvFSIIUa15QX+pC1hp/5TEYhs3GSiPpo4MomBaMgkW9udCHEpI/lWbWG7Xk8kDv+a0iMQOA4A==",
       "files": [
-        "lib/DNXCore50/System.Linq.Expressions.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
-        "lib/netcore50/System.Linq.Expressions.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
@@ -15974,16 +16134,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Linq.Expressions.dll",
-        "System.Linq.Expressions.4.0.11-beta-23429.nupkg",
-        "System.Linq.Expressions.4.0.11-beta-23429.nupkg.sha512",
+        "System.Linq.Expressions.4.0.11-beta-23506.nupkg",
+        "System.Linq.Expressions.4.0.11-beta-23506.nupkg.sha512",
         "System.Linq.Expressions.nuspec"
       ]
     },
-    "System.Linq.Parallel/4.0.1-beta-23429": {
+    "System.Linq.Parallel/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "w3Rh0aVfph7mYiU2f+4wkRbL3opfQY2kk2eSmddAZX+dgkZP671g+cQT9iGyKeYoUEaOgoozabaGRU1i1JEZAg==",
+      "sha512": "QIMH0TEGDDjjWhl72oX0Z0WmO3vVBdQQLC05xJQuAOUInEn+CuImKfbxOg7c0vF5nqW1udMpGsQGSsIChfs+/w==",
       "files": [
         "lib/dotnet5.4/System.Linq.Parallel.dll",
         "lib/net45/_._",
@@ -16015,15 +16174,15 @@
         "ref/netcore50/zh-hant/System.Linq.Parallel.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
-        "System.Linq.Parallel.4.0.1-beta-23429.nupkg",
-        "System.Linq.Parallel.4.0.1-beta-23429.nupkg.sha512",
+        "System.Linq.Parallel.4.0.1-beta-23506.nupkg",
+        "System.Linq.Parallel.4.0.1-beta-23506.nupkg.sha512",
         "System.Linq.Parallel.nuspec"
       ]
     },
-    "System.Linq.Queryable/4.0.1-beta-23429": {
+    "System.Linq.Queryable/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "7m7rmuH1NOwFfzm/nlwHpcIOJ6JGzb+hH/2PSkzIKEdzhMEdXkjLihx7OIHfQ4cyZvcX+iMuPpjBhs8oTVY0oA==",
+      "sha512": "MfiFJ3uwldsDK1GZs/FzCf+rb1A2vKxfjdF2pk7lhGef8VhP45PjZIv14OI2nJnH9jBiK5pWq2rjY8fu7wW2vw==",
       "files": [
         "lib/dotnet5.4/System.Linq.Queryable.dll",
         "lib/net45/_._",
@@ -16057,15 +16216,15 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "System.Linq.Queryable.4.0.1-beta-23429.nupkg",
-        "System.Linq.Queryable.4.0.1-beta-23429.nupkg.sha512",
+        "System.Linq.Queryable.4.0.1-beta-23506.nupkg",
+        "System.Linq.Queryable.4.0.1-beta-23506.nupkg.sha512",
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-beta-23429": {
+    "System.Net.Http/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "893z4V/PKEE4Q8wGHGYN2CO3DVsabQvEgz1SkbedqYjUVvNCaeyvwiQyWyI5XmQxB+399u1g8Jizd7G5uG69xQ==",
+      "sha512": "Pc1jf2qxpg6P0u39217TFLsl8TCTUiUu1JLzAznvfdVl+VDWA/egJZQ2CIs9OKpDqlkZ0yIXi+T4EdtqXO9i/A==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
@@ -16096,15 +16255,15 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-beta-23429.nupkg",
-        "System.Net.Http.4.0.1-beta-23429.nupkg.sha512",
+        "System.Net.Http.4.0.1-beta-23506.nupkg",
+        "System.Net.Http.4.0.1-beta-23506.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-beta-23429": {
+    "System.Net.NameResolution/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "rJPJzU9uRaLpB5LZhNujB78AHtpKvkq7NCJJy2hE4Zrx+Ef6cOwJsnnCwms7hw0mruFjJCbQeIFQdDRYmvUXFA==",
+      "sha512": "nHT9tg8Jz3xJ9NByF1I7djb9uDYCu2FFGFT1f/PUnukGBBPjmUTEM06pW5LuLV8HNhsYjGafbnJaRNVPnSUBXg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -16128,15 +16287,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-beta-23429.nupkg",
-        "System.Net.NameResolution.4.0.0-beta-23429.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-beta-23506.nupkg",
+        "System.Net.NameResolution.4.0.0-beta-23506.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
-    "System.Net.NetworkInformation/4.1.0-beta-23429": {
+    "System.Net.NetworkInformation/4.1.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "r9O+JDYyy73uMjrf3YZ7IBgpPceAtwXyFHRyyy7ok4LrKRaUKWQQ8vQ7/qEowzm4eA8cJvrhw/E9erqAD0ERSQ==",
+      "sha512": "CdOsCU4Zi7gc4uDKDB3fjHmVCsUkZQjh0TjVYHD8lg9ZqmxZEdcqmRzc544SK0f1OwgRDkSu4VIPvP3DCDH3HA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -16190,15 +16349,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NetworkInformation.4.1.0-beta-23429.nupkg",
-        "System.Net.NetworkInformation.4.1.0-beta-23429.nupkg.sha512",
+        "System.Net.NetworkInformation.4.1.0-beta-23506.nupkg",
+        "System.Net.NetworkInformation.4.1.0-beta-23506.nupkg.sha512",
         "System.Net.NetworkInformation.nuspec"
       ]
     },
-    "System.Net.Primitives/4.0.11-beta-23429": {
+    "System.Net.Primitives/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "uV8kNWj4F3kEBkqVUD79GT3VdWhMFnO4SSKUxAfVSAPPmRaEG3x1nsnQkziMv4R27VTRD16mGMNLtJle3BsPLg==",
+      "sha512": "aldqVUmrLghkA9pjJ3Re/lI8Kgcju35JHfKYuV/xxvKMx4oWGPpYoA9mGli4DYwFbTbVcJ2Q6AxCkR9YSWGIhw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -16261,15 +16420,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.Primitives.4.0.11-beta-23429.nupkg",
-        "System.Net.Primitives.4.0.11-beta-23429.nupkg.sha512",
+        "System.Net.Primitives.4.0.11-beta-23506.nupkg",
+        "System.Net.Primitives.4.0.11-beta-23506.nupkg.sha512",
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Requests/4.0.11-beta-23429": {
+    "System.Net.Requests/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "0/iZj/qWvv7GU2FlXoWYmihHy35cWuGZfGQgtWoLa8oQsmhSxuKWYrC6boabZHUDdrKIGVyM0UJQtfvu9riB6A==",
+      "sha512": "ej8jifpJRtXrpvKECjVWPpB3MHT9Y7Vxha35MayfsC1a3KbEsTBfbSdXrmNDsDA/jGdAdOtPdMM8TVb4VVM/uw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -16332,14 +16491,14 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.Requests.4.0.11-beta-23429.nupkg",
-        "System.Net.Requests.4.0.11-beta-23429.nupkg.sha512",
+        "System.Net.Requests.4.0.11-beta-23506.nupkg",
+        "System.Net.Requests.4.0.11-beta-23506.nupkg.sha512",
         "System.Net.Requests.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-beta-23429": {
+    "System.Net.Security/4.0.0-beta-23506": {
       "type": "package",
-      "sha512": "Bp2FqJYs7mEOxO2mn/mxBq9VQzYJGx5qzsc+0FncfbAnIIUHdtoHKqML0fERiij8v3n8p7FCH7Oes9FRBDojUw==",
+      "sha512": "yJM6z+NWl0PFZiSBipJqhdM/NZluIz+5CXOaVClK7cqjghvhyJW5iqdGuxTmS0+OTH9Fy9IvSt0UlkW0s/UXsg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -16363,15 +16522,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.Security.4.0.0-beta-23429.nupkg",
-        "System.Net.Security.4.0.0-beta-23429.nupkg.sha512",
+        "System.Net.Security.4.0.0-beta-23506.nupkg",
+        "System.Net.Security.4.0.0-beta-23506.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
-    "System.Net.Sockets/4.1.0-beta-23429": {
+    "System.Net.Sockets/4.1.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "S46aGR1uFvZ/XjnAqFK9H9IDT0HgcWHhOkwiwVHR5HqG9GHkQi6WHlpKjM/gk0FDeHHKzYc/evhL8i12/kLxMA==",
+      "sha512": "RP0imKisSL3uPjVANlhbnokANTQ+k9h22x5sWQGVEQIzyU2GKJn85Ps/CtpJVCPz/Rqrv9gGSQiO0MBIw4RC1A==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -16389,32 +16548,21 @@
         "ref/dotnet5.4/System.Net.Sockets.xml",
         "ref/dotnet5.4/zh-hans/System.Net.Sockets.xml",
         "ref/dotnet5.4/zh-hant/System.Net.Sockets.xml",
-        "ref/dotnet5.5/de/System.Net.Sockets.xml",
-        "ref/dotnet5.5/es/System.Net.Sockets.xml",
-        "ref/dotnet5.5/fr/System.Net.Sockets.xml",
-        "ref/dotnet5.5/it/System.Net.Sockets.xml",
-        "ref/dotnet5.5/ja/System.Net.Sockets.xml",
-        "ref/dotnet5.5/ko/System.Net.Sockets.xml",
-        "ref/dotnet5.5/ru/System.Net.Sockets.xml",
-        "ref/dotnet5.5/System.Net.Sockets.dll",
-        "ref/dotnet5.5/System.Net.Sockets.xml",
-        "ref/dotnet5.5/zh-hans/System.Net.Sockets.xml",
-        "ref/dotnet5.5/zh-hant/System.Net.Sockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Sockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.Sockets.4.1.0-beta-23429.nupkg",
-        "System.Net.Sockets.4.1.0-beta-23429.nupkg.sha512",
+        "System.Net.Sockets.4.1.0-beta-23506.nupkg",
+        "System.Net.Sockets.4.1.0-beta-23506.nupkg.sha512",
         "System.Net.Sockets.nuspec"
       ]
     },
-    "System.Net.Utilities/4.0.0-beta-23429": {
+    "System.Net.Utilities/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JstDtzHDMwAUSsfE2uSJ7DVPkQu0iIpXyxkMzbZek7K6I/noljRlCtzPCAcmF6SDSxAqBKgiW7vWj2YNjGpWiQ==",
+      "sha512": "V3qiOdMsRTcbrcXMmbV9S87bsAo++8y5Ok1GKtQmExUOpuKtrLIVamWwCGg/j2OVfCuo1bedTg/ldfr7GVLEtA==",
       "files": [
         "lib/DNXCore50/System.Net.Utilities.dll",
         "lib/MonoAndroid10/_._",
@@ -16438,15 +16586,15 @@
         "ref/net46/System.Net.Utilities.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Utilities.4.0.0-beta-23429.nupkg",
-        "System.Net.Utilities.4.0.0-beta-23429.nupkg.sha512",
+        "System.Net.Utilities.4.0.0-beta-23506.nupkg",
+        "System.Net.Utilities.4.0.0-beta-23506.nupkg.sha512",
         "System.Net.Utilities.nuspec"
       ]
     },
-    "System.Net.WebHeaderCollection/4.0.1-beta-23429": {
+    "System.Net.WebHeaderCollection/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2xGWflmwqXUyQ0KKI/XZCPJ9CGWWSP8pVsCAm1DjDqL7xAIFLma/J4GExorZMP7MCmFZYhEG0tZ/Hcw+A/OLLA==",
+      "sha512": "33zmEqsc67K3L6ZL9U9CP9wzYxJcFHpuUirPt8dMpcajIWIhZN/9kEwBUE4KttBswLOS9vZfc8RzqKfMAOCtjw==",
       "files": [
         "lib/dotnet5.4/System.Net.WebHeaderCollection.dll",
         "lib/MonoAndroid10/_._",
@@ -16470,15 +16618,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebHeaderCollection.4.0.1-beta-23429.nupkg",
-        "System.Net.WebHeaderCollection.4.0.1-beta-23429.nupkg.sha512",
+        "System.Net.WebHeaderCollection.4.0.1-beta-23506.nupkg",
+        "System.Net.WebHeaderCollection.4.0.1-beta-23506.nupkg.sha512",
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-beta-23429": {
+    "System.Net.WebSockets/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "4SxMyfg+c9XkSa/brzZ1P00urM54qBzC0fatsPUnKEHlxA/FrJ8ovcDNCGLwKg9CgnJ2ETEPsLY+jcl1kY8paw==",
+      "sha512": "3fDnRNSccj59ENAXY86yHP7vQbV13l3eZZ+6HxwYYboRvmpwIzV4BmE9ydde3flYbs55HkL2brAHqhAdE9neNA==",
       "files": [
         "lib/dotnet5.4/System.Net.WebSockets.dll",
         "lib/MonoAndroid10/_._",
@@ -16486,30 +16634,30 @@
         "lib/net46/System.Net.WebSockets.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.Net.WebSockets.xml",
-        "ref/dotnet5.1/es/System.Net.WebSockets.xml",
-        "ref/dotnet5.1/fr/System.Net.WebSockets.xml",
-        "ref/dotnet5.1/it/System.Net.WebSockets.xml",
-        "ref/dotnet5.1/ja/System.Net.WebSockets.xml",
-        "ref/dotnet5.1/ko/System.Net.WebSockets.xml",
-        "ref/dotnet5.1/ru/System.Net.WebSockets.xml",
-        "ref/dotnet5.1/System.Net.WebSockets.dll",
-        "ref/dotnet5.1/System.Net.WebSockets.xml",
-        "ref/dotnet5.1/zh-hans/System.Net.WebSockets.xml",
-        "ref/dotnet5.1/zh-hant/System.Net.WebSockets.xml",
+        "ref/dotnet5.4/de/System.Net.WebSockets.xml",
+        "ref/dotnet5.4/es/System.Net.WebSockets.xml",
+        "ref/dotnet5.4/fr/System.Net.WebSockets.xml",
+        "ref/dotnet5.4/it/System.Net.WebSockets.xml",
+        "ref/dotnet5.4/ja/System.Net.WebSockets.xml",
+        "ref/dotnet5.4/ko/System.Net.WebSockets.xml",
+        "ref/dotnet5.4/ru/System.Net.WebSockets.xml",
+        "ref/dotnet5.4/System.Net.WebSockets.dll",
+        "ref/dotnet5.4/System.Net.WebSockets.xml",
+        "ref/dotnet5.4/zh-hans/System.Net.WebSockets.xml",
+        "ref/dotnet5.4/zh-hant/System.Net.WebSockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-beta-23429.nupkg",
-        "System.Net.WebSockets.4.0.0-beta-23429.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-beta-23506.nupkg",
+        "System.Net.WebSockets.4.0.0-beta-23506.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-beta-23429": {
+    "System.Net.WebSockets.Client/4.0.0-beta-23506": {
       "type": "package",
-      "sha512": "NAziy7DFPEo4FSQlDv70VkjE4kEbKtSJ4XOPvva7PE1PD7Q8EIcZD+LCcceQWqzFAq/UFl5IgoyD52HRWj8PxQ==",
+      "sha512": "fqkhJeR6rqIBn8/tZem+qlrbhRI1OkZ91wV+XAkf8WYmeTvxwESyHyRpL2o5aBHBR1Hl78CyTBMB0opUSPKhYw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -16533,15 +16681,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.WebSockets.Client.4.0.0-beta-23429.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-beta-23429.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-beta-23506.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-beta-23506.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
-    "System.Numerics.Vectors/4.1.1-beta-23429": {
+    "System.Numerics.Vectors/4.1.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xqUdHC+yzbwVFo9nnk2takEyhmBgyXwfhsQeSJF4oejAaYuJr8OfAxlhTDgBOIfzBDfFL1Z4Qse3FT3mdD6S3A==",
+      "sha512": "cjWXTrSsW5zWa9A+9GJZxw5T+lPvY9lb4gAbI3RgZv/FBbuaA9cDdUJnN4pqxbripgIOOOMYMASMvfg4YcGWcA==",
       "files": [
         "lib/dotnet5.4/System.Numerics.Vectors.dll",
         "lib/MonoAndroid10/_._",
@@ -16558,15 +16706,15 @@
         "ref/net46/System.Numerics.Vectors.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Numerics.Vectors.4.1.1-beta-23429.nupkg",
-        "System.Numerics.Vectors.4.1.1-beta-23429.nupkg.sha512",
+        "System.Numerics.Vectors.4.1.1-beta-23506.nupkg",
+        "System.Numerics.Vectors.4.1.1-beta-23506.nupkg.sha512",
         "System.Numerics.Vectors.nuspec"
       ]
     },
-    "System.ObjectModel/4.0.11-beta-23429": {
+    "System.ObjectModel/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "nZZLyhULmgq7JTIUaJhr/7zmV1RqfJTTIrCiYEirn1jIEzy8TbIH6Uoc1n7/1fcM9NW1NdBHW46mBJIUjP1hrg==",
+      "sha512": "IeFupPCApN8opsvb3ZbkY2txgvFrO/CLNl6zzyyPjQOI1Ju6jNqTZtkUUfmD6VR/5oSSEVtUXx4JOFT23MgfEQ==",
       "files": [
         "lib/dotnet5.4/System.ObjectModel.dll",
         "lib/MonoAndroid10/_._",
@@ -16619,71 +16767,67 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ObjectModel.4.0.11-beta-23429.nupkg",
-        "System.ObjectModel.4.0.11-beta-23429.nupkg.sha512",
+        "System.ObjectModel.4.0.11-beta-23506.nupkg",
+        "System.ObjectModel.4.0.11-beta-23506.nupkg.sha512",
         "System.ObjectModel.nuspec"
       ]
     },
-    "System.Private.DataContractSerialization/4.1.0-beta-23429": {
+    "System.Private.DataContractSerialization/4.1.0-beta-23506": {
       "type": "package",
-      "serviceable": true,
-      "sha512": "7kio39NJztQ54ggXdqYTQ5Q2LNYS5p1PYl/AaYBcsFLRe3VtNqyx34utcqz3icfcJ9r+PdPX1+kjy/MbGvkq/g==",
+      "sha512": "BK4uMJK0ECDN543JLjQw0CkM7z8VEqjf0udbp0FKWV0xNGmTPcp8ZNKxJw6OEq6cfqx8gfalCc29WpS8rqkfIg==",
       "files": [
-        "lib/DNXCore50/System.Private.DataContractSerialization.dll",
-        "lib/netcore50/System.Private.DataContractSerialization.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Private.DataContractSerialization.dll",
-        "System.Private.DataContractSerialization.4.1.0-beta-23429.nupkg",
-        "System.Private.DataContractSerialization.4.1.0-beta-23429.nupkg.sha512",
+        "System.Private.DataContractSerialization.4.1.0-beta-23506.nupkg",
+        "System.Private.DataContractSerialization.4.1.0-beta-23506.nupkg.sha512",
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23429": {
+    "System.Private.Networking/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fZxZjpcBeHWJFhJzWxQEt4w9XWG2p4vmhM9/s7cJI2lVyz61U750aJfhgbSeY0J5wqO/53lMDQMo/m9usHV3nQ==",
+      "sha512": "9/+BZfDoVMhoYg+3pazJKGtNn986GK+t0qy/SPJ9GgIzG6SYfxcX/rc9HI7hvOgbXXiLsmOm7njs9ZqXX3BTSw==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23429.nupkg",
-        "System.Private.Networking.4.0.1-beta-23429.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23506.nupkg",
+        "System.Private.Networking.4.0.1-beta-23506.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-beta-23429": {
+    "System.Private.ServiceModel/4.1.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "TUIrWJJgRYMqPbMDQdikbq5H+qIlFBE/TBgAyKhAliEBk4jY5rfX+gHSI8ORSkf2HWMDW+DHSIjymPJUURX/Cw==",
+      "sha512": "Ao3aBG+Dno9DcGK/caPb2R1TXuny+fBHmjufM/dsutHiwgTMIGZXU4l68jOhezYvioY79QmmpABLVROylZW34A==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-beta-23429.nupkg",
-        "System.Private.ServiceModel.4.1.0-beta-23429.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-beta-23506.nupkg",
+        "System.Private.ServiceModel.4.1.0-beta-23506.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
-    "System.Private.Uri/4.0.1-beta-23429": {
+    "System.Private.Uri/4.0.1-beta-23506": {
       "type": "package",
-      "sha512": "hoktsfQZsUk+6YkjIM4AFsS6Hz8mXfyvYVRPN1IZBHZ/1znLrgibl/KStEJIACMTK1DaZlYZDNA5nsQZsuUzAw==",
+      "sha512": "t9xN9sH13VPi9PEJ/94WvJQla1qC82t5tChrJv8/Fcahi0X5uoOdxLCnD4uE03dokPJyUytY6otN9COup6rIBA==",
       "files": [
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
         "runtime.json",
-        "System.Private.Uri.4.0.1-beta-23429.nupkg",
-        "System.Private.Uri.4.0.1-beta-23429.nupkg.sha512",
+        "System.Private.Uri.4.0.1-beta-23506.nupkg",
+        "System.Private.Uri.4.0.1-beta-23506.nupkg.sha512",
         "System.Private.Uri.nuspec"
       ]
     },
-    "System.Reflection/4.1.0-beta-23429": {
+    "System.Reflection/4.1.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bxpSF1VpUIeqZvSU15rXk1iYfFsZvCy99/D9HBOjf4RQU4HpSB3zVb/Td0NQx5c8CpEtiWI04LPpnJDrW9CBjA==",
+      "sha512": "oVr5B1kqp8ZmXQDRCNDDGPXgO/GbHWzPUZLorb0bSRtNqDqZck2dlb8u8S8jcDEyTP1VtEa8Gvh7x/WzGQRxog==",
       "files": [
         "lib/DNXCore50/System.Reflection.dll",
         "lib/MonoAndroid10/_._",
@@ -16739,49 +16883,45 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
-        "System.Reflection.4.1.0-beta-23429.nupkg",
-        "System.Reflection.4.1.0-beta-23429.nupkg.sha512",
+        "System.Reflection.4.1.0-beta-23506.nupkg",
+        "System.Reflection.4.1.0-beta-23506.nupkg.sha512",
         "System.Reflection.nuspec"
       ]
     },
-    "System.Reflection.DispatchProxy/4.0.1-beta-23429": {
+    "System.Reflection.DispatchProxy/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZCrE2AcIcC9uhUZ4fSe0Rzt1hV88yuFI11+Rd2gE01qx/vGfiIyJD7Z5NbJtnXOJxf4g/BhLzDrhQHsSmaw7Bw==",
+      "sha512": "XvbK/9jEb1B69oA1YqRO5PG9pBYTqQuv96au0tYgjOYapk4+TC+OjyjHL61iAFHr4A1TSKD5X9RjkBXzU1QSqg==",
       "files": [
-        "lib/DNXCore50/System.Reflection.DispatchProxy.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
-        "lib/net46/System.Reflection.DispatchProxy.dll",
-        "lib/netcore50/System.Reflection.DispatchProxy.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet5.1/es/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet5.1/fr/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet5.1/it/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet5.1/ja/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet5.1/ko/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet5.1/ru/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet5.1/System.Reflection.DispatchProxy.dll",
-        "ref/dotnet5.1/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet5.1/zh-hans/System.Reflection.DispatchProxy.xml",
-        "ref/dotnet5.1/zh-hant/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet5.4/de/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet5.4/es/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet5.4/fr/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet5.4/it/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet5.4/ja/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet5.4/ko/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet5.4/ru/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet5.4/System.Reflection.DispatchProxy.dll",
+        "ref/dotnet5.4/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet5.4/zh-hans/System.Reflection.DispatchProxy.xml",
+        "ref/dotnet5.4/zh-hant/System.Reflection.DispatchProxy.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Reflection.DispatchProxy.dll",
-        "System.Reflection.DispatchProxy.4.0.1-beta-23429.nupkg",
-        "System.Reflection.DispatchProxy.4.0.1-beta-23429.nupkg.sha512",
+        "System.Reflection.DispatchProxy.4.0.1-beta-23506.nupkg",
+        "System.Reflection.DispatchProxy.4.0.1-beta-23506.nupkg.sha512",
         "System.Reflection.DispatchProxy.nuspec"
       ]
     },
-    "System.Reflection.Emit/4.0.1-beta-23429": {
+    "System.Reflection.Emit/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "rbcPYTLxmAZLpLdnoKF+UaFrdE+siJv/U6nTpv7qHR0W4qXiqoSOQQqjUEZvfiXpx94olJ8bdt0XsZVF+V7ntw==",
+      "sha512": "HeB7pCznsZnNHQBcYWLSSBu2tfYxYy7XgYHZc6dXUYDrN2NnR9olJdmkBnSBJmlVZdiLPhm3VGv/qFh1aDhgCA==",
       "files": [
         "lib/DNXCore50/System.Reflection.Emit.dll",
         "lib/MonoAndroid10/_._",
@@ -16803,15 +16943,15 @@
         "ref/net45/_._",
         "ref/xamarinmac20/_._",
         "runtimes/aot/lib/netcore50/_._",
-        "System.Reflection.Emit.4.0.1-beta-23429.nupkg",
-        "System.Reflection.Emit.4.0.1-beta-23429.nupkg.sha512",
+        "System.Reflection.Emit.4.0.1-beta-23506.nupkg",
+        "System.Reflection.Emit.4.0.1-beta-23506.nupkg.sha512",
         "System.Reflection.Emit.nuspec"
       ]
     },
-    "System.Reflection.Emit.ILGeneration/4.0.1-beta-23429": {
+    "System.Reflection.Emit.ILGeneration/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "L9fXH3Z75ij5gzlhtBToDsi4rH8nOFpUW9hI7uujO8Oh/UszKTYsC7leNw3fvcK4UqEiPAxh7R9oxVE+pjj94g==",
+      "sha512": "ixp8YhJonq4BYoVgjJ1MBzwKHjc6t0I+Vi2OMzkV/1DLLsqovFne9u/7PFbBSsso1a+x1jafyIj5CvI7Rku5BA==",
       "files": [
         "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll",
         "lib/net45/_._",
@@ -16831,15 +16971,15 @@
         "ref/net45/_._",
         "ref/wp80/_._",
         "runtimes/aot/lib/netcore50/_._",
-        "System.Reflection.Emit.ILGeneration.4.0.1-beta-23429.nupkg",
-        "System.Reflection.Emit.ILGeneration.4.0.1-beta-23429.nupkg.sha512",
+        "System.Reflection.Emit.ILGeneration.4.0.1-beta-23506.nupkg",
+        "System.Reflection.Emit.ILGeneration.4.0.1-beta-23506.nupkg.sha512",
         "System.Reflection.Emit.ILGeneration.nuspec"
       ]
     },
-    "System.Reflection.Emit.Lightweight/4.0.1-beta-23429": {
+    "System.Reflection.Emit.Lightweight/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gZvh1Q59uwxy7JMvrBz8fLSpiNtEPekKoF9qzdyDUMWAcO+X/wR9UHPxOD1HG6ZbJ3En6Odldz5HUmXgIi5aUw==",
+      "sha512": "rmE9GE/0G7j9df4O8hbJBNTEJh/01+8N30as38OIkIJwwiK0qBegLHij6FzvhhaVjkxAxbe02TyMib4RsXCG9Q==",
       "files": [
         "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll",
         "lib/net45/_._",
@@ -16859,15 +16999,15 @@
         "ref/net45/_._",
         "ref/wp80/_._",
         "runtimes/aot/lib/netcore50/_._",
-        "System.Reflection.Emit.Lightweight.4.0.1-beta-23429.nupkg",
-        "System.Reflection.Emit.Lightweight.4.0.1-beta-23429.nupkg.sha512",
+        "System.Reflection.Emit.Lightweight.4.0.1-beta-23506.nupkg",
+        "System.Reflection.Emit.Lightweight.4.0.1-beta-23506.nupkg.sha512",
         "System.Reflection.Emit.Lightweight.nuspec"
       ]
     },
-    "System.Reflection.Extensions/4.0.1-beta-23429": {
+    "System.Reflection.Extensions/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "LIUtHNsUNPSLKkiOpnaOTnXzT/Ed3jANyvhKaf7/QRkxtxjJSFLSzzzIGZfpGOA4KOwmcsniSh0kZpSv51qu3A==",
+      "sha512": "8d4PRpBVlfcFzgzUvK6enn1uIkBiweQBD82pXLWk5w36Uu1vGz/GIrlMVWvqETs60gxPBR/TEyprx3Z1SQMxww==",
       "files": [
         "lib/DNXCore50/System.Reflection.Extensions.dll",
         "lib/net45/_._",
@@ -16902,29 +17042,29 @@
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
-        "System.Reflection.Extensions.4.0.1-beta-23429.nupkg",
-        "System.Reflection.Extensions.4.0.1-beta-23429.nupkg.sha512",
+        "System.Reflection.Extensions.4.0.1-beta-23506.nupkg",
+        "System.Reflection.Extensions.4.0.1-beta-23506.nupkg.sha512",
         "System.Reflection.Extensions.nuspec"
       ]
     },
-    "System.Reflection.Metadata/1.1.1-beta-23429": {
+    "System.Reflection.Metadata/1.1.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "tZk4Gd+xRdhCFkZfJt2J9To1K1NMmoMu97Zj+4eOl69KvRN6lTYTjXQlkkf4+8y1kXnvsA4lb6QiqWMpN33h5Q==",
+      "sha512": "WYgRbiSV1s/55NkC+TWrlIM2shQ4kPanTcr/GaZLAHeHt6NP0FjXlODsoCmRa5cTEdwe1JExaIkBAdR91W24KQ==",
       "files": [
         "lib/dotnet5.2/System.Reflection.Metadata.dll",
         "lib/dotnet5.2/System.Reflection.Metadata.xml",
         "lib/portable-net45+win8/System.Reflection.Metadata.dll",
         "lib/portable-net45+win8/System.Reflection.Metadata.xml",
-        "System.Reflection.Metadata.1.1.1-beta-23429.nupkg",
-        "System.Reflection.Metadata.1.1.1-beta-23429.nupkg.sha512",
+        "System.Reflection.Metadata.1.1.1-beta-23506.nupkg",
+        "System.Reflection.Metadata.1.1.1-beta-23506.nupkg.sha512",
         "System.Reflection.Metadata.nuspec"
       ]
     },
-    "System.Reflection.Primitives/4.0.1-beta-23429": {
+    "System.Reflection.Primitives/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "TldMrURn8hjyJbMiyeNS1JMfuozWSD+IcAqcmx7trTdH3LoxY1XrnGgUtg7fPEQrRXZxOhxRJy4JEyq/Xz+dKA==",
+      "sha512": "F28hjA9Nfld6UFN8Qkbw5swEYqb4B4qrY6UzWKwdeiBDE9wF9oYZyRIO2MLiqeH/DgFxNhO96Wi/awqokju7Tw==",
       "files": [
         "lib/DNXCore50/System.Reflection.Primitives.dll",
         "lib/net45/_._",
@@ -16959,15 +17099,15 @@
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
-        "System.Reflection.Primitives.4.0.1-beta-23429.nupkg",
-        "System.Reflection.Primitives.4.0.1-beta-23429.nupkg.sha512",
+        "System.Reflection.Primitives.4.0.1-beta-23506.nupkg",
+        "System.Reflection.Primitives.4.0.1-beta-23506.nupkg.sha512",
         "System.Reflection.Primitives.nuspec"
       ]
     },
-    "System.Reflection.TypeExtensions/4.1.0-beta-23429": {
+    "System.Reflection.TypeExtensions/4.1.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bn5zy5zYqKI3vYKR59ycERwyrfHYtdYc0EJZVJAaojU1oYAS8v87rczawqL0gya8uQJbUx8AkmH+TVhlkfXz/w==",
+      "sha512": "H4K1TwRsKOlVAxZEUXqPBQUUx+w3A2fk4IKquXk6RBimV4y/wsrIK2Layir+P+8C4f+S9QkoXLA2du7+85EdWA==",
       "files": [
         "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
         "lib/MonoAndroid10/_._",
@@ -16976,32 +17116,32 @@
         "lib/netcore50/System.Reflection.TypeExtensions.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet5.1/es/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet5.1/fr/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet5.1/it/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet5.1/ja/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet5.1/ko/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet5.1/ru/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet5.1/System.Reflection.TypeExtensions.dll",
-        "ref/dotnet5.1/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet5.1/zh-hans/System.Reflection.TypeExtensions.xml",
-        "ref/dotnet5.1/zh-hant/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet5.4/de/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet5.4/es/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet5.4/fr/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet5.4/it/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet5.4/ja/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet5.4/ko/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet5.4/ru/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet5.4/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet5.4/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet5.4/zh-hans/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet5.4/zh-hant/System.Reflection.TypeExtensions.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Reflection.TypeExtensions.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
-        "System.Reflection.TypeExtensions.4.1.0-beta-23429.nupkg",
-        "System.Reflection.TypeExtensions.4.1.0-beta-23429.nupkg.sha512",
+        "System.Reflection.TypeExtensions.4.1.0-beta-23506.nupkg",
+        "System.Reflection.TypeExtensions.4.1.0-beta-23506.nupkg.sha512",
         "System.Reflection.TypeExtensions.nuspec"
       ]
     },
-    "System.Resources.ReaderWriter/4.0.0-beta-23429": {
+    "System.Resources.ReaderWriter/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "WguJVXtebpMaq/tHEd05sen1PlYl+C0r4IB/vIFnbhljBc3fTcBdD8tIM3Iu4EYfSTKFQ7Iz499UTSPxc58NKw==",
+      "sha512": "6IHEitWg2vm4t3bbK62gpfPapLiO7emahTF/Y1GobNr4zFvTcorieAj0c2XJ5Rz34VoC2VX9jdgF6yajVZAcXQ==",
       "files": [
         "lib/DNXCore50/System.Resources.ReaderWriter.dll",
         "lib/MonoAndroid10/_._",
@@ -17009,31 +17149,31 @@
         "lib/net46/System.Resources.ReaderWriter.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.Resources.ReaderWriter.xml",
-        "ref/dotnet5.1/es/System.Resources.ReaderWriter.xml",
-        "ref/dotnet5.1/fr/System.Resources.ReaderWriter.xml",
-        "ref/dotnet5.1/it/System.Resources.ReaderWriter.xml",
-        "ref/dotnet5.1/ja/System.Resources.ReaderWriter.xml",
-        "ref/dotnet5.1/ko/System.Resources.ReaderWriter.xml",
-        "ref/dotnet5.1/ru/System.Resources.ReaderWriter.xml",
-        "ref/dotnet5.1/System.Resources.ReaderWriter.dll",
-        "ref/dotnet5.1/System.Resources.ReaderWriter.xml",
-        "ref/dotnet5.1/zh-hans/System.Resources.ReaderWriter.xml",
-        "ref/dotnet5.1/zh-hant/System.Resources.ReaderWriter.xml",
+        "ref/dotnet5.4/de/System.Resources.ReaderWriter.xml",
+        "ref/dotnet5.4/es/System.Resources.ReaderWriter.xml",
+        "ref/dotnet5.4/fr/System.Resources.ReaderWriter.xml",
+        "ref/dotnet5.4/it/System.Resources.ReaderWriter.xml",
+        "ref/dotnet5.4/ja/System.Resources.ReaderWriter.xml",
+        "ref/dotnet5.4/ko/System.Resources.ReaderWriter.xml",
+        "ref/dotnet5.4/ru/System.Resources.ReaderWriter.xml",
+        "ref/dotnet5.4/System.Resources.ReaderWriter.dll",
+        "ref/dotnet5.4/System.Resources.ReaderWriter.xml",
+        "ref/dotnet5.4/zh-hans/System.Resources.ReaderWriter.xml",
+        "ref/dotnet5.4/zh-hant/System.Resources.ReaderWriter.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Resources.ReaderWriter.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Resources.ReaderWriter.4.0.0-beta-23429.nupkg",
-        "System.Resources.ReaderWriter.4.0.0-beta-23429.nupkg.sha512",
+        "System.Resources.ReaderWriter.4.0.0-beta-23506.nupkg",
+        "System.Resources.ReaderWriter.4.0.0-beta-23506.nupkg.sha512",
         "System.Resources.ReaderWriter.nuspec"
       ]
     },
-    "System.Resources.ResourceManager/4.0.1-beta-23429": {
+    "System.Resources.ResourceManager/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "KGoTemNd76d7dJhUfc6hSZMMlDISNjTwyh6KfwIbqkuDrwJYz29PFDZ5CVabCN4zJ+PZKuUuNGtzzPDd8f4FZA==",
+      "sha512": "N3L7bwTGyQ9nIhMzPg4Lq8uOe3LEpMw9gs32fM1or33ZClRPedfApMwSdv7O/OtkAVkMF4WVC3quSbWlCTIn1w==",
       "files": [
         "lib/DNXCore50/System.Resources.ResourceManager.dll",
         "lib/net45/_._",
@@ -17068,15 +17208,15 @@
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
-        "System.Resources.ResourceManager.4.0.1-beta-23429.nupkg",
-        "System.Resources.ResourceManager.4.0.1-beta-23429.nupkg.sha512",
+        "System.Resources.ResourceManager.4.0.1-beta-23506.nupkg",
+        "System.Resources.ResourceManager.4.0.1-beta-23506.nupkg.sha512",
         "System.Resources.ResourceManager.nuspec"
       ]
     },
-    "System.Runtime/4.0.21-beta-23429": {
+    "System.Runtime/4.0.21-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Py96w2WPgphlLVK2vi7zj8mC/gbHM8GcmzyRNhCY64ym6z8AIoE4zO9rIvdwDr8/p6MkG1O3Z3dbczHJh9TIPQ==",
+      "sha512": "m0emcn0QKtlzjM/F1DCYm4aZOT+MT6gJqU6rcC/suE0QxuVdxSLDbeWM8S7SgIDb047HIMbaOUOP+pCkbS25Rw==",
       "files": [
         "lib/DNXCore50/System.Runtime.dll",
         "lib/MonoAndroid10/_._",
@@ -17141,15 +17281,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
-        "System.Runtime.4.0.21-beta-23429.nupkg",
-        "System.Runtime.4.0.21-beta-23429.nupkg.sha512",
+        "System.Runtime.4.0.21-beta-23506.nupkg",
+        "System.Runtime.4.0.21-beta-23506.nupkg.sha512",
         "System.Runtime.nuspec"
       ]
     },
-    "System.Runtime.CompilerServices.VisualC/4.0.0-beta-23429": {
+    "System.Runtime.CompilerServices.VisualC/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "vC3NEIC8INGFnlx+temT3J/y+JJ0sV6gLx7aAGNZQRSP36j0hN6QdNM95ilCQZkPzKOfe0FVIJ8q2vHE5EerXA==",
+      "sha512": "q6dT9Y8AnRC6rWEBWtIrcaajL6+9JLvJdWjV9qCSuu4RlkXMOSAb+kOCSfa9TE76FmQLk1AZHIUGcz/AApn6GQ==",
       "files": [
         "lib/DNXCore50/System.Runtime.CompilerServices.VisualC.dll",
         "lib/MonoAndroid10/_._",
@@ -17157,31 +17297,31 @@
         "lib/net46/System.Runtime.CompilerServices.VisualC.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.Runtime.CompilerServices.VisualC.xml",
-        "ref/dotnet5.1/es/System.Runtime.CompilerServices.VisualC.xml",
-        "ref/dotnet5.1/fr/System.Runtime.CompilerServices.VisualC.xml",
-        "ref/dotnet5.1/it/System.Runtime.CompilerServices.VisualC.xml",
-        "ref/dotnet5.1/ja/System.Runtime.CompilerServices.VisualC.xml",
-        "ref/dotnet5.1/ko/System.Runtime.CompilerServices.VisualC.xml",
-        "ref/dotnet5.1/ru/System.Runtime.CompilerServices.VisualC.xml",
-        "ref/dotnet5.1/System.Runtime.CompilerServices.VisualC.dll",
-        "ref/dotnet5.1/System.Runtime.CompilerServices.VisualC.xml",
-        "ref/dotnet5.1/zh-hans/System.Runtime.CompilerServices.VisualC.xml",
-        "ref/dotnet5.1/zh-hant/System.Runtime.CompilerServices.VisualC.xml",
+        "ref/dotnet5.4/de/System.Runtime.CompilerServices.VisualC.xml",
+        "ref/dotnet5.4/es/System.Runtime.CompilerServices.VisualC.xml",
+        "ref/dotnet5.4/fr/System.Runtime.CompilerServices.VisualC.xml",
+        "ref/dotnet5.4/it/System.Runtime.CompilerServices.VisualC.xml",
+        "ref/dotnet5.4/ja/System.Runtime.CompilerServices.VisualC.xml",
+        "ref/dotnet5.4/ko/System.Runtime.CompilerServices.VisualC.xml",
+        "ref/dotnet5.4/ru/System.Runtime.CompilerServices.VisualC.xml",
+        "ref/dotnet5.4/System.Runtime.CompilerServices.VisualC.dll",
+        "ref/dotnet5.4/System.Runtime.CompilerServices.VisualC.xml",
+        "ref/dotnet5.4/zh-hans/System.Runtime.CompilerServices.VisualC.xml",
+        "ref/dotnet5.4/zh-hant/System.Runtime.CompilerServices.VisualC.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Runtime.CompilerServices.VisualC.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Runtime.CompilerServices.VisualC.4.0.0-beta-23429.nupkg",
-        "System.Runtime.CompilerServices.VisualC.4.0.0-beta-23429.nupkg.sha512",
+        "System.Runtime.CompilerServices.VisualC.4.0.0-beta-23506.nupkg",
+        "System.Runtime.CompilerServices.VisualC.4.0.0-beta-23506.nupkg.sha512",
         "System.Runtime.CompilerServices.VisualC.nuspec"
       ]
     },
-    "System.Runtime.Extensions/4.0.11-beta-23429": {
+    "System.Runtime.Extensions/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "syz5pqIZHrY8eWetFWX4u5+doPXIhzFg8V6gAaiEqQFbAhyU4Ua9aX1L75jekJrH1sNDrqSAa/mBxe3uY6RMEQ==",
+      "sha512": "3gAc1WUYHjlu0d2X3JZXRH9sCXsQQgF4IQqaV9Cznx0kAZtam81JPXQzujATCU9ESlK6EzZ6WxAey5E7Yyi3tA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -17233,15 +17373,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Runtime.Extensions.4.0.11-beta-23429.nupkg",
-        "System.Runtime.Extensions.4.0.11-beta-23429.nupkg.sha512",
+        "System.Runtime.Extensions.4.0.11-beta-23506.nupkg",
+        "System.Runtime.Extensions.4.0.11-beta-23506.nupkg.sha512",
         "System.Runtime.Extensions.nuspec"
       ]
     },
-    "System.Runtime.Handles/4.0.1-beta-23429": {
+    "System.Runtime.Handles/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "buKDz7nTAGBDLL5HDhOOpk5IVcXtq5s+FxHf+GeG/4XfZmsf+4Cb3QTlQxN611Twzde2+pdhZLXRfMVBUNaJVg==",
+      "sha512": "jKd2rHTckr6pbzGtTtJuvGBv3SJky2TDgkmFLRYfAUnwOaqKgKKh/mO/6g34lq1gyWy7WjXa5BOWiaR9erJ2SQ==",
       "files": [
         "lib/DNXCore50/System.Runtime.Handles.dll",
         "lib/MonoAndroid10/_._",
@@ -17267,15 +17407,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
-        "System.Runtime.Handles.4.0.1-beta-23429.nupkg",
-        "System.Runtime.Handles.4.0.1-beta-23429.nupkg.sha512",
+        "System.Runtime.Handles.4.0.1-beta-23506.nupkg",
+        "System.Runtime.Handles.4.0.1-beta-23506.nupkg.sha512",
         "System.Runtime.Handles.nuspec"
       ]
     },
-    "System.Runtime.InteropServices/4.0.21-beta-23429": {
+    "System.Runtime.InteropServices/4.0.21-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fntGsjslW/iLSCvfWBrga23qaKeeVGT0CaN/xxEeT+lBsaFU3agbN4xzQubi2whELhHaKnta8u15fGRRXhloCg==",
+      "sha512": "xf5VWhV9XbZzu8F9KhKntIXPVYM4/i0hXYTV75G8s7ZOJ0BsESwPDmNQGkRZLx/oDHWZrmjyKYhqaNmQFYjpHQ==",
       "files": [
         "lib/DNXCore50/System.Runtime.InteropServices.dll",
         "lib/MonoAndroid10/_._",
@@ -17338,35 +17478,35 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
-        "System.Runtime.InteropServices.4.0.21-beta-23429.nupkg",
-        "System.Runtime.InteropServices.4.0.21-beta-23429.nupkg.sha512",
+        "System.Runtime.InteropServices.4.0.21-beta-23506.nupkg",
+        "System.Runtime.InteropServices.4.0.21-beta-23506.nupkg.sha512",
         "System.Runtime.InteropServices.nuspec"
       ]
     },
-    "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23429": {
+    "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "PL64fcZClO39Oz9jURj9HG0JD2t0a/Ok6VfcCo4JyaSto/Wf8CVWERNu7ztgTKy980iyII8zOAoCBf341CzhPQ==",
+      "sha512": "jmcDt1o5+Sg928HM7R0C60nPdaOEY6X7fX+SMt/J6a+NCpysF6GBeOf8DJFAjE1dKRi+4GPssimsJbL9QzbILw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll",
+        "ref/dotnet5.2/System.Runtime.InteropServices.RuntimeInformation.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23429.nupkg",
-        "System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23429.nupkg.sha512",
+        "System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23506.nupkg",
+        "System.Runtime.InteropServices.RuntimeInformation.4.0.0-beta-23506.nupkg.sha512",
         "System.Runtime.InteropServices.RuntimeInformation.nuspec"
       ]
     },
-    "System.Runtime.Loader/4.0.0-beta-23429": {
+    "System.Runtime.Loader/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "btDKGnfr9lWFzRe6do7oL0yKRuSHkqnjIgeEGTwD4CUlh4bbEtHD6rArREff63ax/1Q/YmkzxzoHes/dfG88Kw==",
+      "sha512": "TlU+pfqzO6kqlTGgWDy8xpXkSltDnCYyVlvo1T9SX/+BPN1PdGosVM+/y/X2xKLLhfrDvi3/PRbISbHFTtx3cA==",
       "files": [
         "lib/DNXCore50/System.Runtime.Loader.dll",
         "ref/dotnet5.1/de/System.Runtime.Loader.xml",
@@ -17380,15 +17520,15 @@
         "ref/dotnet5.1/System.Runtime.Loader.xml",
         "ref/dotnet5.1/zh-hans/System.Runtime.Loader.xml",
         "ref/dotnet5.1/zh-hant/System.Runtime.Loader.xml",
-        "System.Runtime.Loader.4.0.0-beta-23429.nupkg",
-        "System.Runtime.Loader.4.0.0-beta-23429.nupkg.sha512",
+        "System.Runtime.Loader.4.0.0-beta-23506.nupkg",
+        "System.Runtime.Loader.4.0.0-beta-23506.nupkg.sha512",
         "System.Runtime.Loader.nuspec"
       ]
     },
-    "System.Runtime.Numerics/4.0.1-beta-23429": {
+    "System.Runtime.Numerics/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "nGDWH9Z7CVWV8gZP+YDz5WQFfo4E7n1VpjBBbIoxD9GkFbJIBqSUMV0cx4uKlUg7mpH1p0AgpUg668wOrQvWCg==",
+      "sha512": "TX6eF6pcizPgqcPHepHwOWCT+HlUDu4PbbnZ3uNKd/UPvgoVh5uJ8aPz5vkIE3difQa0l7+da80JEBD1G105QQ==",
       "files": [
         "lib/dotnet5.4/System.Runtime.Numerics.dll",
         "lib/net45/_._",
@@ -17420,15 +17560,15 @@
         "ref/netcore50/zh-hant/System.Runtime.Numerics.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
-        "System.Runtime.Numerics.4.0.1-beta-23429.nupkg",
-        "System.Runtime.Numerics.4.0.1-beta-23429.nupkg.sha512",
+        "System.Runtime.Numerics.4.0.1-beta-23506.nupkg",
+        "System.Runtime.Numerics.4.0.1-beta-23506.nupkg.sha512",
         "System.Runtime.Numerics.nuspec"
       ]
     },
-    "System.Runtime.Serialization.Json/4.0.1-beta-23429": {
+    "System.Runtime.Serialization.Json/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "+NrXpYCfQcqWiBzKW2vtf3MdE8ZQkIixI4RhATkjiwHfgkAcgKZP0x3fcWmt0avYcvU3ks27qcUg3zdBAIKpfA==",
+      "sha512": "dybvU1HPDf/J1vMu9MIGaGq/PdIxS9P7x9I/2eOUNwTirWrsQChEWHgFs8LZjhSQAVw2nsAksThI4DRmnwEUYQ==",
       "files": [
         "lib/DNXCore50/System.Runtime.Serialization.Json.dll",
         "lib/net45/_._",
@@ -17463,15 +17603,15 @@
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Json.dll",
-        "System.Runtime.Serialization.Json.4.0.1-beta-23429.nupkg",
-        "System.Runtime.Serialization.Json.4.0.1-beta-23429.nupkg.sha512",
+        "System.Runtime.Serialization.Json.4.0.1-beta-23506.nupkg",
+        "System.Runtime.Serialization.Json.4.0.1-beta-23506.nupkg.sha512",
         "System.Runtime.Serialization.Json.nuspec"
       ]
     },
-    "System.Runtime.Serialization.Primitives/4.1.0-beta-23429": {
+    "System.Runtime.Serialization.Primitives/4.1.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "kzIWcHeypP1IwNj6s8dGJ9LWWGaiRcUfdwsuM/mXWxM2CRCMS6Qc/okws6NiA6zcMaxcmxHztO6xudk7XjLYKQ==",
+      "sha512": "Lw8kqRXXU/QfeGt8Eui1sl8Td6t7ZRlRdlMDtFhrGWw+NOrwJl3aVSi394sLh0JIXM18jNDms3t1cPql9DZy3g==",
       "files": [
         "lib/dotnet5.4/System.Runtime.Serialization.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -17524,15 +17664,15 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Runtime.Serialization.Primitives.4.1.0-beta-23429.nupkg",
-        "System.Runtime.Serialization.Primitives.4.1.0-beta-23429.nupkg.sha512",
+        "System.Runtime.Serialization.Primitives.4.1.0-beta-23506.nupkg",
+        "System.Runtime.Serialization.Primitives.4.1.0-beta-23506.nupkg.sha512",
         "System.Runtime.Serialization.Primitives.nuspec"
       ]
     },
-    "System.Runtime.Serialization.Xml/4.1.0-beta-23429": {
+    "System.Runtime.Serialization.Xml/4.1.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VrUCWYA7Okmc+K/IqGGlbjrnTSJvdtWdj7Ku+2Ta6EHOMIccMBBGMspG+m93/TrNZixmklBzz2UKHpDjNB+Q3Q==",
+      "sha512": "AiJECIEUp4/PeVqswwWnvF5QnT96cxykO4cAJTa0wFUmgBO5Ie1VhwrIoYVvUAfINOJKpckU3R+QhBkCAX/UAA==",
       "files": [
         "lib/DNXCore50/System.Runtime.Serialization.Xml.dll",
         "lib/MonoAndroid10/_._",
@@ -17586,15 +17726,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll",
-        "System.Runtime.Serialization.Xml.4.1.0-beta-23429.nupkg",
-        "System.Runtime.Serialization.Xml.4.1.0-beta-23429.nupkg.sha512",
+        "System.Runtime.Serialization.Xml.4.1.0-beta-23506.nupkg",
+        "System.Runtime.Serialization.Xml.4.1.0-beta-23506.nupkg.sha512",
         "System.Runtime.Serialization.Xml.nuspec"
       ]
     },
-    "System.Security.Claims/4.0.1-beta-23429": {
+    "System.Security.Claims/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "oMctwDBSwpcjQOBVD2yW7RBQB5Pjzoihs/Uux+1lI+t74l3mjfpD9tGC8YfRBDaTeRczvnRqSaAtLJPA8EOGDw==",
+      "sha512": "TEQSybWBKEfwn/QxPHODSiBnGDB1/wP4DPsjX5GOA3iUNx2kITbFPlGbbs9lbT3aufYbXD+9R8weIBScVAg/vQ==",
       "files": [
         "lib/dotnet5.4/System.Security.Claims.dll",
         "lib/MonoAndroid10/_._",
@@ -17602,67 +17742,67 @@
         "lib/net46/System.Security.Claims.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.Security.Claims.xml",
-        "ref/dotnet5.1/es/System.Security.Claims.xml",
-        "ref/dotnet5.1/fr/System.Security.Claims.xml",
-        "ref/dotnet5.1/it/System.Security.Claims.xml",
-        "ref/dotnet5.1/ja/System.Security.Claims.xml",
-        "ref/dotnet5.1/ko/System.Security.Claims.xml",
-        "ref/dotnet5.1/ru/System.Security.Claims.xml",
-        "ref/dotnet5.1/System.Security.Claims.dll",
-        "ref/dotnet5.1/System.Security.Claims.xml",
-        "ref/dotnet5.1/zh-hans/System.Security.Claims.xml",
-        "ref/dotnet5.1/zh-hant/System.Security.Claims.xml",
+        "ref/dotnet5.4/de/System.Security.Claims.xml",
+        "ref/dotnet5.4/es/System.Security.Claims.xml",
+        "ref/dotnet5.4/fr/System.Security.Claims.xml",
+        "ref/dotnet5.4/it/System.Security.Claims.xml",
+        "ref/dotnet5.4/ja/System.Security.Claims.xml",
+        "ref/dotnet5.4/ko/System.Security.Claims.xml",
+        "ref/dotnet5.4/ru/System.Security.Claims.xml",
+        "ref/dotnet5.4/System.Security.Claims.dll",
+        "ref/dotnet5.4/System.Security.Claims.xml",
+        "ref/dotnet5.4/zh-hans/System.Security.Claims.xml",
+        "ref/dotnet5.4/zh-hant/System.Security.Claims.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Claims.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Claims.4.0.1-beta-23429.nupkg",
-        "System.Security.Claims.4.0.1-beta-23429.nupkg.sha512",
+        "System.Security.Claims.4.0.1-beta-23506.nupkg",
+        "System.Security.Claims.4.0.1-beta-23506.nupkg.sha512",
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23429": {
+    "System.Security.Cryptography.Algorithms/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "/og4dlxdlMUsqpeZHK32C4AqGpF5chvN8bd37rYcEkihw7sGVqMP0rKGocjMXrhDAOYZaTBUxdzGbQkIX8VE/Q==",
+      "sha512": "Oc6fG3adDwQqx+xi9oVdxJCaXOJwA8Smph8ADOCUK5Z8NYhTOHB/WOSdJWvnozFoyBWLhHW8FGc88fL2lCKTFw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Algorithms.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/System.Security.Cryptography.Algorithms.dll",
+        "ref/dotnet5.4/System.Security.Cryptography.Algorithms.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Algorithms.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23429.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23429.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23506.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-beta-23506.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Cng/4.0.0-beta-23429": {
+    "System.Security.Cryptography.Cng/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2Tbhih8tlWopK7q/6Ag0xwtcduIKUKd/BWxRG0U0FJXr8+7qUE4yMpW9GdD4B9dcQf1qrnn12Y42AScQX9LYaA==",
+      "sha512": "fNittx7X00uUpEA7DSycxRiLADKbKfwUrGwCIRXQwLLG/v4Qr9lwYPUOuazoCy8pjfiSfIdhPGCar/J2J0gXpA==",
       "files": [
         "lib/dotnet5.4/System.Security.Cryptography.Cng.dll",
         "lib/net46/System.Security.Cryptography.Cng.dll",
-        "ref/dotnet5.2/System.Security.Cryptography.Cng.dll",
+        "ref/dotnet5.4/System.Security.Cryptography.Cng.dll",
         "ref/net46/System.Security.Cryptography.Cng.dll",
-        "System.Security.Cryptography.Cng.4.0.0-beta-23429.nupkg",
-        "System.Security.Cryptography.Cng.4.0.0-beta-23429.nupkg.sha512",
+        "System.Security.Cryptography.Cng.4.0.0-beta-23506.nupkg",
+        "System.Security.Cryptography.Cng.4.0.0-beta-23506.nupkg.sha512",
         "System.Security.Cryptography.Cng.nuspec"
       ]
     },
-    "System.Security.Cryptography.Csp/4.0.0-beta-23429": {
+    "System.Security.Cryptography.Csp/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "q0A5yBHeTfD0CMyXscKSJhp5zF1sJ8an5+M3ECFa/zMwIAmGZaXLX/iuhF+eQKQkOLzoHXIh6qdPIH3Umbhfnw==",
+      "sha512": "TpqVfCEnVXNRYfMOJcHUGXuTrDXHERsd0h0h+N8DrC5x71Z0vD+uo2L/bqRU58MMMZbNrrGKX6VfIKQzq7UHWQ==",
       "files": [
         "lib/DNXCore50/System.Security.Cryptography.Csp.dll",
         "lib/MonoAndroid10/_._",
@@ -17670,65 +17810,65 @@
         "lib/net46/System.Security.Cryptography.Csp.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/System.Security.Cryptography.Csp.dll",
+        "ref/dotnet5.4/System.Security.Cryptography.Csp.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Csp.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Csp.4.0.0-beta-23429.nupkg",
-        "System.Security.Cryptography.Csp.4.0.0-beta-23429.nupkg.sha512",
+        "System.Security.Cryptography.Csp.4.0.0-beta-23506.nupkg",
+        "System.Security.Cryptography.Csp.4.0.0-beta-23506.nupkg.sha512",
         "System.Security.Cryptography.Csp.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23429": {
+    "System.Security.Cryptography.Encoding/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "STKZkoANDE+uhzSpZY4rVsN8Cz6c2pG7TYJ4yX5WetQg2x4wxYClazASmpku/saSMOGzSp33B3d62RnCPaB+PQ==",
+      "sha512": "mxbJvzqlJg5E5Uc1QA0B8hPSi011wDxHZ6yHWH1LFLU8lW5HE+CTuhJvo91QCfma9cidhERom/90OgZHe/p7mw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/System.Security.Cryptography.Encoding.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.1/es/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.1/fr/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.1/it/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.1/ja/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.1/ko/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.1/ru/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.1/System.Security.Cryptography.Encoding.dll",
-        "ref/dotnet5.1/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.1/zh-hans/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.1/zh-hant/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet5.4/de/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet5.4/es/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet5.4/fr/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet5.4/it/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet5.4/ja/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet5.4/ko/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet5.4/ru/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet5.4/System.Security.Cryptography.Encoding.dll",
+        "ref/dotnet5.4/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet5.4/zh-hans/System.Security.Cryptography.Encoding.xml",
+        "ref/dotnet5.4/zh-hant/System.Security.Cryptography.Encoding.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Encoding.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23429.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23429.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23506.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-beta-23506.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.OpenSsl/4.0.0-beta-23429": {
+    "System.Security.Cryptography.OpenSsl/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "qsmOowMXcmx8eqQTtcoQCZ74WWovscgbTsawpr/R72Laq2xGKFn2Mj3NZQCSfKhSWAvtOtzTXTeedfl754tUXg==",
+      "sha512": "wnBN5e4Q5w+p//Vex0xBko2WiwV0LaKWKgQbH/uyQx9Hmz1aTZuwuw0ayiZNrYX3TBQEgfBDp8yPxdMNLNHyrQ==",
       "files": [
         "ref/dotnet5.4/System.Security.Cryptography.OpenSsl.dll",
         "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.OpenSsl.dll",
-        "System.Security.Cryptography.OpenSsl.4.0.0-beta-23429.nupkg",
-        "System.Security.Cryptography.OpenSsl.4.0.0-beta-23429.nupkg.sha512",
+        "System.Security.Cryptography.OpenSsl.4.0.0-beta-23506.nupkg",
+        "System.Security.Cryptography.OpenSsl.4.0.0-beta-23506.nupkg.sha512",
         "System.Security.Cryptography.OpenSsl.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23429": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "9TTbaRqupSB3pPFKI+t4HHjwivq2PQEQkuO1UH4ZT/vflkACp/Qht4dTmmWYm5x+cIIBU3rUeNWipYjZ/YNC3w==",
+      "sha512": "53QKTzQIXvUzkcLyCqYLIGxXfVy3JRjDJWwih2rl61wGhusaY6nn8tu3IV9rYsIkFGpdOhScUjW93N7ADu4YjQ==",
       "files": [
         "lib/dotnet5.4/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -17736,21 +17876,21 @@
         "lib/net46/System.Security.Cryptography.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/System.Security.Cryptography.Primitives.dll",
+        "ref/dotnet5.4/System.Security.Cryptography.Primitives.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23429.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23429.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23506.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23506.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23429": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "tW8zhHUG/ZY2dxObdAajCbus8FSe6GdykMSUFbowQBZpgli6Gu5slDVwiiSUWOXZLZcSLVefEpnZbWqU9exZEQ==",
+      "sha512": "q89O276lHrUiDX5GavkT3LnHsLuWr+ViWrGzreWHL4Xr4q9bN/8Yz5XVvNAhNXpXp0YOCV2U5mfmFpNdcgfwNA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -17774,15 +17914,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23429.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23429.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23506.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23506.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
-    "System.Security.Principal/4.0.1-beta-23429": {
+    "System.Security.Principal/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "AXIZr1l9GAaOS7qXwlfVSe9rcbBaEuhbTgBp/fMUTLjODzXiuNU1oNRpL5q/EsI31Urs/+AcXup0mHscRwbBeQ==",
+      "sha512": "aExlQVRppUoHZnPLZS5PG+DVl5ofpX1vGE3IeZNpc9F5bSt9s1zJOe+YH6Y2Z4WgOllliSNxPGvKYeWsZi7h7A==",
       "files": [
         "lib/dotnet5.1/System.Security.Principal.dll",
         "lib/net45/_._",
@@ -17816,15 +17956,15 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "System.Security.Principal.4.0.1-beta-23429.nupkg",
-        "System.Security.Principal.4.0.1-beta-23429.nupkg.sha512",
+        "System.Security.Principal.4.0.1-beta-23506.nupkg",
+        "System.Security.Principal.4.0.1-beta-23506.nupkg.sha512",
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-beta-23429": {
+    "System.Security.Principal.Windows/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "X3APdvYQQ2BUXI0oyDgJUjDPSQzK+rmG//icSdyjGTZ6SQ2NCAEKapvFNrnnMwnBjPaCvpxjj8qC7IvDmrP5sg==",
+      "sha512": "7OXeP881m1GbK/HvBArocQvtW2R6ctRrpzhsBan3uQ3OssMgjjWXuHhYbP//4tLHTOR3lDQYL9Jtgow7Mlov9A==",
       "files": [
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
         "lib/net46/System.Security.Principal.Windows.dll",
@@ -17840,15 +17980,15 @@
         "ref/dotnet5.4/zh-hans/System.Security.Principal.Windows.xml",
         "ref/dotnet5.4/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23429.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23429.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-beta-23506.nupkg",
+        "System.Security.Principal.Windows.4.0.0-beta-23506.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Duplex/4.0.1-beta-23429": {
+    "System.ServiceModel.Duplex/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "tXdKxDSK967ig1hhtnDKeiTR3/4A8HbYKy1Hee8emu2EKfSFaP1dSXRmIItEm+Uy5TIpkRdX1Og8CqFAKScUXw==",
+      "sha512": "cdzzRstKQQBX0+hNXMMSgHpgLF6ujuMnr9ktCIhJ4PT223wcaT2occ9KzEY8UHBVx4quI0yF1QaeVDssb2LOPA==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
@@ -17878,15 +18018,15 @@
         "ref/netcore50/zh-hans/System.ServiceModel.Duplex.xml",
         "ref/netcore50/zh-hant/System.ServiceModel.Duplex.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Duplex.4.0.1-beta-23429.nupkg",
-        "System.ServiceModel.Duplex.4.0.1-beta-23429.nupkg.sha512",
+        "System.ServiceModel.Duplex.4.0.1-beta-23506.nupkg",
+        "System.ServiceModel.Duplex.4.0.1-beta-23506.nupkg.sha512",
         "System.ServiceModel.Duplex.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-beta-23429": {
+    "System.ServiceModel.Http/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "+8RtelYU3mFzOhuec+k02T5Vw0xDGMlwnQCGF5uMfxRu8zsQJq1ohTipMCMT9OLBBN2SHEN3qvmMiSoJh/0SDw==",
+      "sha512": "yQo1UyHdn2qJkMoaTXcVRiMyQTylYJZUiIH0/FEF3buOYHMiDZelnmmCfKJwdLeslRpqrENn5V4ae5LuVsh4sQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -17948,15 +18088,15 @@
         "ref/wp80/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-beta-23429.nupkg",
-        "System.ServiceModel.Http.4.0.11-beta-23429.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-beta-23506.nupkg",
+        "System.ServiceModel.Http.4.0.11-beta-23506.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.1.0-beta-23429": {
+    "System.ServiceModel.NetTcp/4.1.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "X7R8aXUg8DOWOOMHx3uB+JhksJCUdlLDfTZtJM6x3OlcIhO/cy6ZXnrKGmMURXrNmmqIXI+Hza9QQU22vGQ4hA==",
+      "sha512": "S56NguabOE7BFwBoraWibuT/LuocNEzPd4x1BPkhs7nx0L93qzSWw+dljepX4xC3Ne7XztxD7W8X81i9XdMXvA==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
@@ -17999,15 +18139,15 @@
         "ref/netcore50/zh-hans/System.ServiceModel.NetTcp.xml",
         "ref/netcore50/zh-hant/System.ServiceModel.NetTcp.xml",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.1.0-beta-23429.nupkg",
-        "System.ServiceModel.NetTcp.4.1.0-beta-23429.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.1.0-beta-23506.nupkg",
+        "System.ServiceModel.NetTcp.4.1.0-beta-23506.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.1.0-beta-23429": {
+    "System.ServiceModel.Primitives/4.1.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ceP0yz1hBFNmv71ZYw0JQko8+5jW03SL9V4LbaN34lQ1Aik8PE5mxyC39EYuoLJfsNNfD8/Cf38P5TAwhUAM9Q==",
+      "sha512": "Sfv71WuKoydy+blwCKXbyurzUdmYSEzqvJcMsT/oYib8MSdn8gDQYrnL+Y4/YnIQ0JdFtIzxZjI45ZU3QSJqLQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -18063,15 +18203,15 @@
         "ref/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "System.ServiceModel.Primitives.4.1.0-beta-23429.nupkg",
-        "System.ServiceModel.Primitives.4.1.0-beta-23429.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.1.0-beta-23506.nupkg",
+        "System.ServiceModel.Primitives.4.1.0-beta-23506.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
-    "System.ServiceModel.Security/4.0.1-beta-23429": {
+    "System.ServiceModel.Security/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "LRcnzeQNfzx7ioNDwDpJZZlj26OLNZJ0uQOMWuNhxFzfew6q28Hx48PVo6JjG1lSeWbdJ0BFakuS9Q1yNToSnw==",
+      "sha512": "8JdCXPKD6n4B0ktyI87W+fvnxEtsbLzKXVgCty3EdqoH0JM4ZlcfALITPduySR8ubktnHClohJcjBf9EBrxrKg==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Security.dll",
         "lib/net45/_._",
@@ -18114,15 +18254,15 @@
         "ref/netcore50/zh-hant/System.ServiceModel.Security.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "System.ServiceModel.Security.4.0.1-beta-23429.nupkg",
-        "System.ServiceModel.Security.4.0.1-beta-23429.nupkg.sha512",
+        "System.ServiceModel.Security.4.0.1-beta-23506.nupkg",
+        "System.ServiceModel.Security.4.0.1-beta-23506.nupkg.sha512",
         "System.ServiceModel.Security.nuspec"
       ]
     },
-    "System.Text.Encoding/4.0.11-beta-23429": {
+    "System.Text.Encoding/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "xu/TeJsBYB5VKHVGe4zhoe9DG2qLPhIvxefmv/AI/YUYtWzshwH6LKwOK1u2+V93Rcsnvx4drwXvTk0Eo+vj3g==",
+      "sha512": "3bdL5+2ROM+BKfb/zyEkYi+wvjLqN49wkVNy7vnaoPQYzVK/khNMq+SGTy1hYhOtznFisPuSeVLhuHRr46d4/w==",
       "files": [
         "lib/DNXCore50/System.Text.Encoding.dll",
         "lib/MonoAndroid10/_._",
@@ -18176,45 +18316,45 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
-        "System.Text.Encoding.4.0.11-beta-23429.nupkg",
-        "System.Text.Encoding.4.0.11-beta-23429.nupkg.sha512",
+        "System.Text.Encoding.4.0.11-beta-23506.nupkg",
+        "System.Text.Encoding.4.0.11-beta-23506.nupkg.sha512",
         "System.Text.Encoding.nuspec"
       ]
     },
-    "System.Text.Encoding.CodePages/4.0.0": {
+    "System.Text.Encoding.CodePages/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZHBTr1AXLjY9OuYR7pKx5xfN6QFye1kgd5QAbGrvfCOu7yxRnJs3VUaxERe1fOlnF0mi/xD/Dvb3T3x3HNuPWQ==",
+      "sha512": "zij6xWBrZxoF+Um6KMdUao43GFslbtdokjJ4HSLNAWUwWxdl6heNX0w1MU5y26/szV3WCz64jBVlR57isj5rQg==",
       "files": [
-        "lib/dotnet/System.Text.Encoding.CodePages.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet/de/System.Text.Encoding.CodePages.xml",
-        "ref/dotnet/es/System.Text.Encoding.CodePages.xml",
-        "ref/dotnet/fr/System.Text.Encoding.CodePages.xml",
-        "ref/dotnet/it/System.Text.Encoding.CodePages.xml",
-        "ref/dotnet/ja/System.Text.Encoding.CodePages.xml",
-        "ref/dotnet/ko/System.Text.Encoding.CodePages.xml",
-        "ref/dotnet/ru/System.Text.Encoding.CodePages.xml",
-        "ref/dotnet/System.Text.Encoding.CodePages.dll",
-        "ref/dotnet/System.Text.Encoding.CodePages.xml",
-        "ref/dotnet/zh-hans/System.Text.Encoding.CodePages.xml",
-        "ref/dotnet/zh-hant/System.Text.Encoding.CodePages.xml",
+        "ref/dotnet5.4/de/System.Text.Encoding.CodePages.xml",
+        "ref/dotnet5.4/es/System.Text.Encoding.CodePages.xml",
+        "ref/dotnet5.4/fr/System.Text.Encoding.CodePages.xml",
+        "ref/dotnet5.4/it/System.Text.Encoding.CodePages.xml",
+        "ref/dotnet5.4/ja/System.Text.Encoding.CodePages.xml",
+        "ref/dotnet5.4/ko/System.Text.Encoding.CodePages.xml",
+        "ref/dotnet5.4/ru/System.Text.Encoding.CodePages.xml",
+        "ref/dotnet5.4/System.Text.Encoding.CodePages.dll",
+        "ref/dotnet5.4/System.Text.Encoding.CodePages.xml",
+        "ref/dotnet5.4/zh-hans/System.Text.Encoding.CodePages.xml",
+        "ref/dotnet5.4/zh-hant/System.Text.Encoding.CodePages.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Text.Encoding.CodePages.4.0.0.nupkg",
-        "System.Text.Encoding.CodePages.4.0.0.nupkg.sha512",
+        "runtime.json",
+        "System.Text.Encoding.CodePages.4.0.1-beta-23506.nupkg",
+        "System.Text.Encoding.CodePages.4.0.1-beta-23506.nupkg.sha512",
         "System.Text.Encoding.CodePages.nuspec"
       ]
     },
-    "System.Text.Encoding.Extensions/4.0.11-beta-23429": {
+    "System.Text.Encoding.Extensions/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Rjz3mBiQQnY3eyIMt8/e1o9+ufn/NPhsmEi76MDyCxy1oVZ58Mw/+tv7CEq7B/5lM83o7Su+9FQVjaZZQMogXg==",
+      "sha512": "29qIqrfZxZDct5yTHtYUmjCi3LNJkJ5Iunaes7RPPlb6rND5R2Hxt4ChqH9kFDK6GiFa50Klnhi7GLi303/c6w==",
       "files": [
         "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
         "lib/MonoAndroid10/_._",
@@ -18268,15 +18408,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
-        "System.Text.Encoding.Extensions.4.0.11-beta-23429.nupkg",
-        "System.Text.Encoding.Extensions.4.0.11-beta-23429.nupkg.sha512",
+        "System.Text.Encoding.Extensions.4.0.11-beta-23506.nupkg",
+        "System.Text.Encoding.Extensions.4.0.11-beta-23506.nupkg.sha512",
         "System.Text.Encoding.Extensions.nuspec"
       ]
     },
-    "System.Text.RegularExpressions/4.0.11-beta-23429": {
+    "System.Text.RegularExpressions/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Tc9MAEHif/jIh/9q+VGHgUX5udFGWIt1vT3gko3eOP97iDNmTq1p1NLyWGkatVLzA4iaI3b0c/1+zbn9X7XM4Q==",
+      "sha512": "qMrLHkvFeNpFROy6vZxDsXavk0KI3iAUParHx27UMsMl/WXXFLscErBHD4CBtObOHI7R2TQzJ9zKID83cm1AIg==",
       "files": [
         "lib/dotnet5.4/System.Text.RegularExpressions.dll",
         "lib/MonoAndroid10/_._",
@@ -18329,15 +18469,15 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Text.RegularExpressions.4.0.11-beta-23429.nupkg",
-        "System.Text.RegularExpressions.4.0.11-beta-23429.nupkg.sha512",
+        "System.Text.RegularExpressions.4.0.11-beta-23506.nupkg",
+        "System.Text.RegularExpressions.4.0.11-beta-23506.nupkg.sha512",
         "System.Text.RegularExpressions.nuspec"
       ]
     },
-    "System.Threading/4.0.11-beta-23429": {
+    "System.Threading/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "mE4zKNSJL/BjmhZQZZQmudqKCfWhBjitJY4FBCLmHSXTTkb8xrFAy4M9MQTB9JjJR8Wph/Zu+gaFA3ZVQibo3w==",
+      "sha512": "eMzPImjfV66F1GQ7nkZGP51bUg5EEd93DY02mE703xx6IHUaecuj62iGx8mDuUXx47nd1Yy1lM4IeyC/8Jm/Sw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -18389,8 +18529,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Threading.4.0.11-beta-23429.nupkg",
-        "System.Threading.4.0.11-beta-23429.nupkg.sha512",
+        "System.Threading.4.0.11-beta-23506.nupkg",
+        "System.Threading.4.0.11-beta-23506.nupkg.sha512",
         "System.Threading.nuspec"
       ]
     },
@@ -18419,10 +18559,35 @@
         "System.Threading.Overlapped.nuspec"
       ]
     },
-    "System.Threading.Tasks/4.0.11-beta-23429": {
+    "System.Threading.Overlapped/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "j1bPiBJ64OK0dih2Td0VyZbc62knYZ/jJ2rjplwUaWul0AdtAQtA9i4QYn+kram1qieOck2ti8pPXW2tLT7Bww==",
+      "sha512": "j4xDZisxc6anOnpbWparMb7kckgQnTH80wdWqn3KGaTrhdhFpA+Pi55Jt9e2Icu6zgcGArbGtUnelTynBUUNrg==",
+      "files": [
+        "lib/DNXCore50/System.Threading.Overlapped.dll",
+        "lib/net46/System.Threading.Overlapped.dll",
+        "lib/netcore50/System.Threading.Overlapped.dll",
+        "ref/dotnet5.4/de/System.Threading.Overlapped.xml",
+        "ref/dotnet5.4/es/System.Threading.Overlapped.xml",
+        "ref/dotnet5.4/fr/System.Threading.Overlapped.xml",
+        "ref/dotnet5.4/it/System.Threading.Overlapped.xml",
+        "ref/dotnet5.4/ja/System.Threading.Overlapped.xml",
+        "ref/dotnet5.4/ko/System.Threading.Overlapped.xml",
+        "ref/dotnet5.4/ru/System.Threading.Overlapped.xml",
+        "ref/dotnet5.4/System.Threading.Overlapped.dll",
+        "ref/dotnet5.4/System.Threading.Overlapped.xml",
+        "ref/dotnet5.4/zh-hans/System.Threading.Overlapped.xml",
+        "ref/dotnet5.4/zh-hant/System.Threading.Overlapped.xml",
+        "ref/net46/System.Threading.Overlapped.dll",
+        "System.Threading.Overlapped.4.0.1-beta-23506.nupkg",
+        "System.Threading.Overlapped.4.0.1-beta-23506.nupkg.sha512",
+        "System.Threading.Overlapped.nuspec"
+      ]
+    },
+    "System.Threading.Tasks/4.0.11-beta-23506": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "GOIKFzQrfpKGaHOXoxblenq6FxXDPrAUrlXwrHXVfTUzOsYq1YfNsA3iRoiRrhJwtBctXVynO72PbUyOBecqGQ==",
       "files": [
         "lib/DNXCore50/System.Threading.Tasks.dll",
         "lib/MonoAndroid10/_._",
@@ -18476,15 +18641,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
-        "System.Threading.Tasks.4.0.11-beta-23429.nupkg",
-        "System.Threading.Tasks.4.0.11-beta-23429.nupkg.sha512",
+        "System.Threading.Tasks.4.0.11-beta-23506.nupkg",
+        "System.Threading.Tasks.4.0.11-beta-23506.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.Tasks.Dataflow/4.5.26-beta-23429": {
+    "System.Threading.Tasks.Dataflow/4.5.26-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "cMBpEnpOx62UAqAZMyNerNX58phcYDoybxsSQe9aRux36uLZV3CmqEfuGw8ZfnT3J01s0Cd6IebXscp8G7qnAw==",
+      "sha512": "+1soDqL/2UQ4Dsx6Q9J1sortTIJsbdocjgqROBX37jCw5f7kbVKd7B5xH6XMsVKTICcfRCn4YBZah4OXtHQDbw==",
       "files": [
         "lib/dotnet5.2/System.Threading.Tasks.Dataflow.dll",
         "lib/dotnet5.2/System.Threading.Tasks.Dataflow.XML",
@@ -18492,15 +18657,15 @@
         "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.XML",
         "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
         "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.XML",
-        "System.Threading.Tasks.Dataflow.4.5.26-beta-23429.nupkg",
-        "System.Threading.Tasks.Dataflow.4.5.26-beta-23429.nupkg.sha512",
+        "System.Threading.Tasks.Dataflow.4.5.26-beta-23506.nupkg",
+        "System.Threading.Tasks.Dataflow.4.5.26-beta-23506.nupkg.sha512",
         "System.Threading.Tasks.Dataflow.nuspec"
       ]
     },
-    "System.Threading.Tasks.Parallel/4.0.1-beta-23429": {
+    "System.Threading.Tasks.Parallel/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "00Wn9KGniKIBPwivZii70iTo4VCy11/T5UxdKLpf82DDqLyfIwPjzO4sje7NZddQnSC7vZYYkmVuGCB0gj/nMg==",
+      "sha512": "HzwG7YcwP4+1PQMu3Vb8S8vUmEsp/G8w+OTsc492ggEG62S5jCiaUcvz/cHQLSPX+BLF1iGuVGn7mQjF/bfh/Q==",
       "files": [
         "lib/dotnet5.4/System.Threading.Tasks.Parallel.dll",
         "lib/net45/_._",
@@ -18532,15 +18697,15 @@
         "ref/netcore50/zh-hant/System.Threading.Tasks.Parallel.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
-        "System.Threading.Tasks.Parallel.4.0.1-beta-23429.nupkg",
-        "System.Threading.Tasks.Parallel.4.0.1-beta-23429.nupkg.sha512",
+        "System.Threading.Tasks.Parallel.4.0.1-beta-23506.nupkg",
+        "System.Threading.Tasks.Parallel.4.0.1-beta-23506.nupkg.sha512",
         "System.Threading.Tasks.Parallel.nuspec"
       ]
     },
-    "System.Threading.Thread/4.0.0-beta-23429": {
+    "System.Threading.Thread/4.0.0-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "NkX7+aFoEgAZ1NKeRXWZcDmqyXcAclP60ecMQTvvoTpL0x/+7MXU/fIB0RxuDoLh5ndYo/BBGyY7VSoAEeQaEA==",
+      "sha512": "IB/WT+Sxiho3DAdEboMC3QACOFCv3y/yD4ngCTVSYTINr1Is/jZx2zQYm8DZMxtrpbtrggfbGy38khJ56pOBnQ==",
       "files": [
         "lib/DNXCore50/System.Threading.Thread.dll",
         "lib/MonoAndroid10/_._",
@@ -18548,31 +18713,31 @@
         "lib/net46/System.Threading.Thread.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.Threading.Thread.xml",
-        "ref/dotnet5.1/es/System.Threading.Thread.xml",
-        "ref/dotnet5.1/fr/System.Threading.Thread.xml",
-        "ref/dotnet5.1/it/System.Threading.Thread.xml",
-        "ref/dotnet5.1/ja/System.Threading.Thread.xml",
-        "ref/dotnet5.1/ko/System.Threading.Thread.xml",
-        "ref/dotnet5.1/ru/System.Threading.Thread.xml",
-        "ref/dotnet5.1/System.Threading.Thread.dll",
-        "ref/dotnet5.1/System.Threading.Thread.xml",
-        "ref/dotnet5.1/zh-hans/System.Threading.Thread.xml",
-        "ref/dotnet5.1/zh-hant/System.Threading.Thread.xml",
+        "ref/dotnet5.4/de/System.Threading.Thread.xml",
+        "ref/dotnet5.4/es/System.Threading.Thread.xml",
+        "ref/dotnet5.4/fr/System.Threading.Thread.xml",
+        "ref/dotnet5.4/it/System.Threading.Thread.xml",
+        "ref/dotnet5.4/ja/System.Threading.Thread.xml",
+        "ref/dotnet5.4/ko/System.Threading.Thread.xml",
+        "ref/dotnet5.4/ru/System.Threading.Thread.xml",
+        "ref/dotnet5.4/System.Threading.Thread.dll",
+        "ref/dotnet5.4/System.Threading.Thread.xml",
+        "ref/dotnet5.4/zh-hans/System.Threading.Thread.xml",
+        "ref/dotnet5.4/zh-hant/System.Threading.Thread.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Threading.Thread.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.Thread.4.0.0-beta-23429.nupkg",
-        "System.Threading.Thread.4.0.0-beta-23429.nupkg.sha512",
+        "System.Threading.Thread.4.0.0-beta-23506.nupkg",
+        "System.Threading.Thread.4.0.0-beta-23506.nupkg.sha512",
         "System.Threading.Thread.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23429": {
+    "System.Threading.ThreadPool/4.0.10-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "mKGHqUiDubu5hTL6jKgjisATYALf7O4EZbN5+rm+FN4oyr0/OjSobvp3CYWrILB//wMkdwsb+YrvGNjkqkQDPQ==",
+      "sha512": "yAUdypw226HwTln0KQO+C3zxxOPRnNxG3CE09hrXKS0VOnFRiARFcQZTlOKf70VFUVcU15A1BmJdDBPZ84N7Dw==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -18580,31 +18745,31 @@
         "lib/net46/System.Threading.ThreadPool.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.2/de/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.2/es/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.2/fr/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.2/it/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.2/ja/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.2/ko/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.2/ru/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.2/System.Threading.ThreadPool.dll",
-        "ref/dotnet5.2/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.2/zh-hans/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.2/zh-hant/System.Threading.ThreadPool.xml",
+        "ref/dotnet5.4/de/System.Threading.ThreadPool.xml",
+        "ref/dotnet5.4/es/System.Threading.ThreadPool.xml",
+        "ref/dotnet5.4/fr/System.Threading.ThreadPool.xml",
+        "ref/dotnet5.4/it/System.Threading.ThreadPool.xml",
+        "ref/dotnet5.4/ja/System.Threading.ThreadPool.xml",
+        "ref/dotnet5.4/ko/System.Threading.ThreadPool.xml",
+        "ref/dotnet5.4/ru/System.Threading.ThreadPool.xml",
+        "ref/dotnet5.4/System.Threading.ThreadPool.dll",
+        "ref/dotnet5.4/System.Threading.ThreadPool.xml",
+        "ref/dotnet5.4/zh-hans/System.Threading.ThreadPool.xml",
+        "ref/dotnet5.4/zh-hant/System.Threading.ThreadPool.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23429.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23429.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-beta-23506.nupkg",
+        "System.Threading.ThreadPool.4.0.10-beta-23506.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
-    "System.Threading.Timer/4.0.1-beta-23429": {
+    "System.Threading.Timer/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "5yvrUtYc6bA+ce5Sg/tjzsUluFwAO9zTRF8Buev7mjPZGRkhV/36H/ZWA7pc8y7M0Cr/GJHo4zNm4WYox6h2JA==",
+      "sha512": "v56s0FnxoS11HeQak1no13CV7GL7pZWon1foCphNmmy6PKpiVPRco+3sHtSGx/KJJI6GowDZStTjWgS8YNu7vA==",
       "files": [
         "lib/DNXCore50/System.Threading.Timer.dll",
         "lib/net451/_._",
@@ -18637,15 +18802,15 @@
         "ref/win81/_._",
         "ref/wpa81/_._",
         "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
-        "System.Threading.Timer.4.0.1-beta-23429.nupkg",
-        "System.Threading.Timer.4.0.1-beta-23429.nupkg.sha512",
+        "System.Threading.Timer.4.0.1-beta-23506.nupkg",
+        "System.Threading.Timer.4.0.1-beta-23506.nupkg.sha512",
         "System.Threading.Timer.nuspec"
       ]
     },
-    "System.Xml.ReaderWriter/4.0.11-beta-23429": {
+    "System.Xml.ReaderWriter/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "qpzZ5CgWZZTlt+neUFDyJVP13V2KQM5Kz3kj5zXqxN2dFz4BghlRsF72ieVWk4uB+4VLuRxbvmTFLMcEw8/rxg==",
+      "sha512": "Uz51YrAETSoyppMrDa0ZhmO7Jtc2IeNWbPNY/2ohhekbjMbLZuQV56v75EZ8/0gcUMaszjZDGWkyI8jNSna0XA==",
       "files": [
         "lib/dotnet5.4/System.Xml.ReaderWriter.dll",
         "lib/MonoAndroid10/_._",
@@ -18698,15 +18863,15 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Xml.ReaderWriter.4.0.11-beta-23429.nupkg",
-        "System.Xml.ReaderWriter.4.0.11-beta-23429.nupkg.sha512",
+        "System.Xml.ReaderWriter.4.0.11-beta-23506.nupkg",
+        "System.Xml.ReaderWriter.4.0.11-beta-23506.nupkg.sha512",
         "System.Xml.ReaderWriter.nuspec"
       ]
     },
-    "System.Xml.XDocument/4.0.11-beta-23429": {
+    "System.Xml.XDocument/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Z34hAsV1oibidMd3N7TFOB1dW0VwCHzPU+CvjmPcdc0BRQyHCkML7e0Tf94UKO7QDQ8FfgFQxTKWpsdQR1uG+A==",
+      "sha512": "+OL/iFG4FOHiwjnBYG1sgrf6SJmaXvg7THrX/MaE1ToILIql6A5Gr7dxgxMoyuQnREFx2crRMJZUvT7vYaOE/A==",
       "files": [
         "lib/dotnet5.4/System.Xml.XDocument.dll",
         "lib/MonoAndroid10/_._",
@@ -18759,15 +18924,15 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Xml.XDocument.4.0.11-beta-23429.nupkg",
-        "System.Xml.XDocument.4.0.11-beta-23429.nupkg.sha512",
+        "System.Xml.XDocument.4.0.11-beta-23506.nupkg",
+        "System.Xml.XDocument.4.0.11-beta-23506.nupkg.sha512",
         "System.Xml.XDocument.nuspec"
       ]
     },
-    "System.Xml.XmlDocument/4.0.1-beta-23429": {
+    "System.Xml.XmlDocument/4.0.1-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "iZvyR6I4g5ck/GZXJ0ey74atXg6D3ete4Svvz82hD0MQ3pCWBNIVuh4cJ0DNT8jYgcZpaCOmrYxehXn74ypErQ==",
+      "sha512": "V0xe3c/C4QPs1YKJftqYu661n9Djd86Az55FuyaaJvJ3bAAspZdBh1HxO1NzW8QN9EXSChz9tOYcBOfpohyOtA==",
       "files": [
         "lib/dotnet5.4/System.Xml.XmlDocument.dll",
         "lib/MonoAndroid10/_._",
@@ -18775,37 +18940,35 @@
         "lib/net46/System.Xml.XmlDocument.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.1/de/System.Xml.XmlDocument.xml",
-        "ref/dotnet5.1/es/System.Xml.XmlDocument.xml",
-        "ref/dotnet5.1/fr/System.Xml.XmlDocument.xml",
-        "ref/dotnet5.1/it/System.Xml.XmlDocument.xml",
-        "ref/dotnet5.1/ja/System.Xml.XmlDocument.xml",
-        "ref/dotnet5.1/ko/System.Xml.XmlDocument.xml",
-        "ref/dotnet5.1/ru/System.Xml.XmlDocument.xml",
-        "ref/dotnet5.1/System.Xml.XmlDocument.dll",
-        "ref/dotnet5.1/System.Xml.XmlDocument.xml",
-        "ref/dotnet5.1/zh-hans/System.Xml.XmlDocument.xml",
-        "ref/dotnet5.1/zh-hant/System.Xml.XmlDocument.xml",
+        "ref/dotnet5.4/de/System.Xml.XmlDocument.xml",
+        "ref/dotnet5.4/es/System.Xml.XmlDocument.xml",
+        "ref/dotnet5.4/fr/System.Xml.XmlDocument.xml",
+        "ref/dotnet5.4/it/System.Xml.XmlDocument.xml",
+        "ref/dotnet5.4/ja/System.Xml.XmlDocument.xml",
+        "ref/dotnet5.4/ko/System.Xml.XmlDocument.xml",
+        "ref/dotnet5.4/ru/System.Xml.XmlDocument.xml",
+        "ref/dotnet5.4/System.Xml.XmlDocument.dll",
+        "ref/dotnet5.4/System.Xml.XmlDocument.xml",
+        "ref/dotnet5.4/zh-hans/System.Xml.XmlDocument.xml",
+        "ref/dotnet5.4/zh-hant/System.Xml.XmlDocument.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Xml.XmlDocument.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Xml.XmlDocument.4.0.1-beta-23429.nupkg",
-        "System.Xml.XmlDocument.4.0.1-beta-23429.nupkg.sha512",
+        "System.Xml.XmlDocument.4.0.1-beta-23506.nupkg",
+        "System.Xml.XmlDocument.4.0.1-beta-23506.nupkg.sha512",
         "System.Xml.XmlDocument.nuspec"
       ]
     },
-    "System.Xml.XmlSerializer/4.0.11-beta-23429": {
+    "System.Xml.XmlSerializer/4.0.11-beta-23506": {
       "type": "package",
       "serviceable": true,
-      "sha512": "69HhxRRbubgxNwplHCAJfeSzOOt9s4ue+kusdD76h4zHQ8Nu2mO6jotPagKT0A6Grvn0ig3rD0D1HSH8HdPjjg==",
+      "sha512": "dKKFW9kNDuMViZWkmW50asuQvaVWRfbrV0hYALOAg/NJu6UYr2HOjyiMYfWQk9+YQYPQLSZsQOipRYCkMQot9Q==",
       "files": [
-        "lib/DNXCore50/System.Xml.XmlSerializer.dll",
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net45/_._",
-        "lib/netcore50/System.Xml.XmlSerializer.dll",
         "lib/win8/_._",
         "lib/wp80/_._",
         "lib/wpa81/_._",
@@ -18853,9 +19016,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "runtimes/win8-aot/lib/netcore50/System.Xml.XmlSerializer.dll",
-        "System.Xml.XmlSerializer.4.0.11-beta-23429.nupkg",
-        "System.Xml.XmlSerializer.4.0.11-beta-23429.nupkg.sha512",
+        "System.Xml.XmlSerializer.4.0.11-beta-23506.nupkg",
+        "System.Xml.XmlSerializer.4.0.11-beta-23506.nupkg.sha512",
         "System.Xml.XmlSerializer.nuspec"
       ]
     },
@@ -19032,10 +19194,10 @@
   },
   "projectFileDependencyGroups": {
     "": [
-      "Microsoft.NETCore.Platforms >= 1.0.1-beta-23429",
-      "Microsoft.NETCore.TestHost >= 1.0.0-beta-23429",
-      "Microsoft.NETCore.Console >= 1.0.0-beta-23429",
-      "System.IO.Compression >= 4.1.0-beta-23429",
+      "Microsoft.NETCore.Platforms >= 1.0.1-beta-23506",
+      "Microsoft.NETCore.TestHost >= 1.0.0-beta-23506",
+      "Microsoft.NETCore.Console >= 1.0.0-beta-23506",
+      "System.IO.Compression >= 4.1.0-beta-23506",
       "coveralls.io >= 1.4.0",
       "OpenCover >= 4.6.166",
       "ReportGenerator >= 2.3.1",


### PR DESCRIPTION
Motivated by needing to pick up newer System.Console and System.Diagnostic.Debug assemblies.

cc: @ericstj, @ellismg, @roncain 