### PR TITLE
Fix Culture bug around NameValueCollection tests

### DIFF
--- a/src/System.Collections.Specialized/tests/HybridDictionary/GetItemObjTests.cs
+++ b/src/System.Collections.Specialized/tests/HybridDictionary/GetItemObjTests.cs
@@ -2,10 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-using System;
-using System.Collections;
-using System.Collections.Specialized;
-
 using GenStrings;
 
 namespace System.Collections.Specialized.Tests
@@ -14,52 +10,89 @@ namespace System.Collections.Specialized.Tests
     {
         public const int MAX_LEN = 50;          // max length of random strings
 
-
-        [Fact]
-        [ActiveIssue(1360)]
-        public void Test01()
+        private string[] TestValues(int length)
         {
-            IntlStrings intl;
+            string[] values = new string[length];
+            for (int i = 0; i < length; i++)
+                values[i] = "Item" + i;
+            return values;
+        }
 
+        private string[] TestKeys(int length)
+        {
+            string[] keys = new string[length];
+            for (int i = 0; i < length; i++)
+                keys[i] = "keY" + i;
+            return keys;
+        }
 
-            HybridDictionary hd;
-
-            const int BIG_LENGTH = 100;
-
-            // simple string values
-            string[] valuesShort =
+        private string[] Test_EdgeCases()
+        {
+            return new string[]
             {
                 "",
                 " ",
                 "$%^#",
                 System.DateTime.Today.ToString(),
                 Int32.MaxValue.ToString()
-             };
+            };
+        }
+
+        [Theory]
+        [InlineData(50)]
+        [InlineData(100)]
+        public void Add(int size)
+        {
+            string[] values = TestValues(size);
+            string[] keys = TestKeys(size);
+
+            HybridDictionary hd = new HybridDictionary(true);
+            for (int i = 0; i < size; i++)
+            {
+                hd.Add(keys[i], values[i]);
+                Assert.Equal(hd[keys[i].ToLower()], values[i]);
+                Assert.Equal(hd[keys[i].ToUpper()], values[i]);
+            }
+        }
+
+        [Fact]
+        public void Add_EdgeCases()
+        {
+            string[] values = Test_EdgeCases();
+            string[] keys = Test_EdgeCases();
+
+            HybridDictionary hd = new HybridDictionary(true);
+            for (int i = 0; i < values.Length; i++)
+            {
+                hd.Add(keys[i], values[i]);
+                Assert.Equal(hd[keys[i].ToLower()], values[i]);
+                Assert.Equal(hd[keys[i].ToUpper()], values[i]);
+            }
+        }
+
+
+        [Fact]
+        public void Test01()
+        {
+            IntlStrings intl;
+
+            HybridDictionary hd;
+
+
+            // simple string values
+            string[] valuesShort = Test_EdgeCases();
 
             // keys for simple string values
-            string[] keysShort =
-            {
-                Int32.MaxValue.ToString(),
-                " ",
-                System.DateTime.Today.ToString(),
-                "",
-                "$%^#"
-            };
+            string[] keysShort = Test_EdgeCases();
 
-            string[] valuesLong = new string[BIG_LENGTH];
-            string[] keysLong = new string[BIG_LENGTH];
+            string[] valuesLong = TestValues(100);
+            string[] keysLong = TestKeys(100);
 
             int cnt = 0;            // Count
             Object itm;         // Item
 
             // initialize IntStrings
             intl = new IntlStrings();
-
-            for (int i = 0; i < BIG_LENGTH; i++)
-            {
-                valuesLong[i] = "Item" + i;
-                keysLong[i] = "keY" + i;
-            }
 
             // [] HybridDictionary is constructed as expected
             //-----------------------------------------------------------------

--- a/src/System.Collections.Specialized/tests/NameValueCollection/CtorIKCTests.cs
+++ b/src/System.Collections.Specialized/tests/NameValueCollection/CtorIKCTests.cs
@@ -48,48 +48,55 @@ namespace System.Collections.Specialized.Tests
 
             // Set current CultureInfo to Turkish, so we can verify CurrentCulture vs. InvariantCulture
             // comparison types.  Must be done before calling any constructors.
-            var prevCulture = CultureInfo.DefaultThreadCurrentCulture;
-            CultureInfo.DefaultThreadCurrentCulture = new System.Globalization.CultureInfo("tr-TR");
+            var prevCulture = CultureInfo.CurrentCulture;
+            CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
 
-            // [] NameValueCollection is constructed as expected
-            //-----------------------------------------------------------------
+            try
+            {
+                // [] NameValueCollection is constructed as expected
+                //-----------------------------------------------------------------
 
-            //
-            //  create collection
-            //
-            //  capacity=0
-            //
-            nvc = new NameValueCollection(new IdiotComparer());
-            int len = values.Length;
-            for (int i = 0; i < len; i++)
-            {
-                nvc.Add(names[i], values[i]);
-            }
-            if (nvc.Count != 1)
-            {
-                Assert.False(true, string.Format("Error, Count is {0} instead of {1}", nvc.Count, 1));
-            }
-            for (int i = 0; i < len; i++)
-            {
-                if (String.Compare(nvc[names[i]], exp3) != 0)
+                //
+                //  create collection
+                //
+                //  capacity=0
+                //
+                nvc = new NameValueCollection(new IdiotComparer());
+                int len = values.Length;
+                for (int i = 0; i < len; i++)
                 {
-                    Assert.False(true, string.Format("Error, returned {0} instead of {1}", nvc[names[i]], exp3));
+                    nvc.Add(names[i], values[i]);
                 }
-            }
-            if (nvc["Everything Is Equal!"] == null)
-            {
-                Assert.False(true, string.Format("Error, returned null instead of {0} ", exp3));
-            }
-            else if (String.Compare(nvc["Everything Is Equal!"], exp3) != 0)
-            {
-                Assert.False(true, string.Format("Error, returned {0} instead of {1}", nvc["Everything Is Equal!"], exp3));
-            }
+                if (nvc.Count != 1)
+                {
+                    Assert.False(true, string.Format("Error, Count is {0} instead of {1}", nvc.Count, 1));
+                }
+                for (int i = 0; i < len; i++)
+                {
+                    if (String.Compare(nvc[names[i]], exp3) != 0)
+                    {
+                        Assert.False(true, string.Format("Error, returned {0} instead of {1}", nvc[names[i]], exp3));
+                    }
+                }
+                if (nvc["Everything Is Equal!"] == null)
+                {
+                    Assert.False(true, string.Format("Error, returned null instead of {0} ", exp3));
+                }
+                else if (String.Compare(nvc["Everything Is Equal!"], exp3) != 0)
+                {
+                    Assert.False(true, string.Format("Error, returned {0} instead of {1}", nvc["Everything Is Equal!"], exp3));
+                }
 
-            // Comparer is null --> use default comparer
+                // Comparer is null --> use default comparer
 
-            NameValueCollection nvc2 = new NameValueCollection((IEqualityComparer)null);
-            nvc.Add("one", "one");
-            nvc.Remove("one");
+                NameValueCollection nvc2 = new NameValueCollection((IEqualityComparer)null);
+                nvc.Add("one", "one");
+                nvc.Remove("one");
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = prevCulture;
+            }
         }
     }
 }

