### PR TITLE
Add clean.sh for Linux dev workflow

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -25,6 +25,8 @@
 
   <Import Project="dir.traversal.targets" />
 
+  <Import Project="$(ToolsDir)clean.targets" />
+
   <PropertyGroup>
     <!--
       Until we have the full clean\sync\build dev workflow in place we still default to restoring during build.
@@ -83,19 +85,6 @@
   <!-- Override clean from dir.traversal.targets and just remove the full BinDir -->
   <Target Name="Clean">
     <RemoveDir Directories="$(BinDir)" />
-  </Target>
-
-  <PropertyGroup>
-    <UserLocalFolder Condition="'$(OsEnvironment)'!='Unix'">$(LocalAppData)/</UserLocalFolder>
-    <UserLocalFolder Condition="'$(OsEnvironment)'=='Unix'">$(HOME)/.local/share/</UserLocalFolder>
-  </PropertyGroup>
-
-  <Target Name="CleanPackages">
-    <RemoveDir Directories="$(PackagesDir)" />
-  </Target>
-
-  <Target Name="CleanPackagesCache">
-    <RemoveDir Directories="$(UserLocalFolder)NuGet/Cache/;$(UserLocalFolder)NuGet/v3-cache/;$(UserLocalFolder)dnu/cache/" />
   </Target>
 
 </Project>

--- a/clean.cmd
+++ b/clean.cmd
@@ -13,6 +13,7 @@ set clean_targets=
 set clean_src=
 set clean_tools=
 set clean_all=
+set clean_successful=true
 
 :Loop
 if [%1] == [] goto Begin
@@ -61,35 +62,47 @@ goto Loop
 
 :Begin
 
+echo Running init-tools.cmd
 call %~dp0init-tools.cmd
 
 if /I [%clean_src%] == [true] (
   echo Cleaning src directory ...
-  call git clean %~dp0src -xdf >> %cleanlog%
+  echo. >> %cleanlog% && echo git clean -xdf %~dp0src >> %cleanlog%
+  call git clean -xdf %~dp0src >> %cleanlog%
+  call :CheckErrorLevel
 )
 
 if NOT "%clean_targets%" == "" (
   echo Running msbuild clean targets "%clean_targets:~0,-1%" ...
-  echo msbuild.exe %~dp0build.proj /t:%clean_targets:~0,-1% /nologo /v:minimal /flp:v=detailed;Append;LogFile=%cleanlog% >> %cleanlog%
+  echo. >> %cleanlog% && echo msbuild.exe %~dp0build.proj /t:%clean_targets:~0,-1% /nologo /v:minimal /flp:v=detailed;Append;LogFile=%cleanlog% >> %cleanlog%
   call msbuild.exe %~dp0build.proj /t:%clean_targets:~0,-1% /nologo /v:minimal /flp:v=detailed;Append;LogFile=%cleanlog%
-  if NOT [%ERRORLEVEL%]==[0] (
-    echo ERROR: An error occurred while cleaning, see %cleanlog% for more details.
-    exit /b
-  )
+  call :CheckErrorLevel
 )
 
 if /I [%clean_tools%] == [true] (
   echo Cleaning tools directory ...
-  rmdir /s /q %~dp0tools >> %cleanlog%dir
+  echo. >> %cleanlog% && echo rmdir /s /q %~dp0tools >> %cleanlog%
+  rmdir /s /q %~dp0tools >> %cleanlog%
+  REM Don't call CheckErrorLevel because if the Tools directory didn't exist when this script was
+  REM invoked, then it sometimes exits with error level 3 despite successfully deleting the directory.
 )
 
 if /I [%clean_all%] == [true] (
   echo Cleaning entire working directory ...
-  call git clean %~dp0 -xdf >> %cleanlog%
+  echo. >> %cleanlog% && echo git clean -xdf -e clean.log %~dp0 >> %cleanlog%
+  call git clean -xdf -e clean.log %~dp0 >> %cleanlog%
+  call :CheckErrorLevel
 )
 
-echo Done Cleaning.
-exit /b 0
+if /I [%clean_successful%] == [true] (
+  echo Clean completed successfully.
+  echo. >> %cleanlog% && echo Clean completed successfully. >> %cleanlog%
+  exit /b 0
+) else (
+  echo An error occured while cleaning; see %cleanlog% for more details.
+  echo. >> %cleanlog% && echo Clean completed with errors. >> %cleanlog%
+  exit /b 1
+)
 
 :Usage
 echo.
