### PR TITLE
Fix several issues in Process.ProcessorAffinity on Linux

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.SchedGetSetAffinity.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SchedGetSetAffinity.cs
@@ -8,22 +8,10 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        internal unsafe struct CpuSetBits
-        {
-            private fixed ulong Bits[16];
-        }
+        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        internal static extern int SchedSetAffinity(int pid, ref IntPtr mask);
 
         [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static extern int SchedSetAffinity(int pid, ref CpuSetBits mask);
-
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static extern int SchedGetAffinity(int pid, out CpuSetBits mask);
-
-        [DllImport(Libraries.SystemNative)]
-        internal static extern void CpuSet(int cpu, ref CpuSetBits set);
-
-        [DllImport(Libraries.SystemNative)]
-        internal static extern bool CpuIsSet(int cpu, ref CpuSetBits set);
-
+        internal static extern int SchedGetAffinity(int pid, out IntPtr mask);
     }
 }

--- a/src/Native/System.Native/pal_process.cpp
+++ b/src/Native/System.Native/pal_process.cpp
@@ -63,12 +63,6 @@ static_assert(PAL_PRIO_PROCESS == static_cast<int>(PRIO_PROCESS), "");
 static_assert(PAL_PRIO_PGRP == static_cast<int>(PRIO_PGRP), "");
 static_assert(PAL_PRIO_USER == static_cast<int>(PRIO_USER), "");
 
-#if HAVE_SCHED_SETAFFINITY || HAVE_SCHED_GETAFFINITY
-// Validate that the number of bits in the PAL CPU affinity struct is
-// greater than or equal to the native one so we can memcpy correctly
-static_assert(sizeof(CpuSetBits) >= sizeof(cpu_set_t), "");
-#endif
-
 enum
 {
     READ_END_OF_PIPE = 0,
@@ -429,66 +423,57 @@ extern "C" char* GetCwd(char* buffer, int32_t bufferSize)
 }
 
 #if HAVE_SCHED_SETAFFINITY
-static bool ConvertPalToNativeCpuSet(const CpuSetBits& pal, cpu_set_t& native)
-{
-    if (sizeof(pal) > sizeof(native))
-    {
-        // If the PAL struct is bigger than the native struct
-        // then make sure the user hasn't put data in the
-        // bits that would be inaccessible to the underlying OS
-        for (size_t i = sizeof(native); i < sizeof(pal); i++)
-        {
-            if (pal.Bits[i] != 0)
-                return false;
-        }
-    }
-
-    memcpy(native.__bits, pal.Bits, ARRAY_SIZE(native.__bits));
-    return true;
-}
-
-extern "C" int32_t SchedSetAffinity(int32_t pid, CpuSetBits* mask)
+extern "C" int32_t SchedSetAffinity(int32_t pid, intptr_t* mask)
 {
     assert(mask != nullptr);
-    cpu_set_t set = {};
-    if (!ConvertPalToNativeCpuSet(*mask, set))
+
+    int maxCpu = sizeof(intptr_t) * 8;
+    assert(maxCpu <= CPU_SETSIZE);
+
+    cpu_set_t set;
+    CPU_ZERO(&set);
+
+    intptr_t bits = *mask; 
+    for (int cpu = 0; cpu < maxCpu; cpu++)
     {
-        errno = EINVAL;
-        return -1;
+        if ((bits & (1u << cpu)) != 0)
+        {
+            CPU_SET(cpu, &set);
+        }
     }
+ 
     return sched_setaffinity(pid, sizeof(cpu_set_t), &set);
 }
 #endif
 
 #if HAVE_SCHED_GETAFFINITY
-static void ConvertNativeToPalCpuSet(const cpu_set_t& native, CpuSetBits& pal)
-{
-    pal = {};
-    memcpy(pal.Bits, native.__bits, ARRAY_SIZE(native.__bits));
-}
-
-extern "C" int32_t SchedGetAffinity(int32_t pid, CpuSetBits* mask)
+extern "C" int32_t SchedGetAffinity(int32_t pid, intptr_t* mask)
 {
     assert(mask != nullptr);
+
     cpu_set_t set;
     int32_t result = sched_getaffinity(pid, sizeof(cpu_set_t), &set);
     if (result == 0)
     {
-        ConvertNativeToPalCpuSet(set, *mask);
+        int maxCpu = sizeof(intptr_t) * 8;
+        assert(maxCpu <= CPU_SETSIZE);
+
+        intptr_t bits = 0;
+        for (int cpu = 0; cpu < maxCpu; cpu++)
+        {
+            if (CPU_ISSET(cpu, &set))
+            {
+                bits |= (1u << cpu);
+            }
+        }
+
+        *mask = bits;
+    }
+    else
+    {
+        *mask = 0;
     }
 
     return result;
-}
-#endif
-
-#if HAVE_SCHED_GETAFFINITY || HAVE_SCHED_SETAFFINITY
-extern "C" void CpuSet(int32_t cpu, CpuSetBits* set)
-{
-    set->Bits[__CPUELT(cpu)] |= __CPUMASK(cpu);
-}
-
-extern "C" bool CpuIsSet(int32_t cpu, CpuSetBits* set)
-{
-    return (set->Bits[__CPUELT(cpu)] & __CPUMASK(cpu)) != 0;
 }
 #endif

