### PR TITLE
Add System.Net.WebSockets.Client tests

### DIFF
--- a/src/Common/tests/System/AssertExtensions.cs
+++ b/src/Common/tests/System/AssertExtensions.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+
+namespace System
+{
+    public static class AssertExtensions
+    {
+        public static void Throws<T>(Action action, string message)
+            where T : Exception
+        {
+            Assert.Equal(Assert.Throws<T>(action).Message, message);
+        }
+    }
+}

--- a/src/Common/tests/System/Net/WebSocketTestServers.cs
+++ b/src/Common/tests/System/Net/WebSocketTestServers.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Net.Tests
+{
+    internal class WebSocketTestServers
+    {
+        public const string Host = "corefx-networking.azurewebsites.net";
+
+        private const string EchoHandler = "WebSocket/EchoWebSocket.ashx";
+
+        public readonly static Uri RemoteEchoServer = new Uri("ws://" + Host + "/" + EchoHandler);
+        public readonly static Uri SecureRemoteEchoServer = new Uri("wss://" + Host + "/" + EchoHandler);
+
+        public readonly static object[][] EchoServers = { new object[] { RemoteEchoServer }, new object[] { SecureRemoteEchoServer } };
+    }
+}

--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketTest.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Net.Tests;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.WebSockets.Client.Tests
+{
+    /// <summary>
+    /// ClientWebSocket tests that do require a remote server.
+    /// </summary>
+    public class ClientWebSocketTest
+    {
+        public readonly static object[][] EchoServers = WebSocketTestServers.EchoServers;
+
+        private const int s_TimeOutMilliseconds = 2000;
+
+        private readonly ITestOutputHelper _output;
+
+        public ClientWebSocketTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Theory, MemberData("EchoServers")]
+        public async Task EchoBinaryMessage_Success(Uri server)
+        {
+            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
+            {
+                return;
+            }
+
+            var helper = new WebSocketHelper(server, s_TimeOutMilliseconds);
+            await helper.TestEcho(WebSocketMessageType.Binary);
+        }
+
+        [Theory, MemberData("EchoServers")]
+        public async Task EchoTextMessage_Success(Uri server)
+        {
+            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
+            {
+                return;
+            }
+
+            var helper = new WebSocketHelper(server, s_TimeOutMilliseconds);
+            await helper.TestEcho(WebSocketMessageType.Text);
+        }        
+    }
+}

--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketUnitTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketUnitTest.cs
@@ -1,39 +1,45 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Net.WebSockets;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Text;
 
 using Xunit;
+using Xunit.Abstractions;
 
