### PR TITLE
Port more System.Net.WebSockets.Client tests

### DIFF
--- a/src/Common/tests/System/Net/WebSocketTestServers.cs
+++ b/src/Common/tests/System/Net/WebSocketTestServers.cs
@@ -8,10 +8,15 @@ namespace System.Net.Tests
         public const string Host = "corefx-networking.azurewebsites.net";
 
         private const string EchoHandler = "WebSocket/EchoWebSocket.ashx";
+        private const string EchoHeadersHandler = "WebSocket/EchoWebSocketHeaders.ashx";
 
         public readonly static Uri RemoteEchoServer = new Uri("ws://" + Host + "/" + EchoHandler);
         public readonly static Uri SecureRemoteEchoServer = new Uri("wss://" + Host + "/" + EchoHandler);
 
+        public readonly static Uri RemoteEchoHeadersServer = new Uri("ws://" + Host + "/" + EchoHeadersHandler);
+        public readonly static Uri SecureRemoteEchoHeadersServer = new Uri("wss://" + Host + "/" + EchoHeadersHandler);
+        
         public readonly static object[][] EchoServers = { new object[] { RemoteEchoServer }, new object[] { SecureRemoteEchoServer } };
+        public readonly static object[][] EchoHeadersServers = { new object[] { RemoteEchoHeadersServer }, new object[] { SecureRemoteEchoHeadersServer } };
     }
 }

