### PR TITLE
Support TLS client certs in CurlHandler (for libcurl+openssl) 

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.CURLcode.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.CURLcode.cs
@@ -12,6 +12,7 @@ internal static partial class Interop
             CURLE_UNSUPPORTED_PROTOCOL  =  1,
             CURLE_NOT_BUILT_IN = 4,
             CURLE_COULDNT_RESOLVE_HOST  =  6,
+            CURLE_ABORTED_BY_CALLBACK = 42,
             CURLE_UNKNOWN_OPTION = 48,
         }
     }

--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Easy.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Easy.cs
@@ -45,7 +45,7 @@ internal static partial class Interop
 
         public delegate ulong ReadWriteCallback(IntPtr buffer, ulong bufferSize, ulong nitems, IntPtr userPointer);
 
-        public delegate CURLcode SslCtxCallback(IntPtr curl, IntPtr sslCtx);
+        public delegate CURLcode SslCtxCallback(IntPtr curl, IntPtr sslCtx, IntPtr userPointer);
 
         [DllImport(Libraries.HttpNative)]
         public static extern void RegisterSeekCallback(
@@ -66,6 +66,7 @@ internal static partial class Interop
         public static extern CURLcode RegisterSslCtxCallback(
             SafeCurlHandle curl,
             SslCtxCallback callback,
+            IntPtr userPointer,
             ref SafeCallbackHandle callbackHandle);
 
         [DllImport(Libraries.HttpNative)]

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -36,9 +36,6 @@ internal static partial class Interop
         internal static extern IntPtr TlsV1_2Method();
 
         [DllImport(Libraries.CryptoNative)]
-        internal static extern void SetProtocolOptions(SafeSslContextHandle ctx, SslProtocols protocols);
-
-        [DllImport(Libraries.CryptoNative)]
         internal static extern SafeSslHandle SslCreate(SafeSslContextHandle ctx);
 
         [DllImport(Libraries.CryptoNative)]
@@ -104,16 +101,19 @@ internal static partial class Interop
         internal static extern SafeSharedX509StackHandle SslGetPeerCertChain(SafeSslHandle ssl);
 
         [DllImport(Libraries.CryptoNative)]
-        internal static extern int SslCtxUseCertificate(SafeSslContextHandle ctx, SafeX509Handle certPtr);
+        internal static extern void GetStreamSizes(out int header, out int trailer, out int maximumMessage);
 
         [DllImport(Libraries.CryptoNative)]
-        internal static extern int SslCtxUsePrivateKey(SafeSslContextHandle ctx, SafeEvpPKeyHandle keyPtr);
+        internal static extern int SslGetPeerFinished(SafeSslHandle ssl, IntPtr buf, int count);
 
         [DllImport(Libraries.CryptoNative)]
-        internal static extern int SslCtxCheckPrivateKey(SafeSslContextHandle ctx);
+        internal static extern int SslGetFinished(SafeSslHandle ssl, IntPtr buf, int count);
 
         [DllImport(Libraries.CryptoNative)]
-        internal static extern void SslCtxSetQuietShutdown(SafeSslContextHandle ctx);
+        internal static extern bool SslSessionReused(SafeSslHandle ssl);
+
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern bool SslAddExtraChainCert(SafeSslHandle ssl, SafeX509Handle x509);
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "SslGetClientCAList")]
         private static extern SafeSharedX509NameStackHandle SslGetClientCAList_private(SafeSslHandle ssl);
@@ -131,27 +131,6 @@ internal static partial class Interop
 
             return handle;
         }
-
-        [DllImport(Libraries.CryptoNative)]
-        internal static extern void SslCtxSetVerify(SafeSslContextHandle ctx, SslCtxSetVerifyCallback callback);
-
-        [DllImport(Libraries.CryptoNative)]
-        internal static extern void SetEncryptionPolicy(SafeSslContextHandle ctx, EncryptionPolicy policy);
-
-        [DllImport(Libraries.CryptoNative)]
-        internal static extern void SslCtxSetClientCAList(SafeSslContextHandle ctx, SafeX509NameStackHandle x509NameStackPtr);
-
-        [DllImport(Libraries.CryptoNative)]
-        internal static extern void GetStreamSizes(out int header, out int trailer, out int maximumMessage);
-
-        [DllImport(Libraries.CryptoNative)]
-        internal static extern int SslGetPeerFinished(SafeSslHandle ssl, IntPtr buf, int count);
-
-        [DllImport(Libraries.CryptoNative)]
-        internal static extern int SslGetFinished(SafeSslHandle ssl, IntPtr buf, int count);
-
-        [DllImport(Libraries.CryptoNative)]
-        internal static extern bool SslSessionReused(SafeSslHandle ssl);
 
         internal static class SslMethods
         {
@@ -288,6 +267,11 @@ namespace Microsoft.Win32.SafeHandles
 
         private SafeSslHandle() : base(IntPtr.Zero, true)
         {
+        }
+
+        internal SafeSslHandle(IntPtr validSslPointer, bool ownsHandle) : base(IntPtr.Zero, ownsHandle)
+        {
+            handle = validSslPointer;
         }
     }
 

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
@@ -10,6 +10,7 @@ internal static partial class Interop
     internal static partial class Ssl
     {
         internal delegate int AppVerifyCallback(IntPtr storeCtx, IntPtr arg);
+        internal delegate int ClientCertCallback(IntPtr ssl, out IntPtr x509, out IntPtr pkey);
 
         [DllImport(Libraries.CryptoNative)]
         internal static extern SafeSslContextHandle SslCtxCreate(IntPtr method);
@@ -19,6 +20,9 @@ internal static partial class Interop
 
         [DllImport(Libraries.CryptoNative)]
         internal static extern void SslCtxSetCertVerifyCallback(SafeSslContextHandle ctx, AppVerifyCallback cb, IntPtr arg);
+
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern void SslCtxSetClientCertCallback(SafeSslContextHandle ctx, ClientCertCallback callback);
     }
 }
 

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtxOptions.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtxOptions.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Net.Security;
+using System.Runtime.InteropServices;
+using System.Security.Authentication;
+using System.Security.Authentication.ExtendedProtection;
+using System.Security.Cryptography;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class Ssl
+    {
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern void SetProtocolOptions(SafeSslContextHandle ctx, SslProtocols protocols);
+
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern int SslCtxUseCertificate(SafeSslContextHandle ctx, SafeX509Handle certPtr);
+
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern int SslCtxUsePrivateKey(SafeSslContextHandle ctx, SafeEvpPKeyHandle keyPtr);
+
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern int SslCtxCheckPrivateKey(SafeSslContextHandle ctx);
+
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern void SslCtxSetQuietShutdown(SafeSslContextHandle ctx);
+
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern void SslCtxSetVerify(SafeSslContextHandle ctx, SslCtxSetVerifyCallback callback);
+
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern void SetEncryptionPolicy(SafeSslContextHandle ctx, EncryptionPolicy policy);
+
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern void SslCtxSetClientCAList(SafeSslContextHandle ctx, SafeX509NameStackHandle x509NameStackPtr);
+    }
+}

--- a/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
@@ -14,7 +14,7 @@ using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {
-    internal static class OpenSsl
+    internal static partial class OpenSsl
     {
         private static Ssl.SslCtxSetVerifyCallback s_verifyClientCertificate = VerifyClientCertificate;
 
@@ -289,38 +289,6 @@ internal static partial class Interop
             }
 
             bindingHandle.SetCertHashLength(certHashLength);
-        }
-
-        private static HashAlgorithm GetHashForChannelBinding(X509Certificate2 cert)
-        {
-            Oid signatureAlgorithm = cert.SignatureAlgorithm;
-            switch (signatureAlgorithm.Value)
-            {
-                // RFC 5929 4.1 says that MD5 and SHA1 both upgrade to EvpSha256 for cbt calculation
-                case "1.2.840.113549.2.5": // MD5
-                case "1.2.840.113549.1.1.4": // MD5RSA
-                case "1.3.14.3.2.26": // SHA1
-                case "1.2.840.10040.4.3": // SHA1DSA
-                case "1.2.840.10045.4.1": // SHA1ECDSA
-                case "1.2.840.113549.1.1.5": // SHA1RSA
-                case "2.16.840.1.101.3.4.2.1": // SHA256
-                case "1.2.840.10045.4.3.2": // SHA256ECDSA
-                case "1.2.840.113549.1.1.11": // SHA256RSA
-                    return SHA256.Create();
-
-                case "2.16.840.1.101.3.4.2.2": // SHA384
-                case "1.2.840.10045.4.3.3": // SHA384ECDSA
-                case "1.2.840.113549.1.1.12": // SHA384RSA
-                    return SHA384.Create();
-
-                case "2.16.840.1.101.3.4.2.3": // SHA512
-                case "1.2.840.10045.4.3.4": // SHA512ECDSA
-                case "1.2.840.113549.1.1.13": // SHA512RSA
-                    return SHA512.Create();
-
-                default:
-                    throw new ArgumentException(signatureAlgorithm.Value);
-            }
         }
 
         private static IntPtr GetSslMethod(SslProtocols protocols)

