### PR TITLE
Fix XmlSerializer writes empty element when serializing TimeSpan

### DIFF
--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -2702,3 +2702,8 @@ public class TypeWithBinaryProperty
     [XmlElement(DataType = "base64Binary")]
     public byte[] Base64Content { get; set; }
 }
+
+public class TypeWithTimeSpanProperty
+{
+    public TimeSpan TimeSpanProperty;
+}

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/PrimitiveXmlSerializers.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/PrimitiveXmlSerializers.cs
@@ -193,6 +193,18 @@ namespace System.Xml.Serialization
             WriteElementStringRaw(@"guid", @"", System.Xml.XmlConvert.ToString(guid));
         }
 
+        internal void Write_TimeSpan(object o)
+        {
+            WriteStartDocument();
+            if (o == null)
+            {
+                WriteEmptyTag(@"TimeSpan", @"");
+                return;
+            }
+            TimeSpan timeSpan = (TimeSpan)o;
+            WriteElementStringRaw(@"TimeSpan", @"", System.Xml.XmlConvert.ToString(timeSpan));
+        }
+
         internal void Write_char(object o)
         {
             WriteStartDocument();
@@ -617,6 +629,30 @@ namespace System.Xml.Serialization
             return (object)o;
         }
 
+        internal object Read_TimeSpan()
+        {
+            object o = null;
+            Reader.MoveToContent();
+            if (Reader.NodeType == System.Xml.XmlNodeType.Element)
+            {
+                if (((object)Reader.LocalName == (object)_id19_TimeSpan && (object)Reader.NamespaceURI == (object)_id2_Item))
+                {
+                    {
+                        o = System.Xml.XmlConvert.ToTimeSpan(Reader.ReadElementString());
+                    }
+                }
+                else
+                {
+                    throw CreateUnknownNodeException();
+                }
+            }
+            else
+            {
+                UnknownNode(null);
+            }
+            return (object)o;
+        }
+
         internal object Read_char()
         {
             object o = null;
@@ -683,6 +719,7 @@ namespace System.Xml.Serialization
         private System.String _id9_decimal;
         private System.String _id8_double;
         private System.String _id17_guid;
+        private System.String _id19_TimeSpan;
         private System.String _id2_Item;
         private System.String _id13_unsignedShort;
         private System.String _id18_char;
@@ -705,6 +742,7 @@ namespace System.Xml.Serialization
             _id9_decimal = Reader.NameTable.Add(@"decimal");
             _id8_double = Reader.NameTable.Add(@"double");
             _id17_guid = Reader.NameTable.Add(@"guid");
+            _id19_TimeSpan = Reader.NameTable.Add(@"TimeSpan");
             _id2_Item = Reader.NameTable.Add(@"");
             _id13_unsignedShort = Reader.NameTable.Add(@"unsignedShort");
             _id18_char = Reader.NameTable.Add(@"char");

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/Types.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/Types.cs
@@ -483,7 +483,7 @@ namespace System.Xml.Serialization
 
             AddNonXsdPrimitive(typeof(Guid), "guid", UrtTypes.Namespace, "Guid", new XmlQualifiedName("string", XmlSchema.Namespace), null, TypeFlags.CanBeAttributeValue | TypeFlags.CanBeElementValue | TypeFlags.XmlEncodingNotRequired | TypeFlags.IgnoreDefault);
             AddNonXsdPrimitive(typeof(char), "char", UrtTypes.Namespace, "Char", new XmlQualifiedName("unsignedShort", XmlSchema.Namespace), null, TypeFlags.CanBeAttributeValue | TypeFlags.CanBeElementValue | TypeFlags.HasCustomFormatter | TypeFlags.IgnoreDefault);
-
+            AddNonXsdPrimitive(typeof(TimeSpan), "TimeSpan", UrtTypes.Namespace, "TimeSpan", new XmlQualifiedName("string", XmlSchema.Namespace), null, TypeFlags.CanBeAttributeValue | TypeFlags.CanBeElementValue | TypeFlags.XmlEncodingNotRequired | TypeFlags.IgnoreDefault);
 
             // Unsuppoted types that we map to string, if in the future we decide 
             // to add support for them we would need to create custom formatters for them
@@ -524,6 +524,8 @@ namespace System.Xml.Serialization
                     else if (type == typeof(byte[]))
                         return true;
                     else if (type == typeof(Guid))
+                        return true;
+                    else if (type == typeof (TimeSpan))
                         return true;
                     else if (type == typeof(XmlNode[]))
                         return true;

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationReader.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationReader.cs
@@ -110,6 +110,7 @@ namespace System.Xml.Serialization
 
         private string _charID;
         private string _guidID;
+        private string _timeSpanID;
 
 
 
@@ -226,6 +227,7 @@ namespace System.Xml.Serialization
             _oldTimeInstantID = _r.NameTable.Add("timeInstant");
             _charID = _r.NameTable.Add("char");
             _guidID = _r.NameTable.Add("guid");
+            _timeSpanID = _r.NameTable.Add("TimeSpan");
             _base64ID = _r.NameTable.Add("base64");
 
             _anyURIID = _r.NameTable.Add("anyURI");
@@ -531,6 +533,8 @@ namespace System.Xml.Serialization
                     value = ToChar(ReadStringValue());
                 else if ((object)type.Name == (object)_guidID)
                     value = new Guid(CollapseWhitespace(ReadStringValue()));
+                else if ((object)type.Name == (object)_timeSpanID)
+                    value = XmlConvert.ToTimeSpan(ReadStringValue());
                 else
                     value = ReadXmlNodes(elementCanBeType);
             }