--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Net.Tests;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Xunit;
@@ -15,9 +16,10 @@ namespace System.Net.WebSockets.Client.Tests
     public class ClientWebSocketTest
     {
         public readonly static object[][] EchoServers = WebSocketTestServers.EchoServers;
+        public readonly static object[][] EchoHeadersServers = WebSocketTestServers.EchoHeadersServers;
 
-        private const int s_TimeOutMilliseconds = 2000;
-
+        private const int TimeOutMilliseconds = 10000;
+        private const int CloseDescriptionMaxLength = 123;
         private readonly ITestOutputHelper _output;
         
         public ClientWebSocketTest(ITestOutputHelper output)
@@ -27,18 +29,637 @@ namespace System.Net.WebSockets.Client.Tests
 
         private static bool WebSocketsSupported { get { return WebSocketHelper.WebSocketsSupported; } }
 
+#region Connect
         [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
         public async Task EchoBinaryMessage_Success(Uri server)
         {
-            var helper = new WebSocketHelper(server, s_TimeOutMilliseconds);
-            await helper.TestEcho(WebSocketMessageType.Binary);
+            await WebSocketHelper.TestEcho(server, WebSocketMessageType.Binary, TimeOutMilliseconds, _output);
         }
 
         [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
         public async Task EchoTextMessage_Success(Uri server)
         {
-            var helper = new WebSocketHelper(server, s_TimeOutMilliseconds);
-            await helper.TestEcho(WebSocketMessageType.Text);
+            await WebSocketHelper.TestEcho(server, WebSocketMessageType.Text, TimeOutMilliseconds, _output);
+        }
+
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoHeadersServers")]
+        public async Task ConnectAsync_AddCustomHeaders_Success(Uri server)
+        {
+            using (var cws = new ClientWebSocket())
+            {
+                cws.Options.SetRequestHeader("X-CustomHeader1", "Value1");
+                cws.Options.SetRequestHeader("X-CustomHeader2", "Value2");
+                using (var cts = new CancellationTokenSource(TimeOutMilliseconds))
+                {
+                    Task taskConnect = cws.ConnectAsync(server, cts.Token);
+                    Assert.True(
+                        (cws.State == WebSocketState.None) ||
+                        (cws.State == WebSocketState.Connecting) ||
+                        (cws.State == WebSocketState.Open),
+                        "State immediately after ConnectAsync incorrect: " + cws.State);
+                    await taskConnect;
+                }
+
+                Assert.Equal(WebSocketState.Open, cws.State);
+
+                byte[] buffer = new byte[65536];
+                var segment = new ArraySegment<byte>(buffer, 0, buffer.Length);
+                WebSocketReceiveResult recvResult;
+                using (var cts = new CancellationTokenSource(TimeOutMilliseconds))
+                {
+                    recvResult = await cws.ReceiveAsync(segment, cts.Token);
+                }
+
+                Assert.Equal(WebSocketMessageType.Text, recvResult.MessageType);
+                string headers = WebSocketData.GetTextFromBuffer(segment);
+                Assert.True(headers.Contains("X-CustomHeader1:Value1"));
+                Assert.True(headers.Contains("X-CustomHeader2:Value2"));
+
+                await cws.CloseAsync(WebSocketCloseStatus.NormalClosure, string.Empty, CancellationToken.None);
+            }
+        }
+#endregion
+
+#region SendReceive
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public async Task SendReceive_PartialMessage_Success(Uri server)
+        {
+            var sendBuffer = new byte[1024];
+            var sendSegment = new ArraySegment<byte>(sendBuffer);
+
+            var receiveBuffer = new byte[1024];
+            var receiveSegment = new ArraySegment<byte>(receiveBuffer);
+            
+            using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(server, TimeOutMilliseconds, _output))
+            {
+                var ctsDefault = new CancellationTokenSource(TimeOutMilliseconds);
+
+                // The server will read buffers and aggregate it up to 64KB before echoing back a complete message.
+                // But since this test uses a receive buffer that is small, we will get back partial message fragments
+                // as we read them until we read the complete message payload.
+                for (int i = 0; i < 63; i++)
+                {
+                    await cws.SendAsync(sendSegment, WebSocketMessageType.Binary, false, ctsDefault.Token);
+                }
+                await cws.SendAsync(sendSegment, WebSocketMessageType.Binary, true, ctsDefault.Token);
+
+                WebSocketReceiveResult recvResult = await cws.ReceiveAsync(receiveSegment, ctsDefault.Token);
+                Assert.Equal(false, recvResult.EndOfMessage);
+
+                while (recvResult.EndOfMessage == false)
+                {
+                    recvResult = await cws.ReceiveAsync(receiveSegment, ctsDefault.Token);
+                }
+
+                await cws.CloseAsync(WebSocketCloseStatus.NormalClosure, "PartialMessageTest", ctsDefault.Token);
+            }
+        }
+
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public async Task SendAsync_SendCloseMessageType_ThrowsArgumentExceptionWithMessage(Uri server)
+        {
+            using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(server, TimeOutMilliseconds, _output))
+            {
+                var cts = new CancellationTokenSource(TimeOutMilliseconds);
+
+                string expectedInnerMessage = ResourceHelper.GetExceptionMessage(
+                        "net_WebSockets_Argument_InvalidMessageType",
+                        "Close",
+                        "SendAsync",
+                        "Binary",
+                        "Text",
+                        "CloseOutputAsync");
+
+                var expectedException = new ArgumentException(expectedInnerMessage, "messageType");
+                string expectedMessage = expectedException.Message;
+
+                Assert.Throws<ArgumentException>(() => {
+                        Task t = cws.SendAsync(new ArraySegment<byte>(), WebSocketMessageType.Close, true, cts.Token); } );
+
+                Assert.Equal(WebSocketState.Open, cws.State);
+            }
+        }
+        
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public async Task SendAsync__MultipleOutstandingSendOperations_Throws(Uri server)
+        {
+            using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(server, TimeOutMilliseconds, _output))
+            {
+                var cts = new CancellationTokenSource(TimeOutMilliseconds);
+
+                Task [] tasks = new Task[10];
+
+                try
+                {
+                    for (int i = 0; i < tasks.Length; i++)
+                    {
+                        tasks[i] = cws.SendAsync(
+                            WebSocketData.GetBufferFromText("hello"), 
+                            WebSocketMessageType.Text, 
+                            true, 
+                            cts.Token);
+                    }
+
+                    Task.WaitAll(tasks);
+
+                    Assert.Equal(WebSocketState.Open, cws.State);
+                }
+                catch (AggregateException ag)
+                {
+                    foreach (var ex in ag.InnerExceptions)
+                    {
+                        if (ex is InvalidOperationException)
+                        {
+                            Assert.Equal(
+                                ResourceHelper.GetExceptionMessage(
+                                    "net_Websockets_AlreadyOneOutstandingOperation", 
+                                    "SendAsync"),
+                                ex.Message);
+
+                            Assert.Equal(WebSocketState.Aborted, cws.State);
+                        }
+                        else if (ex is WebSocketException)
+                        {
+                            // Multiple cases.
+                            Assert.Equal(WebSocketState.Aborted, cws.State);
+
+                            WebSocketError errCode = (ex as WebSocketException).WebSocketErrorCode;
+                            Assert.True(
+                                (errCode == WebSocketError.InvalidState) || (errCode == WebSocketError.Success),
+                                "WebSocketErrorCode");
+                        }
+                        else
+                        {
+                            Assert.True(false, "Unexpected exception: " + ex.Message);
+                        }
+                    }
+                }
+            }
+        }
+
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public async Task ReceiveAsync_MultipleOutstandingReceiveOperations_Throws(Uri server)
+        {
+            using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(server, TimeOutMilliseconds, _output))
+            {
+                var cts = new CancellationTokenSource(TimeOutMilliseconds);
+
+                Task[] tasks = new Task[2];
+
+                await cws.SendAsync(
+                    WebSocketData.GetBufferFromText(".delay5sec"), 
+                    WebSocketMessageType.Text, 
+                    true, 
+                    cts.Token);
+
+                var recvBuffer = new byte[100];
+                var recvSegment = new ArraySegment<byte>(recvBuffer);
+
+                try
+                {
+                    for (int i = 0; i < tasks.Length; i++)
+                    {
+                        tasks[i] = cws.ReceiveAsync(recvSegment, cts.Token);
+                    }
+
+                    Task.WaitAll(tasks);
+                    Assert.Equal(WebSocketState.Open, cws.State);
+                }
+                catch (AggregateException ag)
+                {
+                    foreach (var ex in ag.InnerExceptions)
+                    {
+                        if (ex is InvalidOperationException)
+                        {
+                            Assert.Equal(
+                                ResourceHelper.GetExceptionMessage(
+                                    "net_Websockets_AlreadyOneOutstandingOperation",
+                                    "ReceiveAsync"),
+                                ex.Message);
+
+                            Assert.Equal(WebSocketState.Aborted, cws.State);
+                        }
+                        else if (ex is WebSocketException)
+                        {
+                            // Multiple cases.
+                            Assert.Equal(WebSocketState.Aborted, cws.State);
+
+                            WebSocketError errCode = (ex as WebSocketException).WebSocketErrorCode;
+                            Assert.True(
+                                (errCode == WebSocketError.InvalidState) || (errCode == WebSocketError.Success), 
+                                "WebSocketErrorCode");
+                        }
+                        else
+                        {
+                            Assert.True(false, "Unexpected exception: " + ex.Message);
+                        }
+                    }
+                }
+            }
+        }
+
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public async Task SendAsync_SendZeroLengthPayloadAsEndOfMessage_Success(Uri server)
+        {
+            using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(server, TimeOutMilliseconds, _output))
+            {
+                var cts = new CancellationTokenSource(TimeOutMilliseconds);
+                string message = "hello";
+                await cws.SendAsync(
+                            WebSocketData.GetBufferFromText(message), 
+                            WebSocketMessageType.Text, 
+                            false, 
+                            cts.Token);
+                Assert.Equal(WebSocketState.Open, cws.State);
+                await cws.SendAsync(new ArraySegment<byte>(new byte[0]),
+                            WebSocketMessageType.Text, 
+                            true, 
+                            cts.Token);
+                Assert.Equal(WebSocketState.Open, cws.State);
+
+                var recvBuffer = new byte[100];
+                var receiveSegment = new ArraySegment<byte>(recvBuffer);
+                WebSocketReceiveResult recvRet = await cws.ReceiveAsync(receiveSegment, cts.Token);
+
+                Assert.Equal(WebSocketState.Open, cws.State);
+                Assert.Equal(message.Length, recvRet.Count);
+                Assert.Equal(WebSocketMessageType.Text, recvRet.MessageType);
+                Assert.Equal(true, recvRet.EndOfMessage);
+                Assert.Equal(null, recvRet.CloseStatus);
+                Assert.Equal(null, recvRet.CloseStatusDescription);
+
+                var recvSegment = new ArraySegment<byte>(receiveSegment.Array, receiveSegment.Offset, recvRet.Count);
+                Assert.Equal(message, WebSocketData.GetTextFromBuffer(recvSegment));
+            }
         }        