--- a/src/Common/src/Interop/Unix/libssl/Interop.X509ChannelBindingHash.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.X509ChannelBindingHash.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+
+internal static partial class Interop
+{
+    internal static partial class OpenSsl
+    {
+        internal static HashAlgorithm GetHashForChannelBinding(X509Certificate2 cert)
+        {
+            Oid signatureAlgorithm = cert.SignatureAlgorithm;
+            switch (signatureAlgorithm.Value)
+            {
+                // RFC 5929 4.1 says that MD5 and SHA1 both upgrade to EvpSha256 for cbt calculation
+                case "1.2.840.113549.2.5": // MD5
+                case "1.2.840.113549.1.1.4": // MD5RSA
+                case "1.3.14.3.2.26": // SHA1
+                case "1.2.840.10040.4.3": // SHA1DSA
+                case "1.2.840.10045.4.1": // SHA1ECDSA
+                case "1.2.840.113549.1.1.5": // SHA1RSA
+                case "2.16.840.1.101.3.4.2.1": // SHA256
+                case "1.2.840.10045.4.3.2": // SHA256ECDSA
+                case "1.2.840.113549.1.1.11": // SHA256RSA
+                    return SHA256.Create();
+
+                case "2.16.840.1.101.3.4.2.2": // SHA384
+                case "1.2.840.10045.4.3.3": // SHA384ECDSA
+                case "1.2.840.113549.1.1.12": // SHA384RSA
+                    return SHA384.Create();
+
+                case "2.16.840.1.101.3.4.2.3": // SHA512
+                case "1.2.840.10045.4.3.4": // SHA512ECDSA
+                case "1.2.840.113549.1.1.13": // SHA512RSA
+                    return SHA512.Create();
+
+                default:
+                    throw new ArgumentException(signatureAlgorithm.Value);
+            }
+        }
+    }
+}

--- a/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
+++ b/src/Common/src/System/Net/Http/HttpHandlerDefaults.cs
@@ -13,5 +13,6 @@ namespace System.Net.Http
         public const bool DefaultAutomaticRedirection = true;
         public const bool DefaultUseCookies = true;
         public const bool DefaultPreAuthenticate = false;
+        public const ClientCertificateOption DefaultClientCertificateOption = ClientCertificateOption.Manual;
     }
 }