--- a/src/Native/System.Native/pal_process.h
+++ b/src/Native/System.Native/pal_process.h
@@ -263,7 +263,7 @@ extern "C" char* GetCwd(char* buffer, int32_t bufferSize);
  *
  * Returns 0 on success; otherwise, -1 is returned and errno is set
  */
-extern "C" int32_t SchedSetAffinity(int32_t pid, CpuSetBits* mask);
+extern "C" int32_t SchedSetAffinity(int32_t pid, intptr_t* mask);
 #endif
 
 #if HAVE_SCHED_GETAFFINITY
@@ -272,15 +272,5 @@ extern "C" int32_t SchedSetAffinity(int32_t pid, CpuSetBits* mask);
  *
  * Returns 0 on success; otherwise, -1 is returned and errno is set.
  */
-extern "C" int32_t SchedGetAffinity(int32_t pid, CpuSetBits* mask);
-#endif
-
-#if HAVE_SCHED_GETAFFINITY || HAVE_SCHED_SETAFFINITY
-
-/**
- * Shim's for the macros of the same name. Sets a CPU bit or
- * retrieves if the CPU bit is set
- */
-extern "C" void CpuSet(int32_t cpu, CpuSetBits* set);
-extern "C" bool CpuIsSet(int32_t cpu, CpuSetBits* set);
+extern "C" int32_t SchedGetAffinity(int32_t pid, intptr_t* mask);
 #endif

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Linux.cs
@@ -91,42 +91,24 @@ namespace System.Diagnostics
             {
                 EnsureState(State.HaveId);
 
-                Interop.Sys.CpuSetBits set = default(Interop.Sys.CpuSetBits);
+                IntPtr set;
                 if (Interop.Sys.SchedGetAffinity(_processId, out set) != 0)
                 {
                     throw new Win32Exception(); // match Windows exception
                 }
 
-                ulong bits = 0;
-                int maxCpu = IntPtr.Size == 4 ? 32 : 64;
-                for (int cpu = 0; cpu < maxCpu; cpu++)
-                {
-                    if (Interop.Sys.CpuIsSet(cpu, ref set))
-                        bits |= (1u << cpu);
-                }
-                return (IntPtr)bits;
+                return set;
             }
             set
             {
                 EnsureState(State.HaveId);
 
-                Interop.Sys.CpuSetBits set = default(Interop.Sys.CpuSetBits);
-
-                long bits = (long)value;
-                int maxCpu = IntPtr.Size == 4 ? 32 : 64;
-                for (int cpu = 0; cpu < maxCpu; cpu++)
-                {
-                    if ((bits & (1u << cpu)) != 0)
-                        Interop.Sys.CpuSet(cpu, ref set);
-                }
-
-                if (Interop.Sys.SchedSetAffinity(_processId, ref set) != 0)
+                if (Interop.Sys.SchedSetAffinity(_processId, ref value) != 0)
                 {
                     throw new Win32Exception(); // match Windows exception
                 }
             }
         }
-
 
         /// <summary>
         /// Make sure we have obtained the min and max working set limits.


### PR DESCRIPTION
A few issues being fixed with the shim:
- Compilation: The ```sizeof(CpuSetBits) >= sizeof(cpu_set_t)``` static assert was tripping for openSUSE and causing the native build to fail.  With this change, the native build now succeeds on openSUSE.
- Perf: We were making a P/Invoke call for each bit set in the affinity mask, so up to 64 managed/native transitions just to get/set the bits.  We now just make one.

Since the managed API works in terms of IntPtr, I changed the shim to as well, saving most of the complexity.  If we ever add/change to an API that works with a larger number of bits, we can update the shim accordingly.

cc: @ellismg, @sokket, @nguerrera