+#endregion
+
+#region Close
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public async Task CloseAsync_ClientInitiated_Success(Uri server)
+        {
+            using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(server, TimeOutMilliseconds, _output))
+            {
+                var cts = new CancellationTokenSource(TimeOutMilliseconds);
+                Assert.Equal(WebSocketState.Open, cws.State);
+
+                var closeStatus = WebSocketCloseStatus.InvalidMessageType;
+                string closeDescription = "CloseAsync_InvalidMessageType";
+
+                await cws.CloseAsync(closeStatus, closeDescription,  cts.Token);
+
+                Assert.Equal(WebSocketState.Closed, cws.State);
+                Assert.Equal(closeStatus, cws.CloseStatus);
+                Assert.Equal(closeDescription, cws.CloseStatusDescription);
+            }
+        }
+
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public async Task CloseAsync_CloseDescriptionIsMaxLength_Success(Uri server)
+        {
+            string closeDescription = new string('C', CloseDescriptionMaxLength);
+            
+            using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(server, TimeOutMilliseconds, _output))
+            {
+                var cts = new CancellationTokenSource(TimeOutMilliseconds);
+
+                await cws.CloseAsync(WebSocketCloseStatus.NormalClosure, closeDescription, cts.Token);
+            }
+        }
+
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public async Task CloseAsync_CloseDescriptionIsMaxLengthPlusOne_ThrowsArgumentException(Uri server)
+        {
+            string closeDescription = new string('C', CloseDescriptionMaxLength + 1);
+
+            using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(server, TimeOutMilliseconds, _output))
+            {
+                var cts = new CancellationTokenSource(TimeOutMilliseconds);
+
+                string expectedInnerMessage = ResourceHelper.GetExceptionMessage(
+                    "net_WebSockets_InvalidCloseStatusDescription",
+                    closeDescription,
+                    CloseDescriptionMaxLength);
+                    
+                var expectedException = new ArgumentException(expectedInnerMessage, "statusDescription");
+                string expectedMessage = expectedException.Message;
+
+                Assert.Throws<ArgumentException>(() =>
+                    { Task t = cws.CloseAsync(WebSocketCloseStatus.NormalClosure, closeDescription, cts.Token); });
+
+                Assert.Equal(WebSocketState.Open, cws.State);
+            }
+        }
+
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public async Task CloseAsync_CloseDescriptionHasUnicode_Success(Uri server)
+        {
+            using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(server, TimeOutMilliseconds, _output))
+            {
+                var cts = new CancellationTokenSource(TimeOutMilliseconds);
+
+                var closeStatus = WebSocketCloseStatus.InvalidMessageType;
+                string closeDescription = "CloseAsync_Containing\u016Cnicode.";
+
+                await cws.CloseAsync(closeStatus, closeDescription, cts.Token);
+
+                Assert.Equal(closeStatus, cws.CloseStatus);
+                Assert.Equal(closeDescription, cws.CloseStatusDescription);
+            }
+        }
+        
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public async Task CloseAsync_CloseDescriptionIsNull_Success(Uri server)
+        {
+            using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(server, TimeOutMilliseconds, _output))
+            {
+                var cts = new CancellationTokenSource(TimeOutMilliseconds);
+
+                var closeStatus = WebSocketCloseStatus.NormalClosure;
+                string closeDescription = null;
+                
+                await cws.CloseAsync(closeStatus, closeDescription, cts.Token);
+                Assert.Equal(closeStatus, cws.CloseStatus);
+                Assert.Equal(true, String.IsNullOrEmpty(cws.CloseStatusDescription));
+            }
+        }
+
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public async Task CloseOutputAsync_CloseDescriptionIsNull_Success(Uri server)
+        {
+            using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(server, TimeOutMilliseconds, _output))
+            {
+                var cts = new CancellationTokenSource(TimeOutMilliseconds);
+
+                var closeStatus = WebSocketCloseStatus.NormalClosure;
+                string closeDescription = null;
+                
+                await cws.CloseOutputAsync(closeStatus, closeDescription, cts.Token);
+            }
+        }
+#endregion
+
+#region Abort
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public void Abort_ConnectAndAbort_ThrowsWebSocketExceptionWithmessage(Uri server)
+        {
+            using (var cws = new ClientWebSocket())
+            {
+                var cts = new CancellationTokenSource(TimeOutMilliseconds);
+
+                var ub = new UriBuilder(server);
+                ub.Query = "delay10sec";
+
+                Task t = cws.ConnectAsync(ub.Uri, cts.Token);
+                cws.Abort();
+                WebSocketException ex = Assert.Throws<WebSocketException>(() => t.GetAwaiter().GetResult());
+
+                Assert.Equal(ResourceHelper.GetExceptionMessage("net_webstatus_ConnectFailure"), ex.Message);
+
+                Assert.Equal(WebSocketError.Success, ex.WebSocketErrorCode);
+                Assert.Equal(WebSocketState.Closed, cws.State);
+            }
+        }
+
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public async Task Abort_SendAndAbort_Success(Uri server)
+        {
+            await TestCancellation(async (cws) => {
+                var cts = new CancellationTokenSource(TimeOutMilliseconds);
+
+                Task t = cws.SendAsync(
+                    WebSocketData.GetBufferFromText(".delay5sec"),
+                    WebSocketMessageType.Text,
+                    true,
+                    cts.Token);
+
+                cws.Abort();
+
+                await t;
+            }, server);
+        }
+
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public async Task Abort_ReceiveAndAbort_Success(Uri server)
+        {
+            await TestCancellation(async (cws) => {
+                var ctsDefault = new CancellationTokenSource(TimeOutMilliseconds);
+
+                await cws.SendAsync(
+                    WebSocketData.GetBufferFromText(".delay5sec"),
+                    WebSocketMessageType.Text,
+                    true,
+                    ctsDefault.Token);
+
+                var recvBuffer = new byte[100];
+                var segment = new ArraySegment<byte>(recvBuffer);
+
+                Task t = cws.ReceiveAsync(segment, ctsDefault.Token);
+                cws.Abort();
+
+                await t;
+            }, server);
+        }
+        
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public async Task Abort_CloseAndAbort_Success(Uri server)
+        {
+            await TestCancellation(async (cws) => {
+                var ctsDefault = new CancellationTokenSource(TimeOutMilliseconds);
+
+                await cws.SendAsync(
+                    WebSocketData.GetBufferFromText(".delay5sec"),
+                    WebSocketMessageType.Text,
+                    true,
+                    ctsDefault.Token);
+
+                var recvBuffer = new byte[100];
+                var segment = new ArraySegment<byte>(recvBuffer);
+
+                Task t = cws.CloseAsync(WebSocketCloseStatus.NormalClosure, "AbortClose", ctsDefault.Token);
+                cws.Abort();
+
+                await t;
+            }, server);
+        }
+
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public async Task ClientWebSocket_Abort_CloseOutputAsync(Uri server)
+        {
+            await TestCancellation(async (cws) => {
+                var ctsDefault = new CancellationTokenSource(TimeOutMilliseconds);
+
+                await cws.SendAsync(
+                    WebSocketData.GetBufferFromText(".delay5sec"),
+                    WebSocketMessageType.Text,
+                    true,
+                    ctsDefault.Token);
+
+                var recvBuffer = new byte[100];
+                var segment = new ArraySegment<byte>(recvBuffer);
+
+                Task t = cws.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "AbortShutdown", ctsDefault.Token);
+                cws.Abort();
+
+                await t;
+            }, server);
+        }
+#endregion
+
+#region Cancellation
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public async Task ConnectAsync_Cancel_ThrowsWebSocketExceptionWithMessage(Uri server)
+        {
+            using (var cws = new ClientWebSocket())
+            {
+                var cts = new CancellationTokenSource(500);
+
+                var ub = new UriBuilder(server);
+                ub.Query = "delay10sec";
+
+                WebSocketException ex =
+                    await Assert.ThrowsAsync<WebSocketException>(() => cws.ConnectAsync(ub.Uri, cts.Token));
+                Assert.Equal(
+                    ResourceHelper.GetExceptionMessage("net_webstatus_ConnectFailure"),
+                    ex.Message);
+                Assert.Equal(WebSocketError.Success, ex.WebSocketErrorCode);
+                Assert.Equal(WebSocketState.Closed, cws.State);
+            }
+        }
+
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public async Task SendAsync_Cancel_Success(Uri server)
+        {
+            await TestCancellation((cws) => {
+                var cts = new CancellationTokenSource(5);
+                return cws.SendAsync(
+                    WebSocketData.GetBufferFromText(".delay5sec"), 
+                    WebSocketMessageType.Text, 
+                    true, 
+                    cts.Token);
+            }, server);
+        }
+
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public async Task ReceiveAsync_Cancel_Success(Uri server)
+        {
+            await TestCancellation(async (cws) => {
+                var ctsDefault = new CancellationTokenSource(TimeOutMilliseconds);
+                var cts = new CancellationTokenSource(5);
+
+                await cws.SendAsync(
+                    WebSocketData.GetBufferFromText(".delay5sec"), 
+                    WebSocketMessageType.Text, 
+                    true, 
+                    ctsDefault.Token);
+
+                var recvBuffer = new byte[100];
+                var segment = new ArraySegment<byte>(recvBuffer);
+
+                await cws.ReceiveAsync(segment, cts.Token);
+            }, server);
+        }
+
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public async Task CloseAsync_Cancel_Success(Uri server)
+        {
+            await TestCancellation(async (cws) => {
+                var ctsDefault = new CancellationTokenSource(TimeOutMilliseconds);
+                var cts = new CancellationTokenSource(5);
+
+                await cws.SendAsync(
+                    WebSocketData.GetBufferFromText(".delay5sec"),
+                    WebSocketMessageType.Text,
+                    true,
+                    ctsDefault.Token);
+
+                var recvBuffer = new byte[100];
+                var segment = new ArraySegment<byte>(recvBuffer);
+
+                await cws.CloseAsync(WebSocketCloseStatus.NormalClosure, "CancelClose", cts.Token);
+            }, server);
+        }
+
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public async Task CloseOutputAsync_Cancel_Success(Uri server)
+        {
+            await TestCancellation(async (cws) => {
+
+                var cts = new CancellationTokenSource(5);
+                var ctsDefault = new CancellationTokenSource(TimeOutMilliseconds);
+
+                await cws.SendAsync(
+                    WebSocketData.GetBufferFromText(".delay5sec"),
+                    WebSocketMessageType.Text,
+                    true,
+                    ctsDefault.Token);
+
+                var recvBuffer = new byte[100];
+                var segment = new ArraySegment<byte>(recvBuffer);
+
+                await cws.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "CancelShutdown", cts.Token);
+            }, server);
+        }
+
+        [ConditionalTheory("WebSocketsSupported"), MemberData("EchoServers")]
+        public async Task ReceiveAsync_CancelAndReceive_ThrowsWebSocketExceptionWithMessage(Uri server)
+        {
+            using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(server, TimeOutMilliseconds, _output))
+            {
+                var cts = new CancellationTokenSource(500);
+
+                var recvBuffer = new byte[100];
+                var segment = new ArraySegment<byte>(recvBuffer);
+
+                try
+                {
+                    await cws.ReceiveAsync(segment, cts.Token);
+                    Assert.True(false, "Receive should not complete.");
+                }
+                catch (OperationCanceledException) { }
+                catch (ObjectDisposedException) { }
+                catch (WebSocketException) { }
+
+                WebSocketException ex = await Assert.ThrowsAsync<WebSocketException>(() =>
+                    cws.ReceiveAsync(segment, CancellationToken.None));
+                Assert.Equal(
+                    ResourceHelper.GetExceptionMessage("net_WebSockets_InvalidState", "Aborted", "Open, CloseSent"),
+                    ex.Message);
+            }
+        }
+
+        private async Task TestCancellation(Func<ClientWebSocket, Task> action, Uri server)
+        {
+            using (ClientWebSocket cws = await WebSocketHelper.GetConnectedWebSocket(server, TimeOutMilliseconds, _output))
+            {
+                try
+                {
+                    await action(cws);
+                    // Operation finished before CTS expired.
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected exception
+                    Assert.Equal(WebSocketState.Aborted, cws.State);
+                }
+                catch (ObjectDisposedException)
+                {
+                    // Expected exception
+                    Assert.Equal(WebSocketState.Aborted, cws.State);
+                }
+                catch (WebSocketException exception)
+                {
+                    Assert.Equal(ResourceHelper.GetExceptionMessage(
+                        "net_WebSockets_InvalidState_ClosedOrAborted",
+                        "System.Net.WebSockets.InternalClientWebSocket",
+                        "Aborted"),
+                        exception.Message);
+
+                    Assert.Equal(WebSocketError.InvalidState, exception.WebSocketErrorCode);
+                    Assert.Equal(WebSocketState.Aborted, cws.State);
+                }
+            }
+        }
+#endregion
     }
 }

