### PR TITLE
Optimize Enumerable.Skip() for IList<> parameter

### DIFF
--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -884,7 +884,22 @@ namespace System.Linq
         public static IEnumerable<TSource> Skip<TSource>(this IEnumerable<TSource> source, int count)
         {
             if (source == null) throw Error.ArgumentNull("source");
-            return SkipIterator<TSource>(source, count);
+
+            IList<TSource> sourceList = source as IList<TSource>;
+            return sourceList != null ? SkipList(sourceList, count) : SkipIterator<TSource>(source, count);
+        }
+
+        private static IEnumerable<TSource> SkipList<TSource>(IList<TSource> source, int count)
+        {
+            if (count < 0)
+            {
+                count = 0;
+            }
+
+            while (count < source.Count)
+            {
+                yield return source[count++];
+            }
         }
 
         private static IEnumerable<TSource> SkipIterator<TSource>(IEnumerable<TSource> source, int count)

--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -896,7 +896,9 @@ namespace System.Linq
                 count = 0;
             }
 
-            while (count < source.Count)
+            int sourceCount = source.Count;
+
+            while (count < sourceCount)
             {
                 yield return source[count++];
             }

--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -896,9 +896,7 @@ namespace System.Linq
                 count = 0;
             }
 
-            int sourceCount = source.Count;
-
-            while (count < sourceCount)
+            while (count < source.Count)
             {
                 yield return source[count++];
             }


### PR DESCRIPTION
Changes Enumerable.Skip() from O(n) to O(1) when an IList<> is passed.