### PR TITLE
Fix recently added Task test

### DIFF
--- a/src/System.Threading.Tasks/tests/Task/RunContinuationsAsynchronouslyTests.cs
+++ b/src/System.Threading.Tasks/tests/Task/RunContinuationsAsynchronouslyTests.cs
@@ -41,7 +41,7 @@ namespace System.Threading.Tasks.Tests
 
         private static void Run(bool useRunContinuationsAsynchronously, Func<Task,Task> getIntermediateContinuation)
         {
-            Task.Run(() => // run test off of xunit's thread so as not to be confused by its TaskScheduler or SynchronizationContext
+            Task t = Task.Run(() => // run test off of xunit's thread so as not to be confused by its TaskScheduler or SynchronizationContext
             {
                 int callingThreadId = Environment.CurrentManagedThreadId;
 
@@ -57,7 +57,9 @@ namespace System.Threading.Tasks.Tests
 
                 ((IAsyncResult)cont).AsyncWaitHandle.WaitOne(); // ensure we don't inline as part of waiting
                 cont.GetAwaiter().GetResult(); // propagate any errors
-            }).GetAwaiter().GetResult(); // propagate any errors
+            });
+            ((IAsyncResult)t).AsyncWaitHandle.WaitOne(); // ensure we don't inline as part of waiting
+            t.GetAwaiter().GetResult(); // propagate any errors
         }
 
     }


### PR DESCRIPTION
The test needs to run its work off of xunit's thread in order to escape the synchronization context that will mess up the results of the test. But we were inadvertently still potentially running on the calling thread due to how we were waiting on the task.

Fixes #4555