### PR TITLE
Cleanup System.Net.Http tests

### DIFF
--- a/src/Common/tests/System/Net/HttpTestServers2.cs
+++ b/src/Common/tests/System/Net/HttpTestServers2.cs
@@ -17,13 +17,24 @@ namespace System.Net.Tests
         private const string EchoHandler = "Echo.ashx";
         private const string EmptyContentHandler = "EmptyContent.ashx";
         private const string StatusCodeHandler = "StatusCode.ashx";
+        private const string RedirectHandler = "Redirect.ashx";
+        private const string VerifyUploadHandler = "VerifyUpload.ashx";
+        private const string DeflateHandler = "Deflate.ashx";
+        private const string GZipHandler = "GZip.ashx";
         
         public readonly static Uri RemoteEchoServer = new Uri("http://" + Host + "/" + EchoHandler);
         public readonly static Uri SecureRemoteEchoServer = new Uri("https://" + Host + "/" + EchoHandler);
         
+        public readonly static Uri RemoteVerifyUploadServer = new Uri("http://" + Host + "/" + VerifyUploadHandler);
+        public readonly static Uri SecureRemoteVerifyUploadServer = new Uri("https://" + Host + "/" + VerifyUploadHandler);
+        
         public readonly static Uri RemoteEmptyContentServer = new Uri("http://" + Host + "/" + EmptyContentHandler);
+        public readonly static Uri RemoteDeflateServer = new Uri("http://" + Host + "/" + DeflateHandler);
+        public readonly static Uri RemoteGZipServer = new Uri("http://" + Host + "/" + GZipHandler);
 
         public readonly static object[][] EchoServers = { new object[] { RemoteEchoServer }, new object[] { SecureRemoteEchoServer } };
+        public readonly static object[][] VerifyUploadServers = { new object[] { RemoteVerifyUploadServer }, new object[] { SecureRemoteVerifyUploadServer } };
+        public readonly static object[][] CompressedServers = { new object[] { RemoteDeflateServer }, new object[] { RemoteGZipServer } };
 
         public static Uri BasicAuthUriForCreds(bool secure, string userName, string password)
         {
@@ -46,6 +57,56 @@ namespace System.Net.Tests
                     Host,
                     StatusCodeHandler,
                     statusCode));
+        }
+
+        public static Uri StatusCodeUri(bool secure, int statusCode, string statusDescription)
+        {
+            return new Uri(
+                string.Format(
+                    "{0}://{1}/{2}?statuscode={3}&statusDescription={4}",
+                    secure ? HttpsScheme : HttpScheme,
+                    Host,
+                    StatusCodeHandler,
+                    statusCode,
+                    statusDescription));
+        }
+
+        public static Uri RedirectUriForDestinationUri(bool secure, Uri destinationUri, int hops)
+        {
+            string uriString;
+            string destination = Uri.EscapeDataString(destinationUri.AbsoluteUri);
+            
+            if (hops > 1)
+            {
+                uriString = string.Format("{0}://{1}/{2}?uri={3}&hops={4}",
+                    secure ? HttpsScheme : HttpScheme,
+                    Host,
+                    RedirectHandler,
+                    destination,
+                    hops);
+            }
+            else
+            {
+                uriString = string.Format("{0}://{1}/{2}?uri={3}",
+                    secure ? HttpsScheme : HttpScheme,
+                    Host,
+                    RedirectHandler,
+                    destination);
+            }
+            
+            return new Uri(uriString);
+        }
+
+        public static Uri RedirectUriForCreds(bool secure, string userName, string password)
+        {
+                Uri destinationUri = BasicAuthUriForCreds(secure, userName, password);
+                string destination = Uri.EscapeDataString(destinationUri.AbsoluteUri);
+                
+                return new Uri(string.Format("{0}://{1}/{2}?uri={3}",
+                    secure ? HttpsScheme : HttpScheme,
+                    Host,
+                    RedirectHandler,
+                    destination));
         }
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
@@ -25,7 +25,7 @@ namespace System.Net.Http.Functional.Tests
         {
             HttpClient client = GetHttpClient();
             
-            Stream stream = await client.GetStreamAsync(HttpTestServers.RemoteGetServer);
+            Stream stream = await client.GetStreamAsync(HttpTestServers2.RemoteEchoServer);
             using (var reader = new StreamReader(stream))
             {
                 string responseBody = reader.ReadToEnd();
@@ -40,7 +40,7 @@ namespace System.Net.Http.Functional.Tests
             HttpClient client = GetHttpClient();
             
             HttpResponseMessage response =
-                await client.GetAsync(HttpTestServers.RemoteGetServer, HttpCompletionOption.ResponseHeadersRead);
+                await client.GetAsync(HttpTestServers2.RemoteEchoServer, HttpCompletionOption.ResponseHeadersRead);
             await response.Content.LoadIntoBufferAsync();
 
             string responseBody = await response.Content.ReadAsStringAsync();
@@ -54,7 +54,7 @@ namespace System.Net.Http.Functional.Tests
             HttpClient client = GetHttpClient();
             
             HttpResponseMessage response =
-                await client.GetAsync(HttpTestServers.RemoteGetServer, HttpCompletionOption.ResponseHeadersRead);
+                await client.GetAsync(HttpTestServers2.RemoteEchoServer, HttpCompletionOption.ResponseHeadersRead);
 
             var memoryStream = new MemoryStream();
             await response.Content.CopyToAsync(memoryStream);

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -18,9 +18,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU' " />  
   <ItemGroup>
-    <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers.cs">
-      <Link>Common\System\Net\HttpTestServers.cs</Link>
-    </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers2.cs">
       <Link>Common\System\Net\HttpTestServers2.cs</Link>
     </Compile>


### PR DESCRIPTION
* Move more tests to the new test server
* Cleanup 'var' coding patterns
* Remove duplicate tests (*Content clas related) that are already covered with the *Content class tests
* Utiilize the newer test server VerifyUpload endpoint which does 'Content-MD5' verification of transmitted payload to the server as well as payload from the server
* Add GZip related tests in addition to Deflate compression schemes