--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketUnitTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketUnitTest.cs
@@ -27,111 +27,124 @@ namespace System.Net.WebSockets.Client.Tests
         public void Ctor_Success()
         {
             var cws = new ClientWebSocket();
+            cws.Dispose();
         }
 
         [ConditionalFact("WebSocketsSupported")]
         public void Abort_CreateAndAbort_StateIsClosed()
         {
-            var cws = new ClientWebSocket();
-            cws.Abort();
+            using (var cws = new ClientWebSocket())
+            {
+                cws.Abort();
 
-            Assert.Equal(WebSocketState.Closed, cws.State);
+                Assert.Equal(WebSocketState.Closed, cws.State);
+            }
         }
 
         [ConditionalFact("WebSocketsSupported")]
         public void CloseAsync_CreateAndClose_ThrowsInvalidOperationException()
         {
-            var cws = new ClientWebSocket();
-            Assert.Throws<InvalidOperationException>(() =>
-                { Task t = cws.CloseAsync(WebSocketCloseStatus.Empty, "", new CancellationToken()); });
+            using (var cws = new ClientWebSocket())
+            {
+                Assert.Throws<InvalidOperationException>(() =>
+                    { Task t = cws.CloseAsync(WebSocketCloseStatus.Empty, "", new CancellationToken()); });
 
-            Assert.Equal(WebSocketState.None, cws.State);
+                Assert.Equal(WebSocketState.None, cws.State);
+            }
         }
 
         [ConditionalFact("WebSocketsSupported")]
