### PR TITLE
Resuable WebSocketReceiveResult

### DIFF
--- a/src/System.Net.WebSockets/src/System/Net/WebSockets/WebSocketReceiveResult.cs
+++ b/src/System.Net.WebSockets/src/System/Net/WebSockets/WebSocketReceiveResult.cs
@@ -30,11 +30,11 @@ namespace System.Net.WebSockets
             CloseStatusDescription = closeStatusDescription;
         }
 
-        public int Count { get; private set; }
-        public bool EndOfMessage { get; private set; }
-        public WebSocketMessageType MessageType { get; private set; }
-        public WebSocketCloseStatus? CloseStatus { get; private set; }
-        public string CloseStatusDescription { get; private set; }
+        public int Count { get; protected set; }
+        public bool EndOfMessage { get; protected set; }
+        public WebSocketMessageType MessageType { get; protected set; }
+        public WebSocketCloseStatus? CloseStatus { get; protected set; }
+        public string CloseStatusDescription { get; protected set; }
 
         internal WebSocketReceiveResult Copy(int count)
         {


### PR DESCRIPTION
Resuable WebSocketReceiveResult by derived type. 

At the moment is `WebSocketReceiveResult` is a readonly POCO type that as a class must be garbage collected on every single socket message; probably gen0; but changing the setters to protected opens up more possibilities for types derived from `System.Net.WebSockets.WebSocket` and using a derived `WebSocketReceiveResult`.