### PR TITLE
Cleanup Some Runtime Tests

### DIFF
--- a/src/Common/tests/System/PerfUtils.cs
+++ b/src/Common/tests/System/PerfUtils.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.IO;
 
 namespace System

--- a/src/Common/tests/System/RandomDataGenerator.cs
+++ b/src/Common/tests/System/RandomDataGenerator.cs
@@ -316,7 +316,7 @@ namespace System
             char c;
             int length;
 
-            if (0 == minLength && 0 == maxLength) return String.Empty;
+            if (0 == minLength && 0 == maxLength) return string.Empty;
             if (minLength > maxLength) return null;
 
             length = minLength;

--- a/src/System.Runtime/tests/Common/CompareHelper.cs
+++ b/src/System.Runtime/tests/Common/CompareHelper.cs
@@ -1,0 +1,13 @@
+﻿namespace System.Runtime.Tests.Common
+{
+    internal static class CompareHelper
+    {
+        public static int NormalizeCompare(int i)
+        {
+            return
+                i == 0 ? 0 :
+                i > 0 ? 1 :
+                -1;
+        }
+    }
+}

--- a/src/System.Runtime/tests/Performance/Perf.Boolean.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Boolean.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
 using Microsoft.Xunit.Performance;
 
 namespace System.Runtime.Tests
@@ -15,16 +14,16 @@ namespace System.Runtime.Tests
                 using (iteration.StartMeasurement())
                     for (int i = 0; i < 10000; i++)
                     {
-                        Boolean.Parse("True"); Boolean.Parse("True"); Boolean.Parse("True");
-                        Boolean.Parse("True"); Boolean.Parse("True"); Boolean.Parse("True");
-                        Boolean.Parse("True"); Boolean.Parse("True"); Boolean.Parse("True");
+                        bool.Parse("True"); bool.Parse("True"); bool.Parse("True");
+                        bool.Parse("True"); bool.Parse("True"); bool.Parse("True");
+                        bool.Parse("True"); bool.Parse("True"); bool.Parse("True");
                     }
         }
 
         [Benchmark]
         public void ToString_()
         {
-            Boolean boo = true;
+            bool boo = true;
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                     for (int i = 0; i < 10000; i++)

--- a/src/System.Runtime/tests/Performance/Perf.Guid.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Guid.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Xunit.Performance;
-using System.Text;
 
 namespace System.Runtime.Tests
 {

--- a/src/System.Runtime/tests/Performance/Perf.Int32.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Int32.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Xunit;
 using Microsoft.Xunit.Performance;
 
 namespace System.Runtime.Tests
@@ -11,7 +10,7 @@ namespace System.Runtime.Tests
         [Benchmark]
         public void ToString_()
         {
-            Int32 i32 = 32;
+            int i32 = 32;
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                     for (int i = 0; i < 10000; i++)
@@ -30,9 +29,9 @@ namespace System.Runtime.Tests
                 using (iteration.StartMeasurement())
                     for (int i = 0; i < 10000; i++)
                     {
-                        Int32.Parse(builtString); Int32.Parse(builtString); Int32.Parse(builtString);
-                        Int32.Parse(builtString); Int32.Parse(builtString); Int32.Parse(builtString);
-                        Int32.Parse(builtString); Int32.Parse(builtString); Int32.Parse(builtString);
+                        int.Parse(builtString); int.Parse(builtString); int.Parse(builtString);
+                        int.Parse(builtString); int.Parse(builtString); int.Parse(builtString);
+                        int.Parse(builtString); int.Parse(builtString); int.Parse(builtString);
                     }
         }
     }

--- a/src/System.Runtime/tests/Performance/Perf.Object.cs
+++ b/src/System.Runtime/tests/Performance/Perf.Object.cs
@@ -14,16 +14,16 @@ namespace System.Runtime.Tests
                 using (iteration.StartMeasurement())
                     for (int i = 0; i < 10000; i++)
                     {
-                        new Object(); new Object(); new Object();
-                        new Object(); new Object(); new Object();
-                        new Object(); new Object(); new Object();
+                        new object(); new object(); new object();
+                        new object(); new object(); new object();
+                        new object(); new object(); new object();
                     }
         }
 
         [Benchmark]
         public void GetType_()
         {
-            Object obj = new Object();
+            object obj = new object();
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                     for (int i = 0; i < 10000; i++)

--- a/src/System.Runtime/tests/Performance/Perf.UInt32.cs
+++ b/src/System.Runtime/tests/Performance/Perf.UInt32.cs
@@ -10,7 +10,7 @@ namespace System.Runtime.Tests
         [Benchmark]
         public void ToString_()
         {
-            UInt32 testint = new UInt32();
+            uint testint = new uint();
             foreach (var iteration in Benchmark.Iterations)
                 using (iteration.StartMeasurement())
                     for (int i = 0; i < 10000; i++)

--- a/src/System.Runtime/tests/System.Runtime.Tests.csproj
+++ b/src/System.Runtime/tests/System.Runtime.Tests.csproj
@@ -19,6 +19,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Common\CompareHelper.cs" />
     <Compile Include="System\Activator.cs" />
     <Compile Include="System\Array.cs" />
     <Compile Include="System\Array.CustomClassStructTests.cs" />

--- a/src/System.Runtime/tests/System/Activator.cs
+++ b/src/System.Runtime/tests/System/Activator.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Reflection;
-using System.Collections;
-using System.Collections.Generic;
 
 using ActivatorTestsTestData;
 using Xunit;
@@ -15,11 +13,11 @@ public static class ActivatorTests
     public static void TestActivatorCreateInstanceBinding()
     {
         Type t;
-        Object[] args;
+        object[] args;
         Choice1 c1;
 
         // Root the constructors
-        if (String.Empty.Length > 0)
+        if (string.Empty.Length > 0)
         {
             new Choice1();
             new Choice1(123);
@@ -31,7 +29,7 @@ public static class ActivatorTests
         }
 
         t = null;
-        args = new Object[1];
+        args = new object[1];
         Assert.Throws<ArgumentNullException>(() => Activator.CreateInstance(t, args));
 
         t = typeof(Choice1);
@@ -40,12 +38,12 @@ public static class ActivatorTests
         Assert.Equal(c1.I, 1);
 
         t = typeof(Choice1);
-        args = new Object[] { };
+        args = new object[] { };
         c1 = (Choice1)(Activator.CreateInstance(t, args));
         Assert.Equal(c1.I, 1);
 
         t = typeof(Choice1);
-        args = new Object[] { 42 };
+        args = new object[] { 42 };
         c1 = (Choice1)(Activator.CreateInstance(t, args));
         Assert.Equal(c1.I, 2);
 
@@ -53,31 +51,31 @@ public static class ActivatorTests
         // but not by Dynamic.DelegateInvoke()... 
         {
             t = typeof(Choice1);
-            args = new Object[] { (short)(-2) };
+            args = new object[] { (short)(-2) };
             c1 = (Choice1)(Activator.CreateInstance(t, args));
             Assert.Equal(c1.I, 2);
         }
 
         t = typeof(Choice1);
-        args = new Object[] { "Hello" };
+        args = new object[] { "Hello" };
         c1 = (Choice1)(Activator.CreateInstance(t, args));
         Assert.Equal(c1.I, 3);
 
         t = typeof(Choice1);
-        args = new Object[] { null };
+        args = new object[] { null };
         Assert.Throws<AmbiguousMatchException>(() => Activator.CreateInstance(t, args));
 
         // "optional" parameters are not optional as far as Activator.CreateInstance() is concerned.
         t = typeof(Choice1);
-        args = new Object[] { 5.1 };
+        args = new object[] { 5.1 };
         Assert.ThrowsAny<MissingMemberException>(() => Activator.CreateInstance(t, args));
 
         t = typeof(Choice1);
-        args = new Object[] { 5.1, Type.Missing };
+        args = new object[] { 5.1, Type.Missing };
         Assert.ThrowsAny<MissingMemberException>(() => Activator.CreateInstance(t, args));
 
         t = typeof(Choice1);
-        args = new Object[] { 5.1, "Yes" };
+        args = new object[] { 5.1, "Yes" };
         c1 = (Choice1)(Activator.CreateInstance(t, args));
         Assert.Equal(c1.I, 4);
 
@@ -86,38 +84,38 @@ public static class ActivatorTests
         //
         VarArgs varArgs = new VarArgs();
         t = typeof(Choice1);
-        args = new Object[] { varArgs };
+        args = new object[] { varArgs };
         c1 = (Choice1)(Activator.CreateInstance(t, args));
         Assert.Equal(c1.I, 5);
 
         t = typeof(Choice1);
-        args = new Object[] { varArgs, "P1" };
+        args = new object[] { varArgs, "P1" };
         c1 = (Choice1)(Activator.CreateInstance(t, args));
         Assert.Equal(c1.I, 5);
 
         t = typeof(Choice1);
-        args = new Object[] { varArgs, "P1", "P2" };
+        args = new object[] { varArgs, "P1", "P2" };
         c1 = (Choice1)(Activator.CreateInstance(t, args));
         Assert.Equal(c1.I, 5);
 
         VarStringArgs varStringArgs = new VarStringArgs();
         t = typeof(Choice1);
-        args = new Object[] { varStringArgs };
+        args = new object[] { varStringArgs };
         c1 = (Choice1)(Activator.CreateInstance(t, args));
         Assert.Equal(c1.I, 6);
 
         t = typeof(Choice1);
-        args = new Object[] { varStringArgs, "P1" };
+        args = new object[] { varStringArgs, "P1" };
         c1 = (Choice1)(Activator.CreateInstance(t, args));
         Assert.Equal(c1.I, 6);
 
         t = typeof(Choice1);
-        args = new Object[] { varStringArgs, "P1", "P2" };
+        args = new object[] { varStringArgs, "P1", "P2" };
         c1 = (Choice1)(Activator.CreateInstance(t, args));
         Assert.Equal(c1.I, 6);
 
         t = typeof(Choice1);
-        args = new Object[] { varStringArgs, 5, 6 };
+        args = new object[] { varStringArgs, 5, 6 };
         Assert.ThrowsAny<MissingMemberException>(() => Activator.CreateInstance(t, args));
 
         //
@@ -130,7 +128,7 @@ public static class ActivatorTests
         //
         VarIntArgs varIntArgs = new VarIntArgs();
         t = typeof(Choice1);
-        args = new Object[] { varIntArgs, 1, (short)2 };
+        args = new object[] { varIntArgs, 1, (short)2 };
         Assert.Throws<InvalidCastException>(() => Activator.CreateInstance(t, args));
 
         return;
@@ -196,22 +194,22 @@ namespace ActivatorTestsTestData
             I = 2;
         }
 
-        public Choice1(String s)
+        public Choice1(string s)
         {
             I = 3;
         }
 
-        public Choice1(double d, String optionalS = "Hey")
+        public Choice1(double d, string optionalS = "Hey")
         {
             I = 4;
         }
 
-        public Choice1(VarArgs varArgs, params Object[] parameters)
+        public Choice1(VarArgs varArgs, params object[] parameters)
         {
             I = 5;
         }
 
-        public Choice1(VarStringArgs varArgs, params String[] parameters)
+        public Choice1(VarStringArgs varArgs, params string[] parameters)
         {
             I = 6;
         }

--- a/src/System.Runtime/tests/System/Array.CustomClassStructTests.cs
+++ b/src/System.Runtime/tests/System/Array.CustomClassStructTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+
 using Xunit;
 
 public static class CustomClassStructTests

--- a/src/System.Runtime/tests/System/Array.EmptyTests.cs
+++ b/src/System.Runtime/tests/System/Array.EmptyTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+
 using Xunit;
 
 public class EmptyTests

--- a/src/System.Runtime/tests/System/Array.RegionSorting.cs
+++ b/src/System.Runtime/tests/System/Array.RegionSorting.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+
 using Xunit;
 
 public static class RegionSorting

--- a/src/System.Runtime/tests/System/Array.SystemArrayKeyValueSortTests.cs
+++ b/src/System.Runtime/tests/System/Array.SystemArrayKeyValueSortTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+
 using Xunit;
 
 public class SystemArrayKeyValueSortTests

--- a/src/System.Runtime/tests/System/Array.TestTypes.cs
+++ b/src/System.Runtime/tests/System/Array.TestTypes.cs
@@ -13,7 +13,7 @@ public class ComparableRefType : IComparable, IEquatable<ComparableRefType>
         this.Id = id;
     }
 
-    public int CompareTo(Object other)
+    public int CompareTo(object other)
     {
         ComparableRefType o = (ComparableRefType)other;
         if (o.Id == this.Id)
@@ -60,7 +60,7 @@ public class ComparableValueType : IComparable, IEquatable<ComparableValueType>
         this.Id = id;
     }
 
-    public int CompareTo(Object other)
+    public int CompareTo(object other)
     {
         ComparableValueType o = (ComparableValueType)other;
         if (o.Id == this.Id)
@@ -201,7 +201,7 @@ public static class TestObjects
         Array array = new int[length];
         for (int g = 0; g < length; g++)
         {
-            array.SetValue(random.Next(Int32.MinValue, Int32.MaxValue), g);
+            array.SetValue(random.Next(int.MinValue, int.MaxValue), g);
         }
         return array;
     }

--- a/src/System.Runtime/tests/System/Array.Util.cs
+++ b/src/System.Runtime/tests/System/Array.Util.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+
 using Xunit;
 
 public static class ArrayUtil
@@ -66,8 +67,8 @@ public static class ArrayUtil
             bool swapped = false;
             for (int g = startingIndex; g < startingIndex + length - 1; g++)
             {
-                Object first = array.GetValue(g);
-                Object second = array.GetValue(g + 1);
+                object first = array.GetValue(g);
+                object second = array.GetValue(g + 1);
                 int comparison = comparer.Compare(first, second);
                 if (comparison == 1)
                 {
@@ -87,7 +88,7 @@ public static class ArrayUtil
 
     private static void Swap(int from, int to, Array array, Array items)
     {
-        Object temp = array.GetValue(from);
+        object temp = array.GetValue(from);
         array.SetValue(array.GetValue(to), from);
         array.SetValue(temp, to);
 

--- a/src/System.Runtime/tests/System/Array.cs
+++ b/src/System.Runtime/tests/System/Array.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+
 using Xunit;
 
 public static unsafe class ArrayTests
@@ -11,14 +12,14 @@ public static unsafe class ArrayTests
     [Fact]
     public static void TestArrayAsIListOfT()
     {
-        String[] sa = { "Hello", "There" };
-        String s;
+        string[] sa = { "Hello", "There" };
+        string s;
         int idx;
 
-        bool b = (sa is IList<String>);
+        bool b = (sa is IList<string>);
         Assert.True(b);
 
-        IList<String> ils = sa;
+        IList<string> ils = sa;
         int len = ils.Count;
         Assert.Equal(len, 2);
 
@@ -33,7 +34,7 @@ public static unsafe class ArrayTests
         idx = ils.IndexOf(null);
         Assert.Equal(idx, -1);
 
-        String[] sa2 = new String[2];
+        string[] sa2 = new string[2];
         ils.CopyTo(sa2, 0);
         Assert.Equal(sa2[0], sa[0]);
         Assert.Equal(sa2[1], sa[1]);
@@ -59,7 +60,7 @@ public static unsafe class ArrayTests
         Assert.Throws<NotSupportedException>(() => ils.RemoveAt(1));
         Assert.Throws<NotSupportedException>(() => ils.Insert(0, "x"));
 
-        IEnumerator<String> e = ils.GetEnumerator();
+        IEnumerator<string> e = ils.GetEnumerator();
         b = e.MoveNext();
         Assert.True(b);
         s = e.Current;
@@ -106,7 +107,7 @@ public static unsafe class ArrayTests
         Assert.False(il.Contains(999));
         Assert.Equal(il.IndexOf(1), 0);
         Assert.Equal(il.IndexOf(999), -1);
-        Object v = il[0];
+        object v = il[0];
         Assert.Equal(v, 1);
         v = il[1];
         Assert.Equal(v, 2);
@@ -310,17 +311,17 @@ public static unsafe class ArrayTests
         int[] idirect = new int[3] { 7, 8, 9 };
         Array a = idirect;
 
-        Object seven = a.GetValue(0);
+        object seven = a.GetValue(0);
         Assert.Equal(7, seven);
         a.SetValue(41, 0);
         Assert.Equal(41, idirect[0]);
 
-        Object eight = a.GetValue(1);
+        object eight = a.GetValue(1);
         Assert.Equal(8, eight);
         a.SetValue(42, 1);
         Assert.Equal(42, idirect[1]);
 
-        Object nine = a.GetValue(2);
+        object nine = a.GetValue(2);
         Assert.Equal(9, nine);
         a.SetValue(43, 2);
         Assert.Equal(43, idirect[2]);
@@ -399,32 +400,32 @@ public static unsafe class ArrayTests
         //----------------------------------------------------------
         // GC-refs
         //----------------------------------------------------------
-        String[] sdirect;
+        string[] sdirect;
 
-        sdirect = new String[] { "7", "8", "9" };
+        sdirect = new string[] { "7", "8", "9" };
 
         Array.Clear((Array)sdirect, 0, 3);
         Assert.Null(sdirect[0]);
         Assert.Null(sdirect[1]);
         Assert.Null(sdirect[2]);
 
-        sdirect = new String[] { "7", "8", "9" };
+        sdirect = new string[] { "7", "8", "9" };
 
         ((IList)sdirect).Clear();
         Assert.Null(sdirect[0]);
         Assert.Null(sdirect[1]);
         Assert.Null(sdirect[2]);
 
-        sdirect = new String[] { "0x1234567", "0x789abcde", "0x22334455", "0x66778899", "0x11335577", "0x22446688" };
+        sdirect = new string[] { "0x1234567", "0x789abcde", "0x22334455", "0x66778899", "0x11335577", "0x22446688" };
         Array.Clear((Array)sdirect, 2, 3);
-        Assert.Equal<String>(sdirect[0], "0x1234567");
-        Assert.Equal<String>(sdirect[1], "0x789abcde");
+        Assert.Equal<string>(sdirect[0], "0x1234567");
+        Assert.Equal<string>(sdirect[1], "0x789abcde");
         Assert.Null(sdirect[2]);
         Assert.Null(sdirect[3]);
         Assert.Null(sdirect[4]);
-        Assert.Equal<String>(sdirect[5], "0x22446688");
+        Assert.Equal<string>(sdirect[5], "0x22446688");
 
-        sdirect = new String[] { "0x1234567", "0x789abcde", "0x22334455", "0x66778899", "0x11335577", "0x22446688" };
+        sdirect = new string[] { "0x1234567", "0x789abcde", "0x22334455", "0x66778899", "0x11335577", "0x22446688" };
         Array.Clear((Array)sdirect, 0, 6);
         Assert.Null(sdirect[0]);
         Assert.Null(sdirect[1]);
@@ -433,23 +434,23 @@ public static unsafe class ArrayTests
         Assert.Null(sdirect[4]);
         Assert.Null(sdirect[5]);
 
-        sdirect = new String[] { "0x1234567", "0x789abcde", "0x22334455", "0x66778899", "0x11335577", "0x22446688" };
+        sdirect = new string[] { "0x1234567", "0x789abcde", "0x22334455", "0x66778899", "0x11335577", "0x22446688" };
         Array.Clear((Array)sdirect, 6, 0);
-        Assert.Equal<String>(sdirect[0], "0x1234567");
-        Assert.Equal<String>(sdirect[1], "0x789abcde");
-        Assert.Equal<String>(sdirect[2], "0x22334455");
-        Assert.Equal<String>(sdirect[3], "0x66778899");
-        Assert.Equal<String>(sdirect[4], "0x11335577");
-        Assert.Equal<String>(sdirect[5], "0x22446688");
+        Assert.Equal<string>(sdirect[0], "0x1234567");
+        Assert.Equal<string>(sdirect[1], "0x789abcde");
+        Assert.Equal<string>(sdirect[2], "0x22334455");
+        Assert.Equal<string>(sdirect[3], "0x66778899");
+        Assert.Equal<string>(sdirect[4], "0x11335577");
+        Assert.Equal<string>(sdirect[5], "0x22446688");
 
-        sdirect = new String[] { "0x1234567", "0x789abcde", "0x22334455", "0x66778899", "0x11335577", "0x22446688" };
+        sdirect = new string[] { "0x1234567", "0x789abcde", "0x22334455", "0x66778899", "0x11335577", "0x22446688" };
         Array.Clear((Array)sdirect, 0, 0);
-        Assert.Equal<String>(sdirect[0], "0x1234567");
-        Assert.Equal<String>(sdirect[1], "0x789abcde");
-        Assert.Equal<String>(sdirect[2], "0x22334455");
-        Assert.Equal<String>(sdirect[3], "0x66778899");
-        Assert.Equal<String>(sdirect[4], "0x11335577");
-        Assert.Equal<String>(sdirect[5], "0x22446688");
+        Assert.Equal<string>(sdirect[0], "0x1234567");
+        Assert.Equal<string>(sdirect[1], "0x789abcde");
+        Assert.Equal<string>(sdirect[2], "0x22334455");
+        Assert.Equal<string>(sdirect[3], "0x66778899");
+        Assert.Equal<string>(sdirect[4], "0x11335577");
+        Assert.Equal<string>(sdirect[5], "0x22446688");
 
         //----------------------------------------------------------
         // Valuetypes with embedded GC-refs
@@ -499,10 +500,10 @@ public static unsafe class ArrayTests
 
         Array.Clear((Array)g, 2, 3);
         Assert.Equal<int>(g[0].x, 7);
-        Assert.Equal<String>(g[0].s, "Hello");
+        Assert.Equal<string>(g[0].s, "Hello");
         Assert.Equal<int>(g[0].z, 8);
         Assert.Equal<int>(g[1].x, 7);
-        Assert.Equal<String>(g[1].s, "Hello");
+        Assert.Equal<string>(g[1].s, "Hello");
         Assert.Equal<int>(g[1].z, 8);
         for (int i = 2; i < 2 + 3; i++)
         {
@@ -532,23 +533,23 @@ public static unsafe class ArrayTests
     [Fact]
     public static void TestCopy_GCRef()
     {
-        String[] s;
-        String[] d;
+        string[] s;
+        string[] d;
 
-        s = new String[] { "Red", "Green", null, "Blue" };
-        d = new String[] { "X", "X", "X", "X" };
+        s = new string[] { "Red", "Green", null, "Blue" };
+        d = new string[] { "X", "X", "X", "X" };
         Array.Copy(s, 0, d, 0, 4);
-        Assert.Equal<String>(d[0], "Red");
-        Assert.Equal<String>(d[1], "Green");
+        Assert.Equal<string>(d[0], "Red");
+        Assert.Equal<string>(d[1], "Green");
         Assert.Null(d[2]);
-        Assert.Equal<String>(d[3], "Blue");
+        Assert.Equal<string>(d[3], "Blue");
 
         // With reverse overlap
-        s = new String[] { "Red", "Green", null, "Blue" };
+        s = new string[] { "Red", "Green", null, "Blue" };
         Array.Copy(s, 1, s, 2, 2);
-        Assert.Equal<String>(s[0], "Red");
-        Assert.Equal<String>(s[1], "Green");
-        Assert.Equal<String>(s[2], "Green");
+        Assert.Equal<string>(s[0], "Red");
+        Assert.Equal<string>(s[1], "Green");
+        Assert.Equal<string>(s[2], "Green");
         Assert.Null(s[3]);
     }
 
@@ -557,9 +558,9 @@ public static unsafe class ArrayTests
     {
         // Test the Array.Copy code for value-type arrays => Object[]
         G[] s;
-        Object[] d;
+        object[] d;
         s = new G[5];
-        d = new Object[5];
+        d = new object[5];
 
         s[0].x = 7;
         s[0].s = "Hello0";
@@ -587,7 +588,7 @@ public static unsafe class ArrayTests
             Assert.True(d[i] is G);
             G g = (G)(d[i]);
             Assert.Equal<int>(g.x, s[i].x);
-            Assert.Equal<String>(g.s, s[i].s);
+            Assert.Equal<string>(g.s, s[i].s);
             Assert.Equal<int>(g.z, s[i].z);
         }
     }
@@ -626,30 +627,30 @@ public static unsafe class ArrayTests
         for (int i = 0; i < d.Length; i++)
         {
             Assert.Equal<int>(d[i].x, s[i].x);
-            Assert.Equal<String>(d[i].s, s[i].s);
+            Assert.Equal<string>(d[i].s, s[i].s);
             Assert.Equal<int>(d[i].z, s[i].z);
         }
 
         // With overlap
         Array.Copy(s, 1, s, 2, 3);
         Assert.Equal<int>(s[0].x, 7);
-        Assert.Equal<String>(s[0].s, "Hello0");
+        Assert.Equal<string>(s[0].s, "Hello0");
         Assert.Equal<int>(s[0].z, 8);
 
         Assert.Equal<int>(s[1].x, 9);
-        Assert.Equal<String>(s[1].s, "Hello1");
+        Assert.Equal<string>(s[1].s, "Hello1");
         Assert.Equal<int>(s[1].z, 10);
 
         Assert.Equal<int>(s[2].x, 9);
-        Assert.Equal<String>(s[2].s, "Hello1");
+        Assert.Equal<string>(s[2].s, "Hello1");
         Assert.Equal<int>(s[2].z, 10);
 
         Assert.Equal<int>(s[3].x, 11);
-        Assert.Equal<String>(s[3].s, "Hello2");
+        Assert.Equal<string>(s[3].s, "Hello2");
         Assert.Equal<int>(s[3].z, 12);
 
         Assert.Equal<int>(s[4].x, 13);
-        Assert.Equal<String>(s[4].s, "Hello3");
+        Assert.Equal<string>(s[4].s, "Hello3");
         Assert.Equal<int>(s[4].z, 14);
     }
 
@@ -691,23 +692,23 @@ public static unsafe class ArrayTests
     [Fact]
     public static void TestConstrainedCopy_GCRef()
     {
-        String[] s;
-        String[] d;
+        string[] s;
+        string[] d;
 
-        s = new String[] { "Red", "Green", null, "Blue" };
-        d = new String[] { "X", "X", "X", "X" };
+        s = new string[] { "Red", "Green", null, "Blue" };
+        d = new string[] { "X", "X", "X", "X" };
         Array.ConstrainedCopy(s, 0, d, 0, 4);
-        Assert.Equal<String>(d[0], "Red");
-        Assert.Equal<String>(d[1], "Green");
+        Assert.Equal<string>(d[0], "Red");
+        Assert.Equal<string>(d[1], "Green");
         Assert.Null(d[2]);
-        Assert.Equal<String>(d[3], "Blue");
+        Assert.Equal<string>(d[3], "Blue");
 
         // With reverse overlap
-        s = new String[] { "Red", "Green", null, "Blue" };
+        s = new string[] { "Red", "Green", null, "Blue" };
         Array.ConstrainedCopy(s, 1, s, 2, 2);
-        Assert.Equal<String>(s[0], "Red");
-        Assert.Equal<String>(s[1], "Green");
-        Assert.Equal<String>(s[2], "Green");
+        Assert.Equal<string>(s[0], "Red");
+        Assert.Equal<string>(s[1], "Green");
+        Assert.Equal<string>(s[2], "Green");
         Assert.Null(s[3]);
     }
 
@@ -745,30 +746,30 @@ public static unsafe class ArrayTests
         for (int i = 0; i < d.Length; i++)
         {
             Assert.Equal<int>(d[i].x, s[i].x);
-            Assert.Equal<String>(d[i].s, s[i].s);
+            Assert.Equal<string>(d[i].s, s[i].s);
             Assert.Equal<int>(d[i].z, s[i].z);
         }
 
         // With overlap
         Array.ConstrainedCopy(s, 1, s, 2, 3);
         Assert.Equal<int>(s[0].x, 7);
-        Assert.Equal<String>(s[0].s, "Hello0");
+        Assert.Equal<string>(s[0].s, "Hello0");
         Assert.Equal<int>(s[0].z, 8);
 
         Assert.Equal<int>(s[1].x, 9);
-        Assert.Equal<String>(s[1].s, "Hello1");
+        Assert.Equal<string>(s[1].s, "Hello1");
         Assert.Equal<int>(s[1].z, 10);
 
         Assert.Equal<int>(s[2].x, 9);
-        Assert.Equal<String>(s[2].s, "Hello1");
+        Assert.Equal<string>(s[2].s, "Hello1");
         Assert.Equal<int>(s[2].z, 10);
 
         Assert.Equal<int>(s[3].x, 11);
-        Assert.Equal<String>(s[3].s, "Hello2");
+        Assert.Equal<string>(s[3].s, "Hello2");
         Assert.Equal<int>(s[3].z, 12);
 
         Assert.Equal<int>(s[4].x, 13);
-        Assert.Equal<String>(s[4].s, "Hello3");
+        Assert.Equal<string>(s[4].s, "Hello3");
         Assert.Equal<int>(s[4].z, 14);
     }
 
@@ -826,8 +827,8 @@ public static unsafe class ArrayTests
         Assert.True(Array.Exists<int>(results, i => i == 7));
         Assert.True(Array.Exists<int>(results, i => i == 9));
 
-        String[] sa = { "7", "8", "88", "888", "9" };
-        String elem;
+        string[] sa = { "7", "8", "88", "888", "9" };
+        string elem;
         elem = Array.Find<String>(sa, s => s.StartsWith("8"));
         Assert.Equal(elem, "8");
 
@@ -854,7 +855,7 @@ public static unsafe class ArrayTests
         idx = Array.FindIndex<int>(ia, 1, 2, i => i == 43);
         Assert.Equal(idx, -1);
 
-        sa = new String[] { "7", "8", "88", "888", "9" };
+        sa = new string[] { "7", "8", "88", "888", "9" };
         elem = Array.FindLast<String>(sa, s => s.StartsWith("8"));
         Assert.Equal(elem, "888");
 
@@ -888,7 +889,7 @@ public static unsafe class ArrayTests
 
         IEnumerator ie = i.GetEnumerator();
         bool b;
-        Object v;
+        object v;
 
         b = ie.MoveNext();
         Assert.True(b);
@@ -953,7 +954,7 @@ public static unsafe class ArrayTests
         idx = Array.IndexOf<int>(ia, 9, 2, 2);
         Assert.Equal(idx, -1);
 
-        a = new String[] { null, null, "Hello", "Hello", "Goodbye", "Goodbye", null, null };
+        a = new string[] { null, null, "Hello", "Hello", "Goodbye", "Goodbye", null, null };
         idx = Array.IndexOf(a, null);
         Assert.Equal(idx, 0);
         idx = Array.IndexOf(a, "Hello");
@@ -971,7 +972,7 @@ public static unsafe class ArrayTests
         idx = Array.IndexOf(a, "Goodbye", 2, 2);
         Assert.Equal(idx, -1);
 
-        String[] sa = (String[])a;
+        string[] sa = (string[])a;
         idx = Array.IndexOf<String>(sa, null);
         Assert.Equal(idx, 0);
         idx = Array.IndexOf<String>(sa, "Hello");
@@ -1028,7 +1029,7 @@ public static unsafe class ArrayTests
         idx = Array.LastIndexOf<int>(ia, 7, 3, 2);
         Assert.Equal(idx, -1);
 
-        a = new String[] { null, null, "Hello", "Hello", "Goodbye", "Goodbye", null, null };
+        a = new string[] { null, null, "Hello", "Hello", "Goodbye", "Goodbye", null, null };
         idx = Array.LastIndexOf(a, null);
         Assert.Equal(idx, 7);
         idx = Array.LastIndexOf(a, "Hello");
@@ -1046,7 +1047,7 @@ public static unsafe class ArrayTests
         idx = Array.LastIndexOf(a, "Goodbye", 7, 2);
         Assert.Equal(idx, -1);
 
-        String[] sa = (String[])a;
+        string[] sa = (string[])a;
         idx = Array.LastIndexOf<String>(sa, null);
         Assert.Equal(idx, 7);
         idx = Array.LastIndexOf<String>(sa, "Hello");
@@ -1144,9 +1145,9 @@ public static unsafe class ArrayTests
         Assert.Equal(i[3], 4);
         Assert.Equal(i[4], 3);
 
-        String[] s;
+        string[] s;
 
-        s = new String[] { "1", "2", "3", "4", "5" };
+        s = new string[] { "1", "2", "3", "4", "5" };
         Array.Reverse((Array)s);
         Assert.Equal(s[0], "5");
         Assert.Equal(s[1], "4");
@@ -1154,7 +1155,7 @@ public static unsafe class ArrayTests
         Assert.Equal(s[3], "2");
         Assert.Equal(s[4], "1");
 
-        s = new String[] { "1", "2", "3", "4", "5" };
+        s = new string[] { "1", "2", "3", "4", "5" };
         Array.Reverse((Array)s, 2, 3);
         Assert.Equal(s[0], "1");
         Assert.Equal(s[1], "2");
@@ -1176,14 +1177,14 @@ public static unsafe class ArrayTests
         TestSortHelper<int>(new int[] { 5, 2, 9, 8, 4, 3, 2, 4, 6 }, 3, 4, icomparer);
         TestSortHelper<int>(new int[] { 5, 2, 9, 8, 4, 3, 2, 4, 6 }, 3, 6, icomparer);
 
-        IComparer<String> scomparer = new StringComparer();
-        TestSortHelper<String>(new String[] { }, 0, 0, scomparer);
-        TestSortHelper<String>(new String[] { "5" }, 0, 1, scomparer);
-        TestSortHelper<String>(new String[] { "5", "2" }, 0, 2, scomparer);
+        IComparer<string> scomparer = new StringComparer();
+        TestSortHelper<String>(new string[] { }, 0, 0, scomparer);
+        TestSortHelper<String>(new string[] { "5" }, 0, 1, scomparer);
+        TestSortHelper<String>(new string[] { "5", "2" }, 0, 2, scomparer);
 
-        TestSortHelper<String>(new String[] { "5", "2", null, "8", "4", "3", "2", "4", "6" }, 0, 9, scomparer);
-        TestSortHelper<String>(new String[] { "5", "2", null, "8", "4", "3", "2", "4", "6" }, 3, 4, scomparer);
-        TestSortHelper<String>(new String[] { "5", "2", null, "8", "4", "3", "2", "4", "6" }, 3, 6, scomparer);
+        TestSortHelper<String>(new string[] { "5", "2", null, "8", "4", "3", "2", "4", "6" }, 0, 9, scomparer);
+        TestSortHelper<String>(new string[] { "5", "2", null, "8", "4", "3", "2", "4", "6" }, 3, 4, scomparer);
+        TestSortHelper<String>(new string[] { "5", "2", null, "8", "4", "3", "2", "4", "6" }, 3, 6, scomparer);
     }
 
     private static void TestSortHelper<T>(T[] array, int index, int length, IComparer<T> comparer)
@@ -1270,14 +1271,14 @@ public static unsafe class ArrayTests
 
         {
             int[] lengths = { 10 };
-            String[] sa = (String[])Array.CreateInstance(typeof(String), lengths);
-            Assert.Equal(sa, new String[10]);
+            string[] sa = (string[])Array.CreateInstance(typeof(string), lengths);
+            Assert.Equal(sa, new string[10]);
         }
 
         {
             int[] lengths = { 0 };
-            String[] sa = (String[])Array.CreateInstance(typeof(String), lengths);
-            Assert.Equal(sa, new String[0]);
+            string[] sa = (string[])Array.CreateInstance(typeof(string), lengths);
+            Assert.Equal(sa, new string[0]);
         }
 
         {
@@ -1414,7 +1415,7 @@ public static unsafe class ArrayTests
     private struct G
     {
         public int x;
-        public String s;
+        public string s;
         public int z;
     }
 
@@ -1441,14 +1442,14 @@ public static unsafe class ArrayTests
         }
     }
 
-    private class StringComparer : IComparer, IComparer<String>
+    private class StringComparer : IComparer, IComparer<string>
     {
-        public int Compare(Object x, Object y)
+        public int Compare(object x, object y)
         {
-            return Compare((String)x, (String)y);
+            return Compare((string)x, (string)y);
         }
 
-        public int Compare(String x, String y)
+        public int Compare(string x, string y)
         {
             if (x == y)
                 return 0;
@@ -1539,14 +1540,14 @@ public static unsafe class ArrayTests
     {
         {
             int[] s = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-            Object[] d = new IEnumerable<int>[10];
+            object[] d = new IEnumerable<int>[10];
 
             Assert.Throws<ArrayTypeMismatchException>(() => Array.Copy(s, 0, d, 0, 10));
         }
 
         {
             int[] s = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-            Object[] d = new Object[10];
+            object[] d = new object[10];
 
             Array.Copy(s, 2, d, 5, 3);
 
@@ -1564,7 +1565,7 @@ public static unsafe class ArrayTests
 
         {
             int[] s = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-            Object[] d = new IEquatable<int>[10];
+            object[] d = new IEquatable<int>[10];
 
             Array.Copy(s, 2, d, 5, 3);
 
@@ -1582,7 +1583,7 @@ public static unsafe class ArrayTests
 
         {
             Nullable<int>[] s = { 0, 1, 2, default(Nullable<int>), 4, 5, 6, 7, 8, 9 };
-            Object[] d = new Object[10];
+            object[] d = new object[10];
 
             Array.Copy(s, 2, d, 5, 3);
 
@@ -1607,7 +1608,7 @@ public static unsafe class ArrayTests
         const int cc = unchecked((int)0xcccccccc);
 
         {
-            Object[] s = new String[10];
+            object[] s = new string[10];
             int[] d = new int[10];
             for (int i = 0; i < d.Length; i++)
                 d[i] = cc;
@@ -1616,7 +1617,7 @@ public static unsafe class ArrayTests
         }
 
         {
-            Object[] s = new Object[10];
+            object[] s = new object[10];
             for (int i = 0; i < s.Length; i++)
                 s[i] = i;
 
@@ -1638,7 +1639,7 @@ public static unsafe class ArrayTests
         }
 
         {
-            Object[] s = new IEquatable<int>[10];
+            object[] s = new IEquatable<int>[10];
             for (int i = 0; i < s.Length; i++)
                 s[i] = i;
 
@@ -1660,7 +1661,7 @@ public static unsafe class ArrayTests
         }
 
         {
-            Object[] s = new IEquatable<int>[10];
+            object[] s = new IEquatable<int>[10];
             for (int i = 0; i < s.Length; i++)
                 s[i] = i;
             s[1] = new NotInt32();
@@ -1684,7 +1685,7 @@ public static unsafe class ArrayTests
         }
 
         {
-            Object[] s = new IEquatable<int>[10];
+            object[] s = new IEquatable<int>[10];
             for (int i = 0; i < s.Length; i++)
                 s[i] = i;
             s[4] = new NotInt32();
@@ -1699,7 +1700,7 @@ public static unsafe class ArrayTests
         }
 
         {
-            Object[] s = new IEquatable<int>[10];
+            object[] s = new IEquatable<int>[10];
             for (int i = 0; i < s.Length; i++)
                 s[i] = i;
             s[4] = null;
@@ -1714,7 +1715,7 @@ public static unsafe class ArrayTests
         }
 
         {
-            Object[] s = new Object[10];
+            object[] s = new object[10];
             for (int i = 0; i < s.Length; i++)
                 s[i] = i;
             s[4] = null;
@@ -1800,4 +1801,3 @@ public static unsafe class ArrayTests
         Assert.Equal(arr.GetValue(0, 0, 0, 2), 3);
     }
 }
-

--- a/src/System.Runtime/tests/System/ArraySegment.cs
+++ b/src/System.Runtime/tests/System/ArraySegment.cs
@@ -2,8 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
+
 using Xunit;
 
 public static unsafe class ArraySegmentTests
@@ -63,7 +63,7 @@ public static unsafe class ArraySegmentTests
         b = a.Equals(a3);
         Assert.False(b);
 
-        Object o;
+        object o;
         o = null;
         b = a.Equals(null);
         Assert.False(b);
@@ -150,18 +150,18 @@ public static unsafe class ArraySegmentTests
     public static void TestCopyTo()
     {
         {
-            String[] src;
-            IList<String> seg;
+            string[] src;
+            IList<string> seg;
 
-            src = new String[] { "0", "1", "2", "3", "4" };
-            seg = new ArraySegment<String>(src, 1, 3);
+            src = new string[] { "0", "1", "2", "3", "4" };
+            seg = new ArraySegment<string>(src, 1, 3);
             seg.CopyTo(src, 2);
-            Assert.Equal(src, new String[] { "0", "1", "1", "2", "3" });
+            Assert.Equal(src, new string[] { "0", "1", "1", "2", "3" });
 
-            src = new String[] { "0", "1", "2", "3", "4" };
-            seg = new ArraySegment<String>(src, 1, 3);
+            src = new string[] { "0", "1", "2", "3", "4" };
+            seg = new ArraySegment<string>(src, 1, 3);
             seg.CopyTo(src, 0);
-            Assert.Equal(src, new String[] { "1", "2", "3", "3", "4" });
+            Assert.Equal(src, new string[] { "1", "2", "3", "3", "4" });
         }
 
         {
@@ -180,4 +180,3 @@ public static unsafe class ArraySegmentTests
         }
     }
 }
-

--- a/src/System.Runtime/tests/System/Attribute.cs
+++ b/src/System.Runtime/tests/System/Attribute.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Reflection;
 using System.Linq;
+
 using Xunit;
 
 public static unsafe class AttributeTests

--- a/src/System.Runtime/tests/System/Boolean.cs
+++ b/src/System.Runtime/tests/System/Boolean.cs
@@ -2,209 +2,143 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Runtime.Tests.Common;
+
 using Xunit;
 
 public static class BooleanTests
 {
-    private static void VerifyBooleanTryParse(string s, bool expectedResult, bool expectedReturn)
-    {
-        Boolean b;
-        Assert.Equal(expectedReturn, Boolean.TryParse(s, out b));
-        Assert.Equal(expectedResult, b);
-    }
     [Fact]
-    public static void TestTryParse()
+    public static void TestTrueString()
     {
-        // Boolean Boolean.TryParse(String, Boolean)
-
-        // Success cases
-        VerifyBooleanTryParse(Boolean.TrueString, true, true);
-        VerifyBooleanTryParse(Boolean.FalseString, false, true);
-        VerifyBooleanTryParse("True", true, true);
-        VerifyBooleanTryParse("true", true, true);
-        VerifyBooleanTryParse("TRUE", true, true);
-        VerifyBooleanTryParse("tRuE", true, true);
-        VerifyBooleanTryParse("False", false, true);
-        VerifyBooleanTryParse("false", false, true);
-        VerifyBooleanTryParse("FALSE", false, true);
-        VerifyBooleanTryParse("fAlSe", false, true);
-        VerifyBooleanTryParse("  True  ", true, true);
-        VerifyBooleanTryParse("False  ", false, true);
-        VerifyBooleanTryParse("True\0", true, true);
-        VerifyBooleanTryParse("False\0", false, true);
-        VerifyBooleanTryParse("True\0    ", true, true);
-        VerifyBooleanTryParse(" \0 \0  True   \0 ", true, true);
-        VerifyBooleanTryParse("  False \0\0\0  ", false, true);
-
-        // Fail cases
-        VerifyBooleanTryParse(null, false, false);
-        VerifyBooleanTryParse("", false, false);
-        VerifyBooleanTryParse(" ", false, false);
-        VerifyBooleanTryParse("Garbage", false, false);
-        VerifyBooleanTryParse("True\0Garbage", false, false);
-        VerifyBooleanTryParse("True\0True", false, false);
-        VerifyBooleanTryParse("True True", false, false);
-        VerifyBooleanTryParse("True False", false, false);
-        VerifyBooleanTryParse("False True", false, false);
-        VerifyBooleanTryParse("Fa lse", false, false);
-        VerifyBooleanTryParse("T", false, false);
-        VerifyBooleanTryParse("0", false, false);
-        VerifyBooleanTryParse("1", false, false);
-    }
-
-    private static void VerifyBooleanParse(string s, bool expectedResult, bool shouldSucceed)
-    {
-        Boolean b;
-        Boolean succeeded;
-        try
-        {
-            b = Boolean.Parse(s);
-            Assert.Equal(expectedResult, b);
-            succeeded = true;
-        }
-        catch (Exception)
-        {
-            succeeded = false;
-        }
-        Assert.Equal(shouldSucceed, succeeded);
-    }
-
-    [Fact]
-    public static void TestParse()
-    {
-        // Boolean Boolean.Parse(String)
-        // Success cases
-        VerifyBooleanParse(Boolean.TrueString, true, true);
-        VerifyBooleanParse(Boolean.FalseString, false, true);
-        VerifyBooleanParse("True", true, true);
-        VerifyBooleanParse("true", true, true);
-        VerifyBooleanParse("TRUE", true, true);
-        VerifyBooleanParse("tRuE", true, true);
-        VerifyBooleanParse("False", false, true);
-        VerifyBooleanParse("false", false, true);
-        VerifyBooleanParse("FALSE", false, true);
-        VerifyBooleanParse("fAlSe", false, true);
-        VerifyBooleanParse("  True  ", true, true);
-        VerifyBooleanParse("False  ", false, true);
-        VerifyBooleanParse("True\0", true, true);
-        VerifyBooleanParse("False\0", false, true);
-        VerifyBooleanParse("True\0    ", true, true);
-        VerifyBooleanParse(" \0 \0  True   \0 ", true, true);
-        VerifyBooleanParse("  False \0\0\0  ", false, true);
-
-        // Fail cases
-        VerifyBooleanParse(null, false, false);
-        VerifyBooleanParse("", false, false);
-        VerifyBooleanParse(" ", false, false);
-        VerifyBooleanParse("Garbage", false, false);
-        VerifyBooleanParse("True\0Garbage", false, false);
-        VerifyBooleanParse("True\0True", false, false);
-        VerifyBooleanParse("True True", false, false);
-        VerifyBooleanParse("True False", false, false);
-        VerifyBooleanParse("False True", false, false);
-        VerifyBooleanParse("Fa lse", false, false);
-        VerifyBooleanParse("T", false, false);
-        VerifyBooleanParse("0", false, false);
-        VerifyBooleanParse("1", false, false);
+        Assert.Equal("True", bool.TrueString);
     }
 
     [Fact]
     public static void TestFalseString()
     {
-        // String Boolean.FalseString
-        Assert.Equal("False", Boolean.FalseString);
+        Assert.Equal("False", bool.FalseString);
     }
 
-    [Fact]
-    public static void TestEqualsObject()
-    {
-        // Boolean Boolean.Equals(Object)
-        Boolean bTrue = true;
-        Boolean bFalse = false;
-        Assert.True(bTrue.Equals(true));
-        Assert.True(bFalse.Equals(false));
-        Assert.False(bTrue.Equals(false));
-        Assert.False(bFalse.Equals(true));
+    [Theory]
+    [InlineData("True", true, true)]
+    [InlineData("true", true, true)]
+    [InlineData("TRUE", true, true)]
+    [InlineData("tRuE", true, true)]
+    [InlineData("  True  ", true, true)]
+    [InlineData("True\0", true, true)]
+    [InlineData(" \0 \0  True   \0 ", true, true)]
 
-        Assert.False(bTrue.Equals(1));
-        Assert.False(bTrue.Equals("true"));
-        Assert.False(bFalse.Equals(0));
-        Assert.False(bFalse.Equals("False"));
-        Assert.False(bTrue.Equals(null));
-        Assert.False(bFalse.Equals(null));
+    [InlineData("False", false, true)]
+    [InlineData("false", false, true)]
+    [InlineData("FALSE", false, true)]
+    [InlineData("fAlSe", false, true)]
+    [InlineData("False  ", false, true)]
+    [InlineData("False\0", false, true)]
+    [InlineData("  False \0\0\0  ", false, true)]
+    
+    [InlineData(null, default(bool), false)]
+    [InlineData("", default(bool), false)]
+    [InlineData(" ", default(bool), false)]
+    [InlineData("Garbage", default(bool), false)]
+    [InlineData("True\0Garbage", default(bool), false)]
+    [InlineData("True\0True", default(bool), false)]
+    [InlineData("True True", default(bool), false)]
+    [InlineData("True False", default(bool), false)]
+    [InlineData("False True", default(bool), false)]
+    [InlineData("Fa lse", default(bool), false)]
+    [InlineData("T", default(bool), false)]
+    [InlineData("0", default(bool), false)]
+    [InlineData("1", default(bool), false)]
+    public static void TestParse(string value, bool expectedResult, bool shouldSucceed)
+    {
+        //TryParse
+        bool result;
+        Assert.Equal(shouldSucceed, bool.TryParse(value, out result));
+        Assert.Equal(expectedResult, result);
+
+        //Parse
+        if (shouldSucceed)
+        {
+            Assert.Equal(expectedResult, bool.Parse(value));
+        }
+        else if (value == null)
+        {
+            Assert.Throws<ArgumentNullException>("value", () => bool.Parse(value));
+        }
+        else
+        {
+            Assert.Throws<FormatException>(() => bool.Parse(value));
+        }
     }
 
-    [Fact]
-    public static void TestEquals()
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(true, false, false)]
+    [InlineData(true, "1", false)]
+    [InlineData(true, "True", false)]
+    [InlineData(true, null, false)]
+    [InlineData(false, false, true)]
+    [InlineData(false, true, false)]
+    [InlineData(false, "0", false)]
+    [InlineData(false, "False", false)]
+    [InlineData(false, null, false)]
+    public static void TestEquals(bool b1, object b2, bool expected)
     {
-        // Boolean Boolean.Equals(Boolean)
-        Boolean bTrue = true;
-        Boolean bFalse = false;
-        Assert.True(bTrue.Equals(true));
-        Assert.True(bFalse.Equals(false));
-        Assert.False(bTrue.Equals(false));
-        Assert.False(bFalse.Equals(true));
-    }
-
-    [Fact]
-    public static void TestTrueString()
-    {
-        // String Boolean.TrueString
-        Assert.Equal("True", Boolean.TrueString);
+        if (b2 is bool)
+        {
+            Assert.Equal(expected, b1.Equals((bool)b2));
+        }
+        Assert.Equal(expected, b1.Equals(b2));
     }
 
     [Fact]
     public static void TestGetHashCode()
     {
-        // Int32 Boolean.GetHashCode()
         Assert.Equal(1, true.GetHashCode());
         Assert.Equal(0, false.GetHashCode());
-    }
-
-    private static void VerifyCompareToFailures(IComparable b, object o)
-    {
-        Assert.True(b is Boolean);
-        Assert.Throws<ArgumentException>(() => b.CompareTo(o));
-    }
-
-    [Fact]
-    public static void TestCompareTo()
-    {
-        // Int32 Boolean.CompareTo(Boolean)
-        Boolean bTrue = true;
-        Boolean bFalse = false;
-        Assert.True(bTrue.CompareTo(true) == 0);
-        Assert.True(bFalse.CompareTo(false) == 0);
-        Assert.False(bTrue.CompareTo(false) < 0);
-        Assert.False(bFalse.CompareTo(true) > 0);
     }
 
     [Fact]
     public static void TestToString()
     {
-        // String Boolean.ToString()
-        Boolean bTrue = true;
-        Boolean bFalse = false;
-        Assert.Equal(Boolean.TrueString, bTrue.ToString());
-        Assert.Equal(Boolean.FalseString, bFalse.ToString());
+        Assert.Equal(bool.TrueString, true.ToString());
+        Assert.Equal(bool.FalseString, false.ToString());
     }
 
-    [Fact]
-    public static void TestSystemIComparableCompareTo()
+    [Theory]
+    [InlineData(true, true, 0)]
+    [InlineData(true, false, 1)]
+    [InlineData(true, null, 1)]
+    [InlineData(false, false, 0)]
+    [InlineData(false, true, -1)]
+    [InlineData(false, null, 0)]
+    public static void TestCompareTo(bool b1, bool b2, int expected)
     {
-        // Int32 Boolean.System.IComparable.CompareTo(Object)
-        IComparable bTrue = true;
-        IComparable bFalse = false;
-        Assert.True(bTrue.CompareTo(true) == 0);
-        Assert.True(bFalse.CompareTo(false) == 0);
-        Assert.False(bTrue.CompareTo(false) < 0);
-        Assert.False(bFalse.CompareTo(true) > 0);
+        int i = CompareHelper.NormalizeCompare(b1.CompareTo(b2));
+        Assert.Equal(expected, i);
+    }
 
-        VerifyCompareToFailures(bTrue, 1);
-        VerifyCompareToFailures(bTrue, "true");
-        VerifyCompareToFailures(bFalse, 0);
-        VerifyCompareToFailures(bFalse, "false");
-        Assert.True(bTrue.CompareTo(null) > 0);
-        Assert.True(bFalse.CompareTo(null) > 0);
+    [Theory]
+    [InlineData(true, true, 0)]
+    [InlineData(true, false, 1)]
+    [InlineData(true, null, 1)]
+    [InlineData(false, false, 0)]
+    [InlineData(false, true, -1)]
+    [InlineData(false, null, 1)]
+    public static void TestIComparableCompareTo(IComparable b1, IComparable b2, int expected)
+    {
+        int i = CompareHelper.NormalizeCompare(b1.CompareTo(b2));
+        Assert.Equal(expected, i);
+    }
+
+    [Theory]
+    [InlineData(true, 1)]
+    [InlineData(true, "true")]
+    [InlineData(false, 0)]
+    [InlineData(false, "false")]
+    private static void VerifyCompareToFailures(IComparable b, object obj)
+    {
+        Assert.Throws<ArgumentException>(null, () => b.CompareTo(obj));
     }
 }

--- a/src/System.Runtime/tests/System/Buffer.MemoryCopy.cs
+++ b/src/System.Runtime/tests/System/Buffer.MemoryCopy.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+
 using Xunit;
 
 public static class BufferMemoryCopyTests

--- a/src/System.Runtime/tests/System/Buffer.cs
+++ b/src/System.Runtime/tests/System/Buffer.cs
@@ -2,10 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Runtime.InteropServices;
+
 using Xunit;
 
 public static unsafe class BufferTests
@@ -34,7 +33,7 @@ public static unsafe class BufferTests
         Assert.Equal(b2[3], 0x3c);
         Assert.Equal(b2[4], 0x5e);
 
-        Assert.Throws<ArgumentException>(() => Buffer.BlockCopy(new String[3], 0, new int[3], 0, 0));
+        Assert.Throws<ArgumentException>(() => Buffer.BlockCopy(new string[3], 0, new int[3], 0, 0));
         Assert.Throws<ArgumentException>(() => Buffer.BlockCopy(new byte[3], 3, new byte[3], 0, 1));
         Assert.Throws<ArgumentException>(() => Buffer.BlockCopy(new byte[3], 0, new byte[3], 3, 1));
         Assert.Throws<ArgumentException>(() => Buffer.BlockCopy(new byte[3], 0, new byte[3], 4, 0));
@@ -112,4 +111,3 @@ public static unsafe class BufferTests
         Assert.Equal<uint>(a[1], 0xa2abcdef);
     }
 }
-

--- a/src/System.Runtime/tests/System/Byte.cs
+++ b/src/System.Runtime/tests/System/Byte.cs
@@ -2,96 +2,101 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Runtime.Tests.Common;
+
 using Xunit;
 
 public static class ByteTests
 {
     [Fact]
-    public static void TestCtor()
+    public static void TestCtorEmpty()
     {
-        Byte i = new Byte();
-        Assert.True(i == 0);
-
-        i = 41;
-        Assert.True(i == 41);
+        byte i = new byte();
+        Assert.Equal(0, i);
+    }
+    
+    [Fact]
+    public static void TestCtorValue()
+    {
+        byte i = 41;
+        Assert.Equal(41, i);
     }
 
     [Fact]
     public static void TestMaxValue()
     {
-        Byte max = Byte.MaxValue;
-
-        Assert.True(max == (Byte)0xFF);
+        Assert.Equal(0xFF, byte.MaxValue);
     }
 
     [Fact]
     public static void TestMinValue()
     {
-        Byte min = Byte.MinValue;
+        Assert.Equal(0, byte.MinValue);
+    }
 
-        Assert.True(min == 0);
+    [Theory]
+    [InlineData((byte)234, 0)]
+    [InlineData(byte.MinValue, 1)]
+    [InlineData((byte)0, 1)]
+    [InlineData((byte)45, 1)]
+    [InlineData((byte)123, 1)]
+    [InlineData((byte)235, -1)]
+    [InlineData(byte.MaxValue, -1)]
+    public static void TestCompareTo(byte value, int expected)
+    {
+        byte i = 234;
+        int result = CompareHelper.NormalizeCompare(i.CompareTo(value));
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null, 1)]
+    [InlineData((byte)234, 0)]
+    [InlineData(byte.MinValue, 1)]
+    [InlineData((byte)0, 1)]
+    [InlineData((byte)45, 1)]
+    [InlineData((byte)123, 1)]
+    [InlineData((byte)235, -1)]
+    [InlineData(byte.MaxValue, -1)]
+    public static void TestCompareToObject(object obj, int expected)
+    {
+        IComparable comparable = (byte)234;
+        int i = CompareHelper.NormalizeCompare(comparable.CompareTo(obj));
+        Assert.Equal(expected, i);
     }
 
     [Fact]
-    public static void TestCompareToObject()
+    public static void TestCompareToObjectInvalid()
     {
-        Byte i = 234;
-        IComparable comparable = i;
-
-        Assert.Equal(1, comparable.CompareTo(null));
-        Assert.Equal(0, comparable.CompareTo((Byte)234));
-
-        Assert.True(comparable.CompareTo(Byte.MinValue) > 0);
-        Assert.True(comparable.CompareTo((Byte)0) > 0);
-        Assert.True(comparable.CompareTo((Byte)(23)) > 0);
-        Assert.True(comparable.CompareTo((Byte)123) > 0);
-        Assert.True(comparable.CompareTo((Byte)45) > 0);
-        Assert.True(comparable.CompareTo(Byte.MaxValue) < 0);
-
-        Assert.Throws<ArgumentException>(() => comparable.CompareTo("a"));
+        IComparable comparable = (byte)234;
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); //Obj is not a byte
     }
 
-    [Fact]
-    public static void TestCompareTo()
+    [Theory]
+    [InlineData((byte)78, true)]
+    [InlineData((byte)0, false)]
+    public static void TestEqualsObject(object obj, bool expected)
     {
-        Byte i = 234;
-
-        Assert.Equal(0, i.CompareTo((Byte)234));
-
-        Assert.True(i.CompareTo(Byte.MinValue) > 0);
-        Assert.True(i.CompareTo((Byte)0) > 0);
-        Assert.True(i.CompareTo((Byte)123) > 0);
-        Assert.True(i.CompareTo((Byte)45) > 0);
-        Assert.True(i.CompareTo(Byte.MaxValue) < 0);
+        byte i = 78;
+        Assert.Equal(expected, i.Equals(obj));
     }
 
-    [Fact]
-    public static void TestEqualsObject()
+    [Theory]
+    [InlineData((byte)78, true)]
+    [InlineData((byte)0, false)]
+    public static void TestEquals(byte i2, bool expected)
     {
-        Byte i = 78;
-
-        object obj1 = (Byte)78;
-        Assert.True(i.Equals(obj1));
-
-        object obj3 = (Byte)0;
-        Assert.True(!i.Equals(obj3));
-    }
-
-    [Fact]
-    public static void TestEquals()
-    {
-        Byte i = 91;
-
-        Assert.True(i.Equals((Byte)91));
-        Assert.True(!i.Equals((Byte)0));
+        byte i = 78;
+        Assert.Equal(expected, i.Equals(i2));
     }
 
     [Fact]
     public static void TestGetHashCode()
     {
-        Byte i1 = 123;
-        Byte i2 = 65;
+        byte i1 = 123;
+        byte i2 = 65;
 
         Assert.NotEqual(0, i1.GetHashCode());
         Assert.NotEqual(i1.GetHashCode(), i2.GetHashCode());
@@ -100,134 +105,170 @@ public static class ByteTests
     [Fact]
     public static void TestToString()
     {
-        Byte i1 = 63;
+        byte i1 = 63;
         Assert.Equal("63", i1.ToString());
     }
 
     [Fact]
     public static void TestToStringFormatProvider()
     {
-        var numberFormat = new System.Globalization.NumberFormatInfo();
+        var numberFormat = new NumberFormatInfo();
 
-        Byte i1 = 63;
+        byte i1 = 63;
         Assert.Equal("63", i1.ToString(numberFormat));
     }
 
     [Fact]
     public static void TestToStringFormat()
     {
-        Byte i1 = 63;
+        byte i1 = 63;
         Assert.Equal("63", i1.ToString("G"));
 
-        Byte i2 = 82;
+        byte i2 = 82;
         Assert.Equal("82", i2.ToString("g"));
 
-        Byte i3 = 246;
+        byte i3 = 246;
         Assert.Equal(string.Format("{0:N}", 246.00), i3.ToString("N"));
 
-        Byte i4 = 0x24;
+        byte i4 = 0x24;
         Assert.Equal("24", i4.ToString("x"));
     }
 
     [Fact]
     public static void TestToStringFormatFormatProvider()
     {
-        var numberFormat = new System.Globalization.NumberFormatInfo();
+        var numberFormat = new NumberFormatInfo();
 
-        Byte i1 = 63;
+        byte i1 = 63;
         Assert.Equal("63", i1.ToString("G", numberFormat));
 
-        Byte i2 = 82;
+        byte i2 = 82;
         Assert.Equal("82", i2.ToString("g", numberFormat));
 
         numberFormat.NegativeSign = "xx"; // setting it to trash to make sure it doesn't show up
         numberFormat.NumberGroupSeparator = "*";
         numberFormat.NumberNegativePattern = 0;
         numberFormat.NumberDecimalSeparator = ".";
-        Byte i3 = 24;
+        byte i3 = 24;
         Assert.Equal("24.00", i3.ToString("N", numberFormat));
     }
 
-    [Fact]
-    public static void TestParse()
+    public static IEnumerable<object[]> ParseValidData()
     {
-        Assert.Equal<Byte>(123, Byte.Parse("123"));
-        //TODO: Negative tests once we get better exceptions
+        NumberFormatInfo defaultFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+        var emptyNfi = new NumberFormatInfo();
+
+        var testNfi = new NumberFormatInfo();
+        testNfi.CurrencySymbol = "$";
+
+        yield return new object[] { "0", defaultStyle, defaultFormat, (byte)0 };
+        yield return new object[] { "123", defaultStyle, defaultFormat, (byte)123 };
+        yield return new object[] { "  123  ", defaultStyle, defaultFormat, (byte)123 };
+        yield return new object[] { "255", defaultStyle, defaultFormat, (byte)255 };
+
+        yield return new object[] { "12", NumberStyles.HexNumber, defaultFormat, (byte)0x12 };
+        yield return new object[] { "10", NumberStyles.AllowThousands, defaultFormat, (byte)10 };
+
+        yield return new object[] { "123", defaultStyle, emptyNfi, (byte)123 };
+
+        yield return new object[] { "123", NumberStyles.Any, emptyNfi, (byte)123 };
+        yield return new object[] { "12", NumberStyles.HexNumber, emptyNfi, (byte)0x12 };
+        yield return new object[] { "ab", NumberStyles.HexNumber, emptyNfi, (byte)0xab };
+        yield return new object[] { "$100", NumberStyles.Currency, testNfi, (byte)100 };
     }
 
-    [Fact]
-    public static void TestParseNumberStyle()
+    public static IEnumerable<object[]> ParseInvalidData()
     {
-        Assert.Equal<Byte>(0x12, Byte.Parse("12", NumberStyles.HexNumber));
-        Assert.Equal<Byte>(10, Byte.Parse("10", NumberStyles.AllowThousands));
-        //TODO: Negative tests once we get better exceptions
+        NumberFormatInfo defaultFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+        var emptyNfi = new NumberFormatInfo();
+
+        var testNfi = new NumberFormatInfo();
+        testNfi.CurrencySymbol = "$";
+        testNfi.NumberDecimalSeparator = ".";
+
+        yield return new object[] { null, defaultStyle, defaultFormat, typeof(ArgumentNullException) };
+        yield return new object[] { "", defaultStyle, defaultFormat, typeof(FormatException) };
+        yield return new object[] { " ", defaultStyle, defaultFormat, typeof(FormatException) };
+        yield return new object[] { "Garbage", defaultStyle, defaultFormat, typeof(FormatException) };
+
+        yield return new object[] { "ab", defaultStyle, defaultFormat, typeof(FormatException) }; // Hex value
+        yield return new object[] { "1E23", defaultStyle, defaultFormat, typeof(FormatException) }; // Exponent
+        yield return new object[] { "(123)", defaultStyle, defaultFormat, typeof(FormatException) }; // Parentheses
+        yield return new object[] { 100.ToString("C0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Currency
+        yield return new object[] { 1000.ToString("N0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Thousands
+        yield return new object[] { 67.90.ToString("F2"), defaultStyle, defaultFormat, typeof(FormatException) }; //Decimal
+
+        yield return new object[] { "ab", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Negative hex value
+        yield return new object[] { "  123  ", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Trailing and leading whitespace
+
+        yield return new object[] { "67.90", defaultStyle, testNfi, typeof(FormatException) }; // Decimal
+
+        yield return new object[] { "-1", defaultStyle, defaultFormat, typeof(OverflowException) }; // < min value
+        yield return new object[] { "256", defaultStyle, defaultFormat, typeof(OverflowException) }; // > max value
+        yield return new object[] { "(123)", NumberStyles.AllowParentheses, defaultFormat, typeof(OverflowException) }; // Parentheses = negative
     }
 
-    [Fact]
-    public static void TestParseFormatProvider()
+    [Theory, MemberData("ParseValidData")]
+    public static void TestParse(string value, NumberStyles style, NumberFormatInfo nfi, byte expected)
     {
-        var nfi = new NumberFormatInfo();
-        Assert.Equal<Byte>(123, Byte.Parse("123", nfi));
-        //TODO: Negative tests once we get better exceptions
+        byte i;
+        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        if (style == NumberStyles.Integer)
+        {
+            Assert.Equal(true, byte.TryParse(value, out i));
+            Assert.Equal(expected, i);
+
+            Assert.Equal(expected, byte.Parse(value));
+            
+            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (nfi != null)
+            {
+                Assert.Equal(expected, byte.Parse(value, nfi));
+            }
+        }
+
+        // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
+        Assert.Equal(true, byte.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
+        Assert.Equal(expected, i);
+
+        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (nfi == null)
+        {
+            Assert.Equal(expected, byte.Parse(value, style));
+        }
+        Assert.Equal(expected, byte.Parse(value, style, nfi ?? new NumberFormatInfo()));
     }
 
-    [Fact]
-    public static void TestParseNumberStyleFormatProvider()
+    [Theory, MemberData("ParseInvalidData")]
+    public static void TestParseInvalid(string value, NumberStyles style, NumberFormatInfo nfi, Type exceptionType)
     {
-        var nfi = new NumberFormatInfo();
-        Assert.Equal<Byte>(0x12, Byte.Parse("12", NumberStyles.HexNumber, nfi));
+        byte i;
+        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        if (style == NumberStyles.Integer)
+        {
+            Assert.Equal(false, byte.TryParse(value, out i));
+            Assert.Equal(default(byte), i);
+            
+            Assert.Throws(exceptionType, () => byte.Parse(value));
 
-        nfi.CurrencySymbol = "$";
-        Assert.Equal<Byte>(100, Byte.Parse("$100", NumberStyles.Currency, nfi));
-        //TODO: Negative tests once we get better exception support
-    }
+            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (nfi != null)
+            {
+                Assert.Throws(exceptionType, () => byte.Parse(value, nfi));
+            }
+        }
 
-    [Fact]
-    public static void TestTryParse()
-    {
-        // Defaults NumberStyles.Integer = NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite | NumberStyles.AllowLeadingSign
+        // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
+        Assert.Equal(false, byte.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
+        Assert.Equal(default(byte), i);
 
-        Byte i;
-        Assert.True(Byte.TryParse("123", out i));     // Simple
-        Assert.Equal<Byte>(123, i);
-
-        Assert.False(Byte.TryParse("-38", out i));    // LeadingSign negative
-
-        Assert.True(Byte.TryParse(" 67 ", out i));   // Leading/Trailing whitespace
-        Assert.Equal<Byte>(67, i);
-
-        Assert.False(Byte.TryParse((100).ToString("C0"), out i));  // Currency
-        Assert.False(Byte.TryParse((1000).ToString("N0"), out i));  // Thousands
-        Assert.False(Byte.TryParse("ab", out i));    // Hex digits
-        Assert.False(Byte.TryParse((67.90).ToString("F2"), out i)); // Decimal
-        Assert.False(Byte.TryParse("(135)", out i));  // Parentheses
-        Assert.False(Byte.TryParse("1E23", out i));   // Exponent
-    }
-
-    [Fact]
-    public static void TestTryParseNumberStyleFormatProvider()
-    {
-        Byte i;
-        var nfi = new NumberFormatInfo();
-        Assert.True(Byte.TryParse("123", NumberStyles.Any, nfi, out i));   // Simple positive
-        Assert.Equal<Byte>(123, i);
-
-        Assert.True(Byte.TryParse("12", NumberStyles.HexNumber, nfi, out i));   // Simple Hex
-        Assert.Equal<Byte>(0x12, i);
-
-        nfi.CurrencySymbol = "$";
-        Assert.True(Byte.TryParse("$100", NumberStyles.Currency, nfi, out i)); // Currency/Thousands postive
-        Assert.Equal<Byte>(100, i);
-
-        Assert.False(Byte.TryParse("ab", NumberStyles.None, nfi, out i));       // Hex Number negative
-        Assert.True(Byte.TryParse("ab", NumberStyles.HexNumber, nfi, out i));   // Hex Number positive
-        Assert.Equal<Byte>(0xab, i);
-
-        nfi.NumberDecimalSeparator = ".";
-        Assert.False(Byte.TryParse("67.90", NumberStyles.Integer, nfi, out i));  // Decimal
-        Assert.False(Byte.TryParse(" 67 ", NumberStyles.None, nfi, out i));      // Trailing/Leading whitespace negative
-
-        Assert.False(Byte.TryParse("(135)", NumberStyles.AllowParentheses, nfi, out i)); // Parenthese negative
+        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (nfi == null)
+        {
+            Assert.Throws(exceptionType, () => byte.Parse(value, style));
+        }
+        Assert.Throws(exceptionType, () => byte.Parse(value, style, nfi ?? new NumberFormatInfo()));
     }
 }
-

--- a/src/System.Runtime/tests/System/Char.cs
+++ b/src/System.Runtime/tests/System/Char.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+
 using Xunit;
+
 public static class CharTests
 {
     [Fact]
@@ -61,8 +63,8 @@ public static class CharTests
         ValidateConvertFromUtf32(0xDFFF, null);
         ValidateConvertFromUtf32(0x110000, null);
         ValidateConvertFromUtf32(-1, null);
-        ValidateConvertFromUtf32(Int32.MaxValue, null);
-        ValidateConvertFromUtf32(Int32.MinValue, null);
+        ValidateConvertFromUtf32(int.MaxValue, null);
+        ValidateConvertFromUtf32(int.MinValue, null);
     }
 
     private static void ValidateconverToUtf32<T>(string s, int i, int expected) where T : Exception
@@ -74,7 +76,7 @@ public static class CharTests
         }
         catch (T)
         {
-            Assert.True(expected == Int32.MinValue, "Expected an exception to be thrown");
+            Assert.True(expected == int.MinValue, "Expected an exception to be thrown");
         }
     }
 
@@ -98,20 +100,20 @@ public static class CharTests
         ValidateconverToUtf32<Exception>("\uD800\u0000", 1, 0);  // high, non-surrogate
         ValidateconverToUtf32<Exception>("\uDF01\u0000", 1, 0);  // low, non-surrogate
         // Invalid inputs
-        ValidateconverToUtf32<ArgumentException>("\uD800\uD800", 0, Int32.MinValue);  // high, high
-        ValidateconverToUtf32<ArgumentException>("\uD800\uD7FF", 0, Int32.MinValue);  // high, non-surrogate
-        ValidateconverToUtf32<ArgumentException>("\uD800\u0000", 0, Int32.MinValue);  // high, non-surrogate
-        ValidateconverToUtf32<ArgumentException>("\uDC01\uD940", 0, Int32.MinValue);  // low, high
-        ValidateconverToUtf32<ArgumentException>("\uDD00\uDE00", 0, Int32.MinValue);  // low, low
-        ValidateconverToUtf32<ArgumentException>("\uDF01\u0000", 0, Int32.MinValue);  // low, non-surrogate
-        ValidateconverToUtf32<ArgumentException>("\uD800\uD800", 1, Int32.MinValue);  // high, high
-        ValidateconverToUtf32<ArgumentException>("\uDC01\uD940", 1, Int32.MinValue);  // low, high
-        ValidateconverToUtf32<ArgumentException>("\uDD00\uDE00", 1, Int32.MinValue);  // low, low
-        ValidateconverToUtf32<ArgumentNullException>(null, 0, Int32.MinValue);  // null string
-        ValidateconverToUtf32<ArgumentOutOfRangeException>("", 0, Int32.MinValue);  // index out of range
-        ValidateconverToUtf32<ArgumentOutOfRangeException>("", -1, Int32.MinValue);  // index out of range
-        ValidateconverToUtf32<ArgumentOutOfRangeException>("abcde", -1, Int32.MinValue);  // index out of range
-        ValidateconverToUtf32<ArgumentOutOfRangeException>("abcde", 5, Int32.MinValue);  // index out of range
+        ValidateconverToUtf32<ArgumentException>("\uD800\uD800", 0, int.MinValue);  // high, high
+        ValidateconverToUtf32<ArgumentException>("\uD800\uD7FF", 0, int.MinValue);  // high, non-surrogate
+        ValidateconverToUtf32<ArgumentException>("\uD800\u0000", 0, int.MinValue);  // high, non-surrogate
+        ValidateconverToUtf32<ArgumentException>("\uDC01\uD940", 0, int.MinValue);  // low, high
+        ValidateconverToUtf32<ArgumentException>("\uDD00\uDE00", 0, int.MinValue);  // low, low
+        ValidateconverToUtf32<ArgumentException>("\uDF01\u0000", 0, int.MinValue);  // low, non-surrogate
+        ValidateconverToUtf32<ArgumentException>("\uD800\uD800", 1, int.MinValue);  // high, high
+        ValidateconverToUtf32<ArgumentException>("\uDC01\uD940", 1, int.MinValue);  // low, high
+        ValidateconverToUtf32<ArgumentException>("\uDD00\uDE00", 1, int.MinValue);  // low, low
+        ValidateconverToUtf32<ArgumentNullException>(null, 0, int.MinValue);  // null string
+        ValidateconverToUtf32<ArgumentOutOfRangeException>("", 0, int.MinValue);  // index out of range
+        ValidateconverToUtf32<ArgumentOutOfRangeException>("", -1, int.MinValue);  // index out of range
+        ValidateconverToUtf32<ArgumentOutOfRangeException>("abcde", -1, int.MinValue);  // index out of range
+        ValidateconverToUtf32<ArgumentOutOfRangeException>("abcde", 5, int.MinValue);  // index out of range
     }
 
     private static void ValidateconverToUtf32<T>(char c1, char c2, int expected) where T : Exception
@@ -123,7 +125,7 @@ public static class CharTests
         }
         catch (T)
         {
-            Assert.True(expected == Int32.MinValue, "Expected an exception to be thrown");
+            Assert.True(expected == int.MinValue, "Expected an exception to be thrown");
         }
     }
 
@@ -137,14 +139,14 @@ public static class CharTests
         ValidateconverToUtf32<Exception>('\uDBFF', '\uDC00', 0x10FC00);
         ValidateconverToUtf32<Exception>('\uDBFF', '\uDFFF', 0x10FFFF);
 
-        ValidateconverToUtf32<ArgumentOutOfRangeException>('\uD800', '\uD800', Int32.MinValue);  // high, high
-        ValidateconverToUtf32<ArgumentOutOfRangeException>('\uD800', '\uD7FF', Int32.MinValue);  // high, non-surrogate
-        ValidateconverToUtf32<ArgumentOutOfRangeException>('\uD800', '\u0000', Int32.MinValue);  // high, non-surrogate
-        ValidateconverToUtf32<ArgumentOutOfRangeException>('\uDC01', '\uD940', Int32.MinValue);  // low, high
-        ValidateconverToUtf32<ArgumentOutOfRangeException>('\uDD00', '\uDE00', Int32.MinValue);  // low, low
-        ValidateconverToUtf32<ArgumentOutOfRangeException>('\uDF01', '\u0000', Int32.MinValue);  // low, non-surrogate
-        ValidateconverToUtf32<ArgumentOutOfRangeException>('\u0032', '\uD7FF', Int32.MinValue);  // both non-surrogate
-        ValidateconverToUtf32<ArgumentOutOfRangeException>('\u0000', '\u0000', Int32.MinValue);  // both non-surrogate
+        ValidateconverToUtf32<ArgumentOutOfRangeException>('\uD800', '\uD800', int.MinValue);  // high, high
+        ValidateconverToUtf32<ArgumentOutOfRangeException>('\uD800', '\uD7FF', int.MinValue);  // high, non-surrogate
+        ValidateconverToUtf32<ArgumentOutOfRangeException>('\uD800', '\u0000', int.MinValue);  // high, non-surrogate
+        ValidateconverToUtf32<ArgumentOutOfRangeException>('\uDC01', '\uD940', int.MinValue);  // low, high
+        ValidateconverToUtf32<ArgumentOutOfRangeException>('\uDD00', '\uDE00', int.MinValue);  // low, low
+        ValidateconverToUtf32<ArgumentOutOfRangeException>('\uDF01', '\u0000', int.MinValue);  // low, non-surrogate
+        ValidateconverToUtf32<ArgumentOutOfRangeException>('\u0032', '\uD7FF', int.MinValue);  // both non-surrogate
+        ValidateconverToUtf32<ArgumentOutOfRangeException>('\u0000', '\u0000', int.MinValue);  // both non-surrogate
     }
 
     [Fact]

--- a/src/System.Runtime/tests/System/Collections/ObjectModel/Collection.cs
+++ b/src/System.Runtime/tests/System/Collections/ObjectModel/Collection.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+
 using Xunit;
 
 /// <summary>

--- a/src/System.Runtime/tests/System/Collections/ObjectModel/CollectionTestBase.cs
+++ b/src/System.Runtime/tests/System/Collections/ObjectModel/CollectionTestBase.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
+
 using Xunit;
 
 public class CollectionTestBase

--- a/src/System.Runtime/tests/System/Collections/ObjectModel/ReadOnlyCollection.cs
+++ b/src/System.Runtime/tests/System/Collections/ObjectModel/ReadOnlyCollection.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+
 using Xunit;
 
 /// <summary>

--- a/src/System.Runtime/tests/System/DateTime.cs
+++ b/src/System.Runtime/tests/System/DateTime.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Threading.Tasks;
+
 using Xunit;
 
 public static unsafe class DateTimeTests
@@ -188,9 +188,9 @@ public static unsafe class DateTimeTests
     public static void TestParse1()
     {
         DateTime src = DateTime.MaxValue;
-        String s = src.ToString();
+        string s = src.ToString();
         DateTime in_1 = DateTime.Parse(s);
-        String actual = in_1.ToString();
+        string actual = in_1.ToString();
         Assert.Equal(s, actual);
     }
 
@@ -198,9 +198,9 @@ public static unsafe class DateTimeTests
     public static void TestParse2()
     {
         DateTime src = DateTime.MaxValue;
-        String s = src.ToString();
+        string s = src.ToString();
         DateTime in_1 = DateTime.Parse(s, null);
-        String actual = in_1.ToString();
+        string actual = in_1.ToString();
         Assert.Equal(s, actual);
     }
 
@@ -208,9 +208,9 @@ public static unsafe class DateTimeTests
     public static void TestParse3()
     {
         DateTime src = DateTime.MaxValue;
-        String s = src.ToString();
+        string s = src.ToString();
         DateTime in_1 = DateTime.Parse(s, null, DateTimeStyles.None);
-        String actual = in_1.ToString();
+        string actual = in_1.ToString();
         Assert.Equal(s, actual);
     }
 
@@ -218,9 +218,9 @@ public static unsafe class DateTimeTests
     public static void TestParseExact3()
     {
         DateTime src = DateTime.MaxValue;
-        String s = src.ToString("g");
+        string s = src.ToString("g");
         DateTime in_1 = DateTime.ParseExact(s, "g", null);
-        String actual = in_1.ToString("g");
+        string actual = in_1.ToString("g");
         Assert.Equal(s, actual);
     }
 
@@ -228,9 +228,9 @@ public static unsafe class DateTimeTests
     public static void TestParseExact4()
     {
         DateTime src = DateTime.MaxValue;
-        String s = src.ToString("g");
+        string s = src.ToString("g");
         DateTime in_1 = DateTime.ParseExact(s, "g", null, DateTimeStyles.None);
-        String actual = in_1.ToString("g");
+        string actual = in_1.ToString("g");
         Assert.Equal(s, actual);
     }
 
@@ -238,10 +238,10 @@ public static unsafe class DateTimeTests
     public static void TestParseExact4a()
     {
         DateTime src = DateTime.MaxValue;
-        String s = src.ToString("g");
-        String[] formats = { "g" };
+        string s = src.ToString("g");
+        string[] formats = { "g" };
         DateTime in_1 = DateTime.ParseExact(s, formats, null, DateTimeStyles.None);
-        String actual = in_1.ToString("g");
+        string actual = in_1.ToString("g");
         Assert.Equal(s, actual);
     }
 
@@ -249,11 +249,11 @@ public static unsafe class DateTimeTests
     public static void TestTryParse2()
     {
         DateTime src = DateTime.MaxValue;
-        String s = src.ToString("g");
+        string s = src.ToString("g");
         DateTime in_1;
         bool b = DateTime.TryParse(s, out in_1);
         Assert.True(b);
-        String actual = in_1.ToString("g");
+        string actual = in_1.ToString("g");
         Assert.Equal(s, actual);
     }
 
@@ -261,11 +261,11 @@ public static unsafe class DateTimeTests
     public static void TestTryParse4()
     {
         DateTime src = DateTime.MaxValue;
-        String s = src.ToString("g");
+        string s = src.ToString("g");
         DateTime in_1;
         bool b = DateTime.TryParse(s, null, DateTimeStyles.None, out in_1);
         Assert.True(b);
-        String actual = in_1.ToString("g");
+        string actual = in_1.ToString("g");
         Assert.Equal(s, actual);
     }
 
@@ -273,11 +273,11 @@ public static unsafe class DateTimeTests
     public static void TestTryParseExact()
     {
         DateTime src = DateTime.MaxValue;
-        String s = src.ToString("g");
+        string s = src.ToString("g");
         DateTime in_1;
         bool b = DateTime.TryParseExact(s, "g", null, DateTimeStyles.None, out in_1);
         Assert.True(b);
-        String actual = in_1.ToString("g");
+        string actual = in_1.ToString("g");
         Assert.Equal(s, actual);
     }
 
@@ -285,12 +285,12 @@ public static unsafe class DateTimeTests
     public static void TestTryParseExactA()
     {
         DateTime src = DateTime.MaxValue;
-        String s = src.ToString("g");
-        String[] formats = { "g" };
+        string s = src.ToString("g");
+        string[] formats = { "g" };
         DateTime in_1;
         bool b = DateTime.TryParseExact(s, formats, null, DateTimeStyles.None, out in_1);
         Assert.True(b);
-        String actual = in_1.ToString("g");
+        string actual = in_1.ToString("g");
         Assert.Equal(s, actual);
     }
 
@@ -413,4 +413,3 @@ public static unsafe class DateTimeTests
         Assert.Equal(dt.Millisecond, millisecond);
     }
 }
-

--- a/src/System.Runtime/tests/System/DateTimeOffset.UnixTimeConversions.cs
+++ b/src/System.Runtime/tests/System/DateTimeOffset.UnixTimeConversions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+
 using Xunit;
 
 public static class DateTimeOffsetUnixTimeConversionTests

--- a/src/System.Runtime/tests/System/DateTimeOffset.cs
+++ b/src/System.Runtime/tests/System/DateTimeOffset.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+
 using Xunit;
 
 public class DateTimeOffsetTests
@@ -192,9 +193,9 @@ public class DateTimeOffsetTests
     public static void TestParse1()
     {
         DateTimeOffset src = DateTimeOffset.MaxValue;
-        String s = src.ToString();
+        string s = src.ToString();
         DateTimeOffset in_1 = DateTimeOffset.Parse(s);
-        String actual = in_1.ToString();
+        string actual = in_1.ToString();
         Assert.Equal(s, actual);
     }
 
@@ -202,9 +203,9 @@ public class DateTimeOffsetTests
     public static void TestParse2()
     {
         DateTimeOffset src = DateTimeOffset.MaxValue;
-        String s = src.ToString();
+        string s = src.ToString();
         DateTimeOffset in_1 = DateTimeOffset.Parse(s, null);
-        String actual = in_1.ToString();
+        string actual = in_1.ToString();
         Assert.Equal(s, actual);
     }
 
@@ -212,9 +213,9 @@ public class DateTimeOffsetTests
     public static void TestParse3()
     {
         DateTimeOffset src = DateTimeOffset.MaxValue;
-        String s = src.ToString();
+        string s = src.ToString();
         DateTimeOffset in_1 = DateTimeOffset.Parse(s, null, DateTimeStyles.None);
-        String actual = in_1.ToString();
+        string actual = in_1.ToString();
         Assert.Equal(s, actual);
     }
 
@@ -222,9 +223,9 @@ public class DateTimeOffsetTests
     public static void TestParseExact2()
     {
         DateTimeOffset src = DateTimeOffset.MaxValue;
-        String s = src.ToString("u");
+        string s = src.ToString("u");
         DateTimeOffset in_1 = DateTimeOffset.ParseExact(s, "u", null, DateTimeStyles.None);
-        String actual = in_1.ToString("u");
+        string actual = in_1.ToString("u");
         Assert.Equal(s, actual);
     }
 
@@ -232,9 +233,9 @@ public class DateTimeOffsetTests
     public static void TestParseExact3()
     {
         DateTimeOffset src = DateTimeOffset.MaxValue;
-        String s = src.ToString("g");
+        string s = src.ToString("g");
         DateTimeOffset in_1 = DateTimeOffset.ParseExact(s, "g", null, DateTimeStyles.AssumeUniversal);
-        String actual = in_1.ToString("g");
+        string actual = in_1.ToString("g");
         Assert.Equal(s, actual);
     }
 
@@ -242,9 +243,9 @@ public class DateTimeOffsetTests
     public static void TestParseExact4()
     {
         DateTimeOffset src = DateTimeOffset.MaxValue;
-        String s = src.ToString("o");
+        string s = src.ToString("o");
         DateTimeOffset in_1 = DateTimeOffset.ParseExact(s, "o", null, DateTimeStyles.None);
-        String actual = in_1.ToString("o");
+        string actual = in_1.ToString("o");
         Assert.Equal(s, actual);
     }
 
@@ -252,10 +253,10 @@ public class DateTimeOffsetTests
     public static void TestParseExact4a()
     {
         DateTimeOffset src = DateTimeOffset.MaxValue;
-        String s = src.ToString("g");
-        String[] formats = { "g" };
+        string s = src.ToString("g");
+        string[] formats = { "g" };
         DateTimeOffset in_1 = DateTimeOffset.ParseExact(s, formats, null, DateTimeStyles.AssumeUniversal);
-        String actual = in_1.ToString("g");
+        string actual = in_1.ToString("g");
         Assert.Equal(s, actual);
     }
 
@@ -263,11 +264,11 @@ public class DateTimeOffsetTests
     public static void TestTryParse1()
     {
         DateTimeOffset src = DateTimeOffset.MaxValue;
-        String s = src.ToString("u");
+        string s = src.ToString("u");
         DateTimeOffset in_1;
         bool b = DateTimeOffset.TryParse(s, out in_1);
         Assert.True(b);
-        String actual = in_1.ToString("u");
+        string actual = in_1.ToString("u");
         Assert.Equal(s, actual);
     }
 
@@ -275,11 +276,11 @@ public class DateTimeOffsetTests
     public static void TestTryParse2()
     {
         DateTimeOffset src = DateTimeOffset.MaxValue;
-        String s = src.ToString("u");
+        string s = src.ToString("u");
         DateTimeOffset in_1;
         bool b = DateTimeOffset.TryParse(s, out in_1);
         Assert.True(b);
-        String actual = in_1.ToString("u");
+        string actual = in_1.ToString("u");
         Assert.Equal(s, actual);
     }
 
@@ -287,11 +288,11 @@ public class DateTimeOffsetTests
     public static void TestTryParse4()
     {
         DateTimeOffset src = DateTimeOffset.MaxValue;
-        String s = src.ToString("u");
+        string s = src.ToString("u");
         DateTimeOffset in_1;
         bool b = DateTimeOffset.TryParse(s, null, DateTimeStyles.None, out in_1);
         Assert.True(b);
-        String actual = in_1.ToString("u");
+        string actual = in_1.ToString("u");
         Assert.Equal(s, actual);
     }
 
@@ -299,11 +300,11 @@ public class DateTimeOffsetTests
     public static void TestTryParse4a()
     {
         DateTimeOffset src = DateTimeOffset.MaxValue;
-        String s = src.ToString("g");
+        string s = src.ToString("g");
         DateTimeOffset in_1;
         bool b = DateTimeOffset.TryParse(s, null, DateTimeStyles.AssumeUniversal, out in_1);
         Assert.True(b);
-        String actual = in_1.ToString("g");
+        string actual = in_1.ToString("g");
         Assert.Equal(s, actual);
     }
 
@@ -311,11 +312,11 @@ public class DateTimeOffsetTests
     public static void TestTryParseExact()
     {
         DateTimeOffset src = DateTimeOffset.MaxValue;
-        String s = src.ToString("g");
+        string s = src.ToString("g");
         DateTimeOffset in_1;
         bool b = DateTimeOffset.TryParseExact(s, "g", null, DateTimeStyles.AssumeUniversal, out in_1);
         Assert.True(b);
-        String actual = in_1.ToString("g");
+        string actual = in_1.ToString("g");
         Assert.Equal(s, actual);
     }
 
@@ -323,12 +324,12 @@ public class DateTimeOffsetTests
     public static void TestTryParseExactA()
     {
         DateTimeOffset src = DateTimeOffset.MaxValue;
-        String s = src.ToString("g");
-        String[] formats = { "g" };
+        string s = src.ToString("g");
+        string[] formats = { "g" };
         DateTimeOffset in_1;
         bool b = DateTimeOffset.TryParseExact(s, formats, null, DateTimeStyles.AssumeUniversal, out in_1);
         Assert.True(b);
-        String actual = in_1.ToString("g");
+        string actual = in_1.ToString("g");
         Assert.Equal(s, actual);
     }
 

--- a/src/System.Runtime/tests/System/Decimal.cs
+++ b/src/System.Runtime/tests/System/Decimal.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+
 using Xunit;
 
 public static class DecimalTests
@@ -12,141 +13,141 @@ public static class DecimalTests
     public static void TestEquals()
     {
         // Boolean Decimal.Equals(Decimal)
-        Assert.True(Decimal.Zero.Equals(Decimal.Zero));
-        Assert.False(Decimal.Zero.Equals(Decimal.One));
-        Assert.True(Decimal.MaxValue.Equals(Decimal.MaxValue));
-        Assert.True(Decimal.MinValue.Equals(Decimal.MinValue));
-        Assert.False(Decimal.MaxValue.Equals(Decimal.MinValue));
-        Assert.False(Decimal.MinValue.Equals(Decimal.MaxValue));
+        Assert.True(decimal.Zero.Equals(decimal.Zero));
+        Assert.False(decimal.Zero.Equals(decimal.One));
+        Assert.True(decimal.MaxValue.Equals(decimal.MaxValue));
+        Assert.True(decimal.MinValue.Equals(decimal.MinValue));
+        Assert.False(decimal.MaxValue.Equals(decimal.MinValue));
+        Assert.False(decimal.MinValue.Equals(decimal.MaxValue));
     }
 
     [Fact]
     public static void TestEqualsDecDec()
     {
         // Boolean Decimal.Equals(Decimal, Decimal)
-        Assert.True(Decimal.Equals(Decimal.Zero, Decimal.Zero));
-        Assert.False(Decimal.Equals(Decimal.Zero, Decimal.One));
-        Assert.True(Decimal.Equals(Decimal.MaxValue, Decimal.MaxValue));
-        Assert.True(Decimal.Equals(Decimal.MinValue, Decimal.MinValue));
-        Assert.False(Decimal.Equals(Decimal.MinValue, Decimal.MaxValue));
-        Assert.False(Decimal.Equals(Decimal.MaxValue, Decimal.MinValue));
+        Assert.True(decimal.Equals(decimal.Zero, decimal.Zero));
+        Assert.False(decimal.Equals(decimal.Zero, decimal.One));
+        Assert.True(decimal.Equals(decimal.MaxValue, decimal.MaxValue));
+        Assert.True(decimal.Equals(decimal.MinValue, decimal.MinValue));
+        Assert.False(decimal.Equals(decimal.MinValue, decimal.MaxValue));
+        Assert.False(decimal.Equals(decimal.MaxValue, decimal.MinValue));
     }
 
     [Fact]
     public static void TestEqualsObj()
     {
         // Boolean Decimal.Equals(Object)
-        Assert.True(Decimal.Zero.Equals((object)Decimal.Zero));
-        Assert.False(Decimal.Zero.Equals((object)Decimal.One));
-        Assert.True(Decimal.MaxValue.Equals((object)Decimal.MaxValue));
-        Assert.True(Decimal.MinValue.Equals((object)Decimal.MinValue));
-        Assert.False(Decimal.MinValue.Equals((object)Decimal.MaxValue));
-        Assert.False(Decimal.MaxValue.Equals((object)Decimal.MinValue));
-        Assert.False(Decimal.One.Equals(null));
-        Assert.False(Decimal.One.Equals("one"));
-        Assert.False(Decimal.One.Equals((object)1));
+        Assert.True(decimal.Zero.Equals((object)decimal.Zero));
+        Assert.False(decimal.Zero.Equals((object)decimal.One));
+        Assert.True(decimal.MaxValue.Equals((object)decimal.MaxValue));
+        Assert.True(decimal.MinValue.Equals((object)decimal.MinValue));
+        Assert.False(decimal.MinValue.Equals((object)decimal.MaxValue));
+        Assert.False(decimal.MaxValue.Equals((object)decimal.MinValue));
+        Assert.False(decimal.One.Equals(null));
+        Assert.False(decimal.One.Equals("one"));
+        Assert.False(decimal.One.Equals((object)1));
     }
 
     [Fact]
     public static void Testop_Equality()
     {
         // Boolean Decimal.op_Equality(Decimal, Decimal)
-        Assert.True(Decimal.Zero == Decimal.Zero);
-        Assert.False(Decimal.Zero == Decimal.One);
-        Assert.True(Decimal.MaxValue == Decimal.MaxValue);
-        Assert.True(Decimal.MinValue == Decimal.MinValue);
-        Assert.False(Decimal.MinValue == Decimal.MaxValue);
-        Assert.False(Decimal.MaxValue == Decimal.MinValue);
+        Assert.True(decimal.Zero == decimal.Zero);
+        Assert.False(decimal.Zero == decimal.One);
+        Assert.True(decimal.MaxValue == decimal.MaxValue);
+        Assert.True(decimal.MinValue == decimal.MinValue);
+        Assert.False(decimal.MinValue == decimal.MaxValue);
+        Assert.False(decimal.MaxValue == decimal.MinValue);
     }
 
     [Fact]
     public static void Testop_GreaterThan()
     {
         // Boolean Decimal.op_GreaterThan(Decimal, Decimal)
-        Assert.False(Decimal.Zero > Decimal.Zero);
-        Assert.False(Decimal.Zero > Decimal.One);
-        Assert.True(Decimal.One > Decimal.Zero);
-        Assert.False(Decimal.MaxValue > Decimal.MaxValue);
-        Assert.False(Decimal.MinValue > Decimal.MinValue);
-        Assert.False(Decimal.MinValue > Decimal.MaxValue);
-        Assert.True(Decimal.MaxValue > Decimal.MinValue);
+        Assert.False(decimal.Zero > decimal.Zero);
+        Assert.False(decimal.Zero > decimal.One);
+        Assert.True(decimal.One > decimal.Zero);
+        Assert.False(decimal.MaxValue > decimal.MaxValue);
+        Assert.False(decimal.MinValue > decimal.MinValue);
+        Assert.False(decimal.MinValue > decimal.MaxValue);
+        Assert.True(decimal.MaxValue > decimal.MinValue);
     }
 
     [Fact]
     public static void Testop_GreaterThanOrEqual()
     {
         // Boolean Decimal.op_GreaterThanOrEqual(Decimal, Decimal)
-        Assert.True(Decimal.Zero >= Decimal.Zero);
-        Assert.False(Decimal.Zero >= Decimal.One);
-        Assert.True(Decimal.One >= Decimal.Zero);
-        Assert.True(Decimal.MaxValue >= Decimal.MaxValue);
-        Assert.True(Decimal.MinValue >= Decimal.MinValue);
-        Assert.False(Decimal.MinValue >= Decimal.MaxValue);
-        Assert.True(Decimal.MaxValue >= Decimal.MinValue);
+        Assert.True(decimal.Zero >= decimal.Zero);
+        Assert.False(decimal.Zero >= decimal.One);
+        Assert.True(decimal.One >= decimal.Zero);
+        Assert.True(decimal.MaxValue >= decimal.MaxValue);
+        Assert.True(decimal.MinValue >= decimal.MinValue);
+        Assert.False(decimal.MinValue >= decimal.MaxValue);
+        Assert.True(decimal.MaxValue >= decimal.MinValue);
     }
 
     [Fact]
     public static void Testop_Inequality()
     {
         // Boolean Decimal.op_Inequality(Decimal, Decimal)
-        Assert.False(Decimal.Zero != Decimal.Zero);
-        Assert.True(Decimal.Zero != Decimal.One);
-        Assert.True(Decimal.One != Decimal.Zero);
-        Assert.False(Decimal.MaxValue != Decimal.MaxValue);
-        Assert.False(Decimal.MinValue != Decimal.MinValue);
-        Assert.True(Decimal.MinValue != Decimal.MaxValue);
-        Assert.True(Decimal.MaxValue != Decimal.MinValue);
+        Assert.False(decimal.Zero != decimal.Zero);
+        Assert.True(decimal.Zero != decimal.One);
+        Assert.True(decimal.One != decimal.Zero);
+        Assert.False(decimal.MaxValue != decimal.MaxValue);
+        Assert.False(decimal.MinValue != decimal.MinValue);
+        Assert.True(decimal.MinValue != decimal.MaxValue);
+        Assert.True(decimal.MaxValue != decimal.MinValue);
     }
 
     [Fact]
     public static void Testop_LessThan()
     {
         // Boolean Decimal.op_LessThan(Decimal, Decimal)
-        Assert.False(Decimal.Zero < Decimal.Zero);
-        Assert.True(Decimal.Zero < Decimal.One);
-        Assert.False(Decimal.One < Decimal.Zero);
+        Assert.False(decimal.Zero < decimal.Zero);
+        Assert.True(decimal.Zero < decimal.One);
+        Assert.False(decimal.One < decimal.Zero);
         Assert.True(5m < 15m);
         decimal d5 = 5;
         decimal d3 = 3;
         Assert.False(d5 < d3);
-        Assert.False(Decimal.MaxValue < Decimal.MaxValue);
-        Assert.False(Decimal.MinValue < Decimal.MinValue);
-        Assert.True(Decimal.MinValue < Decimal.MaxValue);
-        Assert.False(Decimal.MaxValue < Decimal.MinValue);
+        Assert.False(decimal.MaxValue < decimal.MaxValue);
+        Assert.False(decimal.MinValue < decimal.MinValue);
+        Assert.True(decimal.MinValue < decimal.MaxValue);
+        Assert.False(decimal.MaxValue < decimal.MinValue);
     }
 
     [Fact]
     public static void Testop_LessThanOrEqual()
     {
         // Boolean Decimal.op_LessThanOrEqual(Decimal, Decimal)
-        Assert.True(Decimal.Zero <= Decimal.Zero);
-        Assert.True(Decimal.Zero <= Decimal.One);
-        Assert.False(Decimal.One <= Decimal.Zero);
-        Assert.True(Decimal.MaxValue <= Decimal.MaxValue);
-        Assert.True(Decimal.MinValue <= Decimal.MinValue);
-        Assert.True(Decimal.MinValue <= Decimal.MaxValue);
-        Assert.False(Decimal.MaxValue <= Decimal.MinValue);
+        Assert.True(decimal.Zero <= decimal.Zero);
+        Assert.True(decimal.Zero <= decimal.One);
+        Assert.False(decimal.One <= decimal.Zero);
+        Assert.True(decimal.MaxValue <= decimal.MaxValue);
+        Assert.True(decimal.MinValue <= decimal.MinValue);
+        Assert.True(decimal.MinValue <= decimal.MaxValue);
+        Assert.False(decimal.MaxValue <= decimal.MinValue);
     }
 
     [Fact]
     public static void TestToByte()
     {
         // Byte Decimal.ToByte(Decimal)
-        Assert.Equal(0, Decimal.ToByte(0));
-        Assert.Equal(1, Decimal.ToByte(1));
-        Assert.Equal(255, Decimal.ToByte(255));
+        Assert.Equal(0, decimal.ToByte(0));
+        Assert.Equal(1, decimal.ToByte(1));
+        Assert.Equal(255, decimal.ToByte(255));
 
-        Assert.Throws<OverflowException>(() => Decimal.ToByte(256));
+        Assert.Throws<OverflowException>(() => decimal.ToByte(256));
     }
 
-    private static void VerifyAdd<T>(Decimal d1, Decimal d2, Decimal expected = Decimal.Zero) where T : Exception
+    private static void VerifyAdd<T>(decimal d1, decimal d2, decimal expected = decimal.Zero) where T : Exception
     {
         bool expectFailure = typeof(T) != typeof(Exception);
 
         try
         {
-            Decimal result1 = Decimal.Add(d1, d2);
-            Decimal result2 = d1 + d2;
+            decimal result1 = decimal.Add(d1, d2);
+            decimal result2 = d1 + d2;
 
             Assert.False(expectFailure, "Expected an exception to be thrown");
             Assert.Equal(result1, result2);
@@ -165,11 +166,11 @@ public static class DecimalTests
         VerifyAdd<Exception>(1, 1, 2);
         VerifyAdd<Exception>(-1, 1, 0);
         VerifyAdd<Exception>(1, -1, 0);
-        VerifyAdd<Exception>(Decimal.MaxValue, Decimal.Zero, Decimal.MaxValue);
-        VerifyAdd<Exception>(Decimal.MinValue, Decimal.Zero, Decimal.MinValue);
-        VerifyAdd<Exception>(79228162514264337593543950330m, 5, Decimal.MaxValue);
+        VerifyAdd<Exception>(decimal.MaxValue, decimal.Zero, decimal.MaxValue);
+        VerifyAdd<Exception>(decimal.MinValue, decimal.Zero, decimal.MinValue);
+        VerifyAdd<Exception>(79228162514264337593543950330m, 5, decimal.MaxValue);
         VerifyAdd<Exception>(79228162514264337593543950330m, -5, 79228162514264337593543950325m);
-        VerifyAdd<Exception>(-79228162514264337593543950330m, -5, Decimal.MinValue);
+        VerifyAdd<Exception>(-79228162514264337593543950330m, -5, decimal.MinValue);
         VerifyAdd<Exception>(-79228162514264337593543950330m, 5, -79228162514264337593543950325m);
         VerifyAdd<Exception>(1234.5678m, 0.00009m, 1234.56789m);
         VerifyAdd<Exception>(-1234.5678m, 0.00009m, -1234.56771m);
@@ -181,30 +182,30 @@ public static class DecimalTests
                              1.1111111111111111111111111110m);
 
         // Exceptions
-        VerifyAdd<OverflowException>(Decimal.MaxValue, Decimal.MaxValue);
+        VerifyAdd<OverflowException>(decimal.MaxValue, decimal.MaxValue);
         VerifyAdd<OverflowException>(79228162514264337593543950330m, 6);
-        VerifyAdd<OverflowException>(-79228162514264337593543950330m, -6, Decimal.MinValue);
+        VerifyAdd<OverflowException>(-79228162514264337593543950330m, -6, decimal.MinValue);
     }
 
     [Fact]
     public static void TestCeiling()
     {
         // Decimal Decimal.Ceiling(Decimal)
-        Assert.Equal<Decimal>(123, Decimal.Ceiling((Decimal)123));
-        Assert.Equal<Decimal>(124, Decimal.Ceiling((Decimal)123.123));
-        Assert.Equal<Decimal>(-123, Decimal.Ceiling((Decimal)(-123.123)));
-        Assert.Equal<Decimal>(124, Decimal.Ceiling((Decimal)123.567));
-        Assert.Equal<Decimal>(-123, Decimal.Ceiling((Decimal)(-123.567)));
+        Assert.Equal<Decimal>(123, decimal.Ceiling((decimal)123));
+        Assert.Equal<Decimal>(124, decimal.Ceiling((decimal)123.123));
+        Assert.Equal<Decimal>(-123, decimal.Ceiling((decimal)(-123.123)));
+        Assert.Equal<Decimal>(124, decimal.Ceiling((decimal)123.567));
+        Assert.Equal<Decimal>(-123, decimal.Ceiling((decimal)(-123.567)));
     }
 
-    private static void VerifyDivide<T>(Decimal d1, Decimal d2, Decimal expected = Decimal.Zero) where T : Exception
+    private static void VerifyDivide<T>(decimal d1, decimal d2, decimal expected = decimal.Zero) where T : Exception
     {
         bool expectFailure = typeof(T) != typeof(Exception);
 
         try
         {
-            Decimal result1 = Decimal.Divide(d1, d2);
-            Decimal result2 = d1 / d2;
+            decimal result1 = decimal.Divide(d1, d2);
+            decimal result2 = d1 / d2;
 
             Assert.False(expectFailure, "Expected an exception to be thrown");
             Assert.Equal(result1, result2);
@@ -222,11 +223,11 @@ public static class DecimalTests
         // Decimal Decimal.op_Division(Decimal, Decimal)
 
         // Vanilla cases
-        VerifyDivide<Exception>(Decimal.One, Decimal.One, Decimal.One);
-        VerifyDivide<Exception>(Decimal.MaxValue, Decimal.MinValue, Decimal.MinusOne);
-        VerifyDivide<Exception>(0.9214206543486529434634231456m, Decimal.MaxValue, Decimal.Zero);
+        VerifyDivide<Exception>(decimal.One, decimal.One, decimal.One);
+        VerifyDivide<Exception>(decimal.MaxValue, decimal.MinValue, decimal.MinusOne);
+        VerifyDivide<Exception>(0.9214206543486529434634231456m, decimal.MaxValue, decimal.Zero);
         VerifyDivide<Exception>(38214206543486529434634231456m, 0.49214206543486529434634231456m, 77648730371625094566866001277m);
-        VerifyDivide<Exception>(-78228162514264337593543950335m, Decimal.MaxValue, -0.987378225516463811113412343m);
+        VerifyDivide<Exception>(-78228162514264337593543950335m, decimal.MaxValue, -0.987378225516463811113412343m);
         VerifyDivide<Exception>(5m + 10m, 2m, 7.5m);
         VerifyDivide<Exception>(10m, 2m, 5m);
 
@@ -273,12 +274,12 @@ public static class DecimalTests
         VerifyDivide<Exception>(7922816251426433759354395033.5m, 1.0000000000000000000000000002m, 7922816251426433759354395031.9m);
         VerifyDivide<Exception>(7922816251426433759354395033.5m, 0.9999999999999999999999999999m, 7922816251426433759354395034m);
         VerifyDivide<Exception>(79228162514264337593543950335m, 1.0000000000000000000000000001m, 79228162514264337593543950327m);
-        Decimal boundary7 = new Decimal((int)429u, (int)2133437386u, 0, false, 0);
-        Decimal boundary71 = new Decimal((int)429u, (int)2133437387u, 0, false, 0);
-        Decimal maxValueBy7 = Decimal.MaxValue * 0.0000001m;
+        decimal boundary7 = new decimal((int)429u, (int)2133437386u, 0, false, 0);
+        decimal boundary71 = new decimal((int)429u, (int)2133437387u, 0, false, 0);
+        decimal maxValueBy7 = decimal.MaxValue * 0.0000001m;
         VerifyDivide<Exception>(maxValueBy7, 1m, maxValueBy7);
         VerifyDivide<Exception>(maxValueBy7, 1m, maxValueBy7);
-        VerifyDivide<Exception>(maxValueBy7, 0.0000001m, Decimal.MaxValue);
+        VerifyDivide<Exception>(maxValueBy7, 0.0000001m, decimal.MaxValue);
         VerifyDivide<Exception>(boundary7, 1m, boundary7);
         VerifyDivide<Exception>(boundary7, 0.000000100000000000000000001m, 91630438009337286849083695.62m);
         VerifyDivide<Exception>(boundary71, 0.000000100000000000000000001m, 91630438052286959809083695.62m);
@@ -286,9 +287,9 @@ public static class DecimalTests
         VerifyDivide<Exception>(7922816251426433759354.3950335m, 0.0000001m, 79228162514264337593543950335m);
 
         //[] DivideByZero exceptions
-        VerifyDivide<DivideByZeroException>(Decimal.One, Decimal.Zero);
-        VerifyDivide<DivideByZeroException>(Decimal.Zero, Decimal.Zero);
-        VerifyDivide<DivideByZeroException>(-5.00m, (-1m) * Decimal.Zero);
+        VerifyDivide<DivideByZeroException>(decimal.One, decimal.Zero);
+        VerifyDivide<DivideByZeroException>(decimal.Zero, decimal.Zero);
+        VerifyDivide<DivideByZeroException>(-5.00m, (-1m) * decimal.Zero);
         VerifyDivide<DivideByZeroException>(0.0m, -0.00m);
 
         //[] Overflow exceptions
@@ -326,63 +327,63 @@ public static class DecimalTests
         VerifyDivide<OverflowException>(79228162514264337593543950335m, 0.9999999999999999999999999999m);
         VerifyDivide<OverflowException>(79228162514264337593543950335m, -0.1m);
         VerifyDivide<OverflowException>(79228162514264337593543950335m, -0.9999999999999999999999999m);
-        VerifyDivide<OverflowException>(Decimal.MaxValue / 2, 0.5m);
+        VerifyDivide<OverflowException>(decimal.MaxValue / 2, 0.5m);
     }
 
     [Fact]
     public static void TestFloor()
     {
         // Decimal Decimal.Floor(Decimal)
-        Assert.Equal<Decimal>(123, Decimal.Floor((Decimal)123));
-        Assert.Equal<Decimal>(123, Decimal.Floor((Decimal)123.123));
-        Assert.Equal<Decimal>(-124, Decimal.Floor((Decimal)(-123.123)));
-        Assert.Equal<Decimal>(123, Decimal.Floor((Decimal)123.567));
-        Assert.Equal<Decimal>(-124, Decimal.Floor((Decimal)(-123.567)));
+        Assert.Equal<Decimal>(123, decimal.Floor((decimal)123));
+        Assert.Equal<Decimal>(123, decimal.Floor((decimal)123.123));
+        Assert.Equal<Decimal>(-124, decimal.Floor((decimal)(-123.123)));
+        Assert.Equal<Decimal>(123, decimal.Floor((decimal)123.567));
+        Assert.Equal<Decimal>(-124, decimal.Floor((decimal)(-123.567)));
     }
 
     [Fact]
     public static void TestMaxValue()
     {
         // Decimal Decimal.MaxValue
-        Assert.Equal(Decimal.MaxValue, 79228162514264337593543950335m);
+        Assert.Equal(decimal.MaxValue, 79228162514264337593543950335m);
     }
 
     [Fact]
     public static void TestMinusOne()
     {
         // Decimal Decimal.MinusOne
-        Assert.Equal(Decimal.MinusOne, -1);
+        Assert.Equal(decimal.MinusOne, -1);
     }
 
     [Fact]
     public static void TestZero()
     {
         // Decimal Decimal.Zero
-        Assert.Equal(Decimal.Zero, 0);
+        Assert.Equal(decimal.Zero, 0);
     }
 
     [Fact]
     public static void TestOne()
     {
         // Decimal Decimal.One
-        Assert.Equal(Decimal.One, 1);
+        Assert.Equal(decimal.One, 1);
     }
 
     [Fact]
     public static void TestMinValue()
     {
         // Decimal Decimal.MinValue
-        Assert.Equal(Decimal.MinValue, -79228162514264337593543950335m);
+        Assert.Equal(decimal.MinValue, -79228162514264337593543950335m);
     }
 
-    private static void VerifyMultiply<T>(Decimal d1, Decimal d2, Decimal expected = Decimal.Zero) where T : Exception
+    private static void VerifyMultiply<T>(decimal d1, decimal d2, decimal expected = decimal.Zero) where T : Exception
     {
         bool expectFailure = typeof(T) != typeof(Exception);
 
         try
         {
-            Decimal result1 = Decimal.Multiply(d1, d2);
-            Decimal result2 = d1 * d2;
+            decimal result1 = decimal.Multiply(d1, d2);
+            decimal result2 = d1 * d2;
 
             Assert.False(expectFailure, "Expected an exception to be thrown");
             Assert.Equal(result1, result2);
@@ -400,8 +401,8 @@ public static class DecimalTests
         // Decimal Decimal.Multiply(Decimal, Decimal)
         // Decimal Decimal.op_Multiply(Decimal, Decimal)
 
-        VerifyMultiply<Exception>(Decimal.One, Decimal.One, Decimal.One);
-        VerifyMultiply<Exception>(7922816251426433759354395033.5m, new Decimal(10), Decimal.MaxValue);
+        VerifyMultiply<Exception>(decimal.One, decimal.One, decimal.One);
+        VerifyMultiply<Exception>(7922816251426433759354395033.5m, new decimal(10), decimal.MaxValue);
         VerifyMultiply<Exception>(0.2352523523423422342354395033m, 56033525474612414574574757495m, 13182018677937129120135020796m);
         VerifyMultiply<Exception>(46161363632634613634.093453337m, 461613636.32634613634083453337m, 21308714924243214928823669051m);
         VerifyMultiply<Exception>(0.0000000000000345435353453563m, .0000000000000023525235234234m, 0.0000000000000000000000000001m);
@@ -415,8 +416,8 @@ public static class DecimalTests
         VerifyMultiply<Exception>(-79228162514264337593543950335m, 0.9999999999999999999999999999m, -79228162514264337593543950327m);
 
         // Exceptions
-        VerifyMultiply<OverflowException>(Decimal.MaxValue, Decimal.MinValue);
-        VerifyMultiply<OverflowException>(Decimal.MinValue, 1.1m);
+        VerifyMultiply<OverflowException>(decimal.MaxValue, decimal.MinValue);
+        VerifyMultiply<OverflowException>(decimal.MinValue, 1.1m);
         VerifyMultiply<OverflowException>(79228162514264337593543950335m, 1.1m);
         VerifyMultiply<OverflowException>(79228162514264337593543950335m, 1.01m);
         VerifyMultiply<OverflowException>(79228162514264337593543950335m, 1.001m);
@@ -444,23 +445,23 @@ public static class DecimalTests
         VerifyMultiply<OverflowException>(79228162514264337593543950335m, 1.0000000000000000000000001m);
         VerifyMultiply<OverflowException>(79228162514264337593543950335m, 1.00000000000000000000000001m);
         VerifyMultiply<OverflowException>(79228162514264337593543950335m, 1.000000000000000000000000001m);
-        VerifyMultiply<OverflowException>(Decimal.MaxValue / 2, 2m);
+        VerifyMultiply<OverflowException>(decimal.MaxValue / 2, 2m);
     }
 
     [Fact]
     public static void TestNegate()
     {
         // Decimal Decimal.Negate(Decimal)
-        Assert.Equal(0, Decimal.Negate(0));
-        Assert.Equal(1, Decimal.Negate(-1));
-        Assert.Equal(-1, Decimal.Negate(1));
+        Assert.Equal(0, decimal.Negate(0));
+        Assert.Equal(1, decimal.Negate(-1));
+        Assert.Equal(-1, decimal.Negate(1));
     }
 
     [Fact]
     public static void Testop_Decrement()
     {
         // Decimal Decimal.op_Decrement(Decimal)
-        Decimal d = 12345;
+        decimal d = 12345;
         Assert.Equal(12344, --d);
         d = 12345.678m;
         Assert.Equal(12344.678m, --d);
@@ -474,7 +475,7 @@ public static class DecimalTests
     public static void Testop_Increment()
     {
         // Decimal Decimal.op_Increment(Decimal)
-        Decimal d = 12345;
+        decimal d = 12345;
         Assert.Equal(12346, ++d);
         d = 12345.678m;
         Assert.Equal(12346.678m, ++d);
@@ -488,30 +489,30 @@ public static class DecimalTests
     public static void TestParse()
     {
         // Boolean Decimal.TryParse(String, NumberStyles, IFormatProvider, Decimal)
-        Assert.Equal(123, Decimal.Parse("123"));
-        Assert.Equal(-123, Decimal.Parse("-123"));
-        Assert.Equal(123.123m, Decimal.Parse((123.123).ToString()));
-        Assert.Equal(-123.123m, Decimal.Parse((-123.123).ToString()));
+        Assert.Equal(123, decimal.Parse("123"));
+        Assert.Equal(-123, decimal.Parse("-123"));
+        Assert.Equal(123.123m, decimal.Parse((123.123).ToString()));
+        Assert.Equal(-123.123m, decimal.Parse((-123.123).ToString()));
 
-        Decimal d;
-        Assert.True(Decimal.TryParse("79228162514264337593543950335", out d));
-        Assert.Equal(Decimal.MaxValue, d);
+        decimal d;
+        Assert.True(decimal.TryParse("79228162514264337593543950335", out d));
+        Assert.Equal(decimal.MaxValue, d);
 
-        Assert.True(Decimal.TryParse("-79228162514264337593543950335", out d));
-        Assert.Equal(Decimal.MinValue, d);
+        Assert.True(decimal.TryParse("-79228162514264337593543950335", out d));
+        Assert.Equal(decimal.MinValue, d);
 
         var nfi = new NumberFormatInfo() { NumberGroupSeparator = "," };
-        Assert.True(Decimal.TryParse("79,228,162,514,264,337,593,543,950,335", NumberStyles.AllowThousands, nfi, out d));
-        Assert.Equal(Decimal.MaxValue, d);
+        Assert.True(decimal.TryParse("79,228,162,514,264,337,593,543,950,335", NumberStyles.AllowThousands, nfi, out d));
+        Assert.Equal(decimal.MaxValue, d);
 
-        Assert.False(Decimal.TryParse("ysaidufljasdf", out d));
-        Assert.False(Decimal.TryParse("79228162514264337593543950336", out d));
+        Assert.False(decimal.TryParse("ysaidufljasdf", out d));
+        Assert.False(decimal.TryParse("79228162514264337593543950336", out d));
     }
 
-    private static void VerifyRemainder(Decimal d1, Decimal d2, Decimal expectedResult)
+    private static void VerifyRemainder(decimal d1, decimal d2, decimal expectedResult)
     {
-        Decimal result1 = Decimal.Remainder(d1, d2);
-        Decimal result2 = d1 % d2;
+        decimal result1 = decimal.Remainder(d1, d2);
+        decimal result2 = d1 % d2;
 
         Assert.Equal(result1, result2);
         Assert.Equal(expectedResult, result1);
@@ -522,7 +523,7 @@ public static class DecimalTests
     {
         // Decimal Decimal.Remainder(Decimal, Decimal)
         // Decimal Decimal.op_Modulus(Decimal, Decimal)
-        Decimal NegativeZero = new Decimal(0, 0, 0, true, 0);
+        decimal NegativeZero = new decimal(0, 0, 0, true, 0);
         VerifyRemainder(5m, 3m, 2m);
         VerifyRemainder(5m, -3m, 2m);
         VerifyRemainder(-5m, 3m, -2m);
@@ -543,25 +544,25 @@ public static class DecimalTests
         VerifyRemainder(NegativeZero, 2.2m, NegativeZero);
 
         // [] Max/Min
-        VerifyRemainder(Decimal.MaxValue, Decimal.MaxValue, 0m);
-        VerifyRemainder(Decimal.MaxValue, Decimal.MinValue, 0m);
-        VerifyRemainder(Decimal.MaxValue, 1, 0m);
-        VerifyRemainder(Decimal.MaxValue, 2394713m, 1494647m);
-        VerifyRemainder(Decimal.MaxValue, -32768m, 32767m);
-        VerifyRemainder(-0.00m, Decimal.MaxValue, -0.00m);
-        VerifyRemainder(1.23984m, Decimal.MaxValue, 1.23984m);
-        VerifyRemainder(2398412.12983m, Decimal.MaxValue, 2398412.12983m);
-        VerifyRemainder(-0.12938m, Decimal.MaxValue, -0.12938m);
+        VerifyRemainder(decimal.MaxValue, decimal.MaxValue, 0m);
+        VerifyRemainder(decimal.MaxValue, decimal.MinValue, 0m);
+        VerifyRemainder(decimal.MaxValue, 1, 0m);
+        VerifyRemainder(decimal.MaxValue, 2394713m, 1494647m);
+        VerifyRemainder(decimal.MaxValue, -32768m, 32767m);
+        VerifyRemainder(-0.00m, decimal.MaxValue, -0.00m);
+        VerifyRemainder(1.23984m, decimal.MaxValue, 1.23984m);
+        VerifyRemainder(2398412.12983m, decimal.MaxValue, 2398412.12983m);
+        VerifyRemainder(-0.12938m, decimal.MaxValue, -0.12938m);
 
-        VerifyRemainder(Decimal.MinValue, Decimal.MinValue, NegativeZero);
-        VerifyRemainder(Decimal.MinValue, Decimal.MaxValue, NegativeZero);
-        VerifyRemainder(Decimal.MinValue, 1, NegativeZero);
-        VerifyRemainder(Decimal.MinValue, 2394713m, -1494647m);
-        VerifyRemainder(Decimal.MinValue, -32768m, -32767m); // ASURT #90921
-        VerifyRemainder(0.0m, Decimal.MinValue, 0.0m);
-        VerifyRemainder(1.23984m, Decimal.MinValue, 1.23984m);
-        VerifyRemainder(2398412.12983m, Decimal.MinValue, 2398412.12983m);
-        VerifyRemainder(-0.12938m, Decimal.MinValue, -0.12938m);
+        VerifyRemainder(decimal.MinValue, decimal.MinValue, NegativeZero);
+        VerifyRemainder(decimal.MinValue, decimal.MaxValue, NegativeZero);
+        VerifyRemainder(decimal.MinValue, 1, NegativeZero);
+        VerifyRemainder(decimal.MinValue, 2394713m, -1494647m);
+        VerifyRemainder(decimal.MinValue, -32768m, -32767m); // ASURT #90921
+        VerifyRemainder(0.0m, decimal.MinValue, 0.0m);
+        VerifyRemainder(1.23984m, decimal.MinValue, 1.23984m);
+        VerifyRemainder(2398412.12983m, decimal.MinValue, 2398412.12983m);
+        VerifyRemainder(-0.12938m, decimal.MinValue, -0.12938m);
 
         VerifyRemainder(57675350989891243676868034225m, 7m, 5m); // VSWhidbey #325142
         VerifyRemainder(-57675350989891243676868034225m, 7m, -5m);
@@ -579,14 +580,14 @@ public static class DecimalTests
         VerifyRemainder(79228162514264337567774146559m, 10m, 9m);
     }
 
-    private static void VerifySubtract<T>(Decimal d1, Decimal d2, Decimal expected = Decimal.Zero) where T : Exception
+    private static void VerifySubtract<T>(decimal d1, decimal d2, decimal expected = decimal.Zero) where T : Exception
     {
         bool expectFailure = typeof(T) != typeof(Exception);
 
         try
         {
-            Decimal result1 = Decimal.Subtract(d1, d2);
-            Decimal result2 = d1 - d2;
+            decimal result1 = decimal.Subtract(d1, d2);
+            decimal result2 = d1 - d2;
 
             Assert.False(expectFailure, "Expected an exception to be thrown");
             Assert.Equal(result1, result2);
@@ -607,11 +608,11 @@ public static class DecimalTests
         VerifySubtract<Exception>(1, 1, 0);
         VerifySubtract<Exception>(-1, 1, -2);
         VerifySubtract<Exception>(1, -1, 2);
-        VerifySubtract<Exception>(Decimal.MaxValue, Decimal.Zero, Decimal.MaxValue);
-        VerifySubtract<Exception>(Decimal.MinValue, Decimal.Zero, Decimal.MinValue);
-        VerifySubtract<Exception>(79228162514264337593543950330m, -5, Decimal.MaxValue);
+        VerifySubtract<Exception>(decimal.MaxValue, decimal.Zero, decimal.MaxValue);
+        VerifySubtract<Exception>(decimal.MinValue, decimal.Zero, decimal.MinValue);
+        VerifySubtract<Exception>(79228162514264337593543950330m, -5, decimal.MaxValue);
         VerifySubtract<Exception>(79228162514264337593543950330m, 5, 79228162514264337593543950325m);
-        VerifySubtract<Exception>(-79228162514264337593543950330m, 5, Decimal.MinValue);
+        VerifySubtract<Exception>(-79228162514264337593543950330m, 5, decimal.MinValue);
         VerifySubtract<Exception>(-79228162514264337593543950330m, -5, -79228162514264337593543950325m);
         VerifySubtract<Exception>(1234.5678m, 0.00009m, 1234.56771m);
         VerifySubtract<Exception>(-1234.5678m, 0.00009m, -1234.56789m);
@@ -628,11 +629,11 @@ public static class DecimalTests
     public static void TestTruncate()
     {
         // Decimal Decimal.Truncate(Decimal)
-        Assert.Equal<Decimal>(123, Decimal.Truncate((Decimal)123));
-        Assert.Equal<Decimal>(123, Decimal.Truncate((Decimal)123.123));
-        Assert.Equal<Decimal>(-123, Decimal.Truncate((Decimal)(-123.123)));
-        Assert.Equal<Decimal>(123, Decimal.Truncate((Decimal)123.567));
-        Assert.Equal<Decimal>(-123, Decimal.Truncate((Decimal)(-123.567)));
+        Assert.Equal<Decimal>(123, decimal.Truncate((decimal)123));
+        Assert.Equal<Decimal>(123, decimal.Truncate((decimal)123.123));
+        Assert.Equal<Decimal>(-123, decimal.Truncate((decimal)(-123.123)));
+        Assert.Equal<Decimal>(123, decimal.Truncate((decimal)123.567));
+        Assert.Equal<Decimal>(-123, decimal.Truncate((decimal)(-123.567)));
     }
 
     [Fact]
@@ -650,26 +651,26 @@ public static class DecimalTests
     public static void TestCompare()
     {
         // Int32 Decimal.Compare(Decimal, Decimal)
-        Assert.True(Decimal.Compare(Decimal.Zero, Decimal.Zero) == 0);
-        Assert.True(Decimal.Compare(Decimal.Zero, Decimal.One) < 0);
-        Assert.True(Decimal.Compare(Decimal.One, Decimal.Zero) > 0);
-        Assert.True(Decimal.Compare(Decimal.MinusOne, Decimal.Zero) < 0);
-        Assert.True(Decimal.Compare(Decimal.Zero, Decimal.MinusOne) > 0);
-        Assert.True(Decimal.Compare(5, 3) > 0);
-        Assert.True(Decimal.Compare(5, 5) == 0);
-        Assert.True(Decimal.Compare(5, 9) < 0);
-        Assert.True(Decimal.Compare(-123.123m, 123.123m) < 0);
-        Assert.True(Decimal.Compare(Decimal.MaxValue, Decimal.MaxValue) == 0);
-        Assert.True(Decimal.Compare(Decimal.MinValue, Decimal.MinValue) == 0);
-        Assert.True(Decimal.Compare(Decimal.MinValue, Decimal.MaxValue) < 0);
-        Assert.True(Decimal.Compare(Decimal.MaxValue, Decimal.MinValue) > 0);
+        Assert.True(decimal.Compare(decimal.Zero, decimal.Zero) == 0);
+        Assert.True(decimal.Compare(decimal.Zero, decimal.One) < 0);
+        Assert.True(decimal.Compare(decimal.One, decimal.Zero) > 0);
+        Assert.True(decimal.Compare(decimal.MinusOne, decimal.Zero) < 0);
+        Assert.True(decimal.Compare(decimal.Zero, decimal.MinusOne) > 0);
+        Assert.True(decimal.Compare(5, 3) > 0);
+        Assert.True(decimal.Compare(5, 5) == 0);
+        Assert.True(decimal.Compare(5, 9) < 0);
+        Assert.True(decimal.Compare(-123.123m, 123.123m) < 0);
+        Assert.True(decimal.Compare(decimal.MaxValue, decimal.MaxValue) == 0);
+        Assert.True(decimal.Compare(decimal.MinValue, decimal.MinValue) == 0);
+        Assert.True(decimal.Compare(decimal.MinValue, decimal.MaxValue) < 0);
+        Assert.True(decimal.Compare(decimal.MaxValue, decimal.MinValue) > 0);
     }
 
     [Fact]
     public static void TestCompareTo()
     {
         // Int32 Decimal.CompareTo(Decimal)
-        Decimal d = 456;
+        decimal d = 456;
         Assert.True(d.CompareTo(456m) == 0);
         Assert.True(d.CompareTo(457m) < 0);
         Assert.True(d.CompareTo(455m) > 0);
@@ -679,7 +680,7 @@ public static class DecimalTests
     public static void TestSystemIComparableCompareTo()
     {
         // Int32 Decimal.System.IComparable.CompareTo(Object)
-        IComparable d = (Decimal)248;
+        IComparable d = (decimal)248;
         Assert.True(d.CompareTo(248m) == 0);
         Assert.True(d.CompareTo(249m) < 0);
         Assert.True(d.CompareTo(247m) > 0);
@@ -692,7 +693,7 @@ public static class DecimalTests
     public static void TestGetHashCode()
     {
         // Int32 Decimal.GetHashCode()
-        Assert.NotEqual(Decimal.MinusOne.GetHashCode(), Decimal.One.GetHashCode());
+        Assert.NotEqual(decimal.MinusOne.GetHashCode(), decimal.One.GetHashCode());
     }
 
     [Fact]
@@ -700,56 +701,56 @@ public static class DecimalTests
     {
         // Single Decimal.ToSingle(Decimal)
         Single s = 12345.12f;
-        Assert.Equal(s, Decimal.ToSingle((Decimal)s));
-        Assert.Equal(-s, Decimal.ToSingle((Decimal)(-s)));
+        Assert.Equal(s, decimal.ToSingle((decimal)s));
+        Assert.Equal(-s, decimal.ToSingle((decimal)(-s)));
 
         s = 1e20f;
-        Assert.Equal(s, Decimal.ToSingle((Decimal)s));
-        Assert.Equal(-s, Decimal.ToSingle((Decimal)(-s)));
+        Assert.Equal(s, decimal.ToSingle((decimal)s));
+        Assert.Equal(-s, decimal.ToSingle((decimal)(-s)));
 
         s = 1e27f;
-        Assert.Equal(s, Decimal.ToSingle((Decimal)s));
-        Assert.Equal(-s, Decimal.ToSingle((Decimal)(-s)));
+        Assert.Equal(s, decimal.ToSingle((decimal)s));
+        Assert.Equal(-s, decimal.ToSingle((decimal)(-s)));
     }
 
     [Fact]
     public static void TestToDouble()
     {
-        Double d = Decimal.ToDouble(new Decimal(0, 0, 1, false, 0));
+        Double d = decimal.ToDouble(new decimal(0, 0, 1, false, 0));
 
         // Double Decimal.ToDouble(Decimal)
         Double dbl = 123456789.123456;
-        Assert.Equal(dbl, Decimal.ToDouble((Decimal)dbl));
-        Assert.Equal(-dbl, Decimal.ToDouble((Decimal)(-dbl)));
+        Assert.Equal(dbl, decimal.ToDouble((decimal)dbl));
+        Assert.Equal(-dbl, decimal.ToDouble((decimal)(-dbl)));
 
         dbl = 1e20;
-        Assert.Equal(dbl, Decimal.ToDouble((Decimal)dbl));
-        Assert.Equal(-dbl, Decimal.ToDouble((Decimal)(-dbl)));
+        Assert.Equal(dbl, decimal.ToDouble((decimal)dbl));
+        Assert.Equal(-dbl, decimal.ToDouble((decimal)(-dbl)));
 
         dbl = 1e27;
-        Assert.Equal(dbl, Decimal.ToDouble((Decimal)dbl));
-        Assert.Equal(-dbl, Decimal.ToDouble((Decimal)(-dbl)));
+        Assert.Equal(dbl, decimal.ToDouble((decimal)dbl));
+        Assert.Equal(-dbl, decimal.ToDouble((decimal)(-dbl)));
 
-        dbl = Int64.MaxValue;
+        dbl = long.MaxValue;
         // Need to pass in the Int64.MaxValue to ToDouble and not dbl because the conversion to double is a little lossy and we want precision
-        Assert.Equal(dbl, Decimal.ToDouble((Decimal)Int64.MaxValue));
-        Assert.Equal(-dbl, Decimal.ToDouble((Decimal)(-Int64.MaxValue)));
+        Assert.Equal(dbl, decimal.ToDouble((decimal)long.MaxValue));
+        Assert.Equal(-dbl, decimal.ToDouble((decimal)(-long.MaxValue)));
     }
 
     [Fact]
     public static void TestToInt16()
     {
         // Int16 Decimal.ToInt16(Decimal)
-        Assert.Equal(Int16.MaxValue, Decimal.ToInt16((Decimal)Int16.MaxValue));
-        Assert.Equal(Int16.MinValue, Decimal.ToInt16((Decimal)Int16.MinValue));
+        Assert.Equal(short.MaxValue, decimal.ToInt16((decimal)short.MaxValue));
+        Assert.Equal(short.MinValue, decimal.ToInt16((decimal)short.MinValue));
     }
 
     [Fact]
     public static void TestToInt32()
     {
         // Int32 Decimal.ToInt32(Decimal)
-        Assert.Equal(Int32.MaxValue, Decimal.ToInt32((Decimal)Int32.MaxValue));
-        Assert.Equal(Int32.MinValue, Decimal.ToInt32((Decimal)Int32.MinValue));
+        Assert.Equal(int.MaxValue, decimal.ToInt32((decimal)int.MaxValue));
+        Assert.Equal(int.MinValue, decimal.ToInt32((decimal)int.MinValue));
     }
 
     public static IEnumerable<object[]> DecimalTestData
@@ -768,23 +769,23 @@ public static class DecimalTests
                 new object[] {0.000000000000000000123456789M, new int[] { 0x075BCD15, 0x00000000, 0x00000000, 0x001B0000 } },
                 new object[] {4294967295M, new int[] { unchecked((int)0xFFFFFFFF), 0x00000000, 0x00000000, 0x00000000 } },
                 new object[] {18446744073709551615M, new int[] { unchecked((int)0xFFFFFFFF), unchecked((int)0xFFFFFFFF), 0x00000000, 0x00000000 } },
-                new object[] {Decimal.MaxValue, new int[] { unchecked((int)0xFFFFFFFF), unchecked((int)0xFFFFFFFF), unchecked((int)0xFFFFFFFF), 0x00000000 } },
-                new object[] {Decimal.MinValue, new int[] { unchecked((int)0xFFFFFFFF), unchecked((int)0xFFFFFFFF), unchecked((int)0xFFFFFFFF), unchecked((int)0x80000000) } },
+                new object[] { decimal.MaxValue, new int[] { unchecked((int)0xFFFFFFFF), unchecked((int)0xFFFFFFFF), unchecked((int)0xFFFFFFFF), 0x00000000 } },
+                new object[] { decimal.MinValue, new int[] { unchecked((int)0xFFFFFFFF), unchecked((int)0xFFFFFFFF), unchecked((int)0xFFFFFFFF), unchecked((int)0x80000000) } },
                 new object[] {-7.9228162514264337593543950335M, new int[] { unchecked((int)0xFFFFFFFF), unchecked((int)0xFFFFFFFF), unchecked((int)0xFFFFFFFF), unchecked((int)0x801C0000) } }
             };
         }
     }
 
     [Theory, MemberData("DecimalTestData")]
-    public static void TestGetBits(Decimal input, int[] expectedBits)
+    public static void TestGetBits(decimal input, int[] expectedBits)
     {
-        int[] actualsBits = Decimal.GetBits(input);
+        int[] actualsBits = decimal.GetBits(input);
 
         Assert.Equal(expectedBits, actualsBits);
 
         bool sign = (actualsBits[3] & 0x80000000) != 0;
         byte scale = (byte)((actualsBits[3] >> 16) & 0x7F);
-        Decimal newValue = new Decimal(actualsBits[0], actualsBits[1], actualsBits[2], sign, scale);
+        decimal newValue = new decimal(actualsBits[0], actualsBits[1], actualsBits[2], sign, scale);
 
         Assert.Equal(input, newValue);
     }
@@ -793,105 +794,104 @@ public static class DecimalTests
     public static void TestToInt64()
     {
         // Int64 Decimal.ToInt64(Decimal)
-        Assert.Equal(Int64.MaxValue, Decimal.ToInt64((Decimal)Int64.MaxValue));
-        Assert.Equal(Int64.MinValue, Decimal.ToInt64((Decimal)Int64.MinValue));
+        Assert.Equal(long.MaxValue, decimal.ToInt64((decimal)long.MaxValue));
+        Assert.Equal(long.MinValue, decimal.ToInt64((decimal)long.MinValue));
     }
 
     [Fact]
     public static void TestToSByte()
     {
         // SByte Decimal.ToSByte(Decimal)
-        Assert.Equal(SByte.MaxValue, Decimal.ToSByte((Decimal)SByte.MaxValue));
-        Assert.Equal(SByte.MinValue, Decimal.ToSByte((Decimal)SByte.MinValue));
+        Assert.Equal(sbyte.MaxValue, decimal.ToSByte((decimal)sbyte.MaxValue));
+        Assert.Equal(sbyte.MinValue, decimal.ToSByte((decimal)sbyte.MinValue));
     }
 
     [Fact]
     public static void TestToUInt16()
     {
         // UInt16 Decimal.ToUInt16(Decimal)
-        Assert.Equal(UInt16.MaxValue, Decimal.ToUInt16((Decimal)UInt16.MaxValue));
-        Assert.Equal(UInt16.MinValue, Decimal.ToUInt16((Decimal)UInt16.MinValue));
+        Assert.Equal(ushort.MaxValue, decimal.ToUInt16((decimal)ushort.MaxValue));
+        Assert.Equal(ushort.MinValue, decimal.ToUInt16((decimal)ushort.MinValue));
     }
 
     [Fact]
     public static void TestToUInt32()
     {
         // UInt32 Decimal.ToUInt32(Decimal)
-        Assert.Equal(UInt32.MaxValue, Decimal.ToUInt32((Decimal)UInt32.MaxValue));
-        Assert.Equal(UInt32.MinValue, Decimal.ToUInt32((Decimal)UInt32.MinValue));
+        Assert.Equal(uint.MaxValue, decimal.ToUInt32((decimal)uint.MaxValue));
+        Assert.Equal(uint.MinValue, decimal.ToUInt32((decimal)uint.MinValue));
     }
 
     [Fact]
     public static void TestToUInt64()
     {
         // UInt64 Decimal.ToUInt64(Decimal)
-        Assert.Equal(UInt64.MaxValue, Decimal.ToUInt64((Decimal)UInt64.MaxValue));
-        Assert.Equal(UInt64.MinValue, Decimal.ToUInt64((Decimal)UInt64.MinValue));
+        Assert.Equal(ulong.MaxValue, decimal.ToUInt64((decimal)ulong.MaxValue));
+        Assert.Equal(ulong.MinValue, decimal.ToUInt64((decimal)ulong.MinValue));
     }
 
     [Fact]
     public static void TestToString()
     {
         // String Decimal.ToString()
-        Decimal d1 = 6310.23m;
+        decimal d1 = 6310.23m;
         Assert.Equal(string.Format("{0}", 6310.23), d1.ToString());
 
-        Decimal d2 = -8249.000003m;
+        decimal d2 = -8249.000003m;
         Assert.Equal(string.Format("{0}", -8249.000003), d2.ToString());
 
-        Assert.Equal("79228162514264337593543950335", Decimal.MaxValue.ToString());
-        Assert.Equal("-79228162514264337593543950335", Decimal.MinValue.ToString());
+        Assert.Equal("79228162514264337593543950335", decimal.MaxValue.ToString());
+        Assert.Equal("-79228162514264337593543950335", decimal.MinValue.ToString());
     }
 
     [Fact]
     public static void Testctor()
     {
-        Decimal d;
+        decimal d;
         // Void Decimal..ctor(Double)
-        d = new Decimal((Double)123456789.123456);
-        Assert.Equal<Decimal>(d, (Decimal)123456789.123456);
+        d = new decimal((Double)123456789.123456);
+        Assert.Equal<Decimal>(d, (decimal)123456789.123456);
 
         // Void Decimal..ctor(Int32)
-        d = new Decimal((Int32)Int32.MaxValue);
-        Assert.Equal<Decimal>(d, Int32.MaxValue);
+        d = new decimal((int)int.MaxValue);
+        Assert.Equal<Decimal>(d, int.MaxValue);
 
         // Void Decimal..ctor(Int64)
-        d = new Decimal((Int64)Int64.MaxValue);
-        Assert.Equal<Decimal>(d, Int64.MaxValue);
+        d = new decimal((long)long.MaxValue);
+        Assert.Equal<Decimal>(d, long.MaxValue);
 
         // Void Decimal..ctor(Single)
-        d = new Decimal((Single)123.123);
-        Assert.Equal<Decimal>(d, (Decimal)123.123);
+        d = new decimal((Single)123.123);
+        Assert.Equal<Decimal>(d, (decimal)123.123);
 
         // Void Decimal..ctor(UInt32)
-        d = new Decimal((UInt32)UInt32.MaxValue);
-        Assert.Equal<Decimal>(d, UInt32.MaxValue);
+        d = new decimal((uint)uint.MaxValue);
+        Assert.Equal<Decimal>(d, uint.MaxValue);
 
         // Void Decimal..ctor(UInt64)
-        d = new Decimal((UInt64)UInt64.MaxValue);
-        Assert.Equal<Decimal>(d, UInt64.MaxValue);
+        d = new decimal((ulong)ulong.MaxValue);
+        Assert.Equal<Decimal>(d, ulong.MaxValue);
 
         // Void Decimal..ctor(Int32, Int32, Int32, Boolean, Byte)
-        d = new Decimal(1, 1, 1, false, 0);
-        Decimal d2 = 3;
-        d2 += UInt32.MaxValue;
-        d2 += UInt64.MaxValue;
+        d = new decimal(1, 1, 1, false, 0);
+        decimal d2 = 3;
+        d2 += uint.MaxValue;
+        d2 += ulong.MaxValue;
         Assert.Equal(d, d2);
 
         // Void Decimal..ctor(Int32[])
-        d = new Decimal(new Int32[] { 1, 1, 1, 0 });
+        d = new decimal(new int[] { 1, 1, 1, 0 });
         Assert.Equal(d, d2);
     }
 
     [Fact]
     public static void TestNumberBufferLimit()
     {
-        Decimal dE = 1234567890123456789012345.6785m;
+        decimal dE = 1234567890123456789012345.6785m;
         string s1 = "1234567890123456789012345.678456";
         var nfi = new NumberFormatInfo() { NumberDecimalSeparator = "." };
-        Decimal d1 = Decimal.Parse(s1, nfi);
+        decimal d1 = decimal.Parse(s1, nfi);
         Assert.Equal(d1, dE);
         return;
     }
 }
-

--- a/src/System.Runtime/tests/System/Delegate.cs
+++ b/src/System.Runtime/tests/System/Delegate.cs
@@ -2,10 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using DelegateTestInternal;
+
 using Xunit;
 
 namespace DelegateTestInternal
@@ -127,14 +126,14 @@ public static unsafe class DelegateTests
     {
         {
             Delegate d = new DFoo2(Foo2);
-            Object[] args = { 7 };
+            object[] args = { 7 };
             d.DynamicInvoke(args);
             Assert.Equal(args[0], 8);
         }
 
         {
             Delegate d = new DFoo2(Foo2);
-            Object[] args = { null };
+            object[] args = { null };
             d.DynamicInvoke(args);
             Assert.Equal(args[0], 1);
         }
@@ -142,7 +141,7 @@ public static unsafe class DelegateTests
         // for "byref ValueType" arguments, the incoming is allowed to be null. The target will receive default(ValueType).
         {
             Delegate d = new DFoo3(Foo3);
-            Object[] args = { null };
+            object[] args = { null };
             d.DynamicInvoke(args);
             MyStruct s = (MyStruct)(args[0]);
             Assert.Equal(s.X, 7);
@@ -152,13 +151,13 @@ public static unsafe class DelegateTests
         // For "byref ValueType" arguments, the type must match exactly.
         {
             Delegate d = new DFoo2(Foo2);
-            Object[] args = { (uint)7 };
+            object[] args = { (uint)7 };
             Assert.Throws<ArgumentException>(() => d.DynamicInvoke(args));
         }
 
         {
             Delegate d = new DFoo2(Foo2);
-            Object[] args = { E4.One };
+            object[] args = { E4.One };
             Assert.Throws<ArgumentException>(() => d.DynamicInvoke(args));
         }
 
@@ -171,49 +170,49 @@ public static unsafe class DelegateTests
         {
             // For primitives, value-preserving widenings allowed.
             Delegate d = new DFoo1(Foo1);
-            Object[] args = { 7, (short)7 };
+            object[] args = { 7, (short)7 };
             d.DynamicInvoke(args);
         }
 
         {
             // For primitives, conversion of enum to underlying integral prior to value-preserving widening allowed.
             Delegate d = new DFoo1(Foo1);
-            Object[] args = { 7, E4.Seven };
+            object[] args = { 7, E4.Seven };
             d.DynamicInvoke(args);
         }
 
         {
             // For primitives, conversion of enum to underlying integral prior to value-preserving widening allowed.
             Delegate d = new DFoo1(Foo1);
-            Object[] args = { 7, E2.Seven };
+            object[] args = { 7, E2.Seven };
             d.DynamicInvoke(args);
         }
 
         {
             // For primitives, conversion to enum after value-preserving widening allowed.
             Delegate d = new DFoo4(Foo4);
-            Object[] args = { E4.Seven, 7 };
+            object[] args = { E4.Seven, 7 };
             d.DynamicInvoke(args);
         }
 
         {
             // For primitives, conversion to enum after value-preserving widening allowed.
             Delegate d = new DFoo4(Foo4);
-            Object[] args = { E4.Seven, (short)7 };
+            object[] args = { E4.Seven, (short)7 };
             d.DynamicInvoke(args);
         }
 
         {
             // Size-preserving but non-value-preserving conversions NOT allowed.
             Delegate d = new DFoo1(Foo1);
-            Object[] args = { 7, (uint)7 };
+            object[] args = { 7, (uint)7 };
             Assert.Throws<ArgumentException>(() => d.DynamicInvoke(args));
         }
 
         {
             // Size-preserving but non-value-preserving conversions NOT allowed.
             Delegate d = new DFoo1(Foo1);
-            Object[] args = { 7, U4.Seven };
+            object[] args = { 7, U4.Seven };
             Assert.Throws<ArgumentException>(() => d.DynamicInvoke(args));
         }
 
@@ -226,28 +225,28 @@ public static unsafe class DelegateTests
         {
             // DynamicInvoke allows "null" for any value type (converts to default(valuetype)).
             Delegate d = new DFoo5(Foo5);
-            Object[] args = { null };
+            object[] args = { null };
             d.DynamicInvoke(args);
         }
 
         {
             // DynamicInvoke allows conversion of T to Nullable<T>
             Delegate d = new DFoo6(Foo6);
-            Object[] args = { 7 };
+            object[] args = { 7 };
             d.DynamicInvoke(args);
         }
 
         {
             // DynamicInvoke allows conversion of T to Nullable<T> but T must match exactly.
             Delegate d = new DFoo6(Foo6);
-            Object[] args = { (short)7 };
+            object[] args = { (short)7 };
             Assert.Throws<ArgumentException>(() => d.DynamicInvoke(args));
         }
 
         {
             // DynamicInvoke allows conversion of T to Nullable<T> but T must match exactly.
             Delegate d = new DFoo6(Foo6);
-            Object[] args = { E4.Seven };
+            object[] args = { E4.Seven };
             Assert.Throws<ArgumentException>(() => d.DynamicInvoke(args));
         }
 
@@ -324,4 +323,3 @@ public static unsafe class DelegateTests
         Seven = 7,
     }
 }
-

--- a/src/System.Runtime/tests/System/Double.cs
+++ b/src/System.Runtime/tests/System/Double.cs
@@ -3,166 +3,156 @@
 
 using System;
 using System.Globalization;
+using System.Runtime.Tests.Common;
+
 using Xunit;
 
 public static class DoubleTests
 {
     [Fact]
-    public static void TestCtor()
+    public static void TestCtorEmpty()
     {
-        Double i = new Double();
-        Assert.True(i == 0);
+        double i = new double();
+        Assert.Equal(0, i);
+    }
 
-        i = 41;
-        Assert.True(i == 41);
+    [Fact]
+    public static void TestCtorValue()
+    {
+        double i = 41;
+        Assert.Equal(41, i);
 
-        i = (Double)41.3;
-        Assert.True(i == (Double)41.3);
+        i = 41.3;
+        Assert.Equal(41.3, i);
     }
 
     [Fact]
     public static void TestMaxValue()
     {
-        Double max = Double.MaxValue;
-
-        Assert.True(max == (Double)1.7976931348623157E+308);
+        Assert.Equal((double)1.7976931348623157E+308, double.MaxValue);
     }
 
     [Fact]
     public static void TestMinValue()
     {
-        Double min = Double.MinValue;
-
-        Assert.True(min == ((Double)(-1.7976931348623157E+308)));
+        Assert.Equal((double)(-1.7976931348623157E+308), double.MinValue);
     }
 
     [Fact]
     public static void TestEpsilon()
     {
-        // Double Double.Epsilon
-        Assert.Equal<Double>((Double)4.9406564584124654E-324, Double.Epsilon);
+        Assert.Equal((double)4.9406564584124654E-324, double.Epsilon);
     }
 
     [Fact]
     public static void TestIsInfinity()
     {
-        // Boolean Double.IsInfinity(Double)
-        Assert.True(Double.IsInfinity(Double.NegativeInfinity));
-        Assert.True(Double.IsInfinity(Double.PositiveInfinity));
+        Assert.True(double.IsInfinity(double.NegativeInfinity));
+        Assert.True(double.IsInfinity(double.PositiveInfinity));
     }
 
     [Fact]
     public static void TestNaN()
     {
-        // Double Double.NaN
-        Assert.Equal<Double>((Double)0.0 / (Double)0.0, Double.NaN);
+        Assert.Equal((double)0.0 / (double)0.0, double.NaN);
     }
 
     [Fact]
     public static void TestIsNaN()
     {
-        // Boolean Double.IsNaN(Double)
-        Assert.True(Double.IsNaN(Double.NaN));
+        Assert.True(double.IsNaN(double.NaN));
     }
 
     [Fact]
     public static void TestNegativeInfinity()
     {
-        // Double Double.NegativeInfinity
-        Assert.Equal<Double>((Double)(-1.0) / (Double)0.0, Double.NegativeInfinity);
+        Assert.Equal((double)(-1.0) / (double)0.0, double.NegativeInfinity);
     }
 
     [Fact]
     public static void TestIsNegativeInfinity()
     {
-        // Boolean Double.IsNegativeInfinity(Double)
-        Assert.True(Double.IsNegativeInfinity(Double.NegativeInfinity));
+        Assert.True(double.IsNegativeInfinity(double.NegativeInfinity));
     }
 
     [Fact]
     public static void TestPositiveInfinity()
     {
-        // Double Double.PositiveInfinity
-        Assert.Equal<Double>((Double)1.0 / (Double)0.0, Double.PositiveInfinity);
+        Assert.Equal((double)1.0 / (double)0.0, double.PositiveInfinity);
     }
 
     [Fact]
     public static void TestIsPositiveInfinity()
     {
-        // Boolean Double.IsPositiveInfinity(Double)
-        Assert.True(Double.IsPositiveInfinity(Double.PositiveInfinity));
+        Assert.True(double.IsPositiveInfinity(double.PositiveInfinity));
+    }
+
+    [Theory]
+    [InlineData((double)234, (double)234, 0)]
+    [InlineData((double)234, double.MinValue, 1)]
+    [InlineData((double)234, (double)(-123), 1)]
+    [InlineData((double)234, (double)0, 1)]
+    [InlineData((double)234, (double)123, 1)]
+    [InlineData((double)234, (double)456, -1)]
+    [InlineData((double)234, double.MaxValue, -1)]
+    [InlineData((double)234, double.NaN, 1)]
+    [InlineData(double.NaN, double.NaN, 0)]
+    [InlineData(double.NaN, 0, -1)]
+    public static void TestCompareTo(double i, double value, int expected)
+    {
+        int result = CompareHelper.NormalizeCompare(i.CompareTo(value));
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null, 1)]
+    [InlineData((double)234, 0)]
+    [InlineData(double.MinValue, 1)]
+    [InlineData((double)(-123), 1)]
+    [InlineData((double)0, 1)]
+    [InlineData((double)123, 1)]
+    [InlineData((double)456, -1)]
+    [InlineData(double.MaxValue, -1)]
+    public static void TestCompareToObject(object obj, int expected)
+    {
+        IComparable comparable = (double)234;
+        int i = CompareHelper.NormalizeCompare(comparable.CompareTo(obj));
+        Assert.Equal(expected, i);
     }
 
     [Fact]
-    public static void TestCompareToObject()
+    public static void TestCompareToObjectInvalid()
     {
-        Double i = 234;
-        IComparable comparable = i;
-
-        Assert.Equal(1, comparable.CompareTo(null));
-        Assert.Equal(0, comparable.CompareTo((Double)234));
-
-        Assert.True(comparable.CompareTo(Double.MinValue) > 0);
-        Assert.True(comparable.CompareTo((Double)0) > 0);
-        Assert.True(comparable.CompareTo((Double)(-123)) > 0);
-        Assert.True(comparable.CompareTo((Double)123) > 0);
-        Assert.True(comparable.CompareTo((Double)456) < 0);
-        Assert.True(comparable.CompareTo(Double.MaxValue) < 0);
-
-        Assert.Throws<ArgumentException>(() => comparable.CompareTo("a"));
+        IComparable comparable = (double)234;
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); //Obj is not a double
     }
 
-    [Fact]
-    public static void TestCompareTo()
+    [Theory]
+    [InlineData((double)789, true)]
+    [InlineData((double)(-789), false)]
+    [InlineData((double)0, false)]
+    public static void TestEqualsObject(object obj, bool expected)
     {
-        Double i = 234;
-
-        Assert.Equal(0, i.CompareTo((Double)234));
-
-        Assert.True(i.CompareTo(Double.MinValue) > 0);
-        Assert.True(i.CompareTo((Double)0) > 0);
-        Assert.True(i.CompareTo((Double)(-123)) > 0);
-        Assert.True(i.CompareTo((Double)123) > 0);
-        Assert.True(i.CompareTo((Double)456) < 0);
-        Assert.True(i.CompareTo(Double.MaxValue) < 0);
-
-        Assert.True(Double.NaN.CompareTo(Double.NaN) == 0);
-        Assert.True(Double.NaN.CompareTo(0) < 0);
-        Assert.True(i.CompareTo(Double.NaN) > 0);
+        double i = 789;
+        Assert.Equal(expected, i.Equals(obj));
     }
 
-    [Fact]
-    public static void TestEqualsObject()
+    [Theory]
+    [InlineData((double)789, (double)789, true)]
+    [InlineData((double)789, (double)(-789), false)]
+    [InlineData((double)789, (double)0, false)]
+    [InlineData(double.NaN, double.NaN, true)]
+    public static void TestEquals(double i1, double i2, bool expected)
     {
-        Double i = 789;
-
-        object obj1 = (Double)789;
-        Assert.True(i.Equals(obj1));
-
-        object obj2 = (Double)(-789);
-        Assert.True(!i.Equals(obj2));
-
-        object obj3 = (Double)0;
-        Assert.True(!i.Equals(obj3));
+        Assert.Equal(expected, i1.Equals(i2));
     }
 
-    [Fact]
-    public static void TestEquals()
-    {
-        Double i = -911;
-
-        Assert.True(i.Equals((Double)(-911)));
-
-        Assert.True(!i.Equals((Double)911));
-        Assert.True(!i.Equals((Double)0));
-        Assert.True(Double.NaN.Equals(Double.NaN));
-    }
 
     [Fact]
     public static void TestGetHashCode()
     {
-        Double i1 = 123;
-        Double i2 = 654;
+        double i1 = 123;
+        double i2 = 654;
 
         Assert.NotEqual(0, i1.GetHashCode());
         Assert.NotEqual(i1.GetHashCode(), i2.GetHashCode());
@@ -171,79 +161,79 @@ public static class DoubleTests
     [Fact]
     public static void TestToString()
     {
-        Double i1 = 6310;
+        double i1 = 6310;
         Assert.Equal("6310", i1.ToString());
 
-        Double i2 = -8249;
+        double i2 = -8249;
         Assert.Equal("-8249", i2.ToString());
     }
 
     [Fact]
     public static void TestToStringFormatProvider()
     {
-        var numberFormat = new System.Globalization.NumberFormatInfo();
+        var numberFormat = new NumberFormatInfo();
 
-        Double i1 = 6310;
+        double i1 = 6310;
         Assert.Equal("6310", i1.ToString(numberFormat));
 
-        Double i2 = -8249;
+        double i2 = -8249;
         Assert.Equal("-8249", i2.ToString(numberFormat));
 
-        Double i3 = -2468;
+        double i3 = -2468;
 
         // Changing the negative pattern doesn't do anything without also passing in a format string
         numberFormat.NumberNegativePattern = 0;
         Assert.Equal("-2468", i3.ToString(numberFormat));
 
-        Assert.Equal("NaN", Double.NaN.ToString(NumberFormatInfo.InvariantInfo));
-        Assert.Equal("Infinity", Double.PositiveInfinity.ToString(NumberFormatInfo.InvariantInfo));
-        Assert.Equal("-Infinity", Double.NegativeInfinity.ToString(NumberFormatInfo.InvariantInfo));
+        Assert.Equal("NaN", double.NaN.ToString(NumberFormatInfo.InvariantInfo));
+        Assert.Equal("Infinity", double.PositiveInfinity.ToString(NumberFormatInfo.InvariantInfo));
+        Assert.Equal("-Infinity", double.NegativeInfinity.ToString(NumberFormatInfo.InvariantInfo));
     }
 
     [Fact]
     public static void TestToStringFormat()
     {
-        Double i1 = 6310;
+        double i1 = 6310;
         Assert.Equal("6310", i1.ToString("G"));
 
-        Double i2 = -8249;
+        double i2 = -8249;
         Assert.Equal("-8249", i2.ToString("g"));
 
-        Double i3 = -2468;
+        double i3 = -2468;
         Assert.Equal(string.Format("{0:N}", -2468.00), i3.ToString("N"));
     }
 
     [Fact]
     public static void TestToStringFormatFormatProvider()
     {
-        var numberFormat = new System.Globalization.NumberFormatInfo();
+        var numberFormat = new NumberFormatInfo();
 
-        Double i1 = 6310;
+        double i1 = 6310;
         Assert.Equal("6310", i1.ToString("G", numberFormat));
 
-        Double i2 = -8249;
+        double i2 = -8249;
         Assert.Equal("-8249", i2.ToString("g", numberFormat));
 
         numberFormat.NegativeSign = "xx"; // setting it to trash to make sure it doesn't show up
         numberFormat.NumberGroupSeparator = "*";
         numberFormat.NumberNegativePattern = 0;
-        Double i3 = -2468;
+        double i3 = -2468;
         Assert.Equal("(2*468.00)", i3.ToString("N", numberFormat));
     }
 
     [Fact]
     public static void TestParse()
     {
-        Assert.Equal(123, Double.Parse("123"));
-        Assert.Equal(-123, Double.Parse("-123"));
+        Assert.Equal(123, double.Parse("123"));
+        Assert.Equal(-123, double.Parse("-123"));
         //TODO: Negative tests once we get better exceptions
     }
 
     [Fact]
     public static void TestParseNumberStyle()
     {
-        Assert.Equal<Double>((Double)123.1, Double.Parse(string.Format("{0}", 123.1), NumberStyles.AllowDecimalPoint));
-        Assert.Equal(1000, Double.Parse(string.Format("{0}", 1000), NumberStyles.AllowThousands));
+        Assert.Equal((double)123.1, double.Parse(string.Format("{0}", 123.1), NumberStyles.AllowDecimalPoint));
+        Assert.Equal(1000, double.Parse(string.Format("{0}", 1000), NumberStyles.AllowThousands));
         //TODO: Negative tests once we get better exceptions
     }
 
@@ -251,8 +241,8 @@ public static class DoubleTests
     public static void TestParseFormatProvider()
     {
         var nfi = new NumberFormatInfo();
-        Assert.Equal(123, Double.Parse("123", nfi));
-        Assert.Equal(-123, Double.Parse("-123", nfi));
+        Assert.Equal(123, double.Parse("123", nfi));
+        Assert.Equal(-123, double.Parse("-123", nfi));
         //TODO: Negative tests once we get better exceptions
     }
 
@@ -261,11 +251,11 @@ public static class DoubleTests
     {
         var nfi = new NumberFormatInfo();
         nfi.NumberDecimalSeparator = ".";
-        Assert.Equal<Double>((Double)123.123, Double.Parse("123.123", NumberStyles.Float, nfi));
+        Assert.Equal((double)123.123, double.Parse("123.123", NumberStyles.Float, nfi));
 
         nfi.CurrencySymbol = "$";
         nfi.CurrencyGroupSeparator = ",";
-        Assert.Equal(1000, Double.Parse("$1,000", NumberStyles.Currency, nfi));
+        Assert.Equal(1000, double.Parse("$1,000", NumberStyles.Currency, nfi));
         //TODO: Negative tests once we get better exception support
     }
 
@@ -274,64 +264,63 @@ public static class DoubleTests
     {
         // Defaults AllowLeadingWhite | AllowTrailingWhite | AllowLeadingSign | AllowDecimalPoint | AllowExponent | AllowThousands
 
-        Double i;
-        Assert.True(Double.TryParse("123", out i));     // Simple
+        double i;
+        Assert.True(double.TryParse("123", out i));     // Simple
         Assert.Equal(123, i);
 
-        Assert.True(Double.TryParse("-385", out i));    // LeadingSign
+        Assert.True(double.TryParse("-385", out i));    // LeadingSign
         Assert.Equal(-385, i);
 
-        Assert.True(Double.TryParse(" 678 ", out i));   // Leading/Trailing whitespace
+        Assert.True(double.TryParse(" 678 ", out i));   // Leading/Trailing whitespace
         Assert.Equal(678, i);
 
-        Assert.True(Double.TryParse((678.90).ToString("F2"), out i)); // Decimal
-        Assert.Equal((Double)678.90, i);
+        Assert.True(double.TryParse((678.90).ToString("F2"), out i)); // Decimal
+        Assert.Equal((double)678.90, i);
 
-        Assert.True(Double.TryParse("1E23", out i));   // Exponent
-        Assert.Equal((Double)1E23, i);
+        Assert.True(double.TryParse("1E23", out i));   // Exponent
+        Assert.Equal((double)1E23, i);
 
-        Assert.True(Double.TryParse((1000).ToString("N0"), out i));  // Thousands
+        Assert.True(double.TryParse((1000).ToString("N0"), out i));  // Thousands
         Assert.Equal(1000, i);
 
         var nfi = new NumberFormatInfo() { CurrencyGroupSeparator = "" };
-        Assert.False(Double.TryParse((1000).ToString("C0", nfi), out i));  // Currency
-        Assert.False(Double.TryParse("abc", out i));    // Hex digits
-        Assert.False(Double.TryParse("(135)", out i));  // Parentheses
+        Assert.False(double.TryParse((1000).ToString("C0", nfi), out i));  // Currency
+        Assert.False(double.TryParse("abc", out i));    // Hex digits
+        Assert.False(double.TryParse("(135)", out i));  // Parentheses
     }
 
     [Fact]
     public static void TestTryParseNumberStyleFormatProvider()
     {
-        Double i;
+        double i;
         var nfi = new NumberFormatInfo();
         nfi.NumberDecimalSeparator = ".";
-        Assert.True(Double.TryParse("123.123", NumberStyles.Any, nfi, out i));   // Simple positive
-        Assert.Equal((Double)123.123, i);
+        Assert.True(double.TryParse("123.123", NumberStyles.Any, nfi, out i));   // Simple positive
+        Assert.Equal((double)123.123, i);
 
-        Assert.True(Double.TryParse("123", NumberStyles.Float, nfi, out i));   // Simple Hex
+        Assert.True(double.TryParse("123", NumberStyles.Float, nfi, out i));   // Simple Hex
         Assert.Equal(123, i);
 
         nfi.CurrencySymbol = "$";
         nfi.CurrencyGroupSeparator = ",";
-        Assert.True(Double.TryParse("$1,000", NumberStyles.Currency, nfi, out i)); // Currency/Thousands postive
+        Assert.True(double.TryParse("$1,000", NumberStyles.Currency, nfi, out i)); // Currency/Thousands postive
         Assert.Equal(1000, i);
 
-        Assert.False(Double.TryParse("abc", NumberStyles.None, nfi, out i));       // Hex Number negative
+        Assert.False(double.TryParse("abc", NumberStyles.None, nfi, out i));       // Hex Number negative
 
-        Assert.False(Double.TryParse("678.90", NumberStyles.Integer, nfi, out i));  // Decimal
-        Assert.False(Double.TryParse(" 678 ", NumberStyles.None, nfi, out i));      // Trailing/Leading whitespace negative
+        Assert.False(double.TryParse("678.90", NumberStyles.Integer, nfi, out i));  // Decimal
+        Assert.False(double.TryParse(" 678 ", NumberStyles.None, nfi, out i));      // Trailing/Leading whitespace negative
 
-        Assert.True(Double.TryParse("(135)", NumberStyles.AllowParentheses, nfi, out i)); // Parenthese postive
+        Assert.True(double.TryParse("(135)", NumberStyles.AllowParentheses, nfi, out i)); // Parenthese postive
         Assert.Equal(-135, i);
 
-        Assert.True(Double.TryParse("Infinity", NumberStyles.Any, NumberFormatInfo.InvariantInfo, out i));
-        Assert.True(Double.IsPositiveInfinity(i));
+        Assert.True(double.TryParse("Infinity", NumberStyles.Any, NumberFormatInfo.InvariantInfo, out i));
+        Assert.True(double.IsPositiveInfinity(i));
 
-        Assert.True(Double.TryParse("-Infinity", NumberStyles.Any, NumberFormatInfo.InvariantInfo, out i));
-        Assert.True(Double.IsNegativeInfinity(i));
+        Assert.True(double.TryParse("-Infinity", NumberStyles.Any, NumberFormatInfo.InvariantInfo, out i));
+        Assert.True(double.IsNegativeInfinity(i));
 
-        Assert.True(Double.TryParse("NaN", NumberStyles.Any, NumberFormatInfo.InvariantInfo, out i));
-        Assert.True(Double.IsNaN(i));
+        Assert.True(double.TryParse("NaN", NumberStyles.Any, NumberFormatInfo.InvariantInfo, out i));
+        Assert.True(double.IsNaN(i));
     }
 }
-

--- a/src/System.Runtime/tests/System/Enum.cs
+++ b/src/System.Runtime/tests/System/Enum.cs
@@ -2,903 +2,469 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Runtime.Tests.Common;
+
 using Xunit;
 
-public static unsafe class EnumTests
+public static class EnumTests
 {
-    [Fact]
-    public static void TestParse()
+    [Theory]
+    [InlineData("Red", false, true, SimpleEnum.Red)]
+    [InlineData(" Red", false, true, SimpleEnum.Red)]
+    [InlineData(" red ", true, true, SimpleEnum.Red)]
+    [InlineData(" Red , Blue ", false, true, (SimpleEnum)3)]
+
+    [InlineData("1", false, true, SimpleEnum.Red)]
+    [InlineData(" 1 ", false, true, SimpleEnum.Red)]
+    [InlineData("2", false, true, SimpleEnum.Blue)]
+    [InlineData("99", false, true, (SimpleEnum)99)]
+
+    [InlineData(" red ", false, false, default(SimpleEnum))] // No actual expected result
+    [InlineData("Purple", false, false, default(SimpleEnum))]
+    public static void TestParse(string value, bool ignoreCase, bool expectedCanParse, Enum expectedParseResult)
     {
+        bool b;
+        SimpleEnum e;
+        if (!ignoreCase)
         {
-            Type t = typeof(SimpleEnum);
-            bool b;
-            SimpleEnum e;
-
-            b = Enum.TryParse<SimpleEnum>("Red", out e);
-            Assert.True(b);
-            Assert.Equal(e, SimpleEnum.Red);
-
-            b = Enum.TryParse<SimpleEnum>(" Red ", out e);
-            Assert.True(b);
-            Assert.Equal(e, SimpleEnum.Red);
-
-            b = Enum.TryParse<SimpleEnum>(" red ", out e);
-            Assert.True(!b);
-
-            b = Enum.TryParse<SimpleEnum>(" red ", false, out e);
-            Assert.True(!b);
-
-            b = Enum.TryParse<SimpleEnum>(" red ", true, out e);
-            Assert.True(b);
-            Assert.Equal(e, SimpleEnum.Red);
-
-            b = Enum.TryParse<SimpleEnum>(" Red , Blue ", out e);
-            Assert.True(b);
-            Assert.Equal(e, (SimpleEnum)3);
-
-            b = Enum.TryParse<SimpleEnum>("Purple", out e);
-            Assert.True(!b);
-
-            b = Enum.TryParse<SimpleEnum>("1", out e);
-            Assert.True(b);
-            Assert.Equal(e, SimpleEnum.Red);
-
-            b = Enum.TryParse<SimpleEnum>(" 1 ", out e);
-            Assert.True(b);
-            Assert.Equal(e, SimpleEnum.Red);
-
-            b = Enum.TryParse<SimpleEnum>("2", out e);
-            Assert.True(b);
-            Assert.Equal(e, SimpleEnum.Blue);
-
-            b = Enum.TryParse<SimpleEnum>("99", out e);
-            Assert.True(b);
-            Assert.Equal(e, (SimpleEnum)99);
-
-            return;
+            b = Enum.TryParse(value, out e);
+            Assert.Equal(expectedCanParse, b);
+            Assert.Equal(expectedParseResult, e);
         }
+
+        b = Enum.TryParse(value, ignoreCase, out e);
+        Assert.Equal(expectedCanParse, b);
+        Assert.Equal(expectedParseResult, e);
+    }
+
+    [Theory]
+    [InlineData(99, null)]
+    [InlineData(1, "Red")]
+    [InlineData(SimpleEnum.Red, "Red")]
+    public static void TestGetName(object value, string expected)
+    {
+        string s = Enum.GetName(typeof(SimpleEnum), value);
+        Assert.Equal(expected, s);
     }
 
     [Fact]
-    public static void TestGetName()
+    public static void TestGetNameMultipleMatches()
     {
-        String s;
-        {
-            Type t = typeof(SimpleEnum);
-            s = Enum.GetName(t, 99);
-            Assert.Equal(s, null);
-
-            s = Enum.GetName(t, 1);
-            Assert.Equal(s, "Red");
-
-            s = Enum.GetName(t, SimpleEnum.Red);
-            Assert.Equal(s, "Red");
-
-            // In the case of multiple matches, GetName returns one of them (which one is an implementation detail.)
-            s = Enum.GetName(t, 3);
-            Assert.True(s == "Green" || s == "Green_a" || s == "Green_b");
-        }
-
-        // Negative tests
-        {
-            Type t = typeof(SimpleEnum);
-            Assert.Throws<ArgumentNullException>(() => Enum.GetName(null, 1));
-            Assert.Throws<ArgumentNullException>(() => Enum.GetName(t, null));
-            Assert.Throws<ArgumentNullException>(() => Enum.GetName(typeof(Object), null));
-            Assert.Throws<ArgumentException>(() => Enum.GetName(t, "Red"));
-            Assert.Throws<ArgumentException>(() => Enum.GetName(t, (IntPtr)0));
-        }
-
-        {
-            /*
-             * Despite what MSDN says, GetName() does not require passing in the exact integral type.
-             * 
-             * For the purposes of comparison:
-             * 
-             *  - The enum member value are normalized as follows:
-             *    - unsigned ints zero-extended to 64-bits
-             *    - signed ints sign-extended to 64-bits
-             *
-             *  - The value passed in as an argument to GetNames() is normalized as follows:
-             *    - unsigned ints zero-extended to 64-bits
-             *    - signed ints sign-extended to 64-bits
-             *
-             *  Then comparison is done on all 64 bits.
-             */
-
-            Type t = typeof(SByteEnum);
-            s = Enum.GetName(t, 0xffffffffffffff80LU);
-            Assert.Equal(s, "Min");
-
-            s = Enum.GetName(t, 0xffffff80u);
-            Assert.Equal(s, null);
-
-            s = Enum.GetName(t, unchecked((int)(0xffffff80u)));
-            Assert.Equal(s, "Min");
-
-            s = Enum.GetName(t, true);
-            Assert.Equal(s, "One");
-
-            s = Enum.GetName(t, (char)1);
-            Assert.Equal(s, "One");
-
-            // The api doesn't even care if you pass in a completely different enum!
-            s = Enum.GetName(t, SimpleEnum.Red);
-            Assert.Equal(s, "One");
-        }
-        return;
+        // In the case of multiple matches, GetName returns one of them (which one is an implementation detail.)
+        string s = Enum.GetName(typeof(SimpleEnum), 3);
+        Assert.True(s == "Green" || s == "Green_a" || s == "Green_b");
     }
 
     [Fact]
-    public static void TestIsDefined()
+    public static void TestGetNameInvalid()
     {
         Type t = typeof(SimpleEnum);
-        bool b;
+        Assert.Throws<ArgumentNullException>("enumType", () => Enum.GetName(null, 1)); // Enum type is null
+        Assert.Throws<ArgumentNullException>("value", () => Enum.GetName(t, null)); // Value is null
 
-        // Value can be a string...
-        b = Enum.IsDefined(t, "Red");
-        Assert.True(b);
+        Assert.Throws<ArgumentException>(null, () => Enum.GetName(typeof(object), 1)); // Enum type is not an enum
+        Assert.Throws<ArgumentException>("value", () => Enum.GetName(t, "Red")); // Value is not the type of the enum's raw data
+        Assert.Throws<ArgumentException>("value", () => Enum.GetName(t, (IntPtr)0)); // Value is out of range
+    }
 
-        b = Enum.IsDefined(t, "Green");
-        Assert.True(b);
+    [Theory]
+    [InlineData(0xffffffffffffff80LU, "Min")]
+    [InlineData(0xffffff80u, null)]
+    [InlineData(unchecked((int)(0xffffff80u)), "Min")]
+    [InlineData(true, "One")]
+    [InlineData((char)1, "One")]
+    [InlineData(SimpleEnum.Red, "One")] // API doesnt't care if you pass in a completely different enum
+    public static void TestGetNameNonIntegralTypes(object value, string expected)
+    {
+        /*
+            * Despite what MSDN says, GetName() does not require passing in the exact integral type.
+            * 
+            * For the purposes of comparison:
+            * 
+            *  - The enum member value are normalized as follows:
+            *    - unsigned ints zero-extended to 64-bits
+            *    - signed ints sign-extended to 64-bits
+            *
+            *  - The value passed in as an argument to GetNames() is normalized as follows:
+            *    - unsigned ints zero-extended to 64-bits
+            *    - signed ints sign-extended to 64-bits
+            *
+            *  Then comparison is done on all 64 bits.
+            */
+        string s = Enum.GetName(typeof(SByteEnum), value);
+        Assert.Equal(expected, s);
+    }
 
-        b = Enum.IsDefined(t, "Blue");
-        Assert.True(b);
+    [Theory]
+    [InlineData(typeof(SimpleEnum), "Red", true)] //string
+    [InlineData(typeof(SimpleEnum), "Green", true)]
+    [InlineData(typeof(SimpleEnum), "Blue", true)]
+    [InlineData(typeof(SimpleEnum), " Blue", false)]
+    [InlineData(typeof(SimpleEnum), "blue", false)]
+    [InlineData(typeof(SimpleEnum), "", false)]
+    [InlineData(typeof(SimpleEnum), SimpleEnum.Red, true)] //Enum
+    [InlineData(typeof(SimpleEnum), (SimpleEnum)99, false)]
+    [InlineData(typeof(SimpleEnum), 1, true)] // Integer
+    [InlineData(typeof(SimpleEnum), 99, false)]
+    [InlineData(typeof(Int32Enum), 0x1 | 0x02, false)] // "Combos" do not pass
+    public static void TestIsDefined(Type t, object value, bool expected)
+    {
+        bool b = Enum.IsDefined(t, value);
+        Assert.Equal(expected, b);
+    }
 
-        b = Enum.IsDefined(t, " Blue");
-        Assert.True(!b);
+    [Fact]
+    public static void TestIsDefinedInvalid()
+    {
+        Type t = typeof(SimpleEnum);
+        
+        Assert.Throws<ArgumentNullException>("enumType", () => Enum.IsDefined(null, 1)); // Enum type is null
+        Assert.Throws<ArgumentNullException>("value", () => Enum.IsDefined(t, null)); // Value is null
 
-        b = Enum.IsDefined(t, "blue");
-        Assert.True(!b);
-
-        // or an Enum value
-        b = Enum.IsDefined(t, SimpleEnum.Red);
-        Assert.True(b);
-
-        b = Enum.IsDefined(t, (SimpleEnum)(99));
-        Assert.True(!b);
-
-        // but not a different enum.
-        Assert.Throws<ArgumentException>(() => Enum.IsDefined(t, Int32Enum.One));
-
-        // or the underlying integer
-        b = Enum.IsDefined(t, 1);
-        Assert.True(b);
-
-        b = Enum.IsDefined(t, 99);
-        Assert.True(!b);
-
-        // but not just any integer type.
-        Assert.Throws<ArgumentException>(() => Enum.IsDefined(t, (short)1));
-
-        Assert.Throws<ArgumentException>(() => Enum.IsDefined(t, (uint)1));
-
-        // "Combos" do not pass.
-        b = Enum.IsDefined(typeof(Int32Enum), 0x1 | 0x2);
-        Assert.True(!b);
-
-        // Other negative tests
-        Assert.Throws<ArgumentNullException>(() => Enum.IsDefined(null, 1));
-        Assert.Throws<ArgumentNullException>(() => Enum.IsDefined(t, null));
-
-        // These throws ArgumentException (though MSDN claims it should throw InvalidOperationException)
-        Assert.Throws<ArgumentException>(() => Enum.IsDefined(t, true));
-        Assert.Throws<ArgumentException>(() => Enum.IsDefined(t, 'a'));
+        Assert.Throws<ArgumentException>(null, () => Enum.IsDefined(t, Int32Enum.One)); // Value is different enum type
+                                                                                           
+        // Value is not a valid type (MSDN claims this should throw InvalidOperationException)
+        Assert.Throws<ArgumentException>(null, () => Enum.IsDefined(t, true));
+        Assert.Throws<ArgumentException>(null, () => Enum.IsDefined(t, 'a'));
 
         // Non-integers throw InvalidOperationException prior to Win8P.
         Assert.Throws<InvalidOperationException>(() => Enum.IsDefined(t, (IntPtr)0));
         Assert.Throws<InvalidOperationException>(() => Enum.IsDefined(t, 5.5));
         Assert.Throws<InvalidOperationException>(() => Enum.IsDefined(t, 5.5f));
+    }
+    
+    [Fact]
+    public static void TestHasFlagInvalid()
+    {
+        Int32Enum e = (Int32Enum)0x3f06;
 
-        return;
+        Assert.Throws<ArgumentNullException>("flag", () => e.HasFlag(null)); // Flag is null
+        Assert.Throws<ArgumentException>(null, () => e.HasFlag((SimpleEnum)0x2)); // Different enum type
     }
 
-    [Fact]
-    public static void TestHasFlag()
+    [Theory]
+    [InlineData((Int32Enum)0x3000, true)]
+    [InlineData((Int32Enum)0x1000, true)]
+    [InlineData((Int32Enum)0x0000, true)]
+    [InlineData((Int32Enum)0x3f06, true)]
+    [InlineData((Int32Enum)0x0010, false)]
+    [InlineData((Int32Enum)0x3f16, false)]    
+    public static void TestHasFlag(Enum flag, bool expected)
     {
-        EI32 e = (EI32)0x3f06;
+        Int32Enum e = (Int32Enum)0x3f06;
 
-        Assert.Throws<ArgumentNullException>(() => e.HasFlag(null));
-        Assert.Throws<ArgumentException>(() => e.HasFlag((EI32a)0x2));
-
-        Assert.True(e.HasFlag((EI32)(0x3000)));
-        Assert.True(e.HasFlag((EI32)(0x1000)));
-        Assert.True(e.HasFlag((EI32)(0x0000)));
-        Assert.False(e.HasFlag((EI32)(0x0010)));
-        Assert.True(e.HasFlag((EI32)(0x3f06)));
-        Assert.False(e.HasFlag((EI32)(0x3f16)));
+        bool b = e.HasFlag(flag);
+        Assert.Equal(expected, b);
     }
 
     [Fact]
     public static void TestToObject()
     {
-        Assert.Throws<ArgumentNullException>(() => Enum.ToObject(null, 3));
-        Assert.Throws<ArgumentNullException>(() => Enum.ToObject(typeof(EI8), null));
-        Assert.Throws<ArgumentException>(() => Enum.ToObject(typeof(Enum), 1));
-        Assert.Throws<ArgumentException>(() => Enum.ToObject(typeof(EI8), "Hello"));
-
-        TestToObjectVerifySuccess<EI8, sbyte>(42);
-        TestToObjectVerifySuccess<EI8, EI8>((EI8)0x42);
-        TestToObjectVerifySuccess<EU64, ulong>(0x0123456789abcdefL);
+        TestToObjectVerifySuccess<SByteEnum, sbyte>(42);
+        TestToObjectVerifySuccess<SByteEnum, SByteEnum>((SByteEnum)0x42);
+        TestToObjectVerifySuccess<UInt64Enum, ulong>(0x0123456789abcdefL);
 
         ulong l = 0x0ccccccccccccc2aL;
-        EI8 e = (EI8)(Enum.ToObject(typeof(EI8), l));
+        ByteEnum e = (ByteEnum)(Enum.ToObject(typeof(ByteEnum), l));
         Assert.True((sbyte)e == 0x2a);
     }
 
     private static void TestToObjectVerifySuccess<E, T>(T value)
     {
-        Object oValue = value;
-        Object e = Enum.ToObject(typeof(E), oValue);
+        object oValue = value;
+        object e = Enum.ToObject(typeof(E), oValue);
         Assert.Equal(e.GetType(), typeof(E));
-        E expected = (E)(Object)(value);
-        Object oExpected = (Object)expected; // Workaround for Bartok codegen bug: Calling Object methods on enum through type variable fails (due to missing box)
+        E expected = (E)(object)(value);
+        object oExpected = (object)expected; // Workaround for Bartok codegen bug: Calling Object methods on enum through type variable fails (due to missing box)
         Assert.True(oExpected.Equals(e));
+    }
+
+    [Fact]
+    public static void TestToObjectInvalid()
+    {
+        Assert.Throws<ArgumentNullException>("enumType", () => Enum.ToObject(null, 3)); // Enum type is null
+        Assert.Throws<ArgumentNullException>("value", () => Enum.ToObject(typeof(SimpleEnum), null)); // Value is null
+
+        Assert.Throws<ArgumentException>("enumType", () => Enum.ToObject(typeof(Enum), 1)); // Enum type is simply an enum
+        Assert.Throws<ArgumentException>("value", () => Enum.ToObject(typeof(SimpleEnum), "Hello")); //Value is not a supported enum type
     }
 
     [Fact]
     public static void TestHashCode()
     {
-        EI64 e = (EI64)42;
+        SimpleEnum e = (SimpleEnum)42;
         int h = e.GetHashCode();
         int h2 = e.GetHashCode();
         Assert.Equal(h, h2);
     }
 
-    [Fact]
-    public static void TestEquals()
+    [Theory]
+    [InlineData(null, false)]
+    [InlineData((long)42, false)]
+    [InlineData((Int32Enum)42, false)]
+    [InlineData((Int64Enum)43, false)]
+    [InlineData((Int64Enum)0x700000000000002aL, false)]
+    [InlineData((Int64Enum)42, true)]
+    public static void TestEquals(object obj, bool expected)
     {
-        EI64 e = (EI64)42;
-        bool b;
+        Int64Enum e = (Int64Enum)42;
+        bool b = e.Equals(obj);
+        Assert.Equal(expected, b);
+    }
 
-        b = e.Equals(null);
-        Assert.False(b);
-
-        b = e.Equals((long)42);
-        Assert.False(b);
-
-        b = e.Equals((EI32)42);
-        Assert.False(b);
-
-        b = e.Equals((EI64)43);
-        Assert.False(b);
-
-        long l = 0x700000000000002aL;
-        b = e.Equals((EI64)l);
-        Assert.False(b);
-
-        b = e.Equals((EI64)42);
-        Assert.True(b);
+    [Theory]
+    [InlineData(null, 1)] // Special case: All values are "greater than" null
+    [InlineData(SimpleEnum.Red, 0)]
+    [InlineData((SimpleEnum)0, 1)]
+    [InlineData((SimpleEnum)2, -1)]
+    public static void TestCompareTo(object target, int expected)
+    {
+        SimpleEnum e = SimpleEnum.Red;
+        int i = CompareHelper.NormalizeCompare(e.CompareTo(target));
+        Assert.Equal(expected, i);
     }
 
     [Fact]
-    public static void TestCompareTo()
+    public static void TestCompareToInvalid()
     {
-        EI8 e = EI8.One;
+        Assert.Throws<ArgumentException>(null, () => SimpleEnum.Red.CompareTo((sbyte)1)); //Target is an enum type
+        Assert.Throws<ArgumentException>(null, () => SimpleEnum.Red.CompareTo(Int32Enum.One)); //Target is a different enum type
+    }
 
-        // Special case: All values are "greater than" null.
-        Assert.Equal(1, e.CompareTo(null));
-
-        Assert.Throws<ArgumentException>(() => e.CompareTo((sbyte)1));
-
-        Assert.Equal(0, e.CompareTo(EI8.One));
-        Assert.InRange(e.CompareTo((EI8)0), 1, int.MaxValue);
-        Assert.InRange(e.CompareTo((EI8)2), int.MinValue, -1);
+    [Theory]
+    [InlineData(typeof(SByteEnum), typeof(sbyte))]
+    [InlineData(typeof(ByteEnum), typeof(byte))]
+    [InlineData(typeof(Int16Enum), typeof(short))]
+    [InlineData(typeof(UInt16Enum), typeof(ushort))]
+    [InlineData(typeof(Int32Enum), typeof(int))]
+    [InlineData(typeof(UInt32Enum), typeof(uint))]
+    [InlineData(typeof(Int64Enum), typeof(long))]
+    [InlineData(typeof(UInt64Enum), typeof(ulong))]
+    public static void TestGetUnderlyingType(Type enumType, Type expected)
+    {
+        Assert.Equal(expected, Enum.GetUnderlyingType(enumType));
     }
 
     [Fact]
-    public static void TestGetUnderlyingType()
+    public static void TestGetUnderlyingTypeInvalid()
     {
-        Assert.Throws<ArgumentNullException>(() => Enum.GetUnderlyingType(null));
-        Assert.Throws<ArgumentException>(() => Enum.GetUnderlyingType(typeof(Enum)));
-
-        Assert.Equal(typeof(SByte), Enum.GetUnderlyingType(typeof(EI8)));
-        Assert.Equal(typeof(Byte), Enum.GetUnderlyingType(typeof(EU8)));
-        Assert.Equal(typeof(Int16), Enum.GetUnderlyingType(typeof(EI16)));
-        Assert.Equal(typeof(UInt16), Enum.GetUnderlyingType(typeof(EU16)));
-        Assert.Equal(typeof(Int32), Enum.GetUnderlyingType(typeof(EI32)));
-        Assert.Equal(typeof(UInt32), Enum.GetUnderlyingType(typeof(EU32)));
-        Assert.Equal(typeof(Int64), Enum.GetUnderlyingType(typeof(EI64)));
-        Assert.Equal(typeof(UInt64), Enum.GetUnderlyingType(typeof(EU64)));
+        Assert.Throws<ArgumentNullException>("enumType", () => Enum.GetUnderlyingType(null)); // Enum type is null
+        Assert.Throws<ArgumentException>("enumType", () => Enum.GetUnderlyingType(typeof(Enum))); // Enum type is simply an enum
     }
 
-    private enum EI8 : sbyte
+    [Theory]
+    [InlineData(typeof(SimpleEnum), 
+        new[] { "Red", "Blue", "Green", "Green_a", "Green_b" },
+        new object[] { SimpleEnum.Red, SimpleEnum.Blue, SimpleEnum.Green, SimpleEnum.Green_a, SimpleEnum.Green_b })]
+
+    [InlineData(typeof(ByteEnum),
+        new[] { "Min", "One", "Two", "Max" },
+        new object[] { ByteEnum.Min, ByteEnum.One, ByteEnum.Two, ByteEnum.Max })]
+
+    [InlineData(typeof(SByteEnum),
+        new[] { "One", "Two", "Max", "Min" },
+        new object[] { SByteEnum.One, SByteEnum.Two, SByteEnum.Max, SByteEnum.Min })]
+
+    [InlineData(typeof(UInt16Enum),
+        new[] { "Min", "One", "Two", "Max" },
+        new object[] { UInt16Enum.Min, UInt16Enum.One, UInt16Enum.Two, UInt16Enum.Max })]
+
+    [InlineData(typeof(Int16Enum),
+        new[] { "One", "Two", "Max", "Min" },
+        new object[] { Int16Enum.One, Int16Enum.Two, Int16Enum.Max, Int16Enum.Min })]
+
+    [InlineData(typeof(UInt32Enum),
+        new[] { "Min", "One", "Two", "Max" },
+        new object[] { UInt32Enum.Min, UInt32Enum.One, UInt32Enum.Two, UInt32Enum.Max })]
+
+    [InlineData(typeof(Int32Enum),
+        new[] { "One", "Two", "Max", "Min" },
+        new object[] { Int32Enum.One, Int32Enum.Two, Int32Enum.Max, Int32Enum.Min })]
+
+    [InlineData(typeof(UInt64Enum),
+        new[] { "Min", "One", "Two", "Max" },
+        new object[] { UInt64Enum.Min, UInt64Enum.One, UInt64Enum.Two, UInt64Enum.Max })]
+
+    [InlineData(typeof(Int64Enum),
+        new[] { "One", "Two", "Max", "Min" },
+        new object[] { Int64Enum.One, Int64Enum.Two, Int64Enum.Max, Int64Enum.Min })]
+
+    public static void TestGetNamesAndValues(Type t, string[] expectedNames, object[] expectedValues)
     {
-        One = 1,
+        string[] names = Enum.GetNames(t);
+        Array values = Enum.GetValues(t);
+        Assert.Equal(names.Length, values.Length);
+
+        for (int i = 0; i < names.Length; i++)
+        {
+            Assert.Equal(expectedNames[i], names[i]);
+            Assert.Equal(expectedValues[i], values.GetValue(i));
+        }
     }
 
-    private enum EU8 : byte
-    {
-    }
+    [Theory]
+    // Format: "D"
+    [InlineData(ByteEnum.Min, "D", "0")]
+    [InlineData(ByteEnum.One, "D", "1")]
+    [InlineData(ByteEnum.Two, "D", "2")]
+    [InlineData((ByteEnum)99, "D", "99")]
+    [InlineData(ByteEnum.Max, "D", "255")]
 
-    private enum EI16 : short
-    {
-    }
+    [InlineData(SByteEnum.Min, "D", "-128")]
+    [InlineData(SByteEnum.One, "D", "1")]
+    [InlineData(SByteEnum.Two, "D", "2")]
+    [InlineData((SByteEnum)99, "D", "99")]
+    [InlineData(SByteEnum.Max, "D", "127")]
 
-    private enum EU16 : ushort
-    {
-    }
+    [InlineData(UInt16Enum.Min, "D", "0")]
+    [InlineData(UInt16Enum.One, "D", "1")]
+    [InlineData(UInt16Enum.Two, "D", "2")]
+    [InlineData((UInt16Enum)99, "D", "99")]
+    [InlineData(UInt16Enum.Max, "D", "65535")]
 
-    private enum EI32 : int
-    {
-    }
+    [InlineData(Int16Enum.Min, "D", "-32768")]
+    [InlineData(Int16Enum.One, "D", "1")]
+    [InlineData(Int16Enum.Two, "D", "2")]
+    [InlineData((Int16Enum)99, "D", "99")]
+    [InlineData(Int16Enum.Max, "D", "32767")]
 
-    private enum EI32a : int
-    {
-    }
+    [InlineData(UInt32Enum.Min, "D", "0")]
+    [InlineData(UInt32Enum.One, "D", "1")]
+    [InlineData(UInt32Enum.Two, "D", "2")]
+    [InlineData((UInt32Enum)99, "D", "99")]
+    [InlineData(UInt32Enum.Max, "D", "4294967295")]
 
-    private enum EU32 : uint
-    {
-    }
+    [InlineData(Int32Enum.Min, "D", "-2147483648")]
+    [InlineData(Int32Enum.One, "D", "1")]
+    [InlineData(Int32Enum.Two, "D", "2")]
+    [InlineData((Int32Enum)99, "D", "99")]
+    [InlineData(Int32Enum.Max, "D", "2147483647")]
 
-    private enum EI64 : long
-    {
-    }
+    [InlineData(UInt64Enum.Min, "D", "0")]
+    [InlineData(UInt64Enum.One, "D", "1")]
+    [InlineData(UInt64Enum.Two, "D", "2")]
+    [InlineData((UInt64Enum)99, "D", "99")]
+    [InlineData(UInt64Enum.Max, "D", "18446744073709551615")]
 
-    private enum EU64 : ulong
+    [InlineData(Int64Enum.Min, "D", "-9223372036854775808")]
+    [InlineData(Int64Enum.One, "D", "1")]
+    [InlineData(Int64Enum.Two, "D", "2")]
+    [InlineData((Int64Enum)99, "D", "99")]
+    [InlineData(Int64Enum.Max, "D", "9223372036854775807")]
+    //Format "X": value in hex form without a leading "0x"
+    [InlineData(ByteEnum.Min, "X", "00")]
+    [InlineData(ByteEnum.One, "X", "01")]
+    [InlineData(ByteEnum.Two, "X", "02")]
+    [InlineData((ByteEnum)99, "X", "63")]
+    [InlineData(ByteEnum.Max, "X", "FF")]
+
+    [InlineData(SByteEnum.Min, "X", "80")]
+    [InlineData(SByteEnum.One, "X", "01")]
+    [InlineData(SByteEnum.Two, "X", "02")]
+    [InlineData((SByteEnum)99, "X", "63")]
+    [InlineData(SByteEnum.Max, "X", "7F")]
+
+    [InlineData(UInt16Enum.Min, "X", "0000")]
+    [InlineData(UInt16Enum.One, "X", "0001")]
+    [InlineData(UInt16Enum.Two, "X", "0002")]
+    [InlineData((UInt16Enum)99, "X", "0063")]
+    [InlineData(UInt16Enum.Max, "X", "FFFF")]
+
+    [InlineData(Int16Enum.Min, "X", "8000")]
+    [InlineData(Int16Enum.One, "X", "0001")]
+    [InlineData(Int16Enum.Two, "X", "0002")]
+    [InlineData((Int16Enum)99, "X", "0063")]
+    [InlineData(Int16Enum.Max, "X", "7FFF")]
+
+    [InlineData(UInt32Enum.Min, "X", "00000000")]
+    [InlineData(UInt32Enum.One, "X", "00000001")]
+    [InlineData(UInt32Enum.Two, "X", "00000002")]
+    [InlineData((UInt32Enum)99, "X", "00000063")]
+    [InlineData(UInt32Enum.Max, "X", "FFFFFFFF")]
+
+    [InlineData(Int32Enum.Min, "X", "80000000")]
+    [InlineData(Int32Enum.One, "X", "00000001")]
+    [InlineData(Int32Enum.Two, "X", "00000002")]
+    [InlineData((Int32Enum)99, "X", "00000063")]
+    [InlineData(Int32Enum.Max, "X", "7FFFFFFF")]
+
+    [InlineData(UInt64Enum.Min, "X", "0000000000000000")]
+    [InlineData(UInt64Enum.One, "X", "0000000000000001")]
+    [InlineData(UInt64Enum.Two, "X", "0000000000000002")]
+    [InlineData((UInt64Enum)99, "X", "0000000000000063")]
+    [InlineData(UInt64Enum.Max, "X", "FFFFFFFFFFFFFFFF")]
+
+    [InlineData(Int64Enum.Min, "X", "8000000000000000")]
+    [InlineData(Int64Enum.One, "X", "0000000000000001")]
+    [InlineData(Int64Enum.Two, "X", "0000000000000002")]
+    [InlineData((Int64Enum)99, "X", "0000000000000063")]
+    [InlineData(Int64Enum.Max, "X", "7FFFFFFFFFFFFFFF")]
+
+    // Format "F". value is treated as a bit field that contains one or more flags that consist of one or more bits.
+    // If value is equal to a combination of named enumerated constants, a delimiter-separated list of the names 
+    // of those constants is returned. value is searched for flags, going from the flag with the largest value 
+    // to the smallest value. For each flag that corresponds to a bit field in value, the name of the constant 
+    // is concatenated to the delimiter-separated list. The value of that flag is then excluded from further 
+    // consideration, and the search continues for the next flag.
+    //
+    // If value is not equal to a combination of named enumerated constants, the decimal equivalent of value is returned. 
+    [InlineData(SimpleEnum.Red, "F", "Red")]
+    [InlineData(SimpleEnum.Blue, "F", "Blue")]
+    [InlineData((SimpleEnum)99, "F", "99")]
+    [InlineData((SimpleEnum)0, "F", "0")] // Not found
+
+    [InlineData((ByteEnum)0, "F", "Min")]
+    [InlineData((ByteEnum)3, "F", "One, Two")]
+    [InlineData((ByteEnum)0xff, "F", "Max")] // Larger values take precedence (and remove the bits from consideration.)
+                                             
+    // Format "G": If value is equal to a named enumerated constant, the name of that constant is returned.
+    // Otherwise, if "[Flags]" present, do as Format "F" - else return the decimal value of "value".
+    [InlineData(SimpleEnum.Red, "G", "Red")]
+    [InlineData(SimpleEnum.Blue, "G", "Blue")]
+    [InlineData((SimpleEnum)99, "G", "99")]
+    [InlineData((SimpleEnum)0, "G", "0")] // Not found
+
+    [InlineData((ByteEnum)0, "G", "Min")]
+    [InlineData((ByteEnum)3, "G", "3")] // No [Flags] attribute
+    [InlineData((ByteEnum)0xff, "F", "Max")] // Larger values take precedence (and remove the bits from consideration.)
+    [InlineData(AttributeTargets.Class | AttributeTargets.Delegate, "F", "Class, Delegate")] // [Flags] attribute
+    public static void TestFormat(Enum e, string format, string expected)
     {
+        string s = e.ToString(format);
+        Assert.Equal(expected, s);
     }
 
     [Fact]
-    public static void TestGetNamesAndValues()
+    public static void TestFormatMultipleMatches()
     {
-        {
-            String[] names = Enum.GetNames(typeof(SimpleEnum));
-            SimpleEnum[] values = (SimpleEnum[])(Enum.GetValues(typeof(SimpleEnum)));
-
-            int i = 0;
-            Assert.Equal(names[i], "Red");
-            Assert.Equal(values[i], SimpleEnum.Red);
-            i++;
-            Assert.Equal(names[i], "Blue");
-            Assert.Equal(values[i], SimpleEnum.Blue);
-            i++;
-            Assert.Equal(names[i], "Green");
-            Assert.Equal(values[i], SimpleEnum.Green);
-            i++;
-            Assert.Equal(names[i], "Green_a");
-            Assert.Equal(values[i], SimpleEnum.Green_a);
-            i++;
-            Assert.Equal(names[i], "Green_b");
-            Assert.Equal(values[i], SimpleEnum.Green_a);
-            i++;
-
-            Assert.Equal(names.Length, i);
-            Assert.Equal(values.Length, i);
-        }
-
-        {
-            String[] names = Enum.GetNames(typeof(ByteEnum));
-            ByteEnum[] values = (ByteEnum[])(Enum.GetValues(typeof(ByteEnum)));
-
-            int i = 0;
-            Assert.Equal(names[i], "Min");
-            Assert.Equal(values[i], ByteEnum.Min);
-            i++;
-            Assert.Equal(names[i], "One");
-            Assert.Equal(values[i], ByteEnum.One);
-            i++;
-            Assert.Equal(names[i], "Two");
-            Assert.Equal(values[i], ByteEnum.Two);
-            i++;
-            Assert.Equal(names[i], "Max");
-            Assert.Equal(values[i], ByteEnum.Max);
-            i++;
-
-            Assert.Equal(names.Length, i);
-            Assert.Equal(values.Length, i);
-        }
-
-        {
-            String[] names = Enum.GetNames(typeof(SByteEnum));
-            SByteEnum[] values = (SByteEnum[])(Enum.GetValues(typeof(SByteEnum)));
-
-            int i = 0;
-            Assert.Equal(names[i], "One");
-            Assert.Equal(values[i], SByteEnum.One);
-            i++;
-            Assert.Equal(names[i], "Two");
-            Assert.Equal(values[i], SByteEnum.Two);
-            i++;
-            Assert.Equal(names[i], "Max");
-            Assert.Equal(values[i], SByteEnum.Max);
-            i++;
-            Assert.Equal(names[i], "Min");
-            Assert.Equal(values[i], SByteEnum.Min);
-            i++;
-
-            Assert.Equal(names.Length, i);
-            Assert.Equal(values.Length, i);
-        }
-
-        {
-            String[] names = Enum.GetNames(typeof(UInt16Enum));
-            UInt16Enum[] values = (UInt16Enum[])(Enum.GetValues(typeof(UInt16Enum)));
-
-            int i = 0;
-            Assert.Equal(names[i], "Min");
-            Assert.Equal(values[i], UInt16Enum.Min);
-            i++;
-            Assert.Equal(names[i], "One");
-            Assert.Equal(values[i], UInt16Enum.One);
-            i++;
-            Assert.Equal(names[i], "Two");
-            Assert.Equal(values[i], UInt16Enum.Two);
-            i++;
-            Assert.Equal(names[i], "Max");
-            Assert.Equal(values[i], UInt16Enum.Max);
-            i++;
-
-            Assert.Equal(names.Length, i);
-            Assert.Equal(values.Length, i);
-        }
-
-        {
-            String[] names = Enum.GetNames(typeof(Int16Enum));
-            Int16Enum[] values = (Int16Enum[])(Enum.GetValues(typeof(Int16Enum)));
-
-            int i = 0;
-            Assert.Equal(names[i], "One");
-            Assert.Equal(values[i], Int16Enum.One);
-            i++;
-            Assert.Equal(names[i], "Two");
-            Assert.Equal(values[i], Int16Enum.Two);
-            i++;
-            Assert.Equal(names[i], "Max");
-            Assert.Equal(values[i], Int16Enum.Max);
-            i++;
-            Assert.Equal(names[i], "Min");
-            Assert.Equal(values[i], Int16Enum.Min);
-            i++;
-
-            Assert.Equal(names.Length, i);
-            Assert.Equal(values.Length, i);
-        }
-
-        {
-            String[] names = Enum.GetNames(typeof(UInt32Enum));
-            UInt32Enum[] values = (UInt32Enum[])(Enum.GetValues(typeof(UInt32Enum)));
-
-            int i = 0;
-            Assert.Equal(names[i], "Min");
-            Assert.Equal(values[i], UInt32Enum.Min);
-            i++;
-            Assert.Equal(names[i], "One");
-            Assert.Equal(values[i], UInt32Enum.One);
-            i++;
-            Assert.Equal(names[i], "Two");
-            Assert.Equal(values[i], UInt32Enum.Two);
-            i++;
-            Assert.Equal(names[i], "Max");
-            Assert.Equal(values[i], UInt32Enum.Max);
-            i++;
-
-            Assert.Equal(names.Length, i);
-            Assert.Equal(values.Length, i);
-        }
-
-        {
-            String[] names = Enum.GetNames(typeof(Int32Enum));
-            Int32Enum[] values = (Int32Enum[])(Enum.GetValues(typeof(Int32Enum)));
-
-            int i = 0;
-            Assert.Equal(names[i], "One");
-            Assert.Equal(values[i], Int32Enum.One);
-            i++;
-            Assert.Equal(names[i], "Two");
-            Assert.Equal(values[i], Int32Enum.Two);
-            i++;
-            Assert.Equal(names[i], "Max");
-            Assert.Equal(values[i], Int32Enum.Max);
-            i++;
-            Assert.Equal(names[i], "Min");
-            Assert.Equal(values[i], Int32Enum.Min);
-            i++;
-
-            Assert.Equal(names.Length, i);
-            Assert.Equal(values.Length, i);
-        }
-
-        {
-            String[] names = Enum.GetNames(typeof(UInt64Enum));
-            UInt64Enum[] values = (UInt64Enum[])(Enum.GetValues(typeof(UInt64Enum)));
-
-            int i = 0;
-            Assert.Equal(names[i], "Min");
-            Assert.Equal(values[i], UInt64Enum.Min);
-            i++;
-            Assert.Equal(names[i], "One");
-            Assert.Equal(values[i], UInt64Enum.One);
-            i++;
-            Assert.Equal(names[i], "Two");
-            Assert.Equal(values[i], UInt64Enum.Two);
-            i++;
-            Assert.Equal(names[i], "Max");
-            Assert.Equal(values[i], UInt64Enum.Max);
-            i++;
-
-            Assert.Equal(names.Length, i);
-            Assert.Equal(values.Length, i);
-        }
-
-        {
-            String[] names = Enum.GetNames(typeof(Int64Enum));
-            Int64Enum[] values = (Int64Enum[])(Enum.GetValues(typeof(Int64Enum)));
-
-            int i = 0;
-            Assert.Equal(names[i], "One");
-            Assert.Equal(values[i], Int64Enum.One);
-            i++;
-            Assert.Equal(names[i], "Two");
-            Assert.Equal(values[i], Int64Enum.Two);
-            i++;
-            Assert.Equal(names[i], "Max");
-            Assert.Equal(values[i], Int64Enum.Max);
-            i++;
-            Assert.Equal(names[i], "Min");
-            Assert.Equal(values[i], Int64Enum.Min);
-            i++;
-
-            Assert.Equal(names.Length, i);
-            Assert.Equal(values.Length, i);
-        }
-    }
-
-    [Fact]
-    public static void TestFormatD()
-    {
-        String s;
-
-        s = ByteEnum.Min.ToString("D");
-        Assert.Equal(s, "0");
-
-        s = ByteEnum.One.ToString("D");
-        Assert.Equal(s, "1");
-
-        s = ByteEnum.Two.ToString("D");
-        Assert.Equal(s, "2");
-
-        s = ((ByteEnum)99).ToString("D");
-        Assert.Equal(s, "99");
-
-        s = ByteEnum.Max.ToString("D");
-        Assert.Equal(s, "255");
-
-        s = SByteEnum.Min.ToString("D");
-        Assert.Equal(s, "-128");
-
-        s = SByteEnum.One.ToString("D");
-        Assert.Equal(s, "1");
-
-        s = SByteEnum.Two.ToString("D");
-        Assert.Equal(s, "2");
-
-        s = ((SByteEnum)99).ToString("D");
-        Assert.Equal(s, "99");
-
-        s = SByteEnum.Max.ToString("D");
-        Assert.Equal(s, "127");
-
-        s = UInt16Enum.Min.ToString("D");
-        Assert.Equal(s, "0");
-
-        s = UInt16Enum.One.ToString("D");
-        Assert.Equal(s, "1");
-
-        s = UInt16Enum.Two.ToString("D");
-        Assert.Equal(s, "2");
-
-        s = ((UInt16Enum)99).ToString("D");
-        Assert.Equal(s, "99");
-
-        s = UInt16Enum.Max.ToString("D");
-        Assert.Equal(s, "65535");
-
-        s = Int16Enum.Min.ToString("D");
-        Assert.Equal(s, "-32768");
-
-        s = Int16Enum.One.ToString("D");
-        Assert.Equal(s, "1");
-
-        s = Int16Enum.Two.ToString("D");
-        Assert.Equal(s, "2");
-
-        s = ((Int16Enum)99).ToString("D");
-        Assert.Equal(s, "99");
-
-        s = Int16Enum.Max.ToString("D");
-        Assert.Equal(s, "32767");
-
-        s = UInt32Enum.Min.ToString("D");
-        Assert.Equal(s, "0");
-
-        s = UInt32Enum.One.ToString("D");
-        Assert.Equal(s, "1");
-
-        s = UInt32Enum.Two.ToString("D");
-        Assert.Equal(s, "2");
-
-        s = ((UInt32Enum)99).ToString("D");
-        Assert.Equal(s, "99");
-
-        s = UInt32Enum.Max.ToString("D");
-        Assert.Equal(s, "4294967295");
-
-        s = Int32Enum.Min.ToString("D");
-        Assert.Equal(s, "-2147483648");
-
-        s = Int32Enum.One.ToString("D");
-        Assert.Equal(s, "1");
-
-        s = Int32Enum.Two.ToString("D");
-        Assert.Equal(s, "2");
-
-        s = ((Int32Enum)99).ToString("D");
-        Assert.Equal(s, "99");
-
-        s = Int32Enum.Max.ToString("D");
-        Assert.Equal(s, "2147483647");
-
-        s = UInt64Enum.Min.ToString("D");
-        Assert.Equal(s, "0");
-
-        s = UInt64Enum.One.ToString("D");
-        Assert.Equal(s, "1");
-
-        s = UInt64Enum.Two.ToString("D");
-        Assert.Equal(s, "2");
-
-        s = ((UInt64Enum)99).ToString("D");
-        Assert.Equal(s, "99");
-
-        s = UInt64Enum.Max.ToString("D");
-        Assert.Equal(s, "18446744073709551615");
-
-        s = Int64Enum.Min.ToString("D");
-        Assert.Equal(s, "-9223372036854775808");
-
-        s = Int64Enum.One.ToString("D");
-        Assert.Equal(s, "1");
-
-        s = Int64Enum.Two.ToString("D");
-        Assert.Equal(s, "2");
-
-        s = ((Int64Enum)99).ToString("D");
-        Assert.Equal(s, "99");
-
-        s = Int64Enum.Max.ToString("D");
-        Assert.Equal(s, "9223372036854775807");
-    }
-
-    [Fact]
-    public static void TestFormatX()
-    {
-        // Format "X": Represents value in hex form without a leading "0x"
-        String s;
-
-        s = ByteEnum.Min.ToString("X");
-        Assert.Equal(s, "00");
-
-        s = ByteEnum.One.ToString("X");
-        Assert.Equal(s, "01");
-
-        s = ByteEnum.Two.ToString("X");
-        Assert.Equal(s, "02");
-
-        s = ((ByteEnum)99).ToString("X");
-        Assert.Equal(s, "63");
-
-        s = ByteEnum.Max.ToString("X");
-        Assert.Equal(s, "FF");
-
-        s = SByteEnum.Min.ToString("X");
-        Assert.Equal(s, "80");
-
-        s = SByteEnum.One.ToString("X");
-        Assert.Equal(s, "01");
-
-        s = SByteEnum.Two.ToString("X");
-        Assert.Equal(s, "02");
-
-        s = ((SByteEnum)99).ToString("X");
-        Assert.Equal(s, "63");
-
-        s = SByteEnum.Max.ToString("X");
-        Assert.Equal(s, "7F");
-
-        s = UInt16Enum.Min.ToString("X");
-        Assert.Equal(s, "0000");
-
-        s = UInt16Enum.One.ToString("X");
-        Assert.Equal(s, "0001");
-
-        s = UInt16Enum.Two.ToString("X");
-        Assert.Equal(s, "0002");
-
-        s = ((UInt16Enum)99).ToString("X");
-        Assert.Equal(s, "0063");
-
-        s = UInt16Enum.Max.ToString("X");
-        Assert.Equal(s, "FFFF");
-
-        s = Int16Enum.Min.ToString("X");
-        Assert.Equal(s, "8000");
-
-        s = Int16Enum.One.ToString("X");
-        Assert.Equal(s, "0001");
-
-        s = Int16Enum.Two.ToString("X");
-        Assert.Equal(s, "0002");
-
-        s = ((Int16Enum)99).ToString("X");
-        Assert.Equal(s, "0063");
-
-        s = Int16Enum.Max.ToString("X");
-        Assert.Equal(s, "7FFF");
-
-        s = UInt32Enum.Min.ToString("X");
-        Assert.Equal(s, "00000000");
-
-        s = UInt32Enum.One.ToString("X");
-        Assert.Equal(s, "00000001");
-
-        s = UInt32Enum.Two.ToString("X");
-        Assert.Equal(s, "00000002");
-
-        s = ((UInt32Enum)99).ToString("X");
-        Assert.Equal(s, "00000063");
-
-        s = UInt32Enum.Max.ToString("X");
-        Assert.Equal(s, "FFFFFFFF");
-
-        s = Int32Enum.Min.ToString("X");
-        Assert.Equal(s, "80000000");
-
-        s = Int32Enum.One.ToString("X");
-        Assert.Equal(s, "00000001");
-
-        s = Int32Enum.Two.ToString("X");
-        Assert.Equal(s, "00000002");
-
-        s = ((Int32Enum)99).ToString("X");
-        Assert.Equal(s, "00000063");
-
-        s = Int32Enum.Max.ToString("X");
-        Assert.Equal(s, "7FFFFFFF");
-
-        s = UInt64Enum.Min.ToString("X");
-        Assert.Equal(s, "0000000000000000");
-
-        s = UInt64Enum.One.ToString("X");
-        Assert.Equal(s, "0000000000000001");
-
-        s = UInt64Enum.Two.ToString("X");
-        Assert.Equal(s, "0000000000000002");
-
-        s = ((UInt64Enum)99).ToString("X");
-        Assert.Equal(s, "0000000000000063");
-
-        s = UInt64Enum.Max.ToString("X");
-        Assert.Equal(s, "FFFFFFFFFFFFFFFF");
-
-        s = Int64Enum.Min.ToString("X");
-        Assert.Equal(s, "8000000000000000");
-
-        s = Int64Enum.One.ToString("X");
-        Assert.Equal(s, "0000000000000001");
-
-        s = Int64Enum.Two.ToString("X");
-        Assert.Equal(s, "0000000000000002");
-
-        s = ((Int64Enum)99).ToString("X");
-        Assert.Equal(s, "0000000000000063");
-
-        s = Int64Enum.Max.ToString("X");
-        Assert.Equal(s, "7FFFFFFFFFFFFFFF");
-    }
-
-    [Fact]
-    public static void TestFormatF()
-    {
-        // Format "F". value is treated as a bit field that contains one or more flags that consist of one or more bits.
-        // If value is equal to a combination of named enumerated constants, a delimiter-separated list of the names 
-        // of those constants is returned. value is searched for flags, going from the flag with the largest value 
-        // to the smallest value. For each flag that corresponds to a bit field in value, the name of the constant 
-        // is concatenated to the delimiter-separated list. The value of that flag is then excluded from further 
-        // consideration, and the search continues for the next flag.
-        //
-        //If value is not equal to a combination of named enumerated constants, the decimal equivalent of value is returned. 
-        String s;
-
-        s = SimpleEnum.Red.ToString("F");
-        Assert.Equal(s, "Red");
-
-        s = SimpleEnum.Blue.ToString("F");
-        Assert.Equal(s, "Blue");
-
-        s = ((SimpleEnum)3).ToString("F");
+        string s = ((SimpleEnum)3).ToString("F");
         Assert.True(s == "Green" || s == "Green_a" || s == "Green_b");
-
-        s = ((SimpleEnum)99).ToString("F");
-        Assert.Equal(s, "99");
-
-        s = ((SimpleEnum)0).ToString("F");
-        Assert.Equal(s, "0");  // Not found.
-
-        s = ((ByteEnum)0).ToString("F");
-        Assert.Equal(s, "Min");  // Found
-
-        s = ((ByteEnum)3).ToString("F");
-        Assert.Equal(s, "One, Two");  // Found
-
-        // Larger values take precedence (and remove the bits from consideration.)
-        s = ((ByteEnum)0xff).ToString("F");
-        Assert.Equal(s, "Max");  // Found
-    }
-
-    [Fact]
-    public static void TestFormatG()
-    {
-        // Format "G": If value is equal to a named enumerated constant, the name of that constant is returned.
-        // Otherwise, if "[Flags]" present, do as Format "F" - else return the decimal value of "value".
-        String s;
-
-        s = SimpleEnum.Red.ToString("G");
-        Assert.Equal(s, "Red");
-
-        s = SimpleEnum.Blue.ToString("G");
-        Assert.Equal(s, "Blue");
 
         s = ((SimpleEnum)3).ToString("G");
         Assert.True(s == "Green" || s == "Green_a" || s == "Green_b");
+    }
 
-        s = ((SimpleEnum)99).ToString("G");
-        Assert.Equal(s, "99");
-
-        s = ((SimpleEnum)0).ToString("G");
-        Assert.Equal(s, "0");  // Not found.
-
-        s = ((ByteEnum)0).ToString("G");
-        Assert.Equal(s, "Min");  // Found
-
-        s = ((ByteEnum)3).ToString("G");
-        Assert.Equal(s, "3");  // No [Flags] attribute
-
-        // Larger values take precedence (and remove the bits from consideration.)
-        s = ((ByteEnum)0xff).ToString("G");
-        Assert.Equal(s, "Max");  // Found
-
-        // An enum with [Flags]
-        s = (AttributeTargets.Class | AttributeTargets.Delegate).ToString("G");
-        Assert.Equal(s, "Class, Delegate");
+    [Theory]
+    [InlineData(SimpleEnum.Red, "Red")]
+    [InlineData(1, "Red")] // Underlying integral
+    public static void TestFormat(object value, string expected)
+    {
+        string s = Enum.Format(typeof(SimpleEnum), value, "F");
+        Assert.Equal(expected, s);
     }
 
     [Fact]
-    public static void TestFormat()
+    public static void TestFormatInvalid()
     {
-        String s;
-
-        s = Enum.Format(typeof(SimpleEnum), SimpleEnum.Red, "F");
-        Assert.Equal(s, "Red");
-
-        // Can pass enum or exact underlying integral.
-        s = Enum.Format(typeof(SimpleEnum), 1, "F");
-        Assert.Equal(s, "Red");
-
-        Assert.Throws<ArgumentNullException>(() => Enum.Format(null, (Int32Enum)1, "F"));
-        Assert.Throws<ArgumentNullException>(() => Enum.Format(typeof(SimpleEnum), null, "F"));
-
-        // Not an enum type.
-        Assert.Throws<ArgumentException>(() => Enum.Format(typeof(Object), 1, "F"));
-
-        // Wrong enumType.
-        Assert.Throws<ArgumentException>(() => Enum.Format(typeof(SimpleEnum), (Int32Enum)1, "F"));
-
-        // Wrong integral.
-        Assert.Throws<ArgumentException>(() => Enum.Format(typeof(SimpleEnum), (short)1, "F"));
-
-        // Not an integral.
-        Assert.Throws<ArgumentException>(() => Enum.Format(typeof(SimpleEnum), "Red", "F"));
+        Assert.Throws<ArgumentNullException>("enumType", () => Enum.Format(null, (Int32Enum)1, "F")); // Enum type is null
+        Assert.Throws<ArgumentNullException>("value", () => Enum.Format(typeof(SimpleEnum), null, "F")); // Value is null
+        
+        Assert.Throws<ArgumentException>("enumType", () => Enum.Format(typeof(object), 1, "F")); // Enum type is not an enum type
+        
+        Assert.Throws<ArgumentException>(null, () => Enum.Format(typeof(SimpleEnum), (Int32Enum)1, "F")); // Value is of the wrong enum type
+        
+        Assert.Throws<ArgumentException>(null, () => Enum.Format(typeof(SimpleEnum), (short)1, "F")); // Value is of the wrong integral
+        Assert.Throws<ArgumentException>(null, () => Enum.Format(typeof(SimpleEnum), "Red", "F")); // Value is of the wrong integral
     }
 
     private enum SimpleEnum
@@ -907,71 +473,70 @@ public static unsafe class EnumTests
         Blue = 2,
         Green = 3,
         Green_a = 3,
-        Green_b = 3,
+        Green_b = 3
     }
 
     private enum ByteEnum : byte
     {
-        Min = 0,
+        Min = byte.MinValue,
         One = 1,
         Two = 2,
-        Max = 0xff,
+        Max = byte.MaxValue,
     }
 
     private enum SByteEnum : sbyte
     {
-        Min = -128,
+        Min = sbyte.MinValue,
         One = 1,
         Two = 2,
-        Max = 127,
+        Max = sbyte.MaxValue,
     }
 
     private enum UInt16Enum : ushort
     {
-        Min = 0,
+        Min = ushort.MinValue,
         One = 1,
         Two = 2,
-        Max = 0xffff,
+        Max = ushort.MaxValue,
     }
 
     private enum Int16Enum : short
     {
-        Min = Int16.MinValue,
+        Min = short.MinValue,
         One = 1,
         Two = 2,
-        Max = 0x7fff,
+        Max = short.MaxValue,
     }
 
     private enum UInt32Enum : uint
     {
-        Min = 0,
+        Min = uint.MinValue,
         One = 1,
         Two = 2,
-        Max = 0xffffffff,
+        Max = uint.MaxValue,
     }
 
     private enum Int32Enum : int
     {
-        Min = Int32.MinValue,
+        Min = int.MinValue,
         One = 1,
         Two = 2,
-        Max = 0x7fffffff,
+        Max = int.MaxValue,
     }
 
     private enum UInt64Enum : ulong
     {
-        Min = 0,
+        Min = ulong.MinValue,
         One = 1,
         Two = 2,
-        Max = 0xffffffffffffffff,
+        Max = ulong.MaxValue,
     }
 
     private enum Int64Enum : long
     {
-        Min = Int64.MinValue,
+        Min = long.MinValue,
         One = 1,
         Two = 2,
-        Max = 0x7fffffffffffffff,
+        Max = long.MaxValue,
     }
 }
-

--- a/src/System.Runtime/tests/System/FieldAccessException.cs
+++ b/src/System.Runtime/tests/System/FieldAccessException.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Globalization;
+
 using Xunit;
 
 public static class FieldAccessExceptionTests

--- a/src/System.Runtime/tests/System/GC.cs
+++ b/src/System.Runtime/tests/System/GC.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+
 using Xunit;
 
 public class GCTests

--- a/src/System.Runtime/tests/System/Guid.cs
+++ b/src/System.Runtime/tests/System/Guid.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Linq;
-using System.Globalization;
+
 using Xunit;
 
 public static class GuidTests

--- a/src/System.Runtime/tests/System/IO/DirectoryNotFoundException.Interop.cs
+++ b/src/System.Runtime/tests/System/IO/DirectoryNotFoundException.Interop.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.IO;
 using System.Runtime.InteropServices;
+
 using Xunit;
 
 public partial class DirectoryNotFoundException_Interop_40100_Tests

--- a/src/System.Runtime/tests/System/IO/DirectoryNotFoundException.cs
+++ b/src/System.Runtime/tests/System/IO/DirectoryNotFoundException.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+
 using Xunit;
 
 public partial class DirectoryNotFoundException_40100_Tests

--- a/src/System.Runtime/tests/System/IO/Exceptions.HResults.cs
+++ b/src/System.Runtime/tests/System/IO/Exceptions.HResults.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using Xunit;
-
 public static class HResults
 {
     public const int COR_E_DIRECTORYNOTFOUND = unchecked((int)0x80070003);

--- a/src/System.Runtime/tests/System/IO/Exceptions.Utility.cs
+++ b/src/System.Runtime/tests/System/IO/Exceptions.Utility.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+
 using Xunit;
 
 public class Utility

--- a/src/System.Runtime/tests/System/IO/FileLoadException.Interop.cs
+++ b/src/System.Runtime/tests/System/IO/FileLoadException.Interop.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.IO;
 using System.Runtime.InteropServices;
+
 using Xunit;
 
 public partial class FileLoadException_Interop_40100_Tests

--- a/src/System.Runtime/tests/System/IO/FileLoadException.cs
+++ b/src/System.Runtime/tests/System/IO/FileLoadException.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+
 using Xunit;
 
 public partial class FileLoadException_40100_Tests
@@ -71,13 +72,13 @@ public partial class FileLoadException_40100_Tests
         try { throw fle; }
         catch
         {
-            Assert.False(String.IsNullOrEmpty(fle.StackTrace));
+            Assert.False(string.IsNullOrEmpty(fle.StackTrace));
             AssertContains(fle.StackTrace, fle.ToString());
         }
     }
 
     private static void AssertContains(string expected, string actual)
     {
-        Assert.True(actual.Contains(expected), String.Format("\"{0}\" contains \"{1}\"", actual, expected));
+        Assert.True(actual.Contains(expected), string.Format("\"{0}\" contains \"{1}\"", actual, expected));
     }
 }

--- a/src/System.Runtime/tests/System/IO/PathTooLongException.Interop.cs
+++ b/src/System.Runtime/tests/System/IO/PathTooLongException.Interop.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.IO;
 using System.Runtime.InteropServices;
+
 using Xunit;
 
 public partial class PathTooLongException_Interop_40100_Tests

--- a/src/System.Runtime/tests/System/IO/PathTooLongException.cs
+++ b/src/System.Runtime/tests/System/IO/PathTooLongException.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Text;
+
 using Xunit;
 
 public partial class PathTooLongException_40100_Tests

--- a/src/System.Runtime/tests/System/Int16.cs
+++ b/src/System.Runtime/tests/System/Int16.cs
@@ -2,102 +2,105 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Runtime.Tests.Common;
+
 using Xunit;
 
 public static class Int16Tests
 {
     [Fact]
-    public static void TestCtor()
+    public static void TestCtorEmpty()
     {
-        Int16 i = new Int16();
-        Assert.True(i == 0);
+        short i = new short();
+        Assert.Equal(0, i);
+    }
 
-        i = 41;
-        Assert.True(i == 41);
+    [Fact]
+    public static void TestCtorValue()
+    {
+        short i = 41;
+        Assert.Equal(41, i);
     }
 
     [Fact]
     public static void TestMaxValue()
     {
-        Int16 max = Int16.MaxValue;
-
-        Assert.True(max == (Int16)0x7FFF);
+        Assert.Equal(0x7FFF, short.MaxValue);
     }
 
     [Fact]
     public static void TestMinValue()
     {
-        Int16 min = Int16.MinValue;
+        Assert.Equal(unchecked((short)0x8000), short.MinValue);
+    }
 
-        Assert.True(min == unchecked((Int16)0x8000));
+    [Theory]
+    [InlineData((short)234, 0)]
+    [InlineData(short.MinValue, 1)]
+    [InlineData((short)(-123), 1)]
+    [InlineData((short)0, 1)]
+    [InlineData((short)45, 1)]
+    [InlineData((short)123, 1)]
+    [InlineData((short)456, -1)]
+    [InlineData(short.MaxValue, -1)]
+    public static void TestCompareTo(short value, int expected)
+    {
+        short i = 234;
+        int result = CompareHelper.NormalizeCompare(i.CompareTo(value));
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null, 1)]
+    [InlineData((short)234, 0)]
+    [InlineData(short.MinValue, 1)]
+    [InlineData((short)(-123), 1)]
+    [InlineData((short)0, 1)]
+    [InlineData((short)45, 1)]
+    [InlineData((short)123, 1)]
+    [InlineData((short)456, -1)]
+    [InlineData(short.MaxValue, -1)]
+    public static void TestCompareToObject(object obj, int expected)
+    {
+        IComparable comparable = (short)234;
+        int i = CompareHelper.NormalizeCompare(comparable.CompareTo(obj));
+        Assert.Equal(expected, i);
     }
 
     [Fact]
-    public static void TestCompareToObject()
+    public static void TestCompareToObjectInvalid()
     {
-        Int16 i = 234;
-        IComparable comparable = i;
-
-        Assert.Equal(1, comparable.CompareTo(null));
-        Assert.Equal(0, comparable.CompareTo((Int16)234));
-
-        Assert.True(comparable.CompareTo(Int16.MinValue) > 0);
-        Assert.True(comparable.CompareTo((Int16)0) > 0);
-        Assert.True(comparable.CompareTo((Int16)(-123)) > 0);
-        Assert.True(comparable.CompareTo((Int16)123) > 0);
-        Assert.True(comparable.CompareTo((Int16)456) < 0);
-        Assert.True(comparable.CompareTo(Int16.MaxValue) < 0);
-
-        Assert.Throws<ArgumentException>(() => comparable.CompareTo("a"));
+        IComparable comparable = (short)234;
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); //Obj is not a short
     }
 
-    [Fact]
-    public static void TestCompareTo()
+    [Theory]
+    [InlineData((short)789, true)]
+    [InlineData((short)(-789), false)]
+    [InlineData((short)0, false)]
+    public static void TestEqualsObject(object obj, bool expected)
     {
-        Int16 i = 234;
-
-        Assert.Equal(0, i.CompareTo((Int16)234));
-
-        Assert.True(i.CompareTo(Int16.MinValue) > 0);
-        Assert.True(i.CompareTo((Int16)0) > 0);
-        Assert.True(i.CompareTo((Int16)(-123)) > 0);
-        Assert.True(i.CompareTo((Int16)123) > 0);
-        Assert.True(i.CompareTo((Int16)456) < 0);
-        Assert.True(i.CompareTo(Int16.MaxValue) < 0);
+        short i = 789;
+        Assert.Equal(expected, i.Equals(obj));
     }
 
-    [Fact]
-    public static void TestEqualsObject()
+    [Theory]
+    [InlineData((short)789, true)]
+    [InlineData((short)(-789), false)]
+    [InlineData((short)0, false)]
+    public static void TestEquals(short i2, bool expected)
     {
-        Int16 i = 789;
-
-        object obj1 = (Int16)789;
-        Assert.True(i.Equals(obj1));
-
-        object obj2 = (Int16)(-789);
-        Assert.True(!i.Equals(obj2));
-
-        object obj3 = (Int16)0;
-        Assert.True(!i.Equals(obj3));
-    }
-
-    [Fact]
-    public static void TestEquals()
-    {
-        Int16 i = -911;
-
-        Assert.True(i.Equals((Int16)(-911)));
-
-        Assert.True(!i.Equals((Int16)911));
-        Assert.True(!i.Equals((Int16)0));
+        short i = 789;
+        Assert.Equal(expected, i.Equals(i2));
     }
 
     [Fact]
     public static void TestGetHashCode()
     {
-        Int16 i1 = 123;
-        Int16 i2 = 654;
+        short i1 = 123;
+        short i2 = 654;
 
         Assert.NotEqual(0, i1.GetHashCode());
         Assert.NotEqual(i1.GetHashCode(), i2.GetHashCode());
@@ -106,25 +109,25 @@ public static class Int16Tests
     [Fact]
     public static void TestToString()
     {
-        Int16 i1 = 6310;
+        short i1 = 6310;
         Assert.Equal("6310", i1.ToString());
 
-        Int16 i2 = -8249;
+        short i2 = -8249;
         Assert.Equal("-8249", i2.ToString());
     }
 
     [Fact]
     public static void TestToStringFormatProvider()
     {
-        var numberFormat = new System.Globalization.NumberFormatInfo();
+        var numberFormat = new NumberFormatInfo();
 
-        Int16 i1 = 6310;
+        short i1 = 6310;
         Assert.Equal("6310", i1.ToString(numberFormat));
 
-        Int16 i2 = -8249;
+        short i2 = -8249;
         Assert.Equal("-8249", i2.ToString(numberFormat));
 
-        Int16 i3 = -2468;
+        short i3 = -2468;
 
         // Changing the negative pattern doesn't do anything without also passing in a format string
         numberFormat.NumberNegativePattern = 0;
@@ -134,122 +137,155 @@ public static class Int16Tests
     [Fact]
     public static void TestToStringFormat()
     {
-        Int16 i1 = 6310;
+        short i1 = 6310;
         Assert.Equal("6310", i1.ToString("G"));
 
-        Int16 i2 = -8249;
+        short i2 = -8249;
         Assert.Equal("-8249", i2.ToString("g"));
 
-        Int16 i3 = -2468;
+        short i3 = -2468;
         Assert.Equal(string.Format("{0:N}", -2468.00), i3.ToString("N"));
 
-        Int16 i4 = 0x248;
+        short i4 = 0x248;
         Assert.Equal("248", i4.ToString("x"));
     }
 
     [Fact]
     public static void TestToStringFormatFormatProvider()
     {
-        var numberFormat = new System.Globalization.NumberFormatInfo();
+        var numberFormat = new NumberFormatInfo();
 
-        Int16 i1 = 6310;
+        short i1 = 6310;
         Assert.Equal("6310", i1.ToString("G", numberFormat));
 
-        Int16 i2 = -8249;
+        short i2 = -8249;
         Assert.Equal("-8249", i2.ToString("g", numberFormat));
 
         numberFormat.NegativeSign = "xx"; // setting it to trash to make sure it doesn't show up
         numberFormat.NumberGroupSeparator = "*";
         numberFormat.NumberNegativePattern = 0;
-        Int16 i3 = -2468;
+        short i3 = -2468;
         Assert.Equal("(2*468.00)", i3.ToString("N", numberFormat));
     }
 
-    [Fact]
-    public static void TestParse()
+    public static IEnumerable<object[]> ParseValidData()
     {
-        Assert.Equal(123, Int16.Parse("123"));
-        Assert.Equal(-123, Int16.Parse("-123"));
-        //TODO: Negative tests once we get better exceptions
+        NumberFormatInfo defaultFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+        var emptyNfi = new NumberFormatInfo();
+
+        var testNfi = new NumberFormatInfo();
+        testNfi.CurrencySymbol = "$";
+
+        yield return new object[] { "-32768", defaultStyle, defaultFormat, (short)-32768 };
+        yield return new object[] { "-123", defaultStyle, defaultFormat, (short)-123 };
+        yield return new object[] { "0", defaultStyle, defaultFormat, (short)0 };
+        yield return new object[] { "123", defaultStyle, defaultFormat, (short)123 };
+        yield return new object[] { "  123  ", defaultStyle, defaultFormat, (short)123 };
+        yield return new object[] { "32767", defaultStyle, defaultFormat, (short)32767 };
+
+        yield return new object[] { "123", NumberStyles.HexNumber, defaultFormat, (short )0x123 };
+        yield return new object[] { "abc", NumberStyles.HexNumber, defaultFormat, (short)0xabc };
+        yield return new object[] { "1000", NumberStyles.AllowThousands, defaultFormat, (short)1000 };
+        yield return new object[] { "(123)", NumberStyles.AllowParentheses, defaultFormat, (short)-123 }; // Parentheses = negative
+
+        yield return new object[] { "123", defaultStyle, emptyNfi, (short)123 };
+
+        yield return new object[] { "123", NumberStyles.Any, emptyNfi, (short)123 };
+        yield return new object[] { "12", NumberStyles.HexNumber, emptyNfi, (short)0x12 };
+        yield return new object[] { "$1,000", NumberStyles.Currency, testNfi, (short)1000 };
     }
 
-    [Fact]
-    public static void TestParseNumberStyle()
+    public static IEnumerable<object[]> ParseInvalidData()
     {
-        Assert.Equal(0x123, Int16.Parse("123", NumberStyles.HexNumber));
-        Assert.Equal(1000, Int16.Parse((1000).ToString("N0"), NumberStyles.AllowThousands));
-        //TODO: Negative tests once we get better exceptions
+        NumberFormatInfo defaultFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+        var emptyNfi = new NumberFormatInfo();
+
+        var testNfi = new NumberFormatInfo();
+        testNfi.CurrencySymbol = "$";
+        testNfi.NumberDecimalSeparator = ".";
+
+        yield return new object[] { null, defaultStyle, defaultFormat, typeof(ArgumentNullException) };
+        yield return new object[] { "", defaultStyle, defaultFormat, typeof(FormatException) };
+        yield return new object[] { " ", defaultStyle, defaultFormat, typeof(FormatException) };
+        yield return new object[] { "Garbage", defaultStyle, defaultFormat, typeof(FormatException) };
+
+        yield return new object[] { "abc", defaultStyle, defaultFormat, typeof(FormatException) }; // Hex value
+        yield return new object[] { "1E23", defaultStyle, defaultFormat, typeof(FormatException) }; // Exponent
+        yield return new object[] { "(123)", defaultStyle, defaultFormat, typeof(FormatException) }; // Parentheses
+        yield return new object[] { 1000.ToString("C0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Currency
+        yield return new object[] { 1000.ToString("N0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Thousands
+        yield return new object[] { 678.90.ToString("F2"), defaultStyle, defaultFormat, typeof(FormatException) }; //Decimal
+
+        yield return new object[] { "abc", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Negative hex value
+        yield return new object[] { "  123  ", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Trailing and leading whitespace
+
+        yield return new object[] { "67.90", defaultStyle, testNfi, typeof(FormatException) }; // Decimal
+        
+        yield return new object[] { "-32769", defaultStyle, defaultFormat, typeof(OverflowException) }; // < min value
+        yield return new object[] { "32768", defaultStyle, defaultFormat, typeof(OverflowException) }; // > max value
     }
 
-    [Fact]
-    public static void TestParseFormatProvider()
+    [Theory, MemberData("ParseValidData")]
+    public static void TestParse(string value, NumberStyles style, NumberFormatInfo nfi, short expected)
     {
-        var nfi = new NumberFormatInfo();
-        Assert.Equal(123, Int16.Parse("123", nfi));
-        Assert.Equal(-123, Int16.Parse("-123", nfi));
-        //TODO: Negative tests once we get better exceptions
+        short i;
+        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        if (style == NumberStyles.Integer)
+        {
+            Assert.Equal(true, short.TryParse(value, out i));
+            Assert.Equal(expected, i);
+
+            Assert.Equal(expected, short.Parse(value));
+
+            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (nfi != null)
+            {
+                Assert.Equal(expected, short.Parse(value, nfi));
+            }
+        }
+
+        // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
+        Assert.Equal(true, short.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
+        Assert.Equal(expected, i);
+
+        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (nfi == null)
+        {
+            Assert.Equal(expected, short.Parse(value, style));
+        }
+        Assert.Equal(expected, short.Parse(value, style, nfi ?? new NumberFormatInfo()));
     }
 
-    [Fact]
-    public static void TestParseNumberStyleFormatProvider()
+    [Theory, MemberData("ParseInvalidData")]
+    public static void TestParseInvalid(string value, NumberStyles style, NumberFormatInfo nfi, Type exceptionType)
     {
-        var nfi = new NumberFormatInfo();
-        Assert.Equal(0x123, Int16.Parse("123", NumberStyles.HexNumber, nfi));
+        short i;
+        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        if (style == NumberStyles.Integer)
+        {
+            Assert.Equal(false, short.TryParse(value, out i));
+            Assert.Equal(default(short), i);
 
-        nfi.CurrencySymbol = "$";
-        nfi.CurrencyGroupSeparator = ",";
-        Assert.Equal(1000, Int16.Parse("$1,000", NumberStyles.Currency, nfi));
-        //TODO: Negative tests once we get better exception support
-    }
+            Assert.Throws(exceptionType, () => short.Parse(value));
 
-    [Fact]
-    public static void TestTryParse()
-    {
-        // Defaults NumberStyles.Integer = NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite | NumberStyles.AllowLeadingSign
+            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (nfi != null)
+            {
+                Assert.Throws(exceptionType, () => short.Parse(value, nfi));
+            }
+        }
 
-        Int16 i;
-        Assert.True(Int16.TryParse("123", out i));     // Simple
-        Assert.Equal(123, i);
+        // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
+        Assert.Equal(false, short.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
+        Assert.Equal(default(short), i);
 
-        Assert.True(Int16.TryParse("-385", out i));    // LeadingSign
-        Assert.Equal(-385, i);
-
-        Assert.True(Int16.TryParse(" 678 ", out i));   // Leading/Trailing whitespace
-        Assert.Equal(678, i);
-
-        var nfi = new NumberFormatInfo() { CurrencyGroupSeparator = "" };
-        Assert.False(Int16.TryParse((1000).ToString("C0", nfi), out i));  // Currency
-        Assert.False(Int16.TryParse((1000).ToString("N0"), out i));  // Thousands
-        Assert.False(Int16.TryParse("abc", out i));    // Hex digits
-        Assert.False(Int16.TryParse((678.90).ToString("F2"), out i)); // Decimal
-        Assert.False(Int16.TryParse("(135)", out i));  // Parentheses
-        Assert.False(Int16.TryParse("1E23", out i));   // Exponent
-    }
-
-    [Fact]
-    public static void TestTryParseNumberStyleFormatProvider()
-    {
-        Int16 i;
-        var nfi = new NumberFormatInfo();
-        Assert.True(Int16.TryParse("123", NumberStyles.Any, nfi, out i));   // Simple positive
-        Assert.Equal(123, i);
-
-        Assert.True(Int16.TryParse("123", NumberStyles.HexNumber, nfi, out i));   // Simple Hex
-        Assert.Equal(0x123, i);
-
-        nfi.CurrencySymbol = "$";
-        Assert.True(Int16.TryParse("$1,000", NumberStyles.Currency, nfi, out i)); // Currency/Thousands postive
-        Assert.Equal(1000, i);
-
-        Assert.False(Int16.TryParse("abc", NumberStyles.None, nfi, out i));       // Hex Number negative
-        Assert.True(Int16.TryParse("abc", NumberStyles.HexNumber, nfi, out i));   // Hex Number positive
-        Assert.Equal(0xabc, i);
-
-        Assert.False(Int16.TryParse("678.90", NumberStyles.Integer, nfi, out i));  // Decimal
-        Assert.False(Int16.TryParse(" 678 ", NumberStyles.None, nfi, out i));      // Trailing/Leading whitespace negative
-
-        Assert.True(Int16.TryParse("(135)", NumberStyles.AllowParentheses, nfi, out i)); // Parenthese postive
-        Assert.Equal(-135, i);
+        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (nfi == null)
+        {
+            Assert.Throws(exceptionType, () => short.Parse(value, style));
+        }
+        Assert.Throws(exceptionType, () => short.Parse(value, style, nfi ?? new NumberFormatInfo()));
     }
 }
-

--- a/src/System.Runtime/tests/System/Int32.cs
+++ b/src/System.Runtime/tests/System/Int32.cs
@@ -2,102 +2,105 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Runtime.Tests.Common;
+
 using Xunit;
 
 public static class Int32Tests
 {
     [Fact]
-    public static void TestCtor()
+    public static void TestCtorEmpty()
     {
-        Int32 i = new Int32();
-        Assert.True(i == 0);
+        int i = new int();
+        Assert.Equal(0, i);
+    }
 
-        i = 41;
-        Assert.True(i == 41);
+    [Fact]
+    public static void TestCtorValue()
+    {
+        int i = 41;
+        Assert.Equal(41, i);
     }
 
     [Fact]
     public static void TestMaxValue()
     {
-        Int32 max = Int32.MaxValue;
-
-        Assert.True(max == (Int32)0x7FFFFFFF);
+        Assert.Equal(0x7FFFFFFF, int.MaxValue);
     }
 
     [Fact]
     public static void TestMinValue()
     {
-        Int32 min = Int32.MinValue;
+        Assert.Equal(unchecked((int)0x80000000), int.MinValue);
+    }
 
-        Assert.True(min == unchecked((Int32)0x80000000));
+    [Theory]
+    [InlineData(234, 0)]
+    [InlineData(int.MinValue, 1)]
+    [InlineData(-123, 1)]
+    [InlineData(0, 1)]
+    [InlineData(45, 1)]
+    [InlineData(123, 1)]
+    [InlineData(456, -1)]
+    [InlineData(int.MaxValue, -1)]
+    public static void TestCompareTo(int value, int expected)
+    {
+        int i = 234;
+        int result = CompareHelper.NormalizeCompare(i.CompareTo(value));
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null, 1)]
+    [InlineData(234, 0)]
+    [InlineData(int.MinValue, 1)]
+    [InlineData(-123, 1)]
+    [InlineData(0, 1)]
+    [InlineData(45, 1)]
+    [InlineData(123, 1)]
+    [InlineData(456, -1)]
+    [InlineData(int.MaxValue, -1)]
+    public static void TestCompareToObject(object obj, int expected)
+    {
+        IComparable comparable = 234;
+        int i = CompareHelper.NormalizeCompare(comparable.CompareTo(obj));
+        Assert.Equal(expected, i);
     }
 
     [Fact]
-    public static void TestCompareToObject()
+    public static void TestCompareToObjectInvalid()
     {
-        Int32 i = 234;
-        IComparable comparable = i;
-
-        Assert.Equal(1, comparable.CompareTo(null));
-        Assert.Equal(0, comparable.CompareTo((Int32)234));
-
-        Assert.True(comparable.CompareTo(Int32.MinValue) > 0);
-        Assert.True(comparable.CompareTo((Int32)0) > 0);
-        Assert.True(comparable.CompareTo((Int32)(-123)) > 0);
-        Assert.True(comparable.CompareTo((Int32)123) > 0);
-        Assert.True(comparable.CompareTo((Int32)456) < 0);
-        Assert.True(comparable.CompareTo(Int32.MaxValue) < 0);
-
-        Assert.Throws<ArgumentException>(() => comparable.CompareTo("a"));
+        IComparable comparable = 234;
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); //Obj is not a int
     }
 
-    [Fact]
-    public static void TestCompareTo()
+    [Theory]
+    [InlineData(789, true)]
+    [InlineData(-789, false)]
+    [InlineData(0, false)]
+    public static void TestEqualsObject(object obj, bool expected)
     {
-        Int32 i = 234;
-
-        Assert.Equal(0, i.CompareTo((Int32)234));
-
-        Assert.True(i.CompareTo(Int32.MinValue) > 0);
-        Assert.True(i.CompareTo((Int32)0) > 0);
-        Assert.True(i.CompareTo((Int32)(-123)) > 0);
-        Assert.True(i.CompareTo((Int32)123) > 0);
-        Assert.True(i.CompareTo((Int32)456) < 0);
-        Assert.True(i.CompareTo(Int32.MaxValue) < 0);
+        int i = 789;
+        Assert.Equal(expected, i.Equals(obj));
     }
 
-    [Fact]
-    public static void TestEqualsObject()
+    [Theory]
+    [InlineData(789, true)]
+    [InlineData(-789, false)]
+    [InlineData(0, false)]
+    public static void TestEquals(int i2, bool expected)
     {
-        Int32 i = 789;
-
-        object obj1 = (Int32)789;
-        Assert.True(i.Equals(obj1));
-
-        object obj2 = (Int32)(-789);
-        Assert.True(!i.Equals(obj2));
-
-        object obj3 = (Int32)0;
-        Assert.True(!i.Equals(obj3));
-    }
-
-    [Fact]
-    public static void TestEquals()
-    {
-        Int32 i = -911;
-
-        Assert.True(i.Equals((Int32)(-911)));
-
-        Assert.True(!i.Equals((Int32)911));
-        Assert.True(!i.Equals((Int32)0));
+        int i = 789;
+        Assert.Equal(expected, i.Equals(i2));
     }
 
     [Fact]
     public static void TestGetHashCode()
     {
-        Int32 i1 = 123;
-        Int32 i2 = 654;
+        int i1 = 123;
+        int i2 = 654;
 
         Assert.NotEqual(0, i1.GetHashCode());
         Assert.NotEqual(i1.GetHashCode(), i2.GetHashCode());
@@ -106,25 +109,25 @@ public static class Int32Tests
     [Fact]
     public static void TestToString()
     {
-        Int32 i1 = 6310;
+        int i1 = 6310;
         Assert.Equal("6310", i1.ToString());
 
-        Int32 i2 = -8249;
+        int i2 = -8249;
         Assert.Equal("-8249", i2.ToString());
     }
 
     [Fact]
     public static void TestToStringFormatProvider()
     {
-        var numberFormat = new System.Globalization.NumberFormatInfo();
+        var numberFormat = new NumberFormatInfo();
 
-        Int32 i1 = 6310;
+        int i1 = 6310;
         Assert.Equal("6310", i1.ToString(numberFormat));
 
-        Int32 i2 = -8249;
+        int i2 = -8249;
         Assert.Equal("-8249", i2.ToString(numberFormat));
 
-        Int32 i3 = -2468;
+        int i3 = -2468;
 
         // Changing the negative pattern doesn't do anything without also passing in a format string
         numberFormat.NumberNegativePattern = 0;
@@ -134,124 +137,154 @@ public static class Int32Tests
     [Fact]
     public static void TestToStringFormat()
     {
-        Int32 i1 = 6310;
+        int i1 = 6310;
         Assert.Equal("6310", i1.ToString("G"));
 
-        Int32 i2 = -8249;
+        int i2 = -8249;
         Assert.Equal("-8249", i2.ToString("g"));
 
-        Int32 i3 = -2468;
+        int i3 = -2468;
         Assert.Equal(string.Format("{0:N}", -2468.00), i3.ToString("N"));
 
-        Int32 i4 = 0x248;
+        int i4 = 0x248;
         Assert.Equal("248", i4.ToString("x"));
     }
 
     [Fact]
     public static void TestToStringFormatFormatProvider()
     {
-        var numberFormat = new System.Globalization.NumberFormatInfo();
+        var numberFormat = new NumberFormatInfo();
 
-        Int32 i1 = 6310;
+        int i1 = 6310;
         Assert.Equal("6310", i1.ToString("G", numberFormat));
 
-        Int32 i2 = -8249;
+        int i2 = -8249;
         Assert.Equal("-8249", i2.ToString("g", numberFormat));
 
         numberFormat.NegativeSign = "xx"; // setting it to trash to make sure it doesn't show up
         numberFormat.NumberGroupSeparator = "*";
         numberFormat.NumberNegativePattern = 0;
-        Int32 i3 = -2468;
+        int i3 = -2468;
         Assert.Equal("(2*468.00)", i3.ToString("N", numberFormat));
     }
 
-    [Fact]
-    public static void TestParse()
+    public static IEnumerable<object[]> ParseValidData()
     {
-        Assert.Equal(123, Int32.Parse("123"));
-        Assert.Equal(-123, Int32.Parse("-123"));
-        //TODO: Negative tests once we get better exceptions
+        NumberFormatInfo defaultFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+        var emptyNfi = new NumberFormatInfo();
+
+        var testNfi = new NumberFormatInfo();
+        testNfi.CurrencySymbol = "$";
+
+        yield return new object[] { "-2147483648", defaultStyle, defaultFormat, -2147483648 };
+        yield return new object[] { "0", defaultStyle, defaultFormat, 0 };
+        yield return new object[] { "123", defaultStyle, defaultFormat, 123 };
+        yield return new object[] { "  123  ", defaultStyle, defaultFormat, 123 };
+        yield return new object[] { "2147483647", defaultStyle, defaultFormat, 2147483647 };
+
+        yield return new object[] { "123", NumberStyles.HexNumber, defaultFormat, 0x123 };
+        yield return new object[] { "abc", NumberStyles.HexNumber, defaultFormat, 0xabc };
+        yield return new object[] { "1000", NumberStyles.AllowThousands, defaultFormat, 1000 };
+        yield return new object[] { "(123)", NumberStyles.AllowParentheses, defaultFormat, -123 }; // Parentheses = negative
+
+        yield return new object[] { "123", defaultStyle, emptyNfi, 123 };
+
+        yield return new object[] { "123", NumberStyles.Any, emptyNfi, 123 };
+        yield return new object[] { "12", NumberStyles.HexNumber, emptyNfi, 0x12 };
+        yield return new object[] { "$1,000", NumberStyles.Currency, testNfi, 1000 };
     }
 
-    [Fact]
-    public static void TestParseNumberStyle()
+    public static IEnumerable<object[]> ParseInvalidData()
     {
-        Assert.Equal(0x123, Int64.Parse("123", NumberStyles.HexNumber));
-        Assert.Equal(1000, Int32.Parse((1000).ToString("N0"), NumberStyles.AllowThousands));
-        //TODO: Negative tests once we get better exceptions
+        NumberFormatInfo defaultFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+        var emptyNfi = new NumberFormatInfo();
+
+        var testNfi = new NumberFormatInfo();
+        testNfi.CurrencySymbol = "$";
+        testNfi.NumberDecimalSeparator = ".";
+
+        yield return new object[] { null, defaultStyle, defaultFormat, typeof(ArgumentNullException) };
+        yield return new object[] { "", defaultStyle, defaultFormat, typeof(FormatException) };
+        yield return new object[] { " ", defaultStyle, defaultFormat, typeof(FormatException) };
+        yield return new object[] { "Garbage", defaultStyle, defaultFormat, typeof(FormatException) };
+
+        yield return new object[] { "abc", defaultStyle, defaultFormat, typeof(FormatException) }; // Hex value
+        yield return new object[] { "1E23", defaultStyle, defaultFormat, typeof(FormatException) }; // Exponent
+        yield return new object[] { "(123)", defaultStyle, defaultFormat, typeof(FormatException) }; // Parentheses
+        yield return new object[] { 1000.ToString("C0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Currency
+        yield return new object[] { 1000.ToString("N0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Thousands
+        yield return new object[] { 678.90.ToString("F2"), defaultStyle, defaultFormat, typeof(FormatException) }; //Decimal
+
+        yield return new object[] { "abc", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Negative hex value
+        yield return new object[] { "  123  ", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Trailing and leading whitespace
+
+        yield return new object[] { "67.90", defaultStyle, testNfi, typeof(FormatException) }; // Decimal
+        
+        yield return new object[] { "-2147483649", defaultStyle, defaultFormat, typeof(OverflowException) }; // > max value
+        yield return new object[] { "2147483648", defaultStyle, defaultFormat, typeof(OverflowException) }; // < min value
     }
 
-    [Fact]
-    public static void TestParseFormatProvider()
+    [Theory, MemberData("ParseValidData")]
+    public static void TestParse(string value, NumberStyles style, NumberFormatInfo nfi, int expected)
     {
-        var nfi = new NumberFormatInfo();
-        Assert.Equal(123, Int32.Parse("123", nfi));
-        Assert.Equal(-123, Int32.Parse("-123", nfi));
-        //TODO: Negative tests once we get better exceptions
+        int i;
+        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        if (style == NumberStyles.Integer)
+        {
+            Assert.Equal(true, int.TryParse(value, out i));
+            Assert.Equal(expected, i);
+
+            Assert.Equal(expected, int.Parse(value));
+
+            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (nfi != null)
+            {
+                Assert.Equal(expected, int.Parse(value, nfi));
+            }
+        }
+
+        // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
+        Assert.Equal(true, int.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
+        Assert.Equal(expected, i);
+
+        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (nfi == null)
+        {
+            Assert.Equal(expected, int.Parse(value, style));
+        }
+        Assert.Equal(expected, int.Parse(value, style, nfi ?? new NumberFormatInfo()));
     }
 
-    [Fact]
-    public static void TestParseNumberStyleFormatProvider()
+    [Theory, MemberData("ParseInvalidData")]
+    public static void TestParseInvalid(string value, NumberStyles style, NumberFormatInfo nfi, Type exceptionType)
     {
-        var nfi = new NumberFormatInfo();
-        Assert.Equal(0x123, Int32.Parse("123", NumberStyles.HexNumber, nfi));
+        int i;
+        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        if (style == NumberStyles.Integer)
+        {
+            Assert.Equal(false, int.TryParse(value, out i));
+            Assert.Equal(default(int), i);
 
-        nfi.CurrencySymbol = "$";
-        nfi.CurrencyGroupSeparator = ",";
-        Assert.Equal(1000, Int32.Parse("$1,000", NumberStyles.Currency, nfi));
-        //TODO: Negative tests once we get better exception support
-    }
+            Assert.Throws(exceptionType, () => int.Parse(value));
 
-    [Fact]
-    public static void TestTryParse()
-    {
-        // Defaults NumberStyles.Integer = NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite | NumberStyles.AllowLeadingSign
+            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (nfi != null)
+            {
+                Assert.Throws(exceptionType, () => int.Parse(value, nfi));
+            }
+        }
 
-        Int32 i;
-        Assert.True(Int32.TryParse("123", out i));     // Simple
-        Assert.Equal(123, i);
+        // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
+        Assert.Equal(false, int.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
+        Assert.Equal(default(int), i);
 
-        Assert.True(Int32.TryParse("-385", out i));    // LeadingSign
-        Assert.Equal(-385, i);
-
-        Assert.True(Int32.TryParse(" 678 ", out i));   // Leading/Trailing whitespace
-        Assert.Equal(678, i);
-
-        var nfi = new NumberFormatInfo() { CurrencyGroupSeparator = "" };
-        Assert.False(Int32.TryParse((1000).ToString("C0", nfi), out i));  // Currency
-        Assert.False(Int32.TryParse((1000).ToString("N0"), out i));  // Thousands
-        Assert.False(Int32.TryParse("abc", out i));    // Hex digits
-        Assert.False(Int32.TryParse((678.90).ToString("F2"), out i)); // Decimal
-        Assert.False(Int32.TryParse("(135)", out i));  // Parentheses
-        Assert.False(Int32.TryParse("1E23", out i));   // Exponent
-    }
-
-    [Fact]
-    public static void TestTryParseNumberStyleFormatProvider()
-    {
-        Int32 i;
-        var nfi = new NumberFormatInfo();
-        Assert.True(Int32.TryParse("123", NumberStyles.Any, nfi, out i));   // Simple positive
-        Assert.Equal(123, i);
-
-        Assert.True(Int32.TryParse("123", NumberStyles.HexNumber, nfi, out i));   // Simple Hex
-        Assert.Equal(0x123, i);
-
-        nfi.CurrencySymbol = "$";
-        nfi.CurrencyGroupSeparator = ",";
-        Assert.True(Int32.TryParse("$1,000", NumberStyles.Currency, nfi, out i)); // Currency/Thousands postive
-        Assert.Equal(1000, i);
-
-        Assert.False(Int32.TryParse("abc", NumberStyles.None, nfi, out i));       // Hex Number negative
-        Assert.True(Int32.TryParse("abc", NumberStyles.HexNumber, nfi, out i));   // Hex Number positive
-        Assert.Equal(0xabc, i);
-
-        nfi.CurrencyGroupSeparator = ".";
-        Assert.False(Int32.TryParse("678.90", NumberStyles.Integer, nfi, out i));  // Decimal
-        Assert.False(Int32.TryParse(" 678 ", NumberStyles.None, nfi, out i));      // Trailing/Leading whitespace negative
-
-        Assert.True(Int32.TryParse("(135)", NumberStyles.AllowParentheses, nfi, out i)); // Parenthese postive
-        Assert.Equal(-135, i);
+        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (nfi == null)
+        {
+            Assert.Throws(exceptionType, () => int.Parse(value, style));
+        }
+        Assert.Throws(exceptionType, () => int.Parse(value, style, nfi ?? new NumberFormatInfo()));
     }
 }
-

--- a/src/System.Runtime/tests/System/Int64.cs
+++ b/src/System.Runtime/tests/System/Int64.cs
@@ -2,102 +2,105 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Runtime.Tests.Common;
+
 using Xunit;
 
 public static class Int64Tests
 {
     [Fact]
-    public static void TestCtor()
+    public static void TestCtorEmpty()
     {
-        Int64 i = new Int64();
-        Assert.True(i == 0);
+        long i = new long();
+        Assert.Equal(0, i);
+    }
 
-        i = 41;
-        Assert.True(i == 41);
+    [Fact]
+    public static void TestCtorValue()
+    {
+        long i = 41;
+        Assert.Equal(41, i);
     }
 
     [Fact]
     public static void TestMaxValue()
     {
-        Int64 max = Int64.MaxValue;
-
-        Assert.True(max == (Int64)0x7FFFFFFFFFFFFFFF);
+        Assert.Equal(0x7FFFFFFFFFFFFFFF, long.MaxValue);
     }
 
     [Fact]
     public static void TestMinValue()
     {
-        Int64 min = Int64.MinValue;
+        Assert.Equal(unchecked((long)0x8000000000000000), long.MinValue);
+    }
 
-        Assert.True(min == unchecked((Int64)0x8000000000000000));
+    [Theory]
+    [InlineData((long)234, 0)]
+    [InlineData(long.MinValue, 1)]
+    [InlineData((long)(-123), 1)]
+    [InlineData((long)0, 1)]
+    [InlineData((long)45, 1)]
+    [InlineData((long)123, 1)]
+    [InlineData((long)456, -1)]
+    [InlineData(long.MaxValue, -1)]
+    public static void TestCompareTo(long value, long expected)
+    {
+        long i = 234;
+        long result = CompareHelper.NormalizeCompare(i.CompareTo(value));
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null, 1)]
+    [InlineData((long)234, 0)]
+    [InlineData(long.MinValue, 1)]
+    [InlineData((long)(-123), 1)]
+    [InlineData((long)0, 1)]
+    [InlineData((long)45, 1)]
+    [InlineData((long)123, 1)]
+    [InlineData((long)456, -1)]
+    [InlineData(long.MaxValue, -1)]
+    public static void TestCompareToObject(object obj, long expected)
+    {
+        IComparable comparable = (long)234;
+        long i = CompareHelper.NormalizeCompare(comparable.CompareTo(obj));
+        Assert.Equal(expected, i);
     }
 
     [Fact]
-    public static void TestCompareToObject()
+    public static void TestCompareToObjectInvalid()
     {
-        Int64 i = 234;
-        IComparable comparable = i;
-
-        Assert.Equal(1, comparable.CompareTo(null));
-        Assert.Equal(0, comparable.CompareTo((Int64)234));
-
-        Assert.True(comparable.CompareTo(Int64.MinValue) > 0);
-        Assert.True(comparable.CompareTo((Int64)0) > 0);
-        Assert.True(comparable.CompareTo((Int64)(-123)) > 0);
-        Assert.True(comparable.CompareTo((Int64)123) > 0);
-        Assert.True(comparable.CompareTo((Int64)456) < 0);
-        Assert.True(comparable.CompareTo(Int64.MaxValue) < 0);
-
-        Assert.Throws<ArgumentException>(() => comparable.CompareTo("a"));
+        IComparable comparable = (long)234;
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); //Obj is not a long
     }
 
-    [Fact]
-    public static void TestCompareTo()
+    [Theory]
+    [InlineData((long)789, true)]
+    [InlineData((long)(-789), false)]
+    [InlineData((long)0, false)]
+    public static void TestEqualsObject(object obj, bool expected)
     {
-        Int64 i = 234;
-
-        Assert.Equal(0, i.CompareTo((Int64)234));
-
-        Assert.True(i.CompareTo(Int64.MinValue) > 0);
-        Assert.True(i.CompareTo((Int64)0) > 0);
-        Assert.True(i.CompareTo((Int64)(-123)) > 0);
-        Assert.True(i.CompareTo((Int64)123) > 0);
-        Assert.True(i.CompareTo((Int64)456) < 0);
-        Assert.True(i.CompareTo(Int64.MaxValue) < 0);
+        long i = 789;
+        Assert.Equal(expected, i.Equals(obj));
     }
 
-    [Fact]
-    public static void TestEqualsObject()
+    [Theory]
+    [InlineData((long)789, true)]
+    [InlineData((long)(-789), false)]
+    [InlineData((long)0, false)]
+    public static void TestEquals(long i2, bool expected)
     {
-        Int64 i = 789;
-
-        object obj1 = (Int64)789;
-        Assert.True(i.Equals(obj1));
-
-        object obj2 = (Int64)(-789);
-        Assert.True(!i.Equals(obj2));
-
-        object obj3 = (Int64)0;
-        Assert.True(!i.Equals(obj3));
-    }
-
-    [Fact]
-    public static void TestEquals()
-    {
-        Int64 i = -911;
-
-        Assert.True(i.Equals((Int64)(-911)));
-
-        Assert.True(!i.Equals((Int64)911));
-        Assert.True(!i.Equals((Int64)0));
+        long i = 789;
+        Assert.Equal(expected, i.Equals(i2));
     }
 
     [Fact]
     public static void TestGetHashCode()
     {
-        Int64 i1 = 123;
-        Int64 i2 = 654;
+        long i1 = 123;
+        long i2 = 654;
 
         Assert.NotEqual(0, i1.GetHashCode());
         Assert.NotEqual(i1.GetHashCode(), i2.GetHashCode());
@@ -106,28 +109,28 @@ public static class Int64Tests
     [Fact]
     public static void TestToString()
     {
-        Int64 i1 = 6310;
+        long i1 = 6310;
         Assert.Equal("6310", i1.ToString());
 
-        Int64 i2 = -8249;
+        long i2 = -8249;
         Assert.Equal("-8249", i2.ToString());
 
-        Assert.Equal(Int64.MaxValue.ToString(), "9223372036854775807");
-        Assert.Equal(Int64.MinValue.ToString(), "-9223372036854775808");
+        Assert.Equal(long.MaxValue.ToString(), "9223372036854775807");
+        Assert.Equal(long.MinValue.ToString(), "-9223372036854775808");
     }
 
     [Fact]
     public static void TestToStringFormatProvider()
     {
-        var numberFormat = new System.Globalization.NumberFormatInfo();
+        var numberFormat = new NumberFormatInfo();
 
-        Int64 i1 = 6310;
+        long i1 = 6310;
         Assert.Equal("6310", i1.ToString(numberFormat));
 
-        Int64 i2 = -8249;
+        long i2 = -8249;
         Assert.Equal("-8249", i2.ToString(numberFormat));
 
-        Int64 i3 = -2468;
+        long i3 = -2468;
 
         // Changing the negative pattern doesn't do anything without also passing in a format string
         numberFormat.NumberNegativePattern = 0;
@@ -137,127 +140,158 @@ public static class Int64Tests
     [Fact]
     public static void TestToStringFormat()
     {
-        Int64 i1 = 6310;
+        long i1 = 6310;
         Assert.Equal("6310", i1.ToString("G"));
 
-        Int64 i2 = -8249;
+        long i2 = -8249;
         Assert.Equal("-8249", i2.ToString("g"));
 
-        Int64 i3 = -2468;
+        long i3 = -2468;
         Assert.Equal(string.Format("{0:N}", -2468.00), i3.ToString("N"));
 
-        Int64 i4 = 0x248;
+        long i4 = 0x248;
         Assert.Equal("248", i4.ToString("x"));
 
-        Assert.Equal(Int64.MinValue.ToString("X"), "8000000000000000");
-        Assert.Equal(Int64.MaxValue.ToString("X"), "7FFFFFFFFFFFFFFF");
+        Assert.Equal(long.MinValue.ToString("X"), "8000000000000000");
+        Assert.Equal(long.MaxValue.ToString("X"), "7FFFFFFFFFFFFFFF");
     }
 
     [Fact]
     public static void TestToStringFormatFormatProvider()
     {
-        var numberFormat = new System.Globalization.NumberFormatInfo();
+        var numberFormat = new NumberFormatInfo();
 
-        Int64 i1 = 6310;
+        long i1 = 6310;
         Assert.Equal("6310", i1.ToString("G", numberFormat));
 
-        Int64 i2 = -8249;
+        long i2 = -8249;
         Assert.Equal("-8249", i2.ToString("g", numberFormat));
 
         numberFormat.NegativeSign = "xx"; // setting it to trash to make sure it doesn't show up
         numberFormat.NumberGroupSeparator = "*";
         numberFormat.NumberNegativePattern = 0;
-        Int64 i3 = -2468;
+        long i3 = -2468;
         Assert.Equal("(2*468.00)", i3.ToString("N", numberFormat));
     }
 
-    [Fact]
-    public static void TestParse()
+    public static IEnumerable<object[]> ParseValidData()
     {
-        Assert.Equal(123, Int64.Parse("123"));
-        Assert.Equal(-123, Int64.Parse("-123"));
-        //TODO: Negative tests once we get better exceptions
+        NumberFormatInfo defaultFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+        var emptyNfi = new NumberFormatInfo();
+
+        var testNfi = new NumberFormatInfo();
+        testNfi.CurrencySymbol = "$";
+
+        yield return new object[] { "-9223372036854775808", defaultStyle, defaultFormat, -9223372036854775808 };
+        yield return new object[] { "-123", defaultStyle, defaultFormat, (long)-123 };
+        yield return new object[] { "0", defaultStyle, defaultFormat, (long)0 };
+        yield return new object[] { "123", defaultStyle, defaultFormat, (long)123 };
+        yield return new object[] { "  123  ", defaultStyle, defaultFormat, (long)123 };
+        yield return new object[] { "9223372036854775807", defaultStyle, defaultFormat, 9223372036854775807 };
+
+        yield return new object[] { "123", NumberStyles.HexNumber, defaultFormat, (long)0x123 };
+        yield return new object[] { "abc", NumberStyles.HexNumber, defaultFormat, (long)0xabc };
+        yield return new object[] { "1000", NumberStyles.AllowThousands, defaultFormat, (long)1000 };
+        yield return new object[] { "(123)", NumberStyles.AllowParentheses, defaultFormat, (long)-123 }; // Parentheses = negative
+
+        yield return new object[] { "123", defaultStyle, emptyNfi, (long)123 };
+
+        yield return new object[] { "123", NumberStyles.Any, emptyNfi, (long)123 };
+        yield return new object[] { "12", NumberStyles.HexNumber, emptyNfi, (long)0x12 };
+        yield return new object[] { "$1,000", NumberStyles.Currency, testNfi, (long)1000 };
     }
 
-    [Fact]
-    public static void TestParseNumberStyle()
+    public static IEnumerable<object[]> ParseInvalidData()
     {
-        Assert.Equal(0x123, Int64.Parse("123", NumberStyles.HexNumber));
-        Assert.Equal(1000, Int64.Parse((1000).ToString("N0"), NumberStyles.AllowThousands));
-        //TODO: Negative tests once we get better exceptions
+        NumberFormatInfo defaultFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+        var emptyNfi = new NumberFormatInfo();
+
+        var testNfi = new NumberFormatInfo();
+        testNfi.CurrencySymbol = "$";
+        testNfi.NumberDecimalSeparator = ".";
+
+        yield return new object[] { null, defaultStyle, defaultFormat, typeof(ArgumentNullException) };
+        yield return new object[] { "", defaultStyle, defaultFormat, typeof(FormatException) };
+        yield return new object[] { " ", defaultStyle, defaultFormat, typeof(FormatException) };
+        yield return new object[] { "Garbage", defaultStyle, defaultFormat, typeof(FormatException) };
+
+        yield return new object[] { "abc", defaultStyle, defaultFormat, typeof(FormatException) }; // Hex value
+        yield return new object[] { "1E23", defaultStyle, defaultFormat, typeof(FormatException) }; // Exponent
+        yield return new object[] { "(123)", defaultStyle, defaultFormat, typeof(FormatException) }; // Parentheses
+        yield return new object[] { 1000.ToString("C0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Currency
+        yield return new object[] { 1000.ToString("N0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Thousands
+        yield return new object[] { 678.90.ToString("F2"), defaultStyle, defaultFormat, typeof(FormatException) }; //Decimal
+
+        yield return new object[] { "abc", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Negative hex value
+        yield return new object[] { "  123  ", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Trailing and leading whitespace
+
+        yield return new object[] { "67.90", defaultStyle, testNfi, typeof(FormatException) }; // Decimal
+        
+        yield return new object[] { "-9223372036854775809", defaultStyle, defaultFormat, typeof(OverflowException) }; // < min value
+        yield return new object[] { "9223372036854775808", defaultStyle, defaultFormat, typeof(OverflowException) }; // > max value
     }
 
-    [Fact]
-    public static void TestParseFormatProvider()
+    [Theory, MemberData("ParseValidData")]
+    public static void TestParse(string value, NumberStyles style, NumberFormatInfo nfi, long expected)
     {
-        var nfi = new NumberFormatInfo();
-        Assert.Equal(123, Int64.Parse("123", nfi));
-        Assert.Equal(-123, Int64.Parse("-123", nfi));
-        //TODO: Negative tests once we get better exceptions
+        long i;
+        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        if (style == NumberStyles.Integer)
+        {
+            Assert.Equal(true, long.TryParse(value, out i));
+            Assert.Equal(expected, i);
+
+            Assert.Equal(expected, long.Parse(value));
+
+            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (nfi != null)
+            {
+                Assert.Equal(expected, long.Parse(value, nfi));
+            }
+        }
+
+        // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
+        Assert.Equal(true, long.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
+        Assert.Equal(expected, i);
+
+        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (nfi == null)
+        {
+            Assert.Equal(expected, long.Parse(value, style));
+        }
+        Assert.Equal(expected, long.Parse(value, style, nfi ?? new NumberFormatInfo()));
     }
 
-    [Fact]
-    public static void TestParseNumberStyleFormatProvider()
+    [Theory, MemberData("ParseInvalidData")]
+    public static void TestParseInvalid(string value, NumberStyles style, NumberFormatInfo nfi, Type exceptionType)
     {
-        var nfi = new NumberFormatInfo();
-        Assert.Equal(0x123, Int64.Parse("123", NumberStyles.HexNumber, nfi));
+        long i;
+        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        if (style == NumberStyles.Integer)
+        {
+            Assert.Equal(false, long.TryParse(value, out i));
+            Assert.Equal(default(long), i);
 
-        nfi.CurrencySymbol = "$";
-        nfi.CurrencyGroupSeparator = ",";
-        Assert.Equal(1000, Int64.Parse("$1,000", NumberStyles.Currency, nfi));
-        //TODO: Negative tests once we get better exception support
-    }
+            Assert.Throws(exceptionType, () => long.Parse(value));
 
-    [Fact]
-    public static void TestTryParse()
-    {
-        // Defaults NumberStyles.Integer = NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite | NumberStyles.AllowLeadingSign
+            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (nfi != null)
+            {
+                Assert.Throws(exceptionType, () => long.Parse(value, nfi));
+            }
+        }
 
-        Int64 i;
-        Assert.True(Int64.TryParse("123", out i));     // Simple
-        Assert.Equal(123, i);
+        // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
+        Assert.Equal(false, long.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
+        Assert.Equal(default(long), i);
 
-        Assert.True(Int64.TryParse("-385", out i));    // LeadingSign
-        Assert.Equal(-385, i);
-
-        Assert.True(Int64.TryParse(" 678 ", out i));   // Leading/Trailing whitespace
-        Assert.Equal(678, i);
-
-        var nfi = new NumberFormatInfo() { CurrencyGroupSeparator = "" };
-        Assert.False(Int64.TryParse((1000).ToString("C0", nfi), out i));  // Currency
-        Assert.False(Int64.TryParse((1000).ToString("N0"), out i));  // Thousands
-        Assert.False(Int64.TryParse("abc", out i));    // Hex digits
-        Assert.False(Int64.TryParse((678.90).ToString("F2"), out i)); // Decimal
-        Assert.False(Int64.TryParse("(135)", out i));  // Parentheses
-        Assert.False(Int64.TryParse("1E23", out i));   // Exponent
-    }
-
-    [Fact]
-    public static void TestTryParseNumberStyleFormatProvider()
-    {
-        Int64 i;
-        var nfi = new NumberFormatInfo();
-        Assert.True(Int64.TryParse("123", NumberStyles.Any, nfi, out i));   // Simple positive
-        Assert.Equal(123, i);
-
-        Assert.True(Int64.TryParse("123", NumberStyles.HexNumber, nfi, out i));   // Simple Hex
-        Assert.Equal(0x123, i);
-
-        nfi.CurrencySymbol = "$";
-        nfi.CurrencyGroupSeparator = ",";
-        Assert.True(Int64.TryParse("$1,000", NumberStyles.Currency, nfi, out i)); // Currency/Thousands postive
-        Assert.Equal(1000, i);
-
-        Assert.False(Int64.TryParse("abc", NumberStyles.None, nfi, out i));       // Hex Number negative
-        Assert.True(Int64.TryParse("abc", NumberStyles.HexNumber, nfi, out i));   // Hex Number positive
-        Assert.Equal(0xabc, i);
-
-        nfi.NumberDecimalSeparator = ".";
-        Assert.False(Int64.TryParse("678.90", NumberStyles.Integer, nfi, out i));  // Decimal
-        Assert.False(Int64.TryParse(" 678 ", NumberStyles.None, nfi, out i));      // Trailing/Leading whitespace negative
-
-        Assert.True(Int64.TryParse("(135)", NumberStyles.AllowParentheses, nfi, out i)); // Parenthese postive
-        Assert.Equal(-135, i);
+        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (nfi == null)
+        {
+            Assert.Throws(exceptionType, () => long.Parse(value, style));
+        }
+        Assert.Throws(exceptionType, () => long.Parse(value, style, nfi ?? new NumberFormatInfo()));
     }
 }
-

--- a/src/System.Runtime/tests/System/IntPtr.cs
+++ b/src/System.Runtime/tests/System/IntPtr.cs
@@ -2,8 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
+
 using Xunit;
 
 public static unsafe class IntPtrTests
@@ -61,9 +60,9 @@ public static unsafe class IntPtrTests
         p = new IntPtr(42);
         b = p.Equals(null);
         Assert.False(b);
-        b = p.Equals((Object)42);
+        b = p.Equals((object)42);
         Assert.False(b);
-        b = p.Equals((Object)(new IntPtr(42)));
+        b = p.Equals((object)(new IntPtr(42)));
         Assert.True(b);
 
         int h = p.GetHashCode();
@@ -108,8 +107,8 @@ public static unsafe class IntPtrTests
             Assert.Equal(i, expected32);
         }
 
-        String s = p.ToString();
-        String sExpected = expected.ToString();
+        string s = p.ToString();
+        string sExpected = expected.ToString();
         Assert.Equal(s, sExpected);
 
         s = p.ToString("x");
@@ -131,4 +130,3 @@ public static unsafe class IntPtrTests
         Assert.True(b);
     }
 }
-

--- a/src/System.Runtime/tests/System/Lazy.cs
+++ b/src/System.Runtime/tests/System/Lazy.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Threading;
+
 using Xunit;
 
 namespace System.Tests

--- a/src/System.Runtime/tests/System/LazyOfTMetadata.cs
+++ b/src/System.Runtime/tests/System/LazyOfTMetadata.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Threading;
+
 using Xunit;
 
 namespace System.Tests

--- a/src/System.Runtime/tests/System/MethodAccessException.cs
+++ b/src/System.Runtime/tests/System/MethodAccessException.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Globalization;
+
 using Xunit;
 
 public static class MethodAccessExceptionTests

--- a/src/System.Runtime/tests/System/MissingFieldException.cs
+++ b/src/System.Runtime/tests/System/MissingFieldException.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Globalization;
+
 using Xunit;
 
 public static class MissingFieldExceptionTests

--- a/src/System.Runtime/tests/System/MissingMethodException.cs
+++ b/src/System.Runtime/tests/System/MissingMethodException.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Globalization;
+
 using Xunit;
 
 public static class MissingMethodExceptionTests

--- a/src/System.Runtime/tests/System/MulticastDelegate.cs
+++ b/src/System.Runtime/tests/System/MulticastDelegate.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+
 using Xunit;
 
 public static unsafe class MulticastDelegateTests
@@ -63,7 +62,7 @@ public static unsafe class MulticastDelegateTests
         DRet dret1 = new DRet(t.ARet);
         DRet dret2 = new DRet(t.BRet);
         DRet dret12 = (DRet)Delegate.Combine(dret1, dret2);
-        String s = dret12(4);
+        string s = dret12(4);
         Assert.Equal(s, "BRet4");
         Assert.Equal(t.S, "ARet4BRet4");
         return;
@@ -125,7 +124,7 @@ public static unsafe class MulticastDelegateTests
         D abcc = (D)(Delegate.Remove(abcdabc, dab));
         t1.Clear();
         abcc(9);
-        String s = t1.S;
+        string s = t1.S;
         Assert.Equal(s, "A9B9C9C9");
         CheckInvokeList(new D[] { a, b, c, c }, abcc, t1);
 
@@ -208,11 +207,11 @@ public static unsafe class MulticastDelegateTests
 
         target.Clear();
         expected(9);
-        String sExpected = target.S;
+        string sExpected = target.S;
 
         target.Clear();
         actual(9);
-        String sActual = target.S;
+        string sActual = target.S;
 
         Assert.Equal(sExpected, sActual);
 
@@ -226,7 +225,7 @@ public static unsafe class MulticastDelegateTests
             S = "";
         }
 
-        public String S;
+        public string S;
 
         public void Clear()
         {
@@ -238,7 +237,7 @@ public static unsafe class MulticastDelegateTests
             S = S + "A" + x;
         }
 
-        public String ARet(int x)
+        public string ARet(int x)
         {
             S = S + "ARet" + x;
             return "ARet" + x;
@@ -249,7 +248,7 @@ public static unsafe class MulticastDelegateTests
             S = S + "B" + x;
         }
 
-        public String BRet(int x)
+        public string BRet(int x)
         {
             S = S + "BRet" + x;
             return "BRet" + x;
@@ -277,22 +276,21 @@ public static unsafe class MulticastDelegateTests
     }
 
     private delegate void D(int x);
-    private delegate String DRet(int x);
+    private delegate string DRet(int x);
 
-    private delegate String DFoo(int x);
-    private delegate String DGoo(int x);
+    private delegate string DFoo(int x);
+    private delegate string DGoo(int x);
 
     private class C
     {
-        public String Foo(int x)
+        public string Foo(int x)
         {
-            return new String('A', x);
+            return new string('A', x);
         }
 
-        public String Goo(int x)
+        public string Goo(int x)
         {
-            return new String('A', x);
+            return new string('A', x);
         }
     }
 }
-

--- a/src/System.Runtime/tests/System/Nullable.cs
+++ b/src/System.Runtime/tests/System/Nullable.cs
@@ -2,8 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
+
 using Xunit;
 
 public static unsafe class NullableTests
@@ -47,7 +46,7 @@ public static unsafe class NullableTests
         Foo(n);
     }
 
-    private static void Foo(Object o)
+    private static void Foo(object o)
     {
         Type t = o.GetType();
         Assert.IsNotType<Nullable<int>>(t);
@@ -124,4 +123,3 @@ public static unsafe class NullableTests
     {
     }
 }
-

--- a/src/System.Runtime/tests/System/Object.cs
+++ b/src/System.Runtime/tests/System/Object.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using Xunit;
 
 public static unsafe class ObjectTests
@@ -11,7 +9,7 @@ public static unsafe class ObjectTests
     [Fact]
     public static void TestEqualsAndHashCode()
     {
-        Object o1 = new Object();
+        object o1 = new object();
         int h1 = o1.GetHashCode();
         int h2 = o1.GetHashCode();
         Assert.Equal(h1, h2);
@@ -23,7 +21,7 @@ public static unsafe class ObjectTests
         b = o1.Equals(null);
         Assert.False(b);
 
-        Object o2 = new Object();
+        object o2 = new object();
         b = o1.Equals(o2);
         Assert.False(b);
 
@@ -79,11 +77,11 @@ public static unsafe class ObjectTests
     [Fact]
     public static void TestGetType()
     {
-        Object o1 = new Object();
-        Object o2 = new Object();
+        object o1 = new object();
+        object o2 = new object();
         Type t1 = o1.GetType();
         Type t2 = o2.GetType();
-        Assert.Equal(t1, typeof(Object));
+        Assert.Equal(t1, typeof(object));
         Assert.Equal(t1, t2);
         Assert.Equal(t1.ToString(), o1.ToString());
 
@@ -107,10 +105,10 @@ public static unsafe class ObjectTests
     [Fact]
     public static void TestToString()
     {
-        Object o = new Object();
-        String s = o.ToString();
+        object o = new object();
+        string s = o.ToString();
         Assert.Equal(s, "System.Object");
-        String s1 = o.GetType().ToString();
+        string s1 = o.GetType().ToString();
         Assert.Equal(s, s1);
     }
 
@@ -126,13 +124,13 @@ public static unsafe class ObjectTests
 
     private class C
     {
-        public C(String s, int x, int y)
+        public C(string s, int x, int y)
         {
             this.s = s;
             this.x = x;
             this.y = y;
         }
-        public String s;
+        public string s;
         public int x;
         public int y;
 
@@ -149,7 +147,7 @@ public static unsafe class ObjectTests
             X = x;
         }
 
-        public override bool Equals(Object obj)
+        public override bool Equals(object obj)
         {
             s_EqualsCalled = true;
 
@@ -169,4 +167,3 @@ public static unsafe class ObjectTests
         public static bool s_EqualsCalled = false;
     }
 }
-

--- a/src/System.Runtime/tests/System/Runtime/CompilerServices/ConditionalWeakTable.cs
+++ b/src/System.Runtime/tests/System/Runtime/CompilerServices/ConditionalWeakTable.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Runtime.CompilerServices;
-using Xunit;
 
+using Xunit;
 
 public class ConditionalWeakTableTests
 {
@@ -82,4 +82,3 @@ public class ConditionalWeakTableTests
         Assert.False(wrkey.TryGetTarget(out obj));
     }
 }
-

--- a/src/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeHelpers.cs
+++ b/src/System.Runtime/tests/System/Runtime/CompilerServices/RuntimeHelpers.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.CompilerServices;
+
 using Xunit;
 
 public static class RuntimeHelpersTests
@@ -56,7 +57,7 @@ public static class RuntimeHelpersTests
         object tOV = RuntimeHelpers.GetObjectValue(t);
         Assert.Equal(t, (TestStruct)tOV);
 
-        Object o = new object();
+        object o = new object();
         object oOV = RuntimeHelpers.GetObjectValue(o);
         Assert.Equal(o, oOV);
 
@@ -101,12 +102,12 @@ public static class RuntimeHelpersTests
     {
         static HasCctor()
         {
-            HasCctorReceiver.S = "Hello" + (Guid.NewGuid().ToString().Substring(String.Empty.Length, 0));  // Make sure the preinitialization optimization doesn't eat this.
+            HasCctorReceiver.S = "Hello" + (Guid.NewGuid().ToString().Substring(string.Empty.Length, 0));  // Make sure the preinitialization optimization doesn't eat this.
         }
     }
 
     internal class HasCctorReceiver
     {
-        public static String S;
+        public static string S;
     }
 }

--- a/src/System.Runtime/tests/System/SByte.cs
+++ b/src/System.Runtime/tests/System/SByte.cs
@@ -2,96 +2,102 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Runtime.Tests.Common;
+
 using Xunit;
 
 public static class SByteTests
 {
     [Fact]
-    public static void TestCtor()
+    public static void TestCtorEmpty()
     {
-        SByte i = new SByte();
-        Assert.True(i == 0);
+        sbyte i = new sbyte();
+        Assert.Equal(0, i);
+    }
 
-        i = 41;
-        Assert.True(i == 41);
+    [Fact]
+    public static void TestCtorValue()
+    {
+        sbyte i = 41;
+        Assert.Equal(41, i);
     }
 
     [Fact]
     public static void TestMaxValue()
     {
-        SByte max = SByte.MaxValue;
-
-        Assert.True(max == (SByte)0x7F);
+        Assert.Equal(0x7F, sbyte.MaxValue);
     }
 
     [Fact]
     public static void TestMinValue()
     {
-        SByte min = SByte.MinValue;
+        Assert.Equal(-0x80, sbyte.MinValue);
+    }
+    
+    [Theory]
+    [InlineData((sbyte)114, 0)]
+    [InlineData(sbyte.MinValue, 1)]
+    [InlineData((sbyte)0, 1)]
+    [InlineData((sbyte)45, 1)]
+    [InlineData((sbyte)123, -1)]
+    [InlineData(sbyte.MaxValue, -1)]
+    public static void TestCompareTo(sbyte value, int expected)
+    {
+        sbyte i = 114;
+        int result = CompareHelper.NormalizeCompare(i.CompareTo(value));
+        Assert.Equal(expected, result);
+    }
 
-        Assert.True(min == (SByte)(-0x80));
+    [Theory]
+    [InlineData(null, 1)]
+    [InlineData((sbyte)114, 0)]
+    [InlineData(sbyte.MinValue, 1)]
+    [InlineData((sbyte)(-23), 1)]
+    [InlineData((sbyte)0, 1)]
+    [InlineData((sbyte)45, 1)]
+    [InlineData((sbyte)123, -1)]
+    [InlineData(sbyte.MaxValue, -1)]
+    public static void TestCompareToObject(object obj, int expected)
+    {
+        IComparable comparable = (sbyte)114;
+        int i = CompareHelper.NormalizeCompare(comparable.CompareTo(obj));
+        Assert.Equal(expected, i);
     }
 
     [Fact]
-    public static void TestCompareToObject()
+    public static void TestCompareToObjectInvalid()
     {
-        SByte i = 114;
-        IComparable comparable = i;
-
-        Assert.Equal(1, comparable.CompareTo(null));
-        Assert.Equal(0, comparable.CompareTo((SByte)114));
-
-        Assert.True(comparable.CompareTo(SByte.MinValue) > 0);
-        Assert.True(comparable.CompareTo((SByte)0) > 0);
-        Assert.True(comparable.CompareTo((SByte)(-23)) > 0);
-        Assert.True(comparable.CompareTo((SByte)123) < 0);
-        Assert.True(comparable.CompareTo((SByte)45) > 0);
-        Assert.True(comparable.CompareTo(SByte.MaxValue) < 0);
-
-        Assert.Throws<ArgumentException>(() => comparable.CompareTo("a"));
+        IComparable comparable = (sbyte)114;
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); //Obj is not a sbyte
     }
 
-    [Fact]
-    public static void TestCompareTo()
+    [Theory]
+    [InlineData((sbyte)78, true)]
+    [InlineData((sbyte)(-78), false)]
+    [InlineData((sbyte)0, false)]
+    public static void TestEqualsObject(object obj, bool expected)
     {
-        SByte i = 114;
-
-        Assert.Equal(0, i.CompareTo((SByte)114));
-
-        Assert.True(i.CompareTo(SByte.MinValue) > 0);
-        Assert.True(i.CompareTo((SByte)0) > 0);
-        Assert.True(i.CompareTo((SByte)123) < 0);
-        Assert.True(i.CompareTo((SByte)45) > 0);
-        Assert.True(i.CompareTo(SByte.MaxValue) < 0);
+        sbyte i = 78;
+        Assert.Equal(expected, i.Equals(obj));
     }
 
-    [Fact]
-    public static void TestEqualsObject()
+    [Theory]
+    [InlineData((sbyte)78, true)]
+    [InlineData((sbyte)(-78), false)]
+    [InlineData((sbyte)0, false)]
+    public static void TestEqualsObject(sbyte i2, bool expected)
     {
-        SByte i = 78;
-
-        object obj1 = (SByte)78;
-        Assert.True(i.Equals(obj1));
-
-        object obj3 = (SByte)0;
-        Assert.True(!i.Equals(obj3));
-    }
-
-    [Fact]
-    public static void TestEquals()
-    {
-        SByte i = 91;
-
-        Assert.True(i.Equals((SByte)91));
-        Assert.True(!i.Equals((SByte)0));
+        sbyte i = 78;
+        Assert.Equal(expected, i.Equals(i2));
     }
 
     [Fact]
     public static void TestGetHashCode()
     {
-        SByte i1 = 123;
-        SByte i2 = 65;
+        sbyte i1 = 123;
+        sbyte i2 = 65;
 
         Assert.NotEqual(0, i1.GetHashCode());
         Assert.NotEqual(i1.GetHashCode(), i2.GetHashCode());
@@ -100,136 +106,170 @@ public static class SByteTests
     [Fact]
     public static void TestToString()
     {
-        SByte i1 = 63;
+        sbyte i1 = 63;
         Assert.Equal("63", i1.ToString());
     }
 
     [Fact]
     public static void TestToStringFormatProvider()
     {
-        var numberFormat = new System.Globalization.NumberFormatInfo();
+        var numberFormat = new NumberFormatInfo();
 
-        SByte i1 = 63;
+        sbyte i1 = 63;
         Assert.Equal("63", i1.ToString(numberFormat));
     }
 
     [Fact]
     public static void TestToStringFormat()
     {
-        SByte i1 = 63;
+        sbyte i1 = 63;
         Assert.Equal("63", i1.ToString("G"));
 
-        SByte i2 = 82;
+        sbyte i2 = 82;
         Assert.Equal("82", i2.ToString("g"));
 
-        SByte i3 = 46;
+        sbyte i3 = 46;
         Assert.Equal(string.Format("{0:N}", 46.00), i3.ToString("N"));
 
-        SByte i4 = 0x24;
+        sbyte i4 = 0x24;
         Assert.Equal("24", i4.ToString("x"));
     }
 
     [Fact]
     public static void TestToStringFormatFormatProvider()
     {
-        var numberFormat = new System.Globalization.NumberFormatInfo();
+        var numberFormat = new NumberFormatInfo();
 
-        SByte i1 = 63;
+        sbyte i1 = 63;
         Assert.Equal("63", i1.ToString("G", numberFormat));
 
-        SByte i2 = 82;
+        sbyte i2 = 82;
         Assert.Equal("82", i2.ToString("g", numberFormat));
 
         numberFormat.NegativeSign = "xx"; // setting it to trash to make sure it doesn't show up
         numberFormat.NumberGroupSeparator = "*";
         numberFormat.NumberNegativePattern = 0;
         numberFormat.NumberDecimalSeparator = ".";
-        SByte i3 = 24;
+        sbyte i3 = 24;
         Assert.Equal("24.00", i3.ToString("N", numberFormat));
     }
 
-    [Fact]
-    public static void TestParse()
+    public static IEnumerable<object[]> ParseValidData()
     {
-        Assert.Equal<SByte>(123, SByte.Parse("123"));
-        //TODO: Negative tests once we get better exceptions
+        NumberFormatInfo defaultFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+        var emptyNfi = new NumberFormatInfo();
+
+        var testNfi = new NumberFormatInfo();
+        testNfi.CurrencySymbol = "$";
+
+        yield return new object[] { "-123", defaultStyle, defaultFormat, (sbyte)-123 };
+        yield return new object[] { "0", defaultStyle, defaultFormat, (sbyte)0 };
+        yield return new object[] { "123", defaultStyle, defaultFormat, (sbyte)123 };
+        yield return new object[] { "  123  ", defaultStyle, defaultFormat, (sbyte)123 };
+        yield return new object[] { "127", defaultStyle, defaultFormat, (sbyte)127 };
+
+        yield return new object[] { "12", NumberStyles.HexNumber, defaultFormat, (sbyte)0x12 };
+        yield return new object[] { "10", NumberStyles.AllowThousands, defaultFormat, (sbyte)10 };
+        yield return new object[] { "(123)", NumberStyles.AllowParentheses, defaultFormat, (sbyte)-123 }; // Parentheses = negative
+
+        yield return new object[] { "123", defaultStyle, emptyNfi, (sbyte)123 };
+
+        yield return new object[] { "123", NumberStyles.Any, emptyNfi, (sbyte)123 };
+        yield return new object[] { "12", NumberStyles.HexNumber, emptyNfi, (sbyte)0x12 };
+        yield return new object[] { "$100", NumberStyles.Currency, testNfi, (sbyte)100 };
     }
 
-    [Fact]
-    public static void TestParseNumberStyle()
+    public static IEnumerable<object[]> ParseInvalidData()
     {
-        Assert.Equal<SByte>(0x12, SByte.Parse("12", NumberStyles.HexNumber));
-        Assert.Equal<SByte>(10, SByte.Parse("10", NumberStyles.AllowThousands));
-        //TODO: Negative tests once we get better exceptions
+        NumberFormatInfo defaultFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+        var emptyNfi = new NumberFormatInfo();
+
+        var testNfi = new NumberFormatInfo();
+        testNfi.CurrencySymbol = "$";
+        testNfi.NumberDecimalSeparator = ".";
+
+        yield return new object[] { null, defaultStyle, defaultFormat, typeof(ArgumentNullException) };
+        yield return new object[] { "", defaultStyle, defaultFormat, typeof(FormatException) };
+        yield return new object[] { " ", defaultStyle, defaultFormat, typeof(FormatException) };
+        yield return new object[] { "Garbage", defaultStyle, defaultFormat, typeof(FormatException) };
+
+        yield return new object[] { "ab", defaultStyle, defaultFormat, typeof(FormatException) }; // Hex value
+        yield return new object[] { "1E23", defaultStyle, defaultFormat, typeof(FormatException) }; // Exponent
+        yield return new object[] { "(123)", defaultStyle, defaultFormat, typeof(FormatException) }; // Parentheses
+        yield return new object[] { 100.ToString("C0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Currency
+        yield return new object[] { 1000.ToString("N0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Thousands
+        yield return new object[] { 67.90.ToString("F2"), defaultStyle, defaultFormat, typeof(FormatException) }; //Decimal
+
+        yield return new object[] { "ab", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Hex value
+        yield return new object[] { "  123  ", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Trailing and leading whitespace
+
+        yield return new object[] { "67.90", defaultStyle, testNfi, typeof(FormatException) }; // Decimal
+
+        yield return new object[] { "-129", defaultStyle, defaultFormat, typeof(OverflowException) }; // < min value
+        yield return new object[] { "128", defaultStyle, defaultFormat, typeof(OverflowException) }; // > max value
     }
 
-    [Fact]
-    public static void TestParseFormatProvider()
+    [Theory, MemberData("ParseValidData")]
+    public static void TestParse(string value, NumberStyles style, NumberFormatInfo nfi, sbyte expected)
     {
-        var nfi = new NumberFormatInfo();
-        Assert.Equal<SByte>(123, SByte.Parse("123", nfi));
-        //TODO: Negative tests once we get better exceptions
+        sbyte i;
+        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        if (style == NumberStyles.Integer)
+        {
+            Assert.Equal(true, sbyte.TryParse(value, out i));
+            Assert.Equal(expected, i);
+
+            Assert.Equal(expected, sbyte.Parse(value));
+
+            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (nfi != null)
+            {
+                Assert.Equal(expected, sbyte.Parse(value, nfi));
+            }
+        }
+
+        // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
+        Assert.Equal(true, sbyte.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
+        Assert.Equal(expected, i);
+
+        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (nfi == null)
+        {
+            Assert.Equal(expected, sbyte.Parse(value, style));
+        }
+        Assert.Equal(expected, sbyte.Parse(value, style, nfi ?? new NumberFormatInfo()));
     }
 
-    [Fact]
-    public static void TestParseNumberStyleFormatProvider()
+    [Theory, MemberData("ParseInvalidData")]
+    public static void TestParseInvalid(string value, NumberStyles style, NumberFormatInfo nfi, Type exceptionType)
     {
-        var nfi = new NumberFormatInfo();
-        Assert.Equal<SByte>(0x12, SByte.Parse("12", NumberStyles.HexNumber, nfi));
+        sbyte i;
+        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        if (style == NumberStyles.Integer)
+        {
+            Assert.Equal(false, sbyte.TryParse(value, out i));
+            Assert.Equal(default(sbyte), i);
 
-        nfi.CurrencySymbol = "$";
-        Assert.Equal<SByte>(100, SByte.Parse("$100", NumberStyles.Currency, nfi));
-        //TODO: Negative tests once we get better exception support
-    }
+            Assert.Throws(exceptionType, () => sbyte.Parse(value));
 
-    [Fact]
-    public static void TestTryParse()
-    {
-        // Defaults NumberStyles.Integer = NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite | NumberStyles.AllowLeadingSign
+            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (nfi != null)
+            {
+                Assert.Throws(exceptionType, () => sbyte.Parse(value, nfi));
+            }
+        }
 
-        SByte i;
-        Assert.True(SByte.TryParse("123", out i));     // Simple
-        Assert.Equal<SByte>(123, i);
+        // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
+        Assert.Equal(false, sbyte.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
+        Assert.Equal(default(sbyte), i);
 
-        Assert.True(SByte.TryParse("-38", out i));    // LeadingSign negative
-        Assert.Equal(-38, i);
-
-        Assert.True(SByte.TryParse(" 67 ", out i));   // Leading/Trailing whitespace
-        Assert.Equal<SByte>(67, i);
-
-        Assert.False(SByte.TryParse((100).ToString("C0"), out i));  // Currency
-        Assert.False(SByte.TryParse((1000).ToString("N0"), out i));  // Thousands
-        Assert.False(SByte.TryParse("ab", out i));    // Hex digits
-        Assert.False(SByte.TryParse((67.90).ToString("F2"), out i)); // Decimal
-        Assert.False(SByte.TryParse("(35)", out i));  // Parentheses
-        Assert.False(SByte.TryParse("1E23", out i));   // Exponent
-    }
-
-    [Fact]
-    public static void TestTryParseNumberStyleFormatProvider()
-    {
-        SByte i;
-        var nfi = new NumberFormatInfo();
-        Assert.True(SByte.TryParse("123", NumberStyles.Any, nfi, out i));   // Simple positive
-        Assert.Equal<SByte>(123, i);
-
-        Assert.True(SByte.TryParse("12", NumberStyles.HexNumber, nfi, out i));   // Simple Hex
-        Assert.Equal<SByte>(0x12, i);
-
-        nfi.CurrencySymbol = "$";
-        Assert.True(SByte.TryParse("$100", NumberStyles.Currency, nfi, out i)); // Currency/Thousands postive
-        Assert.Equal<SByte>(100, i);
-
-        Assert.False(SByte.TryParse("ab", NumberStyles.None, nfi, out i));       // Hex Number negative
-        Assert.True(SByte.TryParse("2b", NumberStyles.HexNumber, nfi, out i));   // Hex Number positive
-        Assert.Equal<SByte>(0x2b, i);
-
-        nfi.NumberDecimalSeparator = ".";
-        Assert.False(SByte.TryParse("67.90", NumberStyles.Integer, nfi, out i));  // Decimal
-        Assert.False(SByte.TryParse(" 67 ", NumberStyles.None, nfi, out i));      // Trailing/Leading whitespace negative
-
-        Assert.True(SByte.TryParse("(35)", NumberStyles.AllowParentheses, nfi, out i)); // Parenthese
-        Assert.Equal(-35, i);
+        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (nfi == null)
+        {
+            Assert.Throws(exceptionType, () => sbyte.Parse(value, style));
+        }
+        Assert.Throws(exceptionType, () => sbyte.Parse(value, style, nfi ?? new NumberFormatInfo()));
     }
 }
-

--- a/src/System.Runtime/tests/System/Single.cs
+++ b/src/System.Runtime/tests/System/Single.cs
@@ -3,166 +3,152 @@
 
 using System;
 using System.Globalization;
+using System.Runtime.Tests.Common;
+
 using Xunit;
 
 public static class SingleTests
 {
     [Fact]
-    public static void TestCtor()
+    public static void TestCtorEmpty()
     {
-        Single i = new Single();
-        Assert.True(i == 0);
+        float i = new float();
+        Assert.Equal(0, i);
+    }
 
-        i = 41;
-        Assert.True(i == 41);
-
-        i = (Single)41.3;
-        Assert.True(i == (Single)41.3);
+    [Fact]
+    public static void TestCtorValue()
+    {
+        float i = 41;
+        Assert.Equal(41, i);
     }
 
     [Fact]
     public static void TestMaxValue()
     {
-        Single max = Single.MaxValue;
-
-        Assert.True(max == (Single)3.40282346638528859e+38);
+        Assert.Equal((float)3.40282346638528859e+38, float.MaxValue);
     }
 
     [Fact]
     public static void TestMinValue()
     {
-        Single min = Single.MinValue;
-
-        Assert.True(min == ((Single)(-3.40282346638528859e+38)));
+        Assert.Equal((float)(-3.40282346638528859e+38), float.MinValue);
     }
 
     [Fact]
     public static void TestEpsilon()
     {
-        // Single Single.Epsilon
-        Assert.Equal<Single>((Single)1.4e-45, Single.Epsilon);
+        Assert.Equal((float)1.4e-45, float.Epsilon);
     }
 
     [Fact]
     public static void TestIsInfinity()
     {
-        // Boolean Single.IsInfinity(Single)
-        Assert.True(Single.IsInfinity(Single.NegativeInfinity));
-        Assert.True(Single.IsInfinity(Single.PositiveInfinity));
+        Assert.True(float.IsInfinity(float.NegativeInfinity));
+        Assert.True(float.IsInfinity(float.PositiveInfinity));
     }
 
     [Fact]
     public static void TestNaN()
     {
-        // Single Single.NaN
-        Assert.Equal<Single>((Single)0.0 / (Single)0.0, Single.NaN);
+        Assert.Equal((float)0.0 / (float)0.0, float.NaN);
     }
 
     [Fact]
     public static void TestIsNaN()
     {
-        // Boolean Single.IsNaN(Single)
-        Assert.True(Single.IsNaN(Single.NaN));
+        Assert.True(float.IsNaN(float.NaN));
     }
 
     [Fact]
     public static void TestNegativeInfinity()
     {
-        // Single Single.NegativeInfinity
-        Assert.Equal<Single>((Single)(-1.0) / (Single)0.0, Single.NegativeInfinity);
+        Assert.Equal((float)(-1.0) / (float)0.0, float.NegativeInfinity);
     }
 
     [Fact]
     public static void TestIsNegativeInfinity()
     {
-        // Boolean Single.IsNegativeInfinity(Single)
-        Assert.True(Single.IsNegativeInfinity(Single.NegativeInfinity));
+        Assert.True(float.IsNegativeInfinity(float.NegativeInfinity));
     }
 
     [Fact]
     public static void TestPositiveInfinity()
     {
-        // Single Single.PositiveInfinity
-        Assert.Equal<Single>((Single)1.0 / (Single)0.0, Single.PositiveInfinity);
+        Assert.Equal((float)1.0 / (float)0.0, float.PositiveInfinity);
     }
 
     [Fact]
     public static void TestIsPositiveInfinity()
     {
-        // Boolean Single.IsPositiveInfinity(Single)
-        Assert.True(Single.IsPositiveInfinity(Single.PositiveInfinity));
+        Assert.True(float.IsPositiveInfinity(float.PositiveInfinity));
+    }
+
+    [Theory]
+    [InlineData((float)234, (float)234, 0)]
+    [InlineData((float)234, float.MinValue, 1)]
+    [InlineData((float)234, (float)(-123), 1)]
+    [InlineData((float)234, (float)0, 1)]
+    [InlineData((float)234, (float)123, 1)]
+    [InlineData((float)234, (float)456, -1)]
+    [InlineData((float)234, float.MaxValue, -1)]
+    [InlineData((float)234, float.NaN, 1)]
+    [InlineData(float.NaN, float.NaN, 0)]
+    [InlineData(float.NaN, 0, -1)]
+    public static void TestCompareTo(float i, float value, int expected)
+    {
+        int result = CompareHelper.NormalizeCompare(i.CompareTo(value));
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null, 1)]
+    [InlineData((float)234, 0)]
+    [InlineData(float.MinValue, 1)]
+    [InlineData((float)(-123), 1)]
+    [InlineData((float)0, 1)]
+    [InlineData((float)123, 1)]
+    [InlineData((float)456, -1)]
+    [InlineData(float.MaxValue, -1)]
+    public static void TestCompareToObject(object obj, int expected)
+    {
+        IComparable comparable = (float)234;
+        int i = CompareHelper.NormalizeCompare(comparable.CompareTo(obj));
+        Assert.Equal(expected, i);
     }
 
     [Fact]
-    public static void TestCompareToObject()
+    public static void TestCompareToObjectInvalid()
     {
-        Single i = 234;
-        IComparable comparable = i;
-
-        Assert.Equal(1, comparable.CompareTo(null));
-        Assert.Equal(0, comparable.CompareTo((Single)234));
-
-        Assert.True(comparable.CompareTo(Single.MinValue) > 0);
-        Assert.True(comparable.CompareTo((Single)0) > 0);
-        Assert.True(comparable.CompareTo((Single)(-123)) > 0);
-        Assert.True(comparable.CompareTo((Single)123) > 0);
-        Assert.True(comparable.CompareTo((Single)456) < 0);
-        Assert.True(comparable.CompareTo(Single.MaxValue) < 0);
-
-        Assert.Throws<ArgumentException>(() => comparable.CompareTo("a"));
+        IComparable comparable = (float)234;
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); //Obj is not a float
+    }
+    
+    [Theory]
+    [InlineData((float)789, true)]
+    [InlineData((float)(-789), false)]
+    [InlineData((float)0, false)]
+    public static void TestEqualsObject(object obj, bool expected)
+    {
+        float i = 789;
+        Assert.Equal(expected, i.Equals(obj));
     }
 
-    [Fact]
-    public static void TestCompareTo()
+    [Theory]
+    [InlineData((float)789, (float)789, true)]
+    [InlineData((float)789, (float)(-789), false)]
+    [InlineData((float)789, (float)0, false)]
+    [InlineData(float.NaN, float.NaN, true)]
+    public static void TestEquals(float i1, float i2, bool expected)
     {
-        Single i = 234;
-
-        Assert.Equal(0, i.CompareTo((Single)234));
-
-        Assert.True(i.CompareTo(Single.MinValue) > 0);
-        Assert.True(i.CompareTo((Single)0) > 0);
-        Assert.True(i.CompareTo((Single)(-123)) > 0);
-        Assert.True(i.CompareTo((Single)123) > 0);
-        Assert.True(i.CompareTo((Single)456) < 0);
-        Assert.True(i.CompareTo(Single.MaxValue) < 0);
-
-        Assert.True(Single.NaN.CompareTo(Single.NaN) == 0);
-        Assert.True(Single.NaN.CompareTo(0) < 0);
-        Assert.True(i.CompareTo(Single.NaN) > 0);
-    }
-
-    [Fact]
-    public static void TestEqualsObject()
-    {
-        Single i = 789;
-
-        object obj1 = (Single)789;
-        Assert.True(i.Equals(obj1));
-
-        object obj2 = (Single)(-789);
-        Assert.True(!i.Equals(obj2));
-
-        object obj3 = (Single)0;
-        Assert.True(!i.Equals(obj3));
-    }
-
-    [Fact]
-    public static void TestEquals()
-    {
-        Single i = -911;
-
-        Assert.True(i.Equals((Single)(-911)));
-
-        Assert.True(!i.Equals((Single)911));
-        Assert.True(!i.Equals((Single)0));
-        Assert.True(Single.NaN.Equals(Single.NaN));
+        Assert.Equal(expected, i1.Equals(i2));
     }
 
     [Fact]
     public static void TestGetHashCode()
     {
-        Single i1 = 123;
-        Single i2 = 654;
+        float i1 = 123;
+        float i2 = 654;
 
         Assert.NotEqual(0, i1.GetHashCode());
         Assert.NotEqual(i1.GetHashCode(), i2.GetHashCode());
@@ -171,79 +157,79 @@ public static class SingleTests
     [Fact]
     public static void TestToString()
     {
-        Single i1 = 6310;
+        float i1 = 6310;
         Assert.Equal("6310", i1.ToString());
 
-        Single i2 = -8249;
+        float i2 = -8249;
         Assert.Equal("-8249", i2.ToString());
     }
 
     [Fact]
     public static void TestToStringFormatProvider()
     {
-        var numberFormat = new System.Globalization.NumberFormatInfo();
+        var numberFormat = new NumberFormatInfo();
 
-        Single i1 = 6310;
+        float i1 = 6310;
         Assert.Equal("6310", i1.ToString(numberFormat));
 
-        Single i2 = -8249;
+        float i2 = -8249;
         Assert.Equal("-8249", i2.ToString(numberFormat));
 
-        Single i3 = -2468;
+        float i3 = -2468;
 
         // Changing the negative pattern doesn't do anything without also passing in a format string
         numberFormat.NumberNegativePattern = 0;
         Assert.Equal("-2468", i3.ToString(numberFormat));
 
-        Assert.Equal("NaN", Single.NaN.ToString(NumberFormatInfo.InvariantInfo));
-        Assert.Equal("Infinity", Single.PositiveInfinity.ToString(NumberFormatInfo.InvariantInfo));
-        Assert.Equal("-Infinity", Single.NegativeInfinity.ToString(NumberFormatInfo.InvariantInfo));
+        Assert.Equal("NaN", float.NaN.ToString(NumberFormatInfo.InvariantInfo));
+        Assert.Equal("Infinity", float.PositiveInfinity.ToString(NumberFormatInfo.InvariantInfo));
+        Assert.Equal("-Infinity", float.NegativeInfinity.ToString(NumberFormatInfo.InvariantInfo));
     }
 
     [Fact]
     public static void TestToStringFormat()
     {
-        Single i1 = 6310;
+        float i1 = 6310;
         Assert.Equal("6310", i1.ToString("G"));
 
-        Single i2 = -8249;
+        float i2 = -8249;
         Assert.Equal("-8249", i2.ToString("g"));
 
-        Single i3 = -2468;
+        float i3 = -2468;
         Assert.Equal(string.Format("{0:N}", -2468.00), i3.ToString("N"));
     }
 
     [Fact]
     public static void TestToStringFormatFormatProvider()
     {
-        var numberFormat = new System.Globalization.NumberFormatInfo();
+        var numberFormat = new NumberFormatInfo();
 
-        Single i1 = 6310;
+        float i1 = 6310;
         Assert.Equal("6310", i1.ToString("G", numberFormat));
 
-        Single i2 = -8249;
+        float i2 = -8249;
         Assert.Equal("-8249", i2.ToString("g", numberFormat));
 
         numberFormat.NegativeSign = "xx"; // setting it to trash to make sure it doesn't show up
         numberFormat.NumberGroupSeparator = "*";
         numberFormat.NumberNegativePattern = 0;
-        Single i3 = -2468;
+        float i3 = -2468;
         Assert.Equal("(2*468.00)", i3.ToString("N", numberFormat));
     }
 
     [Fact]
     public static void TestParse()
     {
-        Assert.Equal(123, Single.Parse("123"));
-        Assert.Equal(-123, Single.Parse("-123"));
+        Assert.Equal(123, float.Parse("123"));
+        Assert.Equal(-123, float.Parse("-123"));
         //TODO: Negative tests once we get better exceptions
     }
 
     [Fact]
     public static void TestParseNumberStyle()
     {
-        Assert.Equal<Single>(123.1f, Single.Parse((123.1).ToString("F"), NumberStyles.AllowDecimalPoint));
-        Assert.Equal(1000, Single.Parse((1000).ToString("N0"), NumberStyles.AllowThousands));
+        Assert.Equal(123.1f, float.Parse((123.1).ToString("F"), NumberStyles.AllowDecimalPoint));
+        Assert.Equal(1000, float.Parse((1000).ToString("N0"), NumberStyles.AllowThousands));
         //TODO: Negative tests once we get better exceptions
     }
 
@@ -251,8 +237,8 @@ public static class SingleTests
     public static void TestParseFormatProvider()
     {
         var nfi = new NumberFormatInfo();
-        Assert.Equal(123, Single.Parse("123", nfi));
-        Assert.Equal(-123, Single.Parse("-123", nfi));
+        Assert.Equal(123, float.Parse("123", nfi));
+        Assert.Equal(-123, float.Parse("-123", nfi));
         //TODO: Negative tests once we get better exceptions
     }
 
@@ -261,11 +247,11 @@ public static class SingleTests
     {
         var nfi = new NumberFormatInfo();
         nfi.NumberDecimalSeparator = ".";
-        Assert.Equal<Single>(123.123f, Single.Parse("123.123", NumberStyles.Float, nfi));
+        Assert.Equal(123.123f, float.Parse("123.123", NumberStyles.Float, nfi));
 
         nfi.CurrencySymbol = "$";
         nfi.CurrencyGroupSeparator = ",";
-        Assert.Equal(1000, Single.Parse("$1,000", NumberStyles.Currency, nfi));
+        Assert.Equal(1000, float.Parse("$1,000", NumberStyles.Currency, nfi));
         //TODO: Negative tests once we get better exception support
     }
 
@@ -274,64 +260,63 @@ public static class SingleTests
     {
         // Defaults AllowLeadingWhite | AllowTrailingWhite | AllowLeadingSign | AllowDecimalPoint | AllowExponent | AllowThousands
 
-        Single i;
-        Assert.True(Single.TryParse("123", out i));     // Simple
+        float i;
+        Assert.True(float.TryParse("123", out i));     // Simple
         Assert.Equal(123, i);
 
-        Assert.True(Single.TryParse("-385", out i));    // LeadingSign
+        Assert.True(float.TryParse("-385", out i));    // LeadingSign
         Assert.Equal(-385, i);
 
-        Assert.True(Single.TryParse(" 678 ", out i));   // Leading/Trailing whitespace
+        Assert.True(float.TryParse(" 678 ", out i));   // Leading/Trailing whitespace
         Assert.Equal(678, i);
 
-        Assert.True(Single.TryParse((678.90).ToString("F2"), out i)); // Decimal
-        Assert.Equal((Single)678.90, i);
+        Assert.True(float.TryParse((678.90).ToString("F2"), out i)); // Decimal
+        Assert.Equal((float)678.90, i);
 
-        Assert.True(Single.TryParse("1E23", out i));   // Exponent
-        Assert.Equal((Single)1E23, i);
+        Assert.True(float.TryParse("1E23", out i));   // Exponent
+        Assert.Equal((float)1E23, i);
 
-        Assert.True(Single.TryParse((1000).ToString("N0"), out i));  // Thousands
+        Assert.True(float.TryParse((1000).ToString("N0"), out i));  // Thousands
         Assert.Equal(1000, i);
 
         var nfi = new NumberFormatInfo() { CurrencyGroupSeparator = "" };
-        Assert.False(Single.TryParse((1000).ToString("C0", nfi), out i));  // Currency
-        Assert.False(Single.TryParse("abc", out i));    // Hex digits
-        Assert.False(Single.TryParse("(135)", out i));  // Parentheses
+        Assert.False(float.TryParse((1000).ToString("C0", nfi), out i));  // Currency
+        Assert.False(float.TryParse("abc", out i));    // Hex digits
+        Assert.False(float.TryParse("(135)", out i));  // Parentheses
     }
 
     [Fact]
     public static void TestTryParseNumberStyleFormatProvider()
     {
-        Single i;
+        float i;
         var nfi = new NumberFormatInfo();
         nfi.NumberDecimalSeparator = ".";
-        Assert.True(Single.TryParse("123.123", NumberStyles.Any, nfi, out i));   // Simple positive
+        Assert.True(float.TryParse("123.123", NumberStyles.Any, nfi, out i));   // Simple positive
         Assert.Equal(123.123f, i);
 
-        Assert.True(Single.TryParse("123", NumberStyles.Float, nfi, out i));   // Simple Hex
+        Assert.True(float.TryParse("123", NumberStyles.Float, nfi, out i));   // Simple Hex
         Assert.Equal(123, i);
 
         nfi.CurrencySymbol = "$";
         nfi.CurrencyGroupSeparator = ",";
-        Assert.True(Single.TryParse("$1,000", NumberStyles.Currency, nfi, out i)); // Currency/Thousands postive
+        Assert.True(float.TryParse("$1,000", NumberStyles.Currency, nfi, out i)); // Currency/Thousands postive
         Assert.Equal(1000, i);
 
-        Assert.False(Single.TryParse("abc", NumberStyles.None, nfi, out i));       // Hex Number negative
+        Assert.False(float.TryParse("abc", NumberStyles.None, nfi, out i));       // Hex Number negative
 
-        Assert.False(Single.TryParse("678.90", NumberStyles.Integer, nfi, out i));  // Decimal
-        Assert.False(Single.TryParse(" 678 ", NumberStyles.None, nfi, out i));      // Trailing/Leading whitespace negative
+        Assert.False(float.TryParse("678.90", NumberStyles.Integer, nfi, out i));  // Decimal
+        Assert.False(float.TryParse(" 678 ", NumberStyles.None, nfi, out i));      // Trailing/Leading whitespace negative
 
-        Assert.True(Single.TryParse("(135)", NumberStyles.AllowParentheses, nfi, out i)); // Parenthese postive
+        Assert.True(float.TryParse("(135)", NumberStyles.AllowParentheses, nfi, out i)); // Parenthese postive
         Assert.Equal(-135, i);
 
-        Assert.True(Single.TryParse("Infinity", NumberStyles.Any, NumberFormatInfo.InvariantInfo, out i));
-        Assert.True(Single.IsPositiveInfinity(i));
+        Assert.True(float.TryParse("Infinity", NumberStyles.Any, NumberFormatInfo.InvariantInfo, out i));
+        Assert.True(float.IsPositiveInfinity(i));
 
-        Assert.True(Single.TryParse("-Infinity", NumberStyles.Any, NumberFormatInfo.InvariantInfo, out i));
-        Assert.True(Single.IsNegativeInfinity(i));
+        Assert.True(float.TryParse("-Infinity", NumberStyles.Any, NumberFormatInfo.InvariantInfo, out i));
+        Assert.True(float.IsNegativeInfinity(i));
 
-        Assert.True(Single.TryParse("NaN", NumberStyles.Any, NumberFormatInfo.InvariantInfo, out i));
-        Assert.True(Single.IsNaN(i));
+        Assert.True(float.TryParse("NaN", NumberStyles.Any, NumberFormatInfo.InvariantInfo, out i));
+        Assert.True(float.IsNaN(i));
     }
 }
-

--- a/src/System.Runtime/tests/System/String.Split.cs
+++ b/src/System.Runtime/tests/System/String.Split.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+
 using Xunit;
 
 // TODO: Remove these extension methods when the actual methods are available on String in System.Runtime.dll

--- a/src/System.Runtime/tests/System/Text/StringBuilder.cs
+++ b/src/System.Runtime/tests/System/Text/StringBuilder.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Text;
-using System.Globalization;
+
 using Xunit;
 
 public static class StringBuilderTests
@@ -12,7 +12,7 @@ public static class StringBuilderTests
     public static void TestToString()
     {
         StringBuilder sb = new StringBuilder("Finally");
-        String s = sb.ToString(2, 3);
+        string s = sb.ToString(2, 3);
         Assert.Equal(s, "nal");
     }
 
@@ -20,7 +20,7 @@ public static class StringBuilderTests
     public static void TestReplace()
     {
         StringBuilder sb;
-        String s;
+        string s;
 
         sb = new StringBuilder("aaaabbbbccccdddd");
         sb.Replace('a', '!', 2, 3);
@@ -38,7 +38,7 @@ public static class StringBuilderTests
     {
         StringBuilder sb = new StringBuilder("Almost");
         sb.Remove(1, 3);
-        String s = sb.ToString();
+        string s = sb.ToString();
         Assert.Equal(s, "Ast");
     }
 
@@ -48,7 +48,7 @@ public static class StringBuilderTests
         //@todo: Not testing all the Insert() overloads that just call ToString() on the input and forward to Insert(int, String).
         StringBuilder sb = new StringBuilder("Hello");
         sb.Insert(2, "!!");
-        String s = sb.ToString();
+        string s = sb.ToString();
         Assert.Equal(s, "He!!llo");
     }
 
@@ -88,7 +88,7 @@ public static class StringBuilderTests
     public static void TestClear()
     {
         StringBuilder sb;
-        String s;
+        string s;
 
         sb = new StringBuilder("Hello");
         sb.Clear();
@@ -100,7 +100,7 @@ public static class StringBuilderTests
     public static void TestLength()
     {
         StringBuilder sb;
-        String s;
+        string s;
         int len;
 
         sb = new StringBuilder("Hello");
@@ -115,14 +115,14 @@ public static class StringBuilderTests
         len = sb.Length;
         Assert.Equal(len, 10);
         s = sb.ToString();
-        Assert.Equal(s, "He" + new String((char)0, 8));
+        Assert.Equal(s, "He" + new string((char)0, 8));
     }
 
     [Fact]
     public static void TestAppendFormat()
     {
         StringBuilder sb;
-        String s;
+        string s;
 
         sb = new StringBuilder();
         sb.AppendFormat("Foo {0} Bar {1}", "Red", "Green");
@@ -136,7 +136,7 @@ public static class StringBuilderTests
         //@todo: Skipped all the Append overloads that just call ToString() on the argument and delegate to Append(String)
 
         StringBuilder sb;
-        String s;
+        string s;
 
         sb = new StringBuilder();
         s = "";
@@ -155,7 +155,7 @@ public static class StringBuilderTests
             char c = (char)(0x41 + (i % 10));
             int repeat = i % 8;
             sb.Append(c, repeat);
-            s += new String(c, repeat);
+            s += new string(c, repeat);
             Assert.Equal(sb.ToString(), s);
         }
 
@@ -169,7 +169,7 @@ public static class StringBuilderTests
             for (int j = 0; j < ca.Length; j++)
                 ca[j] = c;
             sb.Append(ca);
-            s += new String(ca);
+            s += new string(ca);
             Assert.Equal(sb.ToString(), s);
         }
 
@@ -195,7 +195,7 @@ public static class StringBuilderTests
         char c = sb[1];
         Assert.Equal(c, 'e');
         sb[1] = 'X';
-        String s = sb.ToString();
+        string s = sb.ToString();
         Assert.Equal(s, "HXllo");
     }
 
@@ -203,7 +203,7 @@ public static class StringBuilderTests
     public static void TestCtors()
     {
         StringBuilder sb;
-        String s;
+        string s;
         int c;
         int l;
         int m;

--- a/src/System.Runtime/tests/System/Threading/WaitHandle.cs
+++ b/src/System.Runtime/tests/System/Threading/WaitHandle.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Threading;
-using System.Threading.Tasks;
+
 using Xunit;
 
 public static class WaitHandleTests

--- a/src/System.Runtime/tests/System/TimeSpan.cs
+++ b/src/System.Runtime/tests/System/TimeSpan.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+
 using Xunit;
 
 public static unsafe class TimeSpanTests

--- a/src/System.Runtime/tests/System/TimeZoneInfo.cs
+++ b/src/System.Runtime/tests/System/TimeZoneInfo.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Runtime.InteropServices;
+
 using Xunit;
 
 public static class TimeZoneInfoTests
@@ -12,20 +13,20 @@ public static class TimeZoneInfoTests
     private static readonly bool s_isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
     private static readonly bool s_isOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 
-    private static String s_strPacific = s_isWindows ? "Pacific Standard Time" : "America/Los_Angeles";
-    private static String s_strSydney = s_isWindows ? "AUS Eastern Standard Time" : "Australia/Sydney";
-    private static String s_strGMT = s_isWindows ? "GMT Standard Time" : "Europe/London";
-    private static String s_strTonga = s_isWindows ? "Tonga Standard Time" : "Pacific/Tongatapu";
-    private static String s_strBrasil = s_isWindows ? "E. South America Standard Time" : "America/Sao_Paulo";
-    private static String s_strPerth = s_isWindows ? "W. Australia Standard Time" : "Australia/Perth";
-    private static String s_strBrasilia = s_isWindows ? "E. South America Standard Time" : "America/Sao_Paulo";
-    private static String s_strNairobi = s_isWindows ? "E. Africa Standard Time" : "Africa/Nairobi";
-    private static String s_strAmsterdam = s_isWindows ? "W. Europe Standard Time" : "Europe/Berlin";
-    private static String s_strRussian = s_isWindows ? "Russian Standard Time" : "Europe/Moscow";
-    private static String s_strLibya = s_isWindows ? "Libya Standard Time" : "Africa/Tripoli";
-    private static String s_strCatamarca = s_isWindows ? "Argentina Standard Time" : "America/Argentina/Catamarca";
-    private static String s_strLisbon = s_isWindows ? "GMT Standard Time" : "Europe/Lisbon";
-    private static String s_strNewfoundland = s_isWindows ? "Newfoundland Standard Time" : "America/St_Johns";
+    private static string s_strPacific = s_isWindows ? "Pacific Standard Time" : "America/Los_Angeles";
+    private static string s_strSydney = s_isWindows ? "AUS Eastern Standard Time" : "Australia/Sydney";
+    private static string s_strGMT = s_isWindows ? "GMT Standard Time" : "Europe/London";
+    private static string s_strTonga = s_isWindows ? "Tonga Standard Time" : "Pacific/Tongatapu";
+    private static string s_strBrasil = s_isWindows ? "E. South America Standard Time" : "America/Sao_Paulo";
+    private static string s_strPerth = s_isWindows ? "W. Australia Standard Time" : "Australia/Perth";
+    private static string s_strBrasilia = s_isWindows ? "E. South America Standard Time" : "America/Sao_Paulo";
+    private static string s_strNairobi = s_isWindows ? "E. Africa Standard Time" : "Africa/Nairobi";
+    private static string s_strAmsterdam = s_isWindows ? "W. Europe Standard Time" : "Europe/Berlin";
+    private static string s_strRussian = s_isWindows ? "Russian Standard Time" : "Europe/Moscow";
+    private static string s_strLibya = s_isWindows ? "Libya Standard Time" : "Africa/Tripoli";
+    private static string s_strCatamarca = s_isWindows ? "Argentina Standard Time" : "America/Argentina/Catamarca";
+    private static string s_strLisbon = s_isWindows ? "GMT Standard Time" : "Europe/Lisbon";
+    private static string s_strNewfoundland = s_isWindows ? "Newfoundland Standard Time" : "America/St_Johns";
 
     private static TimeZoneInfo s_myUtc = TimeZoneInfo.Utc;
     private static TimeZoneInfo s_myLocal = TimeZoneInfo.Local;
@@ -103,7 +104,7 @@ public static class TimeZoneInfoTests
 
         DateTime libyaLocalTime = TimeZoneInfo.ConvertTime(endOf2011, tripoli);
         DateTime expectResult = new DateTime(2012, 1, 1, 2, 0, 0).AddTicks(-1);
-        Assert.True(libyaLocalTime.Equals(expectResult), String.Format("Expected {0} and got {1}", expectResult, libyaLocalTime));
+        Assert.True(libyaLocalTime.Equals(expectResult), string.Format("Expected {0} and got {1}", expectResult, libyaLocalTime));
     }
 
     [Fact]
@@ -114,11 +115,11 @@ public static class TimeZoneInfoTests
 
         DateTime russiaTime = TimeZoneInfo.ConvertTime(inputUtcDate, tz);
         DateTime expectResult = new DateTime(2013, 6, 1, 4, 0, 0);
-        Assert.True(russiaTime.Equals(expectResult), String.Format("Expected {0} and got {1}", expectResult, russiaTime));
+        Assert.True(russiaTime.Equals(expectResult), string.Format("Expected {0} and got {1}", expectResult, russiaTime));
 
         DateTime dt = new DateTime(2011, 12, 31, 23, 30, 0);
         TimeSpan o = tz.GetUtcOffset(dt);
-        Assert.True(o.Equals(TimeSpan.FromHours(4)), String.Format("Expected {0} and got {1}", TimeSpan.FromHours(4), o));
+        Assert.True(o.Equals(TimeSpan.FromHours(4)), string.Format("Expected {0} and got {1}", TimeSpan.FromHours(4), o));
     }
 
     [Fact]
@@ -133,7 +134,7 @@ public static class TimeZoneInfoTests
         // in .NET Core
         //
 
-        VerifyConvertException<Exception>(time1, String.Empty);
+        VerifyConvertException<Exception>(time1, string.Empty);
         VerifyConvertException<Exception>(time1, "    ");
         VerifyConvertException<Exception>(time1, "\0");
         VerifyConvertException<Exception>(time1, "Pacific"); // whole string must match
@@ -145,7 +146,7 @@ public static class TimeZoneInfoTests
         VerifyConvertException<Exception>(time1, "Pacific Standard Time\\  "); // no trailing null
         VerifyConvertException<Exception>(time1, "Pacific Standard Time\\Display");
         VerifyConvertException<Exception>(time1, "Pacific Standard Time\n"); // no trailing newline
-        VerifyConvertException<Exception>(time1, new String('a', 256)); // long string
+        VerifyConvertException<Exception>(time1, new string('a', 256)); // long string
     }
 
     [Fact]
@@ -1789,7 +1790,7 @@ public static class TimeZoneInfoTests
     //  Helper Methods
     //
 
-    private static void VerifyConvertException<EXCTYPE>(DateTimeOffset inputTime, String destinationTimeZoneId) where EXCTYPE : Exception
+    private static void VerifyConvertException<EXCTYPE>(DateTimeOffset inputTime, string destinationTimeZoneId) where EXCTYPE : Exception
     {
         Assert.ThrowsAny<EXCTYPE>(() =>
         {
@@ -1797,7 +1798,7 @@ public static class TimeZoneInfoTests
         });
     }
 
-    private static void VerifyConvertException<EXCTYPE>(DateTime inputTime, String destinationTimeZoneId) where EXCTYPE : Exception
+    private static void VerifyConvertException<EXCTYPE>(DateTime inputTime, string destinationTimeZoneId) where EXCTYPE : Exception
     {
         Assert.ThrowsAny<EXCTYPE>(() =>
         {
@@ -1805,7 +1806,7 @@ public static class TimeZoneInfoTests
         });
     }
 
-    private static void VerifyConvertException<EXCTYPE>(DateTime inputTime, String sourceTimeZoneId, String destinationTimeZoneId) where EXCTYPE : Exception
+    private static void VerifyConvertException<EXCTYPE>(DateTime inputTime, string sourceTimeZoneId, string destinationTimeZoneId) where EXCTYPE : Exception
     {
         Assert.ThrowsAny<EXCTYPE>(() =>
         {
@@ -1813,34 +1814,34 @@ public static class TimeZoneInfoTests
         });
     }
 
-    private static void VerifyConvert(DateTimeOffset inputTime, String destinationTimeZoneId, DateTimeOffset expectedTime)
+    private static void VerifyConvert(DateTimeOffset inputTime, string destinationTimeZoneId, DateTimeOffset expectedTime)
     {
         DateTimeOffset returnedTime = TimeZoneInfo.ConvertTime(inputTime, TimeZoneInfo.FindSystemTimeZoneById(destinationTimeZoneId));
-        Assert.True(returnedTime.Equals(expectedTime), String.Format("Error: Expected value '{0}' but got '{1}', input value is '{2}', TimeZone: {3}", expectedTime, returnedTime, inputTime, destinationTimeZoneId));
+        Assert.True(returnedTime.Equals(expectedTime), string.Format("Error: Expected value '{0}' but got '{1}', input value is '{2}', TimeZone: {3}", expectedTime, returnedTime, inputTime, destinationTimeZoneId));
     }
 
-    private static void VerifyConvert(DateTime inputTime, String destinationTimeZoneId, DateTime expectedTime)
+    private static void VerifyConvert(DateTime inputTime, string destinationTimeZoneId, DateTime expectedTime)
     {
         DateTime returnedTime = TimeZoneInfo.ConvertTime(inputTime, TimeZoneInfo.FindSystemTimeZoneById(destinationTimeZoneId));
-        Assert.True(returnedTime.Equals(expectedTime), String.Format("Error: Expected value '{0}' but got '{1}', input value is '{2}', TimeZone: {3}", expectedTime, returnedTime, inputTime, destinationTimeZoneId));
-        Assert.True(expectedTime.Kind == returnedTime.Kind, String.Format("Error: Expected value '{0}' but got '{1}', input value is '{2}', TimeZone: {3}", expectedTime.Kind, returnedTime.Kind, inputTime, destinationTimeZoneId));
+        Assert.True(returnedTime.Equals(expectedTime), string.Format("Error: Expected value '{0}' but got '{1}', input value is '{2}', TimeZone: {3}", expectedTime, returnedTime, inputTime, destinationTimeZoneId));
+        Assert.True(expectedTime.Kind == returnedTime.Kind, string.Format("Error: Expected value '{0}' but got '{1}', input value is '{2}', TimeZone: {3}", expectedTime.Kind, returnedTime.Kind, inputTime, destinationTimeZoneId));
     }
 
-    private static void VerifyConvert(DateTime inputTime, String destinationTimeZoneId, DateTime expectedTime, DateTimeKind expectedKind)
+    private static void VerifyConvert(DateTime inputTime, string destinationTimeZoneId, DateTime expectedTime, DateTimeKind expectedKind)
     {
         DateTime returnedTime = TimeZoneInfo.ConvertTime(inputTime, TimeZoneInfo.FindSystemTimeZoneById(destinationTimeZoneId));
-        Assert.True(returnedTime.Equals(expectedTime), String.Format("Error: Expected value '{0}' but got '{1}', input value is '{2}', TimeZone: {3}", expectedTime, returnedTime, inputTime, destinationTimeZoneId));
-        Assert.True(expectedKind == returnedTime.Kind, String.Format("Error: Expected value '{0}' but got '{1}', input value is '{2}', TimeZone: {3}", expectedTime.Kind, returnedTime.Kind, inputTime, destinationTimeZoneId));
+        Assert.True(returnedTime.Equals(expectedTime), string.Format("Error: Expected value '{0}' but got '{1}', input value is '{2}', TimeZone: {3}", expectedTime, returnedTime, inputTime, destinationTimeZoneId));
+        Assert.True(expectedKind == returnedTime.Kind, string.Format("Error: Expected value '{0}' but got '{1}', input value is '{2}', TimeZone: {3}", expectedTime.Kind, returnedTime.Kind, inputTime, destinationTimeZoneId));
     }
 
-    private static void VerifyConvert(DateTime inputTime, String sourceTimeZoneId, String destinationTimeZoneId, DateTime expectedTime)
+    private static void VerifyConvert(DateTime inputTime, string sourceTimeZoneId, string destinationTimeZoneId, DateTime expectedTime)
     {
         DateTime returnedTime = TimeZoneInfo.ConvertTime(inputTime, TimeZoneInfo.FindSystemTimeZoneById(sourceTimeZoneId), TimeZoneInfo.FindSystemTimeZoneById(destinationTimeZoneId));
-        Assert.True(returnedTime.Equals(expectedTime), String.Format("Error: Expected value '{0}' but got '{1}', input value is '{2}', Source TimeZone: {3}, Dest. Time Zone: {4}", expectedTime, returnedTime, inputTime, sourceTimeZoneId, destinationTimeZoneId));
-        Assert.True(expectedTime.Kind == returnedTime.Kind, String.Format("Error: Expected value '{0}' but got '{1}', input value is '{2}', Source TimeZone: {3}, Dest. Time Zone: {4}", expectedTime.Kind, returnedTime.Kind, inputTime, sourceTimeZoneId, destinationTimeZoneId));
+        Assert.True(returnedTime.Equals(expectedTime), string.Format("Error: Expected value '{0}' but got '{1}', input value is '{2}', Source TimeZone: {3}, Dest. Time Zone: {4}", expectedTime, returnedTime, inputTime, sourceTimeZoneId, destinationTimeZoneId));
+        Assert.True(expectedTime.Kind == returnedTime.Kind, string.Format("Error: Expected value '{0}' but got '{1}', input value is '{2}', Source TimeZone: {3}, Dest. Time Zone: {4}", expectedTime.Kind, returnedTime.Kind, inputTime, sourceTimeZoneId, destinationTimeZoneId));
     }
 
-    private static void VerifyRoundTrip(DateTime dt1, String sourceTimeZoneId, String destinationTimeZoneId)
+    private static void VerifyRoundTrip(DateTime dt1, string sourceTimeZoneId, string destinationTimeZoneId)
     {
         TimeZoneInfo sourceTzi = TimeZoneInfo.FindSystemTimeZoneById(sourceTimeZoneId);
         TimeZoneInfo destTzi = TimeZoneInfo.FindSystemTimeZoneById(destinationTimeZoneId);
@@ -1848,11 +1849,11 @@ public static class TimeZoneInfoTests
         DateTime dt2 = TimeZoneInfo.ConvertTime(dt1, sourceTzi, destTzi);
         DateTime dt3 = TimeZoneInfo.ConvertTime(dt2, destTzi, sourceTzi);
 
-        Assert.True(dt1.Equals(dt3), String.Format("{0} failed to round trip using source '{1}' and '{2}' zones. wrong result {3}", dt1, sourceTimeZoneId, destinationTimeZoneId, dt3));
+        Assert.True(dt1.Equals(dt3), string.Format("{0} failed to round trip using source '{1}' and '{2}' zones. wrong result {3}", dt1, sourceTimeZoneId, destinationTimeZoneId, dt3));
 
         if (sourceTimeZoneId == TimeZoneInfo.Utc.Id)
         {
-            Assert.True(dt3.Kind == DateTimeKind.Utc, String.Format("failed to get the right DT Kind after round trip {0} using source TZ {1} and dest TZi {2}", dt1, sourceTimeZoneId, destinationTimeZoneId));
+            Assert.True(dt3.Kind == DateTimeKind.Utc, string.Format("failed to get the right DT Kind after round trip {0} using source TZ {1} and dest TZi {2}", dt1, sourceTimeZoneId, destinationTimeZoneId));
         }
     }
 
@@ -1867,10 +1868,10 @@ public static class TimeZoneInfoTests
     private static void VerifyOffsets(TimeZoneInfo tz, DateTime dt, TimeSpan[] expectedOffsets)
     {
         TimeSpan[] ret = tz.GetAmbiguousTimeOffsets(dt);
-        VerifyTimeSpanArray(ret, expectedOffsets, String.Format("Wrong offsets when used {0} with teh zone {1}", dt, tz.Id));
+        VerifyTimeSpanArray(ret, expectedOffsets, string.Format("Wrong offsets when used {0} with teh zone {1}", dt, tz.Id));
     }
 
-    static public void VerifyTimeSpanArray(TimeSpan[] actual, TimeSpan[] expected, String errorMsg)
+    static public void VerifyTimeSpanArray(TimeSpan[] actual, TimeSpan[] expected, string errorMsg)
     {
         Assert.True(actual != null);
         Assert.True(expected != null);
@@ -1887,19 +1888,19 @@ public static class TimeZoneInfoTests
     private static void VerifyDST(TimeZoneInfo tz, DateTime dt, bool expectedDST)
     {
         bool ret = tz.IsDaylightSavingTime(dt);
-        Assert.True(ret == expectedDST, String.Format("Test with the zone {0} and date {1} failed", tz.Id, dt));
+        Assert.True(ret == expectedDST, string.Format("Test with the zone {0} and date {1} failed", tz.Id, dt));
     }
 
     private static void VerifyInv(TimeZoneInfo tz, DateTime dt, bool expectedInvalid)
     {
         bool ret = tz.IsInvalidTime(dt);
-        Assert.True(expectedInvalid == ret, String.Format("Test with the zone {0} and date {1} failed", tz.Id, dt));
+        Assert.True(expectedInvalid == ret, string.Format("Test with the zone {0} and date {1} failed", tz.Id, dt));
     }
 
     private static void VerifyAmbiguous(TimeZoneInfo tz, DateTime dt, bool expectedAmbiguous)
     {
         bool ret = tz.IsAmbiguousTime(dt);
-        Assert.True(expectedAmbiguous == ret, String.Format("Test with the zone {0} and date {1} failed", tz.Id, dt));
+        Assert.True(expectedAmbiguous == ret, string.Format("Test with the zone {0} and date {1} failed", tz.Id, dt));
     }
 
     /// <summary>

--- a/src/System.Runtime/tests/System/Tuple.cs
+++ b/src/System.Runtime/tests/System/Tuple.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections;
+
 using Xunit;
 
 public class TupleTests
@@ -206,13 +207,13 @@ public class TupleTests
 
         public void TestNotEqual()
         {
-            Tuple<Int32> tupleB = new Tuple<Int32>((Int32)10000);
+            Tuple<int> tupleB = new Tuple<int>((int)10000);
             Assert.NotEqual(Tuple, tupleB);
         }
 
         internal void TestCompareToThrows()
         {
-            Tuple<Int32> tupleB = new Tuple<Int32>((Int32)10000);
+            Tuple<int> tupleB = new Tuple<int>((int)10000);
             Assert.Throws<ArgumentException>(() => ((IComparable)Tuple).CompareTo(tupleB));
         }
     }
@@ -220,126 +221,126 @@ public class TupleTests
     [Fact]
     public static void TestConstructor()
     {
-        TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan> tupleDriverA;
+        TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan> tupleDriverA;
         //Tuple-1
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>(Int16.MaxValue);
-        tupleDriverA.TestConstructor(Int16.MaxValue);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MaxValue);
+        tupleDriverA.TestConstructor(short.MaxValue);
         //Tuple-2
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>(Int16.MinValue, Int32.MaxValue);
-        tupleDriverA.TestConstructor(Int16.MinValue, Int32.MaxValue);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MinValue, int.MaxValue);
+        tupleDriverA.TestConstructor(short.MinValue, int.MaxValue);
         //Tuple-3
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)0, (Int32)0, Int64.MaxValue);
-        tupleDriverA.TestConstructor((Int16)0, (Int32)0, Int64.MaxValue);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)0, (int)0, long.MaxValue);
+        tupleDriverA.TestConstructor((short)0, (int)0, long.MaxValue);
         //Tuple-4
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)1, (Int32)1, Int64.MinValue, "This");
-        tupleDriverA.TestConstructor((Int16)1, (Int32)1, Int64.MinValue, "This");
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)1, (int)1, long.MinValue, "This");
+        tupleDriverA.TestConstructor((short)1, (int)1, long.MinValue, "This");
         //Tuple-5
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)(-1), (Int32)(-1), (Int64)0, "is", 'A');
-        tupleDriverA.TestConstructor((Int16)(-1), (Int32)(-1), (Int64)0, "is", 'A');
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-1), (int)(-1), (long)0, "is", 'A');
+        tupleDriverA.TestConstructor((short)(-1), (int)(-1), (long)0, "is", 'A');
         //Tuple-6
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)10, (Int32)100, (Int64)1, "testing", 'Z', Single.MaxValue);
-        tupleDriverA.TestConstructor((Int16)10, (Int32)100, (Int64)1, "testing", 'Z', Single.MaxValue);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)10, (int)100, (long)1, "testing", 'Z', Single.MaxValue);
+        tupleDriverA.TestConstructor((short)10, (int)100, (long)1, "testing", 'Z', Single.MaxValue);
         //Tuple-7
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)(-100), (Int32)(-1000), (Int64)(-1), "Tuples", ' ', Single.MinValue, Double.MaxValue);
-        tupleDriverA.TestConstructor((Int16)(-100), (Int32)(-1000), (Int64)(-1), "Tuples", ' ', Single.MinValue, Double.MaxValue);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-100), (int)(-1000), (long)(-1), "Tuples", ' ', Single.MinValue, Double.MaxValue);
+        tupleDriverA.TestConstructor((short)(-100), (int)(-1000), (long)(-1), "Tuples", ' ', Single.MinValue, Double.MaxValue);
 
-        Object myObj = new Object();
+        object myObj = new object();
         //Tuple-10
         DateTime now = DateTime.Now;
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)10000, (Int32)1000000, (Int64)10000000, "2008年7月2日", '0', (Single)0.0001, (Double)0.0000001, now, Tuple.Create(false, myObj), TimeSpan.Zero);
-        tupleDriverA.TestConstructor((Int16)10000, (Int32)1000000, (Int64)10000000, "2008年7月2日", '0', (Single)0.0001, (Double)0.0000001, now, Tuple.Create(false, myObj), TimeSpan.Zero);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008年7月2日", '0', (Single)0.0001, (Double)0.0000001, now, Tuple.Create(false, myObj), TimeSpan.Zero);
+        tupleDriverA.TestConstructor((short)10000, (int)1000000, (long)10000000, "2008年7月2日", '0', (Single)0.0001, (Double)0.0000001, now, Tuple.Create(false, myObj), TimeSpan.Zero);
     }
 
     [Fact]
     public static void TestToString()
     {
-        TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan> tupleDriverA;
+        TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan> tupleDriverA;
         //Tuple-1
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>(Int16.MaxValue);
-        tupleDriverA.TestToString("(" + Int16.MaxValue + ")");
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MaxValue);
+        tupleDriverA.TestToString("(" + short.MaxValue + ")");
         //Tuple-2
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>(Int16.MinValue, Int32.MaxValue);
-        tupleDriverA.TestToString("(" + Int16.MinValue + ", " + Int32.MaxValue + ")");
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MinValue, int.MaxValue);
+        tupleDriverA.TestToString("(" + short.MinValue + ", " + int.MaxValue + ")");
         //Tuple-3
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)0, (Int32)0, Int64.MaxValue);
-        tupleDriverA.TestToString("(" + ((Int16)0) + ", " + ((Int32)0) + ", " + Int64.MaxValue + ")");
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)0, (int)0, long.MaxValue);
+        tupleDriverA.TestToString("(" + ((short)0) + ", " + ((int)0) + ", " + long.MaxValue + ")");
         //Tuple-4
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)1, (Int32)1, Int64.MinValue, "This");
-        tupleDriverA.TestConstructor((Int16)1, (Int32)1, Int64.MinValue, "This");
-        tupleDriverA.TestToString("(" + ((Int16)1) + ", " + ((Int32)1) + ", " + Int64.MinValue + ", This)");
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)1, (int)1, long.MinValue, "This");
+        tupleDriverA.TestConstructor((short)1, (int)1, long.MinValue, "This");
+        tupleDriverA.TestToString("(" + ((short)1) + ", " + ((int)1) + ", " + long.MinValue + ", This)");
         //Tuple-5
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)(-1), (Int32)(-1), (Int64)0, "is", 'A');
-        tupleDriverA.TestToString("(" + ((Int16)(-1)) + ", " + ((Int32)(-1)) + ", " + ((Int64)0) + ", is, A)");
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-1), (int)(-1), (long)0, "is", 'A');
+        tupleDriverA.TestToString("(" + ((short)(-1)) + ", " + ((int)(-1)) + ", " + ((long)0) + ", is, A)");
         //Tuple-6
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)10, (Int32)100, (Int64)1, "testing", 'Z', Single.MaxValue);
-        tupleDriverA.TestToString("(" + ((Int16)10) + ", " + ((Int32)100) + ", " + ((Int64)1) + ", testing, Z, " + Single.MaxValue + ")");
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)10, (int)100, (long)1, "testing", 'Z', Single.MaxValue);
+        tupleDriverA.TestToString("(" + ((short)10) + ", " + ((int)100) + ", " + ((long)1) + ", testing, Z, " + Single.MaxValue + ")");
         //Tuple-7
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)(-100), (Int32)(-1000), (Int64)(-1), "Tuples", ' ', Single.MinValue, Double.MaxValue);
-        tupleDriverA.TestToString("(" + ((Int16)(-100)) + ", " + ((Int32)(-1000)) + ", " + ((Int64)(-1)) + ", Tuples,  , " + Single.MinValue + ", " + Double.MaxValue + ")");
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-100), (int)(-1000), (long)(-1), "Tuples", ' ', Single.MinValue, Double.MaxValue);
+        tupleDriverA.TestToString("(" + ((short)(-100)) + ", " + ((int)(-1000)) + ", " + ((long)(-1)) + ", Tuples,  , " + Single.MinValue + ", " + Double.MaxValue + ")");
 
-        Object myObj = new Object();
+        object myObj = new object();
         //Tuple-10
         DateTime now = DateTime.Now;
 
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)10000, (Int32)1000000, (Int64)10000000, "2008年7月2日", '0', (Single)0.0001, (Double)0.0000001, now, Tuple.Create(false, myObj), TimeSpan.Zero);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008年7月2日", '0', (Single)0.0001, (Double)0.0000001, now, Tuple.Create(false, myObj), TimeSpan.Zero);
         // .NET Native bug 438149 - object.ToString in incorrect
-        tupleDriverA.TestToString("(" + ((Int16)10000) + ", " + ((Int32)1000000) + ", " + ((Int64)10000000) + ", 2008年7月2日, 0, " + ((Single)0.0001) + ", " + ((Double)0.0000001) + ", " + now + ", (False, System.Object), " + TimeSpan.Zero + ")");
+        tupleDriverA.TestToString("(" + ((short)10000) + ", " + ((int)1000000) + ", " + ((long)10000000) + ", 2008年7月2日, 0, " + ((Single)0.0001) + ", " + ((Double)0.0000001) + ", " + now + ", (False, System.Object), " + TimeSpan.Zero + ")");
     }
 
     [Fact]
     public static void TestEquals_GetHashCode()
     {
-        TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan> tupleDriverA, tupleDriverB, tupleDriverC;
+        TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan> tupleDriverA, tupleDriverB, tupleDriverC;
         //Tuple-1
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>(Int16.MaxValue);
-        tupleDriverB = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>(Int16.MaxValue);
-        tupleDriverC = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>(Int16.MinValue);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MaxValue);
+        tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MaxValue);
+        tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MinValue);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverB, true, true);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverC, false, false);
         //Tuple-2
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>(Int16.MinValue, Int32.MaxValue);
-        tupleDriverB = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>(Int16.MinValue, Int32.MaxValue);
-        tupleDriverC = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>(Int16.MinValue, Int32.MinValue);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MinValue, int.MaxValue);
+        tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MinValue, int.MaxValue);
+        tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MinValue, int.MinValue);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverB, true, true);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverC, false, false);
         //Tuple-3
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)0, (Int32)0, Int64.MaxValue);
-        tupleDriverB = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)0, (Int32)0, Int64.MaxValue);
-        tupleDriverC = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)(-1), (Int32)(-1), Int64.MinValue);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)0, (int)0, long.MaxValue);
+        tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)0, (int)0, long.MaxValue);
+        tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-1), (int)(-1), long.MinValue);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverB, true, true);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverC, false, false);
         //Tuple-4
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)1, (Int32)1, Int64.MinValue, "This");
-        tupleDriverB = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)1, (Int32)1, Int64.MinValue, "This");
-        tupleDriverC = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)1, (Int32)1, Int64.MinValue, "this");
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)1, (int)1, long.MinValue, "This");
+        tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)1, (int)1, long.MinValue, "This");
+        tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)1, (int)1, long.MinValue, "this");
         tupleDriverA.TestEquals_GetHashCode(tupleDriverB, true, true);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverC, false, false);
         //Tuple-5
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)(-1), (Int32)(-1), (Int64)0, "is", 'A');
-        tupleDriverB = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)(-1), (Int32)(-1), (Int64)0, "is", 'A');
-        tupleDriverC = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)0, (Int32)0, (Int64)1, "IS", 'a');
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-1), (int)(-1), (long)0, "is", 'A');
+        tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-1), (int)(-1), (long)0, "is", 'A');
+        tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)0, (int)0, (long)1, "IS", 'a');
         tupleDriverA.TestEquals_GetHashCode(tupleDriverB, true, true);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverC, false, false);
         //Tuple-6
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)10, (Int32)100, (Int64)1, "testing", 'Z', Single.MaxValue);
-        tupleDriverB = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)10, (Int32)100, (Int64)1, "testing", 'Z', Single.MaxValue);
-        tupleDriverC = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)10, (Int32)100, (Int64)1, "testing", 'Z', Single.MinValue);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)10, (int)100, (long)1, "testing", 'Z', Single.MaxValue);
+        tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)10, (int)100, (long)1, "testing", 'Z', Single.MaxValue);
+        tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)10, (int)100, (long)1, "testing", 'Z', Single.MinValue);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverB, true, true);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverC, false, false);
         //Tuple-7
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)(-100), (Int32)(-1000), (Int64)(-1), "Tuples", ' ', Single.MinValue, Double.MaxValue);
-        tupleDriverB = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)(-100), (Int32)(-1000), (Int64)(-1), "Tuples", ' ', Single.MinValue, Double.MaxValue);
-        tupleDriverC = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)(-101), (Int32)(-1001), (Int64)(-2), "tuples", ' ', Single.MinValue, (Double)0.0);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-100), (int)(-1000), (long)(-1), "Tuples", ' ', Single.MinValue, Double.MaxValue);
+        tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-100), (int)(-1000), (long)(-1), "Tuples", ' ', Single.MinValue, Double.MaxValue);
+        tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-101), (int)(-1001), (long)(-2), "tuples", ' ', Single.MinValue, (Double)0.0);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverB, true, true);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverC, false, false);
 
-        Object myObj = new Object();
+        object myObj = new object();
         //Tuple-10
         DateTime now = DateTime.Now;
 
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)10000, (Int32)1000000, (Int64)10000000, "2008年7月2日", '0', (Single)0.0001, (Double)0.0000001, now, Tuple.Create(false, myObj), TimeSpan.Zero);
-        tupleDriverB = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)10000, (Int32)1000000, (Int64)10000000, "2008年7月2日", '0', (Single)0.0001, (Double)0.0000001, now, Tuple.Create(false, myObj), TimeSpan.Zero);
-        tupleDriverC = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)10001, (Int32)1000001, (Int64)10000001, "2008年7月3日", '1', (Single)0.0002, (Double)0.0000002, now.AddMilliseconds(1), Tuple.Create(true, myObj), TimeSpan.MaxValue);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008年7月2日", '0', (Single)0.0001, (Double)0.0000001, now, Tuple.Create(false, myObj), TimeSpan.Zero);
+        tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008年7月2日", '0', (Single)0.0001, (Double)0.0000001, now, Tuple.Create(false, myObj), TimeSpan.Zero);
+        tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)10001, (int)1000001, (long)10000001, "2008年7月3日", '1', (Single)0.0002, (Double)0.0000002, now.AddMilliseconds(1), Tuple.Create(true, myObj), TimeSpan.MaxValue);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverB, true, true);
         tupleDriverA.TestEquals_GetHashCode(tupleDriverC, false, false);
     }
@@ -347,57 +348,57 @@ public class TupleTests
     [Fact]
     public static void TestCompareTo()
     {
-        TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan> tupleDriverA, tupleDriverB, tupleDriverC;
+        TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan> tupleDriverA, tupleDriverB, tupleDriverC;
         //Tuple-1
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>(Int16.MaxValue);
-        tupleDriverB = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>(Int16.MaxValue);
-        tupleDriverC = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>(Int16.MinValue);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MaxValue);
+        tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MaxValue);
+        tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MinValue);
         tupleDriverA.TestCompareTo(tupleDriverB, 0, 5);
         tupleDriverA.TestCompareTo(tupleDriverC, 65535, 5);
         //Tuple-2
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>(Int16.MinValue, Int32.MaxValue);
-        tupleDriverB = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>(Int16.MinValue, Int32.MaxValue);
-        tupleDriverC = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>(Int16.MinValue, Int32.MinValue);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MinValue, int.MaxValue);
+        tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MinValue, int.MaxValue);
+        tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>(short.MinValue, int.MinValue);
         tupleDriverA.TestCompareTo(tupleDriverB, 0, 5);
         tupleDriverA.TestCompareTo(tupleDriverC, 1, 5);
         //Tuple-3
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)0, (Int32)0, Int64.MaxValue);
-        tupleDriverB = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)0, (Int32)0, Int64.MaxValue);
-        tupleDriverC = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)(-1), (Int32)(-1), Int64.MinValue);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)0, (int)0, long.MaxValue);
+        tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)0, (int)0, long.MaxValue);
+        tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-1), (int)(-1), long.MinValue);
         tupleDriverA.TestCompareTo(tupleDriverB, 0, 5);
         tupleDriverA.TestCompareTo(tupleDriverC, 1, 5);
         //Tuple-4
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)1, (Int32)1, Int64.MinValue, "This");
-        tupleDriverB = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)1, (Int32)1, Int64.MinValue, "This");
-        tupleDriverC = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)1, (Int32)1, Int64.MinValue, "this");
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)1, (int)1, long.MinValue, "This");
+        tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)1, (int)1, long.MinValue, "This");
+        tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)1, (int)1, long.MinValue, "this");
         tupleDriverA.TestCompareTo(tupleDriverB, 0, 5);
         tupleDriverA.TestCompareTo(tupleDriverC, 1, 5);
         //Tuple-5
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)(-1), (Int32)(-1), (Int64)0, "is", 'A');
-        tupleDriverB = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)(-1), (Int32)(-1), (Int64)0, "is", 'A');
-        tupleDriverC = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)0, (Int32)0, (Int64)1, "IS", 'a');
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-1), (int)(-1), (long)0, "is", 'A');
+        tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-1), (int)(-1), (long)0, "is", 'A');
+        tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)0, (int)0, (long)1, "IS", 'a');
         tupleDriverA.TestCompareTo(tupleDriverB, 0, 5);
         tupleDriverA.TestCompareTo(tupleDriverC, -1, 5);
         //Tuple-6
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)10, (Int32)100, (Int64)1, "testing", 'Z', Single.MaxValue);
-        tupleDriverB = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)10, (Int32)100, (Int64)1, "testing", 'Z', Single.MaxValue);
-        tupleDriverC = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)10, (Int32)100, (Int64)1, "testing", 'Z', Single.MinValue);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)10, (int)100, (long)1, "testing", 'Z', Single.MaxValue);
+        tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)10, (int)100, (long)1, "testing", 'Z', Single.MaxValue);
+        tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)10, (int)100, (long)1, "testing", 'Z', Single.MinValue);
         tupleDriverA.TestCompareTo(tupleDriverB, 0, 5);
         tupleDriverA.TestCompareTo(tupleDriverC, 1, 5);
         //Tuple-7
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)(-100), (Int32)(-1000), (Int64)(-1), "Tuples", ' ', Single.MinValue, Double.MaxValue);
-        tupleDriverB = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)(-100), (Int32)(-1000), (Int64)(-1), "Tuples", ' ', Single.MinValue, Double.MaxValue);
-        tupleDriverC = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)(-101), (Int32)(-1001), (Int64)(-2), "tuples", ' ', Single.MinValue, (Double)0.0);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-100), (int)(-1000), (long)(-1), "Tuples", ' ', Single.MinValue, Double.MaxValue);
+        tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-100), (int)(-1000), (long)(-1), "Tuples", ' ', Single.MinValue, Double.MaxValue);
+        tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)(-101), (int)(-1001), (long)(-2), "tuples", ' ', Single.MinValue, (Double)0.0);
         tupleDriverA.TestCompareTo(tupleDriverB, 0, 5);
         tupleDriverA.TestCompareTo(tupleDriverC, 1, 5);
 
-        Object myObj = new Object();
+        object myObj = new object();
         //Tuple-10
         DateTime now = DateTime.Now;
 
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)10000, (Int32)1000000, (Int64)10000000, "2008年7月2日", '0', (Single)0.0001, (Double)0.0000001, now, Tuple.Create(false, myObj), TimeSpan.Zero);
-        tupleDriverB = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)10000, (Int32)1000000, (Int64)10000000, "2008年7月2日", '0', (Single)0.0001, (Double)0.0000001, now, Tuple.Create(false, myObj), TimeSpan.Zero);
-        tupleDriverC = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Tuple<Boolean, Object>, TimeSpan>((Int16)10001, (Int32)1000001, (Int64)10000001, "2008年7月3日", '1', (Single)0.0002, (Double)0.0000002, now.AddMilliseconds(1), Tuple.Create(true, myObj), TimeSpan.MaxValue);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008年7月2日", '0', (Single)0.0001, (Double)0.0000001, now, Tuple.Create(false, myObj), TimeSpan.Zero);
+        tupleDriverB = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008年7月2日", '0', (Single)0.0001, (Double)0.0000001, now, Tuple.Create(false, myObj), TimeSpan.Zero);
+        tupleDriverC = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, Tuple<bool, object>, TimeSpan>((short)10001, (int)1000001, (long)10000001, "2008年7月3日", '1', (Single)0.0002, (Double)0.0000002, now.AddMilliseconds(1), Tuple.Create(true, myObj), TimeSpan.MaxValue);
         tupleDriverA.TestCompareTo(tupleDriverB, 0, 5);
         tupleDriverA.TestCompareTo(tupleDriverC, -1, 5);
     }
@@ -405,31 +406,31 @@ public class TupleTests
     [Fact]
     public static void TestNotEqual()
     {
-        TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Boolean, TimeSpan> tupleDriverA;
+        TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan> tupleDriverA;
         //Tuple-1
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Boolean, TimeSpan>((Int16)10000);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000);
         tupleDriverA.TestNotEqual();
         // This is for code coverage purposes
         //Tuple-2
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Boolean, TimeSpan>((Int16)10000, (Int32)1000000);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000);
         tupleDriverA.TestNotEqual();
         //Tuple-3
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Boolean, TimeSpan>((Int16)10000, (Int32)1000000, (Int64)10000000);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000);
         tupleDriverA.TestNotEqual();
         //Tuple-4
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Boolean, TimeSpan>((Int16)10000, (Int32)1000000, (Int64)10000000, "2008年7月2日");
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008年7月2日");
         tupleDriverA.TestNotEqual();
         //Tuple-5
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Boolean, TimeSpan>((Int16)10000, (Int32)1000000, (Int64)10000000, "2008年7月2日", '0');
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008年7月2日", '0');
         tupleDriverA.TestNotEqual();
         //Tuple-6
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Boolean, TimeSpan>((Int16)10000, (Int32)1000000, (Int64)10000000, "2008年7月2日", '0', Single.NaN);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008年7月2日", '0', Single.NaN);
         tupleDriverA.TestNotEqual();
         //Tuple-7
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Boolean, TimeSpan>((Int16)10000, (Int32)1000000, (Int64)10000000, "2008年7月2日", '0', Single.NaN, Double.NegativeInfinity);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008年7月2日", '0', Single.NaN, Double.NegativeInfinity);
         tupleDriverA.TestNotEqual();
         //Tuple-8, extended tuple
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Boolean, TimeSpan>((Int16)10000, (Int32)1000000, (Int64)10000000, "2008年7月2日", '0', Single.NaN, Double.NegativeInfinity, DateTime.Now);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008年7月2日", '0', Single.NaN, Double.NegativeInfinity, DateTime.Now);
         tupleDriverA.TestNotEqual();
         //Tuple-9 and Tuple-10 are not necesary because they use the same code path as Tuple-8
     }
@@ -437,31 +438,31 @@ public class TupleTests
     [Fact]
     public static void IncomparableTypes()
     {
-        TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Boolean, TimeSpan> tupleDriverA;
+        TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan> tupleDriverA;
         //Tuple-1
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Boolean, TimeSpan>((Int16)10000);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000);
         tupleDriverA.TestCompareToThrows();
         // This is for code coverage purposes
         //Tuple-2
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Boolean, TimeSpan>((Int16)10000, (Int32)1000000);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000);
         tupleDriverA.TestCompareToThrows();
         //Tuple-3
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Boolean, TimeSpan>((Int16)10000, (Int32)1000000, (Int64)10000000);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000);
         tupleDriverA.TestCompareToThrows();
         //Tuple-4
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Boolean, TimeSpan>((Int16)10000, (Int32)1000000, (Int64)10000000, "2008年7月2日");
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008年7月2日");
         tupleDriverA.TestCompareToThrows();
         //Tuple-5
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Boolean, TimeSpan>((Int16)10000, (Int32)1000000, (Int64)10000000, "2008年7月2日", '0');
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008年7月2日", '0');
         tupleDriverA.TestCompareToThrows();
         //Tuple-6
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Boolean, TimeSpan>((Int16)10000, (Int32)1000000, (Int64)10000000, "2008年7月2日", '0', Single.NaN);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008年7月2日", '0', Single.NaN);
         tupleDriverA.TestCompareToThrows();
         //Tuple-7
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Boolean, TimeSpan>((Int16)10000, (Int32)1000000, (Int64)10000000, "2008年7月2日", '0', Single.NaN, Double.NegativeInfinity);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008年7月2日", '0', Single.NaN, Double.NegativeInfinity);
         tupleDriverA.TestCompareToThrows();
         //Tuple-8, extended tuple
-        tupleDriverA = new TupleTestDriver<Int16, Int32, Int64, String, Char, Single, Double, DateTime, Boolean, TimeSpan>((Int16)10000, (Int32)1000000, (Int64)10000000, "2008年7月2日", '0', Single.NaN, Double.NegativeInfinity, DateTime.Now);
+        tupleDriverA = new TupleTestDriver<short, int, long, string, Char, Single, Double, DateTime, bool, TimeSpan>((short)10000, (int)1000000, (long)10000000, "2008年7月2日", '0', Single.NaN, Double.NegativeInfinity, DateTime.Now);
         tupleDriverA.TestCompareToThrows();
         //Tuple-9 and Tuple-10 are not necesary because they use the same code path as Tuple-8
     }

--- a/src/System.Runtime/tests/System/UInt16.cs
+++ b/src/System.Runtime/tests/System/UInt16.cs
@@ -2,96 +2,101 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Runtime.Tests.Common;
+
 using Xunit;
 
 public static class UInt16Tests
 {
     [Fact]
-    public static void TestCtor()
+    public static void TestCtorEmpty()
     {
-        UInt16 i = new UInt16();
-        Assert.True(i == 0);
+        ushort i = new ushort();
+        Assert.Equal(0, i);
+    }
 
-        i = 41;
-        Assert.True(i == 41);
+    [Fact]
+    public static void TestCtorValue()
+    {
+        ushort i = 41;
+        Assert.Equal(41, i);
     }
 
     [Fact]
     public static void TestMaxValue()
     {
-        UInt16 max = UInt16.MaxValue;
-
-        Assert.True(max == (UInt16)0xFFFF);
+        Assert.Equal(0xFFFF, ushort.MaxValue);
     }
 
     [Fact]
     public static void TestMinValue()
     {
-        UInt16 min = UInt16.MinValue;
+        Assert.Equal(0, ushort.MinValue);
+    }
 
-        Assert.True(min == 0);
+    [Theory]
+    [InlineData((ushort)234, 0)]
+    [InlineData(ushort.MinValue, 1)]
+    [InlineData((ushort)0, 1)]
+    [InlineData((ushort)45, 1)]
+    [InlineData((ushort)123, 1)]
+    [InlineData((ushort)456, -1)]
+    [InlineData(ushort.MaxValue, -1)]
+    public static void TestCompareTo(ushort value, int expected)
+    {
+        ushort i = 234;
+        int result = CompareHelper.NormalizeCompare(i.CompareTo(value));
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null, 1)]
+    [InlineData((ushort)234, 0)]
+    [InlineData(ushort.MinValue, 1)]
+    [InlineData((ushort)0, 1)]
+    [InlineData((ushort)45, 1)]
+    [InlineData((ushort)123, 1)]
+    [InlineData((ushort)456, -1)]
+    [InlineData(ushort.MaxValue, -1)]
+    public static void TestCompareToObject(object obj, int expected)
+    {
+        IComparable comparable = (ushort)234;
+        int i = CompareHelper.NormalizeCompare(comparable.CompareTo(obj));
+        Assert.Equal(expected, i);
     }
 
     [Fact]
-    public static void TestCompareToObject()
+    public static void TestCompareToObjectInvalid()
     {
-        UInt16 i = 234;
-        IComparable comparable = i;
-
-        Assert.Equal(1, comparable.CompareTo(null));
-        Assert.Equal(0, comparable.CompareTo((UInt16)234));
-
-        Assert.True(comparable.CompareTo(UInt16.MinValue) > 0);
-        Assert.True(comparable.CompareTo((UInt16)0) > 0);
-        Assert.True(comparable.CompareTo((UInt16)(23)) > 0);
-        Assert.True(comparable.CompareTo((UInt16)123) > 0);
-        Assert.True(comparable.CompareTo((UInt16)456) < 0);
-        Assert.True(comparable.CompareTo(UInt16.MaxValue) < 0);
-
-        Assert.Throws<ArgumentException>(() => comparable.CompareTo("a"));
+        IComparable comparable = (ushort)234;
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); //Obj is not a ushort
     }
 
-    [Fact]
-    public static void TestCompareTo()
+    [Theory]
+    [InlineData((ushort)789, true)]
+    [InlineData((ushort)0, false)]
+    public static void TestEqualsObject(object obj, bool expected)
     {
-        UInt16 i = 234;
-
-        Assert.Equal(0, i.CompareTo((UInt16)234));
-
-        Assert.True(i.CompareTo(UInt16.MinValue) > 0);
-        Assert.True(i.CompareTo((UInt16)0) > 0);
-        Assert.True(i.CompareTo((UInt16)123) > 0);
-        Assert.True(i.CompareTo((UInt16)456) < 0);
-        Assert.True(i.CompareTo(UInt16.MaxValue) < 0);
+        ushort i = 789;
+        Assert.Equal(expected, i.Equals(obj));
     }
 
-    [Fact]
-    public static void TestEqualsObject()
+    [Theory]
+    [InlineData((ushort)789, true)]
+    [InlineData((ushort)0, false)]
+    public static void TestEquals(ushort i2, bool expected)
     {
-        UInt16 i = 789;
-
-        object obj1 = (UInt16)789;
-        Assert.True(i.Equals(obj1));
-
-        object obj3 = (UInt16)0;
-        Assert.True(!i.Equals(obj3));
-    }
-
-    [Fact]
-    public static void TestEquals()
-    {
-        UInt16 i = 911;
-
-        Assert.True(i.Equals((UInt16)911));
-        Assert.True(!i.Equals((UInt16)0));
+        ushort i = 789;
+        Assert.Equal(expected, i.Equals(i2));
     }
 
     [Fact]
     public static void TestGetHashCode()
     {
-        UInt16 i1 = 123;
-        UInt16 i2 = 654;
+        ushort i1 = 123;
+        ushort i2 = 654;
 
         Assert.NotEqual(0, i1.GetHashCode());
         Assert.NotEqual(i1.GetHashCode(), i2.GetHashCode());
@@ -100,137 +105,169 @@ public static class UInt16Tests
     [Fact]
     public static void TestToString()
     {
-        UInt16 i1 = 6310;
+        ushort i1 = 6310;
         Assert.Equal("6310", i1.ToString());
     }
 
     [Fact]
     public static void TestToStringFormatProvider()
     {
-        var numberFormat = new System.Globalization.NumberFormatInfo();
+        var numberFormat = new NumberFormatInfo();
 
-        UInt16 i1 = 6310;
+        ushort i1 = 6310;
         Assert.Equal("6310", i1.ToString(numberFormat));
     }
 
     [Fact]
     public static void TestToStringFormat()
     {
-        UInt16 i1 = 6310;
+        ushort i1 = 6310;
         Assert.Equal("6310", i1.ToString("G"));
 
-        UInt16 i2 = 8249;
+        ushort i2 = 8249;
         Assert.Equal("8249", i2.ToString("g"));
 
-        UInt16 i3 = 2468;
+        ushort i3 = 2468;
         Assert.Equal(string.Format("{0:N}", 2468.00), i3.ToString("N"));
 
-        UInt16 i4 = 0x248;
+        ushort i4 = 0x248;
         Assert.Equal("248", i4.ToString("x"));
     }
 
     [Fact]
     public static void TestToStringFormatFormatProvider()
     {
-        var numberFormat = new System.Globalization.NumberFormatInfo();
+        var numberFormat = new NumberFormatInfo();
 
-        UInt16 i1 = 6310;
+        ushort i1 = 6310;
         Assert.Equal("6310", i1.ToString("G", numberFormat));
 
-        UInt16 i2 = 8249;
+        ushort i2 = 8249;
         Assert.Equal("8249", i2.ToString("g", numberFormat));
 
         numberFormat.NegativeSign = "xx"; // setting it to trash to make sure it doesn't show up
         numberFormat.NumberGroupSeparator = "*";
         numberFormat.NumberNegativePattern = 0;
-        UInt16 i3 = 2468;
+        ushort i3 = 2468;
         Assert.Equal("2*468.00", i3.ToString("N", numberFormat));
     }
 
-    [Fact]
-    public static void TestParse()
+    public static IEnumerable<object[]> ParseValidData()
     {
-        Assert.Equal<UInt16>(123, UInt16.Parse("123"));
-        //TODO: Negative tests once we get better exceptions
+        NumberFormatInfo defaultFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+        var emptyNfi = new NumberFormatInfo();
+
+        var testNfi = new NumberFormatInfo();
+        testNfi.CurrencySymbol = "$";
+
+        yield return new object[] { "0", defaultStyle, defaultFormat, (ushort)0 };
+        yield return new object[] { "123", defaultStyle, defaultFormat, (ushort)123 };
+        yield return new object[] { "  123  ", defaultStyle, defaultFormat, (ushort)123 };
+        yield return new object[] { "65535", defaultStyle, defaultFormat, (ushort)65535 };
+
+        yield return new object[] { "12", NumberStyles.HexNumber, defaultFormat, (ushort)0x12 };
+        yield return new object[] { "1000", NumberStyles.AllowThousands, defaultFormat, (ushort)1000 };
+
+        yield return new object[] { "123", defaultStyle, emptyNfi, (ushort)123 };
+
+        yield return new object[] { "123", NumberStyles.Any, emptyNfi, (ushort)123 };
+        yield return new object[] { "12", NumberStyles.HexNumber, emptyNfi, (ushort)0x12 };
+        yield return new object[] { "abc", NumberStyles.HexNumber, emptyNfi, (ushort)0xabc };
+        yield return new object[] { "$1,000", NumberStyles.Currency, testNfi, (ushort)1000 };
     }
 
-    [Fact]
-    public static void TestParseNumberStyle()
+    public static IEnumerable<object[]> ParseInvalidData()
     {
-        Assert.Equal<UInt16>(0x123, UInt16.Parse("123", NumberStyles.HexNumber));
+        NumberFormatInfo defaultFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+        var emptyNfi = new NumberFormatInfo();
 
-        Assert.Equal<UInt16>(1000, UInt16.Parse((1000).ToString("N0"), NumberStyles.AllowThousands));
-        //TODO: Negative tests once we get better exceptions
+        var testNfi = new NumberFormatInfo();
+        testNfi.CurrencySymbol = "$";
+        testNfi.NumberDecimalSeparator = ".";
+
+        yield return new object[] { null, defaultStyle, defaultFormat, typeof(ArgumentNullException) };
+        yield return new object[] { "", defaultStyle, defaultFormat, typeof(FormatException) };
+        yield return new object[] { " ", defaultStyle, defaultFormat, typeof(FormatException) };
+        yield return new object[] { "Garbage", defaultStyle, defaultFormat, typeof(FormatException) };
+
+        yield return new object[] { "abc", defaultStyle, defaultFormat, typeof(FormatException) }; // Hex value
+        yield return new object[] { "1E23", defaultStyle, defaultFormat, typeof(FormatException) }; // Exponent
+        yield return new object[] { "(123)", defaultStyle, defaultFormat, typeof(FormatException) }; // Parentheses
+        yield return new object[] { 100.ToString("C0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Currency
+        yield return new object[] { 1000.ToString("N0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Thousands
+        yield return new object[] { 678.90.ToString("F2"), defaultStyle, defaultFormat, typeof(FormatException) }; //Decimal
+
+        yield return new object[] { "abc", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Negative hex value
+        yield return new object[] { "  123  ", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Trailing and leading whitespace
+
+        yield return new object[] { "678.90", defaultStyle, testNfi, typeof(FormatException) }; // Decimal
+
+        yield return new object[] { "-1", defaultStyle, defaultFormat, typeof(OverflowException) }; // < min value
+        yield return new object[] { "65536", defaultStyle, defaultFormat, typeof(OverflowException) }; // > max value
+        yield return new object[] { "(123)", NumberStyles.AllowParentheses, defaultFormat, typeof(OverflowException) }; // Parentheses = negative
     }
 
-    [Fact]
-    public static void TestParseFormatProvider()
+    [Theory, MemberData("ParseValidData")]
+    public static void TestParse(string value, NumberStyles style, NumberFormatInfo nfi, ushort expected)
     {
-        var nfi = new NumberFormatInfo();
-        Assert.Equal<UInt16>(123, UInt16.Parse("123", nfi));
-        //TODO: Negative tests once we get better exceptions
+        ushort i;
+        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        if (style == NumberStyles.Integer)
+        {
+            Assert.Equal(true, ushort.TryParse(value, out i));
+            Assert.Equal(expected, i);
+
+            Assert.Equal(expected, ushort.Parse(value));
+
+            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (nfi != null)
+            {
+                Assert.Equal(expected, ushort.Parse(value, nfi));
+            }
+        }
+
+        // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
+        Assert.Equal(true, ushort.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
+        Assert.Equal(expected, i);
+
+        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (nfi == null)
+        {
+            Assert.Equal(expected, ushort.Parse(value, style));
+        }
+        Assert.Equal(expected, ushort.Parse(value, style, nfi ?? new NumberFormatInfo()));
     }
 
-    [Fact]
-    public static void TestParseNumberStyleFormatProvider()
+    [Theory, MemberData("ParseInvalidData")]
+    public static void TestParseInvalid(string value, NumberStyles style, NumberFormatInfo nfi, Type exceptionType)
     {
-        var nfi = new NumberFormatInfo();
-        Assert.Equal<UInt16>(0x123, UInt16.Parse("123", NumberStyles.HexNumber, nfi));
+        ushort i;
+        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        if (style == NumberStyles.Integer)
+        {
+            Assert.Equal(false, ushort.TryParse(value, out i));
+            Assert.Equal(default(ushort), i);
 
-        nfi.CurrencySymbol = "$";
-        nfi.CurrencyGroupSeparator = ",";
-        Assert.Equal<UInt16>(1000, UInt16.Parse("$1,000", NumberStyles.Currency, nfi));
-        //TODO: Negative tests once we get better exception support
-    }
+            Assert.Throws(exceptionType, () => ushort.Parse(value));
 
-    [Fact]
-    public static void TestTryParse()
-    {
-        // Defaults NumberStyles.Integer = NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite | NumberStyles.AllowLeadingSign
+            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (nfi != null)
+            {
+                Assert.Throws(exceptionType, () => ushort.Parse(value, nfi));
+            }
+        }
 
-        UInt16 i;
-        Assert.True(UInt16.TryParse("123", out i));     // Simple
-        Assert.Equal<UInt16>(123, i);
+        // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
+        Assert.Equal(false, ushort.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
+        Assert.Equal(default(ushort), i);
 
-        Assert.False(UInt16.TryParse("-385", out i));    // LeadingSign negative
-
-        Assert.True(UInt16.TryParse(" 678 ", out i));   // Leading/Trailing whitespace
-        Assert.Equal<UInt16>(678, i);
-
-        var nfi = new NumberFormatInfo() { CurrencyGroupSeparator = "" };
-        Assert.False(UInt16.TryParse((1000).ToString("C0", nfi), out i));  // Currency
-        Assert.False(UInt16.TryParse((1000).ToString("N0"), out i));  // Thousands
-        Assert.False(UInt16.TryParse("abc", out i));    // Hex digits
-        Assert.False(UInt16.TryParse((678.90).ToString("F2"), out i)); // Decimal
-        Assert.False(UInt16.TryParse("(135)", out i));  // Parentheses
-        Assert.False(UInt16.TryParse("1E23", out i));   // Exponent
-    }
-
-    [Fact]
-    public static void TestTryParseNumberStyleFormatProvider()
-    {
-        UInt16 i;
-        var nfi = new NumberFormatInfo();
-        Assert.True(UInt16.TryParse("123", NumberStyles.Any, nfi, out i));   // Simple positive
-        Assert.Equal<UInt16>(123, i);
-
-        Assert.True(UInt16.TryParse("123", NumberStyles.HexNumber, nfi, out i));   // Simple Hex
-        Assert.Equal<UInt16>(0x123, i);
-
-        nfi.CurrencySymbol = "$";
-        nfi.CurrencyGroupSeparator = ",";
-        Assert.True(UInt16.TryParse("$1,000", NumberStyles.Currency, nfi, out i)); // Currency/Thousands postive
-        Assert.Equal<UInt16>(1000, i);
-
-        Assert.False(UInt16.TryParse("abc", NumberStyles.None, nfi, out i));       // Hex Number negative
-        Assert.True(UInt16.TryParse("abc", NumberStyles.HexNumber, nfi, out i));   // Hex Number positive
-        Assert.Equal<UInt16>(0xabc, i);
-
-        nfi.NumberDecimalSeparator = ".";
-        Assert.False(UInt16.TryParse("678.90", NumberStyles.Integer, nfi, out i));  // Decimal
-        Assert.False(UInt16.TryParse(" 678 ", NumberStyles.None, nfi, out i));      // Trailing/Leading whitespace negative
-
-        Assert.False(UInt16.TryParse("(135)", NumberStyles.AllowParentheses, nfi, out i)); // Parenthese negative
+        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (nfi == null)
+        {
+            Assert.Throws(exceptionType, () => ushort.Parse(value, style));
+        }
+        Assert.Throws(exceptionType, () => ushort.Parse(value, style, nfi ?? new NumberFormatInfo()));
     }
 }
-

--- a/src/System.Runtime/tests/System/UInt32.cs
+++ b/src/System.Runtime/tests/System/UInt32.cs
@@ -2,96 +2,101 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Runtime.Tests.Common;
+
 using Xunit;
 
 public static class UInt32Tests
 {
     [Fact]
-    public static void TestCtor()
+    public static void TestCtorEmpty()
     {
-        UInt32 i = new UInt32();
-        Assert.True(i == 0);
+        uint i = new uint();
+        Assert.Equal((uint)0, i);
+    }
 
-        i = 41;
-        Assert.True(i == 41);
+    [Fact]
+    public static void TestCtorValue()
+    {
+        uint i = 41;
+        Assert.Equal((uint)41, i);
     }
 
     [Fact]
     public static void TestMaxValue()
     {
-        UInt32 max = UInt32.MaxValue;
-
-        Assert.True(max == (UInt32)0xFFFFFFFF);
+        Assert.Equal(0xFFFFFFFF, uint.MaxValue);
     }
 
     [Fact]
     public static void TestMinValue()
     {
-        UInt32 min = UInt32.MinValue;
+        Assert.Equal((uint)0, uint.MinValue);
+    }
 
-        Assert.True(min == 0);
+    [Theory]
+    [InlineData((uint)234, 0)]
+    [InlineData(uint.MinValue, 1)]
+    [InlineData((uint)0, 1)]
+    [InlineData((uint)45, 1)]
+    [InlineData((uint)123, 1)]
+    [InlineData((uint)456, -1)]
+    [InlineData(uint.MaxValue, -1)]
+    public static void TestCompareTo(uint value, int expected)
+    {
+        uint i = 234;
+        int result = CompareHelper.NormalizeCompare(i.CompareTo(value));
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null, 1)]
+    [InlineData((uint)234, 0)]
+    [InlineData(uint.MinValue, 1)]
+    [InlineData((uint)0, 1)]
+    [InlineData((uint)45, 1)]
+    [InlineData((uint)123, 1)]
+    [InlineData((uint)456, -1)]
+    [InlineData(uint.MaxValue, -1)]
+    public static void TestCompareToObject(object obj, int expected)
+    {
+        IComparable comparable = (uint)234;
+        int i = CompareHelper.NormalizeCompare(comparable.CompareTo(obj));
+        Assert.Equal(expected, i);
     }
 
     [Fact]
-    public static void TestCompareToObject()
+    public static void TestCompareToObjectInvalid()
     {
-        UInt32 i = 234;
-        IComparable comparable = i;
-
-        Assert.Equal(1, comparable.CompareTo(null));
-        Assert.Equal(0, comparable.CompareTo((UInt32)234));
-
-        Assert.True(comparable.CompareTo(UInt32.MinValue) > 0);
-        Assert.True(comparable.CompareTo((UInt32)0) > 0);
-        Assert.True(comparable.CompareTo((UInt32)(23)) > 0);
-        Assert.True(comparable.CompareTo((UInt32)123) > 0);
-        Assert.True(comparable.CompareTo((UInt32)456) < 0);
-        Assert.True(comparable.CompareTo(UInt32.MaxValue) < 0);
-
-        Assert.Throws<ArgumentException>(() => comparable.CompareTo("a"));
+        IComparable comparable = (uint)234;
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); //Obj is not a byte
     }
 
-    [Fact]
-    public static void TestCompareTo()
+    [Theory]
+    [InlineData((uint)789, true)]
+    [InlineData((uint)0, false)]
+    public static void TestEqualsObject(object obj, bool expected)
     {
-        UInt32 i = 234;
-
-        Assert.Equal(0, i.CompareTo((UInt32)234));
-
-        Assert.True(i.CompareTo(UInt32.MinValue) > 0);
-        Assert.True(i.CompareTo((UInt32)0) > 0);
-        Assert.True(i.CompareTo((UInt32)123) > 0);
-        Assert.True(i.CompareTo((UInt32)456) < 0);
-        Assert.True(i.CompareTo(UInt32.MaxValue) < 0);
+        uint i = 789;
+        Assert.Equal(expected, i.Equals(obj));
     }
 
-    [Fact]
-    public static void TestEqualsObject()
+    [Theory]
+    [InlineData((uint)789, true)]
+    [InlineData((uint)0, false)]
+    public static void TestEquals(uint i2, bool expected)
     {
-        UInt32 i = 789;
-
-        object obj1 = (UInt32)789;
-        Assert.True(i.Equals(obj1));
-
-        object obj3 = (UInt32)0;
-        Assert.True(!i.Equals(obj3));
-    }
-
-    [Fact]
-    public static void TestEquals()
-    {
-        UInt32 i = 911;
-
-        Assert.True(i.Equals((UInt32)911));
-        Assert.True(!i.Equals((UInt32)0));
+        uint i = 789;
+        Assert.Equal(expected, i.Equals(i2));
     }
 
     [Fact]
     public static void TestGetHashCode()
     {
-        UInt32 i1 = 123;
-        UInt32 i2 = 654;
+        uint i1 = 123;
+        uint i2 = 654;
 
         Assert.NotEqual(0, i1.GetHashCode());
         Assert.NotEqual(i1.GetHashCode(), i2.GetHashCode());
@@ -100,135 +105,169 @@ public static class UInt32Tests
     [Fact]
     public static void TestToString()
     {
-        UInt32 i1 = 6310;
+        uint i1 = 6310;
         Assert.Equal("6310", i1.ToString());
     }
 
     [Fact]
     public static void TestToStringFormatProvider()
     {
-        var numberFormat = new System.Globalization.NumberFormatInfo();
+        var numberFormat = new NumberFormatInfo();
 
-        UInt32 i1 = 6310;
+        uint i1 = 6310;
         Assert.Equal("6310", i1.ToString(numberFormat));
     }
 
     [Fact]
     public static void TestToStringFormat()
     {
-        UInt32 i1 = 6310;
+        uint i1 = 6310;
         Assert.Equal("6310", i1.ToString("G"));
 
-        UInt32 i2 = 8249;
+        uint i2 = 8249;
         Assert.Equal("8249", i2.ToString("g"));
 
-        UInt32 i3 = 2468;
+        uint i3 = 2468;
         Assert.Equal(string.Format("{0:N}", 2468.00), i3.ToString("N"));
 
-        UInt32 i4 = 0x248;
+        uint i4 = 0x248;
         Assert.Equal("248", i4.ToString("x"));
     }
 
     [Fact]
     public static void TestToStringFormatFormatProvider()
     {
-        var numberFormat = new System.Globalization.NumberFormatInfo();
+        var numberFormat = new NumberFormatInfo();
 
-        UInt32 i1 = 6310;
+        uint i1 = 6310;
         Assert.Equal("6310", i1.ToString("G", numberFormat));
 
-        UInt32 i2 = 8249;
+        uint i2 = 8249;
         Assert.Equal("8249", i2.ToString("g", numberFormat));
 
         numberFormat.NegativeSign = "xx"; // setting it to trash to make sure it doesn't show up
         numberFormat.NumberGroupSeparator = "*";
         numberFormat.NumberNegativePattern = 0;
-        UInt32 i3 = 2468;
+        uint i3 = 2468;
         Assert.Equal("2*468.00", i3.ToString("N", numberFormat));
     }
 
-    [Fact]
-    public static void TestParse()
+    public static IEnumerable<object[]> ParseValidData()
     {
-        Assert.Equal<UInt32>(123, UInt32.Parse("123"));
-        //TODO: Negative tests once we get better exceptions
+        NumberFormatInfo defaultFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+        var emptyNfi = new NumberFormatInfo();
+
+        var testNfi = new NumberFormatInfo();
+        testNfi.CurrencySymbol = "$";
+
+        yield return new object[] { "0", defaultStyle, defaultFormat, (uint)0 };
+        yield return new object[] { "123", defaultStyle, defaultFormat, (uint)123 };
+        yield return new object[] { "  123  ", defaultStyle, defaultFormat, (uint)123 };
+        yield return new object[] { "4294967295", defaultStyle, defaultFormat, (uint)4294967295 };
+        
+        yield return new object[] { "12", NumberStyles.HexNumber, defaultFormat, (uint)0x12 };
+        yield return new object[] { "1000", NumberStyles.AllowThousands, defaultFormat, (uint)1000 };
+
+        yield return new object[] { "123", defaultStyle, emptyNfi, (uint)123 };
+
+        yield return new object[] { "123", NumberStyles.Any, emptyNfi, (uint)123 };
+        yield return new object[] { "12", NumberStyles.HexNumber, emptyNfi, (uint)0x12 };
+        yield return new object[] { "abc", NumberStyles.HexNumber, emptyNfi, (uint)0xabc };
+        yield return new object[] { "$1,000", NumberStyles.Currency, testNfi, (uint)1000 };
     }
 
-    [Fact]
-    public static void TestParseNumberStyle()
+    public static IEnumerable<object[]> ParseInvalidData()
     {
-        Assert.Equal<UInt32>(0x123, UInt32.Parse("123", NumberStyles.HexNumber));
-        Assert.Equal<UInt32>(1000, UInt32.Parse((1000).ToString("N0"), NumberStyles.AllowThousands));
-        //TODO: Negative tests once we get better exceptions
+        NumberFormatInfo defaultFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+        var emptyNfi = new NumberFormatInfo();
+
+        var testNfi = new NumberFormatInfo();
+        testNfi.CurrencySymbol = "$";
+        testNfi.NumberDecimalSeparator = ".";
+
+        yield return new object[] { null, defaultStyle, defaultFormat, typeof(ArgumentNullException) };
+        yield return new object[] { "", defaultStyle, defaultFormat, typeof(FormatException) };
+        yield return new object[] { " ", defaultStyle, defaultFormat, typeof(FormatException) };
+        yield return new object[] { "Garbage", defaultStyle, defaultFormat, typeof(FormatException) };
+
+        yield return new object[] { "abc", defaultStyle, defaultFormat, typeof(FormatException) }; // Hex value
+        yield return new object[] { "1E23", defaultStyle, defaultFormat, typeof(FormatException) }; // Exponent
+        yield return new object[] { "(123)", defaultStyle, defaultFormat, typeof(FormatException) }; // Parentheses
+        yield return new object[] { 100.ToString("C0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Currency
+        yield return new object[] { 1000.ToString("N0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Thousands
+        yield return new object[] { 678.90.ToString("F2"), defaultStyle, defaultFormat, typeof(FormatException) }; //Decimal
+
+        yield return new object[] { "abc", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Negative hex value
+        yield return new object[] { "  123  ", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Trailing and leading whitespace
+
+        yield return new object[] { "678.90", defaultStyle, testNfi, typeof(FormatException) }; // Decimal
+        
+        yield return new object[] { "-1", defaultStyle, defaultFormat, typeof(OverflowException) }; // < min value
+        yield return new object[] { "4294967296", defaultStyle, defaultFormat, typeof(OverflowException) }; // > max value
+        yield return new object[] { "(123)", NumberStyles.AllowParentheses, defaultFormat, typeof(OverflowException) }; // Parentheses = negative
     }
 
-    [Fact]
-    public static void TestParseFormatProvider()
+    [Theory, MemberData("ParseValidData")]
+    public static void TestParse(string value, NumberStyles style, NumberFormatInfo nfi, uint expected)
     {
-        var nfi = new NumberFormatInfo();
-        Assert.Equal<UInt32>(123, UInt32.Parse("123", nfi));
-        //TODO: Negative tests once we get better exceptions
+        uint i;
+        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        if (style == NumberStyles.Integer)
+        {
+            Assert.Equal(true, uint.TryParse(value, out i));
+            Assert.Equal(expected, i);
+
+            Assert.Equal(expected, uint.Parse(value));
+
+            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (nfi != null)
+            {
+                Assert.Equal(expected, uint.Parse(value, nfi));
+            }
+        }
+
+        // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
+        Assert.Equal(true, uint.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
+        Assert.Equal(expected, i);
+
+        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (nfi == null)
+        {
+            Assert.Equal(expected, uint.Parse(value, style));
+        }
+        Assert.Equal(expected, uint.Parse(value, style, nfi ?? new NumberFormatInfo()));
     }
 
-    [Fact]
-    public static void TestParseNumberStyleFormatProvider()
+    [Theory, MemberData("ParseInvalidData")]
+    public static void TestParseInvalid(string value, NumberStyles style, NumberFormatInfo nfi, Type exceptionType)
     {
-        var nfi = new NumberFormatInfo();
-        Assert.Equal<UInt32>(0x123, UInt32.Parse("123", NumberStyles.HexNumber, nfi));
+        uint i;
+        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        if (style == NumberStyles.Integer)
+        {
+            Assert.Equal(false, uint.TryParse(value, out i));
+            Assert.Equal(default(uint), i);
 
-        nfi.CurrencySymbol = "$";
-        Assert.Equal<UInt32>(1000, UInt32.Parse("$1,000", NumberStyles.Currency, nfi));
-        //TODO: Negative tests once we get better exception support
-    }
+            Assert.Throws(exceptionType, () => uint.Parse(value));
 
-    [Fact]
-    public static void TestTryParse()
-    {
-        // Defaults NumberStyles.Integer = NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite | NumberStyles.AllowLeadingSign
+            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (nfi != null)
+            {
+                Assert.Throws(exceptionType, () => uint.Parse(value, nfi));
+            }
+        }
 
-        UInt32 i;
-        Assert.True(UInt32.TryParse("123", out i));     // Simple
-        Assert.Equal<UInt32>(123, i);
+        // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
+        Assert.Equal(false, uint.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
+        Assert.Equal(default(uint), i);
 
-        Assert.False(UInt32.TryParse("-385", out i));    // LeadingSign negative
-
-        Assert.True(UInt32.TryParse(" 678 ", out i));   // Leading/Trailing whitespace
-        Assert.Equal<UInt32>(678, i);
-
-        var nfi = new NumberFormatInfo() { CurrencyGroupSeparator = "" };
-        Assert.False(UInt32.TryParse((1000).ToString("C0", nfi), out i));  // Currency
-        Assert.False(UInt32.TryParse((1000).ToString("N0"), out i));  // Thousands
-        Assert.False(UInt32.TryParse("abc", out i));    // Hex digits
-        Assert.False(UInt32.TryParse((678.90).ToString("F2"), out i)); // Decimal
-        Assert.False(UInt32.TryParse("(135)", out i));  // Parentheses
-        Assert.False(UInt32.TryParse("1E23", out i));   // Exponent
-    }
-
-    [Fact]
-    public static void TestTryParseNumberStyleFormatProvider()
-    {
-        UInt32 i;
-        var nfi = new NumberFormatInfo();
-        Assert.True(UInt32.TryParse("123", NumberStyles.Any, nfi, out i));   // Simple positive
-        Assert.Equal<UInt32>(123, i);
-
-        Assert.True(UInt32.TryParse("123", NumberStyles.HexNumber, nfi, out i));   // Simple Hex
-        Assert.Equal<UInt32>(0x123, i);
-
-        nfi.CurrencySymbol = "$";
-        nfi.CurrencyGroupSeparator = ",";
-        Assert.True(UInt32.TryParse("$1,000", NumberStyles.Currency, nfi, out i)); // Currency/Thousands postive
-        Assert.Equal<UInt32>(1000, i);
-
-        Assert.False(UInt32.TryParse("abc", NumberStyles.None, nfi, out i));       // Hex Number negative
-        Assert.True(UInt32.TryParse("abc", NumberStyles.HexNumber, nfi, out i));   // Hex Number positive
-        Assert.Equal<UInt32>(0xabc, i);
-
-        nfi.NumberDecimalSeparator = ".";
-        Assert.False(UInt32.TryParse("678.90", NumberStyles.Integer, nfi, out i));  // Decimal
-        Assert.False(UInt32.TryParse(" 678 ", NumberStyles.None, nfi, out i));      // Trailing/Leading whitespace negative
-
-        Assert.False(UInt32.TryParse("(135)", NumberStyles.AllowParentheses, nfi, out i)); // Parenthese negative
+        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (nfi == null)
+        {
+            Assert.Throws(exceptionType, () => uint.Parse(value, style));
+        }
+        Assert.Throws(exceptionType, () => uint.Parse(value, style, nfi ?? new NumberFormatInfo()));
     }
 }
-

--- a/src/System.Runtime/tests/System/UInt64.cs
+++ b/src/System.Runtime/tests/System/UInt64.cs
@@ -2,96 +2,101 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Runtime.Tests.Common;
+
 using Xunit;
 
 public static class UInt64Tests
 {
     [Fact]
-    public static void TestCtor()
+    public static void TestCtorEmpty()
     {
-        UInt64 i = new UInt64();
-        Assert.True(i == 0);
+        ulong i = new ulong();
+        Assert.Equal((ulong)0, i);
+    }
 
-        i = 41;
-        Assert.True(i == 41);
+    [Fact]
+    public static void TestCtorValue()
+    {
+        ulong i = 41;
+        Assert.Equal((ulong)41, i);
     }
 
     [Fact]
     public static void TestMaxValue()
     {
-        UInt64 max = UInt64.MaxValue;
-
-        Assert.True(max == (UInt64)0xFFFFFFFFFFFFFFFF);
+        Assert.Equal(0xFFFFFFFFFFFFFFFF, ulong.MaxValue);
     }
 
     [Fact]
     public static void TestMinValue()
     {
-        UInt64 min = UInt64.MinValue;
+        Assert.Equal((ulong)0, ulong.MinValue);
+    }
 
-        Assert.True(min == 0);
+    [Theory]
+    [InlineData((ulong)234, 0)]
+    [InlineData(ulong.MinValue, 1)]
+    [InlineData((ulong)0, 1)]
+    [InlineData((ulong)45, 1)]
+    [InlineData((ulong)123, 1)]
+    [InlineData((ulong)456, -1)]
+    [InlineData(ulong.MaxValue, -1)]
+    public static void TestCompareTo(ulong value, int expected)
+    {
+        ulong i = 234;
+        int result = CompareHelper.NormalizeCompare(i.CompareTo(value));
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null, 1)]
+    [InlineData((ulong)234, 0)]
+    [InlineData(ulong.MinValue, 1)]
+    [InlineData((ulong)0, 1)]
+    [InlineData((ulong)45, 1)]
+    [InlineData((ulong)123, 1)]
+    [InlineData((ulong)456, -1)]
+    [InlineData(ulong.MaxValue, -1)]
+    public static void TestCompareToObject(object obj, int expected)
+    {
+        IComparable comparable = (ulong)234;
+        int i = CompareHelper.NormalizeCompare(comparable.CompareTo(obj));
+        Assert.Equal(expected, i);
     }
 
     [Fact]
-    public static void TestCompareToObject()
+    public static void TestCompareToObjectInvalid()
     {
-        UInt64 i = 234;
-        IComparable comparable = i;
-
-        Assert.Equal(1, comparable.CompareTo(null));
-        Assert.Equal(0, comparable.CompareTo((UInt64)234));
-
-        Assert.True(comparable.CompareTo(UInt64.MinValue) > 0);
-        Assert.True(comparable.CompareTo((UInt64)0) > 0);
-        Assert.True(comparable.CompareTo((UInt64)(23)) > 0);
-        Assert.True(comparable.CompareTo((UInt64)123) > 0);
-        Assert.True(comparable.CompareTo((UInt64)456) < 0);
-        Assert.True(comparable.CompareTo(UInt64.MaxValue) < 0);
-
-        Assert.Throws<ArgumentException>(() => comparable.CompareTo("a"));
+        IComparable comparable = (ulong)234;
+        Assert.Throws<ArgumentException>(null, () => comparable.CompareTo("a")); //Obj is not a byte
     }
 
-    [Fact]
-    public static void TestCompareTo()
+    [Theory]
+    [InlineData((ulong)789, true)]
+    [InlineData((ulong)0, false)]
+    public static void TestEqualsObject(object obj, bool expected)
     {
-        UInt64 i = 234;
-
-        Assert.Equal(0, i.CompareTo((UInt64)234));
-
-        Assert.True(i.CompareTo(UInt64.MinValue) > 0);
-        Assert.True(i.CompareTo((UInt64)0) > 0);
-        Assert.True(i.CompareTo((UInt64)123) > 0);
-        Assert.True(i.CompareTo((UInt64)456) < 0);
-        Assert.True(i.CompareTo(UInt64.MaxValue) < 0);
+        ulong i = 789;
+        Assert.Equal(expected, i.Equals(obj));
     }
 
-    [Fact]
-    public static void TestEqualsObject()
+    [Theory]
+    [InlineData((ulong)789, true)]
+    [InlineData((ulong)0, false)]
+    public static void TestEquals(ulong i2, bool expected)
     {
-        UInt64 i = 789;
-
-        object obj1 = (UInt64)789;
-        Assert.True(i.Equals(obj1));
-
-        object obj3 = (UInt64)0;
-        Assert.True(!i.Equals(obj3));
-    }
-
-    [Fact]
-    public static void TestEquals()
-    {
-        UInt64 i = 911;
-
-        Assert.True(i.Equals((UInt64)911));
-        Assert.True(!i.Equals((UInt64)0));
+        ulong i = 789;
+        Assert.Equal(expected, i.Equals(i2));
     }
 
     [Fact]
     public static void TestGetHashCode()
     {
-        UInt64 i1 = 123;
-        UInt64 i2 = 654;
+        ulong i1 = 123;
+        ulong i2 = 654;
 
         Assert.NotEqual(0, i1.GetHashCode());
         Assert.NotEqual(i1.GetHashCode(), i2.GetHashCode());
@@ -100,135 +105,170 @@ public static class UInt64Tests
     [Fact]
     public static void TestToString()
     {
-        UInt64 i1 = 6310;
+        ulong i1 = 6310;
         Assert.Equal("6310", i1.ToString());
     }
 
     [Fact]
     public static void TestToStringFormatProvider()
     {
-        var numberFormat = new System.Globalization.NumberFormatInfo();
+        var numberFormat = new NumberFormatInfo();
 
-        UInt64 i1 = 6310;
+        ulong i1 = 6310;
         Assert.Equal("6310", i1.ToString(numberFormat));
     }
 
     [Fact]
     public static void TestToStringFormat()
     {
-        UInt64 i1 = 6310;
+        ulong i1 = 6310;
         Assert.Equal("6310", i1.ToString("G"));
 
-        UInt64 i2 = 8249;
+        ulong i2 = 8249;
         Assert.Equal("8249", i2.ToString("g"));
 
-        UInt64 i3 = 2468;
+        ulong i3 = 2468;
         Assert.Equal(string.Format("{0:N}", 2468.00), i3.ToString("N"));
 
-        UInt64 i4 = 0x248;
+        ulong i4 = 0x248;
         Assert.Equal("248", i4.ToString("x"));
     }
 
     [Fact]
     public static void TestToStringFormatFormatProvider()
     {
-        var numberFormat = new System.Globalization.NumberFormatInfo();
+        var numberFormat = new NumberFormatInfo();
 
-        UInt64 i1 = 6310;
+        ulong i1 = 6310;
         Assert.Equal("6310", i1.ToString("G", numberFormat));
 
-        UInt64 i2 = 8249;
+        ulong i2 = 8249;
         Assert.Equal("8249", i2.ToString("g", numberFormat));
 
         numberFormat.NegativeSign = "xx"; // setting it to trash to make sure it doesn't show up
         numberFormat.NumberGroupSeparator = "*";
         numberFormat.NumberNegativePattern = 0;
-        UInt64 i3 = 2468;
+        ulong i3 = 2468;
         Assert.Equal("2*468.00", i3.ToString("N", numberFormat));
     }
 
-    [Fact]
-    public static void TestParse()
+
+    public static IEnumerable<object[]> ParseValidData()
     {
-        Assert.Equal<UInt64>(123, UInt64.Parse("123"));
-        //TODO: Negative tests once we get better exceptions
+        NumberFormatInfo defaultFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+        var emptyNfi = new NumberFormatInfo();
+
+        var testNfi = new NumberFormatInfo();
+        testNfi.CurrencySymbol = "$";
+        
+        yield return new object[] { "0", defaultStyle, defaultFormat, (ulong)0 };
+        yield return new object[] { "123", defaultStyle, defaultFormat, (ulong)123 };
+        yield return new object[] { "  123  ", defaultStyle, defaultFormat, (ulong)123 };
+        yield return new object[] { "18446744073709551615", defaultStyle, defaultFormat, (ulong)18446744073709551615 };
+
+        yield return new object[] { "12", NumberStyles.HexNumber, defaultFormat, (ulong)0x12 };
+        yield return new object[] { "1000", NumberStyles.AllowThousands, defaultFormat, (ulong)1000 };
+
+        yield return new object[] { "123", defaultStyle, emptyNfi, (ulong)123 };
+
+        yield return new object[] { "123", NumberStyles.Any, emptyNfi, (ulong)123 };
+        yield return new object[] { "12", NumberStyles.HexNumber, emptyNfi, (ulong)0x12 };
+        yield return new object[] { "abc", NumberStyles.HexNumber, emptyNfi, (ulong)0xabc };
+        yield return new object[] { "$1,000", NumberStyles.Currency, testNfi, (ulong)1000 };
     }
 
-    [Fact]
-    public static void TestParseNumberStyle()
+    public static IEnumerable<object[]> ParseInvalidData()
     {
-        Assert.Equal<UInt64>(0x123, UInt64.Parse("123", NumberStyles.HexNumber));
-        Assert.Equal<UInt64>(1000, UInt64.Parse((1000).ToString("N0"), NumberStyles.AllowThousands));
-        //TODO: Negative tests once we get better exceptions
+        NumberFormatInfo defaultFormat = null;
+        NumberStyles defaultStyle = NumberStyles.Integer;
+        var emptyNfi = new NumberFormatInfo();
+
+        var testNfi = new NumberFormatInfo();
+        testNfi.CurrencySymbol = "$";
+        testNfi.NumberDecimalSeparator = ".";
+
+        yield return new object[] { null, defaultStyle, defaultFormat, typeof(ArgumentNullException) };
+        yield return new object[] { "", defaultStyle, defaultFormat, typeof(FormatException) };
+        yield return new object[] { " ", defaultStyle, defaultFormat, typeof(FormatException) };
+        yield return new object[] { "Garbage", defaultStyle, defaultFormat, typeof(FormatException) };
+
+        yield return new object[] { "abc", defaultStyle, defaultFormat, typeof(FormatException) }; // Hex value
+        yield return new object[] { "1E23", defaultStyle, defaultFormat, typeof(FormatException) }; // Exponent
+        yield return new object[] { "(123)", defaultStyle, defaultFormat, typeof(FormatException) }; // Parentheses
+        yield return new object[] { 100.ToString("C0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Currency
+        yield return new object[] { 1000.ToString("N0"), defaultStyle, defaultFormat, typeof(FormatException) }; //Thousands
+        yield return new object[] { 678.90.ToString("F2"), defaultStyle, defaultFormat, typeof(FormatException) }; //Decimal
+
+        yield return new object[] { "abc", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Negative hex value
+        yield return new object[] { "  123  ", NumberStyles.None, defaultFormat, typeof(FormatException) }; // Trailing and leading whitespace
+
+        yield return new object[] { "678.90", defaultStyle, testNfi, typeof(FormatException) }; // Decimal
+
+        yield return new object[] { "-1", defaultStyle, defaultFormat, typeof(OverflowException) }; // < min value
+        yield return new object[] { "18446744073709551616", defaultStyle, defaultFormat, typeof(OverflowException) }; // > max value
+        yield return new object[] { "(123)", NumberStyles.AllowParentheses, defaultFormat, typeof(OverflowException) }; // Parentheses = negative
     }
 
-    [Fact]
-    public static void TestParseFormatProvider()
+    [Theory, MemberData("ParseValidData")]
+    public static void TestParse(string value, NumberStyles style, NumberFormatInfo nfi, ulong expected)
     {
-        var nfi = new NumberFormatInfo();
-        Assert.Equal<UInt64>(123, UInt64.Parse("123", nfi));
-        //TODO: Negative tests once we get better exceptions
+        ulong i;
+        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        if (style == NumberStyles.Integer)
+        {
+            Assert.Equal(true, ulong.TryParse(value, out i));
+            Assert.Equal(expected, i);
+
+            Assert.Equal(expected, ulong.Parse(value));
+
+            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (nfi != null)
+            {
+                Assert.Equal(expected, ulong.Parse(value, nfi));
+            }
+        }
+
+        // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
+        Assert.Equal(true, ulong.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
+        Assert.Equal(expected, i);
+
+        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (nfi == null)
+        {
+            Assert.Equal(expected, ulong.Parse(value, style));
+        }
+        Assert.Equal(expected, ulong.Parse(value, style, nfi ?? new NumberFormatInfo()));
     }
 
-    [Fact]
-    public static void TestParseNumberStyleFormatProvider()
+    [Theory, MemberData("ParseInvalidData")]
+    public static void TestParseInvalid(string value, NumberStyles style, NumberFormatInfo nfi, Type exceptionType)
     {
-        var nfi = new NumberFormatInfo();
-        Assert.Equal<UInt64>(0x123, UInt64.Parse("123", NumberStyles.HexNumber, nfi));
+        ulong i;
+        //If no style is specified, use the (String) or (String, IFormatProvider) overload
+        if (style == NumberStyles.Integer)
+        {
+            Assert.Equal(false, ulong.TryParse(value, out i));
+            Assert.Equal(default(ulong), i);
 
-        nfi.CurrencySymbol = "$";
-        Assert.Equal<UInt64>(1000, UInt64.Parse("$1,000", NumberStyles.Currency, nfi));
-        //TODO: Negative tests once we get better exception support
-    }
+            Assert.Throws(exceptionType, () => ulong.Parse(value));
 
-    [Fact]
-    public static void TestTryParse()
-    {
-        // Defaults NumberStyles.Integer = NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite | NumberStyles.AllowLeadingSign
+            //If a format provider is specified, but the style is the default, use the (String, IFormatProvider) overload
+            if (nfi != null)
+            {
+                Assert.Throws(exceptionType, () => ulong.Parse(value, nfi));
+            }
+        }
 
-        UInt64 i;
-        Assert.True(UInt64.TryParse("123", out i));     // Simple
-        Assert.Equal<UInt64>(123, i);
+        // If a format provider isn't specified, test the default one, using a new instance of NumberFormatInfo
+        Assert.Equal(false, ulong.TryParse(value, style, nfi ?? new NumberFormatInfo(), out i));
+        Assert.Equal(default(ulong), i);
 
-        Assert.False(UInt64.TryParse("-385", out i));    // LeadingSign negative
-
-        Assert.True(UInt64.TryParse(" 678 ", out i));   // Leading/Trailing whitespace
-        Assert.Equal<UInt64>(678, i);
-
-        var nfi = new NumberFormatInfo() { CurrencyGroupSeparator = "" };
-        Assert.False(UInt64.TryParse((1000).ToString("C0", nfi), out i));  // Currency
-        Assert.False(UInt64.TryParse((1000).ToString("N0"), out i));  // Thousands
-        Assert.False(UInt64.TryParse("abc", out i));    // Hex digits
-        Assert.False(UInt64.TryParse((678.90).ToString("F2"), out i)); // Decimal
-        Assert.False(UInt64.TryParse("(135)", out i));  // Parentheses
-        Assert.False(UInt64.TryParse("1E23", out i));   // Exponent
-    }
-
-    [Fact]
-    public static void TestTryParseNumberStyleFormatProvider()
-    {
-        UInt64 i;
-        var nfi = new NumberFormatInfo();
-        Assert.True(UInt64.TryParse("123", NumberStyles.Any, nfi, out i));   // Simple positive
-        Assert.Equal<UInt64>(123, i);
-
-        Assert.True(UInt64.TryParse("123", NumberStyles.HexNumber, nfi, out i));   // Simple Hex
-        Assert.Equal<UInt64>(0x123, i);
-
-        nfi.CurrencySymbol = "$";
-        nfi.CurrencyGroupSeparator = ",";
-        Assert.True(UInt64.TryParse("$1,000", NumberStyles.Currency, nfi, out i)); // Currency/Thousands postive
-        Assert.Equal<UInt64>(1000, i);
-
-        Assert.False(UInt64.TryParse("abc", NumberStyles.None, nfi, out i));       // Hex Number negative
-        Assert.True(UInt64.TryParse("abc", NumberStyles.HexNumber, nfi, out i));   // Hex Number positive
-        Assert.Equal<UInt64>(0xabc, i);
-
-        nfi.NumberDecimalSeparator = ".";
-        Assert.False(UInt64.TryParse("678.90", NumberStyles.Integer, nfi, out i));  // Decimal
-        Assert.False(UInt64.TryParse(" 678 ", NumberStyles.None, nfi, out i));      // Trailing/Leading whitespace negative
-
-        Assert.False(UInt64.TryParse("(135)", NumberStyles.AllowParentheses, nfi, out i)); // Parenthese negative
+        //If a format provider isn't specified, test the default one, using the (String, NumberStyles) overload
+        if (nfi == null)
+        {
+            Assert.Throws(exceptionType, () => ulong.Parse(value, style));
+        }
+        Assert.Throws(exceptionType, () => ulong.Parse(value, style, nfi ?? new NumberFormatInfo()));
     }
 }
-

--- a/src/System.Runtime/tests/System/UIntPtr.cs
+++ b/src/System.Runtime/tests/System/UIntPtr.cs
@@ -2,8 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
+
 using Xunit;
 
 public static unsafe class UIntPtrTests
@@ -58,9 +57,9 @@ public static unsafe class UIntPtrTests
         p = new UIntPtr(42);
         b = p.Equals(null);
         Assert.False(b);
-        b = p.Equals((Object)42);
+        b = p.Equals((object)42);
         Assert.False(b);
-        b = p.Equals((Object)(new UIntPtr(42)));
+        b = p.Equals((object)(new UIntPtr(42)));
         Assert.True(b);
 
         int h = p.GetHashCode();
@@ -105,8 +104,8 @@ public static unsafe class UIntPtrTests
             Assert.Equal(expected32, i);
         }
 
-        String s = p.ToString();
-        String sExpected = expected.ToString();
+        string s = p.ToString();
+        string sExpected = expected.ToString();
         Assert.Equal(s, sExpected);
 
         Assert.True(p == new UIntPtr(expected));
@@ -117,4 +116,3 @@ public static unsafe class UIntPtrTests
         Assert.True(p != new UIntPtr(expected + 1));
     }
 }
-

--- a/src/System.Runtime/tests/System/Uri.cs
+++ b/src/System.Runtime/tests/System/Uri.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+
 using Xunit;
 
 public static unsafe class UriTests
@@ -12,31 +13,31 @@ public static unsafe class UriTests
         Uri uri = new Uri(@"http://foo/bar/baz#frag");
 
         int i;
-        String s;
+        string s;
         bool b;
         UriHostNameType uriHostNameType;
-        String[] ss;
+        string[] ss;
 
         s = uri.ToString();
         Assert.Equal(s, @"http://foo/bar/baz#frag");
 
         s = uri.AbsolutePath;
-        Assert.Equal<String>(s, @"/bar/baz");
+        Assert.Equal<string>(s, @"/bar/baz");
 
         s = uri.AbsoluteUri;
-        Assert.Equal<String>(s, @"http://foo/bar/baz#frag");
+        Assert.Equal<string>(s, @"http://foo/bar/baz#frag");
 
         s = uri.Authority;
-        Assert.Equal<String>(s, @"foo");
+        Assert.Equal<string>(s, @"foo");
 
         s = uri.DnsSafeHost;
-        Assert.Equal<String>(s, @"foo");
+        Assert.Equal<string>(s, @"foo");
 
         s = uri.Fragment;
-        Assert.Equal<String>(s, @"#frag");
+        Assert.Equal<string>(s, @"#frag");
 
         s = uri.Host;
-        Assert.Equal<String>(s, @"foo");
+        Assert.Equal<string>(s, @"foo");
 
         uriHostNameType = uri.HostNameType;
         Assert.Equal<UriHostNameType>(uriHostNameType, UriHostNameType.Dns);
@@ -57,34 +58,34 @@ public static unsafe class UriTests
         Assert.False(b);
 
         s = uri.LocalPath;
-        Assert.Equal<String>(s, @"/bar/baz");
+        Assert.Equal<string>(s, @"/bar/baz");
 
         s = uri.OriginalString;
-        Assert.Equal<String>(s, @"http://foo/bar/baz#frag");
+        Assert.Equal<string>(s, @"http://foo/bar/baz#frag");
 
         s = uri.PathAndQuery;
-        Assert.Equal<String>(s, @"/bar/baz");
+        Assert.Equal<string>(s, @"/bar/baz");
 
         i = uri.Port;
         Assert.Equal<int>(i, 80);
 
         s = uri.Query;
-        Assert.Equal<String>(s, @"");
+        Assert.Equal<string>(s, @"");
 
         s = uri.Scheme;
-        Assert.Equal<String>(s, @"http");
+        Assert.Equal<string>(s, @"http");
 
         ss = uri.Segments;
         Assert.Equal<int>(ss.Length, 3);
-        Assert.Equal<String>(ss[0], @"/");
-        Assert.Equal<String>(ss[1], @"bar/");
-        Assert.Equal<String>(ss[2], @"baz");
+        Assert.Equal<string>(ss[0], @"/");
+        Assert.Equal<string>(ss[1], @"bar/");
+        Assert.Equal<string>(ss[2], @"baz");
 
         b = uri.UserEscaped;
         Assert.False(b);
 
         s = uri.UserInfo;
-        Assert.Equal<String>(s, @"");
+        Assert.Equal<string>(s, @"");
     }
 
     [Fact]
@@ -96,31 +97,31 @@ public static unsafe class UriTests
         uri = new Uri(uri, "catalog/shownew.htm?date=today");
 
         int i;
-        String s;
+        string s;
         bool b;
         UriHostNameType uriHostNameType;
-        String[] ss;
+        string[] ss;
 
         s = uri.ToString();
         Assert.Equal(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
 
         s = uri.AbsolutePath;
-        Assert.Equal<String>(s, @"/catalog/shownew.htm");
+        Assert.Equal<string>(s, @"/catalog/shownew.htm");
 
         s = uri.AbsoluteUri;
-        Assert.Equal<String>(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
+        Assert.Equal<string>(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
 
         s = uri.Authority;
-        Assert.Equal<String>(s, @"www.contoso.com");
+        Assert.Equal<string>(s, @"www.contoso.com");
 
         s = uri.DnsSafeHost;
-        Assert.Equal<String>(s, @"www.contoso.com");
+        Assert.Equal<string>(s, @"www.contoso.com");
 
         s = uri.Fragment;
-        Assert.Equal<String>(s, @"");
+        Assert.Equal<string>(s, @"");
 
         s = uri.Host;
-        Assert.Equal<String>(s, @"www.contoso.com");
+        Assert.Equal<string>(s, @"www.contoso.com");
 
         uriHostNameType = uri.HostNameType;
         Assert.Equal<UriHostNameType>(uriHostNameType, UriHostNameType.Dns);
@@ -141,34 +142,34 @@ public static unsafe class UriTests
         Assert.False(b);
 
         s = uri.LocalPath;
-        Assert.Equal<String>(s, @"/catalog/shownew.htm");
+        Assert.Equal<string>(s, @"/catalog/shownew.htm");
 
         s = uri.OriginalString;
-        Assert.Equal<String>(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
+        Assert.Equal<string>(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
 
         s = uri.PathAndQuery;
-        Assert.Equal<String>(s, @"/catalog/shownew.htm?date=today");
+        Assert.Equal<string>(s, @"/catalog/shownew.htm?date=today");
 
         i = uri.Port;
         Assert.Equal<int>(i, 80);
 
         s = uri.Query;
-        Assert.Equal<String>(s, @"?date=today");
+        Assert.Equal<string>(s, @"?date=today");
 
         s = uri.Scheme;
-        Assert.Equal<String>(s, @"http");
+        Assert.Equal<string>(s, @"http");
 
         ss = uri.Segments;
         Assert.Equal<int>(ss.Length, 3);
-        Assert.Equal<String>(ss[0], @"/");
-        Assert.Equal<String>(ss[1], @"catalog/");
-        Assert.Equal<String>(ss[2], @"shownew.htm");
+        Assert.Equal<string>(ss[0], @"/");
+        Assert.Equal<string>(ss[1], @"catalog/");
+        Assert.Equal<string>(ss[2], @"shownew.htm");
 
         b = uri.UserEscaped;
         Assert.False(b);
 
         s = uri.UserInfo;
-        Assert.Equal<String>(s, @"");
+        Assert.Equal<string>(s, @"");
     }
 
     [Fact]
@@ -176,55 +177,55 @@ public static unsafe class UriTests
     {
         Uri uri = new Uri("catalog/shownew.htm?date=today", UriKind.Relative);
 
-        String s;
+        string s;
         bool b;
 
         s = uri.ToString();
         Assert.Equal(s, @"catalog/shownew.htm?date=today");
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.AbsolutePath; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.AbsolutePath; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.AbsoluteUri; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.AbsoluteUri; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.Authority; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.Authority; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.DnsSafeHost; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.DnsSafeHost; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.Fragment; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.Fragment; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.Host; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.Host; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.HostNameType; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.HostNameType; });
 
         Assert.False(uri.IsAbsoluteUri);
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.IsDefaultPort; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.IsDefaultPort; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.IsFile; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.IsFile; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.IsLoopback; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.IsLoopback; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.IsUnc; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.IsUnc; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.LocalPath; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.LocalPath; });
 
         s = uri.OriginalString;
-        Assert.Equal<String>(s, @"catalog/shownew.htm?date=today");
+        Assert.Equal<string>(s, @"catalog/shownew.htm?date=today");
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.PathAndQuery; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.PathAndQuery; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.Port; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.Port; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.Query; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.Query; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.Scheme; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.Scheme; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.Segments; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.Segments; });
 
         b = uri.UserEscaped;
         Assert.False(b);
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.UserInfo; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.UserInfo; });
     }
 
     [Fact]
@@ -240,31 +241,31 @@ public static unsafe class UriTests
         Uri uri = new Uri(absoluteUri, relativeUri);
 
         int i;
-        String s;
+        string s;
         bool b;
         UriHostNameType uriHostNameType;
-        String[] ss;
+        string[] ss;
 
         s = uri.ToString();
         Assert.Equal(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
 
         s = uri.AbsolutePath;
-        Assert.Equal<String>(s, @"/catalog/shownew.htm");
+        Assert.Equal<string>(s, @"/catalog/shownew.htm");
 
         s = uri.AbsoluteUri;
-        Assert.Equal<String>(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
+        Assert.Equal<string>(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
 
         s = uri.Authority;
-        Assert.Equal<String>(s, @"www.contoso.com");
+        Assert.Equal<string>(s, @"www.contoso.com");
 
         s = uri.DnsSafeHost;
-        Assert.Equal<String>(s, @"www.contoso.com");
+        Assert.Equal<string>(s, @"www.contoso.com");
 
         s = uri.Fragment;
-        Assert.Equal<String>(s, @"");
+        Assert.Equal<string>(s, @"");
 
         s = uri.Host;
-        Assert.Equal<String>(s, @"www.contoso.com");
+        Assert.Equal<string>(s, @"www.contoso.com");
 
         uriHostNameType = uri.HostNameType;
         Assert.Equal<UriHostNameType>(uriHostNameType, UriHostNameType.Dns);
@@ -285,34 +286,34 @@ public static unsafe class UriTests
         Assert.False(b);
 
         s = uri.LocalPath;
-        Assert.Equal<String>(s, @"/catalog/shownew.htm");
+        Assert.Equal<string>(s, @"/catalog/shownew.htm");
 
         s = uri.OriginalString;
-        Assert.Equal<String>(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
+        Assert.Equal<string>(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
 
         s = uri.PathAndQuery;
-        Assert.Equal<String>(s, @"/catalog/shownew.htm?date=today");
+        Assert.Equal<string>(s, @"/catalog/shownew.htm?date=today");
 
         i = uri.Port;
         Assert.Equal<int>(i, 80);
 
         s = uri.Query;
-        Assert.Equal<String>(s, @"?date=today");
+        Assert.Equal<string>(s, @"?date=today");
 
         s = uri.Scheme;
-        Assert.Equal<String>(s, @"http");
+        Assert.Equal<string>(s, @"http");
 
         ss = uri.Segments;
         Assert.Equal<int>(ss.Length, 3);
-        Assert.Equal<String>(ss[0], @"/");
-        Assert.Equal<String>(ss[1], @"catalog/");
-        Assert.Equal<String>(ss[2], @"shownew.htm");
+        Assert.Equal<string>(ss[0], @"/");
+        Assert.Equal<string>(ss[1], @"catalog/");
+        Assert.Equal<string>(ss[2], @"shownew.htm");
 
         b = uri.UserEscaped;
         Assert.False(b);
 
         s = uri.UserInfo;
-        Assert.Equal<String>(s, @"");
+        Assert.Equal<string>(s, @"");
     }
 
     [Fact]
@@ -323,30 +324,30 @@ public static unsafe class UriTests
         Assert.True(b);
 
         int i;
-        String s;
+        string s;
         UriHostNameType uriHostNameType;
-        String[] ss;
+        string[] ss;
 
         s = uri.ToString();
         Assert.Equal(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
 
         s = uri.AbsolutePath;
-        Assert.Equal<String>(s, @"/catalog/shownew.htm");
+        Assert.Equal<string>(s, @"/catalog/shownew.htm");
 
         s = uri.AbsoluteUri;
-        Assert.Equal<String>(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
+        Assert.Equal<string>(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
 
         s = uri.Authority;
-        Assert.Equal<String>(s, @"www.contoso.com");
+        Assert.Equal<string>(s, @"www.contoso.com");
 
         s = uri.DnsSafeHost;
-        Assert.Equal<String>(s, @"www.contoso.com");
+        Assert.Equal<string>(s, @"www.contoso.com");
 
         s = uri.Fragment;
-        Assert.Equal<String>(s, @"");
+        Assert.Equal<string>(s, @"");
 
         s = uri.Host;
-        Assert.Equal<String>(s, @"www.contoso.com");
+        Assert.Equal<string>(s, @"www.contoso.com");
 
         uriHostNameType = uri.HostNameType;
         Assert.Equal<UriHostNameType>(uriHostNameType, UriHostNameType.Dns);
@@ -367,34 +368,34 @@ public static unsafe class UriTests
         Assert.False(b);
 
         s = uri.LocalPath;
-        Assert.Equal<String>(s, @"/catalog/shownew.htm");
+        Assert.Equal<string>(s, @"/catalog/shownew.htm");
 
         s = uri.OriginalString;
-        Assert.Equal<String>(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
+        Assert.Equal<string>(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
 
         s = uri.PathAndQuery;
-        Assert.Equal<String>(s, @"/catalog/shownew.htm?date=today");
+        Assert.Equal<string>(s, @"/catalog/shownew.htm?date=today");
 
         i = uri.Port;
         Assert.Equal<int>(i, 80);
 
         s = uri.Query;
-        Assert.Equal<String>(s, @"?date=today");
+        Assert.Equal<string>(s, @"?date=today");
 
         s = uri.Scheme;
-        Assert.Equal<String>(s, @"http");
+        Assert.Equal<string>(s, @"http");
 
         ss = uri.Segments;
         Assert.Equal<int>(ss.Length, 3);
-        Assert.Equal<String>(ss[0], @"/");
-        Assert.Equal<String>(ss[1], @"catalog/");
-        Assert.Equal<String>(ss[2], @"shownew.htm");
+        Assert.Equal<string>(ss[0], @"/");
+        Assert.Equal<string>(ss[1], @"catalog/");
+        Assert.Equal<string>(ss[2], @"shownew.htm");
 
         b = uri.UserEscaped;
         Assert.False(b);
 
         s = uri.UserInfo;
-        Assert.Equal<String>(s, @"");
+        Assert.Equal<string>(s, @"");
     }
 
     [Fact]
@@ -406,30 +407,30 @@ public static unsafe class UriTests
         Assert.True(b);
 
         int i;
-        String s;
+        string s;
         UriHostNameType uriHostNameType;
-        String[] ss;
+        string[] ss;
 
         s = uri.ToString();
         Assert.Equal(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
 
         s = uri.AbsolutePath;
-        Assert.Equal<String>(s, @"/catalog/shownew.htm");
+        Assert.Equal<string>(s, @"/catalog/shownew.htm");
 
         s = uri.AbsoluteUri;
-        Assert.Equal<String>(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
+        Assert.Equal<string>(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
 
         s = uri.Authority;
-        Assert.Equal<String>(s, @"www.contoso.com");
+        Assert.Equal<string>(s, @"www.contoso.com");
 
         s = uri.DnsSafeHost;
-        Assert.Equal<String>(s, @"www.contoso.com");
+        Assert.Equal<string>(s, @"www.contoso.com");
 
         s = uri.Fragment;
-        Assert.Equal<String>(s, @"");
+        Assert.Equal<string>(s, @"");
 
         s = uri.Host;
-        Assert.Equal<String>(s, @"www.contoso.com");
+        Assert.Equal<string>(s, @"www.contoso.com");
 
         uriHostNameType = uri.HostNameType;
         Assert.Equal<UriHostNameType>(uriHostNameType, UriHostNameType.Dns);
@@ -450,34 +451,34 @@ public static unsafe class UriTests
         Assert.False(b);
 
         s = uri.LocalPath;
-        Assert.Equal<String>(s, @"/catalog/shownew.htm");
+        Assert.Equal<string>(s, @"/catalog/shownew.htm");
 
         s = uri.OriginalString;
-        Assert.Equal<String>(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
+        Assert.Equal<string>(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
 
         s = uri.PathAndQuery;
-        Assert.Equal<String>(s, @"/catalog/shownew.htm?date=today");
+        Assert.Equal<string>(s, @"/catalog/shownew.htm?date=today");
 
         i = uri.Port;
         Assert.Equal<int>(i, 80);
 
         s = uri.Query;
-        Assert.Equal<String>(s, @"?date=today");
+        Assert.Equal<string>(s, @"?date=today");
 
         s = uri.Scheme;
-        Assert.Equal<String>(s, @"http");
+        Assert.Equal<string>(s, @"http");
 
         ss = uri.Segments;
         Assert.Equal<int>(ss.Length, 3);
-        Assert.Equal<String>(ss[0], @"/");
-        Assert.Equal<String>(ss[1], @"catalog/");
-        Assert.Equal<String>(ss[2], @"shownew.htm");
+        Assert.Equal<string>(ss[0], @"/");
+        Assert.Equal<string>(ss[1], @"catalog/");
+        Assert.Equal<string>(ss[2], @"shownew.htm");
 
         b = uri.UserEscaped;
         Assert.False(b);
 
         s = uri.UserInfo;
-        Assert.Equal<String>(s, @"");
+        Assert.Equal<string>(s, @"");
     }
 
     [Fact]
@@ -490,30 +491,30 @@ public static unsafe class UriTests
         Assert.True(b);
 
         int i;
-        String s;
+        string s;
         UriHostNameType uriHostNameType;
-        String[] ss;
+        string[] ss;
 
         s = uri.ToString();
         Assert.Equal(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
 
         s = uri.AbsolutePath;
-        Assert.Equal<String>(s, @"/catalog/shownew.htm");
+        Assert.Equal<string>(s, @"/catalog/shownew.htm");
 
         s = uri.AbsoluteUri;
-        Assert.Equal<String>(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
+        Assert.Equal<string>(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
 
         s = uri.Authority;
-        Assert.Equal<String>(s, @"www.contoso.com");
+        Assert.Equal<string>(s, @"www.contoso.com");
 
         s = uri.DnsSafeHost;
-        Assert.Equal<String>(s, @"www.contoso.com");
+        Assert.Equal<string>(s, @"www.contoso.com");
 
         s = uri.Fragment;
-        Assert.Equal<String>(s, @"");
+        Assert.Equal<string>(s, @"");
 
         s = uri.Host;
-        Assert.Equal<String>(s, @"www.contoso.com");
+        Assert.Equal<string>(s, @"www.contoso.com");
 
         uriHostNameType = uri.HostNameType;
         Assert.Equal<UriHostNameType>(uriHostNameType, UriHostNameType.Dns);
@@ -534,34 +535,34 @@ public static unsafe class UriTests
         Assert.False(b);
 
         s = uri.LocalPath;
-        Assert.Equal<String>(s, @"/catalog/shownew.htm");
+        Assert.Equal<string>(s, @"/catalog/shownew.htm");
 
         s = uri.OriginalString;
-        Assert.Equal<String>(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
+        Assert.Equal<string>(s, @"http://www.contoso.com/catalog/shownew.htm?date=today");
 
         s = uri.PathAndQuery;
-        Assert.Equal<String>(s, @"/catalog/shownew.htm?date=today");
+        Assert.Equal<string>(s, @"/catalog/shownew.htm?date=today");
 
         i = uri.Port;
         Assert.Equal<int>(i, 80);
 
         s = uri.Query;
-        Assert.Equal<String>(s, @"?date=today");
+        Assert.Equal<string>(s, @"?date=today");
 
         s = uri.Scheme;
-        Assert.Equal<String>(s, @"http");
+        Assert.Equal<string>(s, @"http");
 
         ss = uri.Segments;
         Assert.Equal<int>(ss.Length, 3);
-        Assert.Equal<String>(ss[0], @"/");
-        Assert.Equal<String>(ss[1], @"catalog/");
-        Assert.Equal<String>(ss[2], @"shownew.htm");
+        Assert.Equal<string>(ss[0], @"/");
+        Assert.Equal<string>(ss[1], @"catalog/");
+        Assert.Equal<string>(ss[2], @"shownew.htm");
 
         b = uri.UserEscaped;
         Assert.False(b);
 
         s = uri.UserInfo;
-        Assert.Equal<String>(s, @"");
+        Assert.Equal<string>(s, @"");
     }
 
     [Fact]
@@ -576,56 +577,56 @@ public static unsafe class UriTests
         // Determine the relative Uri.  
         Uri uri = address1.MakeRelativeUri(address2);
 
-        String s;
+        string s;
         bool b;
 
         s = uri.ToString();
         Assert.Equal(s, @"index.htm?date=today");
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.AbsolutePath; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.AbsolutePath; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.AbsoluteUri; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.AbsoluteUri; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.Authority; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.Authority; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.DnsSafeHost; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.DnsSafeHost; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.Fragment; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.Fragment; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.Host; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.Host; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.HostNameType; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.HostNameType; });
 
         b = uri.IsAbsoluteUri;
         Assert.False(b);
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.IsDefaultPort; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.IsDefaultPort; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.IsFile; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.IsFile; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.IsLoopback; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.IsLoopback; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.IsUnc; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.IsUnc; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.LocalPath; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.LocalPath; });
 
         s = uri.OriginalString;
-        Assert.Equal<String>(s, @"index.htm?date=today");
+        Assert.Equal<string>(s, @"index.htm?date=today");
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.PathAndQuery; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.PathAndQuery; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.Port; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.Port; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.Query; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.Query; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.Scheme; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.Scheme; });
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.Segments; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.Segments; });
 
         b = uri.UserEscaped;
         Assert.False(b);
 
-        Assert.Throws<System.InvalidOperationException>(() => { Object o = uri.UserInfo; });
+        Assert.Throws<System.InvalidOperationException>(() => { object o = uri.UserInfo; });
     }
 
     [Fact]
@@ -811,7 +812,7 @@ public static unsafe class UriTests
     [Fact]
     public static void TestEscapeDataString()
     {
-        String s;
+        string s;
 
         s = Uri.EscapeDataString("Hello");
         Assert.Equal(s, "Hello");
@@ -823,7 +824,7 @@ public static unsafe class UriTests
     [Fact]
     public static void TestUnescapeDataString()
     {
-        String s;
+        string s;
 
         s = Uri.UnescapeDataString("Hello");
         Assert.Equal(s, "Hello");
@@ -835,7 +836,7 @@ public static unsafe class UriTests
     [Fact]
     public static void TestEscapeUriString()
     {
-        String s;
+        string s;
 
         s = Uri.EscapeUriString("Hello");
         Assert.Equal(s, "Hello");
@@ -848,7 +849,7 @@ public static unsafe class UriTests
     public static void TestGetComponentParts()
     {
         Uri uri = new Uri("http://www.contoso.com/path?name#frag");
-        String s;
+        string s;
 
         s = uri.GetComponents(UriComponents.Fragment, UriFormat.UriEscaped);
         Assert.Equal(s, "frag");
@@ -857,4 +858,3 @@ public static unsafe class UriTests
         Assert.Equal(s, "www.contoso.com");
     }
 }
-

--- a/src/System.Runtime/tests/System/ValueType.cs
+++ b/src/System.Runtime/tests/System/ValueType.cs
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections;
-using System.Collections.Generic;
 using Xunit;
 
 public static unsafe class ValueTypeTests
@@ -11,10 +8,10 @@ public static unsafe class ValueTypeTests
     [Fact]
     public static void TestToString()
     {
-        Object o = new S();
-        String s = o.ToString();
+        object o = new S();
+        string s = o.ToString();
         Assert.NotNull(s);
-        String s1 = o.GetType().ToString();
+        string s1 = o.GetType().ToString();
         Assert.Equal(s, s1);
         Assert.Equal("ValueTypeTests+S", s);
     }
@@ -25,4 +22,3 @@ public static unsafe class ValueTypeTests
         public int y;
     }
 }
-

--- a/src/System.Runtime/tests/System/Version.cs
+++ b/src/System.Runtime/tests/System/Version.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+
 using Xunit;
 
 public class VersionTests

--- a/src/System.Runtime/tests/System/WeakReference.cs
+++ b/src/System.Runtime/tests/System/WeakReference.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+
 using Xunit;
 
 public static unsafe class WeakReferenceTests
@@ -28,14 +27,14 @@ public static unsafe class WeakReferenceTests
     [Fact]
     public static void TestNonGeneric()
     {
-        Object o1 = new char[10];
+        object o1 = new char[10];
         WeakReference w = new WeakReference(o1);
         VerifyStillAlive(w);
         Assert.True(RuntimeHelpers.ReferenceEquals(o1, w.Target));
         Assert.False(w.TrackResurrection);
         GC.KeepAlive(o1);
 
-        Object o2 = new char[100];
+        object o2 = new char[100];
         w.Target = o2;
         VerifyStillAlive(w);
         Assert.True(RuntimeHelpers.ReferenceEquals(o2, w.Target));
@@ -77,18 +76,18 @@ public static unsafe class WeakReferenceTests
     [Fact]
     public static void TestGeneric()
     {
-        Object o1 = new char[10];
-        WeakReference<Object> w = new WeakReference<Object>(o1);
+        object o1 = new char[10];
+        WeakReference<object> w = new WeakReference<object>(o1);
         VerifyStillAlive(w);
-        Object v1;
+        object v1;
         Assert.True(w.TryGetTarget(out v1));
         Assert.True(Object.ReferenceEquals(v1, o1));
         GC.KeepAlive(o1);
 
-        Object o2 = new char[100];
+        object o2 = new char[100];
         w.SetTarget(o2);
         VerifyStillAlive(w);
-        Object v2;
+        object v2;
         Assert.True(w.TryGetTarget(out v2));
         Assert.True(Object.ReferenceEquals(v2, o2));
         GC.KeepAlive(o2);
@@ -191,4 +190,3 @@ public static unsafe class WeakReferenceTests
         Assert.True(value == null);
     }
 }
-


### PR DESCRIPTION
This PR cleans up the test suite for the following primitives in corefx by modernising and slightly updating the test code:
- Bool
- Enum
- Type
- SByte, Byte
- Int16, UInt16
- Int32, UInt32
- Int64, UInt64
- Single, Double