### PR TITLE
Clean up path handling and align with legacy behavior

### DIFF
--- a/src/Common/src/System/IO/PathInternal.cs
+++ b/src/Common/src/System/IO/PathInternal.cs
@@ -16,13 +16,12 @@ namespace System.IO
         /// <exception cref="System.ArgumentNullException">Thrown if the path is null.</exception>
         /// <exception cref="System.ArgumentException">Thrown if the path has invalid characters.</exception>
         /// <param name="path">The path to check for invalid characters.</param>
-        /// <param name="checkAdditional">Set to true to check for characters that are only valid in specific contexts (such as search characters on Windows).</param>
-        internal static void CheckInvalidPathChars(string path, bool checkAdditional = false)
+        internal static void CheckInvalidPathChars(string path)
         {
             if (path == null)
                 throw new ArgumentNullException("path");
 
-            if (PathInternal.HasIllegalCharacters(path, checkAdditional))
+            if (PathInternal.HasIllegalCharacters(path))
                 throw new ArgumentException(SR.Argument_InvalidPathChars, "path");
         }
 

--- a/src/Common/tests/Common.Tests.csproj
+++ b/src/Common/tests/Common.Tests.csproj
@@ -44,6 +44,7 @@
     <Compile Include="..\src\System\IO\TaskHelpers.cs">
       <Link>Common\System\IO\TaskHelpers.cs</Link>
     </Compile>
+    <Compile Include="Tests\System\IO\PathInternal_Unix_Tests.cs" />
     <Compile Include="Tests\System\StringExtensions.Tests.cs" />
     <Compile Include="Tests\System\IO\PathInternal.Tests.cs" />
     <Compile Include="$(CommonPath)\System\Runtime\InteropServices\SafeHeapHandle.cs">

