### PR TITLE
Consolidate some shared Linux/OSX code in NetworkInformation

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPGlobalProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/LinuxIPGlobalProperties.cs
@@ -11,16 +11,6 @@ namespace System.Net.NetworkInformation
 {
     internal class LinuxIPGlobalProperties : UnixIPGlobalProperties
     {
-        public override string DhcpScopeName { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
-
-        public override string DomainName { get { return HostInformation.DomainName; } }
-
-        public override string HostName { get { return HostInformation.HostName; } }
-
-        public override bool IsWinsProxy { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
-
-        public override NetBiosNodeType NodeType { get { return NetBiosNodeType.Unknown; } }
-
         public override TcpConnectionInformation[] GetActiveTcpConnections()
         {
             return StringParsingHelpers.ParseActiveTcpConnectionsFromFiles(NetworkFiles.Tcp4ConnectionsFile, NetworkFiles.Tcp6ConnectionsFile);

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxIPGlobalProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/OsxIPGlobalProperties.cs
@@ -8,16 +8,6 @@ namespace System.Net.NetworkInformation
 {
     internal class OsxIPGlobalProperties : UnixIPGlobalProperties
     {
-        public override string DhcpScopeName { get { throw new PlatformNotSupportedException(); } }
-
-        public override string DomainName { get { return HostInformation.DomainName; } }
-
-        public override string HostName { get { return HostInformation.HostName; } }
-
-        public override bool IsWinsProxy { get { throw new PlatformNotSupportedException(); } }
-
-        public override NetBiosNodeType NodeType { get { return NetBiosNodeType.Unknown; } }
-
         public unsafe override TcpConnectionInformation[] GetActiveTcpConnections()
         {
             int realCount = Interop.Sys.GetEstimatedTcpConnectionCount();

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPGlobalProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPGlobalProperties.cs
@@ -5,6 +5,16 @@ namespace System.Net.NetworkInformation
 {
     internal abstract class UnixIPGlobalProperties : IPGlobalProperties
     {
+        public override string DhcpScopeName { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
+
+        public override string DomainName { get { return HostInformation.DomainName; } }
+
+        public override string HostName { get { return HostInformation.HostName; } }
+
+        public override bool IsWinsProxy { get { throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform); } }
+
+        public override NetBiosNodeType NodeType { get { return NetBiosNodeType.Unknown; } }
+
         public sealed override Task<UnicastIPAddressInformationCollection> GetUnicastAddressesAsync()
         {
             return Task.Factory.StartNew(s => ((UnixIPGlobalProperties)s).GetUnicastAddresses(), this,


### PR DESCRIPTION
The same code was duplicated in both the Linux and OSX implementations, when it could instead be on the base Unix implementation.  This also results in a better error message being used on OS X.

cc: @mellinoe, @cipop