-        public void CloseAsync_CreateAndCloseOutput_ThrowsInvalidOperationExceptionWithCorrectMessage()
+        public void CloseAsync_CreateAndCloseOutput_ThrowsInvalidOperationExceptionWithMessage()
         {
-            var cws = new ClientWebSocket();
-            AssertExtensions.Throws<InvalidOperationException>(
-                () =>
-                cws.CloseOutputAsync(WebSocketCloseStatus.Empty, "", new CancellationToken()).GetAwaiter().GetResult(),
-                ResourceHelper.GetExceptionMessage("net_WebSockets_NotConnected"));
+            using (var cws = new ClientWebSocket())
+            {
+                AssertExtensions.Throws<InvalidOperationException>(
+                    () =>
+                    cws.CloseOutputAsync(WebSocketCloseStatus.Empty, "", new CancellationToken()).GetAwaiter().GetResult(),
+                    ResourceHelper.GetExceptionMessage("net_WebSockets_NotConnected"));
 
-            Assert.Equal(WebSocketState.None, cws.State);
+                Assert.Equal(WebSocketState.None, cws.State);
+            }
         }
 
         [ConditionalFact("WebSocketsSupported")]
         public void CloseAsync_CreateAndReceive_ThrowsInvalidOperationException()
         {
-            var cws = new ClientWebSocket();
+            using (var cws = new ClientWebSocket())
+            {
+                var buffer = new byte[100];
+                var segment = new ArraySegment<byte>(buffer);
+                var ct = new CancellationToken();
 
-            var buffer = new byte[100];
-            var segment = new ArraySegment<byte>(buffer);
-            var ct = new CancellationToken();
+                Assert.Throws<InvalidOperationException>(() =>
+                    { Task t = cws.ReceiveAsync(segment, ct); });
 
-            Assert.Throws<InvalidOperationException>(() =>
-                { Task t = cws.ReceiveAsync(segment, ct); });
-
-            Assert.Equal(WebSocketState.None, cws.State);
+                Assert.Equal(WebSocketState.None, cws.State);
+            }
         }
 
         [ConditionalFact("WebSocketsSupported")]
