### PR TITLE
Add a test for Guid.NewGuid() randomness

### DIFF
--- a/src/Common/tests/System/RandomDataGenerator.cs
+++ b/src/Common/tests/System/RandomDataGenerator.cs
@@ -400,5 +400,41 @@ namespace System
             return retStrings;
         }
 
+        public static void VerifyRandomDistribution(byte[] random)
+        {
+            // Better tests for randomness are available.  For now just use a simple
+            // check that compares the number of 0s and 1s in the bits.
+            VerifyNeutralParity(random);
+        }
+
+        private static void VerifyNeutralParity(byte[] random)
+        {
+            int zeroCount = 0, oneCount = 0;
+
+            for (int i = 0; i < random.Length; i++)
+            {
+                for (int j = 0; j < 8; j++)
+                {
+                    if (((random[i] >> j) & 1) == 1)
+                    {
+                        oneCount++;
+                    }
+                    else
+                    {
+                        zeroCount++;
+                    }
+                }
+            }
+
+            // Over the long run there should be about as many 1s as 0s.
+            // This isn't a guarantee, just a statistical observation.
+            // Allow a 7% tolerance band before considering it to have gotten out of hand.
+            double bitDifference = Math.Abs(zeroCount - oneCount) / (double)(zeroCount + oneCount);
+            const double AllowedTolerance = 0.07;
+            if (bitDifference > AllowedTolerance)
+            {
+                throw new InvalidOperationException("Expected bitDifference < " + AllowedTolerance + ", got " + bitDifference + ".");
+            }
+        }
     }
 }

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -90,6 +90,9 @@
     <Compile Include="System\ValueType.cs" />
     <Compile Include="System\Version.cs" />
     <Compile Include="System\WeakReference.cs" />
+    <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs">
+      <Link>Common\System\RandomDataGenerator.cs</Link>
+    </Compile>
     <!-- Performance Tests -->
     <Compile Include="Performance\Perf.Boolean.cs" />
     <Compile Include="Performance\Perf.Enum.cs" />

--- a/src/System.Runtime/tests/System/Guid.cs
+++ b/src/System.Runtime/tests/System/Guid.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Linq;
 using System.Globalization;
 using Xunit;
 
@@ -175,5 +176,35 @@ public static class GuidTests
         Assert.Equal(_testGuid.ToString("B"), "{a8a110d5-fc49-43c5-bf46-802db8f843ff}");
         Assert.Equal(_testGuid.ToString("P"), "(a8a110d5-fc49-43c5-bf46-802db8f843ff)");
         Assert.Equal(_testGuid.ToString("X"), "{0xa8a110d5,0xfc49,0x43c5,{0xbf,0x46,0x80,0x2d,0xb8,0xf8,0x43,0xff}}");
+    }
+
+    [Fact]
+    public static void TestRandomness()
+    {
+        const int Iterations = 100;
+        const int GuidSize = 16;
+        byte[] random = new byte[GuidSize * Iterations];
+
+        for (int i = 0; i < Iterations; i++)
+        {
+            // Get a new Guid
+            Guid g = Guid.NewGuid();
+            byte[] bytes = g.ToByteArray();
+
+            // Make sure it's different from all of the previously created ones
+            for (int j = 0; j < i; j++)
+            {
+                Assert.False(bytes.SequenceEqual(new ArraySegment<byte>(random, j * GuidSize, GuidSize)));
+            }
+
+            // Copy it to our randomness array
+            Array.Copy(bytes, 0, random, i * GuidSize, GuidSize);
+        }
+
+        // Verify the randomness of the data in the array. Guid has some small bias in it 
+        // due to several bits fixed based on the format, but that bias is small enough and
+        // the variability allowed by VerifyRandomDistribution large enough that we don't do 
+        // anything special for it.
+        RandomDataGenerator.VerifyRandomDistribution(random);
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/RandomNumberGeneratorTests.cs
@@ -46,7 +46,7 @@ namespace System.Security.Cryptography.RNG.Tests
         }
 
         [Fact]
-        public static void NeutralParity()
+        public static void RandomDistribution()
         {
             byte[] random = new byte[2048];
 
@@ -55,7 +55,7 @@ namespace System.Security.Cryptography.RNG.Tests
                 rng.GetBytes(random);
             }
 
-            AssertNeutralParity(random);
+            RandomDataGenerator.VerifyRandomDistribution(random);
         }
 
         [Fact]
@@ -127,8 +127,8 @@ namespace System.Security.Cryptography.RNG.Tests
             {
                 // The Real test would be to ensure independence of data, but that's difficult.
                 // The other end of the spectrum is to test that they aren't all just new byte[RandomSize].
-                // Middle ground is to assert that each of the chunks has neutral(ish) bit parity.
-                AssertNeutralParity(taskArrays[i]);
+                // Middle ground is to assert that each of the chunks has random data.
+                RandomDataGenerator.VerifyRandomDistribution(taskArrays[i]);
             }
         }
 
@@ -175,37 +175,6 @@ namespace System.Security.Cryptography.RNG.Tests
             // = 1/(256^10)
             // = 1/1,208,925,819,614,629,174,706,176
             Assert.NotEqual(first, second);
-        }
-
-        private static void AssertNeutralParity(byte[] random)
-        {
-            int oneCount = 0;
-            int zeroCount = 0;
-
-            for (int i = 0; i < random.Length; i++)
-            {
-                for (int j = 0; j < 8; j++)
-                {
-                    if (((random[i] >> j) & 1) == 1)
-                    {
-                        oneCount++;
-                    }
-                    else
-                    {
-                        zeroCount++;
-                    }
-                }
-            }
-
-            int totalCount = zeroCount + oneCount;
-            float bitDifference = (float)Math.Abs(zeroCount - oneCount) / totalCount;
-
-            // Over the long run there should be about as many 1s as 0s.
-            // This isn't a guarantee, just a statistical observation.
-            // Allow a 7% tolerance band before considering it to have gotten out of hand.
-            const double AllowedTolerance = 0.07;
-            Assert.True(bitDifference < AllowedTolerance, 
-                "Expected bitDifference < " + AllowedTolerance + ", got " + bitDifference + ".");
         }
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -37,6 +37,9 @@
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\AesFactory.cs">
       <Link>CommonTest\AlgorithmImplementations\AES\AesFactory.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs">
+      <Link>CommonTest\System\RandomDataGenerator.cs</Link>
+    </Compile>
     <Compile Include="AesProvider.cs" />
     <Compile Include="HashAlgorithmTest.cs" />
     <Compile Include="InvalidUsageTests.cs" />


### PR DESCRIPTION
We already have a test for RandomNumberGenerator that provides minimal verification of the randomness of the generated data.  This commit just moves that test to a common location and then reuses it in System.Runtime's tests to verify the randomness of generated Guids.

cc: @bartonjs, @morganbr 
Related to https://github.com/dotnet/coreclr/pull/2049 and https://github.com/dotnet/corefx/issues/4458