--- a/src/Common/src/System/Net/Http/TlsCertificateExtensions.cs
+++ b/src/Common/src/System/Net/Http/TlsCertificateExtensions.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace System.Net.Http
+{
+    /// <summary>
+    /// Defines Extension methods which are meant to be re-used across WinHttp and UnixHttp Handlers
+    /// </summary>
+    internal static class TLSCertificateExtensions
+    {
+        private const string ClientCertificateOid = "1.3.6.1.5.5.7.3.2";
+        private static Oid s_clientCertOidInst = new Oid(ClientCertificateOid);
+
+        /// <summary>
+        ///   returns true if the X509 Certificate can be used  as SSL Client Certificate.
+        /// </summary>
+        private static bool IsClientCertificate(X509Certificate2 cert)
+        {
+            Debug.Assert(cert != null, "certificate cannot be null");
+
+            bool foundEku = false;
+            bool foundKeyUsages = false;
+            bool isClientAuth = true;
+            bool isDigitalSignature = true;
+            foreach(X509Extension extension in cert.Extensions)
+            {
+                // check if the extension is an enhanced usage ext.
+                // But do this only if needed. No point going over it, if we already have established that our cert has the
+                // required extension.
+                if (!foundEku)
+                {
+                    X509EnhancedKeyUsageExtension enhancedUsageExt = extension as X509EnhancedKeyUsageExtension;
+                    if (enhancedUsageExt != null)
+                    {
+                        foundEku = true;
+                        isClientAuth = false;
+                        foreach(Oid oid in enhancedUsageExt.EnhancedKeyUsages)
+                        {
+                            if (string.Equals(ClientCertificateOid, oid.Value))
+                            {
+                                isClientAuth = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                // Check if the extension is a key usage extension.
+                // No point going over it if we have already established that our cert has digital signature
+                if (!foundKeyUsages)
+                {
+                    X509KeyUsageExtension usageExt = extension as X509KeyUsageExtension;
+                    if (usageExt != null)
+                    {
+                        foundKeyUsages = true;
+                        isDigitalSignature = (usageExt.KeyUsages & X509KeyUsageFlags.DigitalSignature) != 0;
+                    }
+                }
+
+                if (foundKeyUsages && foundEku)
+                {
+                    break;
+                }
+            }
+
+            return isClientAuth && isDigitalSignature;
+        }
+
+        /// <summary>
+        ///   Returns a new collection containing valid client certificates from the given X509Certificate2Collection
+        /// </summary>
+        internal static bool TryFindClientCertificate(this X509Certificate2Collection certificates,
+                                                      ISet<string> allowedIssuers,
+                                                      out X509Certificate2 clientCertificate,
+                                                      out X509Chain clientCertChain)
+        {
+            clientCertificate = null;
+            clientCertChain = null;
+            if (certificates == null)
+            {
+                return false;
+            }
+
+            DateTime now = DateTime.Now;
+            foreach(X509Certificate2 cert in certificates)
+            {
+                if (cert.HasPrivateKey && now >= cert.NotBefore && now <= cert.NotAfter)
+                {
+                    if (IsClientCertificate(cert))
+                    {
+                        if (allowedIssuers.Count == 0)
+                        {
+                            clientCertificate = cert;
+                            clientCertChain = null;
+                            return true;
+                        }
+
+                        X509Chain chain = new X509Chain();
+                        chain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllFlags;
+                        chain.ChainPolicy.RevocationFlag = X509RevocationFlag.ExcludeRoot;
+                        chain.ChainPolicy.ApplicationPolicy.Add(s_clientCertOidInst);
+
+                        // We will just build the certificate chain
+                        if (!chain.Build(cert))
+                        {
+                            continue;
+                        }
+
+                        bool isComplete = true;
+                        foreach (X509ChainStatus chainStatus in chain.ChainStatus)
+                        {
+                            if ((chainStatus.Status & X509ChainStatusFlags.PartialChain) == X509ChainStatusFlags.PartialChain)
+                            {
+                                isComplete = false;
+                                break;
+                            }
+                        }
+
+                        if (chain.ChainElements.Count > 0 && isComplete)
+                        {
+                            X509Certificate2 trustAnchor = chain.ChainElements[chain.ChainElements.Count - 1].Certificate;
+                            if (allowedIssuers.Contains(trustAnchor.SubjectName.Name))
+                            {
+                                clientCertificate = cert;
+                                clientCertChain = chain;
+                                return true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Native/System.Net.Http.Native/pal_easy.h
+++ b/src/Native/System.Net.Http.Native/pal_easy.h
@@ -56,6 +56,8 @@ enum PAL_CURLcode : int32_t
     PAL_CURLE_UNSUPPORTED_PROTOCOL = 1,
     PAL_CURLE_NOT_BUILT_IN = 4,
     PAL_CURLE_COULDNT_RESOLVE_HOST = 6,
+    PAL_CURLE_ABORTED_BY_CALLBACK = 42,
+    PAL_CURLE_UNKNOWN_OPTION = 48,
 };
 
 enum
@@ -157,7 +159,7 @@ typedef int32_t(*SeekCallback)(void* userPointer, int64_t offset, int32_t origin
 typedef uint64_t(*ReadWriteCallback)(uint8_t* buffer, uint64_t bufferSize, uint64_t nitems, void* userPointer);
 
 // the function pointer definition for the callback used in RegisterSslCtxCallback
-typedef int32_t(*SslCtxCallback)(CURL* curl, void* sslCtx);
+typedef int32_t(*SslCtxCallback)(CURL* curl, void* sslCtx, void* userPointer);
 
 /*
 The object that is returned from RegisterXXXCallback functions.
@@ -187,7 +189,7 @@ to modify the behaviour of the SSL initialization.
 
 Returns a CURLcode that describes whether registering the callback was successful or not.
 */
-extern "C" int32_t RegisterSslCtxCallback(CURL* curl, SslCtxCallback callback, CallbackHandle** callbackHandle);
+extern "C" int32_t RegisterSslCtxCallback(CURL* curl, SslCtxCallback callback, void *userPointer, CallbackHandle** callbackHandle);
 
 /*
 Frees the CallbackHandle created by a RegisterXXXCallback function.

--- a/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -154,7 +154,7 @@ extern "C" int32_t SslGetPeerFinished(SSL* ssl, void* buf, int32_t count)
 	return static_cast<int32_t>(result);
 }
 
-extern "C" bool SslSessionReused(SSL* ssl)
+extern "C" int32_t SslSessionReused(SSL* ssl)
 {
 	return SSL_session_reused(ssl) == 1;
 }
@@ -599,6 +599,11 @@ extern "C" void SslCtxSetClientCAList(SSL_CTX* ctx, X509NameStack* list)
     SSL_CTX_set_client_CA_list(ctx, list);
 }
 
+extern "C" void SslCtxSetClientCertCallback(SSL_CTX* ctx, SslClientCertCallback callback)
+{
+    SSL_CTX_set_client_cert_cb(ctx, callback);
+}
+
 extern "C" void GetStreamSizes(int32_t* header, int32_t* trailer, int32_t* maximumMessage)
 {
     if (header)
@@ -620,4 +625,21 @@ extern "C" void GetStreamSizes(int32_t* header, int32_t* trailer, int32_t* maxim
     {
         *maximumMessage = SSL3_RT_MAX_PLAIN_LENGTH;
     }
+}
+
+
+extern "C" int32_t SslAddExtraChainCert(SSL* ssl, X509* x509)
+{
+    if (!x509 || !ssl)
+    {
+        return 0;
+    }
+
+    SSL_CTX *ssl_ctx = SSL_get_SSL_CTX(ssl);
+    if (SSL_CTX_add_extra_chain_cert(ssl_ctx, x509) == 1)
+    {
+        return 1;
+    }
+
+    return 0;
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_ssl.h
@@ -116,6 +116,8 @@ typedef int32_t (*SslCtxSetVerifyCallback)(int32_t, X509_STORE_CTX*);
 // the function pointer definition for the callback used in SslCtxSetCertVerifyCallback
 typedef int32_t (*SslCtxSetCertVerifyCallbackCallback)(X509_STORE_CTX*, void* arg);
 
+// the function pointer definition for the callback used in SslCtxSetClientCertCallback
+typedef int32_t (*SslClientCertCallback)(SSL *ssl, X509 **x509, EVP_PKEY **pkey);
 /*
 Ensures that libssl is correctly initialized and ready to use.
 */
@@ -358,6 +360,11 @@ Shims the SSL_CTX_set_client_CA_list method.
 extern "C" void SslCtxSetClientCAList(SSL_CTX* ctx, X509NameStack* list);
 
 /*
+Shims the SSL_CTX_set_client_cert_cb method
+*/
+extern "C" void SslCtxSetClientCertCallback(SSL_CTX* ctx, SslClientCertCallback callback);
+
+/*
 Gets the SSL stream sizes to use.
 */
 extern "C" void GetStreamSizes(int32_t* header, int32_t* trailer, int32_t* maximumMessage);
@@ -376,4 +383,12 @@ extern "C" int32_t SslGetPeerFinished(SSL* ssl, void* buf, int32_t count);
 Returns true/false based on if existing ssl session was re-used or not.
 Shims the SSL_session_reused macro.
 */
-extern "C" bool SslSessionReused(SSL* ssl);
+extern "C" int32_t SslSessionReused(SSL* ssl);
+
+/*
+adds the given certificate to the extra chain certificates associated with ctx that is associated with the ssl.
+
+libssl frees the x509 object.
+Returns 1 if success and 0 in case of failure
+*/
+extern "C" int32_t SslAddExtraChainCert(SSL* ssl, X509* x509);

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -295,7 +295,7 @@
     <value>CookieContainer property must not be null.</value>
   </data>
   <data name="net_http_unix_invalid_client_cert_option" xml:space="preserve">
-    <value>libcurl supports only manual client certificate selection</value>
+    <value>ClientCertificateOption.Automatic is supported only with libcurl with libssl compatible backend.</value>
   </data>
   <data name="net_http_unix_invalid_credential" xml:space="preserve">
     <value>libcurl does not support different credentials for different authentication schemes</value>

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -113,11 +113,11 @@
   <PropertyGroup Condition=" '$(TargetsWindows)' == 'true' ">
     <DefineConstants>$(DefineConstants);HTTP_DLL</DefineConstants>
   </PropertyGroup>
-  <!-- Compile the WinHttpHandler implementation into the System.Net.Http.dll binary.  This is a 
-         temporary solution to remove the cycle dependency between HttpClient and WinHttpHandler. 
+  <!-- Compile the WinHttpHandler implementation into the System.Net.Http.dll binary.  This is a
+         temporary solution to remove the cycle dependency between HttpClient and WinHttpHandler.
          As part of that, we need to define HTTP_DLL in order to compile the 'protected' SendAsync()
          method in WinHttpHandler.cs as 'protected internal' to match the internal definition in
-         HttpMessageHandler.cs. We also use the HTTP_DLL define to change public classes into 
+         HttpMessageHandler.cs. We also use the HTTP_DLL define to change public classes into
          internal ones to remove confusion if someone looks at the implementation dlls. They are
          public in the separate WinHttpHandler.dll binary.  -->
   <Import Project="..\..\System.Net.Http.WinHttpHandler\src\System.Net.Http.WinHttpHandler.msbuild" Condition=" '$(TargetsWindows)' == 'true' " />
@@ -132,7 +132,9 @@
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="System\Net\Http\HttpClientHandler.Unix.cs" />
+    <Compile Include="System\Net\Http\Unix\CurlChannelBinding.cs" />
     <Compile Include="System\Net\Http\Unix\CurlHandler.cs" />
+    <Compile Include="System\Net\Http\Unix\CurlHandler.ClientCertificateProvider.cs" />
     <Compile Include="System\Net\Http\Unix\CurlHandler.EasyRequest.cs" />
     <Compile Include="System\Net\Http\Unix\CurlHandler.HttpContentAsyncStream.cs" />
     <Compile Include="System\Net\Http\Unix\CurlHandler.MultiAgent.cs" />
@@ -140,6 +142,7 @@
     <Compile Include="System\Net\Http\Unix\CurlException.cs" />
     <Compile Include="System\Net\Http\Unix\CurlHandler.CurlResponseMessage.cs" />
     <Compile Include="System\Net\Http\Unix\CurlResponseParseUtils.cs" />
+    <Compile Include="System\Net\Http\Unix\CurlTransportContext.cs" />
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Errors.cs">
       <Link>Common\Interop\Unix\Interop.Errors.cs</Link>
     </Compile>
@@ -191,21 +194,6 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Http.Native\Interop.VersionInfo.cs">
       <Link>Common\Interop\Unix\System.Net.Http.Native\Interop.VersionInfo.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
-      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.SslCtx.cs">
-      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.SslCtx.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Stack.cs">
-      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Stack.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509StoreCtx.cs">
-      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509StoreCtx.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs">
-      <Link>Common\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\System\StringExtensions.cs">
       <Link>Common\System\StringExtensions.cs</Link>
     </Compile>
@@ -215,7 +203,73 @@
     <Compile Include="$(CommonPath)\System\Net\Http\HttpHandlerDefaults.cs">
       <Link>Common\System\Net\Http\HttpHandlerDefaults.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Http\TlsCertificateExtensions.cs">
+        <Link>Common\System\Net\Http\TlsCertificateExtensions</Link>
+    </Compile>
+
+    <!-- Tls Client Certificate -->
+    <Compile Include="$(CommonPath)\Interop\Unix\libssl\Interop.X509ChannelBindingHash.cs">
+      <Link>Common\Interop\Unix\libssl\Interop.X509ChannelBindingHash.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.BIO.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.BIO.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ERR.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Crypto.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Ssl.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Ssl.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.SslCtx.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.SslCtx.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Name.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Name.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Ext.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Ext.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Stack.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509Stack.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509StoreCtx.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509StoreCtx.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Net.Security.Native\Interop.Initialization.cs">
+      <Link>Common\Interop\Unix\System.Net.Security.Native\Interop.Initialization.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeX509Handles.Unix.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeX509Handles.Unix.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeX509NameHandle.Unix.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeX509NameHandle.Unix.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\X509ExtensionSafeHandles.Unix.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeInteriorHandle.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeBioHandle.Unix.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs</Link>
+    </Compile>
   </ItemGroup>
+
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlChannelBinding.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlChannelBinding.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Security.Authentication.ExtendedProtection;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Win32.SafeHandles;
+
+namespace System.Net.Http
+{
+    internal class CurlChannelBinding : ChannelBinding
+    {
+        private SafeChannelBindingHandle _bindingHandle;
+        private string _description = string.Empty;
+
+        internal CurlChannelBinding()
+        {
+        }
+
+        public override bool IsInvalid
+        {
+            get
+            {
+                return _bindingHandle == null ? true : _bindingHandle.IsInvalid;
+            }
+        }
+
+        public override int Size
+        {
+            get
+            {
+                return _bindingHandle == null ? 0 : _bindingHandle.Length;
+            }
+        }
+
+        public override string ToString()
+        {
+            return _description;
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            if (_bindingHandle != null)
+            {
+                _bindingHandle.Dispose();
+                SetHandle(IntPtr.Zero);
+            }
+            return true;
+        }
+
+        internal void SetToken(X509Certificate2 cert)
+        {
+            // Parity with WinHTTP : CurHandler only supports retrieval of ChannelBindingKind.Endpoint for CBT.
+            _bindingHandle = new SafeChannelBindingHandle(ChannelBindingKind.Endpoint);
+            using (HashAlgorithm hashAlgo = Interop.OpenSsl.GetHashForChannelBinding(cert))
+            {
+                byte[] bindingHash = hashAlgo.ComputeHash(cert.RawData);
+                _bindingHandle.SetCertHash(bindingHash);
+                _description = BitConverter.ToString(bindingHash).Replace('-', ' ');
+                SetHandle(_bindingHandle.DangerousGetHandle());
+            }
+        }
+    }
+}

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.ClientCertificateProvider.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.ClientCertificateProvider.cs
@@ -1,0 +1,150 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography;
+using Microsoft.Win32.SafeHandles;
+
+using CURLcode = Interop.Http.CURLcode;
+
+namespace System.Net.Http
+{
+    internal partial class CurlHandler : HttpMessageHandler
+    {
+        internal sealed class ClientCertificateProvider : IDisposable
+        {
+            internal readonly GCHandle _gcHandle;
+            internal readonly Interop.Ssl.ClientCertCallback _callback;
+            private SafeEvpPKeyHandle _privateKeyHandle = null;
+            private SafeX509Handle _certHandle = null;
+
+            internal ClientCertificateProvider ()
+            {
+                _gcHandle = GCHandle.Alloc(this);
+                _callback = TlsClientCertCallback;
+            }
+
+            private int TlsClientCertCallback(IntPtr ssl, out IntPtr certHandle, out IntPtr privateKeyHandle)
+            {
+                Interop.Crypto.CheckValidOpenSslHandle(ssl);
+                using (SafeSslHandle sslHandle = new SafeSslHandle(ssl, false))
+                {
+                    certHandle = IntPtr.Zero;
+                    privateKeyHandle = IntPtr.Zero;
+                    VerboseTrace("libssl's client certificate callback");
+
+                    ISet<string> issuerNames = GetRequestCertificateAuthorities(sslHandle);
+                    X509Certificate2 certificate;
+                    X509Chain chain;
+                    if (!GetClientCertificate(issuerNames, out certificate, out chain))
+                    {
+                        VerboseTrace("no cert or chain");
+                        return 0;
+                    }
+
+                    Interop.Crypto.CheckValidOpenSslHandle(certificate.Handle);
+                    using (RSAOpenSsl rsa = certificate.GetRSAPrivateKey() as RSAOpenSsl)
+                    {
+                        if (rsa != null)
+                        {
+                            _privateKeyHandle = rsa.DuplicateKeyHandle();
+                        }
+                        else
+                        {
+                            using (ECDsaOpenSsl ecdsa = certificate.GetECDsaPrivateKey() as ECDsaOpenSsl)
+                            {
+                                if (ecdsa != null)
+                                {
+                                    _privateKeyHandle = ecdsa.DuplicateKeyHandle();
+                                }
+                            }
+                        }
+                    }
+
+                    if (_privateKeyHandle == null || _privateKeyHandle.IsInvalid)
+                    {
+                        VerboseTrace("invalid private key");
+                        return 0;
+                    }
+
+                    _certHandle = Interop.Crypto.X509Duplicate(certificate.Handle);
+                    Interop.Crypto.CheckValidOpenSslHandle(_certHandle);
+                    if (chain != null)
+                    {
+                        for (int i = chain.ChainElements.Count - 2; i > 0; i--)
+                        {
+                            SafeX509Handle dupCertHandle = Interop.Crypto.X509Duplicate(chain.ChainElements[i].Certificate.Handle);
+                            Interop.Crypto.CheckValidOpenSslHandle(dupCertHandle);
+                            if (!Interop.Ssl.SslAddExtraChainCert(sslHandle, dupCertHandle))
+                            {
+                                VerboseTrace("failed to add extra chain cert");
+                                return -1;
+                            }
+                        }
+                    }
+
+                    certHandle = _certHandle.DangerousGetHandle();
+                    privateKeyHandle = _privateKeyHandle.DangerousGetHandle();
+                    return 1;
+                }
+            }
+
+            public void Dispose()
+            {
+                _gcHandle.Free();
+                if (_privateKeyHandle != null)
+                {
+                    _privateKeyHandle.Dispose();
+                }
+
+                if (_certHandle != null)
+                {
+                    _certHandle.Dispose();
+                }
+                VerboseTrace("Disposed client cert provider");
+            }
+
+            private static ISet<string> GetRequestCertificateAuthorities(SafeSslHandle sslHandle)
+            {
+                HashSet<string> clientAuthorityNames = new HashSet<string>();
+                using (SafeSharedX509NameStackHandle names = Interop.Ssl.SslGetClientCAList(sslHandle))
+                {
+                    if (names.IsInvalid)
+                    {
+                        return clientAuthorityNames;
+                    }
+
+                    int nameCount = Interop.Crypto.GetX509NameStackFieldCount(names);
+
+                    if (nameCount == 0)
+                    {
+                        return clientAuthorityNames;
+                    }
+
+                    for (int i = 0; i < nameCount; i++)
+                    {
+                        using (SafeSharedX509NameHandle nameHandle = Interop.Crypto.GetX509NameStackField(names, i))
+                        {
+                            X500DistinguishedName dn = Interop.Crypto.LoadX500Name(nameHandle);
+                            clientAuthorityNames.Add(dn.Name);
+                        }
+                    }
+
+                    return clientAuthorityNames;
+                }
+            }
+
+            private static bool GetClientCertificate(ISet<string> allowedIssuers, out X509Certificate2 certificate, out X509Chain chain)
+            {
+                using (X509Store myStore = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+                {
+                    myStore.Open(OpenFlags.ReadOnly);
+                    return myStore.Certificates.TryFindClientCertificate(allowedIssuers, out certificate, out chain);
+                }
+            }
+        }
+    }
+}

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -414,7 +414,7 @@ namespace System.Net.Http
                 // While this does slow down the theoretical best path of the request the code
                 // to decide that we need to register the callback is more complicated than, and
                 // potentially more expensive than, just always setting the callback.
-                SslProvider.SetSslOptions(this);
+                SslProvider.SetSslOptions(this, _handler.ClientCertificateOptions);
             }
 
             internal void SetCurlCallbacks(
@@ -466,15 +466,14 @@ namespace System.Net.Http
                 }
             }
 
-            internal CURLcode SetSslCtxCallback(SslCtxCallback callback)
+            internal CURLcode SetSslCtxCallback(SslCtxCallback callback, IntPtr userPointer)
             {
                 if (_callbackHandle == null)
                 {
                     _callbackHandle = new SafeCallbackHandle();
                 }
 
-                CURLcode result = Interop.Http.RegisterSslCtxCallback(_easyHandle, callback, ref _callbackHandle);
-
+                CURLcode result = Interop.Http.RegisterSslCtxCallback(_easyHandle, callback, userPointer, ref _callbackHandle);
                 return result;
             }
 

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
@@ -3,10 +3,15 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
 
 using CURLcode = Interop.Http.CURLcode;
+using CURLINFO = Interop.Http.CURLINFO;
 
 namespace System.Net.Http
 {
@@ -17,9 +22,25 @@ namespace System.Net.Http
             private static readonly Interop.Http.SslCtxCallback s_sslCtxCallback = SetSslCtxVerifyCallback;
             private static readonly Interop.Ssl.AppVerifyCallback s_sslVerifyCallback = VerifyCertChain;
 
-            internal static void SetSslOptions(EasyRequest easy)
+            internal static void SetSslOptions(EasyRequest easy, ClientCertificateOption clientCertOption)
             {
-                CURLcode answer = easy.SetSslCtxCallback(s_sslCtxCallback);
+                IntPtr userPointer = IntPtr.Zero;
+                if (clientCertOption == ClientCertificateOption.Automatic)
+                {
+                    ClientCertificateProvider certProvider = new ClientCertificateProvider();
+                    userPointer = GCHandle.ToIntPtr(certProvider._gcHandle);
+                    easy.Task.ContinueWith((_, state) => ((IDisposable)state).Dispose(),
+                                           certProvider,
+                                           CancellationToken.None,
+                                           TaskContinuationOptions.ExecuteSynchronously,
+                                           TaskScheduler.Default);
+                }
+                else
+                {
+                    Debug.Assert(clientCertOption == ClientCertificateOption.Manual, "ClientCertificateOption is manual or automatic");
+                }
+
+                CURLcode answer = easy.SetSslCtxCallback(s_sslCtxCallback, userPointer);
 
                 switch (answer)
                 {
@@ -30,6 +51,11 @@ namespace System.Net.Http
                     // Curl 7.39 and later
                     case CURLcode.CURLE_NOT_BUILT_IN:
                         VerboseTrace("CURLOPT_SSL_CTX_FUNCTION is not supported, platform default https chain building in use");
+                        if (clientCertOption == ClientCertificateOption.Automatic)
+                        {
+                            throw new PlatformNotSupportedException(SR.net_http_unix_invalid_client_cert_option);
+                        }
+
                         break;
                     default:
                         ThrowIfCURLEError(answer);
@@ -39,14 +65,59 @@ namespace System.Net.Http
 
             private static CURLcode SetSslCtxVerifyCallback(
                 IntPtr curl,
-                IntPtr sslCtx)
+                IntPtr sslCtx,
+                IntPtr userPointer)
             {
                 using (SafeSslContextHandle ctx = new SafeSslContextHandle(sslCtx, ownsHandle: false))
                 {
-                    Interop.Ssl.SslCtxSetCertVerifyCallback(ctx, s_sslVerifyCallback, IntPtr.Zero);
-                }
+                    Interop.Ssl.SslCtxSetCertVerifyCallback(ctx, s_sslVerifyCallback, curl);
 
+                    if (userPointer == IntPtr.Zero)
+                    {
+                        VerboseTrace("Not using client Certificate callback ");
+                    }
+                    else
+                    {
+                        ClientCertificateProvider provider = null;
+                        try
+                        {
+                            GCHandle handle = GCHandle.FromIntPtr(userPointer);
+                            provider = (ClientCertificateProvider)handle.Target;
+                        }
+                        catch (InvalidCastException)
+                        {
+                            Debug.Fail("ClientCertificateProvider wasn't the GCHandle's Target");
+                            return CURLcode.CURLE_ABORTED_BY_CALLBACK;
+                        }
+                        catch (InvalidOperationException)
+                        {
+                            Debug.Fail("Invalid GCHandle in CurlSslCallback");
+                            return CURLcode.CURLE_ABORTED_BY_CALLBACK;
+                        }
+
+                        Debug.Assert(provider != null, "Expected non-null sslCallback in curlCallBack");
+                        Interop.Ssl.SslCtxSetClientCertCallback(ctx, provider._callback);
+                    }
+                }
                 return CURLcode.CURLE_OK;
+            }
+
+            private static void AddChannelBindingToken(X509Certificate2 certificate, IntPtr curlPtr)
+            {
+                Debug.Assert(curlPtr != IntPtr.Zero, "curlPtr is not null");
+                IntPtr gcHandlePtr;
+                CURLcode getInfoResult = Interop.Http.EasyGetInfoPointer(curlPtr, CURLINFO.CURLINFO_PRIVATE, out gcHandlePtr);
+                Debug.Assert(getInfoResult == CURLcode.CURLE_OK, "Failed to get info on a completing easy handle");
+                if (getInfoResult == CURLcode.CURLE_OK)
+                {
+                    GCHandle handle = GCHandle.FromIntPtr(gcHandlePtr);
+                    EasyRequest easy = handle.Target as EasyRequest;
+                    Debug.Assert(easy != null, "Expected non-null EasyRequest in GCHandle");
+                    if (easy._requestContentStream != null)
+                    {
+                        easy._requestContentStream.SetChannelBindingToken(certificate);
+                    }
+                }
             }
 
             private static int VerifyCertChain(IntPtr storeCtxPtr, IntPtr arg)
@@ -89,6 +160,7 @@ namespace System.Net.Http
                     using (X509Certificate2 leafCert = new X509Certificate2(leafCertPtr))
                     {
                         success = chain.Build(leafCert);
+                        AddChannelBindingToken(leafCert, arg);
                     }
                 }
 

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -58,6 +58,7 @@ namespace System.Net.Http
         private bool _useCookie = HttpHandlerDefaults.DefaultUseCookies;
         private bool _automaticRedirection = HttpHandlerDefaults.DefaultAutomaticRedirection;
         private int _maxAutomaticRedirections = HttpHandlerDefaults.DefaultMaxAutomaticRedirections;
+        private ClientCertificateOption _clientCertificateOption = HttpHandlerDefaults.DefaultClientCertificateOption;
 
         private object LockObject { get { return _agent; } }
 
@@ -159,15 +160,13 @@ namespace System.Net.Http
         {
             get
             {
-                return ClientCertificateOption.Manual;
+                return _clientCertificateOption;
             }
 
             set
             {
-                if (ClientCertificateOption.Manual != value)
-                {
-                    throw new PlatformNotSupportedException(SR.net_http_unix_invalid_client_cert_option);
-                }
+                CheckDisposedOrStarted();
+                _clientCertificateOption = value;
             }
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlTransportContext.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlTransportContext.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Security.Authentication.ExtendedProtection;
+
+namespace System.Net.Http
+{
+    internal class CurlTransportContext : TransportContext
+    {
+        private CurlChannelBinding _channelBinding = new CurlChannelBinding();
+
+        internal CurlChannelBinding CurlChannelBinding
+        {
+            get
+            {
+                return _channelBinding;
+            }
+        }
+
+        internal CurlTransportContext()
+        {
+        }
+
+        public override ChannelBinding GetChannelBinding(ChannelBindingKind kind)
+        {
+            // Parity with WinHTTP : CurHandler only supports retrieval of ChannelBindingKind.Endpoint for CBT.
+            if (kind == ChannelBindingKind.Endpoint)
+            {
+                return _channelBinding;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/System.Net.Http/src/project.json
+++ b/src/System.Net.Http/src/project.json
@@ -11,7 +11,8 @@
     "System.Runtime.Extensions": "4.0.10",
     "System.Runtime.Handles": "4.0.0",
     "System.Runtime.InteropServices": "4.0.20",
-    "System.Security.Cryptography.X509Certificates": "4.0.0-*",
+    "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23509",
+    "System.Security.Cryptography.OpenSsl": "4.0.0-beta-23509",
     "System.Text.Encoding": "4.0.10",
     "System.Threading": "4.0.0",
     "System.Threading.Tasks": "4.0.10"

--- a/src/System.Net.Http/src/project.lock.json
+++ b/src/System.Net.Http/src/project.lock.json
@@ -339,6 +339,21 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
+      "System.Runtime.Numerics/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Numerics.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Runtime.Numerics.dll": {}
+        }
+      },
       "System.Security.Cryptography.Algorithms/4.0.0-beta-23509": {
         "type": "package",
         "dependencies": {
@@ -357,6 +372,29 @@
         },
         "compile": {
           "ref/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
+      "System.Security.Cryptography.OpenSsl/4.0.0-beta-23509": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Numerics": "4.0.0",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23509",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23509",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23509",
+          "System.Text.Encoding": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Security.Cryptography.OpenSsl.dll": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.OpenSsl.dll": {}
         }
       },
       "System.Security.Cryptography.Primitives/4.0.0-beta-23509": {
@@ -450,7 +488,7 @@
         }
       }
     },
-    "DNXCore,Version=v5.0/win7-x86": {
+    "DNXCore,Version=v5.0/osx.10.10-x86": {
       "Microsoft.Win32.Primitives/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -464,7 +502,493 @@
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
         }
       },
-      "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-beta-23509": {
+      "System.Collections/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Collections.dll": {}
+        }
+      },
+      "System.Collections.Concurrent/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.Concurrent.dll": {}
+        }
+      },
+      "System.Collections.NonGeneric/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.NonGeneric.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Collections.NonGeneric.dll": {}
+        }
+      },
+      "System.ComponentModel.EventBasedAsync/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
+        }
+      },
+      "System.Diagnostics.Contracts/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Contracts.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Contracts.dll": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Tools.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
+        }
+      },
+      "System.Diagnostics.Tracing/4.0.20": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Diagnostics.Tracing.dll": {}
+        }
+      },
+      "System.Globalization/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Globalization.dll": {}
+        }
+      },
+      "System.IO/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.IO.dll": {}
+        }
+      },
+      "System.IO.Compression/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.0",
+          "System.IO": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.0",
+          "System.Text.Encoding": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.Compression.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.IO.Compression.dll": {}
+        }
+      },
+      "System.IO.FileSystem/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.FileSystem.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.IO.FileSystem.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
+      "System.Net.Primitives/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Networking": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Net.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Primitives.dll": {}
+        }
+      },
+      "System.Private.Networking/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Collections": "4.0.10",
+          "System.Collections.Concurrent": "4.0.0",
+          "System.Collections.NonGeneric": "4.0.0",
+          "System.ComponentModel.EventBasedAsync": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Diagnostics.Tracing": "4.0.20",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Threading": "4.0.10",
+          "System.Threading.Overlapped": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dnxcore50/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.Networking.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/dnxcore50/_._": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Private.Uri.dll": {}
+        }
+      },
+      "System.Reflection/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Resources.ResourceManager.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.0.20": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Uri": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Runtime.Handles/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Handles.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.Handles.dll": {}
+        }
+      },
+      "System.Runtime.InteropServices/4.0.20": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.InteropServices.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
+        }
+      },
+      "System.Runtime.Numerics/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Numerics.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.Runtime.Numerics.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Algorithms/4.0.0-beta-23509": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Runtime": "4.0.0",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23509"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Encoding/4.0.0-beta-23509": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
+        }
+      },
+      "System.Security.Cryptography.OpenSsl/4.0.0-beta-23509": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Runtime.Numerics": "4.0.0",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23509",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23509",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23509",
+          "System.Text.Encoding": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Security.Cryptography.OpenSsl.dll": {}
+        },
+        "runtime": {
+          "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.OpenSsl.dll": {}
+        }
+      },
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23509": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Globalization": "4.0.0",
+          "System.IO": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
+        }
+      },
+      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23509": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23509",
+          "System.Security.Cryptography.Encoding": "4.0.0-beta-23509"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Text.Encoding.Extensions/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
+        }
+      },
+      "System.Threading/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Overlapped/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Runtime.Handles": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Overlapped.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Overlapped.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Threading.Tasks.dll": {}
+        }
+      }
+    },
+    "DNXCore,Version=v5.0/osx.10.10-x64": {
+      "Microsoft.Win32.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
+      "runtime.osx.10.10.System.Security.Cryptography.Algorithms/4.0.0-beta-23509": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -480,10 +1004,10 @@
           "ref/dotnet/_._": {}
         },
         "runtime": {
-          "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
+          "runtimes/osx.10.10/lib/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-beta-23509": {
+      "runtime.unix.System.Security.Cryptography.Encoding/4.0.0-beta-23509": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -495,16 +1019,17 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23509"
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23509",
+          "System.Text.Encoding": "4.0.0"
         },
         "compile": {
           "ref/dotnet/_._": {}
         },
         "runtime": {
-          "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
+          "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-beta-23509": {
+      "runtime.unix.System.Security.Cryptography.X509Certificates/4.0.0-beta-23509": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -512,6 +1037,8 @@
           "System.Globalization.Calendars": "4.0.0",
           "System.IO": "4.0.10",
           "System.IO.FileSystem": "4.0.0",
+          "System.IO.FileSystem.Primitives": "4.0.0",
+          "System.IO.FileSystem.Watcher": "4.0.0-beta-23509",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
@@ -519,9 +1046,8 @@
           "System.Runtime.InteropServices": "4.0.20",
           "System.Runtime.Numerics": "4.0.0",
           "System.Security.Cryptography.Algorithms": "4.0.0-beta-23509",
-          "System.Security.Cryptography.Cng": "4.0.0-beta-23509",
-          "System.Security.Cryptography.Csp": "4.0.0-beta-23509",
           "System.Security.Cryptography.Encoding": "4.0.0-beta-23509",
+          "System.Security.Cryptography.OpenSsl": "4.0.0-beta-23509",
           "System.Security.Cryptography.Primitives": "4.0.0-beta-23509",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10"
@@ -530,7 +1056,7 @@
           "ref/dotnet/_._": {}
         },
         "runtime": {
-          "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
+          "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
       "System.Collections/4.0.10": {
@@ -694,12 +1220,6 @@
           "lib/dotnet/System.IO.Compression.dll": {}
         }
       },
-      "System.IO.Compression.clrcompression-x86/4.0.0": {
-        "type": "package",
-        "native": {
-          "runtimes/win7-x86/native/clrcompression.dll": {}
-        }
-      },
       "System.IO.FileSystem/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -734,6 +1254,15 @@
         },
         "runtime": {
           "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
+        }
+      },
+      "System.IO.FileSystem.Watcher/4.0.0-beta-23509": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.IO.FileSystem.Watcher.dll": {}
         }
       },
       "System.Linq/4.0.0": {
@@ -917,49 +1446,6 @@
           "ref/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Cng/4.0.0-beta-23509": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.10",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Runtime.Handles": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23509",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23509",
-          "System.Text.Encoding": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.Cng.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet5.4/System.Security.Cryptography.Cng.dll": {}
-        }
-      },
-      "System.Security.Cryptography.Csp/4.0.0-beta-23509": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.10",
-          "System.Reflection": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Runtime.Handles": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23509",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23509",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23509",
-          "System.Text.Encoding": "4.0.10",
-          "System.Threading": "4.0.10"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.Csp.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Security.Cryptography.Csp.dll": {}
-        }
-      },
       "System.Security.Cryptography.Encoding/4.0.0-beta-23509": {
         "type": "package",
         "dependencies": {
@@ -969,159 +1455,11 @@
           "ref/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23509": {
-        "type": "package",
-        "dependencies": {
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Globalization": "4.0.0",
-          "System.IO": "4.0.10",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Threading": "4.0.0",
-          "System.Threading.Tasks": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
-        }
-      },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23509": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23509",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23509"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
-        }
-      },
-      "System.Text.Encoding/4.0.10": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Text.Encoding.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Text.Encoding.dll": {}
-        }
-      },
-      "System.Text.Encoding.Extensions/4.0.10": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Text.Encoding": "4.0.10"
-        },
-        "compile": {
-          "ref/dotnet/System.Text.Encoding.Extensions.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
-        }
-      },
-      "System.Threading/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Threading.Tasks": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.dll": {}
-        }
-      },
-      "System.Threading.Overlapped/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Handles": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.Overlapped.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.Overlapped.dll": {}
-        }
-      },
-      "System.Threading.Tasks/4.0.10": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Threading.Tasks.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      }
-    },
-    "DNXCore,Version=v5.0/win7-x64": {
-      "Microsoft.Win32.Primitives/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.20",
-          "System.Runtime.InteropServices": "4.0.20"
-        },
-        "compile": {
-          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
-        }
-      },
-      "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-beta-23509": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.10",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Handles": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23509",
-          "System.Text.Encoding": "4.0.0",
-          "System.Text.Encoding.Extensions": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/_._": {}
-        },
-        "runtime": {
-          "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
-        }
-      },
-      "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-beta-23509": {
+      "System.Security.Cryptography.OpenSsl/4.0.0-beta-23509": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
-          "System.Collections.Concurrent": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Linq": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Runtime.Handles": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23509"
-        },
-        "compile": {
-          "ref/dotnet/_._": {}
-        },
-        "runtime": {
-          "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
-        }
-      },
-      "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-beta-23509": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.Globalization.Calendars": "4.0.0",
           "System.IO": "4.0.10",
