### PR TITLE
Standardize Managed SNI Error Messages.

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNICommon.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNICommon.cs
@@ -54,6 +54,8 @@ namespace System.Data.SqlClient.SNI
 
     internal class SNICommon
     {
+        internal const int SNIInternalExceptionErrorId = 35; // As seen in SNI_ERROR_35
+
         /// <summary>
         /// Validate server certificate callback for SSL
         /// </summary>
@@ -122,7 +124,20 @@ namespace System.Data.SqlClient.SNI
         /// <returns></returns>
         internal static uint ReportSNIError(SNIProviders provider, uint nativeError, uint sniError, string errorMessage)
         {
-            SNILoadHandle.SingletonInstance.LastError = new SNIError(provider, nativeError, sniError, errorMessage);
+            return ReportSNIError(new SNIError(provider, nativeError, sniError, errorMessage));
+        }
+
+        /// <summary>
+        /// Sets last error encountered for SNI
+        /// </summary>
+        /// <param name="provider">SNI provider</param>
+        /// <param name="nativeError">Native error code</param>
+        /// <param name="sniError">SNI error code</param>
+        /// <param name="errorMessage">Error message</param>
+        /// <returns></returns>
+        internal static uint ReportSNIError(SNIError error)
+        {
+            SNILoadHandle.SingletonInstance.LastError = error;
             return TdsEnums.SNI_ERROR;
         }
     }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIHandle.cs
@@ -22,6 +22,12 @@ namespace System.Data.SqlClient.SNI
         public abstract void SetAsyncCallbacks(SNIAsyncCallback receiveCallback, SNIAsyncCallback sendCallback);
 
         /// <summary>
+        /// Set buffer size
+        /// </summary>
+        /// <param name="bufferSize">Buffer size</param>
+        public abstract void SetBufferSize(int bufferSize);
+
+        /// <summary>
         /// Send a packet synchronously
         /// </summary>
         /// <param name="packet">SNI packet</param>

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -68,8 +68,7 @@ namespace System.Data.SqlClient.SNI
                 return TdsEnums.SNI_SUCCESS_IO_PENDING;
             }
 
-            SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.SMUX_PROV, 0, 0, "Could not start MARS async receive");
-            return TdsEnums.SNI_ERROR;
+            return SNICommon.ReportSNIError(SNIProviders.SMUX_PROV, 0, 19, SR.SNI_ERROR_19);
         }
 
         /// <summary>
@@ -246,7 +245,7 @@ namespace System.Data.SqlClient.SNI
 
                     if (!_sessions.ContainsKey(_currentHeader.sessionId))
                     {
-                        SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.SMUX_PROV, 0, 0, "Packet for unknown MARS session received");
+                        SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.SMUX_PROV, 0, 5, SR.SNI_ERROR_5);
                         HandleReceiveError();
                         _lowerHandle.Dispose();
                         _lowerHandle = null;
@@ -269,7 +268,7 @@ namespace System.Data.SqlClient.SNI
                     }
                     catch (Exception e)
                     {
-                        SNICommon.ReportSNIError(SNIProviders.TCP_PROV, 0, 0, e.Message);
+                        SNICommon.ReportSNIError(SNIProviders.TCP_PROV, 0, SNICommon.SNIInternalExceptionErrorId, e.Message);
                     }
                 }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsHandle.cs
@@ -65,7 +65,7 @@ namespace System.Data.SqlClient.SNI
             }
             catch (Exception e)
             {
-                SNICommon.ReportSNIError(SNIProviders.SMUX_PROV, 0, 0, e.Message);
+                SNICommon.ReportSNIError(SNIProviders.SMUX_PROV, 0, SNICommon.SNIInternalExceptionErrorId, e.Message);
             }
         }
 
@@ -279,8 +279,7 @@ namespace System.Data.SqlClient.SNI
 
                 if (_connectionError != null)
                 {
-                    SNILoadHandle.SingletonInstance.LastError = _connectionError;
-                    return TdsEnums.SNI_ERROR;
+                    return SNICommon.ReportSNIError(_connectionError);
                 }
 
                 if (queueCount == 0)