@@ -104,3 +117,12 @@ echo     /s     - Deletes the untracked files under src directory (git clean src
 echo     /all   - Combines all of the above.
 echo.
 echo If no option is specified then clean.cmd /b is implied.
+
+exit /b 1
+
+:CheckErrorLevel
+if NOT [%ERRORLEVEL%]==[0] (
+  echo Command exited with ERRORLEVEL %ERRORLEVEL% >> %cleanlog%
+  set clean_successful=false
+)
+exit /b

--- a/clean.sh
+++ b/clean.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+usage()
+{
+    echo "Usage: clean [options]"
+    echo "Cleans the local dev environment."
+    echo
+    echo "  -b         Delete the binary output directory"
+    echo "  -p         Delete the repo-local NuGet package directory"
+    echo "  -c         Delete the user-local NuGet package caches"
+    echo "  -t         Delete the tools directory"
+    echo "  -s         Remove all untracked files under the src directory"
+    echo "  -a, --all  Clean all of the above"
+    echo
+    echo "If no option is specified, then \"clean.sh -b\" is implied."
+    exit 1
+}
+
+check_exit_status()
+{
+    ExitStatus=$?
+    if [ $ExitStatus -ne 0 ]
+    then
+        echo "Command exited with exit status $ExitStatus" >> $CleanLog
+        CleanSuccessful=false
+    fi
+}
+
+WorkingTreeRoot="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+CleanLog=$WorkingTreeRoot/clean.log
+CleanSuccessful=true
+CleanTargets=
+
+# Parse arguments
+
+echo "Running clean.sh $*" > $CleanLog
+
+if [ $# == 0 ]
+then
+    CleanTargets="Clean;"
+fi
+
+while [[ $# > 0 ]]
+do
+    opt="$1"
+    case $opt in
+        -h|--help)
+        usage
+        ;;
+        -b)
+        CleanTargets="Clean;$CleanTargets"
+        ;;
+        -p)
+        CleanTargets="CleanPackages;$CleanTargets"
+        ;;
+        -c)
+        CleanTargets="CleanPackagesCache;$CleanTargets"
+        ;;
+        -t)
+        CleanToolsDir=true
+        ;;
+        -s)
+        CleanSrc=true
+        ;;
+        -a|--all)
+        CleanWorkingTree=true
+        CleanTargets="Clean;CleanPackages;CleanPackagesCache;"
+        ;;
+        *)
+        echo "Unrecognized argument '$opt'"
+        echo "Use 'clean -h' for help."
+        exit 1
+        ;;
+    esac
+    shift
+done
+
+echo "Running init-tools.sh"
+$WorkingTreeRoot/init-tools.sh
+
+if [ -n "$CleanTargets" ]
+then
+    echo "Running MSBuild target(s): ${CleanTargets:0:-1}"
+    echo -e "\n$WorkingTreeRoot/Tools/corerun $WorkingTreeRoot/Tools/MSBuild.exe $WorkingTreeRoot/build.proj /t:${CleanTargets:0:-1} /nologo /verbosity:minimal /flp:v=detailed;Append;LogFile=$CleanLog" >> $CleanLog
+    $WorkingTreeRoot/Tools/corerun $WorkingTreeRoot/Tools/MSBuild.exe $WorkingTreeRoot/build.proj /t:${CleanTargets:0:-1} /nologo /verbosity:minimal "/flp:v=detailed;Append;LogFile=$CleanLog"
+    check_exit_status
+fi
+
+if [ "$CleanToolsDir" == true ] && [ "$CleanWorkingTree" != true ]
+then
+    echo "Removing Tools directory"
+    # This directory cannot be removed in a build target because MSBuild is in the Tools directory
+    echo -e "\nrm -rf $WorkingTreeRoot/Tools" >> $CleanLog
+    rm -rf $WorkingTreeRoot/Tools >> $CleanLog
+    check_exit_status
+fi
+
+if [ "$CleanSrc" == true ] && [ "$CleanWorkingTree" != true ]
+then
+    echo "Removing all untracked files in the src directory"
+    echo -e "\ngit clean -xdf $WorkingTreeRoot/src" >> $CleanLog
+    git clean -xdf $WorkingTreeRoot/src >> $CleanLog
+    check_exit_status
+fi
+
+if [ "$CleanWorkingTree" == true ]
+then
+    echo "Removing all untracked files in the working tree"
+    echo -e "\ngit clean -xdf -e clean.log $WorkingTreeRoot" >> $CleanLog
+    git clean -xdf -e clean.log $WorkingTreeRoot >> $CleanLog
+    check_exit_status
+fi
+
+if [ "$CleanSuccessful" == true ]
+then
+    echo "Clean completed successfully."
+    echo -e "\nClean completed successfully." >> $CleanLog
+    exit 0
+else
+    echo "An error occured while cleaning; see $CleanLog for more details."
+    echo -e "\nClean completed with errors." >> $CleanLog
+    exit 1
+fi


### PR DESCRIPTION
This script provides a convenient way to clean the local dev environment
on Linux.  It provides options for removing the bin directory, the
packages directory and NuGet package caches, and all untracked files in
the working tree.

A corresponding clean.cmd script is planned for Windows.

cc: @ellismg @maririos @weshaggard 