--- a/src/Common/tests/Tests/System/IO/PathInternal.Windows.Tests.cs
+++ b/src/Common/tests/Tests/System/IO/PathInternal.Windows.Tests.cs
@@ -59,7 +59,7 @@ public class PathInternal_Windows_Tests
         InlineData(@"   C:\", 3),
         InlineData(@"C:\", 0),
         InlineData(@"  ", 0),
-        InlineData(@"  \", 0),
+        InlineData(@"  \", 2),
         InlineData(@"  8:", 0),
         InlineData(@"    \\", 4),
         InlineData(@"\\", 0),
@@ -68,5 +68,51 @@ public class PathInternal_Windows_Tests
     public void PathStartSkipTest(string path, int expected)
     {
         Assert.Equal(expected, PathInternal.PathStartSkip(path));
+    }
+
+    [Theory,
+        InlineData(@"", @""),
+        InlineData(null, null),
+        InlineData(@"\", @"\"),
+        InlineData(@"/", @"\"),
+        InlineData(@"\\", @"\\"),
+        InlineData(@"\\\", @"\\"),
+        InlineData(@"//", @"\\"),
+        InlineData(@"///", @"\\"),
+        InlineData(@"\/", @"\\"),
+        InlineData(@"\/\", @"\\"),
+
+        InlineData(@"a\a", @"a\a"),
+        InlineData(@"a\\a", @"a\a"),
+        InlineData(@"a/a", @"a\a"),
+        InlineData(@"a//a", @"a\a"),
+        InlineData(@"a\", @"a\"),
+        InlineData(@"a\\", @"a\"),
+        InlineData(@"a/", @"a\"),
+        InlineData(@"a//", @"a\"),
+        InlineData(@"\a", @"\a"),
+        InlineData(@"\\a", @"\\a"),
+        InlineData(@"/a", @"\a"),
+        InlineData(@"//a", @"\\a"),
+
+        // Skip tests
+        InlineData(@"  :", @"  :"),
+        InlineData(@"  C:", @"C:"),
+        InlineData(@"   C:\", @"C:\"),
+        InlineData(@"   C:/", @"C:\"),
+        InlineData(@"  ", @"  "),
+        InlineData(@"  \", @"\"),
+        InlineData(@"  /", @"\"),
+        InlineData(@"  8:", @"  8:"),
+        InlineData(@"    \\", @"\\"),
+        InlineData(@"    //", @"\\"),
+        ]
+    [PlatformSpecific(PlatformID.Windows)]
+    public void NormalizeDirectorySeparatorTests(string path, string expected)
+    {
+        string result = PathInternal.NormalizeDirectorySeparators(path);
+        Assert.Equal(expected, result);
+        if (string.Equals(path, expected, StringComparison.Ordinal))
+            Assert.Same(path, result);
     }
 }

--- a/src/Common/tests/Tests/System/IO/PathInternal_Unix_Tests.cs
+++ b/src/Common/tests/Tests/System/IO/PathInternal_Unix_Tests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Text;
+using Xunit;
+
+public class PathInternal_Unix_Tests
+{
+    [Theory,
+        InlineData(@"", @""),
+        InlineData(null, null),
+        InlineData(@"/", @"/"),
+        InlineData(@"//", @"/"),
+        InlineData(@"///", @"/"),
+        InlineData(@"\", @"\"),
+        InlineData(@"\\", @"\\"),
+        InlineData(@"\\\", @"\\\"),
+        InlineData(@"\/", @"\/"),
+        InlineData(@"\/\", @"\/\"),
+
+        InlineData(@"a/a", @"a/a"),
+        InlineData(@"a//a", @"a/a"),
+        InlineData(@"a\\a", @"a\\a"),
+        InlineData(@"/a", @"/a"),
+        InlineData(@"//a", @"/a"),
+        InlineData(@"\\a", @"\\a"),
+        InlineData(@"a/", @"a/"),
+        InlineData(@"a//", @"a/"),
+        InlineData(@"a\\", @"a\\"),
+        ]
+    [PlatformSpecific(PlatformID.AnyUnix)]
+    public void NormalizeDirectorySeparatorTests(string path, string expected)
+    {
+        string result = PathInternal.NormalizeDirectorySeparators(path);
+        Assert.Equal(expected, result);
+        if (string.Equals(path, expected, StringComparison.Ordinal))
+            Assert.Same(path, result);
+    }
+}

--- a/src/System.IO.FileSystem/src/System/IO/PathHelpers.Windows.cs
+++ b/src/System.IO.FileSystem/src/System/IO/PathHelpers.Windows.cs
@@ -33,6 +33,11 @@ namespace System.IO
                     throw new ArgumentException(SR.Arg_InvalidSearchPattern, "searchPattern");
                 }
             }
+
+            if (searchPattern.Length >= PathInternal.MaxComponentLength)
+            {
+                throw new PathTooLongException(SR.IO_PathTooLong);
+            }
         }
 
         // this is a lightweight version of GetDirectoryName that doesn't renormalize

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileSystemEnumerable.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileSystemEnumerable.cs
@@ -221,7 +221,9 @@ namespace System.IO
 
             if (searchCriteria != null)
             {
-                PathInternal.CheckInvalidPathChars(fullPath, true);
+                PathInternal.CheckInvalidPathChars(fullPath);
+                if (PathInternal.HasWildCardCharacters(fullPath))
+                    throw new ArgumentException(SR.Argument_InvalidPathChars, "fullPath");
 
                 _searchData = new PathPair(userPath, normalizedSearchPath);
                 CommonInit();

--- a/src/System.Net.Security/tests/UnitTests/project.lock.json
+++ b/src/System.Net.Security/tests/UnitTests/project.lock.json
@@ -207,7 +207,7 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Sockets/4.1.0-beta-23511": {
+      "System.Net.Sockets/4.1.0-beta-23516": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -216,7 +216,7 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.4/System.Net.Sockets.dll": {}
+          "ref/dotnet5.5/System.Net.Sockets.dll": {}
         }
       },
       "System.Net.TestData/1.0.0-prerelease": {
@@ -757,7 +757,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00121": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00122": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -797,10 +797,10 @@
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
         }
       },
-      "runtime.win7.System.Net.Sockets/4.1.0-beta-23511": {
+      "runtime.win7.System.Net.Sockets/4.1.0-beta-23516": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23511",
+          "System.Private.Networking": "4.0.1-beta-23516",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -988,7 +988,7 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Sockets/4.1.0-beta-23511": {
+      "System.Net.Sockets/4.1.0-beta-23516": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -997,7 +997,7 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.4/System.Net.Sockets.dll": {}
+          "ref/dotnet5.5/System.Net.Sockets.dll": {}
         }
       },
       "System.Net.TestData/1.0.0-prerelease": {
@@ -1012,7 +1012,7 @@
           "ref/dotnet/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23511": {
+      "System.Private.Networking/4.0.1-beta-23516": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -1031,14 +1031,11 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23511",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23511",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23516",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23511",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23511"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -1173,46 +1170,7 @@
           "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "System.Security.Claims/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Globalization": "4.0.0",
-          "System.IO": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Security.Principal": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Security.Claims.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/System.Security.Claims.dll": {}
-        }
-      },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23511": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23511"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
-        }
-      },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23511": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
-        }
-      },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23511": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23516": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -1224,22 +1182,10 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
+          "ref/dotnet5.1/System.Security.Cryptography.Primitives.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
-        }
-      },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23511": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23511",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23511"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
       "System.Security.Principal/4.0.0": {
@@ -1252,29 +1198,6 @@
         },
         "runtime": {
           "lib/dotnet/System.Security.Principal.dll": {}
-        }
-      },
-      "System.Security.Principal.Windows/4.0.0-beta-23511": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Reflection": "4.0.10",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Runtime.Handles": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Claims": "4.0.0",
-          "System.Security.Principal": "4.0.0",
-          "System.Text.Encoding": "4.0.10",
-          "System.Threading": "4.0.10"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Principal.Windows.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
       "System.Text.Encoding/4.0.10": {
@@ -1347,19 +1270,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23511": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "xunit/2.1.0": {
@@ -1457,7 +1367,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00121": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00122": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1497,10 +1407,10 @@
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
         }
       },
-      "runtime.win7.System.Net.Sockets/4.1.0-beta-23511": {
+      "runtime.win7.System.Net.Sockets/4.1.0-beta-23516": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23511",
+          "System.Private.Networking": "4.0.1-beta-23516",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -1688,7 +1598,7 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Sockets/4.1.0-beta-23511": {
+      "System.Net.Sockets/4.1.0-beta-23516": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -1697,7 +1607,7 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.4/System.Net.Sockets.dll": {}
+          "ref/dotnet5.5/System.Net.Sockets.dll": {}
         }
       },
       "System.Net.TestData/1.0.0-prerelease": {
@@ -1712,7 +1622,7 @@
           "ref/dotnet/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23511": {
+      "System.Private.Networking/4.0.1-beta-23516": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -1731,14 +1641,11 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23511",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23511",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23516",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23511",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23511"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -1873,46 +1780,7 @@
           "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "System.Security.Claims/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Globalization": "4.0.0",
-          "System.IO": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Security.Principal": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Security.Claims.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/System.Security.Claims.dll": {}
-        }
-      },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23511": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23511"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
-        }
-      },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23511": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
-        }
-      },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23511": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23516": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -1924,22 +1792,10 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
+          "ref/dotnet5.1/System.Security.Cryptography.Primitives.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
-        }
-      },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23511": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23511",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23511"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
       "System.Security.Principal/4.0.0": {
@@ -1952,29 +1808,6 @@
         },
         "runtime": {
           "lib/dotnet/System.Security.Principal.dll": {}
-        }
-      },
-      "System.Security.Principal.Windows/4.0.0-beta-23511": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Reflection": "4.0.10",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Runtime.Handles": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Claims": "4.0.0",
-          "System.Security.Principal": "4.0.0",
-          "System.Text.Encoding": "4.0.10",
-          "System.Threading": "4.0.10"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Principal.Windows.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
       "System.Text.Encoding/4.0.10": {
@@ -2047,19 +1880,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23511": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "xunit/2.1.0": {
@@ -2157,7 +1977,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00121": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00122": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -2249,16 +2069,16 @@
         "ref/xamarinmac20/_._"
       ]
     },