-          "System.IO.FileSystem": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
@@ -1129,454 +1467,15 @@
           "System.Runtime.InteropServices": "4.0.20",
           "System.Runtime.Numerics": "4.0.0",
           "System.Security.Cryptography.Algorithms": "4.0.0-beta-23509",
-          "System.Security.Cryptography.Cng": "4.0.0-beta-23509",
-          "System.Security.Cryptography.Csp": "4.0.0-beta-23509",
           "System.Security.Cryptography.Encoding": "4.0.0-beta-23509",
           "System.Security.Cryptography.Primitives": "4.0.0-beta-23509",
-          "System.Text.Encoding": "4.0.10",
-          "System.Threading": "4.0.10"
+          "System.Text.Encoding": "4.0.10"
         },
         "compile": {
-          "ref/dotnet/_._": {}
+          "ref/dotnet5.4/System.Security.Cryptography.OpenSsl.dll": {}
         },
         "runtime": {
-          "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
-        }
-      },
-      "System.Collections/4.0.10": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.20"
-        },
-        "compile": {
-          "ref/dotnet/System.Collections.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Collections.dll": {}
-        }
-      },
-      "System.Collections.Concurrent/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Threading.Tasks": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Collections.Concurrent.dll": {}
-        }
-      },
-      "System.Collections.NonGeneric/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Globalization": "4.0.10",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Threading": "4.0.10"
-        },
-        "compile": {
-          "ref/dotnet/System.Collections.NonGeneric.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/System.Collections.NonGeneric.dll": {}
-        }
-      },
-      "System.ComponentModel.EventBasedAsync/4.0.10": {
-        "type": "package",
-        "dependencies": {
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Threading": "4.0.10",
-          "System.Threading.Tasks": "4.0.10"
-        },
-        "compile": {
-          "ref/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/System.ComponentModel.EventBasedAsync.dll": {}
-        }
-      },
-      "System.Diagnostics.Contracts/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Diagnostics.Contracts.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Diagnostics.Contracts.dll": {}
-        }
-      },
-      "System.Diagnostics.Debug/4.0.10": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Diagnostics.Debug.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Diagnostics.Debug.dll": {}
-        }
-      },
-      "System.Diagnostics.Tools/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Diagnostics.Tools.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
-        }
-      },
-      "System.Diagnostics.Tracing/4.0.20": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Diagnostics.Tracing.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Diagnostics.Tracing.dll": {}
-        }
-      },
-      "System.Globalization/4.0.10": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Globalization.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Globalization.dll": {}
-        }
-      },
-      "System.Globalization.Calendars/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Globalization": "4.0.0",
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Globalization.Calendars.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Globalization.Calendars.dll": {}
-        }
-      },
-      "System.IO/4.0.10": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.20",
-          "System.Text.Encoding": "4.0.0",
-          "System.Threading.Tasks": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.IO.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.IO.dll": {}
-        }
-      },
-      "System.IO.Compression/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.IO": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0",
-          "System.Text.Encoding": "4.0.0",
-          "System.Threading": "4.0.0",
-          "System.Threading.Tasks": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.IO.Compression.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/System.IO.Compression.dll": {}
-        }
-      },
-      "System.IO.Compression.clrcompression-x64/4.0.0": {
-        "type": "package",
-        "native": {
-          "runtimes/win7-x64/native/clrcompression.dll": {}
-        }
-      },
-      "System.IO.FileSystem/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.IO.FileSystem.Primitives": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Runtime.Handles": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Text.Encoding": "4.0.10",
-          "System.Text.Encoding.Extensions": "4.0.10",
-          "System.Threading": "4.0.10",
-          "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10"
-        },
-        "compile": {
-          "ref/dotnet/System.IO.FileSystem.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.IO.FileSystem.dll": {}
-        }
-      },
-      "System.IO.FileSystem.Primitives/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.20"
-        },
-        "compile": {
-          "ref/dotnet/System.IO.FileSystem.Primitives.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/System.IO.FileSystem.Primitives.dll": {}
-        }
-      },
-      "System.Linq/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.10",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10"
-        },
-        "compile": {
-          "ref/dotnet/System.Linq.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/System.Linq.dll": {}
-        }
-      },
-      "System.Net.Primitives/4.0.10": {
-        "type": "package",
-        "dependencies": {
-          "System.Private.Networking": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Net.Primitives.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Net.Primitives.dll": {}
-        }
-      },
-      "System.Private.Networking/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "Microsoft.Win32.Primitives": "4.0.0",
-          "System.Collections": "4.0.10",
-          "System.Collections.Concurrent": "4.0.0",
-          "System.Collections.NonGeneric": "4.0.0",
-          "System.ComponentModel.EventBasedAsync": "4.0.10",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Diagnostics.Tracing": "4.0.20",
-          "System.Globalization": "4.0.10",
-          "System.IO": "4.0.10",
-          "System.IO.FileSystem": "4.0.0",
-          "System.IO.FileSystem.Primitives": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Runtime.Handles": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Threading": "4.0.10",
-          "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10"
-        },
-        "compile": {
-          "ref/dnxcore50/_._": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Private.Networking.dll": {}
-        }
-      },
-      "System.Private.Uri/4.0.0": {
-        "type": "package",
-        "compile": {
-          "ref/dnxcore50/_._": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Private.Uri.dll": {}
-        }
-      },
-      "System.Reflection/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Reflection.dll": {}
-        }
-      },
-      "System.Reflection.Primitives/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Reflection.Primitives.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Reflection.Primitives.dll": {}
-        }
-      },
-      "System.Resources.ResourceManager/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Globalization": "4.0.0",
-          "System.Reflection": "4.0.0",
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Resources.ResourceManager.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
-        }
-      },
-      "System.Runtime/4.0.20": {
-        "type": "package",
-        "dependencies": {
-          "System.Private.Uri": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Runtime.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Runtime.dll": {}
-        }
-      },
-      "System.Runtime.Extensions/4.0.10": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.20"
-        },
-        "compile": {
-          "ref/dotnet/System.Runtime.Extensions.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Runtime.Extensions.dll": {}
-        }
-      },
-      "System.Runtime.Handles/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Runtime.Handles.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Runtime.Handles.dll": {}
-        }
-      },
-      "System.Runtime.InteropServices/4.0.20": {
-        "type": "package",
-        "dependencies": {
-          "System.Reflection": "4.0.0",
-          "System.Reflection.Primitives": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Handles": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Runtime.InteropServices.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
-        }
-      },
-      "System.Runtime.Numerics/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Globalization": "4.0.10",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10"
-        },
-        "compile": {
-          "ref/dotnet/System.Runtime.Numerics.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/System.Runtime.Numerics.dll": {}
-        }
-      },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23509": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23509"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
-        }
-      },
-      "System.Security.Cryptography.Cng/4.0.0-beta-23509": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.10",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Runtime.Handles": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23509",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23509",
-          "System.Text.Encoding": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.Cng.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet5.4/System.Security.Cryptography.Cng.dll": {}
-        }
-      },
-      "System.Security.Cryptography.Csp/4.0.0-beta-23509": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.10",
-          "System.Reflection": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.10",
-          "System.Runtime.Handles": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23509",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23509",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23509",
-          "System.Text.Encoding": "4.0.10",
-          "System.Threading": "4.0.10"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.Csp.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Security.Cryptography.Csp.dll": {}
-        }
-      },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23509": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
+          "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.OpenSsl.dll": {}
         }
       },
       "System.Security.Cryptography.Primitives/4.0.0-beta-23509": {
@@ -1704,44 +1603,40 @@
         "ref/xamarinmac20/_._"
       ]
     },