--- a/src/System.Collections.Specialized/tests/NameValueCollection/CtorIntIKCTests.cs
+++ b/src/System.Collections.Specialized/tests/NameValueCollection/CtorIntIKCTests.cs
@@ -35,141 +35,148 @@ namespace System.Collections.Specialized.Tests
 
             // Set current CultureInfo to Turkish, so we can verify CurrentCulture vs. InvariantCulture
             // comparison types.  Must be done before calling any constructors.
-            var prevCulture = CultureInfo.DefaultThreadCurrentCulture;
-            CultureInfo.DefaultThreadCurrentCulture = new System.Globalization.CultureInfo("tr-TR");
+            var prevCulture = CultureInfo.CurrentCulture;
+            CultureInfo.CurrentCulture = new CultureInfo("tr-TR");
+            try
+            {
+                // [] NameValueCollection is constructed as expected
+                //-----------------------------------------------------------------
 
-            // [] NameValueCollection is constructed as expected
-            //-----------------------------------------------------------------
-
-            //
-            //  create collection
-            //
-            //  capacity=0
-            //
-            nvc = new NameValueCollection(0, new IdiotComparer());
-            int len = values.Length;
-            for (int i = 0; i < len; i++)
-            {
-                nvc.Add(names[i], values[i]);
-            }
-            if (nvc.Count != 1)
-            {
-                Assert.False(true, string.Format("Error, Count is {0} instead of {1}", nvc.Count, 1));
-            }
-            for (int i = 0; i < len; i++)
-            {
-                if (String.Compare(nvc[names[i]], exp3) != 0)
+                //
+                //  create collection
+                //
+                //  capacity=0
+                //
+                nvc = new NameValueCollection(0, new IdiotComparer());
+                int len = values.Length;
+                for (int i = 0; i < len; i++)
                 {
-                    Assert.False(true, string.Format("Error, returned {0} instead of {1}", nvc[names[i]], exp3));
+                    nvc.Add(names[i], values[i]);
                 }
-            }
-            if (nvc["Everything Is Equal!"] == null)
-            {
-                Assert.False(true, string.Format("Error, returned null instead of {0} ", exp3));
-            }
-            else if (String.Compare(nvc["Everything Is Equal!"], exp3) != 0)
-            {
-                Assert.False(true, string.Format("Error, returned {0} instead of {1}", nvc["Everything Is Equal!"], exp3));
-            }
-
-            //
-            //  capacity=10
-            //
-            nvc = new NameValueCollection(10, new IdiotComparer());
-            for (int i = 0; i < len; i++)
-            {
-                nvc.Add(names[i], values[i]);
-            }
-            if (nvc.Count != 1)
-            {
-                Assert.False(true, string.Format("Error, Count is {0} instead of {1}", nvc.Count, 1));
-            }
-            for (int i = 0; i < len; i++)
-            {
-                if (String.Compare(nvc[names[i]], exp3) != 0)
+                if (nvc.Count != 1)
                 {
-                    Assert.False(true, string.Format("Error, returned {0} instead of {1}", nvc[names[i]], exp3));
+                    Assert.False(true, string.Format("Error, Count is {0} instead of {1}", nvc.Count, 1));
                 }
-            }
-            if (nvc["Everything Is Equal!"] == null)
-            {
-                Assert.False(true, string.Format("Error, returned null instead of {0} ", exp3));
-            }
-            else if (String.Compare(nvc["Everything Is Equal!"], exp3) != 0)
-            {
-                Assert.False(true, string.Format("Error, returned {0} instead of {1}", nvc["Everything Is Equal!"], exp3));
-            }
-
-            //
-            //  capacity=100
-            //
-            nvc = new NameValueCollection(100, new IdiotComparer());
-            for (int i = 0; i < len; i++)
-            {
-                nvc.Add(names[i], values[i]);
-            }
-            if (nvc.Count != 1)
-            {
-                Assert.False(true, string.Format("Error, Count is {0} instead of {1}", nvc.Count, 1));
-            }
-            for (int i = 0; i < len; i++)
-            {
-                if (String.Compare(nvc[names[i]], exp3) != 0)
+                for (int i = 0; i < len; i++)
                 {
-                    Assert.False(true, string.Format("Error, returned {0} instead of {1}", nvc[names[i]], exp3));
+                    if (String.Compare(nvc[names[i]], exp3) != 0)
+                    {
+                        Assert.False(true, string.Format("Error, returned {0} instead of {1}", nvc[names[i]], exp3));
+                    }
                 }
-            }
-            if (nvc["Everything Is Equal!"] == null)
-            {
-                Assert.False(true, string.Format("Error, returned null instead of {0} ", exp3));
-            }
-            else if (String.Compare(nvc["Everything Is Equal!"], exp3) != 0)
-            {
-                Assert.False(true, string.Format("Error, returned {0} instead of {1}", nvc["Everything Is Equal!"], exp3));
-            }
-
-            //
-            //  capacity=1000
-            //
-            nvc = new NameValueCollection(1000, new IdiotComparer());
-            for (int i = 0; i < len; i++)
-            {
-                nvc.Add(names[i], values[i]);
-            }
-            if (nvc.Count != 1)
-            {
-                Assert.False(true, string.Format("Error, Count is {0} instead of {1}", nvc.Count, 1));
-            }
-            for (int i = 0; i < len; i++)
-            {
-                if (String.Compare(nvc[names[i]], exp3) != 0)
+                if (nvc["Everything Is Equal!"] == null)
                 {
-                    Assert.False(true, string.Format("Error, returned {0} instead of {1}", nvc[names[i]], exp3));
+                    Assert.False(true, string.Format("Error, returned null instead of {0} ", exp3));
                 }
+                else if (String.Compare(nvc["Everything Is Equal!"], exp3) != 0)
+                {
+                    Assert.False(true, string.Format("Error, returned {0} instead of {1}", nvc["Everything Is Equal!"], exp3));
+                }
+
+                //
+                //  capacity=10
+                //
+                nvc = new NameValueCollection(10, new IdiotComparer());
+                for (int i = 0; i < len; i++)
+                {
+                    nvc.Add(names[i], values[i]);
+                }
+                if (nvc.Count != 1)
+                {
+                    Assert.False(true, string.Format("Error, Count is {0} instead of {1}", nvc.Count, 1));
+                }
+                for (int i = 0; i < len; i++)
+                {
+                    if (String.Compare(nvc[names[i]], exp3) != 0)
+                    {
+                        Assert.False(true, string.Format("Error, returned {0} instead of {1}", nvc[names[i]], exp3));
+                    }
+                }
+                if (nvc["Everything Is Equal!"] == null)
+                {
+                    Assert.False(true, string.Format("Error, returned null instead of {0} ", exp3));
+                }
+                else if (String.Compare(nvc["Everything Is Equal!"], exp3) != 0)
+                {
+                    Assert.False(true, string.Format("Error, returned {0} instead of {1}", nvc["Everything Is Equal!"], exp3));
+                }
+
+                //
+                //  capacity=100
+                //
+                nvc = new NameValueCollection(100, new IdiotComparer());
+                for (int i = 0; i < len; i++)
+                {
+                    nvc.Add(names[i], values[i]);
+                }
+                if (nvc.Count != 1)
+                {
+                    Assert.False(true, string.Format("Error, Count is {0} instead of {1}", nvc.Count, 1));
+                }
+                for (int i = 0; i < len; i++)
+                {
+                    if (String.Compare(nvc[names[i]], exp3) != 0)
+                    {
+                        Assert.False(true, string.Format("Error, returned {0} instead of {1}", nvc[names[i]], exp3));
+                    }
+                }
+                if (nvc["Everything Is Equal!"] == null)
+                {
+                    Assert.False(true, string.Format("Error, returned null instead of {0} ", exp3));
+                }
+                else if (String.Compare(nvc["Everything Is Equal!"], exp3) != 0)
+                {
+                    Assert.False(true, string.Format("Error, returned {0} instead of {1}", nvc["Everything Is Equal!"], exp3));
+                }
+
+                //
+                //  capacity=1000
+                //
+                nvc = new NameValueCollection(1000, new IdiotComparer());
+                for (int i = 0; i < len; i++)
+                {
+                    nvc.Add(names[i], values[i]);
+                }
+                if (nvc.Count != 1)
+                {
+                    Assert.False(true, string.Format("Error, Count is {0} instead of {1}", nvc.Count, 1));
+                }
+                for (int i = 0; i < len; i++)
+                {
+                    if (String.Compare(nvc[names[i]], exp3) != 0)
+                    {
+                        Assert.False(true, string.Format("Error, returned {0} instead of {1}", nvc[names[i]], exp3));
+                    }
+                }
+                if (nvc["Everything Is Equal!"] == null)
+                {
+                    Assert.False(true, string.Format("Error, returned null instead of {0} ", exp3));
+                }
+                else if (String.Compare(nvc["Everything Is Equal!"], exp3) != 0)
+                {
+                    Assert.False(true, string.Format("Error, returned {0} instead of {1}", nvc["Everything Is Equal!"], exp3));
+                }
+
+                //
+                // [] capacity=Int32.MaxValue
+                //
+                Assert.Throws<OutOfMemoryException>(() => { nvc = new NameValueCollection(Int32.MaxValue, new IdiotComparer()); });
+
+                //
+                // [] capacity=Int32.MinValue
+                //
+                Assert.Throws<ArgumentOutOfRangeException>(() => { nvc = new NameValueCollection(Int32.MinValue, new IdiotComparer()); });
+
+                //
+                // [] capacity=-1
+                //
+                Assert.Throws<ArgumentOutOfRangeException>(() => { nvc = new NameValueCollection(-1, new IdiotComparer()); });
+
             }
-            if (nvc["Everything Is Equal!"] == null)
+            finally
             {
-                Assert.False(true, string.Format("Error, returned null instead of {0} ", exp3));
+                CultureInfo.CurrentCulture = prevCulture;
             }
-            else if (String.Compare(nvc["Everything Is Equal!"], exp3) != 0)
-            {
-                Assert.False(true, string.Format("Error, returned {0} instead of {1}", nvc["Everything Is Equal!"], exp3));
-            }
-
-            //
-            // [] capacity=Int32.MaxValue
-            //
-            Assert.Throws<OutOfMemoryException>(() => { nvc = new NameValueCollection(Int32.MaxValue, new IdiotComparer()); });
-
-            //
-            // [] capacity=Int32.MinValue
-            //
-            Assert.Throws<ArgumentOutOfRangeException>(() => { nvc = new NameValueCollection(Int32.MinValue, new IdiotComparer()); });
-
-            //
-            // [] capacity=-1
-            //
-            Assert.Throws<ArgumentOutOfRangeException>(() => { nvc = new NameValueCollection(-1, new IdiotComparer()); });
         }
     }
 }


### PR DESCRIPTION
Some tests for NameValueCollection were setting the DefaultThreadCurrentCulture to Turkish and not resetting it back to the default. This was causing failures in the HybridDictionary tests that were running concurrently with these tests. I refactored the code to instead use CurrentCulture and also added a try/finally to reset the CurrentCulture just to be safe.

Resloves #1136

@stephentoub 