### PR TITLE
Temporary workaround to get ECDsa tests passing on CentOS

### DIFF
--- a/src/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslTests.cs
+++ b/src/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslTests.cs
@@ -10,6 +10,24 @@ namespace System.Security.Cryptography.EcDsaOpenSsl.Tests
 {
     public static class EcDsaOpenSslTests
     {
+        // TODO: Issue #4337.  Temporary workaround for tests to pass on CentOS 
+        // where secp224r1 appears to be disabled. 
+        private static bool ECDsa224Available
+        {
+            get
+            {
+                try
+                {
+                    using (ECDsaOpenSsl e = new ECDsaOpenSsl(224)) e.Exercise();
+                    return true;
+                }
+                catch (Exception exc)
+                {
+                    return !exc.Message.Contains("unknown group");
+                }
+            }
+        }
+
         [Fact]
         public static void DefaultCtor()
         {
@@ -21,7 +39,7 @@ namespace System.Security.Cryptography.EcDsaOpenSsl.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact("ECDsa224Available")] // Issue #4337
         public static void Ctor224()
         {
             int expectedKeySize = 224;
@@ -57,7 +75,7 @@ namespace System.Security.Cryptography.EcDsaOpenSsl.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact("ECDsa224Available")] // Issue #4337
         public static void CtorHandle224()
         {
             IntPtr ecKey = Interop.Crypto.EcKeyCreateByCurveName(NID_secp224r1);
@@ -130,7 +148,7 @@ namespace System.Security.Cryptography.EcDsaOpenSsl.Tests
             }
         }
 
-        [Fact]
+        [ConditionalFact("ECDsa224Available")] // Issue #4337
         public static void KeySizeProp()
         {
             using (ECDsaOpenSsl e = new ECDsaOpenSsl())

--- a/src/System.Security.Cryptography.OpenSsl/tests/project.lock.json
+++ b/src/System.Security.Cryptography.OpenSsl/tests/project.lock.json
@@ -412,7 +412,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00119": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00121": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -867,7 +867,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00119": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00121": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1322,7 +1322,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00119": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00121": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -2307,14 +2307,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00119": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00121": {
       "type": "package",
       "serviceable": true,
       "sha512": "oCniHZ9M9IVdGV3iInQDEja2mK+i+r9MyJzH1/gLD8drExfVuvYc1QuzOer9eu0GPZxPRsP/K9MiGR1vC555HQ==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00119.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00119.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00121.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00121.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }


### PR DESCRIPTION
Makes three tests execute conditionally based on whether secp224r1 is enabled.  It's a bit hokey, in that we're using the very mechanism we're intending to test, and further doing string comparison against a known error message, but it's good enough as a temporary workaround, and better than just disabling the tests on all Linux. (Eventually we'll want to look into allowing PlatformSpecific/ActiveIssue to be specialized further.)

cc: @bartonjs 
Related to https://github.com/dotnet/corefx/issues/4337