-    "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-beta-23509": {
+    "runtime.osx.10.10.System.Security.Cryptography.Algorithms/4.0.0-beta-23509": {
       "type": "package",
       "serviceable": true,
-      "sha512": "IvcSomtqAQsuiLqz3DBAT1vK1ed7PxYkW3vDGlutyYLUSQGyCTI2RpGet8eJi3rOJLAGj8su4H10MYCqMlb6VA==",
+      "sha512": "zgORXLOz+FGTU/6npjWFIgSeOY2/ejr/EQubZBcS7weFbVesGihEHsUWMBwqrKtsRhCLm4zElANu2lIJSgYVng==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Security.Cryptography.Algorithms.4.0.0-beta-23509.nupkg",
-        "runtime.win7.System.Security.Cryptography.Algorithms.4.0.0-beta-23509.nupkg.sha512",
-        "runtime.win7.System.Security.Cryptography.Algorithms.nuspec",
-        "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.Algorithms.dll",
-        "runtimes/win7/lib/net/_._"
+        "runtime.osx.10.10.System.Security.Cryptography.Algorithms.4.0.0-beta-23509.nupkg",
+        "runtime.osx.10.10.System.Security.Cryptography.Algorithms.4.0.0-beta-23509.nupkg.sha512",
+        "runtime.osx.10.10.System.Security.Cryptography.Algorithms.nuspec",
+        "runtimes/osx.10.10/lib/dotnet5.4/System.Security.Cryptography.Algorithms.dll"
       ]
     },
