### PR TITLE
Catch right exception in Console for unknown charset

### DIFF
--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -213,7 +213,7 @@ namespace System
             {
                 // Try to use an encoding that matches the current charset
                 try { return new ConsoleEncoding(Encoding.GetEncoding(charset)); }
-                catch (NotSupportedException) { }
+                catch { } // unknown charset, or arbitrary exceptions thrown from providers
             }
             return new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
         }


### PR DESCRIPTION
When System.Console.dll was first ported to Unix, we didn't have our globalization stack implemented at all, and Encoding.GetEncoding would throw a NotSupportedException if the supplied charset wasn't recognized, so Console was written to catch NotSupportedException to handle the case of an unknown charset.  Now that our stack is implemented, GetEncoding throws an ArgumentException as documented on MSDN, and we need to fix Console to catch the right exception type, otherwise an unknown charset causes exceptions when attempting to use Console.

cc: @ellismg, @adityamandaleeka 
Fixes https://github.com/dotnet/corefx/issues/4590