### PR TITLE
Add tests for corrupt values in RegistryKey

### DIFF
--- a/src/Microsoft.Win32.Registry/tests/Helpers.cs
+++ b/src/Microsoft.Win32.Registry/tests/Helpers.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Win32.RegistryTests
 {
     internal static class Helpers
     {
-        [DllImport("api-ms-win-core-registry-l2-1-0.dll", CharSet = CharSet.Unicode, EntryPoint = "RegSetValueW", SetLastError = true)]
+        [DllImport(Interop.Libraries.Registry_L2, CharSet = CharSet.Unicode, EntryPoint = "RegSetValueW", SetLastError = true)]
         private static extern int RegSetValue(SafeRegistryHandle handle, string value, int regType, string sb, int sizeIgnored);
 
         internal static bool SetDefaultValue(this RegistryKey key, string value)
@@ -18,7 +18,7 @@ namespace Microsoft.Win32.RegistryTests
             return RegSetValue(key.Handle, null, REG_SZ, value, 0) == 0;
         }
 
-        [DllImport("api-ms-win-core-registry-l1-1-0.dll", CharSet = CharSet.Unicode, EntryPoint = "RegQueryValueExW", SetLastError = true)]
+        [DllImport(Interop.Libraries.Registry_L1, CharSet = CharSet.Unicode, EntryPoint = "RegQueryValueExW", SetLastError = true)]
         private static extern int RegQueryValueEx(SafeRegistryHandle handle, string valueName, int[] reserved, IntPtr regType, [Out] byte[] value, ref int size);
 
         internal static bool IsDefaultValueSet(this RegistryKey key)
@@ -29,7 +29,7 @@ namespace Microsoft.Win32.RegistryTests
             return RegQueryValueEx(key.Handle, null, null, IntPtr.Zero, b, ref size) != ERROR_FILE_NOT_FOUND;
         }
 
-        [DllImport("api-ms-win-core-processenvironment-l1-1-0.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [DllImport(Interop.Libraries.ProcessEnvironment, CharSet = CharSet.Unicode, SetLastError = true)]
         internal static extern bool SetEnvironmentVariable(string lpName, string lpValue);
     }
 }

--- a/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
+++ b/src/Microsoft.Win32.Registry/tests/Microsoft.Win32.Registry.Tests.csproj
@@ -14,7 +14,14 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+      <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.RegSetValueEx.cs">
+      <Link>Common\Interop\Windows\Interop.RegSetValueEx.cs</Link>
+    </Compile>
     <Compile Include="Helpers.cs" />
+    <Compile Include="RegistryKey\RegistryKey_GetValue_CorruptData.cs" />
     <Compile Include="Registry\Registry_Getvalue_str_str_obj.cs" />
     <Compile Include="Registry\Registry_SetValue_str_str_obj.cs" />
     <Compile Include="Registry\Registry_SetValue_str_str_obj_valuekind.cs" />

--- a/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_GetValue_CorruptData.cs
+++ b/src/Microsoft.Win32.Registry/tests/RegistryKey/RegistryKey_GetValue_CorruptData.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Win32.RegistryTests
+{
+    public class RegistryKey_GetValue_CorruptData : RegistryTestsBase
+    {
+        [Fact]
+        public void ReadRegMultiSzLackingFinalNullTerminatorCorrectly()
+        {
+            // We have to intentionally write a REG_MULTI_SZ value
+            // lacking a final null terminator, like "str1\0str2\0str3\0"
+            // (there should be 2 \0s at the end) to the registry.
+            // Since we can't do this via the RegistryKey APIs,
+            // do it manually via P/Invoke calls.
+
+            const string TestValueName = "CorruptData";
+            string corrupt = "str1\0str2\0str3\0";
+
+            SafeRegistryHandle handle = TestRegistryKey.Handle;
+            int ret = Interop.mincore.RegSetValueEx(handle, TestValueName, 0,
+                RegistryValueKind.MultiString, corrupt, corrupt.Length * 2);
+            Assert.Equal(0, ret);
+
+            object o = TestRegistryKey.GetValue(TestValueName);
+            Assert.IsType<string[]>(o);
+
+            var strings = (string[])o;
+            string[] expected = { "str1", "str2", "str3" };
+            Assert.Equal(expected, strings);
+
+            TestRegistryKey.DeleteValue(TestValueName);
+        }
+
+        [Fact]
+        public void RegSzOddByteLength()
+        {
+            const string TestValueName = "CorruptData2";
+            byte[] contents = { 6, 5, 6 };
+
+            SafeRegistryHandle handle = TestRegistryKey.Handle;
+            int ret = Interop.mincore.RegSetValueEx(handle, TestValueName, 0,
+                RegistryValueKind.String, contents, contents.Length);
+            Assert.Equal(0, ret);
+
+            object o = TestRegistryKey.GetValue(TestValueName);
+            Assert.IsType<string>(o);
+
+            string s = (string)o;
+            Assert.Equal(s.Length, 2); // Math.Ceil(contents.Length / 2);
+
+            Assert.Equal(0x506, s[0]);
+            Assert.Equal(0x6, s[1]);
+
+            TestRegistryKey.DeleteValue(TestValueName);
+        }
+
+        [Fact]
+        public void RegExpandSzOddByteLength()
+        {
+            const string TestValueName = "CorruptData3";
+            byte[] contents = { 6, 5, 6 };
+
+            SafeRegistryHandle handle = TestRegistryKey.Handle;
+            int ret = Interop.mincore.RegSetValueEx(handle, TestValueName, 0,
+                RegistryValueKind.ExpandString, contents, contents.Length);
+            Assert.Equal(0, ret);
+
+            object o = TestRegistryKey.GetValue(TestValueName);
+            Assert.IsType<string>(o);
+
+            string s = (string)o;
+            Assert.Equal(s.Length, 2); // Math.Ceil(contents.Length / 2);
+
+            Assert.Equal(0x506, s[0]);
+            Assert.Equal(0x6, s[1]);
+
+            TestRegistryKey.DeleteValue(TestValueName);
+        }
+
+        [Fact]
+        public void RegMultiSzOddByteLength()
+        {
+            const string TestValueName = "CorruptData4";
+            byte[] contents = { 6, 5, 6, 0, 0 };
+
+            SafeRegistryHandle handle = TestRegistryKey.Handle;
+            int ret = Interop.mincore.RegSetValueEx(handle, TestValueName, 0,
+                RegistryValueKind.MultiString, contents, contents.Length);
+            Assert.Equal(0, ret);
+
+            object o = TestRegistryKey.GetValue(TestValueName);
+            Assert.IsType<string[]>(o);
+
+            var strings = (string[])o;
+            Assert.Equal(strings.Length, 1);
+
+            string s = strings[0];
+            Assert.Equal(s.Length, 2);
+
+            Assert.Equal(0x506, s[0]);
+            Assert.Equal(0x6, s[1]);
+
+            TestRegistryKey.DeleteValue(TestValueName);
+        }
+    }
+}


### PR DESCRIPTION
Adds tests (as promised in #3115). The first one is relatively readable, but the others are a bit messy (feedback/critique?). Some of the P/Invoke declarations from the `Helpers` class have been refactored to the ones in `Common/Interop/...` and a new `RegQueryValueEx` overload has been added.