### PR TITLE
Strengthen SortedList<TKey, TValue>.KeyList to implement IReadOnlyList<TKey>

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/SortedList.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedList.cs
@@ -1042,7 +1042,7 @@ namespace System.Collections.Generic
 
         [DebuggerTypeProxy(typeof(DictionaryKeyCollectionDebugView<,>))]
         [DebuggerDisplay("Count = {Count}")]
-        private sealed class KeyList : IList<TKey>, System.Collections.ICollection
+        private sealed class KeyList : IList<TKey>, IReadOnlyList<TKey>, System.Collections.ICollection
         {
             private SortedList<TKey, TValue> _dict;
 


### PR DESCRIPTION
Some search code I use that takes an IReadOnlyList. Unfortunately it won't work with SortedList.Keys because it returns an `IList<T>`. I don't dare change that (would be backwards incompatible) but this pull request would make what I want possible with a cheeky cast:

    Search((IReadOnlyList<double>)sortedList.Keys)

What do you think?

* * *

Pull request to master branch rather than future, is that right? https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/branching-guide.md