### PR TITLE
Handle overflow in BigInteger.Pow

### DIFF
--- a/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.PowMod.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/BigIntegerCalculator.PowMod.cs
@@ -59,10 +59,13 @@ namespace System.Numerics
 
             while (power != 0)
             {
-                if ((power & 1) == 1)
-                    resultLength += valueLength;
-                if (power != 1)
-                    valueLength += valueLength;
+                checked
+                {
+                    if ((power & 1) == 1)
+                        resultLength += valueLength;
+                    if (power != 1)
+                        valueLength += valueLength;
+                }
                 power = power >> 1;
             }
 

--- a/src/System.Runtime.Numerics/tests/BigInteger/pow.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/pow.cs
@@ -167,6 +167,16 @@ namespace System.Numerics.Tests
             }
         }
 
+        [Fact]
+        public static void RunOverflow()
+        {
+            var bytes = new byte[1000];
+            bytes[bytes.Length - 1] = 1;
+
+            Assert.Throws<OverflowException>(() =>
+                BigInteger.Pow(new BigInteger(bytes), int.MaxValue));
+        }
+
         private static void VerifyPowString(string opstring)
         {
             StackCalc sc = new StackCalc(opstring);


### PR DESCRIPTION
Calling Pow on a big integer with a very large exponent leads naturally
to an overflow, which should result in an ordinary OverflowException.
The current implementation estimates the result buffer, which leads to
an unexpected behavior, since that estimate overflows silently. Adding
`checked` to the estimate fixes this.