### PR TITLE
Add ConsoleColor.Unknown and associated reset behavior

### DIFF
--- a/src/System.Console/src/System/Console.cs
+++ b/src/System.Console/src/System/Console.cs
@@ -112,13 +112,40 @@ namespace System
         public static ConsoleColor BackgroundColor
         {
             get { return ConsolePal.BackgroundColor; }
-            set { ConsolePal.BackgroundColor = value; }
+            set
+            {
+                if (value == ConsoleColor.Unknown)
+                {
+                    // When setting the color to Unknown (which typically will have come
+                    // from a call to get_BackgroundColor when it couldn't be determined),
+                    // we call ResetColor(), even though this will reset both the
+                    // Background and ForegroundColor.  This was deemed less problematic
+                    // than removing get_*Color from the contract, throwing PlatformNotSupportedException
+                    // from the get_*Color or set_*Color members, or any other available solution.
+                    ResetColor();
+                }
+                else
+                {
+                    ConsolePal.BackgroundColor = value;
+                }
+            }
         }
 
         public static ConsoleColor ForegroundColor
         {
             get { return ConsolePal.ForegroundColor; }
-            set { ConsolePal.ForegroundColor = value; }
+            set
+            {
+                if (value == ConsoleColor.Unknown)
+                {
+                    // See comments in set_BackgroundColor
+                    ResetColor();
+                }
+                else
+                {
+                    ConsolePal.ForegroundColor = value;
+                }
+            }
         }
 
         public static void ResetColor()

--- a/src/System.Console/src/System/ConsoleColor.cs
+++ b/src/System.Console/src/System/ConsoleColor.cs
@@ -8,6 +8,8 @@ namespace System
 
     public enum ConsoleColor
     {
+        Unknown = -1,
+
         Black = 0,
         DarkBlue = 1,
         DarkGreen = 2,

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -111,13 +111,23 @@ namespace System
 
         public static ConsoleColor ForegroundColor
         {
-            get { throw new PlatformNotSupportedException(SR.PlatformNotSupported_GettingColor); } // no general mechanism for getting the current color
+            get
+            {
+                // There's no general mechanism for getting the current color.  We could
+                // try to remember what the last set color was, but a) that doesn't help
+                // with the most common case where the getter is accessed first to get the
+                // color to reset back to, and b) it's not necessarily still the current
+                // color, as it could have been changed through another means, such as
+                // writing out the ANSI escape string manually.  As such, we always
+                // simply return Unknown.
+                return ConsoleColor.Unknown;
+            }
             set { ChangeColor(foreground: true, color:  value); }
         }
 
         public static ConsoleColor BackgroundColor
         {
-            get { throw new PlatformNotSupportedException(SR.PlatformNotSupported_GettingColor); } // no general mechanism for getting the current color
+            get { return ConsoleColor.Unknown; } // See comments in get_ForegroundColor.
             set { ChangeColor(foreground: false, color: value); }
         }
 

--- a/src/System.Console/tests/Color.cs
+++ b/src/System.Console/tests/Color.cs
@@ -20,19 +20,22 @@ public class Color
     [Fact]
     public static void RoundtrippingColor()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        // Changing color doesn't have an effect in some testing environments
+        // when there is no associated console, such as when run under a profiler like 
+        // our code coverage tools, so we don't assert that the change took place and 
+        // simple ensure that getting/setting doesn't throw.
+
+        ConsoleColor bg = Console.BackgroundColor;
+        Console.BackgroundColor = bg;
+
+        ConsoleColor fg = Console.ForegroundColor;
+        Console.ForegroundColor = fg;
+
+        // On Unix, get_*Color returns ConsoleColor.Unknown / -1.
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            Console.BackgroundColor = Console.BackgroundColor;
-            Console.ForegroundColor = Console.ForegroundColor;
-            // Changing color on Windows doesn't have effect in some testing environments
-            // when there is no associated console, such as when run under a profiler like 
-            // our code coverage tools, so we don't assert that the change took place and 
-            // simple ensure that getting/setting doesn't throw.
-        }
-        else
-        {
-            Assert.Throws<PlatformNotSupportedException>(() => Console.BackgroundColor);
-            Assert.Throws<PlatformNotSupportedException>(() => Console.ForegroundColor);
+            Assert.Equal(-1, (int)bg);
+            Assert.Equal(-1, (int)fg);
         }
     }
 


### PR DESCRIPTION
This commit adds additional behavior to Console.set_ForegroundColor/set_BackgroundColor that will call ResetColor if the provided value is -1, and in our Unix implementation, we now always return -1 from get_ForegroundColor/get_BackgroundColor.  This makes the typical access pattern of:
```C#
ConsoleColor orig = Console.ForegroundColor; // store original color
Console.ForegroundColor = ConsoleColor.Yellow; // change it temporarily
Console.WriteLine("text"); // write out text in the temporary color
Console.ForegroundColor = orig; // change the color back
```
do what the developer expects, whereas today we throw a PlatformNotSupportedException from the getters.  I've explicitly not added the named value to the contract, as a) we want this to work with the currently shipping code on desktop, and b) the main use case is not via direct access by the user but rather a value returned from the getters.

This still suffers (arguably worse) in cases like this:
```C#
ConsoleColor bOrig = Console.BackgroundColor;
...
ConsoleColor fOrig = Console.ForegroundColor;
Console.ForegroundColor = ConsoleColor.Yellow;
Console.Write("yellow on blue");
Console.ForegroundColor = fOrig;

Console.WriteLine("original foreground color on blue");

fOrig = Console.ForegroundColor;
Console.ForegroundColor = ConsoleColor.Red;
Console.Write("red on blue");
Console.ForegroundColor = fOrig;
...
Console.BackgroundColor = bOrig;
```
The developer's intent here was to have a blue background for all writes, but with this solution, only the first write is going to have the special blue background. That same flaw would exist if the developer used ResetColor directly, but if the developer were forced to use ResetColor, they would be more likely to design their app accordingly, rather than having these weird emergent behaviors.

Other options considered:
- Throwing PlatformNotSupportedException from the getters (the current solution).
- Throwing PlatformNotSupportedException from the setters when set to some unknown value.  This would simply move the point of failure in the common usage rather than eliminating it.
- Remove get_ForegroundColor/get_BackgroundColor from the System.Console.dll contract, leaving just the setters.  **For the record, this is still my preferred solution, but I'm submitting this commit with the mentioned change as, from offline in-person conversations, most (not all) of the folks I've spoken with disagree with me. Additional opinions welcome.**
- Make set_ForegroundColor/set_BackgroundColor a nop when set to an unknown value.  This would be extremely unintuitive, as the APIs would exist but not have the very visible impact they're supposed to have.
- Store the last set color, and choose a set of defaults for the initial access.  This would work on some terminals, where we happened to choose defaults that matched the user's terminal settings, but it would fail on others, causing text to potentially disappear or make it very difficult to read as we set colors back to their wrong "initial" values.

cc: @weshaggard, @pallavit, @joshfree, @ellismg