### PR TITLE
SNIMarsConnection FIN Session Removal Fix

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIMarsConnection.cs
@@ -209,11 +209,6 @@ namespace System.Data.SqlClient.SNI
                         _dataBytesLeft = (int)_currentHeader.length;
                         _currentPacket = new SNIPacket(null);
                         _currentPacket.Allocate((int)_currentHeader.length);
-
-                        if (_currentHeader.flags == (byte)SNISMUXFlags.SMUX_FIN)
-                        {
-                            _sessions.Remove(_currentHeader.sessionId);
-                        }
                     }
 
                     currentHeader = _currentHeader;
@@ -252,7 +247,14 @@ namespace System.Data.SqlClient.SNI
                         return;
                     }
 
-                    currentSession = _sessions[_currentHeader.sessionId];
+                    if (_currentHeader.flags == (byte)SNISMUXFlags.SMUX_FIN)
+                    {
+                        _sessions.Remove(_currentHeader.sessionId);
+                    }
+                    else
+                    {
+                        currentSession = _sessions[_currentHeader.sessionId];
+                    }
                 }
 
                 if (currentHeader.flags == (byte)SNISMUXFlags.SMUX_DATA)


### PR DESCRIPTION
Fixes a bug in SNIMarsConnection where FIN sessions would get removed from the session list immediately before checking if the received session was in the list. Thus an error would be thrown on every received FIN session, even though the session should be treated as valid.

Tracked in: https://github.com/dotnet/corefx/issues/4511