### PR TITLE
Fix faulty dataflow DebugAttributeTests

### DIFF
--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/DebugAttributeTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/DebugAttributeTests.cs
@@ -24,31 +24,32 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 var dboGroupGreedy = new GroupingDataflowBlockOptions();
                 var dboGroupNonGreedy = new GroupingDataflowBlockOptions { Greedy = false };
 
-                // Item1 == test Debuggerdisplay, Item2 == test DebuggerTypeProxy, Item3 == object
+                // Item1 == test DebuggerDisplay, Item2 == test DebuggerTypeProxy, Item3 == object
                 var objectsToTest = new Tuple<bool, bool, object>[]
                 {
                     // Primary Blocks
+                    // (Don't test DebuggerTypeProxy on instances that may internally have async operations in progress)
                     Tuple.Create<bool,bool,object>(true, true, new ActionBlock<int>(i => {})),
                     Tuple.Create<bool,bool,object>(true, true, new ActionBlock<int>(i => {}, dboExBuffering)),
                     Tuple.Create<bool,bool,object>(true, true, new ActionBlock<int>(i => {}, dboExSpsc)),
-                    Tuple.Create<bool,bool,object>(true, true, SendAsyncMessages(new ActionBlock<int>(i => {}, dboExNoBuffering), 2)),
+                    Tuple.Create<bool,bool,object>(true, false, SendAsyncMessages(new ActionBlock<int>(i => {}, dboExNoBuffering), 2)),
                     Tuple.Create<bool,bool,object>(true, true, new TransformBlock<int,int>(i => i)),
                     Tuple.Create<bool,bool,object>(true, true, new TransformBlock<int,int>(i => i, dboExBuffering)),
-                    Tuple.Create<bool,bool,object>(true, true, SendAsyncMessages(new TransformBlock<int,int>(i => i, dboExNoBuffering),2)),
+                    Tuple.Create<bool,bool,object>(true, false, SendAsyncMessages(new TransformBlock<int,int>(i => i, dboExNoBuffering),2)),
                     Tuple.Create<bool,bool,object>(true, true, new TransformManyBlock<int,int>(i => new [] { i })),
                     Tuple.Create<bool,bool,object>(true, true, new TransformManyBlock<int,int>(i => new [] { i }, dboExBuffering)),
-                    Tuple.Create<bool,bool,object>(true, true, SendAsyncMessages(new TransformManyBlock<int,int>(i => new [] { i }, dboExNoBuffering),2)),
+                    Tuple.Create<bool,bool,object>(true, false, SendAsyncMessages(new TransformManyBlock<int,int>(i => new [] { i }, dboExNoBuffering),2)),
                     Tuple.Create<bool,bool,object>(true, true, new BufferBlock<int>()),
                     Tuple.Create<bool,bool,object>(true, true, new BufferBlock<int>(new DataflowBlockOptions() { NameFormat = "none" })),
                     Tuple.Create<bool,bool,object>(true, true, new BufferBlock<int>(new DataflowBlockOptions() { NameFormat = "foo={0}, bar={1}" })),
                     Tuple.Create<bool,bool,object>(true, true, new BufferBlock<int>(new DataflowBlockOptions() { NameFormat = "foo={0}, bar={1}, kaboom={2}" })),
                     Tuple.Create<bool,bool,object>(true, true, new BufferBlock<int>(dboBuffering)),
-                    Tuple.Create<bool,bool,object>(true, true, SendAsyncMessages(new BufferBlock<int>(new DataflowBlockOptions { BoundedCapacity = 10 }), 20)),
+                    Tuple.Create<bool,bool,object>(true, false, SendAsyncMessages(new BufferBlock<int>(new DataflowBlockOptions { BoundedCapacity = 10 }), 20)),
                     Tuple.Create<bool,bool,object>(true, true, new BroadcastBlock<int>(i => i)),
                     Tuple.Create<bool,bool,object>(true, true, new BroadcastBlock<int>(i => i, dboBuffering)),
-                    Tuple.Create<bool,bool,object>(true, true, SendAsyncMessages(new BroadcastBlock<int>(i => i, dboNoBuffering), 20)),
+                    Tuple.Create<bool,bool,object>(true, false, SendAsyncMessages(new BroadcastBlock<int>(i => i, dboNoBuffering), 20)),
                     Tuple.Create<bool,bool,object>(true, true, new WriteOnceBlock<int>(i => i)),
-                    Tuple.Create<bool,bool,object>(true, true, SendAsyncMessages(new WriteOnceBlock<int>(i => i), 1)),
+                    Tuple.Create<bool,bool,object>(true, false, SendAsyncMessages(new WriteOnceBlock<int>(i => i), 1)),
                     Tuple.Create<bool,bool,object>(true, true, new WriteOnceBlock<int>(i => i, dboBuffering)),
                     Tuple.Create<bool,bool,object>(true, true, new JoinBlock<int,int>()),
                     Tuple.Create<bool,bool,object>(true, true, new JoinBlock<int,int>(dboGroupGreedy)),


### PR DESCRIPTION
The dataflow blocks have debugger attributes providing displays and views.  These invoke functionality that examine the state of the block, and that examination expects to be done when everything is paused under the debugger, in particular for the views.  This is because properties on the views may end up enumerating collections that are being modified concurrently by asynchronous operations internal to the block.

We have tests that exercise these debugger views, and do so without the pause-the-world-first semantics provided by the debugger.  As such, every once in a while, we get an InvalidOperationException stemming from trying to examine one of these collections while it's being modified.

This commit simply disables testing the views in the few cases where we've kicked off asynchronous operations on the objects being analyzed.

Fixes #4453
cc: @mellinoe 