### PR TITLE
Fix TODO in several System.Text.Encodings.Web tests

### DIFF
--- a/src/System.Text.Encodings.Web/tests/UnicodeHelpersTests.cs
+++ b/src/System.Text.Encodings.Web/tests/UnicodeHelpersTests.cs
@@ -20,48 +20,62 @@ namespace Microsoft.Framework.WebEncoders
 
         private static readonly UTF8Encoding _utf8EncodingThrowOnInvalidBytes = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
-        [Fact]
-        public void GetScalarValueFromUtf16()
-        {
-            // TODO: [ActiveIssue(3537, PlatformID.AnyUnix)]
-            // This loop should instead be implemented as a [Theory] with multiple [InlineData]s.
-            // However, until globalization support is implemented on Unix, this causes failures when
-            // the xunit runner is configured with -xml to trace out results.  When it does so with 
-            // [InlineData], the parameters get written out to the results xml file, and with our
-            // current temporary globalization implementation on Unix, this causes exceptions like
-            // "The surrogate pair (0xD800, 0x22) is invalid. A high surrogate character 
-            // (0xD800 - 0xDBFF) must always be paired with a low surrogate character (0xDC00 - 0xDFFF)."
-            foreach (var input in new[] {
-                Tuple.Create(1, "a", (int)'a'), // normal BMP char, end of string
-                Tuple.Create(2, "ab", (int)'a'), // normal BMP char, not end of string
-                Tuple.Create(3, "\uDFFF", UnicodeReplacementChar), // trailing surrogate, end of string
-                Tuple.Create(4, "\uDFFFx", UnicodeReplacementChar), // trailing surrogate, not end of string
-                Tuple.Create(5, "\uD800", UnicodeReplacementChar), // leading surrogate, end of string
-                Tuple.Create(6, "\uD800x", UnicodeReplacementChar), // leading surrogate, not end of string, followed by non-surrogate
-                Tuple.Create(7, "\uD800\uD800", UnicodeReplacementChar), // leading surrogate, not end of string, followed by leading surrogate
-                Tuple.Create(8, "\uD800\uDFFF", 0x103FF) // leading surrogate, not end of string, followed by trailing surrogate
-            })
-            {
-                GetScalarValueFromUtf16(input.Item1, input.Item2, input.Item3);
-            }
-        }
-        
-        //[Theory]
-        //[InlineData(1, "a", (int)'a')] // normal BMP char, end of string
-        //[InlineData(2, "ab", (int)'a')] // normal BMP char, not end of string
-        //[InlineData(3, "\uDFFF", UnicodeReplacementChar)] // trailing surrogate, end of string
-        //[InlineData(4, "\uDFFFx", UnicodeReplacementChar)] // trailing surrogate, not end of string
-        //[InlineData(5, "\uD800", UnicodeReplacementChar)] // leading surrogate, end of string
-        //[InlineData(6, "\uD800x", UnicodeReplacementChar)] // leading surrogate, not end of string, followed by non-surrogate
-        //[InlineData(7, "\uD800\uD800", UnicodeReplacementChar)] // leading surrogate, not end of string, followed by leading surrogate
-        //[InlineData(8, "\uD800\uDFFF", 0x103FF)] // leading surrogate, not end of string, followed by trailing surrogate
-        //public
-        private void GetScalarValueFromUtf16(int unused, string input, int expectedResult)
-        {
-            // The 'unused' parameter exists because the xunit runner can't distinguish
-            // the individual malformed data test cases from each other without this
-            // additional identifier.
+        // To future refactorers:
+        // The following GetScalarValueFromUtf16_* tests must not be done as a [Theory].  If done via [InlineData], the invalid 
+        // code points will get sanitized with replacement characters before they even reach the test, as the strings are parsed 
+        // from the attributes in reflection.  And if done via [MemberData], the XmlWriter used by xunit will throw exceptions 
+        // when it attempts to write out the test arguments, due to the invalid text.
 
+        [Fact]
+        public void GetScalarValueFromUtf16_NormalBMPChar_EndOfString()
+        {
+            GetScalarValueFromUtf16("a", 'a');
+        }
+
+        [Fact]
+        public void GetScalarValueFromUtf16_NormalBMPChar_NotEndOfString()
+        {
+            GetScalarValueFromUtf16("ab", 'a');
+        }
+
+        [Fact]
+        public void GetScalarValueFromUtf16_TrailingSurrogate_EndOfString()
+        {
+            GetScalarValueFromUtf16("\uDFFF", UnicodeReplacementChar);
+        }
+
+        [Fact]
+        public void GetScalarValueFromUtf16_TrailingSurrogate_NotEndOfString()
+        {
+            GetScalarValueFromUtf16("\uDFFFx", UnicodeReplacementChar);
+        }
+
+        [Fact]
+        public void GetScalarValueFromUtf16_LeadingSurrogate_EndOfString()
+        {
+            GetScalarValueFromUtf16("\uD800", UnicodeReplacementChar);
+        }
+
+        [Fact]
+        public void GetScalarValueFromUtf16_LeadingSurrogate_NotEndOfString()
+        {
+            GetScalarValueFromUtf16("\uD800x", UnicodeReplacementChar);
+        }
+
+        [Fact]
+        public void GetScalarValueFromUtf16_LeadingSurrogate_NotEndOfString_FollowedByLeadingSurrogate()
+        {
+            GetScalarValueFromUtf16("\uD800\uD800", UnicodeReplacementChar);
+        }
+
+        [Fact]
+        public void GetScalarValueFromUtf16_LeadingSurrogate_NotEndOfString_FollowedByTrailingSurrogate()
+        {
+            GetScalarValueFromUtf16("\uD800\uDFFF", 0x103FF);
+        }
+
+        private void GetScalarValueFromUtf16(string input, int expectedResult)
+        {
             fixed (char* pInput = input)
             {
                 Assert.Equal(expectedResult, UnicodeHelpers.GetScalarValueFromUtf16(pInput, endOfString: (input.Length == 1)));


### PR DESCRIPTION
Some of our System.Text.Encodings.Web tests were written using a loop as a temporary replacement for using a [Theory] due to a failure coming from xunit when trying to write out the results XML file.  The failure was due to text xunit was trying to write containing invalid Unicode.

As it turns out, there were two issues here, one masking the other:
1) The runtime is not handling improper UTF8 on Linux the same way it is on Windows (the text gets converted from UTF8 to UTF16 by the runtime as part of loading the [InlineData] attributes containing the strings).  I've opened https://github.com/dotnet/coreclr/issues/2037 for this.
2) If we didn't have the first bug and had done this using a [Theory], the tests would have been busted anyway (and silently), as the replacements would have already been made by the time the text made it to the test. So, from a corefx perspective, the fix is simply to remove the TODO and expand the tests into better style.

Fixes #3537 
cc: @eerhardt, @ellismg 