### PR TITLE
Enable building all of corefx with an "unknown" Unix

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -254,7 +254,7 @@
     <TargetsLinux Condition="'$(OSGroup)' == 'Linux'">true</TargetsLinux>
     <TargetsOSX Condition="'$(OSGroup)' == 'OSX'">true</TargetsOSX>
     <TargetsFreeBSD Condition="'$(OSGroup)' == 'FreeBSD'">true</TargetsFreeBSD>
-	<TargetsUnknownUnix Condition="'$(TargetsUnix)' == 'true' AND '$(OSGroup)' != 'FreeBSD' AND '$(OSGroup)' != 'Linux' AND '$(OSGroup)' != 'OSX'">true</TargetsUnknownUnix>
+    <TargetsUnknownUnix Condition="'$(TargetsUnix)' == 'true' AND '$(OSGroup)' != 'FreeBSD' AND '$(OSGroup)' != 'Linux' AND '$(OSGroup)' != 'OSX'">true</TargetsUnknownUnix>
   </PropertyGroup>
   <!-- Make some assumptions based on TargetsPlatform -->
   <PropertyGroup Condition="'$(UseUnixPackageTargetRuntimeDefaults)' == 'true' OR '$(UsePackageTargetRuntimeDefaults)' == 'true'">

--- a/dir.props
+++ b/dir.props
@@ -249,11 +249,12 @@
   <!-- Set up common target properties that we use to conditionally include sources -->
   <PropertyGroup>
     <TargetsWindows Condition="'$(OSGroup)' == 'Windows_NT'">true</TargetsWindows>
+    <TargetsUnix Condition="'$(TargetsWindows)' != 'true'">true</TargetsUnix>
+
     <TargetsLinux Condition="'$(OSGroup)' == 'Linux'">true</TargetsLinux>
     <TargetsOSX Condition="'$(OSGroup)' == 'OSX'">true</TargetsOSX>
     <TargetsFreeBSD Condition="'$(OSGroup)' == 'FreeBSD'">true</TargetsFreeBSD>
-
-    <TargetsUnix Condition="'$(TargetsLinux)' == 'true' or '$(TargetsOSX)' == 'true' or '$(TargetsFreeBSD)' == 'true'">true</TargetsUnix>
+	<TargetsUnknownUnix Condition="'$(TargetsUnix)' == 'true' AND '$(OSGroup)' != 'FreeBSD' AND '$(OSGroup)' != 'Linux' AND '$(OSGroup)' != 'OSX'">true</TargetsUnknownUnix>
   </PropertyGroup>
   <!-- Make some assumptions based on TargetsPlatform -->
   <PropertyGroup Condition="'$(UseUnixPackageTargetRuntimeDefaults)' == 'true' OR '$(UsePackageTargetRuntimeDefaults)' == 'true'">

--- a/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -14,6 +14,7 @@
     <UsePackageTargetRuntimeDefaults>true</UsePackageTargetRuntimeDefaults>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetsFreeBSD)' == 'true' OR '$(TargetsUnknownUnix)' == 'true' ">
+    <!-- Suppress unused field warnings when using PlatformNotSupportedException stubs -->
     <NoWarn>0649</NoWarn>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->

--- a/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
+++ b/src/System.Diagnostics.Process/src/System.Diagnostics.Process.csproj
@@ -13,6 +13,9 @@
     <PackageTargetFramework>dotnet5.5</PackageTargetFramework>
     <UsePackageTargetRuntimeDefaults>true</UsePackageTargetRuntimeDefaults>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetsFreeBSD)' == 'true' OR '$(TargetsUnknownUnix)' == 'true' ">
+    <NoWarn>0649</NoWarn>
+  </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU' " />
@@ -288,6 +291,11 @@
     <Compile Include="$(CommonPath)\Interop\OSX\Interop.Libraries.cs">
       <Link>Common\Interop\OSX\Interop.Libraries.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsFreeBSD)' == 'true' OR '$(TargetsUnknownUnix)' == 'true' ">
