### PR TITLE
optimized some string allocations

### DIFF
--- a/src/System.Resources.Reader/System.Resources.Reader.sln
+++ b/src/System.Resources.Reader/System.Resources.Reader.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.24711.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Resources.Reader", "src\System.Resources.Reader.csproj", "{16EE5522-F387-4C9E-9EF2-B5134B043F37}"
 EndProject

--- a/src/System.Resources.Reader/src/Resources/Strings.resx
+++ b/src/System.Resources.Reader/src/Resources/Strings.resx
@@ -120,10 +120,10 @@
   <data name="InvalidOperation_ResourceWriterSaved" xml:space="preserve">
     <value>The resource writer has already been closed and cannot be edited.</value>
   </data>
-  <data name="Argument_StreamNotWritable" xml:space="preserve">
-    <value>Stream was not writable.</value>
+  <data name="Argument_StreamNotSeekable" xml:space="preserve">
+    <value>Stream was not seekable.</value>
   </data>
-<data name="Arg_ResourceFileUnsupportedVersion" xml:space="preserve">
+  <data name="Arg_ResourceFileUnsupportedVersion" xml:space="preserve">
     <value>The ResourceReader class does not know how to read this version of .resources files.</value>
   </data>
   <data name="Resources_StreamNotValid" xml:space="preserve">


### PR DESCRIPTION
ResourceReader is designed to read string resources. Other resource types, when read, result in null values being returned. Because of this, there is no need to build a "type table" as if the type is not a string, we just return null. 

This change eliminates the type table and simply captures and uses the "id" (offset) for System.String.

In addition, this change consolidates string allocations and encoding to a single method ReadString.