-    "runtime.win7.System.Net.Sockets/4.1.0-beta-23511": {
+    "runtime.win7.System.Net.Sockets/4.1.0-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "fIiGEKgEbKPtGbtnz6hrlEuojV5xGhYI/qm/VQO29Fqnj2BokeIRF/lL885Q5aHyZMttZ8ZGZfXwUjUC1u1QLg==",
+      "sha512": "NRBFPlDd/ZdflYqJ++i3+jAxWHjLpCn6CUfJFBJXF1k0uZUCuTc13O+6Q4UhaPnWsQ+xlBk5TE8aFU7jRqR2QA==",
       "files": [
         "lib/DNXCore50/System.Net.Sockets.dll",
         "lib/netcore50/System.Net.Sockets.dll",
         "ref/dotnet/_._",
-        "runtime.win7.System.Net.Sockets.4.1.0-beta-23511.nupkg",
-        "runtime.win7.System.Net.Sockets.4.1.0-beta-23511.nupkg.sha512",
+        "runtime.win7.System.Net.Sockets.4.1.0-beta-23516.nupkg",
+        "runtime.win7.System.Net.Sockets.4.1.0-beta-23516.nupkg.sha512",
         "runtime.win7.System.Net.Sockets.nuspec",
         "runtimes/win7/lib/net/_._"
       ]
@@ -2996,10 +2816,10 @@
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Sockets/4.1.0-beta-23511": {
+    "System.Net.Sockets/4.1.0-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "LtaNQ9zuEGaVNjf4r1geJfKQv4b/JTF+8peT70kpUbbW5fOiGpXCAh5GNG6P4eLq0z1brtl/4bLhK75AU1jjVw==",
+      "sha512": "hJQxXC5OcecCG49Wg9PreHFC2tDZFwpqiGhRnQMK47eo8ozvOMl2XqISanclj1cjCIUZDUSn0XxggVC7Z2WppA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -3017,14 +2837,25 @@
         "ref/dotnet5.4/System.Net.Sockets.xml",
         "ref/dotnet5.4/zh-hans/System.Net.Sockets.xml",
         "ref/dotnet5.4/zh-hant/System.Net.Sockets.xml",
+        "ref/dotnet5.5/de/System.Net.Sockets.xml",
+        "ref/dotnet5.5/es/System.Net.Sockets.xml",
+        "ref/dotnet5.5/fr/System.Net.Sockets.xml",
+        "ref/dotnet5.5/it/System.Net.Sockets.xml",
+        "ref/dotnet5.5/ja/System.Net.Sockets.xml",
+        "ref/dotnet5.5/ko/System.Net.Sockets.xml",
+        "ref/dotnet5.5/ru/System.Net.Sockets.xml",
+        "ref/dotnet5.5/System.Net.Sockets.dll",
+        "ref/dotnet5.5/System.Net.Sockets.xml",
+        "ref/dotnet5.5/zh-hans/System.Net.Sockets.xml",
+        "ref/dotnet5.5/zh-hant/System.Net.Sockets.xml",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Net.Sockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.Sockets.4.1.0-beta-23511.nupkg",
-        "System.Net.Sockets.4.1.0-beta-23511.nupkg.sha512",
+        "System.Net.Sockets.4.1.0-beta-23516.nupkg",
+        "System.Net.Sockets.4.1.0-beta-23516.nupkg.sha512",
         "System.Net.Sockets.nuspec"
       ]
     },