@@ -627,6 +631,8 @@ namespace System.Xml.Serialization
                     value = default(Nullable<char>);
                 else if ((object)type.Name == (object)_guidID)
                     value = default(Nullable<Guid>);
+                else if ((object) type.Name == (object) _timeSpanID)
+                    value = default(Nullable<TimeSpan>);
                 else
                     value = null;
             }

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationWriter.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationWriter.cs
@@ -230,7 +230,12 @@ namespace System.Xml.Serialization
                         typeName = "guid";
                         typeNs = UrtTypes.Namespace;
                     }
-                    else if (type == typeof(XmlNode[]))
+                    else if (type == typeof (TimeSpan))
+                    {
+                        typeName = "TimeSpan";
+                        typeNs = UrtTypes.Namespace;
+                    }
+                    else if (type == typeof (XmlNode[]))
                     {
                         typeName = Soap.UrType;
                     }
@@ -340,6 +345,12 @@ namespace System.Xml.Serialization
                     {
                         value = XmlConvert.ToString((Guid)o);
                         type = "guid";
+                        typeNs = UrtTypes.Namespace;
+                    }
+                    else if (t == typeof(TimeSpan))
+                    {
+                        value = XmlConvert.ToString((TimeSpan)o);
+                        type = "TimeSpan";
                         typeNs = UrtTypes.Namespace;
                     }
                     else if (typeof(XmlNode[]).IsAssignableFrom(t))

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializer.cs
@@ -760,6 +760,10 @@ namespace System.Xml.Serialization
                     {
                         writer.Write_guid(o);
                     }
+                    else if (_primitiveType == typeof(TimeSpan))
+                    {
+                        writer.Write_TimeSpan(o);
+                    }
                     else
                     {
                         throw new InvalidOperationException(SR.Format(SR.XmlUnxpectedType, _primitiveType.FullName));
@@ -833,6 +837,10 @@ namespace System.Xml.Serialization
                     else if (_primitiveType == typeof(Guid))
                     {
                         o = reader.Read_guid();
+                    }
+                    else if (_primitiveType == typeof(TimeSpan))
+                    {
+                        o = reader.Read_TimeSpan();
                     }
                     else
                     {

--- a/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
+++ b/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
@@ -12,7 +12,6 @@ using System.Xml.Linq;
 using System.Xml.Serialization;
 using Xunit;
 
-
 public static partial class XmlSerializerTests
 {
     [Fact]
@@ -1581,6 +1580,35 @@ public static partial class XmlSerializerTests
 
             stream.Dispose();
         }
+    }
+
+    [Fact]
+    public static void Xml_TimeSpanAsRoot()
+    {
+        Assert.StrictEqual(new TimeSpan(1, 2, 3), SerializeAndDeserialize<TimeSpan>(new TimeSpan(1, 2, 3),
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<TimeSpan>PT1H2M3S</TimeSpan>"));
+        Assert.StrictEqual(TimeSpan.Zero, SerializeAndDeserialize<TimeSpan>(TimeSpan.Zero,
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<TimeSpan>PT0S</TimeSpan>"));
+        Assert.StrictEqual(TimeSpan.MinValue, SerializeAndDeserialize<TimeSpan>(TimeSpan.MinValue,
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<TimeSpan>-P10675199DT2H48M5.4775808S</TimeSpan>"));
+        Assert.StrictEqual(TimeSpan.MaxValue, SerializeAndDeserialize<TimeSpan>(TimeSpan.MaxValue,
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<TimeSpan>P10675199DT2H48M5.4775807S</TimeSpan>"));
+    }
+
+    [Fact]
+    public static void Xml_TypeWithTimeSpanProperty()
+    {
+        var obj = new TypeWithTimeSpanProperty { TimeSpanProperty = TimeSpan.FromMilliseconds(1) };
+        var deserializedObj = SerializeAndDeserialize(obj,
+@"<?xml version=""1.0"" encoding=""utf-16""?>
+<TypeWithTimeSpanProperty xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+  <TimeSpanProperty>PT0.001S</TimeSpanProperty>
+</TypeWithTimeSpanProperty>");
+        Assert.StrictEqual(obj.TimeSpanProperty, deserializedObj.TimeSpanProperty);
     }
 
     private static T SerializeAndDeserialize<T>(T value, string baseline, Func<XmlSerializer> serializerFactory = null,


### PR DESCRIPTION
XmlSerializer writes empty element when serializing TimeSpan because this type's properties and fields are get only. This change is to handle TimeSpan type by reading and writing it in string with XmlConvert.

Fixes #4405 

cc: @SGuyGe @shmao @zhenlan 