### PR TITLE
Use new ConditionalFact in WebSockets tests

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -10,7 +10,7 @@
 
   <!-- Build Tools Versions -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-00120</BuildToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-00121</BuildToolsVersion>
     <DnxVersion>1.0.0-rc2-16128</DnxVersion>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'!='Unix'">dnx-coreclr-win-x86.$(DnxVersion)</DnxPackageName>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'=='Unix'">dnx-mono.$(DnxVersion)</DnxPackageName>

--- a/src/.nuget/packages.Unix.config
+++ b/src/.nuget/packages.Unix.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00120" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00121" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
   <package id="dnx-mono" version="1.0.0-rc2-16128" />
   <package id="Microsoft.Net.ToolsetCompilers" version="1.0.0-rc3-20150510-01" />

--- a/src/.nuget/packages.Windows_NT.config
+++ b/src/.nuget/packages.Windows_NT.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00120" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00121" />
   <package id="dnx-coreclr-win-x86" version="1.0.0-rc2-16128" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
 </packages>

--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Net.Tests;
-using System.Threading;
 using System.Threading.Tasks;
 
 using Xunit;
@@ -20,32 +19,24 @@ namespace System.Net.WebSockets.Client.Tests
         private const int s_TimeOutMilliseconds = 2000;
 
         private readonly ITestOutputHelper _output;
-
+        
         public ClientWebSocketTest(ITestOutputHelper output)
         {
             _output = output;
         }
 
-        [Theory, MemberData("EchoServers")]
+        private static bool WebSocketsSupported { get { return WebSocketHelper.WebSocketsSupported; } }
+
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
         public async Task EchoBinaryMessage_Success(Uri server)
         {
-            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
-            {
-                return;
-            }
-
             var helper = new WebSocketHelper(server, s_TimeOutMilliseconds);
             await helper.TestEcho(WebSocketMessageType.Binary);
         }
 
-        [Theory, MemberData("EchoServers")]
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
         public async Task EchoTextMessage_Success(Uri server)
         {
-            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
-            {
-                return;
-            }
-
             var helper = new WebSocketHelper(server, s_TimeOutMilliseconds);
             await helper.TestEcho(WebSocketMessageType.Text);
         }        

--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketUnitTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketUnitTest.cs
@@ -21,39 +21,26 @@ namespace System.Net.WebSockets.Client.Tests
             _output = output;
         }
 
-        [Fact]
+        private static bool WebSocketsSupported { get { return WebSocketHelper.WebSocketsSupported; } }
+
+        [ConditionalFact("WebSocketsSupported")]
         public void Ctor_Success()
         {
-            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
-            {
-                return;
-            }
-
             var cws = new ClientWebSocket();
         }
 
-        [Fact]
+        [ConditionalFact("WebSocketsSupported")]
         public void Abort_CreateAndAbort_StateIsClosed()
         {
-            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
-            {
-                return;
-            }
-
             var cws = new ClientWebSocket();
             cws.Abort();
 
             Assert.Equal(WebSocketState.Closed, cws.State);
         }
 
-        [Fact]
+        [ConditionalFact("WebSocketsSupported")]
         public void CloseAsync_CreateAndClose_ThrowsInvalidOperationException()
         {
-            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
-            {
-                return;
-            }
-
             var cws = new ClientWebSocket();
             Assert.Throws<InvalidOperationException>(() =>
                 { Task t = cws.CloseAsync(WebSocketCloseStatus.Empty, "", new CancellationToken()); });
@@ -61,14 +48,9 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.Equal(WebSocketState.None, cws.State);
         }
 
