### PR TITLE
Fix SByte overflow in Vector<T> tests

### DIFF
--- a/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
+++ b/src/System.Numerics.Vectors/tests/GenericVectorTests.cs
@@ -1201,7 +1201,6 @@ namespace System.Numerics.Tests
         [Fact]
         public void GreaterThanOrEqualAnyByte() { TestVectorGreaterThanOrEqualAny<Byte>(); }
         [Fact]
-        [ActiveIssue(3262)]
         public void GreaterThanOrEqualAnySByte() { TestVectorGreaterThanOrEqualAny<SByte>(); }
         [Fact]
         public void GreaterThanOrEqualAnyUInt16() { TestVectorGreaterThanOrEqualAny<UInt16>(); }
@@ -1221,24 +1220,28 @@ namespace System.Numerics.Tests
         public void GreaterThanOrEqualAnyDouble() { TestVectorGreaterThanOrEqualAny<Double>(); }
         private void TestVectorGreaterThanOrEqualAny<T>() where T : struct
         {
+            int maxT = GetMaxValue<T>();
+            double maxStep = (double)maxT / (double)Vector<T>.Count;
+            double halfStep = maxStep / 2;
+
             T[] values1 = new T[Vector<T>.Count];
             for (int g = 0; g < Vector<T>.Count; g++)
             {
-                values1[g] = (T)(dynamic)(g);
+                values1[g] = (T)(dynamic)(g * halfStep);
             }
             Vector<T> vec1 = new Vector<T>(values1);
 
             T[] values2 = new T[Vector<T>.Count];
             for (int g = 0; g < Vector<T>.Count; g++)
             {
-                values2[g] = (T)(dynamic)(g * 5);
+                values2[g] = (T)(dynamic)(g * maxStep);
             }
             Vector<T> vec2 = new Vector<T>(values2);
 
             T[] values3 = new T[Vector<T>.Count];
             for (int g = 0; g < Vector<T>.Count; g++)
             {
-                values3[g] = (T)(dynamic)(g * 5 + 3);
+                values3[g] = (T)(dynamic)((g + 1) * maxStep);
             }
             Vector<T> vec3 = new Vector<T>(values3);
 
@@ -1257,7 +1260,6 @@ namespace System.Numerics.Tests
         [Fact]
         public void GreaterThanOrEqualAllByte() { TestVectorGreaterThanOrEqualAll<Byte>(); }
         [Fact]
-        [ActiveIssue(3262)]
         public void GreaterThanOrEqualAllSByte() { TestVectorGreaterThanOrEqualAll<SByte>(); }
         [Fact]
         public void GreaterThanOrEqualAllUInt16() { TestVectorGreaterThanOrEqualAll<UInt16>(); }
@@ -1277,24 +1279,28 @@ namespace System.Numerics.Tests
         public void GreaterThanOrEqualAllDouble() { TestVectorGreaterThanOrEqualAll<Double>(); }
         private void TestVectorGreaterThanOrEqualAll<T>() where T : struct
         {
+            int maxT = GetMaxValue<T>();
+            double maxStep = (double)maxT / (double)Vector<T>.Count;
+            double halfStep = maxStep / 2;
+
             T[] values1 = new T[Vector<T>.Count];
             for (int g = 0; g < Vector<T>.Count; g++)
             {
-                values1[g] = (T)(dynamic)(g);
+                values1[g] = (T)(dynamic)(g * halfStep);
             }
             Vector<T> vec1 = new Vector<T>(values1);
 
             T[] values2 = new T[Vector<T>.Count];
             for (int g = 0; g < Vector<T>.Count; g++)
             {
-                values2[g] = (T)(dynamic)(g * 5);
+                values2[g] = (T)(dynamic)(g * maxStep);
             }
             Vector<T> vec2 = new Vector<T>(values2);
 
             T[] values3 = new T[Vector<T>.Count];
             for (int g = 0; g < Vector<T>.Count; g++)
             {
-                values3[g] = (T)(dynamic)(g * 5 + 3);
+                values3[g] = (T)(dynamic)((g + 1) * maxStep);
             }
             Vector<T> vec3 = new Vector<T>(values3);
 

--- a/src/System.Numerics.Vectors/tests/GenericVectorTests.tt
+++ b/src/System.Numerics.Vectors/tests/GenericVectorTests.tt
@@ -869,33 +869,34 @@ namespace System.Numerics.Tests
     {
 #>
         [Fact]
-<# if (type == typeof(SByte)) { #>
-        [ActiveIssue(3262)]
-<# } #>
         public void GreaterThanOrEqualAny<#=type.Name#>() { TestVectorGreaterThanOrEqualAny<<#=type.Name#>>(); }
 <#
     }
 #>
         private void TestVectorGreaterThanOrEqualAny<T>() where T : struct
         {
+            int maxT = GetMaxValue<T>();
+            double maxStep = (double)maxT / (double)Vector<T>.Count;
+            double halfStep = maxStep / 2;
+
             T[] values1 = new T[Vector<T>.Count];
             for (int g = 0; g < Vector<T>.Count; g++)
             {
-                values1[g] = (T)(dynamic)(g);
+                values1[g] = (T)(dynamic)(g * halfStep);
             }
             Vector<T> vec1 = new Vector<T>(values1);
 
             T[] values2 = new T[Vector<T>.Count];
             for (int g = 0; g < Vector<T>.Count; g++)
             {
-                values2[g] = (T)(dynamic)(g * 5);
+                values2[g] = (T)(dynamic)(g * maxStep);
             }
             Vector<T> vec2 = new Vector<T>(values2);
 
             T[] values3 = new T[Vector<T>.Count];
             for (int g = 0; g < Vector<T>.Count; g++)
             {
-                values3[g] = (T)(dynamic)(g * 5 + 3);
+                values3[g] = (T)(dynamic)((g + 1) * maxStep);
             }
             Vector<T> vec3 = new Vector<T>(values3);
 
@@ -916,33 +917,34 @@ namespace System.Numerics.Tests
     {
 #>
         [Fact]
-<# if (type == typeof(SByte)) { #>
-        [ActiveIssue(3262)]
-<# } #>
         public void GreaterThanOrEqualAll<#=type.Name#>() { TestVectorGreaterThanOrEqualAll<<#=type.Name#>>(); }
 <#
     }
 #>
         private void TestVectorGreaterThanOrEqualAll<T>() where T : struct
         {
+            int maxT = GetMaxValue<T>();
+            double maxStep = (double)maxT / (double)Vector<T>.Count;
+            double halfStep = maxStep / 2;
+
             T[] values1 = new T[Vector<T>.Count];
             for (int g = 0; g < Vector<T>.Count; g++)
             {
-                values1[g] = (T)(dynamic)(g);
+                values1[g] = (T)(dynamic)(g * halfStep);
             }
             Vector<T> vec1 = new Vector<T>(values1);
 
             T[] values2 = new T[Vector<T>.Count];
             for (int g = 0; g < Vector<T>.Count; g++)
             {
-                values2[g] = (T)(dynamic)(g * 5);
+                values2[g] = (T)(dynamic)(g * maxStep);
             }
             Vector<T> vec2 = new Vector<T>(values2);
 
             T[] values3 = new T[Vector<T>.Count];
             for (int g = 0; g < Vector<T>.Count; g++)
             {
-                values3[g] = (T)(dynamic)(g * 5 + 3);
+                values3[g] = (T)(dynamic)((g + 1) * maxStep);
             }
             Vector<T> vec3 = new Vector<T>(values3);
 


### PR DESCRIPTION
This fixes #3066 .

I've fixed the issue by computing a "step size" for the generated values. This still ensures that the three arrays have the same relationship to each other (i.e. the first is less than the second, which is less than the third, with some overlap), but will not overflow in any configuration.

(The CI won't notice if this fixes anything because the CI machines don't have AVX2 CPUs.)

@weshaggard 