### PR TITLE
RegistryKey: Use using instead of try/finally

### DIFF
--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/RegistryKey.cs
@@ -358,16 +358,12 @@ namespace Microsoft.Win32
             RegistryKey key = InternalOpenSubKey(subkey, false);
             if (key != null)
             {
-                try
+                using (key)
                 {
                     if (key.InternalSubKeyCount() > 0)
                     {
                         ThrowHelper.ThrowInvalidOperationException(SR.InvalidOperation_RegRemoveSubKey);
                     }
-                }
-                finally
-                {
-                    key.Close();
                 }
 
                 int ret = Interop.mincore.RegDeleteKeyEx(hkey, subkey, (int)regView, 0);
@@ -419,7 +415,7 @@ namespace Microsoft.Win32
             RegistryKey key = InternalOpenSubKey(subkey, true);
             if (key != null)
             {
-                try
+                using (key)
                 {
                     if (key.InternalSubKeyCount() > 0)
                     {
@@ -430,10 +426,6 @@ namespace Microsoft.Win32
                             key.DeleteSubKeyTreeInternal(keys[i]);
                         }
                     }
-                }
-                finally
-                {
-                    key.Close();
                 }
 
                 int ret = Interop.mincore.RegDeleteKeyEx(hkey, subkey, (int)regView, 0);
@@ -454,7 +446,7 @@ namespace Microsoft.Win32
             RegistryKey key = InternalOpenSubKey(subkey, true);
             if (key != null)
             {
-                try
+                using (key)
                 {
                     if (key.InternalSubKeyCount() > 0)
                     {
@@ -465,10 +457,6 @@ namespace Microsoft.Win32
                             key.DeleteSubKeyTreeInternal(keys[i]);
                         }
                     }
-                }
-                finally
-                {
-                    key.Close();
                 }
 
                 int ret = Interop.mincore.RegDeleteKeyEx(hkey, subkey, (int)regView, 0);


### PR DESCRIPTION
Basically what the title says. Shaves off about 12 LOC from `RegistryKey.cs`.

Separated from #4521 since that's likely to need revisions.