+    <Compile Include="System\Diagnostics\Process.UnknownUnix.cs" />
+    <Compile Include="System\Diagnostics\ProcessManager.UnknownUnix.cs" />
+    <Compile Include="System\Diagnostics\ProcessThread.UnknownUnix.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.UnknownUnix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.UnknownUnix.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Diagnostics
+{
+    public partial class Process : IDisposable
+    {
+        /// <summary>
+        /// Creates an array of <see cref="Process"/> components that are associated with process resources on a
+        /// remote computer. These process resources share the specified process name.
+        /// </summary>
+        public static Process[] GetProcessesByName(string processName, string machineName)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        /// <summary>Gets the amount of time the process has spent running code inside the operating system core.</summary>
+        public TimeSpan PrivilegedProcessorTime
+        {
+            get { throw new PlatformNotSupportedException(); }
+        }
+
+        /// <summary>Gets the time the associated process was started.</summary>
+        public DateTime StartTime
+        {
+            get { throw new PlatformNotSupportedException(); }
+        }
+
+        /// <summary>
+        /// Gets the amount of time the associated process has spent utilizing the CPU.
+        /// It is the sum of the <see cref='System.Diagnostics.Process.UserProcessorTime'/> and
+        /// <see cref='System.Diagnostics.Process.PrivilegedProcessorTime'/>.
+        /// </summary>
+        public TimeSpan TotalProcessorTime
+        {
+            get { throw new PlatformNotSupportedException(); }
+        }
+
+        /// <summary>
+        /// Gets the amount of time the associated process has spent running code
+        /// inside the application portion of the process (not the operating system core).
+        /// </summary>
+        public TimeSpan UserProcessorTime
+        {
+            get { throw new PlatformNotSupportedException(); }
+        }
+
+        /// <summary>
+        /// Gets or sets which processors the threads in this process can be scheduled to run on.
+        /// </summary>
+        private unsafe IntPtr ProcessorAffinityCore
+        {
+            get { throw new PlatformNotSupportedException(); }
+            set { throw new PlatformNotSupportedException(); }
+        }
+
+        /// <summary>
+        /// Make sure we have obtained the min and max working set limits.
+        /// </summary>
+        private void GetWorkingSetLimits(out IntPtr minWorkingSet, out IntPtr maxWorkingSet)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        /// <summary>Sets one or both of the minimum and maximum working set limits.</summary>
+        /// <param name="newMin">The new minimum working set limit, or null not to change it.</param>
+        /// <param name="newMax">The new maximum working set limit, or null not to change it.</param>
+        /// <param name="resultingMin">The resulting minimum working set limit after any changes applied.</param>
+        /// <param name="resultingMax">The resulting maximum working set limit after any changes applied.</param>
+        private void SetWorkingSetLimitsCore(IntPtr? newMin, IntPtr? newMax, out IntPtr resultingMin, out IntPtr resultingMax)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        private static string GetExePath()
+        {
+            throw new PlatformNotSupportedException();
+        }
+    }
+}

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.UnknownUnix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.UnknownUnix.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Diagnostics
+{
+    internal static partial class ProcessManager
+    {
+        /// <summary>Gets the IDs of all processes on the current machine.</summary>
+        public static int[] GetProcessIds()
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        /// <summary>Gets process infos for each process on the specified machine.</summary>
+        /// <param name="machineName">The target machine.</param>
+        /// <returns>An array of process infos, one per found process.</returns>
+        public static ProcessInfo[] GetProcessInfos(string machineName)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        /// <summary>Gets an array of module infos for the specified process.</summary>
+        /// <param name="processId">The ID of the process whose modules should be enumerated.</param>
+        /// <returns>The array of modules.</returns>
+        internal static ModuleInfo[] GetModuleInfos(int processId)
+        {
+            return Array.Empty<ModuleInfo>();
+        }
+
+        private static ProcessInfo CreateProcessInfo(int pid)
+        {
+            throw new PlatformNotSupportedException();
+        }
+    }
+}

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.UnknownUnix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessThread.UnknownUnix.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Diagnostics
+{
+    public partial class ProcessThread
+    {
+        /// <summary>
+        /// Returns or sets the priority level of the associated thread.  The priority level is
+        /// not an absolute level, but instead contributes to the actual thread priority by
+        /// considering the priority class of the process.
+        /// </summary>
+        private ThreadPriorityLevel PriorityLevelCore
+        {
+            get { throw new PlatformNotSupportedException(); }
+            set { throw new PlatformNotSupportedException(); }
+        }
+
+        /// <summary>
+        /// Returns the amount of time the thread has spent running code inside the operating
+        /// system core.
+        /// </summary>
+        public TimeSpan PrivilegedProcessorTime
+        {
+            get { throw new PlatformNotSupportedException(); }
+        }
+
+        /// <summary>Returns the time the associated thread was started.</summary>
+        public DateTime StartTime
+        {
+            get { throw new PlatformNotSupportedException(); }
+        }
+
+        /// <summary>
+        /// Returns the amount of time the associated thread has spent utilizing the CPU.
+        /// It is the sum of the System.Diagnostics.ProcessThread.UserProcessorTime and
+        /// System.Diagnostics.ProcessThread.PrivilegedProcessorTime.
+        /// </summary>
+        public TimeSpan TotalProcessorTime
+        {
+            get { throw new PlatformNotSupportedException(); }
+        }
+
+        /// <summary>
+        /// Returns the amount of time the associated thread has spent running code
+        /// inside the application (not the operating system core).
+        /// </summary>
+        public TimeSpan UserProcessorTime
+        {
+            get { throw new PlatformNotSupportedException(); }
+        }
+    }
+}