-    "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-beta-23509": {
+    "runtime.unix.System.Security.Cryptography.Encoding/4.0.0-beta-23509": {
       "type": "package",
       "serviceable": true,
-      "sha512": "BsUFySXdnEdrHa3DLR9zFc5rGSujRXlJZhcY/9trKrMahkKbQiqftj6J1ykLboL9LLRV6eTrVyPR0tTwLZTa/g==",
+      "sha512": "23XdJ++wp2Gbq8/PxLm80RjzBf6Vlp05V8s/Ei3+dqLW7bIAzYO0ViTIRRCcwEq/7H+4tUHZAKoBO6djefuJLA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Security.Cryptography.Encoding.4.0.0-beta-23509.nupkg",
-        "runtime.win7.System.Security.Cryptography.Encoding.4.0.0-beta-23509.nupkg.sha512",
-        "runtime.win7.System.Security.Cryptography.Encoding.nuspec",
-        "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.Encoding.dll",
-        "runtimes/win7/lib/net/_._"
+        "runtime.unix.System.Security.Cryptography.Encoding.4.0.0-beta-23509.nupkg",
+        "runtime.unix.System.Security.Cryptography.Encoding.4.0.0-beta-23509.nupkg.sha512",
+        "runtime.unix.System.Security.Cryptography.Encoding.nuspec",
+        "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.Encoding.dll"
       ]
     },
