### PR TITLE
Improve support for `brew install openssl` on OSX

### DIFF
--- a/src/Native/System.Security.Cryptography.Native/configure.cmake
+++ b/src/Native/System.Security.Cryptography.Native/configure.cmake
@@ -1,6 +1,8 @@
 include(CheckLibraryExists)
 include(CheckStructHasMember)
 
+set(CMAKE_REQUIRED_INCLUDES ${OPENSSL_INCLUDE_DIR})
+
 # Check which versions of TLS the OpenSSL/ssl library supports
 check_library_exists(${OPENSSL_SSL_LIBRARY} "TLSv1_1_method" "" HAVE_TLS_V1_1)
 check_library_exists(${OPENSSL_SSL_LIBRARY} "TLSv1_2_method" "" HAVE_TLS_V1_2)


### PR DESCRIPTION
The test for `algorithm_enc` vs `algorithms` was using only the default includes path. Now it
also includes the place where find_package found the openssl headers, so the test executes
successfully, leading to a successful compilation.

```
brew install openssl
brew link --force openssl
./build.sh clean native
```

cc: @sokket @eerhardt @stephentoub 