--- a/src/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
+++ b/src/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
@@ -115,6 +115,9 @@
       <Link>Common\Microsoft\Win32\SafeHandles\SafeEventStreamHandle.OSX.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsFreeBSD)' == 'true' OR '$(TargetsUnknownUnix)' == 'true' ">
+    <Compile Include="System\IO\FileSystemWatcher.UnknownUnix.cs" />
+  </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.UnknownUnix.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.UnknownUnix.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.IO
+{
+    public partial class FileSystemWatcher
+    {
+        /// <summary>Called when FileSystemWatcher is finalized.</summary>
+        private void FinalizeDispose()
+        {
+        }
+
+        private void StartRaisingEvents()
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        private void StopRaisingEvents()
+        {
+            throw new PlatformNotSupportedException();
+        }
+    }
+}

--- a/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -349,6 +349,12 @@
       <Link>Common\Microsoft\Win32\SafeHandles\SafeCreateHandle.OSX.cs</Link>
     </Compile>
   </ItemGroup>
+  <!-- Unknown Unix -->
+  <ItemGroup Condition=" '$(TargetsFreeBSD)' == 'true' OR '$(TargetsUnknownUnix)' == 'true' ">
+    <Compile Include="System\Net\NetworkInformation\IPGlobalPropertiesPal.UnknownUnix.cs" />
+    <Compile Include="System\Net\NetworkInformation\NetworkInterfacePal.UnknownUnix.cs" />
+    <Compile Include="System\Net\NetworkInformation\NetworkAddressChange.UnknownUnix.cs" />
+  </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPGlobalPropertiesPal.UnknownUnix.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/IPGlobalPropertiesPal.UnknownUnix.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Net.NetworkInformation
+{
+    internal static class IPGlobalPropertiesPal
+    {
+        public static IPGlobalProperties GetIPGlobalProperties()
+        {
+            throw new PlatformNotSupportedException();
+        }
+    }
+}

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.UnknownUnix.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkAddressChange.UnknownUnix.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Net.NetworkInformation
+{
+    public class NetworkChange
+    {
+        public static event NetworkAddressChangedEventHandler NetworkAddressChanged
+        {
+            add { throw new PlatformNotSupportedException(); }
+            remove { throw new PlatformNotSupportedException(); }
+        }
+    }
+}

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkInterfacePal.UnknownUnix.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/NetworkInterfacePal.UnknownUnix.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Net.NetworkInformation
+{
+    internal static class NetworkInterfacePal
+    {
+        /// Returns objects that describe the network interfaces on the local computer.
+        public static NetworkInterface[] GetAllNetworkInterfaces()
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public static bool GetIsNetworkAvailable()
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public static int IPv6LoopbackInterfaceIndex
+        {
+            get { throw new PlatformNotSupportedException(); }
+        }
+
+        public static int LoopbackInterfaceIndex
+        {
+            get { throw new PlatformNotSupportedException(); }
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/RuntimeInformation.UnknownUnix.cs
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/RuntimeInformation.UnknownUnix.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Runtime.InteropServices
+{
+    public static class RuntimeInformation
+    {
+        public static bool IsOSPlatform(OSPlatform osPlatform)
+        {
+            throw new PlatformNotSupportedException();
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices.RuntimeInformation/src/System.Runtime.InteropServices.RuntimeInformation.csproj
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/src/System.Runtime.InteropServices.RuntimeInformation.csproj
@@ -34,6 +34,9 @@
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
     <Compile Include="RuntimeInformation.Windows.cs" />
   </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsUnknownUnix)' == 'true' ">
+    <Compile Include="RuntimeInformation.UnknownUnix.cs" />
+  </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>


### PR DESCRIPTION
After all of the shim work that's been done, the vast majority of corefx assemblies now are either platform-agnostic or have a Windows build and a Unix build, without further specialization based on OS in managed code.  We do still have a few such assemblies, though (and this is unlikely to change any time soon):
- System.Diagnostics.Process
- System.IO.FileSystem.Watcher
- System.Net.NetworkInformation
- System.Runtime.InteropServices.RuntimeInformation

As a result, attempting to do a full build for Unix targets other than Linux or OS X currently results in compilation failures. This commit adds a new TargetsUnknownUnix property to the build as well as stub implementations that throw PlatformNotSupportedException for all of the missing functionality that causes such compilation errors.

With this change, doing ```build.cmd /p:SkipTests=true /p:OSGroup=FreeBSD"``` now completes successfully, as does ```build.cmd /p:SkipTests=true /p:OSGroup=Stephenix```.

cc: @ellismg, @nguerrera, @weshaggard, @mellinoe