### PR TITLE
Disable running Benchmarks as part of unit tests on Unix

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -179,9 +179,9 @@ runtest()
 
   echo
   echo "Running tests in $dirName"
-  echo "./corerun xunit.console.netcore.exe $testDllName -xml testResults.xml -notrait category=failing -notrait category=OuterLoop -notrait category=$xunitOSCategory"
+  echo "./corerun xunit.console.netcore.exe $testDllName -xml testResults.xml -notrait category=failing -notrait category=OuterLoop -notrait category=$xunitOSCategory" -notrait Benchmark=true
   echo
-  ./corerun xunit.console.netcore.exe $testDllName -xml testResults.xml -notrait category=failing -notrait category=OuterLoop -notrait category=$xunitOSCategory
+  ./corerun xunit.console.netcore.exe $testDllName -xml testResults.xml -notrait category=failing -notrait category=OuterLoop -notrait category=$xunitOSCategory -notrait Benchmark=true
   exitCode=$?
 
   if [ $exitCode -ne 0 ]


### PR DESCRIPTION
https://github.com/dotnet/buildtools/pull/332 disabled running benchmarks as part of unit tests, but only on Windows.  They're still running on Linux and OS X, and are causing builds to timeout, e.g. the Process tests are currently taking over 5 minutes:
```
11:03:02    System.Diagnostics.Process.Tests  Total: 77, Errors: 0, Failed: 0, Skipped: 0, Time: 318.916s
```
cc: @ianhays, @ellismg