### PR TITLE
Track and always resend both ConsoleColors

### DIFF
--- a/src/System.Console/src/Resources/Strings.resx
+++ b/src/System.Console/src/Resources/Strings.resx
@@ -207,9 +207,6 @@
   <data name="InvalidOperation_ConsoleReadKeyOnFile" xml:space="preserve">
     <value>Cannot read keys when either application does not have a console or when console input has been redirected. Try Console.Read.</value>
   </data>
-  <data name="PlatformNotSupported_GettingColor" xml:space="preserve">
-    <value>This platform does not support getting the current color.</value>
-  </data>
   <data name="PersistedFiles_NoHomeDirectory" xml:space="preserve">
     <value>The home directory of the current user could not be determined.</value>
   </data>

--- a/src/System.Console/tests/Color.cs
+++ b/src/System.Console/tests/Color.cs
@@ -20,20 +20,13 @@ public class Color
     [Fact]
     public static void RoundtrippingColor()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            Console.BackgroundColor = Console.BackgroundColor;
-            Console.ForegroundColor = Console.ForegroundColor;
-            // Changing color on Windows doesn't have effect in some testing environments
-            // when there is no associated console, such as when run under a profiler like 
-            // our code coverage tools, so we don't assert that the change took place and 
-            // simple ensure that getting/setting doesn't throw.
-        }
-        else
-        {
-            Assert.Throws<PlatformNotSupportedException>(() => Console.BackgroundColor);
-            Assert.Throws<PlatformNotSupportedException>(() => Console.ForegroundColor);
-        }
+        Console.BackgroundColor = Console.BackgroundColor;
+        Console.ForegroundColor = Console.ForegroundColor;
+
+        // Changing color on Windows doesn't have effect in some testing environments
+        // when there is no associated console, such as when run under a profiler like 
+        // our code coverage tools, so we don't assert that the change took place and 
+        // simple ensure that getting/setting doesn't throw.
     }
 
     [Fact]


### PR DESCRIPTION
As an alternative to https://github.com/dotnet/corefx/pull/4418, this commit tracks all changes made to foreground/background color through the APIs, and any time either foreground or background is updated, both are set.