-        public void CloseAsync_CreateAndReceive_ThrowsInvalidOperationExceptionWithCorrectMessage()
+        public void CloseAsync_CreateAndReceive_ThrowsInvalidOperationExceptionWithMessage()
         {
-            var cws = new ClientWebSocket();
+            using (var cws = new ClientWebSocket())
+            {
+                var buffer = new byte[100];
+                var segment = new ArraySegment<byte>(buffer);
+                var ct = new CancellationToken();
 
-            var buffer = new byte[100];
-            var segment = new ArraySegment<byte>(buffer);
-            var ct = new CancellationToken();
+                AssertExtensions.Throws<InvalidOperationException>(
+                    () => cws.ReceiveAsync(segment, ct).GetAwaiter().GetResult(),
+                    ResourceHelper.GetExceptionMessage("net_WebSockets_NotConnected"));
 
-            AssertExtensions.Throws<InvalidOperationException>(
-                () => cws.ReceiveAsync(segment, ct).GetAwaiter().GetResult(),
-                ResourceHelper.GetExceptionMessage("net_WebSockets_NotConnected"));
-
-            Assert.Equal(WebSocketState.None, cws.State);
+                Assert.Equal(WebSocketState.None, cws.State);
+            }
         }
 
         [ConditionalFact("WebSocketsSupported")]
         public void CloseAsync_CreateAndSend_ThrowsInvalidOperationException()
         {
-            var cws = new ClientWebSocket();
+            using (var cws = new ClientWebSocket())
+            {
+                var buffer = new byte[100];
+                var segment = new ArraySegment<byte>(buffer);
+                var ct = new CancellationToken();
 
-            var buffer = new byte[100];
-            var segment = new ArraySegment<byte>(buffer);
-            var ct = new CancellationToken();
+                Assert.Throws<InvalidOperationException>(() =>
+                    { Task t = cws.SendAsync(segment, WebSocketMessageType.Text, false, ct); });
 
-            Assert.Throws<InvalidOperationException>(() =>
-                { Task t = cws.SendAsync(segment, WebSocketMessageType.Text, false, ct); });
-
-            Assert.Equal(WebSocketState.None, cws.State);
+                Assert.Equal(WebSocketState.None, cws.State);
+            }
         }
 
         [ConditionalFact("WebSocketsSupported")]