@@ -433,8 +432,7 @@ namespace System.Data.SqlClient.SNI
                 {
                     if (_connectionError != null)
                     {
-                        SNILoadHandle.SingletonInstance.LastError = _connectionError;
-                        return TdsEnums.SNI_ERROR;
+                        return SNICommon.ReportSNIError(_connectionError);
                     }
 
                     queueCount = _receivedPacketQueue.Count;
@@ -465,7 +463,7 @@ namespace System.Data.SqlClient.SNI
 
                 if (!_packetEvent.Wait(timeoutInMilliseconds))
                 {
-                    SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.SMUX_PROV, 0, 0, "Timeout error");
+                    SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.SMUX_PROV, 0, 11, SR.SNI_ERROR_11);
                     return TdsEnums.SNI_WAIT_TIMEOUT;
                 }
             }
@@ -487,6 +485,14 @@ namespace System.Data.SqlClient.SNI
         /// <param name="receiveCallback">Receive callback</param>
         /// <param name="sendCallback">Send callback</param>
         public override void SetAsyncCallbacks(SNIAsyncCallback receiveCallback, SNIAsyncCallback sendCallback)
+        {
+        }
+
+        /// <summary>
+        /// Set buffer size
+        /// </summary>
+        /// <param name="bufferSize">Buffer size</param>
+        public override void SetBufferSize(int bufferSize)
         {
         }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
@@ -244,7 +244,7 @@ namespace System.Data.SqlClient.SNI
                 Exception e = t.Exception != null ? t.Exception.InnerException : null;
                 if (e != null)
                 {
-                    SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, 0, 0, e.Message);
+                    SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, 0, SNICommon.SNIInternalExceptionErrorId, e.Message);
                     error = true;
                 }
                 else
@@ -253,7 +253,7 @@ namespace System.Data.SqlClient.SNI
 
                     if (_length == 0)
                     {
-                        SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, 0, 0, "Connection was terminated");
+                        SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, 0, 2, SR.SNI_ERROR_2);
                         error = true;
                     }
                 }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -66,8 +66,7 @@ namespace System.Data.SqlClient.SNI
             }
             catch
             {
-                SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.SSL_PROV, 0, 31, SR.SNI_ERROR_31);
-                return TdsEnums.SNI_ERROR;
+                return SNICommon.ReportSNIError(SNIProviders.SSL_PROV, 0, 31, SR.SNI_ERROR_31);
             }
         }
 
@@ -116,11 +115,7 @@ namespace System.Data.SqlClient.SNI
         /// <returns>SNI error code</returns>
         public uint SetConnectionBufferSize(SNIHandle handle, uint bufferSize)
         {
-            if (handle is SNITCPHandle)
-            {
-                (handle as SNITCPHandle).SetBufferSize((int)bufferSize);
-            }
-
+            handle.SetBufferSize((int)bufferSize);
             return TdsEnums.SNI_SUCCESS;
         }
 
@@ -217,7 +212,7 @@ namespace System.Data.SqlClient.SNI
 
             if (serverNameParts.Length > 2)
             {
-                SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.INVALID_PROV, 0, 0, "Connection string is not formatted correctly");
+                SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.INVALID_PROV, 0, 25, SR.SNI_ERROR_25);
                 return null;
             }
 
@@ -268,13 +263,13 @@ namespace System.Data.SqlClient.SNI
                 }
                 catch (Exception)
                 {
-                    SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, 0, 0, "Port number is malformed");
+                    SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, 0, 25, SR.SNI_ERROR_25);
                     return null;
                 }
             }
             else if (serverAndPortParts.Length > 2)
             {
-                SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, 0, 0, "Connection string is not formatted correctly");
+                SNILoadHandle.SingletonInstance.LastError = new SNIError(SNIProviders.TCP_PROV, 0, 25, SR.SNI_ERROR_25);
                 return null;
             }
 


### PR DESCRIPTION
This changeset changes managed SNI to use standardized Strings.resx error messages when reporting errors.

This changeset also adds a SetBufferSize interface method to SNIHandle, so that SNIProxy can set connection buffer sizes for SNI handles without checking the handle type.