@@ -3106,17 +2937,17 @@
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23511": {
+    "System.Private.Networking/4.0.1-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "28vhHuWMA7CqdOPv76mYJOMAi7V3ByAQF5MgC03qEuwUy43R/n6bDZvnp9tgqritTDcv2I8KnkfcHSUNCu5hlw==",
+      "sha512": "x1STivE/maJG95AY82H5A7K5LbEOj4hzjGEGt2p1oEM4NIG0HBqXFauWHRRRQDZI0851wjBwgxHNid/56hHOhg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23511.nupkg",
-        "System.Private.Networking.4.0.1-beta-23511.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23516.nupkg",
+        "System.Private.Networking.4.0.1-beta-23516.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
@@ -3489,38 +3320,6 @@
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Claims/4.0.0": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "94NFR/7JN3YdyTH7hl2iSvYmdA8aqShriTHectcK+EbizT71YczMaG6LuqJBQP/HWo66AQyikYYM9aw+4EzGXg==",
-      "files": [
-        "lib/dotnet/System.Security.Claims.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Security.Claims.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/de/System.Security.Claims.xml",
-        "ref/dotnet/es/System.Security.Claims.xml",
-        "ref/dotnet/fr/System.Security.Claims.xml",
-        "ref/dotnet/it/System.Security.Claims.xml",
-        "ref/dotnet/ja/System.Security.Claims.xml",
-        "ref/dotnet/ko/System.Security.Claims.xml",
-        "ref/dotnet/ru/System.Security.Claims.xml",
-        "ref/dotnet/System.Security.Claims.dll",
-        "ref/dotnet/System.Security.Claims.xml",
-        "ref/dotnet/zh-hans/System.Security.Claims.xml",
-        "ref/dotnet/zh-hant/System.Security.Claims.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Security.Claims.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Security.Claims.4.0.0.nupkg",
-        "System.Security.Claims.4.0.0.nupkg.sha512",
-        "System.Security.Claims.nuspec"
-      ]
-    },
     "System.Security.Cryptography.Algorithms/4.0.0-beta-23127": {
       "type": "package",
       "serviceable": true,
@@ -3540,28 +3339,6 @@
         "ref/xamarinmac20/_._",
         "System.Security.Cryptography.Algorithms.4.0.0-beta-23127.nupkg",
         "System.Security.Cryptography.Algorithms.4.0.0-beta-23127.nupkg.sha512",
-        "System.Security.Cryptography.Algorithms.nuspec"
-      ]
-    },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23511": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "zMxkTZfeS4NmLZyIQMp6/4uTXNjFlucTWxaAeTXUwwpN+dB08w59opcpZB5D2jwfunqxoVDG4dgZ+3XcwmN8iQ==",
-      "files": [
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Security.Cryptography.Algorithms.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet5.4/System.Security.Cryptography.Algorithms.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Security.Cryptography.Algorithms.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23511.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23511.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
@@ -3619,38 +3396,6 @@
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23511": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "jXjl4KYpqWkzTpLJgfSxjBsDsKmxlFaouelzDAHbEscv/aASDjNk/uy7kl0l1L7EMxKiD4s1FuKtzSGGUg5Knw==",
-      "files": [
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Security.Cryptography.Encoding.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet5.4/de/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.4/es/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.4/fr/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.4/it/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.4/ja/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.4/ko/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.4/ru/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.4/System.Security.Cryptography.Encoding.dll",
-        "ref/dotnet5.4/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.4/zh-hans/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.4/zh-hant/System.Security.Cryptography.Encoding.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Security.Cryptography.Encoding.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23511.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23511.nupkg.sha512",
-        "System.Security.Cryptography.Encoding.nuspec"
-      ]
-    },
     "System.Security.Cryptography.Primitives/4.0.0-beta-23127": {
       "type": "package",
       "serviceable": true,
@@ -3673,10 +3418,10 @@
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23511": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "zms85QGS0MAlVofaOX41xJUI6v5lMLJVssqLiFkDAOEuxlG5ndVDjElh+4icFY1YEb4t0FBok2Ae68m4sx4WVA==",
+      "sha512": "ztiLIQf2hl0ljLzaUeCx5tk+TU8TrHwrEatuKgSl2KoZXxeOCeXnB+oE07xQO7RnnMlPLtX7/ucHQtteh9du7A==",
       "files": [
         "lib/dotnet5.4/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -3684,14 +3429,14 @@
         "lib/net46/System.Security.Cryptography.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.4/System.Security.Cryptography.Primitives.dll",
+        "ref/dotnet5.1/System.Security.Cryptography.Primitives.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23511.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23511.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23516.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23516.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
@@ -3724,38 +3469,6 @@
         "ref/xamarinmac20/_._",
         "System.Security.Cryptography.X509Certificates.4.0.0-beta-23127.nupkg",
         "System.Security.Cryptography.X509Certificates.4.0.0-beta-23127.nupkg.sha512",
-        "System.Security.Cryptography.X509Certificates.nuspec"
-      ]
-    },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23511": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "8jJB1vYx8UNhQEAvRcPwNUpdGRnfA1A6MVZr1jy2OhXgLtC09cMGcAI1RZRNLNIef0EBnucToUNcvJ09yXF2tg==",
-      "files": [
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Security.Cryptography.X509Certificates.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet5.4/de/System.Security.Cryptography.X509Certificates.xml",
-        "ref/dotnet5.4/es/System.Security.Cryptography.X509Certificates.xml",
-        "ref/dotnet5.4/fr/System.Security.Cryptography.X509Certificates.xml",
-        "ref/dotnet5.4/it/System.Security.Cryptography.X509Certificates.xml",
-        "ref/dotnet5.4/ja/System.Security.Cryptography.X509Certificates.xml",
-        "ref/dotnet5.4/ko/System.Security.Cryptography.X509Certificates.xml",
-        "ref/dotnet5.4/ru/System.Security.Cryptography.X509Certificates.xml",
-        "ref/dotnet5.4/System.Security.Cryptography.X509Certificates.dll",
-        "ref/dotnet5.4/System.Security.Cryptography.X509Certificates.xml",
-        "ref/dotnet5.4/zh-hans/System.Security.Cryptography.X509Certificates.xml",
-        "ref/dotnet5.4/zh-hant/System.Security.Cryptography.X509Certificates.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Security.Cryptography.X509Certificates.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23511.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23511.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
@@ -3846,30 +3559,6 @@
         "ref/net46/System.Security.Principal.Windows.dll",
         "System.Security.Principal.Windows.4.0.0-beta-23127.nupkg",
         "System.Security.Principal.Windows.4.0.0-beta-23127.nupkg.sha512",
-        "System.Security.Principal.Windows.nuspec"
-      ]
-    },
-    "System.Security.Principal.Windows/4.0.0-beta-23511": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "r9s1wfUOJ67SetTMLc1GrWW+idBHn8TvC5BbfzNLyY6MiA9XgdW4Yvb7HmRSEhsWkHEugKQyxYugxHfGRJpVuw==",
-      "files": [
-        "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/net46/System.Security.Principal.Windows.dll",
-        "ref/dotnet5.4/de/System.Security.Principal.Windows.xml",
-        "ref/dotnet5.4/es/System.Security.Principal.Windows.xml",
-        "ref/dotnet5.4/fr/System.Security.Principal.Windows.xml",
-        "ref/dotnet5.4/it/System.Security.Principal.Windows.xml",
-        "ref/dotnet5.4/ja/System.Security.Principal.Windows.xml",
-        "ref/dotnet5.4/ko/System.Security.Principal.Windows.xml",
-        "ref/dotnet5.4/ru/System.Security.Principal.Windows.xml",
-        "ref/dotnet5.4/System.Security.Principal.Windows.dll",
-        "ref/dotnet5.4/System.Security.Principal.Windows.xml",
-        "ref/dotnet5.4/zh-hans/System.Security.Principal.Windows.xml",
-        "ref/dotnet5.4/zh-hant/System.Security.Principal.Windows.xml",
-        "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23511.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23511.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
@@ -4201,38 +3890,6 @@
         "System.Threading.ThreadPool.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23511": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "3fM8fG3ugqqMDPFIk8nxOfsR2Qdr7xA+d8iLvdxoMuSLha4SpfGtm92UJjRsAH4ls/WfQA804YjD9scTcKXU/g==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet5.4/de/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.4/es/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.4/fr/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.4/it/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.4/ja/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.4/ko/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.4/ru/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.4/System.Threading.ThreadPool.dll",
-        "ref/dotnet5.4/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.4/zh-hans/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.4/zh-hant/System.Threading.ThreadPool.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23511.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23511.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
-      ]
-    },
     "xunit/2.1.0": {
       "type": "package",
       "sha512": "u/7VQSOSXa7kSG4iK6Lcn7RqKZQ3hk7cnyMNVMpXHSP0RI5VQEtc44hvkG3LyWOVsx1dhUDD3rPAHAxyOUDQJw==",
@@ -4350,14 +4007,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00121": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00122": {
       "type": "package",
       "serviceable": true,
-      "sha512": "mNlM09rW84INiukmuUCukBf+MW/VZWsy6Nhnc7l7WqAwzkvdIS3BEzA7tQvfaL6XN2bFEULqsDaW5kapvmAzOg==",
+      "sha512": "eSQ1Jo09hXNAFL+JfcqiiN7+GuOO78RZoXd0darX4V0xYopw0sbe/wxTy54fXE2TvlQj9l7943j5FN2Psz9TWA==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00121.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00121.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00122.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00122.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }

--- a/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
@@ -19,7 +19,6 @@ namespace System.IO
 
         private static readonly int MaxPath = Interop.Sys.MaxPath;
         private static readonly int MaxLongPath = MaxPath;
-        private static readonly int MaxComponentLength = Interop.Sys.MaxName;
 
         private static bool IsDirectoryOrVolumeSeparator(char c)
         {
@@ -35,26 +34,15 @@ namespace System.IO
             if (path == null)
                 throw new ArgumentNullException("path");
 
-            return NormalizePath(path, fullChecks: true);
-        }
-
-        private static string NormalizePath(
-            string path, bool fullChecks)
-        {
-            Debug.Assert(path != null);
-
             if (path.Length == 0)
                 throw new ArgumentException(SR.Arg_PathIllegal);
 
-            if (fullChecks)
-            {
-                PathInternal.CheckInvalidPathChars(path);
+            PathInternal.CheckInvalidPathChars(path);
 
-                // Expand with current directory if necessary
-                if (!IsPathRooted(path))
-                {
-                    path = Combine(Interop.Sys.GetCwd(), path);
-                }
+            // Expand with current directory if necessary
+            if (!IsPathRooted(path))
+            {
+                path = Combine(Interop.Sys.GetCwd(), path);
             }
 
             // We would ideally use realpath to do this, but it resolves symlinks, requires that the file actually exist,
@@ -69,9 +57,7 @@ namespace System.IO
                 throw new PathTooLongException(SR.IO_PathTooLong);
             }
 
-            string result =
-                collapsedString.Length == 0 ? (fullChecks ? DirectorySeparatorCharAsString : string.Empty) :
-                collapsedString;
+            string result = collapsedString.Length == 0 ? DirectorySeparatorCharAsString : collapsedString;
 
             return result;
         }

--- a/src/System.Runtime.Extensions/src/System/IO/Path.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.cs
@@ -69,8 +69,8 @@ namespace System.IO
             if (path != null)
             {
                 PathInternal.CheckInvalidPathChars(path);
+                path = PathInternal.NormalizeDirectorySeparators(path);
                 int root = PathInternal.GetRootLength(path);
-                path = RemoveRelativeSegments(path, root);
 
                 int i = path.Length;
                 if (i > root)
@@ -483,7 +483,7 @@ namespace System.IO
                     }
                 }
 
-                if (++componentCharCount > MaxComponentLength)
+                if (++componentCharCount > PathInternal.MaxComponentLength)
                 {
                     throw new PathTooLongException(SR.IO_PathTooLong);
                 }

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
@@ -33,19 +33,49 @@ public static class PathTests
         Assert.Equal(expected, Path.ChangeExtension(path, newExtension));
     }
 
