### PR TITLE
Address PR feedback for System.Net.Requests

### DIFF
--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -297,9 +297,9 @@ namespace System.Net
             // Match Desktop behavior: prevent someone from getting a request stream
             // if the protocol verb/method doesn't support it. Note that this is not
             // entirely compliant RFC2616 for the aforementioned compatbility reasons.
-            if ((string.Compare(HttpMethod.Get.Method, _originVerb, StringComparison.OrdinalIgnoreCase) == 0) ||
-                (string.Compare(HttpMethod.Head.Method, _originVerb, StringComparison.OrdinalIgnoreCase) == 0) ||
-                (string.Compare("CONNECT", _originVerb, StringComparison.OrdinalIgnoreCase) == 0))
+            if (string.Equals(HttpMethod.Get.Method, _originVerb, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(HttpMethod.Head.Method, _originVerb, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals("CONNECT", _originVerb, StringComparison.OrdinalIgnoreCase))
             {
                 throw new ProtocolViolationException(SR.net_nouploadonget);
             }
@@ -512,7 +512,7 @@ namespace System.Net
         {
             foreach (string contentHeaderName in s_wellKnownContentHeaders)
             {
-                if (string.Compare(header, contentHeaderName, StringComparison.OrdinalIgnoreCase) == 0)
+                if (string.Equals(header, contentHeaderName, StringComparison.OrdinalIgnoreCase))
                 {
                     return true;
                 }

--- a/src/System.Net.Requests/src/System/Net/WebException.cs
+++ b/src/System.Net.Requests/src/System/Net/WebException.cs
@@ -70,16 +70,9 @@ namespace System.Net
             if (exception is HttpRequestException)
             {
                 Exception inner = exception.InnerException;
-                string message;
-
-                if (inner != null)
-                {
-                    message = string.Format("{0} {1}", exception.Message, inner.Message);
-                }
-                else
-                {
-                    message = string.Format("{0}", exception.Message);
-                }
+                string message = inner != null ?
+                    string.Format("{0} {1}", exception.Message, inner.Message) :
+                    exception.Message;
 
                 return new WebException(
                     message,


### PR DESCRIPTION
- Remove unnecessary string.Format in WebException
- Replace several string.Compare calls with string.Equals
- Improve FromAsync usage in WebRequest

cc: @pgavlin, @CIPop, @davidsh
Fixes https://github.com/dotnet/corefx/issues/2409