-        public void CloseAsync_CreateAndSend_ThrowsInvalidOperationExceptionWithCorrectMessage()
+        public void CloseAsync_CreateAndSend_ThrowsInvalidOperationExceptionWithMessage()
         {
-            var cws = new ClientWebSocket();
+            using (var cws = new ClientWebSocket())
+            {
+                var buffer = new byte[100];
+                var segment = new ArraySegment<byte>(buffer);
+                var ct = new CancellationToken();
 
-            var buffer = new byte[100];
-            var segment = new ArraySegment<byte>(buffer);
-            var ct = new CancellationToken();
+                AssertExtensions.Throws<InvalidOperationException>(
+                    () => cws.SendAsync(segment, WebSocketMessageType.Text, false, ct).GetAwaiter().GetResult(),
+                    ResourceHelper.GetExceptionMessage("net_WebSockets_NotConnected"));
 
-            AssertExtensions.Throws<InvalidOperationException>(
-                () => cws.SendAsync(segment, WebSocketMessageType.Text, false, ct).GetAwaiter().GetResult(),
-                ResourceHelper.GetExceptionMessage("net_WebSockets_NotConnected"));
-
-            Assert.Equal(WebSocketState.None, cws.State);
+                Assert.Equal(WebSocketState.None, cws.State);
+            }
         }
 
         [ConditionalFact("WebSocketsSupported")]
         public void Ctor_ExpectedPropertyValues()
         {
-            var cws = new ClientWebSocket();
-            Assert.Equal(null, cws.CloseStatus);
-            Assert.Equal(null, cws.CloseStatusDescription);
-            Assert.NotEqual(null, cws.Options);
-            Assert.Equal(WebSocketState.None, cws.State);
-            Assert.Equal(null, cws.SubProtocol);
-            Assert.Equal("System.Net.WebSockets.ClientWebSocket", cws.ToString());
+            using (var cws = new ClientWebSocket())
+            {
+                Assert.Equal(null, cws.CloseStatus);
+                Assert.Equal(null, cws.CloseStatusDescription);
+                Assert.NotEqual(null, cws.Options);
+                Assert.Equal(WebSocketState.None, cws.State);
+                Assert.Equal(null, cws.SubProtocol);
+                Assert.Equal("System.Net.WebSockets.ClientWebSocket", cws.ToString());
+            }
         }
 
         [ConditionalFact("WebSocketsSupported")]
@@ -157,7 +170,7 @@ namespace System.Net.WebSockets.Client.Tests
         }
 
         [ConditionalFact("WebSocketsSupported")]
-        public void CloseAsync_DisposeAndClose_ThrowsObjectDisposedExceptionWithCorrectMessage()
+        public void CloseAsync_DisposeAndCloseOutput_ThrowsObjectDisposedExceptionWithMessage()
         {
             var cws = new ClientWebSocket();
             cws.Dispose();
@@ -173,7 +186,7 @@ namespace System.Net.WebSockets.Client.Tests
         }
 
         [ConditionalFact("WebSocketsSupported")]
-        public void ReceiveAsync_CreateAndDisposeAndReceive_ThrowsObjectDisposedExceptionWithCorrectMessage()
+        public void ReceiveAsync_CreateAndDisposeAndReceive_ThrowsObjectDisposedExceptionWithMessage()
         {
             var cws = new ClientWebSocket();
             cws.Dispose();
@@ -192,7 +205,7 @@ namespace System.Net.WebSockets.Client.Tests
         }
 
         [ConditionalFact("WebSocketsSupported")]
