### PR TITLE
Ensure CurlHandler sends no-value headers

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -481,8 +481,11 @@ namespace System.Net.Http
             {
                 foreach (KeyValuePair<string, IEnumerable<string>> header in headers)
                 {
-                    string headerStr = header.Key + ": " + headers.GetHeaderString(header.Key);
-                    if (!Interop.Http.SListAppend(handle, headerStr))
+                    string headerValue = headers.GetHeaderString(header.Key);
+                    string headerKeyAndValue = string.IsNullOrEmpty(headerValue) ?
+                        header.Key + ";" : // semicolon used by libcurl to denote empty value that should be sent
+                        header.Key + ": " + headerValue;
+                    if (!Interop.Http.SListAppend(handle, headerKeyAndValue))
                     {
                         throw CreateHttpRequestException();
                     }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -366,7 +366,8 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
-        [InlineData("X-Cust-Header","x-value")]
+        [InlineData("X-Cust-Header", "x-value")]
+        [InlineData("X-Cust-Header-NoValue", "")]
         public async Task GetAsync_RequestHeadersAddCustomHeaders_HeaderAndValueSent(string name, string value)
         {
             using (var client = new HttpClient())


### PR DESCRIPTION
By default libcurl drops headers with empty values, as it uses an empty value as a sentinel to mean "remove a previously added header with this key name."  If you actually want a header with an empty value, it needs to have a semicolon appended to the key name.

cc: @vijaykota, @kapilash, @davidsh 
Fixes #4597 