-    [Fact]
-    public static void GetDirectoryName()
+    [Theory,
+        InlineData(null, null),
+        InlineData(@"", null),
+        InlineData(@".", @""),
+        InlineData(@"..", @""),
+        InlineData(@"baz", @"")
+        ]
+    public static void GetDirectoryName(string path, string expected)
     {
-        Assert.Null(Path.GetDirectoryName(null));
-        Assert.Null(Path.GetDirectoryName(string.Empty));
+        Assert.Equal(expected, Path.GetDirectoryName(path));
+    }
 
-        Assert.Equal(string.Empty, Path.GetDirectoryName("."));
-        Assert.Equal(string.Empty, Path.GetDirectoryName(".."));
+    [Theory,
+        InlineData(@"dir/baz", @"dir"),
+        InlineData(@"dir\baz", @"dir"),
+        InlineData(@"dir\baz\bar", @"dir\baz"),
+        InlineData(@"dir\\baz", @"dir"),
+        InlineData(@" dir\baz", @" dir"),
+        InlineData(@" C:\dir\baz", @"C:\dir"),
+        InlineData(@"..\..\files.txt", @"..\..")
+        ]
+    [PlatformSpecific(PlatformID.Windows)]
+    public static void GetDirectoryName_Windows(string path, string expected)
+    {
+        Assert.Equal(expected, Path.GetDirectoryName(path));
+    }
 
