### PR TITLE
Add Unix support for X500DistinguishedName.Format

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
@@ -38,7 +38,11 @@ namespace Internal.Cryptography.Pal
 
         public string X500DistinguishedNameFormat(byte[] encodedDistinguishedName, bool multiLine)
         {
-            throw new NotImplementedException();
+            return X500NameEncoder.X500DistinguishedNameDecode(
+                encodedDistinguishedName,
+                true,
+                multiLine ? X500DistinguishedNameFlags.UseNewLines : X500DistinguishedNameFlags.None,
+                multiLine);
         }
 
         public X509ContentType GetCertContentType(byte[] rawData)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/X500NameEncoder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/X500NameEncoder.cs
@@ -29,7 +29,8 @@ namespace Internal.Cryptography.Pal
         internal static string X500DistinguishedNameDecode(
             byte[] encodedName,
             bool printOid,
-            X500DistinguishedNameFlags flags)
+            X500DistinguishedNameFlags flags,
+            bool addTrailingDelimieter=false)
         {
             bool reverse = (flags & X500DistinguishedNameFlags.Reversed) == X500DistinguishedNameFlags.Reversed;
             bool quoteIfNeeded = (flags & X500DistinguishedNameFlags.DoNotUseQuotes) != X500DistinguishedNameFlags.DoNotUseQuotes;
@@ -139,6 +140,11 @@ namespace Internal.Cryptography.Pal
                             decodedName.Append('"');
                         }
                     }
+                }
+
+                if (addTrailingDelimieter)
+                {
+                    decodedName.Append(dnSeparator);
                 }
 
                 return decodedName.ToString();

--- a/src/System.Security.Cryptography.X509Certificates/tests/NameTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/NameTests.cs
@@ -33,20 +33,74 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.Equal(encoding, rawData);
         }
 
-        [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
-        public static void TestFormat()
+        [Theory]
+        [InlineData(X500DistinguishedNameFlags.UseCommas)]
+        [InlineData(X500DistinguishedNameFlags.UseSemicolons)]
+        [InlineData(X500DistinguishedNameFlags.UseNewLines)]
+        public static void TestDecodeFormats(X500DistinguishedNameFlags format)
         {
-            byte[] encoding = "300e310c300a06035504031303466f6f".HexToByteArray();
-            String s;
+            // The Issuer field from the Microsoft.com test cert.
+            byte[] encoding = (
+                "3077310B3009060355040613025553311D301B060355040A131453796D616E74" +
+                "656320436F72706F726174696F6E311F301D060355040B131653796D616E7465" +
+                "63205472757374204E6574776F726B312830260603550403131F53796D616E74" +
+                "656320436C61737320332045562053534C204341202D204733").HexToByteArray();
 
-            X500DistinguishedName n = new X500DistinguishedName(encoding);
+            X500DistinguishedName name = new X500DistinguishedName(encoding);
+            string delimiter;
 
-            s = n.Format(multiLine: false);
-            Assert.Equal("CN=Foo", s);
+            switch (format)
+            {
+                case X500DistinguishedNameFlags.UseCommas:
+                    delimiter = ", ";
+                    break;
+                case X500DistinguishedNameFlags.UseSemicolons:
+                    delimiter = "; ";
+                    break;
+                case X500DistinguishedNameFlags.UseNewLines:
+                    delimiter = Environment.NewLine;
+                    break;
+                default:
+                    throw new InvalidOperationException("No handler for format: " + format);
+            }
 
-            s = n.Format(multiLine: true);
-            Assert.Equal("CN=Foo\r\n", s);
+            string expected = string.Format(
+                "C=US{0}O=Symantec Corporation{0}OU=Symantec Trust Network{0}CN=Symantec Class 3 EV SSL CA - G3",
+                delimiter);
+
+            string actual = name.Decode(format);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public static void TestFormat(bool multiLine)
+        {
+            // The Issuer field from the Microsoft.com test cert.
+            byte[] encoding = (
+                "3077310B3009060355040613025553311D301B060355040A131453796D616E74" +
+                "656320436F72706F726174696F6E311F301D060355040B131653796D616E7465" +
+                "63205472757374204E6574776F726B312830260603550403131F53796D616E74" +
+                "656320436C61737320332045562053534C204341202D204733").HexToByteArray();
+
+            X500DistinguishedName name = new X500DistinguishedName(encoding);
+            string formatted = name.Format(multiLine);
+            string expected;
+
+            if (multiLine)
+            {
+                expected = string.Format(
+                    "C=US{0}O=Symantec Corporation{0}OU=Symantec Trust Network{0}CN=Symantec Class 3 EV SSL CA - G3{0}",
+                    Environment.NewLine);
+            }
+            else
+            {
+                expected = "C=US, O=Symantec Corporation, OU=Symantec Trust Network, CN=Symantec Class 3 EV SSL CA - G3";
+            }
+
+            Assert.Equal(expected, formatted);
         }
     }
 }


### PR DESCRIPTION
Format(false) is the same as Decode(None).
Format(true) is the same as Decode(UseNewLines), except it also has a newline at the end.  This is enabled to telling X500DistinguishedNameDecode to just add an extra delimiter in multiLine mode.

This is a partial fix for #1993.