-        [Fact]
+        [ConditionalFact("WebSocketsSupported")]
         public void CloseAsync_CreateAndCloseOutput_ThrowsInvalidOperationExceptionWithCorrectMessage()
         {
-            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
-            {
-                return;
-            }
-
             var cws = new ClientWebSocket();
             AssertExtensions.Throws<InvalidOperationException>(
                 () =>
@@ -78,14 +60,9 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.Equal(WebSocketState.None, cws.State);
         }
 
-        [Fact]
+        [ConditionalFact("WebSocketsSupported")]
         public void CloseAsync_CreateAndReceive_ThrowsInvalidOperationException()
         {
-            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
-            {
-                return;
-            }
-
             var cws = new ClientWebSocket();
 
             var buffer = new byte[100];
@@ -98,14 +75,9 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.Equal(WebSocketState.None, cws.State);
         }
 
-        [Fact]
+        [ConditionalFact("WebSocketsSupported")]
         public void CloseAsync_CreateAndReceive_ThrowsInvalidOperationExceptionWithCorrectMessage()
         {
-            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
-            {
-                return;
-            }
-
             var cws = new ClientWebSocket();
 
             var buffer = new byte[100];
@@ -119,14 +91,9 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.Equal(WebSocketState.None, cws.State);
         }
 
-        [Fact]
+        [ConditionalFact("WebSocketsSupported")]
         public void CloseAsync_CreateAndSend_ThrowsInvalidOperationException()
         {
-            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
-            {
-                return;
-            }
-
             var cws = new ClientWebSocket();
 
             var buffer = new byte[100];
@@ -139,14 +106,9 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.Equal(WebSocketState.None, cws.State);
         }
 
-        [Fact]
+        [ConditionalFact("WebSocketsSupported")]
         public void CloseAsync_CreateAndSend_ThrowsInvalidOperationExceptionWithCorrectMessage()
         {
-            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
-            {
-                return;
-            }
-
             var cws = new ClientWebSocket();
 
             var buffer = new byte[100];
@@ -160,14 +122,9 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.Equal(WebSocketState.None, cws.State);
         }
 
-        [Fact]
+        [ConditionalFact("WebSocketsSupported")]
         public void Ctor_ExpectedPropertyValues()
         {
-            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
-            {
-                return;
-            }
-
             var cws = new ClientWebSocket();
             Assert.Equal(null, cws.CloseStatus);
             Assert.Equal(null, cws.CloseStatusDescription);
@@ -177,14 +134,9 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.Equal("System.Net.WebSockets.ClientWebSocket", cws.ToString());
         }
 
-        [Fact]
+        [ConditionalFact("WebSocketsSupported")]
         public void Abort_CreateAndDisposeAndAbort_StateIsClosedSuccess()
         {
-            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
-            {
-                return;
-            }
-
             var cws = new ClientWebSocket();
             cws.Dispose();
 
@@ -192,14 +144,9 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.Equal(WebSocketState.Closed, cws.State);
         }
 
-        [Fact]
+        [ConditionalFact("WebSocketsSupported")]
         public void CloseAsync_DisposeAndClose_ThrowsObjectDisposedException()
         {
-            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
-            {
-                return;
-            }
-
             var cws = new ClientWebSocket();
             cws.Dispose();
 
@@ -209,14 +156,9 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.Equal(WebSocketState.Closed, cws.State);
         }
 
-        [Fact]
+        [ConditionalFact("WebSocketsSupported")]
         public void CloseAsync_DisposeAndClose_ThrowsObjectDisposedExceptionWithCorrectMessage()
         {
-            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
-            {
-                return;
-            }
-
             var cws = new ClientWebSocket();
             cws.Dispose();
 
@@ -230,14 +172,9 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.Equal(WebSocketState.Closed, cws.State);
         }
 
-        [Fact]
+        [ConditionalFact("WebSocketsSupported")]
         public void ReceiveAsync_CreateAndDisposeAndReceive_ThrowsObjectDisposedExceptionWithCorrectMessage()
         {
-            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
-            {
-                return;
-            }
-
             var cws = new ClientWebSocket();
             cws.Dispose();
 
@@ -254,14 +191,9 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.Equal(WebSocketState.Closed, cws.State);
         }
 
-        [Fact]
+        [ConditionalFact("WebSocketsSupported")]
         public void SendAsync_CreateAndDisposeAndSend_ThrowsObjectDisposedExceptionWithCorrectMessage()
         {
-            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
-            {
-                return;
-            }
-
             var cws = new ClientWebSocket();
             cws.Dispose();
 
@@ -278,14 +210,9 @@ namespace System.Net.WebSockets.Client.Tests
             Assert.Equal(WebSocketState.Closed, cws.State);
         }
 
-        [Fact]
+        [ConditionalFact("WebSocketsSupported")]
         public void Dispose_CreateAndDispose_ExpectedPropertyValues()
         {
-            if (WebSocketHelper.ShouldSkipTestOSNotSupported(_output))
-            {
-                return;
-            }
-
             var cws = new ClientWebSocket();
             cws.Dispose();
 

--- a/src/System.Net.WebSockets.Client/tests/WebSocketHelper.cs
+++ b/src/System.Net.WebSockets.Client/tests/WebSocketHelper.cs
@@ -5,13 +5,12 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Xunit;
-using Xunit.Abstractions;
 
 namespace System.Net.WebSockets.Client.Tests
 {
     public class WebSocketHelper
     {
-        private static Lazy<bool> s_WebSocketSupported = new Lazy<bool>(InitWebSocketSupported);
+        private static readonly Lazy<bool> s_WebSocketSupported = new Lazy<bool>(InitWebSocketSupported);
         private static int s_TimeOutMilliseconds;
         private Uri _echoService;
 
@@ -21,15 +20,7 @@ namespace System.Net.WebSockets.Client.Tests
             s_TimeOutMilliseconds = timeOut;
         }
 
-        public static bool ShouldSkipTestOSNotSupported(ITestOutputHelper output)
-        {
-            if (!s_WebSocketSupported.Value)
-            {
-                output.WriteLine("WinHttp/WebSockets are not supported on this platform.");
-            }
-
-            return !s_WebSocketSupported.Value;
-        }
+        public static bool WebSocketsSupported { get { return s_WebSocketSupported.Value; } }
 
         public async Task TestEcho(WebSocketMessageType type)
         {

--- a/src/System.Net.WebSockets.Client/tests/project.lock.json
+++ b/src/System.Net.WebSockets.Client/tests/project.lock.json
@@ -604,7 +604,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00119": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00121": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1449,7 +1449,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00119": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00121": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -2294,7 +2294,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00119": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00121": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -3925,14 +3925,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00119": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00121": {
       "type": "package",
       "serviceable": true,
       "sha512": "oCniHZ9M9IVdGV3iInQDEja2mK+i+r9MyJzH1/gLD8drExfVuvYc1QuzOer9eu0GPZxPRsP/K9MiGR1vC555HQ==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00119.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00119.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00121.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00121.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }


### PR DESCRIPTION
Upgrade to new buildtools and try out ConditionalFact in the WebSockets tests.  Other tests elsewhere in corefx can be moved over separately.

cc: @davidsh, @CIPop
Fixes #3349