### PR TITLE
Port to RC1: Fix the Select() shim.

### DIFF
--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -1856,6 +1856,8 @@ static void ConvertFdSetPlatformToPal(FdSet& palSet, fd_set& platformSet, int32_
 {
     assert(fdCount >= 0);
 
+    memset(&palSet.Bits[0], 0, sizeof(palSet.Bits));
+
 #if !HAVE_FDS_BITS && !HAVE_PRIVATE_FDS_BITS
     for (int i = 0; i < fdCount; i++)
     {
@@ -1969,17 +1971,17 @@ extern "C" Error Select(int32_t fdCount, FdSet* readFdSet, FdSet* writeFdSet, Fd
 
     if (readFdSet != nullptr)
     {
-        ConvertFdSetPlatformToPal(*writeFdSet, *writeFds, fdCount);
+        ConvertFdSetPlatformToPal(*writeFdSet, *writeFds, rv);
     }
 
     if (writeFdSet != nullptr)
     {
-        ConvertFdSetPlatformToPal(*writeFdSet, *writeFds, fdCount);
+        ConvertFdSetPlatformToPal(*writeFdSet, *writeFds, rv);
     }
 
     if (errorFdSet != nullptr)
     {
-        ConvertFdSetPlatformToPal(*errorFdSet, *errorFds, fdCount);
+        ConvertFdSetPlatformToPal(*errorFdSet, *errorFds, rv);
     }
 
     *selected = rv;


### PR DESCRIPTION
The Select() shim was not zeroing out the destinatino when converting
a platform file descriptor set to a PAL file descriptor set. This was
causing false positives in the caller, which does not check the number
of file descriptors that were signalled.