-        Assert.Equal(string.Empty, Path.GetDirectoryName("baz"));
-        Assert.Equal("dir", Path.GetDirectoryName(Path.Combine("dir", "baz")));
-        Assert.Equal(Path.Combine("dir", "baz"), Path.GetDirectoryName(Path.Combine("dir", "baz", "bar")));
+    [Theory,
+        InlineData(@"dir/baz", @"dir"),
+        InlineData(@"dir//baz", @"dir"),
+        InlineData(@"dir\baz", @""),
+        InlineData(@"dir/baz/bar", @"dir/baz"),
+        InlineData(@"../../files.txt", @"../..")
+        ]
+    [PlatformSpecific(PlatformID.AnyUnix)]
+    public static void GetDirectoryName_Unix(string path, string expected)
+    {
+        Assert.Equal(expected, Path.GetDirectoryName(path));
+    }
 
+    [Fact]
+    public static void GetDirectoryName_CurrentDirectory()
+    {
         string curDir = Directory.GetCurrentDirectory();
         Assert.Equal(curDir, Path.GetDirectoryName(Path.Combine(curDir, "baz")));
         Assert.Equal(null, Path.GetDirectoryName(Path.GetPathRoot(curDir)));
@@ -53,7 +83,7 @@ public static class PathTests
 
     [PlatformSpecific(PlatformID.AnyUnix)]
     [Fact]
-    public static void GetDirectoryName_Unix()
+    public static void GetDirectoryName_ControlCharacters_Unix()
     {
         Assert.Equal(new string('\t', 1), Path.GetDirectoryName(Path.Combine(new string('\t', 1), "file")));
         Assert.Equal(new string('\b', 2), Path.GetDirectoryName(Path.Combine(new string('\b', 2), "fi le")));


### PR DESCRIPTION
Fixes issues with Path.GetDirectoryName() and relative paths.

- Added directory separator normalizer method.
- Added comments clarifying behavior and usage.
- Clarified and simplified internal methods.

Fixes #4274 

@ianhays, @stephentoub, @weshaggard, @Priya91 