-    "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-beta-23509": {
+    "runtime.unix.System.Security.Cryptography.X509Certificates/4.0.0-beta-23509": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lec5Vuyy4CoCEE661es3Q+Osx8Ff+mruzOVV6pY0q2lxz4FV8kfOVS7e1WoHdZneSoN2rL9afOkjmF7oHUvWKw==",
+      "sha512": "GHSDGNKwml4/I62SFQHyXi7uL6TUxjKGlSD75znH1YBk/kXy90xxHgmzWQSSQd92K6oqE8ADLE0VB/7C3rLnxQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Security.Cryptography.X509Certificates.4.0.0-beta-23509.nupkg",
-        "runtime.win7.System.Security.Cryptography.X509Certificates.4.0.0-beta-23509.nupkg.sha512",
-        "runtime.win7.System.Security.Cryptography.X509Certificates.nuspec",
-        "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.X509Certificates.dll",
-        "runtimes/win7/lib/net/_._",
-        "runtimes/win7/lib/netcore50/System.Security.Cryptography.X509Certificates.dll"
+        "runtime.unix.System.Security.Cryptography.X509Certificates.4.0.0-beta-23509.nupkg",
+        "runtime.unix.System.Security.Cryptography.X509Certificates.4.0.0-beta-23509.nupkg.sha512",
+        "runtime.unix.System.Security.Cryptography.X509Certificates.nuspec",
+        "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.X509Certificates.dll"
       ]
     },
     "System.Collections/4.0.10": {
@@ -2163,28 +2058,6 @@
         "System.IO.Compression.nuspec"
       ]
     },
