### PR TITLE
Add test for runtime's encoding fallback when loading strings

### DIFF
--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -27,6 +27,7 @@
     <Compile Include="System\Array.SystemArrayKeyValueSortTests.cs" />
     <Compile Include="System\Array.TestTypes.cs" />
     <Compile Include="System\Array.Util.cs" />
+    <Compile Include="System\Attribute.cs" />
     <Compile Include="System\ArraySegment.cs" />
     <Compile Include="System\Boolean.cs" />
     <Compile Include="System\Buffer.cs" />

--- a/src/System.Runtime/tests/System/Attribute.cs
+++ b/src/System.Runtime/tests/System/Attribute.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reflection;
+using System.Linq;
+using Xunit;
+
+public static unsafe class AttributeTests
+{
+    [ActiveIssue("https://github.com/dotnet/coreclr/issues/2037", PlatformID.AnyUnix)]
+    [Fact]
+    [StringValue("\uDFFF")]
+    public static void StringArgument_InvalidCodeUnits_FallbackUsed()
+    {
+        MethodInfo thisMethod = typeof(AttributeTests).GetTypeInfo().GetDeclaredMethod("StringArgument_InvalidCodeUnits_FallbackUsed");
+        Assert.NotNull(thisMethod);
+
+        CustomAttributeData cad = thisMethod.CustomAttributes.Where(ca => ca.AttributeType == typeof(StringValueAttribute)).FirstOrDefault();
+        Assert.NotNull(cad);
+
+        string stringArg = cad.ConstructorArguments[0].Value as string;
+        Assert.NotNull(stringArg);
+
+        Assert.Equal("\uFFFD\uFFFD", stringArg);
+    }
+
+    [AttributeUsage(AttributeTargets.Method)]
+    private sealed class StringValueAttribute : Attribute
+    {
+        public string Text;
+        public StringValueAttribute(string text) { Text = text; }
+    }
+}


### PR DESCRIPTION
Test for https://github.com/dotnet/coreclr/issues/2037.
Currently passes on Windows and fails on Unix.

cc: @ellismg, @janvorli, @wtgodbe