### PR TITLE
Fix intermittent perf_process test failure.

### DIFF
--- a/src/System.Diagnostics.Process/tests/Performance/Perf.Process.cs
+++ b/src/System.Diagnostics.Process/tests/Performance/Perf.Process.cs
@@ -20,7 +20,7 @@ namespace System.Diagnostics.Tests
                 Process[] processes = new Process[inneriterations];
                 for (int i = 0; i < inneriterations; i++)
                 {
-                    processes[i] = CreateProcessInfinite();
+                    processes[i] = CreateProcessLong();
                     processes[i].Start();
                 }
 

--- a/src/System.Diagnostics.Process/tests/ProcessStandardConsoleTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStandardConsoleTests.cs
@@ -16,7 +16,7 @@ namespace System.Diagnostics.Tests
         {
             Action<int> run = expectedCodePage =>
             {
-                Process p = CreateProcessInfinite();
+                Process p = CreateProcessLong();
                 p.StartInfo.RedirectStandardInput = true;
                 p.StartInfo.RedirectStandardOutput = true;
                 p.StartInfo.RedirectStandardError = true;

--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -259,7 +259,7 @@ namespace System.Diagnostics.Tests
         [Theory, InlineData(true), InlineData(false)]
         public void TestCreateNoWindowProperty(bool value)
         {
-            Process testProcess = CreateProcessInfinite();
+            Process testProcess = CreateProcessLong();
             try
             {
                 testProcess.StartInfo.CreateNoWindow = value;
@@ -290,7 +290,7 @@ namespace System.Diagnostics.Tests
                 return; // test is irrelevant if we can't add a user
             }
 
-            Process p = CreateProcessInfinite();
+            Process p = CreateProcessLong();
 
             p.StartInfo.LoadUserProfile = true;
             p.StartInfo.UserName = username;
@@ -345,7 +345,7 @@ namespace System.Diagnostics.Tests
             // check defaults
             Assert.Equal(string.Empty, _process.StartInfo.WorkingDirectory);
 
-            Process p = CreateProcessInfinite();
+            Process p = CreateProcessLong();
             p.StartInfo.WorkingDirectory = Directory.GetCurrentDirectory();
 
             try

--- a/src/System.Diagnostics.Process/tests/ProcessTestBase.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTestBase.cs
@@ -8,7 +8,7 @@ namespace System.Diagnostics.Tests
 {
     public class ProcessTestBase : RemoteExecutorTestBase
     {
-        protected const int WaitInMS = 100 * 1000;
+        protected const int WaitInMS = 600 * 1000;
         protected readonly Process _process;
         protected readonly List<Process> _processes = new List<Process>();
 
@@ -63,15 +63,6 @@ namespace System.Diagnostics.Tests
             {
                 Thread.Sleep(WaitInMS);
                 return SuccessExitCode;
-            });
-        }
-
-        protected Process CreateProcessInfinite()
-        {
-            return CreateProcess(() =>
-            {
-                while (true)
-                    Thread.Sleep(WaitInMS);
             });
         }
 

--- a/src/System.Diagnostics.Process/tests/ProcessTestBase.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTestBase.cs
@@ -14,7 +14,7 @@ namespace System.Diagnostics.Tests
 
         public ProcessTestBase()
         {
-            _process = CreateProcessInfinite();
+            _process = CreateProcessLong();
             _process.Start();
         }
 
@@ -57,12 +57,21 @@ namespace System.Diagnostics.Tests
             return p;
         }
 
-        protected Process CreateProcessInfinite()
+        protected Process CreateProcessLong()
         {
             return CreateProcess(() =>
             {
                 Thread.Sleep(WaitInMS);
                 return SuccessExitCode;
+            });
+        }
+
+        protected Process CreateProcessInfinite()
+        {
+            return CreateProcess(() =>
+            {
+                while (true)
+                    Thread.Sleep(WaitInMS);
             });
         }
 

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -80,7 +80,7 @@ namespace System.Diagnostics.Tests
         {
             bool exitedInvoked = false;
 
-            Process p = CreateProcessInfinite();
+            Process p = CreateProcessLong();
             if (enable.HasValue)
             {
                 p.EnableRaisingEvents = enable.Value;
@@ -115,7 +115,7 @@ namespace System.Diagnostics.Tests
             }
 
             {
-                Process p = CreateProcessInfinite();
+                Process p = CreateProcessLong();
                 StartSleepKillWait(p);
                 Assert.NotEqual(0, p.ExitCode);
             }
@@ -125,7 +125,7 @@ namespace System.Diagnostics.Tests
         public void TestExitTime()
         {
             DateTime timeBeforeProcessStart = DateTime.UtcNow;
-            Process p = CreateProcessInfinite();
+            Process p = CreateProcessLong();
             p.Start();
             Assert.Throws<InvalidOperationException>(() => p.ExitTime);
             p.Kill();
@@ -158,7 +158,7 @@ namespace System.Diagnostics.Tests
             }
 
             {
-                Process p = CreateProcessInfinite();
+                Process p = CreateProcessLong();
                 p.Start();
                 try
                 {
@@ -361,7 +361,7 @@ namespace System.Diagnostics.Tests
         public void TestProcessStartTime()
         {
             DateTime timeBeforeCreatingProcess = DateTime.UtcNow;
-            Process p = CreateProcessInfinite();
+            Process p = CreateProcessLong();
 
             Assert.Throws<InvalidOperationException>(() => p.StartTime);
             try
@@ -586,7 +586,7 @@ namespace System.Diagnostics.Tests
         public void TestStartInfo()
         {
             {
-                Process process = CreateProcessInfinite();
+                Process process = CreateProcessLong();
                 process.Start();
 
                 Assert.Equal(HostRunner, process.StartInfo.FileName);
@@ -596,7 +596,7 @@ namespace System.Diagnostics.Tests
             }
 
             {
-                Process process = CreateProcessInfinite();
+                Process process = CreateProcessLong();
                 process.Start();
 
                 Assert.Throws<System.InvalidOperationException>(() => (process.StartInfo = new ProcessStartInfo()));

--- a/src/System.Diagnostics.Process/tests/ProcessThreadTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessThreadTests.cs
@@ -57,7 +57,7 @@ namespace System.Diagnostics.Tests
         public void TestStartTimeProperty()
         {
             DateTime timeBeforeCreatingProcess = DateTime.UtcNow;
-            Process p = CreateProcessInfinite();
+            Process p = CreateProcessLong();
             try
             {
                 p.Start();

--- a/src/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
@@ -13,7 +13,7 @@ namespace System.Diagnostics.Tests
         public void MultipleProcesses_StartAllKillAllWaitAll()
         {
             const int Iters = 50;
-            Process[] processes = Enumerable.Range(0, Iters).Select(_ => CreateProcessInfinite()).ToArray();
+            Process[] processes = Enumerable.Range(0, Iters).Select(_ => CreateProcessLong()).ToArray();
 
             foreach (Process p in processes) p.Start();
             foreach (Process p in processes) p.Kill();
@@ -26,7 +26,7 @@ namespace System.Diagnostics.Tests
             const int Iters = 50;
             for (int i = 0; i < Iters; i++)
             {
-                Process p = CreateProcessInfinite();
+                Process p = CreateProcessLong();
                 p.Start();
                 p.Kill();
                 p.WaitForExit(WaitInMS);
@@ -41,7 +41,7 @@ namespace System.Diagnostics.Tests
             {
                 for (int i = 0; i < ItersPerTask; i++)
                 {
-                    Process p = CreateProcessInfinite();
+                    Process p = CreateProcessLong();
                     p.Start();
                     p.Kill();
                     p.WaitForExit(WaitInMS);
@@ -83,7 +83,7 @@ namespace System.Diagnostics.Tests
         [InlineData(true)]
         public async Task SingleProcess_WaitAfterExited(bool addHandlerBeforeStart)
         {
-            Process p = CreateProcessInfinite();
+            Process p = CreateProcessLong();
             p.EnableRaisingEvents = true;
 
             var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
@@ -61,7 +61,7 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void SingleProcess_TryWaitMultipleTimesBeforeCompleting()
         {
-            Process p = CreateProcessInfinite();
+            Process p = CreateProcessLong();
             p.Start();
 
             // Verify we can try to wait for the process to exit multiple times
@@ -106,7 +106,7 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void SingleProcess_CopiesShareExitInformation()
         {
-            Process p = CreateProcessInfinite();
+            Process p = CreateProcessLong();
             p.Start();
 
             Process[] copies = Enumerable.Range(0, 3).Select(_ => Process.GetProcessById(p.Id)).ToArray();
@@ -124,7 +124,7 @@ namespace System.Diagnostics.Tests
         [Fact]
         public void WaitForPeerProcess()
         {
-            Process child1 = CreateProcessInfinite();
+            Process child1 = CreateProcessLong();
             child1.Start();
 
             Process child2 = CreateProcess(peerId =>


### PR DESCRIPTION
Perf_Process.Kill was trying to kill processes that could exit before it had the chance to get to them. I modified the ProcessTestBase helpers to make CreateProcessInfinite create an actually infinitely running process for the Kill test and renamed the old CreateProcessInfinite to the more accurate CreateProcessLong

resolves #4397 

@stephentoub @Priya91 