### PR TITLE
Support reading resources from non-zero offset

### DIFF
--- a/src/System.Resources.Reader/src/System/Resources/StreamExtensions.cs
+++ b/src/System.Resources.Reader/src/System/Resources/StreamExtensions.cs
@@ -34,7 +34,7 @@ namespace System.Resources
         //blatantly copied over from BinaryReader
         public static bool TryReadInt327BitEncoded(this Stream stream, out int result)
         {
-            // Read out an Int32 7 bits at a time.  The high bit
+            // Read out an int 7 bits at a time.  The high bit
             // of the byte when on means to continue reading more bytes.
             result = 0;
             int shift = 0;
@@ -43,7 +43,7 @@ namespace System.Resources
             {
                 // Check for a corrupted stream.  Read a max of 5 bytes.
                 // In a future version, add a DataFormatException.
-                if (shift == 5 * 7)  // 5 bytes max per Int32, shift += 7
+                if (shift == 5 * 7)  // 5 bytes max per int, shift += 7
                     throw new FormatException(SR.Format_Bad7BitInt32);
 
                 // ReadByte handles end of stream cases for us.
@@ -61,8 +61,8 @@ namespace System.Resources
             return true;
         }
 
-        // reads length (7-bit encoded Int32) + UTF8 buffer
-        internal static string ReadString(this Stream stream, bool utf16 = false)
+        // reads length (7-bit encoded int) + UTF8 buffer
+        public static string ReadString(this Stream stream, bool utf16 = false)
         {
             var position = stream.Position;
             int stringLength;

--- a/src/System.Resources.Reader/src/project.lock.json
+++ b/src/System.Resources.Reader/src/project.lock.json
@@ -393,6 +393,7 @@
   "libraries": {
     "System.Diagnostics.Debug/4.0.10": {
       "type": "package",
+      "serviceable": true,
       "sha512": "pi2KthuvI2LWV2c2V+fwReDsDiKpNl040h6DcwFOb59SafsPT/V1fCy0z66OKwysurJkBMmp5j5CBe3Um+ub0g==",
       "files": [
         "lib/DNXCore50/System.Diagnostics.Debug.dll",
@@ -474,6 +475,7 @@
     },
     "System.IO/4.0.10": {
       "type": "package",
+      "serviceable": true,
       "sha512": "kghf1CeYT+W2lw8a50/GxFz5HR9t6RkL4BvjxtTp1NxtEFWywnMA9W8FH/KYXiDNThcw9u/GOViDON4iJFGXIQ==",
       "files": [
         "lib/DNXCore50/System.IO.dll",
@@ -507,6 +509,7 @@
     },
     "System.Private.Uri/4.0.0": {
       "type": "package",
+      "serviceable": true,
       "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
       "files": [
         "lib/DNXCore50/System.Private.Uri.dll",
@@ -569,6 +572,7 @@
     },
     "System.Reflection.Primitives/4.0.0": {
       "type": "package",
+      "serviceable": true,
       "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
       "files": [
         "lib/DNXCore50/System.Reflection.Primitives.dll",
@@ -602,6 +606,7 @@
     },
     "System.Resources.ResourceManager/4.0.0": {
       "type": "package",
+      "serviceable": true,
       "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
       "files": [
         "lib/DNXCore50/System.Resources.ResourceManager.dll",
@@ -635,6 +640,7 @@
     },
     "System.Runtime/4.0.20": {
       "type": "package",
+      "serviceable": true,
       "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
       "files": [
         "lib/DNXCore50/System.Runtime.dll",
@@ -701,6 +707,7 @@
     },
     "System.Threading/4.0.10": {
       "type": "package",
+      "serviceable": true,
       "sha512": "0w6pRxIEE7wuiOJeKabkDgeIKmqf4ER1VNrs6qFwHnooEE78yHwi/bKkg5Jo8/pzGLm0xQJw0nEmPXt1QBAIUA==",
       "files": [
         "lib/DNXCore50/System.Threading.dll",

--- a/src/System.Resources.Reader/tests/ResourceReaderUnitTest.cs
+++ b/src/System.Resources.Reader/tests/ResourceReaderUnitTest.cs
@@ -1,15 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.Collections;
+using System.Collections.Generic;
 using System.IO;
-using System.Text;
-using System.Linq;
-using System.Collections.ObjectModel;
-using System.Globalization;
-using System.Resources;
 using Xunit;
 
 namespace System.Resources.ResourceWriterTests
@@ -40,17 +34,28 @@ namespace System.Resources.ResourceWriterTests
             return rw;
         }
 
-        [Fact]
-        public static void ReadResource()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(8)]
+        [InlineData(100)]
+        public static void ReadResource(int numberOfLeadingBytes)
         {
-
-            using (var ms2 = new MemoryStream())
+            var buffer = new byte[4096];
+            using (var ms2 = new MemoryStream(buffer, true))
             {
+                ms2.Write(new byte[numberOfLeadingBytes], 0, numberOfLeadingBytes);
                 using (var rw = GenerateResourceStream(s_dict, ms2))
                 {
                     //Rewind to begining of stream
 
-                    ms2.Seek(0L, SeekOrigin.Begin);
+                    ms2.Seek(numberOfLeadingBytes, SeekOrigin.Begin);
 
                     var reder = new ResourceReader(ms2);
 
@@ -67,8 +72,8 @@ namespace System.Resources.ResourceWriterTests
                     Assert.True(s_found_list.Count == s_dict.Count);
                 }
             }
-
         }
+
         [Fact]
         public static void ReadResource1()
         {

--- a/src/System.Resources.Reader/tests/System.Resources.Reader.Tests.csproj
+++ b/src/System.Resources.Reader/tests/System.Resources.Reader.Tests.csproj
@@ -8,6 +8,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Resources.Reader.Tests</AssemblyName>
     <RootNamespace>System.Resources.Reader.Tests</RootNamespace>
+    <ProjectGuid>{8D7202E8-084A-4C20-AB93-3BF70D2E0651}</ProjectGuid>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Resources.Reader/tests/project.lock.json
+++ b/src/System.Resources.Reader/tests/project.lock.json
@@ -352,7 +352,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00121": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00122": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -728,7 +728,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00121": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00122": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1104,7 +1104,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00121": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00122": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1134,6 +1134,7 @@
   "libraries": {
     "System.Collections/4.0.10": {
       "type": "package",
+      "serviceable": true,
       "sha512": "ux6ilcZZjV/Gp7JEZpe+2V1eTueq6NuoGRM3eZCFuPM25hLVVgCRuea6STW8hvqreIOE59irJk5/ovpA5xQipw==",
       "files": [
         "lib/DNXCore50/System.Collections.dll",
@@ -1167,6 +1168,7 @@
     },
     "System.Diagnostics.Debug/4.0.10": {
       "type": "package",
+      "serviceable": true,
       "sha512": "pi2KthuvI2LWV2c2V+fwReDsDiKpNl040h6DcwFOb59SafsPT/V1fCy0z66OKwysurJkBMmp5j5CBe3Um+ub0g==",
       "files": [
         "lib/DNXCore50/System.Diagnostics.Debug.dll",
@@ -1248,6 +1250,7 @@
     },
     "System.IO/4.0.10": {
       "type": "package",
+      "serviceable": true,
       "sha512": "kghf1CeYT+W2lw8a50/GxFz5HR9t6RkL4BvjxtTp1NxtEFWywnMA9W8FH/KYXiDNThcw9u/GOViDON4iJFGXIQ==",
       "files": [
         "lib/DNXCore50/System.IO.dll",
@@ -1281,6 +1284,7 @@
     },
     "System.Linq/4.0.0": {
       "type": "package",
+      "serviceable": true,
       "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
       "files": [
         "lib/dotnet/System.Linq.dll",
@@ -1409,6 +1413,7 @@
     },
     "System.Private.Uri/4.0.0": {
       "type": "package",
+      "serviceable": true,
       "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
       "files": [
         "lib/DNXCore50/System.Private.Uri.dll",
@@ -1456,6 +1461,7 @@
     },
     "System.Reflection.Extensions/4.0.0": {
       "type": "package",
+      "serviceable": true,
       "sha512": "dbYaZWCyFAu1TGYUqR2n+Q+1casSHPR2vVW0WVNkXpZbrd2BXcZ7cpvpu9C98CTHtNmyfMWCLpCclDqly23t6A==",
       "files": [
         "lib/DNXCore50/System.Reflection.Extensions.dll",
@@ -1489,6 +1495,7 @@
     },
     "System.Reflection.Primitives/4.0.0": {
       "type": "package",
+      "serviceable": true,
       "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
       "files": [
         "lib/DNXCore50/System.Reflection.Primitives.dll",
@@ -1522,6 +1529,7 @@
     },
     "System.Resources.ResourceManager/4.0.0": {
       "type": "package",
+      "serviceable": true,
       "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
       "files": [
         "lib/DNXCore50/System.Resources.ResourceManager.dll",
@@ -1555,6 +1563,7 @@
     },
     "System.Runtime/4.0.20": {
       "type": "package",
+      "serviceable": true,
       "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
       "files": [
         "lib/DNXCore50/System.Runtime.dll",
@@ -1588,6 +1597,7 @@
     },
     "System.Runtime.Extensions/4.0.10": {
       "type": "package",
+      "serviceable": true,
       "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
       "files": [
         "lib/DNXCore50/System.Runtime.Extensions.dll",
@@ -1621,6 +1631,7 @@
     },
     "System.Runtime.Handles/4.0.0": {
       "type": "package",
+      "serviceable": true,
       "sha512": "638VhpRq63tVcQ6HDb3um3R/J2BtR1Sa96toHo6PcJGPXEPEsleCuqhBgX2gFCz0y0qkutANwW6VPPY5wQu1XQ==",
       "files": [
         "lib/DNXCore50/System.Runtime.Handles.dll",
@@ -1654,6 +1665,7 @@
     },
     "System.Runtime.InteropServices/4.0.20": {
       "type": "package",
+      "serviceable": true,
       "sha512": "ZgDyBYfEnjWoz/viS6VOswA6XOkDSH2DzgbpczbW50RywhnCgTl+w3JEvtAiOGyIh8cyx1NJq80jsNBSUr8Pig==",
       "files": [
         "lib/DNXCore50/System.Runtime.InteropServices.dll",
@@ -1687,6 +1699,7 @@
     },
     "System.Runtime.InteropServices.RuntimeInformation/4.0.0-beta-23213": {
       "type": "package",
+      "serviceable": true,
       "sha512": "yzVJM7dF6XqnGTkv2IRufKs8AiqDpfdfBvMT5sVgY2fCtUXdkcjxiIWzaVIau8IYrJUlQDmSpeQ8NV6l1vz0Lg==",
       "files": [
         "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll",
@@ -1787,6 +1800,7 @@
     },
     "System.Threading/4.0.10": {
       "type": "package",
+      "serviceable": true,
       "sha512": "0w6pRxIEE7wuiOJeKabkDgeIKmqf4ER1VNrs6qFwHnooEE78yHwi/bKkg5Jo8/pzGLm0xQJw0nEmPXt1QBAIUA==",
       "files": [
         "lib/DNXCore50/System.Threading.dll",
@@ -1820,6 +1834,7 @@
     },
     "System.Threading.Tasks/4.0.10": {
       "type": "package",
+      "serviceable": true,
       "sha512": "NOwJGDfk79jR0bnzosbXLVD/PdI8KzBeESoa3CofEM5v9R5EBfcI0Jyf18stx+0IYV9okmDIDxVtxq9TbnR9bQ==",
       "files": [
         "lib/DNXCore50/System.Threading.Tasks.dll",
@@ -1968,13 +1983,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00121": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00122": {
       "type": "package",
-      "sha512": "mNlM09rW84INiukmuUCukBf+MW/VZWsy6Nhnc7l7WqAwzkvdIS3BEzA7tQvfaL6XN2bFEULqsDaW5kapvmAzOg==",
+      "serviceable": true,
+      "sha512": "eSQ1Jo09hXNAFL+JfcqiiN7+GuOO78RZoXd0darX4V0xYopw0sbe/wxTy54fXE2TvlQj9l7943j5FN2Psz9TWA==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00121.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00121.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00122.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00122.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }


### PR DESCRIPTION
Before this change, the reader assumes that the beginning of the resource stream is the absolute beginning of the stream, i.e. that the resources start at stream position 0.

This means the reader cannot be used to read resources from an assembly, as resources are embedded not at the beginning of assemblies.

This change fixes this issue.