### PR TITLE
Remove Console.get_*Color from the contracts

### DIFF
--- a/src/System.Console/ref/System.Console.cs
+++ b/src/System.Console/ref/System.Console.cs
@@ -9,10 +9,10 @@ namespace System
 {
     public static partial class Console
     {
-        public static System.ConsoleColor BackgroundColor { get { return default(System.ConsoleColor); } set { } }
+        public static System.ConsoleColor BackgroundColor { set { } }
         public static bool CursorVisible { get { return default(bool); } set { } }
         public static System.IO.TextWriter Error { get { return default(System.IO.TextWriter); } }
-        public static System.ConsoleColor ForegroundColor { get { return default(System.ConsoleColor); } set { } }
+        public static System.ConsoleColor ForegroundColor { set { } }
         public static bool IsInputRedirected { get { return false; } }
         public static bool IsOutputRedirected { get { return false; } }
         public static bool IsErrorRedirected { get { return false; } }

--- a/src/System.Console/src/System/Console.cs
+++ b/src/System.Console/src/System/Console.cs
@@ -111,13 +111,11 @@ namespace System
 
         public static ConsoleColor BackgroundColor
         {
-            get { return ConsolePal.BackgroundColor; }
             set { ConsolePal.BackgroundColor = value; }
         }
 
         public static ConsoleColor ForegroundColor
         {
-            get { return ConsolePal.ForegroundColor; }
             set { ConsolePal.ForegroundColor = value; }
         }
 

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -111,13 +111,11 @@ namespace System
 
         public static ConsoleColor ForegroundColor
         {
-            get { throw new PlatformNotSupportedException(SR.PlatformNotSupported_GettingColor); } // no general mechanism for getting the current color
             set { ChangeColor(foreground: true, color:  value); }
         }
 
         public static ConsoleColor BackgroundColor
         {
-            get { throw new PlatformNotSupportedException(SR.PlatformNotSupported_GettingColor); } // no general mechanism for getting the current color
             set { ChangeColor(foreground: false, color: value); }
         }
 

--- a/src/System.Console/src/System/ConsolePal.Windows.cs
+++ b/src/System.Console/src/System/ConsolePal.Windows.cs
@@ -319,14 +319,6 @@ namespace System
 
         public static ConsoleColor BackgroundColor
         {
-            get
-            {
-                bool succeeded;
-                Interop.mincore.CONSOLE_SCREEN_BUFFER_INFO csbi = GetBufferInfo(false, out succeeded);
-                return succeeded ?
-                    ColorAttributeToConsoleColor((Interop.mincore.Color)csbi.wAttributes & Interop.mincore.Color.BackgroundMask) :
-                    ConsoleColor.Black; // for code that may be used from Windows app w/ no console
-            }
             set
             {
                 Interop.mincore.Color c = ConsoleColorToColorAttribute(value, true);
@@ -351,16 +343,6 @@ namespace System
 
         public static ConsoleColor ForegroundColor
         {
-            get
-            {
-                bool succeeded;
-                Interop.mincore.CONSOLE_SCREEN_BUFFER_INFO csbi = GetBufferInfo(false, out succeeded);
-
-                // For code that may be used from Windows app w/ no console
-                return succeeded ?
-                    ColorAttributeToConsoleColor((Interop.mincore.Color)csbi.wAttributes & Interop.mincore.Color.ForegroundMask) :
-                    ConsoleColor.Gray;
-            }
             set
             {
                 Interop.mincore.Color c = ConsoleColorToColorAttribute(value, false);
@@ -520,16 +502,6 @@ namespace System
             if (isBackground)
                 c = (Interop.mincore.Color)((int)c << 4);
             return c;
-        }
-
-        private static ConsoleColor ColorAttributeToConsoleColor(Interop.mincore.Color c)
-        {
-            // Turn background colors into foreground colors.
-            if ((c & Interop.mincore.Color.BackgroundMask) != 0)
-            {
-                c = (Interop.mincore.Color)(((int)c) >> 4);
-            }
-            return (ConsoleColor)c;
         }
 
         private static Interop.mincore.CONSOLE_SCREEN_BUFFER_INFO GetBufferInfo()

--- a/src/System.Console/tests/Color.cs
+++ b/src/System.Console/tests/Color.cs
@@ -18,22 +18,11 @@ public class Color
     }
 
     [Fact]
-    public static void RoundtrippingColor()
+    public static void ChangingColor()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            Console.BackgroundColor = Console.BackgroundColor;
-            Console.ForegroundColor = Console.ForegroundColor;
-            // Changing color on Windows doesn't have effect in some testing environments
-            // when there is no associated console, such as when run under a profiler like 
-            // our code coverage tools, so we don't assert that the change took place and 
-            // simple ensure that getting/setting doesn't throw.
-        }
-        else
-        {
-            Assert.Throws<PlatformNotSupportedException>(() => Console.BackgroundColor);
-            Assert.Throws<PlatformNotSupportedException>(() => Console.ForegroundColor);
-        }
+        Console.BackgroundColor = ConsoleColor.Yellow;
+        Console.ForegroundColor = ConsoleColor.Red;
+        Console.ResetColor();
     }
 
     [Fact]


### PR DESCRIPTION
As an alternative to https://github.com/dotnet/corefx/pull/4418, this removes Console.get_ForegroundColor and Console.get_BackgroundColor from the implementations and contracts.