-        public void SendAsync_CreateAndDisposeAndSend_ThrowsObjectDisposedExceptionWithCorrectMessage()
+        public void SendAsync_CreateAndDisposeAndSend_ThrowsObjectDisposedExceptionWithMessage()
         {
             var cws = new ClientWebSocket();
             cws.Dispose();

--- a/src/System.Net.WebSockets.Client/tests/WebSocketHelper.cs
+++ b/src/System.Net.WebSockets.Client/tests/WebSocketHelper.cs
@@ -5,73 +5,78 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Net.WebSockets.Client.Tests
 {
-    public class WebSocketHelper
+    public static class WebSocketHelper
     {
         private static readonly Lazy<bool> s_WebSocketSupported = new Lazy<bool>(InitWebSocketSupported);
-        private static int s_TimeOutMilliseconds;
-        private Uri _echoService;
-
-        public WebSocketHelper(Uri echoService, int timeOut)
-        {
-            _echoService = echoService;
-            s_TimeOutMilliseconds = timeOut;
-        }
-
         public static bool WebSocketsSupported { get { return s_WebSocketSupported.Value; } }
 
-        public async Task TestEcho(WebSocketMessageType type)
+        public static async Task TestEcho(
+            Uri server,
+            WebSocketMessageType type,
+            int timeOutMilliseconds,
+            ITestOutputHelper output)
         {
-            var cts = new CancellationTokenSource(s_TimeOutMilliseconds);
+            var cts = new CancellationTokenSource(timeOutMilliseconds);
             string message = "Hello WebSockets!";
             string closeMessage = "Good bye!";
             var receiveBuffer = new byte[100];
             var receiveSegment = new ArraySegment<byte>(receiveBuffer);
 
-            ClientWebSocket cws = await GetConnectedWebSocket(_echoService);
+            using (ClientWebSocket cws = await GetConnectedWebSocket(server, timeOutMilliseconds, output))
+            {
+                output.WriteLine("TestEcho: SendAsync starting.");
+                await cws.SendAsync(WebSocketData.GetBufferFromText(message), type, true, cts.Token);
+                output.WriteLine("TestEcho: SendAsync done.");
+                Assert.Equal(WebSocketState.Open, cws.State);
 
-            await cws.SendAsync(WebSocketData.GetBufferFromText(message), type, true, cts.Token);
-            Assert.Equal(WebSocketState.Open, cws.State);
+                output.WriteLine("TestEcho: ReceiveAsync starting.");
+                WebSocketReceiveResult recvRet = await cws.ReceiveAsync(receiveSegment, cts.Token);
+                output.WriteLine("TestEcho: ReceiveAsync done.");
+                Assert.Equal(WebSocketState.Open, cws.State);
+                Assert.Equal(message.Length, recvRet.Count);
+                Assert.Equal(type, recvRet.MessageType);
+                Assert.Equal(true, recvRet.EndOfMessage);
+                Assert.Equal(null, recvRet.CloseStatus);
+                Assert.Equal(null, recvRet.CloseStatusDescription);
 
-            WebSocketReceiveResult recvRet = await cws.ReceiveAsync(receiveSegment, cts.Token);
-            Assert.Equal(WebSocketState.Open, cws.State);
-            Assert.Equal(message.Length, recvRet.Count);
-            Assert.Equal(type, recvRet.MessageType);
-            Assert.Equal(true, recvRet.EndOfMessage);
-            Assert.Equal(null, recvRet.CloseStatus);
-            Assert.Equal(null, recvRet.CloseStatusDescription);
+                var recvSegment = new ArraySegment<byte>(receiveSegment.Array, receiveSegment.Offset, recvRet.Count);
+                Assert.Equal(message, WebSocketData.GetTextFromBuffer(recvSegment));
 
-            var recvSegment = new ArraySegment<byte>(receiveSegment.Array, receiveSegment.Offset, recvRet.Count);
-            Assert.Equal(message, WebSocketData.GetTextFromBuffer(recvSegment));
-
-            Task taskClose = cws.CloseAsync(WebSocketCloseStatus.NormalClosure, closeMessage, cts.Token);
-            Assert.True(
-                (cws.State == WebSocketState.Open) || (cws.State == WebSocketState.CloseSent) ||
-                (cws.State == WebSocketState.CloseReceived) || (cws.State == WebSocketState.Closed),
-                "State immediately after CloseAsync : " + cws.State);
-            await taskClose;
-            Assert.Equal(WebSocketState.Closed, cws.State);
-            Assert.Equal(WebSocketCloseStatus.NormalClosure, cws.CloseStatus);
-            Assert.Equal(closeMessage, cws.CloseStatusDescription);
-
-            cws.Dispose();
-            Assert.Equal(WebSocketState.Closed, cws.State);
+                output.WriteLine("TestEcho: CloseAsync starting.");
+                Task taskClose = cws.CloseAsync(WebSocketCloseStatus.NormalClosure, closeMessage, cts.Token);
+                Assert.True(
+                    (cws.State == WebSocketState.Open) || (cws.State == WebSocketState.CloseSent) ||
+                    (cws.State == WebSocketState.CloseReceived) || (cws.State == WebSocketState.Closed),
+                    "State immediately after CloseAsync : " + cws.State);
+                await taskClose;
+                output.WriteLine("TestEcho: CloseAsync done.");
+                Assert.Equal(WebSocketState.Closed, cws.State);
+                Assert.Equal(WebSocketCloseStatus.NormalClosure, cws.CloseStatus);
+                Assert.Equal(closeMessage, cws.CloseStatusDescription);
+            }
         }
 
-        public static async Task<ClientWebSocket> GetConnectedWebSocket(Uri u)
+        public static async Task<ClientWebSocket> GetConnectedWebSocket(
+            Uri server,
+            int timeOutMilliseconds,
+            ITestOutputHelper output)
         {
             var cws = new ClientWebSocket();
-            var cts = new CancellationTokenSource(s_TimeOutMilliseconds);
+            var cts = new CancellationTokenSource(timeOutMilliseconds);
 
-            Task taskConnect = cws.ConnectAsync(u, cts.Token);
+            output.WriteLine("GetConnectedWebSocket: ConnectAsync starting.");
+            Task taskConnect = cws.ConnectAsync(server, cts.Token);
             Assert.True(
                 (cws.State == WebSocketState.None) ||
                 (cws.State == WebSocketState.Connecting) ||
                 (cws.State == WebSocketState.Open),
                 "State immediately after ConnectAsync incorrect: " + cws.State);
             await taskConnect;
+            output.WriteLine("GetConnectedWebSocket: ConnectAsync done.");
             Assert.Equal(WebSocketState.Open, cws.State);
 
             return cws;


### PR DESCRIPTION
Continued porting internal ToF tests to GitHub.
Modified tests to use a good dev pattern of `using` around websocket use.