-namespace System.Net.WebSockets.Client.Test
+namespace System.Net.WebSockets.Client.Tests
 {
     /// <summary>
     /// ClientWebSocket unit tests that do not require a remote server.
     /// </summary>
-    public class ClientWebSocketTest
+    public class ClientWebSocketUnitTest
     {
-        internal static class AssertExtensions
+        private readonly ITestOutputHelper _output;
+
+        public ClientWebSocketUnitTest(ITestOutputHelper output)
         {
-            public static void Throws<T>(Action action, string message)
-                where T : Exception
-            {
-                Assert.Equal(Assert.Throws<T>(action).Message, message);
-            }
+            _output = output;
         }
 
         [Fact]
-        public void ClientWebSocket_Ctor()
+        public void Ctor_Success()
         {
+            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
+            {
+                return;
+            }
+
             var cws = new ClientWebSocket();
         }
 
         [Fact]
-        public void ClientWebSocket_NoConnect_AbortCalled_Ok()
+        public void Abort_CreateAndAbort_StateIsClosed()
         {
+            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
+            {
+                return;
+            }
+
             var cws = new ClientWebSocket();
             cws.Abort();
 
@@ -41,19 +47,28 @@ namespace System.Net.WebSockets.Client.Test
         }
 
         [Fact]
-        public void ClientWebSocket_NoConnect_CloseAsync_Throws()
+        public void CloseAsync_CreateAndClose_ThrowsInvalidOperationException()
         {
+            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
+            {
+                return;
+            }
+
             var cws = new ClientWebSocket();
-            Assert.Throws<InvalidOperationException>(
-                () =>
-                cws.CloseAsync(WebSocketCloseStatus.Empty, "", new CancellationToken()).GetAwaiter().GetResult());
+            Assert.Throws<InvalidOperationException>(() =>
+                { Task t = cws.CloseAsync(WebSocketCloseStatus.Empty, "", new CancellationToken()); });
 
             Assert.Equal(WebSocketState.None, cws.State);
         }
 
         [Fact]
-        public void ClientWebSocket_NoConnect_CloseOutputAsync_Ok()
+        public void CloseAsync_CreateAndCloseOutput_ThrowsInvalidOperationExceptionWithCorrectMessage()
         {
+            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
+            {
+                return;
+            }
+
             var cws = new ClientWebSocket();
             AssertExtensions.Throws<InvalidOperationException>(
                 () =>
@@ -64,8 +79,33 @@ namespace System.Net.WebSockets.Client.Test
         }
 
         [Fact]
-        public void ClientWebSocket_NoConnect_ReceiveAsync_Throws()
+        public void CloseAsync_CreateAndReceive_ThrowsInvalidOperationException()
         {
+            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
+            {
+                return;
+            }
+
+            var cws = new ClientWebSocket();
+
+            var buffer = new byte[100];
+            var segment = new ArraySegment<byte>(buffer);
+            var ct = new CancellationToken();
+
+            Assert.Throws<InvalidOperationException>(() =>
+                { Task t = cws.ReceiveAsync(segment, ct); });
+
+            Assert.Equal(WebSocketState.None, cws.State);
+        }
+
+        [Fact]
+        public void CloseAsync_CreateAndReceive_ThrowsInvalidOperationExceptionWithCorrectMessage()
+        {
+            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
+            {
+                return;
+            }
+
             var cws = new ClientWebSocket();
 
             var buffer = new byte[100];
@@ -80,8 +120,33 @@ namespace System.Net.WebSockets.Client.Test
         }
 
         [Fact]
-        public void ClientWebSocket_NoConnect_SendAsync_Throws()
+        public void CloseAsync_CreateAndSend_ThrowsInvalidOperationException()
         {
+            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
+            {
+                return;
+            }
+
+            var cws = new ClientWebSocket();
+
+            var buffer = new byte[100];
+            var segment = new ArraySegment<byte>(buffer);
+            var ct = new CancellationToken();
+
+            Assert.Throws<InvalidOperationException>(() =>
+                { Task t = cws.SendAsync(segment, WebSocketMessageType.Text, false, ct); });
+
+            Assert.Equal(WebSocketState.None, cws.State);
+        }
+
+        [Fact]
+        public void CloseAsync_CreateAndSend_ThrowsInvalidOperationExceptionWithCorrectMessage()
+        {
+            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
+            {
+                return;
+            }
+
             var cws = new ClientWebSocket();
 
             var buffer = new byte[100];
@@ -96,8 +161,13 @@ namespace System.Net.WebSockets.Client.Test
         }
 
         [Fact]
-        public void ClientWebSocket_NoConnect_Properties_Ok()
+        public void Ctor_ExpectedPropertyValues()
         {
+            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
+            {
+                return;
+            }
+
             var cws = new ClientWebSocket();
             Assert.Equal(null, cws.CloseStatus);
             Assert.Equal(null, cws.CloseStatusDescription);
@@ -108,8 +178,13 @@ namespace System.Net.WebSockets.Client.Test
         }
 
         [Fact]
-        public void ClientWebSocket_Dispose_AbortCalled_Ok()
+        public void Abort_CreateAndDisposeAndAbort_StateIsClosedSuccess()
         {
+            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
+            {
+                return;
+            }
+
             var cws = new ClientWebSocket();
             cws.Dispose();
 
@@ -118,21 +193,30 @@ namespace System.Net.WebSockets.Client.Test
         }
 
         [Fact]
-        public void ClientWebSocket_Dispose_CloseAsync_Throws()
+        public void CloseAsync_DisposeAndClose_ThrowsObjectDisposedException()
         {
+            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
+            {
+                return;
+            }
+
             var cws = new ClientWebSocket();
             cws.Dispose();
 
-            Assert.Throws<ObjectDisposedException>(
-                () =>
-                cws.CloseAsync(WebSocketCloseStatus.Empty, "", new CancellationToken()).GetAwaiter().GetResult());
+            Assert.Throws<ObjectDisposedException>(() =>
+                { Task t = cws.CloseAsync(WebSocketCloseStatus.Empty, "", new CancellationToken()); });
 
             Assert.Equal(WebSocketState.Closed, cws.State);
         }
 
         [Fact]
-        public void ClientWebSocket_Dispose_CloseOutputAsync_Ok()
+        public void CloseAsync_DisposeAndClose_ThrowsObjectDisposedExceptionWithCorrectMessage()
         {
+            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
+            {
+                return;
+            }
+
             var cws = new ClientWebSocket();
             cws.Dispose();
 
@@ -147,8 +231,13 @@ namespace System.Net.WebSockets.Client.Test
         }
 
         [Fact]
-        public void ClientWebSocket_Dispose_ReceiveAsync_Throws()
+        public void ReceiveAsync_CreateAndDisposeAndReceive_ThrowsObjectDisposedExceptionWithCorrectMessage()
         {
+            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
+            {
+                return;
+            }
+
             var cws = new ClientWebSocket();
             cws.Dispose();
 
@@ -166,8 +255,13 @@ namespace System.Net.WebSockets.Client.Test
         }
 
         [Fact]
-        public void ClientWebSocket_Dispose_SendAsync_Throws()
+        public void SendAsync_CreateAndDisposeAndSend_ThrowsObjectDisposedExceptionWithCorrectMessage()
         {
+            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
+            {
+                return;
+            }
+
             var cws = new ClientWebSocket();
             cws.Dispose();
 
@@ -185,8 +279,13 @@ namespace System.Net.WebSockets.Client.Test
         }
 
         [Fact]
-        public void ClientWebSocket_Dispose_Properties_Ok()
+        public void Dispose_CreateAndDispose_ExpectedPropertyValues()
         {
+            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
+            {
+                return;
+            }
+
             var cws = new ClientWebSocket();
             cws.Dispose();
 

--- a/src/System.Net.WebSockets.Client/tests/ResourceHelper.cs
+++ b/src/System.Net.WebSockets.Client/tests/ResourceHelper.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 
 using Xunit;
 
-namespace System.Net.WebSockets.Client.Test
+namespace System.Net.WebSockets.Client.Tests
 {
     public class ResourceHelper
     {

--- a/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
+++ b/src/System.Net.WebSockets.Client/tests/System.Net.WebSockets.Client.Tests.csproj
@@ -15,8 +15,17 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
 
   <ItemGroup>
-    <Compile Include="ClientWebSocketTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\AssertExtensions.cs">
+      <Link>Common\System\AssertExtensions.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\WebSocketTestServers.cs">
+      <Link>Common\System\Net\WebSocketTestServers.cs</Link>
+    </Compile>
+    <Compile Include="ClientWebSocketTest.cs" />
+    <Compile Include="ClientWebSocketUnitTest.cs" />
     <Compile Include="ResourceHelper.cs" />
+    <Compile Include="WebSocketData.cs" />
+    <Compile Include="WebSocketHelper.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Net.WebSockets.Client/tests/WebSocketData.cs
+++ b/src/System.Net.WebSockets.Client/tests/WebSocketData.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+
+namespace System.Net.WebSockets.Client.Tests
+{
+    public static class WebSocketData
+    {
+        public static ArraySegment<byte> GetBufferFromText(string text)
+        {
+            byte[] buffer = Encoding.UTF8.GetBytes(text);
+            return new ArraySegment<byte>(buffer);
+        }
+
+        public static string GetTextFromBuffer(ArraySegment<byte> buffer)
+        {
+            return Encoding.UTF8.GetString(buffer.Array, buffer.Offset, buffer.Count);
+        }
+    }
+}

--- a/src/System.Net.WebSockets.Client/tests/WebSocketHelper.cs
+++ b/src/System.Net.WebSockets.Client/tests/WebSocketHelper.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xunit;
+using Xunit.Abstractions;
+
+namespace System.Net.WebSockets.Client.Tests
+{
+    public class WebSocketHelper
+    {
+        private static Lazy<bool> s_WebSocketSupported = new Lazy<bool>(InitWebSocketSupported);
+        private static int s_TimeOutMilliseconds;
+        private Uri _echoService;
+
+        public WebSocketHelper(Uri echoService, int timeOut)
+        {
+            _echoService = echoService;
+            s_TimeOutMilliseconds = timeOut;
+        }
+
+        public static bool ShouldSkipTestOSNotSupported(ITestOutputHelper output)
+        {
+            if (!s_WebSocketSupported.Value)
+            {
+                output.WriteLine("WinHttp/WebSockets are not supported on this platform.");
+            }
+
+            return !s_WebSocketSupported.Value;
+        }
+
+        public async Task TestEcho(WebSocketMessageType type)
+        {
+            var cts = new CancellationTokenSource(s_TimeOutMilliseconds);
+            string message = "Hello WebSockets!";
+            string closeMessage = "Good bye!";
+            var receiveBuffer = new byte[100];
+            var receiveSegment = new ArraySegment<byte>(receiveBuffer);
+
+            ClientWebSocket cws = await GetConnectedWebSocket(_echoService);
+
+            await cws.SendAsync(WebSocketData.GetBufferFromText(message), type, true, cts.Token);
+            Assert.Equal(WebSocketState.Open, cws.State);
+
+            WebSocketReceiveResult recvRet = await cws.ReceiveAsync(receiveSegment, cts.Token);
+            Assert.Equal(WebSocketState.Open, cws.State);
+            Assert.Equal(message.Length, recvRet.Count);
+            Assert.Equal(type, recvRet.MessageType);
+            Assert.Equal(true, recvRet.EndOfMessage);
+            Assert.Equal(null, recvRet.CloseStatus);
+            Assert.Equal(null, recvRet.CloseStatusDescription);
+
+            var recvSegment = new ArraySegment<byte>(receiveSegment.Array, receiveSegment.Offset, recvRet.Count);
+            Assert.Equal(message, WebSocketData.GetTextFromBuffer(recvSegment));
+
+            Task taskClose = cws.CloseAsync(WebSocketCloseStatus.NormalClosure, closeMessage, cts.Token);
+            Assert.True(
+                (cws.State == WebSocketState.Open) || (cws.State == WebSocketState.CloseSent) ||
+                (cws.State == WebSocketState.CloseReceived) || (cws.State == WebSocketState.Closed),
+                "State immediately after CloseAsync : " + cws.State);
+            await taskClose;
+            Assert.Equal(WebSocketState.Closed, cws.State);
+            Assert.Equal(WebSocketCloseStatus.NormalClosure, cws.CloseStatus);
+            Assert.Equal(closeMessage, cws.CloseStatusDescription);
+
+            cws.Dispose();
+            Assert.Equal(WebSocketState.Closed, cws.State);
+        }
+
+        public static async Task<ClientWebSocket> GetConnectedWebSocket(Uri u)
+        {
+            var cws = new ClientWebSocket();
+            var cts = new CancellationTokenSource(s_TimeOutMilliseconds);
+
+            Task taskConnect = cws.ConnectAsync(u, cts.Token);
+            Assert.True(
+                (cws.State == WebSocketState.None) ||
+                (cws.State == WebSocketState.Connecting) ||
+                (cws.State == WebSocketState.Open),
+                "State immediately after ConnectAsync incorrect: " + cws.State);
+            await taskConnect;
+            Assert.Equal(WebSocketState.Open, cws.State);
+
+            return cws;
+        }
+
+        private static bool InitWebSocketSupported()
+        {
+            ClientWebSocket cws = null;
+
+            try
+            {
+                cws = new ClientWebSocket();
+                return true;
+            }
+            catch (PlatformNotSupportedException)
+            {
+                return false;
+            }
+            finally
+            {
+                if (cws != null)
+                {
+                    cws.Dispose();
+                }
+            }            
+        }
+    }
+}


### PR DESCRIPTION
* Port some of the ToF ClientWebSocket tests that talk to a real websocket server
* Cleanup naming of existing tests to conform to System.Net test method naming
* Skip tests if not supported on platform. Specifically, these tests were failing
on Win7 since Win7 does not support WinHttp WebSockets. We haven't really noticed this
failing since the CI doesn't yet run Win7 tests (issue #4468)

I plan to port the remainder of the ToF websocket related tests in a subsequent PR.