### PR TITLE
Fix and enable Globalization tests that differ based on OS and culture

### DIFF
--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoCalendarWeekRule.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoCalendarWeekRule.cs
@@ -45,33 +45,18 @@ namespace System.Globalization.Tests
             });
         }
 
-        // TestLocaleFirstDay: Verify value of property CalendarWeekRule for specific locale
-        [Fact]
-        public void TestLocaleFirstDay()
+        // Verify value of property CalendarWeekRule for specific locales
+        [Theory]
+        [InlineData("en-US")]
+        [InlineData("br-FR")]
+        public void TestLocale(string localeName)
         {
-            CultureInfo myTestCulture = new CultureInfo("en-US");
-            DateTimeFormatInfo dti = myTestCulture.DateTimeFormat;
-            CalendarWeekRule actual = dti.CalendarWeekRule;
-            Assert.Equal(CalendarWeekRule.FirstDay, actual);
-        }
-
-        // TestLocaleFirstFourDayWeek: Verify value of property CalendarWeekRule for specific locale
-        [Fact]
-        public void TestLocaleFirstFourDayWeek()
-        {
-            CultureInfo myTestCulture = new CultureInfo("br-FR");
+            CultureInfo myTestCulture = new CultureInfo(localeName);
             DateTimeFormatInfo dti = myTestCulture.DateTimeFormat;
             CalendarWeekRule actual = dti.CalendarWeekRule;
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                // note for Win10 this returns FirstFourDayWeek, not FirstFullWeek, this should be cleaned up as part of #3243
-                Assert.True(actual == CalendarWeekRule.FirstFullWeek || actual == CalendarWeekRule.FirstFourDayWeek);
-            }
-            else
-            {
-                Assert.Equal(CalendarWeekRule.FirstFourDayWeek, actual);
-            }
+            CalendarWeekRule expected = DateTimeFormatInfoData.GetCalendarWeekRule(myTestCulture);
+            Assert.Equal(expected, actual);
         }
 
         private void VerificationHelper(DateTimeFormatInfo info, CalendarWeekRule expected, bool setter)

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoData.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoData.cs
@@ -126,7 +126,7 @@ namespace System.Globalization.Tests
             }
         }
 