-    "System.IO.Compression.clrcompression-x64/4.0.0": {
-      "type": "package",
-      "sha512": "Lqr+URMwKzf+8HJF6YrqEqzKzDzFJTE4OekaxqdIns71r8Ufbd8SbZa0LKl9q+7nu6Em4SkIEXVMB7plSXekOw==",
-      "files": [
-        "runtimes/win10-x64/native/ClrCompression.dll",
-        "runtimes/win7-x64/native/clrcompression.dll",
-        "System.IO.Compression.clrcompression-x64.4.0.0.nupkg",
-        "System.IO.Compression.clrcompression-x64.4.0.0.nupkg.sha512",
-        "System.IO.Compression.clrcompression-x64.nuspec"
-      ]
-    },
-    "System.IO.Compression.clrcompression-x86/4.0.0": {
-      "type": "package",
-      "sha512": "GmevpuaMRzYDXHu+xuV10fxTO8DsP7OKweWxYtkaxwVnDSj9X6RBupSiXdiveq9yj/xjZ1NbG+oRRRb99kj+VQ==",
-      "files": [
-        "runtimes/win10-x86/native/ClrCompression.dll",
-        "runtimes/win7-x86/native/clrcompression.dll",
-        "System.IO.Compression.clrcompression-x86.4.0.0.nupkg",
-        "System.IO.Compression.clrcompression-x86.4.0.0.nupkg.sha512",
-        "System.IO.Compression.clrcompression-x86.nuspec"
-      ]
-    },
     "System.IO.FileSystem/4.0.0": {
       "type": "package",
       "serviceable": true,
@@ -2248,6 +2121,38 @@
         "System.IO.FileSystem.Primitives.4.0.0.nupkg",
         "System.IO.FileSystem.Primitives.4.0.0.nupkg.sha512",
         "System.IO.FileSystem.Primitives.nuspec"
+      ]
+    },
+    "System.IO.FileSystem.Watcher/4.0.0-beta-23509": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "RBEiAh3NcTqg0S2YmTkjEgYM8+3TaOLecCRMCVy50wypSmqXONzkXqFNxUT+jYFUG+lsp0zBMgsPDlGRt2whDQ==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.IO.FileSystem.Watcher.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet5.4/de/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet5.4/es/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet5.4/fr/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet5.4/it/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet5.4/ja/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet5.4/ko/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet5.4/ru/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet5.4/System.IO.FileSystem.Watcher.dll",
+        "ref/dotnet5.4/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet5.4/zh-hans/System.IO.FileSystem.Watcher.xml",
+        "ref/dotnet5.4/zh-hant/System.IO.FileSystem.Watcher.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.IO.FileSystem.Watcher.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtime.json",
+        "System.IO.FileSystem.Watcher.4.0.0-beta-23509.nupkg",
+        "System.IO.FileSystem.Watcher.4.0.0-beta-23509.nupkg.sha512",
+        "System.IO.FileSystem.Watcher.nuspec"
       ]
     },
     "System.Linq/4.0.0": {
@@ -2650,42 +2555,6 @@
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Cng/4.0.0-beta-23509": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "eJrG23LCPaVdrRH8QxobS/qOTQubyFWzkbk4pfUx2cTaW5tVqDUgflLnCNoTo3e1gVVjwrutwnrXVis3uSkAig==",
-      "files": [
-        "lib/dotnet5.4/System.Security.Cryptography.Cng.dll",
-        "lib/net46/System.Security.Cryptography.Cng.dll",
-        "ref/dotnet5.4/System.Security.Cryptography.Cng.dll",
-        "ref/net46/System.Security.Cryptography.Cng.dll",
-        "System.Security.Cryptography.Cng.4.0.0-beta-23509.nupkg",
-        "System.Security.Cryptography.Cng.4.0.0-beta-23509.nupkg.sha512",
-        "System.Security.Cryptography.Cng.nuspec"
-      ]
-    },
-    "System.Security.Cryptography.Csp/4.0.0-beta-23509": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "fNSFWC9Jic4KYtMH8DSPfxGqK6wq2piM/URbH97lhuFm8W+clxt4Fx6Sjadv0fgEOGz/3+YkG1lVfEvSYUcudA==",
-      "files": [
-        "lib/DNXCore50/System.Security.Cryptography.Csp.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Security.Cryptography.Csp.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet5.4/System.Security.Cryptography.Csp.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Security.Cryptography.Csp.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Csp.4.0.0-beta-23509.nupkg",
-        "System.Security.Cryptography.Csp.4.0.0-beta-23509.nupkg.sha512",
-        "System.Security.Cryptography.Csp.nuspec"
-      ]
-    },
     "System.Security.Cryptography.Encoding/4.0.0-beta-23509": {
       "type": "package",
       "serviceable": true,
@@ -2716,6 +2585,18 @@
         "System.Security.Cryptography.Encoding.4.0.0-beta-23509.nupkg",
         "System.Security.Cryptography.Encoding.4.0.0-beta-23509.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
+      ]
+    },
+    "System.Security.Cryptography.OpenSsl/4.0.0-beta-23509": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "mNI3jWTsHJyl0SFJpydKPup7Oywb59tP0g5ZWKsbGqTx6NbxH2lKitv3IHuz6e7Us6f0hWxd5TL44SwmTh7Tug==",
+      "files": [
+        "ref/dotnet5.4/System.Security.Cryptography.OpenSsl.dll",
+        "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.OpenSsl.dll",
+        "System.Security.Cryptography.OpenSsl.4.0.0-beta-23509.nupkg",
+        "System.Security.Cryptography.OpenSsl.4.0.0-beta-23509.nupkg.sha512",
+        "System.Security.Cryptography.OpenSsl.nuspec"
       ]
     },
     "System.Security.Cryptography.Primitives/4.0.0-beta-23509": {
@@ -2959,7 +2840,8 @@
       "System.Runtime.Extensions >= 4.0.10",
       "System.Runtime.Handles >= 4.0.0",
       "System.Runtime.InteropServices >= 4.0.20",
-      "System.Security.Cryptography.X509Certificates >= 4.0.0-*",
+      "System.Security.Cryptography.X509Certificates >= 4.0.0-beta-23509",
+      "System.Security.Cryptography.OpenSsl >= 4.0.0-beta-23509",
       "System.Text.Encoding >= 4.0.10",
       "System.Threading >= 4.0.0",
       "System.Threading.Tasks >= 4.0.10"

--- a/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
+++ b/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
@@ -35,6 +35,17 @@
       <Name>System.Net.Requests</Name>
       <Project>{5EE76DCC-9FD5-47FD-AB45-BD0F0857740F}</Project>
     </ProjectReference>
+    <!--
+        TODO: Temporary fix.
+        Current PR introduces a backward-incompatible change in System.Net.Http.Native. Owing to the way tests are run on CI, this change will result in
+        crash when System.Net.Requests.Tests are run. The following is a temporary work around and will be removed as soon as the dlls and native libraries
+        get in sync
+    -->
+    <ProjectReference Include="..\..\System.Net.Http\src\System.Net.Http.csproj">
+      <Name>System.Net.Http</Name>
+      <Project>{1D422B1D-D7C4-41B9-862D-EB3D98DF37DE}</Project>
+    </ProjectReference>
+
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -226,6 +226,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\libssl\Interop.OpenSsl.cs">
       <Link>Common\Interop\Unix\libssl\Interop.OpenSsl.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libssl\Interop.X509ChannelBindingHash.cs">
+      <Link>Common\Interop\Unix\libssl\Interop.X509ChannelBindingHash.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.ASN1.cs</Link>
     </Compile>
@@ -246,6 +249,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.SslCtx.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.SslCtx.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.SslCtxOptions.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.SslCtxOptions.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.X509.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.X509.cs</Link>


### PR DESCRIPTION
Make curlHandler support Client Certificates when the linked libcurl's ssl backend is compatible with openssl.


Fix for #3151
 