### PR TITLE
Removes redundant GChandle object from SNIProxy.

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIProxy.cs
@@ -12,30 +12,11 @@ namespace System.Data.SqlClient.SNI
     {
         public static readonly SNIProxy Singleton = new SNIProxy();
 
-        private readonly GCHandle _gcHandle;
-
         /// <summary>
         /// Terminate SNI
         /// </summary>
         public void Terminate()
         {
-        }
-
-        /// <summary>
-        /// Check if GC handle is allocated
-        /// </summary>
-        /// <returns></returns>
-        public bool IsGcHandleAllocated()
-        {
-            return _gcHandle.IsAllocated;
-        }
-
-        /// <summary>
-        /// Free GC handle
-        /// </summary>
-        public void FreeGcHandle()
-        {
-            _gcHandle.Free();
         }
 
         /// <summary>

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserStateObject.cs
@@ -898,19 +898,12 @@ namespace System.Data.SqlClient
         {
             int remaining = Interlocked.Decrement(ref _pendingCallbacks);
 
-#if MANAGED_SNI
-            if ((0 == remaining || release) && SNIProxy.Singleton.IsGcHandleAllocated())
-#else	
+#if !MANAGED_SNI
             if ((0 == remaining || release) && _gcHandle.IsAllocated)
-#endif // MANAGED_SNI
-
             {
-#if MANAGED_SNI
-                SNIProxy.Singleton.FreeGcHandle();				
-#else
                 _gcHandle.Free();
-#endif // MANAGED_SNI
             }
+#endif // !MANAGED_SNI
 
             // NOTE: TdsParserSessionPool may call DecrementPendingCallbacks on a TdsParserStateObject which is already disposed
             // This is not dangerous (since the stateObj is no longer in use), but we need to add a workaround in the assert for it


### PR DESCRIPTION
Native SNI uses GCHandles to handle passing data objects between managed and unmanaged code. Now that this is all managed code these GCHandles aren't needed for any feature parity, and weren't even used anyway.

Issue tracked in: https://github.com/dotnet/corefx/issues/4454