-        private static Exception GetCultureNotSupportedException(CultureInfo cultureInfo)
+        public static Exception GetCultureNotSupportedException(CultureInfo cultureInfo)
         {
             return new NotSupportedException(string.Format("The culture '{0}' with calendar '{1}' is not supported.",
                 cultureInfo.Name,

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoData.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoData.cs
@@ -8,6 +8,7 @@ namespace System.Globalization.Tests
     internal static class DateTimeFormatInfoData
     {
         private static bool s_isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        private static bool s_isOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 
         public static string GetEraName(CultureInfo cultureInfo)
         {
@@ -41,10 +42,94 @@ namespace System.Globalization.Tests
             throw GetCultureNotSupportedException(cultureInfo);
         }
 
+        internal static string[] GetDayNames(CultureInfo cultureInfo)
+        {
+            if (string.Equals(cultureInfo.Name, "en-US", StringComparison.OrdinalIgnoreCase))
+            {
+                return new string[]
+                {
+                    "Sunday",
+                    "Monday",
+                    "Tuesday",
+                    "Wednesday",
+                    "Thursday",
+                    "Friday",
+                    "Saturday"
+                };
+            }
+            if (string.Equals(cultureInfo.Name, "fr-FR", StringComparison.OrdinalIgnoreCase))
+            {
+                string[] dayNames = new string[]
+                {
+                    "dimanche",
+                    "lundi",
+                    "mardi",
+                    "mercredi",
+                    "jeudi",
+                    "vendredi",
+                    "samedi"
+                };
+
+                if (s_isOSX)
+                {
+                    CapitalizeStrings(dayNames);
+                }
+                return dayNames;
+            }
+
+            throw GetCultureNotSupportedException(cultureInfo);
+        }
+
+        internal static string[] GetAbbreviatedDayNames(CultureInfo cultureInfo)
+        {
+            if (string.Equals(cultureInfo.Name, "en-US", StringComparison.OrdinalIgnoreCase))
+            {
+                return new string[]
+                {
+                    "Sun",
+                    "Mon",
+                    "Tue",
+                    "Wed",
+                    "Thu",
+                    "Fri",
+                    "Sat"
+                };
+            }
+            if (string.Equals(cultureInfo.Name, "fr-FR", StringComparison.OrdinalIgnoreCase))
+            {
+                string[] dayNames = new string[]
+                {
+                    "dim.",
+                    "lun.",
+                    "mar.",
+                    "mer.",
+                    "jeu.",
+                    "ven.",
+                    "sam."
+                };
+
+                if (s_isOSX)
+                {
+                    CapitalizeStrings(dayNames);
+                }
+                return dayNames;
+            }
+
+            throw GetCultureNotSupportedException(cultureInfo);
+        }
+
+        private static void CapitalizeStrings(string[] strings)
+        {
+            for (int i = 0; i < strings.Length; i++)
+            {
+                strings[i] = strings[i].Substring(0, 1).ToUpper() + strings[i].Substring(1);
+            }
+        }
+
         private static Exception GetCultureNotSupportedException(CultureInfo cultureInfo)
         {
-            return new NotSupportedException(string.Format("The culture '{0}' with calendar '{1}' is not supported.", 
-                cultureInfo.Name, 
+            return new NotSupportedException(string.Format("The culture '{0}' with calendar '{1}' is not supported.",
+                cultureInfo.Name,
                 cultureInfo.Calendar.GetType().Name));
         }
     }

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedDayName.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedDayName.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Globalization;
 using Xunit;
 
 namespace System.Globalization.Tests
@@ -26,40 +24,17 @@ namespace System.Globalization.Tests
             VerificationHelper(info, expected);
         }
 
-        // PosTest2: Call GetAbbreviatedDayName on en-us culture DateTimeFormatInfo instance
-        [Fact]
-        public void PosTest2()
+        // Call GetAbbreviatedDayName on en-us culture DateTimeFormatInfo instance
+        // Call GetAbbreviatedDayName on fr-FR culture DateTimeFormatInfo instance
+        [Theory]
+        [InlineData("en-us")]
+        [InlineData("fr-FR")]
+        public void PosTest2(string localeName)
         {
-            DateTimeFormatInfo info = new CultureInfo("en-us").DateTimeFormat;
-            string[] expected = new string[] {
-                "Sun",
-                "Mon",
-                "Tue",
-                "Wed",
-                "Thu",
-                "Fri",
-                "Sat"
-            };
+            CultureInfo culture = new CultureInfo(localeName);
+            string[] expected = DateTimeFormatInfoData.GetAbbreviatedDayNames(culture);
 
-            VerificationHelper(info, expected);
-        }
-
-        // PosTest3: Call GetAbbreviatedDayName on fr-FR culture DateTimeFormatInfo instance
-        [Fact]
-        [ActiveIssue(3243, PlatformID.OSX)]
-        public void PosTest3()
-        {
-            DateTimeFormatInfo info = new CultureInfo("fr-FR").DateTimeFormat;
-            string[] expected = new string[] {
-                "dim.",
-                "lun.",
-                "mar.",
-                "mer.",
-                "jeu.",
-                "ven.",
-                "sam."
-            };
-
+            DateTimeFormatInfo info = culture.DateTimeFormat;
             VerificationHelper(info, expected);
         }
 

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedMonthName.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetAbbreviatedMonthName.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Globalization;
 using Xunit;
 
 namespace System.Globalization.Tests
@@ -12,7 +10,7 @@ namespace System.Globalization.Tests
         private const int c_MIN_MONTH_VALUE = 1;
         private const int c_MAX_MONTH_VALUE = 13;
 
-        // PosTest1: Call GetAbbreviatedDayName on default invariant DateTimeFormatInfo instance
+        // PosTest1: Call GetAbbreviatedMonthName on default invariant DateTimeFormatInfo instance
         [Fact]
         public void PosTest1()
         {
@@ -37,7 +35,7 @@ namespace System.Globalization.Tests
             VerificationHelper(info, expected);
         }
 
-        // PosTest2: Call GetAbbreviatedDayName on en-us culture DateTimeFormatInfo instance
+        // PosTest2: Call GetAbbreviatedMonthName on en-us culture DateTimeFormatInfo instance
         [Fact]
         public void PosTest2()
         {
@@ -62,9 +60,8 @@ namespace System.Globalization.Tests
             VerificationHelper(info, expected);
         }
 
-        // PosTest3: Call GetAbbreviatedDayName on fr-FR culture DateTimeFormatInfo instance
+        // PosTest3: Call GetAbbreviatedMonthName on fr-FR culture DateTimeFormatInfo instance
         [Fact]
-        [ActiveIssue(3243, PlatformID.OSX)]
         public void PosTest3()
         {
             DateTimeFormatInfo info = new CultureInfo("fr-FR").DateTimeFormat;
@@ -88,7 +85,7 @@ namespace System.Globalization.Tests
             VerificationHelper(info, expected);
         }
 
-        // PosTest4: Call GetAbbreviatedDayName on DateTimeFormatInfo instance created from ctor
+        // PosTest4: Call GetAbbreviatedMonthName on DateTimeFormatInfo instance created from ctor
         [Fact]
         public void PosTest4()
         {

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetDayName.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetDayName.cs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Globalization;
 using Xunit;
 
 namespace System.Globalization.Tests
 {
     public class DateTimeFormatInfoGetDayName
     {
-        // PosTest1: Call GetAbbreviatedDayName on default invariant DateTimeFormatInfo instance
+        // PosTest1: Call GetDayName on default invariant DateTimeFormatInfo instance
         [Fact]
         public void PosTest1()
         {
@@ -27,44 +25,21 @@ namespace System.Globalization.Tests
             VerificationHelper(info, expected);
         }
 
-        // PosTest2: Call GetAbbreviatedDayName on en-us culture DateTimeFormatInfo instance
-        [Fact]
-        public void PosTest2()
+        // Call GetDayName on en-us culture DateTimeFormatInfo instance
+        // Call GetDayName on fr-FR culture DateTimeFormatInfo instance
+        [Theory]
+        [InlineData("en-us")]
+        [InlineData("fr-FR")]
+        public void PosTest2(string localeName)
         {
-            DateTimeFormatInfo info = new CultureInfo("en-us").DateTimeFormat;
-            string[] expected = new string[] {
-                "Sunday",
-                "Monday",
-                "Tuesday",
-                "Wednesday",
-                "Thursday",
-                "Friday",
-                "Saturday"
-            };
+            CultureInfo culture = new CultureInfo(localeName);
+            string[] expected = DateTimeFormatInfoData.GetDayNames(culture);
 
+            DateTimeFormatInfo info = culture.DateTimeFormat;
             VerificationHelper(info, expected);
         }
 
-        // PosTest3: Call GetAbbreviatedDayName on fr-FR culture DateTimeFormatInfo instance
-        [Fact]
-        [ActiveIssue(3243, PlatformID.OSX)]
-        public void PosTest3()
-        {
-            DateTimeFormatInfo info = new CultureInfo("fr-FR").DateTimeFormat;
-            string[] expected = new string[] {
-                "dimanche",
-                "lundi",
-                "mardi",
-                "mercredi",
-                "jeudi",
-                "vendredi",
-                "samedi"
-            };
-
-            VerificationHelper(info, expected);
-        }
-
-        // PosTest4: Call GetAbbreviatedDayName on DateTimeFormatInfo instance created from ctor
+        // PosTest4: Call GetDayName on DateTimeFormatInfo instance created from ctor
         [Fact]
         public void PosTest4()
         {
@@ -96,13 +71,13 @@ namespace System.Globalization.Tests
         private void VerificationHelper(DateTimeFormatInfo info, string[] expected)
         {
             DayOfWeek[] values = new DayOfWeek[] {
-            DayOfWeek.Sunday,
-            DayOfWeek.Monday,
-            DayOfWeek.Tuesday,
-            DayOfWeek.Wednesday,
-            DayOfWeek.Thursday,
-            DayOfWeek.Friday,
-            DayOfWeek.Saturday
+                DayOfWeek.Sunday,
+                DayOfWeek.Monday,
+                DayOfWeek.Tuesday,
+                DayOfWeek.Wednesday,
+                DayOfWeek.Thursday,
+                DayOfWeek.Friday,
+                DayOfWeek.Saturday
             };
 
             for (int i = 0; i < values.Length; ++i)

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetMonthName.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetMonthName.cs
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Globalization;
 using Xunit;
 
 namespace System.Globalization.Tests
@@ -12,7 +10,7 @@ namespace System.Globalization.Tests
         private const int c_MIN_MONTH_VALUE = 1;
         private const int c_MAX_MONTH_VALUE = 13;
 
-        // PosTest1: Call GetAbbreviatedDayName on default invariant DateTimeFormatInfo instance
+        // PosTest1: Call GetMonthName on default invariant DateTimeFormatInfo instance
         [Fact]
         public void PosTest1()
         {
@@ -37,7 +35,7 @@ namespace System.Globalization.Tests
             VerificationHelper(info, expected);
         }
 
-        // PosTest2: Call GetAbbreviatedDayName on en-us culture DateTimeFormatInfo instance
+        // PosTest2: Call GetMonthName on en-us culture DateTimeFormatInfo instance
         [Fact]
         public void PosTest2()
         {
@@ -62,9 +60,8 @@ namespace System.Globalization.Tests
             VerificationHelper(info, expected);
         }
 
-        // PosTest3: Call GetAbbreviatedDayName on fr-FR culture DateTimeFormatInfo instance
+        // PosTest3: Call GetMonthName on fr-FR culture DateTimeFormatInfo instance
         [Fact]
-        [ActiveIssue(3243, PlatformID.OSX)]
         public void PosTest3()
         {
             DateTimeFormatInfo info = new CultureInfo("fr-FR").DateTimeFormat;
@@ -88,7 +85,7 @@ namespace System.Globalization.Tests
             VerificationHelper(info, expected);
         }
 
-        // PosTest4: Call GetAbbreviatedDayName on DateTimeFormatInfo instance created from ctor
+        // PosTest4: Call GetMonthName on DateTimeFormatInfo instance created from ctor
         [Fact]
         public void PosTest4()
         {

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyNegativePattern.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoCurrencyNegativePattern.cs
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Globalization;
+using System.Linq;
 using System.Runtime.InteropServices;
 using Xunit;
 
@@ -54,30 +53,22 @@ namespace System.Globalization.Tests
 
         // TestCurrencyNegativePatternLocale: Verify value of property CurrencyNegativePattern for specific locales
         [Theory]
-        [InlineData("en-US", 0, 1, 0)]
-        [InlineData("en-CA", 1, 0, 1)]
-        [InlineData("fa-IR", 3, 1, 0)]
-        [InlineData("fr-CD", 4, 8, 15)]
-        [InlineData("as", 12, 9, 9)]
-        [InlineData("es-BO", 14, 1, 1)]
-        [InlineData("fr-CA", 15, 8, 15)]
-        public void TestCurrencyNegativePatternLocale(string locale, int expectedWindows, int expectedIcu, int alternateExpectedIcu)
+        [InlineData("en-US")]
+        [InlineData("en-CA")]
+        [InlineData("fa-IR")]
+        [InlineData("fr-CD")]
+        [InlineData("as")]
+        [InlineData("es-BO")]
+        [InlineData("fr-CA")]
+        public void TestCurrencyNegativePatternLocale(string locale)
         {
             CultureInfo myTestCulture = new CultureInfo(locale);
             NumberFormatInfo nfi = myTestCulture.NumberFormat;
             int actual = nfi.CurrencyNegativePattern;
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                // todo: determine if Windows version needs to support "accounting" currency explictly which contains parenthesis
-                // Windows 10 uses ICU data here, this should be cleaned up as part of #3243
-                Assert.True(actual == expectedWindows || actual == expectedIcu);
-            }
-            else
-            {
-                // alternateExpectedIcu contain values for CentOS7 which is using an older version of ICU (50) with different data
-                Assert.True(actual == expectedIcu || actual == alternateExpectedIcu);
-            }
+            int[] acceptablePatterns = NumberFormatInfoData.GetCurrencyNegativePatterns(myTestCulture);
+            Assert.True(acceptablePatterns.Contains(actual),
+                string.Format("'{0}' was not found in '[{1}]'", actual, string.Join(",", acceptablePatterns)));
         }
 
         // TestCurrencyNegativePatternLocale2: Verify value of property CurrencyNegativePattern for specific locales

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
@@ -52,5 +52,34 @@ namespace System.Globalization.Tests
                 return "-\u221E";
             }
         }
+
+        internal static int[] GetCurrencyNegativePatterns(CultureInfo cultureInfo)
+        {
+            switch (cultureInfo.Name)
+            {
+                case "en-US":
+                    return s_isWindows ? new int[] { 0 } : new int[] { 1 };
+
+                case "en-CA":
+                    return new int[] { 1 };
+
+                case "fa-IR":
+                    return s_isWindows ? new int[] { 3 } : new int[] { 1 };
+
+                case "fr-CD":
+                    return (s_isWindows && s_WindowsVersion < 10) ? new int[] { 4 } : new int[] { 8 };
+
+                case "as":
+                    return s_isWindows ? new int[] { 12 } : new int[] { 9 };
+
+                case "es-BO":
+                    return (s_isWindows && s_WindowsVersion < 10) ? new int[] { 14 } : new int[] { 1 };
+
+                case "fr-CA":
+                    return s_isWindows ? new int[] { 15 } : new int[] { 8 };
+            }
+
+            throw DateTimeFormatInfoData.GetCultureNotSupportedException(cultureInfo);
+        }
     }
 }

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Globalization.Tests
+{
+    internal static class NumberFormatInfoData
+    {
+        private static bool s_isOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+
+        public static int[] GetNumberGroupSizes(CultureInfo cultureInfo)
+        {
+            if (string.Equals(cultureInfo.Name, "en-US", StringComparison.OrdinalIgnoreCase))
+            {
+                return new int[] { 3 };
+            }
+            if (string.Equals(cultureInfo.Name, "ur-IN", StringComparison.OrdinalIgnoreCase))
+            {
+                if (s_isOSX)
+                {
+                    return new int[] { 3 };
+                }
+                else
+                {
+                    return new int[] { 3, 2 };
+                }
+            }
+
+            throw DateTimeFormatInfoData.GetCultureNotSupportedException(cultureInfo);
+        }
+    }
+}

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
@@ -7,6 +7,8 @@ namespace System.Globalization.Tests
 {
     internal static class NumberFormatInfoData
     {
+        private static bool s_isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        private static int s_WindowsVersion = DateTimeFormatInfoData.GetWindowsVersion();
         private static bool s_isOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
 
         public static int[] GetNumberGroupSizes(CultureInfo cultureInfo)
@@ -17,7 +19,7 @@ namespace System.Globalization.Tests
             }
             if (string.Equals(cultureInfo.Name, "ur-IN", StringComparison.OrdinalIgnoreCase))
             {
-                if (s_isOSX)
+                if (s_isOSX || (s_isWindows && s_WindowsVersion >= 10))
                 {
                     return new int[] { 3 };
                 }
@@ -28,6 +30,27 @@ namespace System.Globalization.Tests
             }
 
             throw DateTimeFormatInfoData.GetCultureNotSupportedException(cultureInfo);
+        }
+
+        internal static string GetNegativeInfinitySymbol(CultureInfo cultureInfo)
+        {
+            if (s_isWindows && s_WindowsVersion < 10)
+            {
+                if (string.Equals(cultureInfo.Name, "en-US", StringComparison.OrdinalIgnoreCase))
+                {
+                    return "-Infinity";
+                }
+                if (string.Equals(cultureInfo.Name, "fr-FR", StringComparison.OrdinalIgnoreCase))
+                {
+                    return "-Infini";
+                }
+
+                throw DateTimeFormatInfoData.GetCultureNotSupportedException(cultureInfo);
+            }
+            else
+            {
+                return "-\u221E";
+            }
         }
     }
 }

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoData.cs
@@ -55,19 +55,31 @@ namespace System.Globalization.Tests
 
         internal static int[] GetCurrencyNegativePatterns(CultureInfo cultureInfo)
         {
+            // CentOS uses an older ICU than Ubuntu, which means the "Linux" values need to allow for
+            // multiple values, since we can't tell which version of ICU we are using, or whether we are
+            // on CentOS or Ubuntu.
+            // When multiple values are returned, the "older" ICU value is returned last.
+
             switch (cultureInfo.Name)
             {
                 case "en-US":
-                    return s_isWindows ? new int[] { 0 } : new int[] { 1 };
+                    return s_isWindows ? new int[] { 0 } : new int[] { 1, 0 };
 
                 case "en-CA":
-                    return new int[] { 1 };
+                    return s_isWindows ? new int[] { 1 } : new int[] { 1, 0 };
 
                 case "fa-IR":
-                    return s_isWindows ? new int[] { 3 } : new int[] { 1 };
+                    return s_isWindows ? new int[] { 3 } : new int[] { 1, 0 };
 
                 case "fr-CD":
-                    return (s_isWindows && s_WindowsVersion < 10) ? new int[] { 4 } : new int[] { 8 };
+                    if (s_isWindows)
+                    {
+                        return (s_WindowsVersion < 10) ? new int[] { 4 } : new int[] { 8 };
+                    }
+                    else
+                    {
+                        return new int[] { 8, 15 };
+                    }
 
                 case "as":
                     return s_isWindows ? new int[] { 12 } : new int[] { 9 };
@@ -76,7 +88,7 @@ namespace System.Globalization.Tests
                     return (s_isWindows && s_WindowsVersion < 10) ? new int[] { 14 } : new int[] { 1 };
 
                 case "fr-CA":
-                    return s_isWindows ? new int[] { 15 } : new int[] { 8 };
+                    return s_isWindows ? new int[] { 15 } : new int[] { 8, 15 };
             }
 
             throw DateTimeFormatInfoData.GetCultureNotSupportedException(cultureInfo);

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNegativeInfinitySymbol.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNegativeInfinitySymbol.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Globalization;
-using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Globalization.Tests
@@ -12,22 +9,16 @@ namespace System.Globalization.Tests
     {
         // PosTest1: Verify value of property NegativeInfinitySymbol for specific locales
         [Theory]
-        [InlineData("en-US", "-Infinity", "-\u221E" )]
-        [InlineData("fr-FR", "-Infini", "-\u221E")]
-        public void PosTest1(string locale, string expectedWindows, string expectedIcu)
+        [InlineData("en-US")]
+        [InlineData("fr-FR")]
+        public void PosTest1(string locale)
         {
             CultureInfo myTestCulture = new CultureInfo(locale);
             NumberFormatInfo nfi = myTestCulture.NumberFormat;
+            string actual = nfi.NegativeInfinitySymbol;
+            string expected = NumberFormatInfoData.GetNegativeInfinitySymbol(myTestCulture);
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                // Windows 10 uses ICU data here, this should be cleaned up as part of #3243
-                Assert.True(nfi.NegativeInfinitySymbol == expectedWindows || nfi.NegativeInfinitySymbol == expectedIcu);
-            }
-            else
-            {
-                Assert.Equal(expectedIcu, nfi.NegativeInfinitySymbol);
-            }
+            Assert.Equal(expected, actual);
         }
     }
 }

--- a/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNumberGroupSizes.cs
+++ b/src/System.Globalization/tests/NumberFormatInfo/NumberFormatInfoNumberGroupSizes.cs
@@ -67,21 +67,15 @@ namespace System.Globalization.Tests
 
         // TestNumberGroupSizesLocale: Verify value of property NumberGroupSizes for specific locales
         [Theory]
-        [InlineData("en-US", 3, 0)]
-        [InlineData("ur-IN", 3, 2)]
-        [ActiveIssue(3243)]
-        public void TestNumberGroupSizesLocale(string locale, int primaryGroupSize, int secondaryGroupSize)
+        [InlineData("en-US")]
+        [InlineData("ur-IN")]
+        public void TestNumberGroupSizesLocale(string locale)
         {
             CultureInfo myTestCulture = new CultureInfo(locale);
             NumberFormatInfo nfi = myTestCulture.NumberFormat;
-            int count = (secondaryGroupSize == 0) ? 1 : 2;
 
-            Assert.Equal(primaryGroupSize, nfi.NumberGroupSizes[0]);
-            Assert.Equal(count, nfi.NumberGroupSizes.Length);
-            if (count == 2)
-            {
-                Assert.Equal(secondaryGroupSize, nfi.NumberGroupSizes[1]);
-            }
+            int[] expected = NumberFormatInfoData.GetNumberGroupSizes(myTestCulture);
+            Assert.Equal(expected, nfi.NumberGroupSizes);
         }
 
         private void VerificationHelper<T>(int[] intArray) where T : Exception

--- a/src/System.Globalization/tests/System.Globalization.Tests.csproj
+++ b/src/System.Globalization/tests/System.Globalization.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -19,6 +19,7 @@
   <ItemGroup>
     <Compile Include="CompareInfo.cs" />
     <Compile Include="CompareInfo.TestData.cs" />
+    <Compile Include="NumberFormatInfo\NumberFormatInfoData.cs" />
     <Compile Include="NumberFormatInfo\NumberFormatInfoCurrencySymbol.cs" />
     <Compile Include="NumberFormatInfo\NumberFormatInfoNegativeInfinitySymbol.cs" />
     <Compile Include="NumberFormatInfo\NumberFormatInfoNumberDecimalDigits.cs" />


### PR DESCRIPTION
There were a few tests that were disabled and/or had TODO comments in them to clean their handling of culture and OS differences.  I've cleaned them up following the established pattern in other tests.

Fix #3243

@ellismg @tarekgh 