### PR TITLE
Fix deadlock when ending process watching on Unix

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -1138,16 +1138,31 @@ namespace System.Diagnostics
         {
             if (_watchingForExit)
             {
+                RegisteredWaitHandle rwh = null;
+                WaitHandle wh = null;
+
                 lock (this)
                 {
                     if (_watchingForExit)
                     {
                         _watchingForExit = false;
-                        _registeredWaitHandle.Unregister(null);
-                        _waitHandle.Dispose();
+
+                        wh = _waitHandle;
                         _waitHandle = null;
+
+                        rwh = _registeredWaitHandle;
                         _registeredWaitHandle = null;
                     }
+                }
+
+                if (rwh != null)
+                {
+                    rwh.Unregister(null);
+                }
+
+                if (wh != null)
+                {
+                    wh.Dispose();
                 }
             }
         }


### PR DESCRIPTION
Move a RegisteredWaitHandle.Unregister out of a lock.

cc: @mellinoe 