### PR TITLE
Fixing a typo in developer-guide.md

### DIFF
--- a/Documentation/project-docs/developer-guide.md
+++ b/Documentation/project-docs/developer-guide.md
@@ -16,4 +16,4 @@ The CoreFX repo can be built from a regular, non-admin command prompt. The build
 |       | [Instructions](../building/windows-instructions.md) | [Instructions](../building/unix-instructions.md) | [Instructions](../building/unix-instructions.md) | [Instructions](../building/unix-instructions.md) |
 
 
-The CoreFX build and test suite is a work in progress, as are the [building and testing instructions](../README.md). The .NET Core team and the community are improving Linux and OS X support on a daily basis are and adding more tests for all platforms. See [CoreFX Issues](https://github.com/dotnet/corefx/issues) to find out about specific work items or report issues.
+The CoreFX build and test suite is a work in progress, as are the [building and testing instructions](../README.md). The .NET Core team and the community are improving Linux and OS X support on a daily basis and are adding more tests for all platforms. See [CoreFX Issues](https://github.com/dotnet/corefx/issues) to find out about specific work items or report issues.


### PR DESCRIPTION
The words 'are' and 'and' were mistyped and need to be switched.  This
is the same issue that was just fixed in coreclr.

Please forgive the fact that I'm new to this process, and I'm not 
sure if there is something special I'm supposed to do to handle
merge commits to my fork so that they don't appear in PRs.  Any info
here would be appreciated.  Thank you.