### PR TITLE
Mark members of BigInteger as readonly

### DIFF
--- a/src/System.Runtime.Numerics/tests/BigInteger/cast_to.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/cast_to.cs
@@ -275,6 +275,9 @@ namespace System.Numerics.Tests
             // Single Explicit Cast to BigInteger: Single.PositiveInfinity
             Assert.Throws<OverflowException>(() => { BigInteger temp = (BigInteger)Single.PositiveInfinity; });
 
+            // double.IsInfinity(float.MaxValue * 2.0f) == false, but we don't want this odd behavior here
+            Assert.Throws<OverflowException>(() => { BigInteger temp = (BigInteger)(float.MaxValue * 2.0f); });
+
             // Single Explicit Cast to BigInteger: Single.Epsilon
             VerifySingleExplicitCastToBigInteger(Single.Epsilon);
 


### PR DESCRIPTION
- Marking members as readonly allows several optimizations and
  BigInteger isn't a mutable structure anyway.
- The unary negate operator mutates the _sign value. Thus, we use the
  internal constructor to negate instead, leading to the same result.
- ~~The method ToByteArray assigns them to local variables to optimize
  their access since they should'nt change; readonly solves that too.~~
- The constructors for Single and Double use a helper method, which
  mutates during construction. But the former can just use the latter,
  which can include the body of this helper method accordingly.