### PR TITLE
Remove workaround from System.Net.Requests tests project

### DIFF
--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -1,9 +1,9 @@
 {
     "dependencies": {
-      "Microsoft.NETCore.Platforms": "1.0.1-rc2-23519",
-      "Microsoft.NETCore.TestHost": "1.0.0-rc2-23519",
-      "Microsoft.NETCore.Console": "1.0.0-rc2-23519",
-      "System.IO.Compression": "4.1.0-rc2-23519",
+      "Microsoft.NETCore.Platforms": "1.0.1-rc2-23525",
+      "Microsoft.NETCore.TestHost": "1.0.0-rc2-23525",
+      "Microsoft.NETCore.Console": "1.0.0-rc2-23525",
+      "System.IO.Compression": "4.1.0-rc2-23525",
 
       "coveralls.io": "1.4",
       "OpenCover": "4.6.166",

--- a/src/Common/test-runtime/project.lock.json
+++ b/src/Common/test-runtime/project.lock.json
@@ -6,7 +6,7 @@
       "coveralls.io/1.4.0": {
         "type": "package"
       },
-      "Microsoft.CSharp/4.0.1-rc2-23519": {
+      "Microsoft.CSharp/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -42,147 +42,147 @@
           "xunit.runner.console": "2.1.0"
         }
       },
-      "Microsoft.NETCore/5.0.1-rc2-23519": {
+      "Microsoft.NETCore/5.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.CSharp": "4.0.1-rc2-23519",
-          "Microsoft.NETCore.Platforms": "1.0.1-rc2-23519",
-          "Microsoft.VisualBasic": "10.0.1-rc2-23519",
-          "System.AppContext": "4.0.1-rc2-23519",
-          "System.Collections": "4.0.11-rc2-23519",
-          "System.Collections.Concurrent": "4.0.11-rc2-23519",
-          "System.Collections.Immutable": "1.1.38-rc2-23519",
-          "System.ComponentModel": "4.0.1-rc2-23519",
-          "System.ComponentModel.Annotations": "4.1.0-rc2-23519",
-          "System.Diagnostics.Debug": "4.0.11-rc2-23519",
-          "System.Diagnostics.Tools": "4.0.1-rc2-23519",
-          "System.Diagnostics.Tracing": "4.0.21-rc2-23519",
-          "System.Dynamic.Runtime": "4.0.11-rc2-23519",
-          "System.Globalization": "4.0.11-rc2-23519",
-          "System.Globalization.Calendars": "4.0.1-rc2-23519",
-          "System.Globalization.Extensions": "4.0.1-rc2-23519",
-          "System.IO": "4.0.11-rc2-23519",
-          "System.IO.Compression": "4.1.0-rc2-23519",
-          "System.IO.Compression.ZipFile": "4.0.1-rc2-23519",
-          "System.IO.FileSystem": "4.0.1-rc2-23519",
-          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23519",
-          "System.IO.UnmanagedMemoryStream": "4.0.1-rc2-23519",
-          "System.Linq": "4.0.1-rc2-23519",
-          "System.Linq.Expressions": "4.0.11-rc2-23519",
-          "System.Linq.Parallel": "4.0.1-rc2-23519",
-          "System.Linq.Queryable": "4.0.1-rc2-23519",
-          "System.Net.Http": "4.0.1-rc2-23519",
-          "System.Net.NetworkInformation": "4.1.0-rc2-23519",
-          "System.Net.Primitives": "4.0.11-rc2-23519",
-          "System.Numerics.Vectors": "4.1.1-rc2-23519",
-          "System.ObjectModel": "4.0.11-rc2-23519",
-          "System.Reflection": "4.1.0-rc2-23519",
-          "System.Reflection.DispatchProxy": "4.0.1-rc2-23519",
-          "System.Reflection.Extensions": "4.0.1-rc2-23519",
-          "System.Reflection.Metadata": "1.1.1-rc2-23519",
-          "System.Reflection.Primitives": "4.0.1-rc2-23519",
-          "System.Reflection.TypeExtensions": "4.1.0-rc2-23519",
-          "System.Resources.ResourceManager": "4.0.1-rc2-23519",
-          "System.Runtime": "4.0.21-rc2-23519",
-          "System.Runtime.Extensions": "4.0.11-rc2-23519",
-          "System.Runtime.Handles": "4.0.1-rc2-23519",
-          "System.Runtime.InteropServices": "4.0.21-rc2-23519",
-          "System.Runtime.Numerics": "4.0.1-rc2-23519",
-          "System.Security.Claims": "4.0.1-rc2-23519",
-          "System.Security.Principal": "4.0.1-rc2-23519",
-          "System.Text.Encoding": "4.0.11-rc2-23519",
-          "System.Text.Encoding.Extensions": "4.0.11-rc2-23519",
-          "System.Text.RegularExpressions": "4.0.11-rc2-23519",
-          "System.Threading": "4.0.11-rc2-23519",
-          "System.Threading.Tasks": "4.0.11-rc2-23519",
-          "System.Threading.Tasks.Dataflow": "4.5.26-rc2-23519",
-          "System.Threading.Tasks.Parallel": "4.0.1-rc2-23519",
-          "System.Threading.Timer": "4.0.1-rc2-23519",
-          "System.Xml.ReaderWriter": "4.0.11-rc2-23519",
-          "System.Xml.XDocument": "4.0.11-rc2-23519"
+          "Microsoft.CSharp": "4.0.1-rc2-23525",
+          "Microsoft.NETCore.Platforms": "1.0.1-rc2-23525",
+          "Microsoft.VisualBasic": "10.0.1-rc2-23525",
+          "System.AppContext": "4.0.1-rc2-23525",
+          "System.Collections": "4.0.11-rc2-23525",
+          "System.Collections.Concurrent": "4.0.11-rc2-23525",
+          "System.Collections.Immutable": "1.1.38-rc2-23525",
+          "System.ComponentModel": "4.0.1-rc2-23525",
+          "System.ComponentModel.Annotations": "4.1.0-rc2-23525",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23525",
+          "System.Diagnostics.Tools": "4.0.1-rc2-23525",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23525",
+          "System.Dynamic.Runtime": "4.0.11-rc2-23525",
+          "System.Globalization": "4.0.11-rc2-23525",
+          "System.Globalization.Calendars": "4.0.1-rc2-23525",
+          "System.Globalization.Extensions": "4.0.1-rc2-23525",
+          "System.IO": "4.0.11-rc2-23525",
+          "System.IO.Compression": "4.1.0-rc2-23525",
+          "System.IO.Compression.ZipFile": "4.0.1-rc2-23525",
+          "System.IO.FileSystem": "4.0.1-rc2-23525",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23525",
+          "System.IO.UnmanagedMemoryStream": "4.0.1-rc2-23525",
+          "System.Linq": "4.0.1-rc2-23525",
+          "System.Linq.Expressions": "4.0.11-rc2-23525",
+          "System.Linq.Parallel": "4.0.1-rc2-23525",
+          "System.Linq.Queryable": "4.0.1-rc2-23525",
+          "System.Net.Http": "4.0.1-rc2-23525",
+          "System.Net.NetworkInformation": "4.1.0-rc2-23525",
+          "System.Net.Primitives": "4.0.11-rc2-23525",
+          "System.Numerics.Vectors": "4.1.1-rc2-23525",
+          "System.ObjectModel": "4.0.11-rc2-23525",
+          "System.Reflection": "4.1.0-rc2-23525",
+          "System.Reflection.DispatchProxy": "4.0.1-rc2-23525",
+          "System.Reflection.Extensions": "4.0.1-rc2-23525",
+          "System.Reflection.Metadata": "1.1.1-rc2-23525",
+          "System.Reflection.Primitives": "4.0.1-rc2-23525",
+          "System.Reflection.TypeExtensions": "4.1.0-rc2-23525",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23525",
+          "System.Runtime": "4.0.21-rc2-23525",
+          "System.Runtime.Extensions": "4.0.11-rc2-23525",
+          "System.Runtime.Handles": "4.0.1-rc2-23525",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23525",
+          "System.Runtime.Numerics": "4.0.1-rc2-23525",
+          "System.Security.Claims": "4.0.1-rc2-23525",
+          "System.Security.Principal": "4.0.1-rc2-23525",
+          "System.Text.Encoding": "4.0.11-rc2-23525",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23525",
+          "System.Text.RegularExpressions": "4.0.11-rc2-23525",
+          "System.Threading": "4.0.11-rc2-23525",
+          "System.Threading.Tasks": "4.0.11-rc2-23525",
+          "System.Threading.Tasks.Dataflow": "4.5.26-rc2-23525",
+          "System.Threading.Tasks.Parallel": "4.0.1-rc2-23525",
+          "System.Threading.Timer": "4.0.1-rc2-23525",
+          "System.Xml.ReaderWriter": "4.0.11-rc2-23525",
+          "System.Xml.XDocument": "4.0.11-rc2-23525"
         }
       },
-      "Microsoft.NETCore.Console/1.0.0-rc2-23519": {
+      "Microsoft.NETCore.Console/1.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore": "5.0.1-rc2-23519",
-          "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23519",
-          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-rc2-23519",
-          "Microsoft.Win32.Primitives": "4.0.1-rc2-23519",
-          "System.ComponentModel.EventBasedAsync": "4.0.11-rc2-23519",
-          "System.Console": "4.0.0-rc2-23519",
-          "System.Data.Common": "4.0.1-rc2-23519",
-          "System.Data.SqlClient": "4.0.0-rc2-23519",
-          "System.Diagnostics.Contracts": "4.0.1-rc2-23519",
-          "System.Diagnostics.FileVersionInfo": "4.0.0-rc2-23519",
-          "System.Diagnostics.Process": "4.1.0-rc2-23519",
-          "System.Diagnostics.StackTrace": "4.0.1-rc2-23519",
-          "System.IO.FileSystem.DriveInfo": "4.0.0-rc2-23519",
-          "System.IO.FileSystem.Watcher": "4.0.0-rc2-23519",
-          "System.IO.MemoryMappedFiles": "4.0.0-rc2-23519",
-          "System.IO.Pipes": "4.0.0-rc2-23519",
-          "System.Net.NameResolution": "4.0.0-rc2-23519",
-          "System.Net.NetworkInformation": "4.1.0-rc2-23519",
-          "System.Net.Requests": "4.0.11-rc2-23519",
-          "System.Net.Security": "4.0.0-rc2-23519",
-          "System.Net.Sockets": "4.1.0-rc2-23519",
-          "System.Net.Utilities": "4.0.0-rc2-23519",
-          "System.Net.WebHeaderCollection": "4.0.1-rc2-23519",
-          "System.Net.WebSockets": "4.0.0-rc2-23519",
-          "System.Net.WebSockets.Client": "4.0.0-rc2-23519",
-          "System.Reflection.Emit": "4.0.1-rc2-23519",
-          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23519",
-          "System.Reflection.Emit.Lightweight": "4.0.1-rc2-23519",
-          "System.Resources.ReaderWriter": "4.0.0-rc2-23519",
-          "System.Runtime.CompilerServices.VisualC": "4.0.0-rc2-23519",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23519",
-          "System.Runtime.Loader": "4.0.0-rc2-23519",
-          "System.Runtime.Serialization.Json": "4.0.1-rc2-23519",
-          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23519",
-          "System.Runtime.Serialization.Xml": "4.1.0-rc2-23519",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
-          "System.ServiceModel.Duplex": "4.0.1-rc2-23519",
-          "System.ServiceModel.Http": "4.0.11-rc2-23519",
-          "System.ServiceModel.NetTcp": "4.1.0-rc2-23519",
-          "System.ServiceModel.Primitives": "4.1.0-rc2-23519",
-          "System.ServiceModel.Security": "4.0.1-rc2-23519",
-          "System.Xml.XmlSerializer": "4.0.11-rc2-23519"
+          "Microsoft.NETCore": "5.0.1-rc2-23525",
+          "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23525",
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-rc2-23525",
+          "Microsoft.Win32.Primitives": "4.0.1-rc2-23525",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-rc2-23525",
+          "System.Console": "4.0.0-rc2-23525",
+          "System.Data.Common": "4.0.1-rc2-23525",
+          "System.Data.SqlClient": "4.0.0-rc2-23525",
+          "System.Diagnostics.Contracts": "4.0.1-rc2-23525",
+          "System.Diagnostics.FileVersionInfo": "4.0.0-rc2-23525",
+          "System.Diagnostics.Process": "4.1.0-rc2-23525",
+          "System.Diagnostics.StackTrace": "4.0.1-rc2-23525",
+          "System.IO.FileSystem.DriveInfo": "4.0.0-rc2-23525",
+          "System.IO.FileSystem.Watcher": "4.0.0-rc2-23525",
+          "System.IO.MemoryMappedFiles": "4.0.0-rc2-23525",
+          "System.IO.Pipes": "4.0.0-rc2-23525",
+          "System.Net.NameResolution": "4.0.0-rc2-23525",
+          "System.Net.NetworkInformation": "4.1.0-rc2-23525",
+          "System.Net.Requests": "4.0.11-rc2-23525",
+          "System.Net.Security": "4.0.0-rc2-23525",
+          "System.Net.Sockets": "4.1.0-rc2-23525",
+          "System.Net.Utilities": "4.0.0-rc2-23525",
+          "System.Net.WebHeaderCollection": "4.0.1-rc2-23525",
+          "System.Net.WebSockets": "4.0.0-rc2-23525",
+          "System.Net.WebSockets.Client": "4.0.0-rc2-23525",
+          "System.Reflection.Emit": "4.0.1-rc2-23525",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23525",
+          "System.Reflection.Emit.Lightweight": "4.0.1-rc2-23525",
+          "System.Resources.ReaderWriter": "4.0.0-rc2-23525",
+          "System.Runtime.CompilerServices.VisualC": "4.0.0-rc2-23525",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23525",
+          "System.Runtime.Loader": "4.0.0-rc2-23525",
+          "System.Runtime.Serialization.Json": "4.0.1-rc2-23525",
+          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23525",
+          "System.Runtime.Serialization.Xml": "4.1.0-rc2-23525",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.ServiceModel.Duplex": "4.0.1-rc2-23525",
+          "System.ServiceModel.Http": "4.0.11-rc2-23525",
+          "System.ServiceModel.NetTcp": "4.1.0-rc2-23525",
+          "System.ServiceModel.Primitives": "4.1.0-rc2-23525",
+          "System.ServiceModel.Security": "4.0.1-rc2-23525",
+          "System.Xml.XmlSerializer": "4.0.11-rc2-23525"
         }
       },
-      "Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23519": {
+      "Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23525": {
         "type": "package"
       },
-      "Microsoft.NETCore.Platforms/1.0.1-rc2-23519": {
+      "Microsoft.NETCore.Platforms/1.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Targets": "1.0.1-rc2-23519"
+          "Microsoft.NETCore.Targets": "1.0.1-rc2-23525"
         }
       },
-      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23519": {
+      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-rc2-23519"
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-rc2-23525"
         }
       },
-      "Microsoft.NETCore.Targets/1.0.1-rc2-23519": {
+      "Microsoft.NETCore.Targets/1.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-rc2-23519"
+          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-rc2-23525"
         }
       },
-      "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23519": {
+      "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23525": {
         "type": "package"
       },
-      "Microsoft.NETCore.TestHost/1.0.0-rc2-23519": {
+      "Microsoft.NETCore.TestHost/1.0.0-rc2-23525": {
         "type": "package"
       },
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23519": {
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23525": {
         "type": "package"
       },
-      "Microsoft.VisualBasic/10.0.1-rc2-23519": {
+      "Microsoft.VisualBasic/10.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -209,7 +209,7 @@
           "lib/dotnet5.4/Microsoft.VisualBasic.dll": {}
         }
       },
-      "Microsoft.Win32.Primitives/4.0.1-rc2-23519": {
+      "Microsoft.Win32.Primitives/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -224,7 +224,7 @@
       "ReportGenerator/2.3.4": {
         "type": "package"
       },
-      "System.AppContext/4.0.1-rc2-23519": {
+      "System.AppContext/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -236,10 +236,10 @@
           "lib/DNXCore50/System.AppContext.dll": {}
         }
       },
-      "System.Collections/4.0.11-rc2-23519": {
+      "System.Collections/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Runtime": "4.0.21-rc2-23519"
+          "System.Runtime": "4.0.21-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Collections.dll": {}
@@ -248,7 +248,7 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Collections.Concurrent/4.0.11-rc2-23519": {
+      "System.Collections.Concurrent/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -268,7 +268,7 @@
           "lib/dotnet5.4/System.Collections.Concurrent.dll": {}
         }
       },
-      "System.Collections.Immutable/1.1.38-rc2-23519": {
+      "System.Collections.Immutable/1.1.38-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -287,7 +287,7 @@
           "lib/dotnet5.1/System.Collections.Immutable.dll": {}
         }
       },
-      "System.Collections.NonGeneric/4.0.1-rc2-23519": {
+      "System.Collections.NonGeneric/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -304,7 +304,7 @@
           "lib/dotnet5.4/System.Collections.NonGeneric.dll": {}
         }
       },
-      "System.Collections.Specialized/4.0.1-rc2-23519": {
+      "System.Collections.Specialized/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections.NonGeneric": "4.0.0",
@@ -322,7 +322,7 @@
           "lib/dotnet5.4/System.Collections.Specialized.dll": {}
         }
       },
-      "System.ComponentModel/4.0.1-rc2-23519": {
+      "System.ComponentModel/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -334,7 +334,7 @@
           "lib/dotnet5.4/System.ComponentModel.dll": {}
         }
       },
-      "System.ComponentModel.Annotations/4.1.0-rc2-23519": {
+      "System.ComponentModel.Annotations/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -356,7 +356,7 @@
           "lib/dotnet5.4/System.ComponentModel.Annotations.dll": {}
         }
       },
-      "System.ComponentModel.EventBasedAsync/4.0.11-rc2-23519": {
+      "System.ComponentModel.EventBasedAsync/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -371,7 +371,7 @@
           "lib/dotnet5.4/System.ComponentModel.EventBasedAsync.dll": {}
         }
       },
-      "System.Console/4.0.0-rc2-23519": {
+      "System.Console/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -381,7 +381,7 @@
           "ref/dotnet5.4/System.Console.dll": {}
         }
       },
-      "System.Data.Common/4.0.1-rc2-23519": {
+      "System.Data.Common/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -401,7 +401,7 @@
           "lib/dotnet5.4/System.Data.Common.dll": {}
         }
       },
-      "System.Data.SqlClient/4.0.0-rc2-23519": {
+      "System.Data.SqlClient/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Data.Common": "4.0.0",
@@ -415,7 +415,7 @@
           "ref/dotnet5.4/System.Data.SqlClient.dll": {}
         }
       },
-      "System.Diagnostics.Contracts/4.0.1-rc2-23519": {
+      "System.Diagnostics.Contracts/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -427,7 +427,7 @@
           "lib/DNXCore50/System.Diagnostics.Contracts.dll": {}
         }
       },
-      "System.Diagnostics.Debug/4.0.11-rc2-23519": {
+      "System.Diagnostics.Debug/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -436,7 +436,7 @@
           "ref/dotnet5.4/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.FileVersionInfo/4.0.0-rc2-23519": {
+      "System.Diagnostics.FileVersionInfo/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -445,7 +445,7 @@
           "ref/dotnet5.4/System.Diagnostics.FileVersionInfo.dll": {}
         }
       },
-      "System.Diagnostics.Process/4.1.0-rc2-23519": {
+      "System.Diagnostics.Process/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -457,7 +457,7 @@
           "ref/dotnet5.5/System.Diagnostics.Process.dll": {}
         }
       },
-      "System.Diagnostics.StackTrace/4.0.1-rc2-23519": {
+      "System.Diagnostics.StackTrace/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -470,7 +470,7 @@
           "lib/DNXCore50/System.Diagnostics.StackTrace.dll": {}
         }
       },
-      "System.Diagnostics.Tools/4.0.1-rc2-23519": {
+      "System.Diagnostics.Tools/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -482,7 +482,7 @@
           "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
         }
       },
-      "System.Diagnostics.Tracing/4.0.21-rc2-23519": {
+      "System.Diagnostics.Tracing/4.0.21-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -494,7 +494,7 @@
           "lib/DNXCore50/System.Diagnostics.Tracing.dll": {}
         }
       },
-      "System.Dynamic.Runtime/4.0.11-rc2-23519": {
+      "System.Dynamic.Runtime/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -520,7 +520,7 @@
           "lib/DNXCore50/System.Dynamic.Runtime.dll": {}
         }
       },
-      "System.Globalization/4.0.11-rc2-23519": {
+      "System.Globalization/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -532,7 +532,7 @@
           "lib/DNXCore50/System.Globalization.dll": {}
         }
       },
-      "System.Globalization.Calendars/4.0.1-rc2-23519": {
+      "System.Globalization.Calendars/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -545,7 +545,7 @@
           "lib/DNXCore50/System.Globalization.Calendars.dll": {}
         }
       },
-      "System.Globalization.Extensions/4.0.1-rc2-23519": {
+      "System.Globalization.Extensions/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -556,7 +556,7 @@
           "ref/dotnet5.4/System.Globalization.Extensions.dll": {}
         }
       },
-      "System.IO/4.0.11-rc2-23519": {
+      "System.IO/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20",
@@ -570,7 +570,7 @@
           "lib/DNXCore50/System.IO.dll": {}
         }
       },
-      "System.IO.Compression/4.1.0-rc2-23519": {
+      "System.IO.Compression/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -582,7 +582,7 @@
           "ref/dotnet5.4/System.IO.Compression.dll": {}
         }
       },
-      "System.IO.Compression.ZipFile/4.0.1-rc2-23519": {
+      "System.IO.Compression.ZipFile/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -601,7 +601,7 @@
           "lib/dotnet5.4/System.IO.Compression.ZipFile.dll": {}
         }
       },
-      "System.IO.FileSystem/4.0.1-rc2-23519": {
+      "System.IO.FileSystem/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -615,7 +615,7 @@
           "ref/dotnet5.4/System.IO.FileSystem.dll": {}
         }
       },
-      "System.IO.FileSystem.DriveInfo/4.0.0-rc2-23519": {
+      "System.IO.FileSystem.DriveInfo/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -626,7 +626,7 @@
           "ref/dotnet5.4/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
-      "System.IO.FileSystem.Primitives/4.0.1-rc2-23519": {
+      "System.IO.FileSystem.Primitives/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -638,7 +638,7 @@
           "lib/dotnet5.4/System.IO.FileSystem.Primitives.dll": {}
         }
       },
-      "System.IO.FileSystem.Watcher/4.0.0-rc2-23519": {
+      "System.IO.FileSystem.Watcher/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -647,7 +647,7 @@
           "ref/dotnet5.4/System.IO.FileSystem.Watcher.dll": {}
         }
       },
-      "System.IO.MemoryMappedFiles/4.0.0-rc2-23519": {
+      "System.IO.MemoryMappedFiles/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO.FileSystem": "4.0.0",
@@ -661,7 +661,7 @@
           "ref/dotnet5.4/System.IO.MemoryMappedFiles.dll": {}
         }
       },
-      "System.IO.Pipes/4.0.0-rc2-23519": {
+      "System.IO.Pipes/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -674,7 +674,7 @@
           "ref/dotnet5.4/System.IO.Pipes.dll": {}
         }
       },
-      "System.IO.UnmanagedMemoryStream/4.0.1-rc2-23519": {
+      "System.IO.UnmanagedMemoryStream/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -692,7 +692,7 @@
           "lib/dotnet5.4/System.IO.UnmanagedMemoryStream.dll": {}
         }
       },
-      "System.Linq/4.0.1-rc2-23519": {
+      "System.Linq/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -708,7 +708,7 @@
           "lib/dotnet5.4/System.Linq.dll": {}
         }
       },
-      "System.Linq.Expressions/4.0.11-rc2-23519": {
+      "System.Linq.Expressions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -718,7 +718,7 @@
           "ref/dotnet5.4/System.Linq.Expressions.dll": {}
         }
       },
-      "System.Linq.Parallel/4.0.1-rc2-23519": {
+      "System.Linq.Parallel/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -739,7 +739,7 @@
           "lib/dotnet5.4/System.Linq.Parallel.dll": {}
         }
       },
-      "System.Linq.Queryable/4.0.1-rc2-23519": {
+      "System.Linq.Queryable/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -758,7 +758,7 @@
           "lib/dotnet5.4/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-rc2-23519": {
+      "System.Net.Http/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -771,7 +771,34 @@
           "ref/dotnet5.2/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-rc2-23519": {
+      "System.Net.Http.WinHttpHandler/4.0.0-rc2-23525": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Net.Http.WinHttpHandler.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Http.WinHttpHandler.dll": {}
+        }
+      },
+      "System.Net.NameResolution/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -782,7 +809,7 @@
           "ref/dotnet5.4/System.Net.NameResolution.dll": {}
         }
       },
-      "System.Net.NetworkInformation/4.1.0-rc2-23519": {
+      "System.Net.NetworkInformation/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -793,7 +820,7 @@
           "ref/dotnet5.4/System.Net.NetworkInformation.dll": {}
         }
       },
-      "System.Net.Primitives/4.0.11-rc2-23519": {
+      "System.Net.Primitives/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -803,7 +830,7 @@
           "ref/dotnet5.4/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Requests/4.0.11-rc2-23519": {
+      "System.Net.Requests/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -816,20 +843,21 @@
           "ref/dotnet5.4/System.Net.Requests.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-rc2-23519": {
+      "System.Net.Security/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Net.Primitives": "4.0.10",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.Security.Principal": "4.0.0",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.Security.dll": {}
         }
       },
-      "System.Net.Sockets/4.1.0-rc2-23519": {
+      "System.Net.Sockets/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -841,10 +869,10 @@
           "ref/dotnet5.4/System.Net.Sockets.dll": {}
         }
       },
-      "System.Net.Utilities/4.0.0-rc2-23519": {
+      "System.Net.Utilities/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-rc2-23519"
+          "System.Private.Networking": "4.0.1-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.Utilities.dll": {}
@@ -853,7 +881,7 @@
           "lib/DNXCore50/System.Net.Utilities.dll": {}
         }
       },
-      "System.Net.WebHeaderCollection/4.0.1-rc2-23519": {
+      "System.Net.WebHeaderCollection/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -869,7 +897,7 @@
           "lib/dotnet5.4/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-rc2-23519": {
+      "System.Net.WebSockets/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -884,20 +912,20 @@
           "lib/dotnet5.4/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-rc2-23519": {
+      "System.Net.WebSockets.Client/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
-          "System.Net.WebSockets": "4.0.0-rc2-23519",
+          "System.Net.WebSockets": "4.0.0-rc2-23525",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.WebSockets.Client.dll": {}
         }
       },
-      "System.Numerics.Vectors/4.1.1-rc2-23519": {
+      "System.Numerics.Vectors/4.1.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -912,7 +940,7 @@
           "lib/dotnet5.4/System.Numerics.Vectors.dll": {}
         }
       },
-      "System.ObjectModel/4.0.11-rc2-23519": {
+      "System.ObjectModel/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -928,13 +956,13 @@
           "lib/dotnet5.4/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.DataContractSerialization/4.1.0-rc2-23519": {
+      "System.Private.DataContractSerialization/4.1.0-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
         }
       },
-      "System.Private.Networking/4.0.1-rc2-23519": {
+      "System.Private.Networking/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -953,14 +981,14 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-rc2-23519",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23525",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-rc2-23519"
+          "System.Threading.ThreadPool": "4.0.10-rc2-23525"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -969,53 +997,57 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-rc2-23519": {
+      "System.Private.ServiceModel/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.11-rc2-23519",
-          "System.Collections.Concurrent": "4.0.11-rc2-23519",
-          "System.Collections.NonGeneric": "4.0.1-rc2-23519",
-          "System.Collections.Specialized": "4.0.1-rc2-23519",
-          "System.ComponentModel.EventBasedAsync": "4.0.11-rc2-23519",
-          "System.Diagnostics.Debug": "4.0.11-rc2-23519",
-          "System.Diagnostics.Tracing": "4.0.21-rc2-23519",
-          "System.Globalization": "4.0.11-rc2-23519",
-          "System.IO": "4.0.11-rc2-23519",
-          "System.IO.Compression": "4.1.0-rc2-23519",
-          "System.Linq": "4.0.1-rc2-23519",
-          "System.Linq.Expressions": "4.0.11-rc2-23519",
-          "System.Linq.Queryable": "4.0.1-rc2-23519",
-          "System.Net.Http": "4.0.1-rc2-23519",
-          "System.Net.NameResolution": "4.0.0-rc2-23519",
-          "System.Net.Primitives": "4.0.11-rc2-23519",
-          "System.Net.Security": "4.0.0-rc2-23519",
-          "System.Net.Sockets": "4.1.0-rc2-23519",
-          "System.Net.WebHeaderCollection": "4.0.1-rc2-23519",
-          "System.Net.WebSockets": "4.0.0-rc2-23519",
-          "System.Net.WebSockets.Client": "4.0.0-rc2-23519",
-          "System.ObjectModel": "4.0.11-rc2-23519",
-          "System.Reflection": "4.1.0-rc2-23519",
-          "System.Reflection.DispatchProxy": "4.0.1-rc2-23519",
-          "System.Reflection.Extensions": "4.0.1-rc2-23519",
-          "System.Reflection.Primitives": "4.0.1-rc2-23519",
-          "System.Reflection.TypeExtensions": "4.0.1-rc2-23519",
-          "System.Resources.ResourceManager": "4.0.1-rc2-23519",
-          "System.Runtime": "4.0.21-rc2-23519",
-          "System.Runtime.Extensions": "4.0.11-rc2-23519",
-          "System.Runtime.InteropServices": "4.0.21-rc2-23519",
+          "System.Collections": "4.0.11-rc2-23525",
+          "System.Collections.Concurrent": "4.0.11-rc2-23525",
+          "System.Collections.NonGeneric": "4.0.1-rc2-23525",
+          "System.Collections.Specialized": "4.0.1-rc2-23525",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-rc2-23525",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23525",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23525",
+          "System.Globalization": "4.0.11-rc2-23525",
+          "System.IO": "4.0.11-rc2-23525",
+          "System.IO.Compression": "4.1.0-rc2-23525",
+          "System.Linq": "4.0.1-rc2-23525",
+          "System.Linq.Expressions": "4.0.11-rc2-23525",
+          "System.Linq.Queryable": "4.0.1-rc2-23525",
+          "System.Net.Http": "4.0.1-rc2-23525",
+          "System.Net.Http.WinHttpHandler": "4.0.0-rc2-23525",
+          "System.Net.NameResolution": "4.0.0-rc2-23525",
+          "System.Net.Primitives": "4.0.11-rc2-23525",
+          "System.Net.Security": "4.0.0-rc2-23525",
+          "System.Net.Sockets": "4.1.0-rc2-23525",
+          "System.Net.WebHeaderCollection": "4.0.1-rc2-23525",
+          "System.Net.WebSockets": "4.0.0-rc2-23525",
+          "System.Net.WebSockets.Client": "4.0.0-rc2-23525",
+          "System.ObjectModel": "4.0.11-rc2-23525",
+          "System.Reflection": "4.1.0-rc2-23525",
+          "System.Reflection.DispatchProxy": "4.0.1-rc2-23525",
+          "System.Reflection.Extensions": "4.0.1-rc2-23525",
+          "System.Reflection.Primitives": "4.0.1-rc2-23525",
+          "System.Reflection.TypeExtensions": "4.0.1-rc2-23525",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23525",
+          "System.Runtime": "4.0.21-rc2-23525",
+          "System.Runtime.Extensions": "4.0.11-rc2-23525",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23525",
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
-          "System.Security.Claims": "4.0.1-rc2-23519",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
-          "System.Security.Principal": "4.0.1-rc2-23519",
-          "System.Security.Principal.Windows": "4.0.0-rc2-23519",
-          "System.Text.Encoding": "4.0.11-rc2-23519",
-          "System.Threading": "4.0.11-rc2-23519",
-          "System.Threading.Tasks": "4.0.11-rc2-23519",
-          "System.Threading.Timer": "4.0.1-rc2-23519",
-          "System.Xml.ReaderWriter": "4.0.11-rc2-23519",
-          "System.Xml.XmlDocument": "4.0.1-rc2-23519",
-          "System.Xml.XmlSerializer": "4.0.11-rc2-23519"
+          "System.Security.Claims": "4.0.1-rc2-23525",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.Security.Principal": "4.0.1-rc2-23525",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23525",
+          "System.Text.Encoding": "4.0.11-rc2-23525",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.11-rc2-23525",
+          "System.Threading.Tasks": "4.0.11-rc2-23525",
+          "System.Threading.Timer": "4.0.1-rc2-23525",
+          "System.Xml.ReaderWriter": "4.0.11-rc2-23525",
+          "System.Xml.XmlDocument": "4.0.1-rc2-23525",
+          "System.Xml.XmlSerializer": "4.0.11-rc2-23525"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -1024,13 +1056,13 @@
           "lib/DNXCore50/System.Private.ServiceModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.1-rc2-23519": {
+      "System.Private.Uri/4.0.1-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
         }
       },
-      "System.Reflection/4.1.0-rc2-23519": {
+      "System.Reflection/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -1044,7 +1076,7 @@
           "lib/DNXCore50/System.Reflection.dll": {}
         }
       },
-      "System.Reflection.DispatchProxy/4.0.1-rc2-23519": {
+      "System.Reflection.DispatchProxy/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -1054,7 +1086,7 @@
           "ref/dotnet5.4/System.Reflection.DispatchProxy.dll": {}
         }
       },
-      "System.Reflection.Emit/4.0.1-rc2-23519": {
+      "System.Reflection.Emit/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -1070,7 +1102,7 @@
           "lib/DNXCore50/System.Reflection.Emit.dll": {}
         }
       },
-      "System.Reflection.Emit.ILGeneration/4.0.1-rc2-23519": {
+      "System.Reflection.Emit.ILGeneration/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -1084,7 +1116,7 @@
           "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
         }
       },
-      "System.Reflection.Emit.Lightweight/4.0.1-rc2-23519": {
+      "System.Reflection.Emit.Lightweight/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -1099,7 +1131,7 @@
           "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll": {}
         }
       },
-      "System.Reflection.Extensions/4.0.1-rc2-23519": {
+      "System.Reflection.Extensions/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -1112,7 +1144,7 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.1.1-rc2-23519": {
+      "System.Reflection.Metadata/1.1.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -1137,7 +1169,7 @@
           "lib/dotnet5.2/System.Reflection.Metadata.dll": {}
         }
       },
-      "System.Reflection.Primitives/4.0.1-rc2-23519": {
+      "System.Reflection.Primitives/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -1149,7 +1181,7 @@
           "lib/DNXCore50/System.Reflection.Primitives.dll": {}
         }
       },
-      "System.Reflection.TypeExtensions/4.1.0-rc2-23519": {
+      "System.Reflection.TypeExtensions/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -1162,7 +1194,7 @@
           "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
         }
       },
-      "System.Resources.ReaderWriter/4.0.0-rc2-23519": {
+      "System.Resources.ReaderWriter/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1180,7 +1212,7 @@
           "lib/DNXCore50/System.Resources.ReaderWriter.dll": {}
         }
       },
-      "System.Resources.ResourceManager/4.0.1-rc2-23519": {
+      "System.Resources.ResourceManager/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -1194,10 +1226,10 @@
           "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
         }
       },
-      "System.Runtime/4.0.21-rc2-23519": {
+      "System.Runtime/4.0.21-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.Uri": "4.0.1-rc2-23519"
+          "System.Private.Uri": "4.0.1-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Runtime.dll": {}
@@ -1206,7 +1238,7 @@
           "lib/DNXCore50/System.Runtime.dll": {}
         }
       },
-      "System.Runtime.CompilerServices.VisualC/4.0.0-rc2-23519": {
+      "System.Runtime.CompilerServices.VisualC/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -1218,7 +1250,7 @@
           "lib/DNXCore50/System.Runtime.CompilerServices.VisualC.dll": {}
         }
       },
-      "System.Runtime.Extensions/4.0.11-rc2-23519": {
+      "System.Runtime.Extensions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -1227,7 +1259,7 @@
           "ref/dotnet5.4/System.Runtime.Extensions.dll": {}
         }
       },
-      "System.Runtime.Handles/4.0.1-rc2-23519": {
+      "System.Runtime.Handles/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -1239,7 +1271,7 @@
           "lib/DNXCore50/System.Runtime.Handles.dll": {}
         }
       },
-      "System.Runtime.InteropServices/4.0.21-rc2-23519": {
+      "System.Runtime.InteropServices/4.0.21-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -1254,7 +1286,7 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23519": {
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -1263,7 +1295,7 @@
           "ref/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "System.Runtime.Loader/4.0.0-rc2-23519": {
+      "System.Runtime.Loader/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -1271,13 +1303,13 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Runtime.Loader.dll": {}
+          "ref/dotnet5.5/System.Runtime.Loader.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Runtime.Loader.dll": {}
         }
       },
-      "System.Runtime.Numerics/4.0.1-rc2-23519": {
+      "System.Runtime.Numerics/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -1292,10 +1324,10 @@
           "lib/dotnet5.4/System.Runtime.Numerics.dll": {}
         }
       },
-      "System.Runtime.Serialization.Json/4.0.1-rc2-23519": {
+      "System.Runtime.Serialization.Json/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.1.0-rc2-23519"
+          "System.Private.DataContractSerialization": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.1/System.Runtime.Serialization.Json.dll": {}
@@ -1304,7 +1336,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Json.dll": {}
         }
       },
-      "System.Runtime.Serialization.Primitives/4.1.0-rc2-23519": {
+      "System.Runtime.Serialization.Primitives/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -1317,11 +1349,11 @@
           "lib/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
         }
       },
-      "System.Runtime.Serialization.Xml/4.1.0-rc2-23519": {
+      "System.Runtime.Serialization.Xml/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.1.0-rc2-23519",
-          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23519"
+          "System.Private.DataContractSerialization": "4.1.0-rc2-23525",
+          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Runtime.Serialization.Xml.dll": {}
@@ -1330,7 +1362,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Xml.dll": {}
         }
       },
-      "System.Security.Claims/4.0.1-rc2-23519": {
+      "System.Security.Claims/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -1349,18 +1381,18 @@
           "lib/dotnet5.4/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.Algorithms/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519"
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.Encoding/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -1369,7 +1401,7 @@
           "ref/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.Primitives/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -1387,19 +1419,19 @@
           "lib/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23519"
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
-      "System.Security.Principal/4.0.1-rc2-23519": {
+      "System.Security.Principal/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -1411,7 +1443,7 @@
           "lib/dotnet5.1/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-rc2-23519": {
+      "System.Security.Principal.Windows/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -1434,10 +1466,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-rc2-23519": {
+      "System.ServiceModel.Duplex/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519"
+          "System.Private.ServiceModel": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.2/System.ServiceModel.Duplex.dll": {}
@@ -1446,10 +1478,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-rc2-23519": {
+      "System.ServiceModel.Http/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519",
+          "System.Private.ServiceModel": "4.1.0-rc2-23525",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -1459,10 +1491,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.1.0-rc2-23519": {
+      "System.ServiceModel.NetTcp/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519"
+          "System.Private.ServiceModel": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.ServiceModel.NetTcp.dll": {}
@@ -1471,10 +1503,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.1.0-rc2-23519": {
+      "System.ServiceModel.Primitives/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519"
+          "System.Private.ServiceModel": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.ServiceModel.Primitives.dll": {}
@@ -1483,10 +1515,10 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
-      "System.ServiceModel.Security/4.0.1-rc2-23519": {
+      "System.ServiceModel.Security/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519"
+          "System.Private.ServiceModel": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.2/System.ServiceModel.Security.dll": {}
@@ -1495,7 +1527,7 @@
           "lib/DNXCore50/System.ServiceModel.Security.dll": {}
         }
       },
-      "System.Text.Encoding/4.0.11-rc2-23519": {
+      "System.Text.Encoding/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -1507,7 +1539,7 @@
           "lib/DNXCore50/System.Text.Encoding.dll": {}
         }
       },
-      "System.Text.Encoding.Extensions/4.0.11-rc2-23519": {
+      "System.Text.Encoding.Extensions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1520,7 +1552,7 @@
           "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
         }
       },
-      "System.Text.RegularExpressions/4.0.11-rc2-23519": {
+      "System.Text.RegularExpressions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1537,7 +1569,7 @@
           "lib/dotnet5.4/System.Text.RegularExpressions.dll": {}
         }
       },
-      "System.Threading/4.0.11-rc2-23519": {
+      "System.Threading/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1560,7 +1592,7 @@
           "lib/DNXCore50/System.Threading.Overlapped.dll": {}
         }
       },
-      "System.Threading.Tasks/4.0.11-rc2-23519": {
+      "System.Threading.Tasks/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -1572,7 +1604,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.Tasks.Dataflow/4.5.26-rc2-23519": {
+      "System.Threading.Tasks.Dataflow/4.5.26-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -1594,7 +1626,7 @@
           "lib/dotnet5.2/System.Threading.Tasks.Dataflow.dll": {}
         }
       },
-      "System.Threading.Tasks.Parallel/4.0.1-rc2-23519": {
+      "System.Threading.Tasks.Parallel/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections.Concurrent": "4.0.10",
@@ -1613,11 +1645,11 @@
           "lib/dotnet5.4/System.Threading.Tasks.Parallel.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-rc2-23519": {
+      "System.Threading.ThreadPool/4.0.10-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
+          "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Threading.ThreadPool.dll": {}
@@ -1626,7 +1658,7 @@
           "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
-      "System.Threading.Timer/4.0.1-rc2-23519": {
+      "System.Threading.Timer/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -1638,7 +1670,7 @@
           "lib/DNXCore50/System.Threading.Timer.dll": {}
         }
       },
-      "System.Xml.ReaderWriter/4.0.11-rc2-23519": {
+      "System.Xml.ReaderWriter/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1663,7 +1695,7 @@
           "lib/dotnet5.4/System.Xml.ReaderWriter.dll": {}
         }
       },
-      "System.Xml.XDocument/4.0.11-rc2-23519": {
+      "System.Xml.XDocument/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1686,7 +1718,7 @@
           "lib/dotnet5.4/System.Xml.XDocument.dll": {}
         }
       },
-      "System.Xml.XmlDocument/4.0.1-rc2-23519": {
+      "System.Xml.XmlDocument/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1707,7 +1739,7 @@
           "lib/dotnet5.4/System.Xml.XmlDocument.dll": {}
         }
       },
-      "System.Xml.XmlSerializer/4.0.11-rc2-23519": {
+      "System.Xml.XmlSerializer/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -1872,7 +1904,7 @@
       "coveralls.io/1.4.0": {
         "type": "package"
       },
-      "Microsoft.CSharp/4.0.1-rc2-23519": {
+      "Microsoft.CSharp/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1908,147 +1940,147 @@
           "xunit.runner.console": "2.1.0"
         }
       },
-      "Microsoft.NETCore/5.0.1-rc2-23519": {
+      "Microsoft.NETCore/5.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.CSharp": "4.0.1-rc2-23519",
-          "Microsoft.NETCore.Platforms": "1.0.1-rc2-23519",
-          "Microsoft.VisualBasic": "10.0.1-rc2-23519",
-          "System.AppContext": "4.0.1-rc2-23519",
-          "System.Collections": "4.0.11-rc2-23519",
-          "System.Collections.Concurrent": "4.0.11-rc2-23519",
-          "System.Collections.Immutable": "1.1.38-rc2-23519",
-          "System.ComponentModel": "4.0.1-rc2-23519",
-          "System.ComponentModel.Annotations": "4.1.0-rc2-23519",
-          "System.Diagnostics.Debug": "4.0.11-rc2-23519",
-          "System.Diagnostics.Tools": "4.0.1-rc2-23519",
-          "System.Diagnostics.Tracing": "4.0.21-rc2-23519",
-          "System.Dynamic.Runtime": "4.0.11-rc2-23519",
-          "System.Globalization": "4.0.11-rc2-23519",
-          "System.Globalization.Calendars": "4.0.1-rc2-23519",
-          "System.Globalization.Extensions": "4.0.1-rc2-23519",
-          "System.IO": "4.0.11-rc2-23519",
-          "System.IO.Compression": "4.1.0-rc2-23519",
-          "System.IO.Compression.ZipFile": "4.0.1-rc2-23519",
-          "System.IO.FileSystem": "4.0.1-rc2-23519",
-          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23519",
-          "System.IO.UnmanagedMemoryStream": "4.0.1-rc2-23519",
-          "System.Linq": "4.0.1-rc2-23519",
-          "System.Linq.Expressions": "4.0.11-rc2-23519",
-          "System.Linq.Parallel": "4.0.1-rc2-23519",
-          "System.Linq.Queryable": "4.0.1-rc2-23519",
-          "System.Net.Http": "4.0.1-rc2-23519",
-          "System.Net.NetworkInformation": "4.1.0-rc2-23519",
-          "System.Net.Primitives": "4.0.11-rc2-23519",
-          "System.Numerics.Vectors": "4.1.1-rc2-23519",
-          "System.ObjectModel": "4.0.11-rc2-23519",
-          "System.Reflection": "4.1.0-rc2-23519",
-          "System.Reflection.DispatchProxy": "4.0.1-rc2-23519",
-          "System.Reflection.Extensions": "4.0.1-rc2-23519",
-          "System.Reflection.Metadata": "1.1.1-rc2-23519",
-          "System.Reflection.Primitives": "4.0.1-rc2-23519",
-          "System.Reflection.TypeExtensions": "4.1.0-rc2-23519",
-          "System.Resources.ResourceManager": "4.0.1-rc2-23519",
-          "System.Runtime": "4.0.21-rc2-23519",
-          "System.Runtime.Extensions": "4.0.11-rc2-23519",
-          "System.Runtime.Handles": "4.0.1-rc2-23519",
-          "System.Runtime.InteropServices": "4.0.21-rc2-23519",
-          "System.Runtime.Numerics": "4.0.1-rc2-23519",
-          "System.Security.Claims": "4.0.1-rc2-23519",
-          "System.Security.Principal": "4.0.1-rc2-23519",
-          "System.Text.Encoding": "4.0.11-rc2-23519",
-          "System.Text.Encoding.Extensions": "4.0.11-rc2-23519",
-          "System.Text.RegularExpressions": "4.0.11-rc2-23519",
-          "System.Threading": "4.0.11-rc2-23519",
-          "System.Threading.Tasks": "4.0.11-rc2-23519",
-          "System.Threading.Tasks.Dataflow": "4.5.26-rc2-23519",
-          "System.Threading.Tasks.Parallel": "4.0.1-rc2-23519",
-          "System.Threading.Timer": "4.0.1-rc2-23519",
-          "System.Xml.ReaderWriter": "4.0.11-rc2-23519",
-          "System.Xml.XDocument": "4.0.11-rc2-23519"
+          "Microsoft.CSharp": "4.0.1-rc2-23525",
+          "Microsoft.NETCore.Platforms": "1.0.1-rc2-23525",
+          "Microsoft.VisualBasic": "10.0.1-rc2-23525",
+          "System.AppContext": "4.0.1-rc2-23525",
+          "System.Collections": "4.0.11-rc2-23525",
+          "System.Collections.Concurrent": "4.0.11-rc2-23525",
+          "System.Collections.Immutable": "1.1.38-rc2-23525",
+          "System.ComponentModel": "4.0.1-rc2-23525",
+          "System.ComponentModel.Annotations": "4.1.0-rc2-23525",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23525",
+          "System.Diagnostics.Tools": "4.0.1-rc2-23525",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23525",
+          "System.Dynamic.Runtime": "4.0.11-rc2-23525",
+          "System.Globalization": "4.0.11-rc2-23525",
+          "System.Globalization.Calendars": "4.0.1-rc2-23525",
+          "System.Globalization.Extensions": "4.0.1-rc2-23525",
+          "System.IO": "4.0.11-rc2-23525",
+          "System.IO.Compression": "4.1.0-rc2-23525",
+          "System.IO.Compression.ZipFile": "4.0.1-rc2-23525",
+          "System.IO.FileSystem": "4.0.1-rc2-23525",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23525",
+          "System.IO.UnmanagedMemoryStream": "4.0.1-rc2-23525",
+          "System.Linq": "4.0.1-rc2-23525",
+          "System.Linq.Expressions": "4.0.11-rc2-23525",
+          "System.Linq.Parallel": "4.0.1-rc2-23525",
+          "System.Linq.Queryable": "4.0.1-rc2-23525",
+          "System.Net.Http": "4.0.1-rc2-23525",
+          "System.Net.NetworkInformation": "4.1.0-rc2-23525",
+          "System.Net.Primitives": "4.0.11-rc2-23525",
+          "System.Numerics.Vectors": "4.1.1-rc2-23525",
+          "System.ObjectModel": "4.0.11-rc2-23525",
+          "System.Reflection": "4.1.0-rc2-23525",
+          "System.Reflection.DispatchProxy": "4.0.1-rc2-23525",
+          "System.Reflection.Extensions": "4.0.1-rc2-23525",
+          "System.Reflection.Metadata": "1.1.1-rc2-23525",
+          "System.Reflection.Primitives": "4.0.1-rc2-23525",
+          "System.Reflection.TypeExtensions": "4.1.0-rc2-23525",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23525",
+          "System.Runtime": "4.0.21-rc2-23525",
+          "System.Runtime.Extensions": "4.0.11-rc2-23525",
+          "System.Runtime.Handles": "4.0.1-rc2-23525",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23525",
+          "System.Runtime.Numerics": "4.0.1-rc2-23525",
+          "System.Security.Claims": "4.0.1-rc2-23525",
+          "System.Security.Principal": "4.0.1-rc2-23525",
+          "System.Text.Encoding": "4.0.11-rc2-23525",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23525",
+          "System.Text.RegularExpressions": "4.0.11-rc2-23525",
+          "System.Threading": "4.0.11-rc2-23525",
+          "System.Threading.Tasks": "4.0.11-rc2-23525",
+          "System.Threading.Tasks.Dataflow": "4.5.26-rc2-23525",
+          "System.Threading.Tasks.Parallel": "4.0.1-rc2-23525",
+          "System.Threading.Timer": "4.0.1-rc2-23525",
+          "System.Xml.ReaderWriter": "4.0.11-rc2-23525",
+          "System.Xml.XDocument": "4.0.11-rc2-23525"
         }
       },
-      "Microsoft.NETCore.Console/1.0.0-rc2-23519": {
+      "Microsoft.NETCore.Console/1.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore": "5.0.1-rc2-23519",
-          "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23519",
-          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-rc2-23519",
-          "Microsoft.Win32.Primitives": "4.0.1-rc2-23519",
-          "System.ComponentModel.EventBasedAsync": "4.0.11-rc2-23519",
-          "System.Console": "4.0.0-rc2-23519",
-          "System.Data.Common": "4.0.1-rc2-23519",
-          "System.Data.SqlClient": "4.0.0-rc2-23519",
-          "System.Diagnostics.Contracts": "4.0.1-rc2-23519",
-          "System.Diagnostics.FileVersionInfo": "4.0.0-rc2-23519",
-          "System.Diagnostics.Process": "4.1.0-rc2-23519",
-          "System.Diagnostics.StackTrace": "4.0.1-rc2-23519",
-          "System.IO.FileSystem.DriveInfo": "4.0.0-rc2-23519",
-          "System.IO.FileSystem.Watcher": "4.0.0-rc2-23519",
-          "System.IO.MemoryMappedFiles": "4.0.0-rc2-23519",
-          "System.IO.Pipes": "4.0.0-rc2-23519",
-          "System.Net.NameResolution": "4.0.0-rc2-23519",
-          "System.Net.NetworkInformation": "4.1.0-rc2-23519",
-          "System.Net.Requests": "4.0.11-rc2-23519",
-          "System.Net.Security": "4.0.0-rc2-23519",
-          "System.Net.Sockets": "4.1.0-rc2-23519",
-          "System.Net.Utilities": "4.0.0-rc2-23519",
-          "System.Net.WebHeaderCollection": "4.0.1-rc2-23519",
-          "System.Net.WebSockets": "4.0.0-rc2-23519",
-          "System.Net.WebSockets.Client": "4.0.0-rc2-23519",
-          "System.Reflection.Emit": "4.0.1-rc2-23519",
-          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23519",
-          "System.Reflection.Emit.Lightweight": "4.0.1-rc2-23519",
-          "System.Resources.ReaderWriter": "4.0.0-rc2-23519",
-          "System.Runtime.CompilerServices.VisualC": "4.0.0-rc2-23519",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23519",
-          "System.Runtime.Loader": "4.0.0-rc2-23519",
-          "System.Runtime.Serialization.Json": "4.0.1-rc2-23519",
-          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23519",
-          "System.Runtime.Serialization.Xml": "4.1.0-rc2-23519",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
-          "System.ServiceModel.Duplex": "4.0.1-rc2-23519",
-          "System.ServiceModel.Http": "4.0.11-rc2-23519",
-          "System.ServiceModel.NetTcp": "4.1.0-rc2-23519",
-          "System.ServiceModel.Primitives": "4.1.0-rc2-23519",
-          "System.ServiceModel.Security": "4.0.1-rc2-23519",
-          "System.Xml.XmlSerializer": "4.0.11-rc2-23519"
+          "Microsoft.NETCore": "5.0.1-rc2-23525",
+          "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23525",
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-rc2-23525",
+          "Microsoft.Win32.Primitives": "4.0.1-rc2-23525",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-rc2-23525",
+          "System.Console": "4.0.0-rc2-23525",
+          "System.Data.Common": "4.0.1-rc2-23525",
+          "System.Data.SqlClient": "4.0.0-rc2-23525",
+          "System.Diagnostics.Contracts": "4.0.1-rc2-23525",
+          "System.Diagnostics.FileVersionInfo": "4.0.0-rc2-23525",
+          "System.Diagnostics.Process": "4.1.0-rc2-23525",
+          "System.Diagnostics.StackTrace": "4.0.1-rc2-23525",
+          "System.IO.FileSystem.DriveInfo": "4.0.0-rc2-23525",
+          "System.IO.FileSystem.Watcher": "4.0.0-rc2-23525",
+          "System.IO.MemoryMappedFiles": "4.0.0-rc2-23525",
+          "System.IO.Pipes": "4.0.0-rc2-23525",
+          "System.Net.NameResolution": "4.0.0-rc2-23525",
+          "System.Net.NetworkInformation": "4.1.0-rc2-23525",
+          "System.Net.Requests": "4.0.11-rc2-23525",
+          "System.Net.Security": "4.0.0-rc2-23525",
+          "System.Net.Sockets": "4.1.0-rc2-23525",
+          "System.Net.Utilities": "4.0.0-rc2-23525",
+          "System.Net.WebHeaderCollection": "4.0.1-rc2-23525",
+          "System.Net.WebSockets": "4.0.0-rc2-23525",
+          "System.Net.WebSockets.Client": "4.0.0-rc2-23525",
+          "System.Reflection.Emit": "4.0.1-rc2-23525",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23525",
+          "System.Reflection.Emit.Lightweight": "4.0.1-rc2-23525",
+          "System.Resources.ReaderWriter": "4.0.0-rc2-23525",
+          "System.Runtime.CompilerServices.VisualC": "4.0.0-rc2-23525",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23525",
+          "System.Runtime.Loader": "4.0.0-rc2-23525",
+          "System.Runtime.Serialization.Json": "4.0.1-rc2-23525",
+          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23525",
+          "System.Runtime.Serialization.Xml": "4.1.0-rc2-23525",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.ServiceModel.Duplex": "4.0.1-rc2-23525",
+          "System.ServiceModel.Http": "4.0.11-rc2-23525",
+          "System.ServiceModel.NetTcp": "4.1.0-rc2-23525",
+          "System.ServiceModel.Primitives": "4.1.0-rc2-23525",
+          "System.ServiceModel.Security": "4.0.1-rc2-23525",
+          "System.Xml.XmlSerializer": "4.0.11-rc2-23525"
         }
       },
-      "Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23519": {
+      "Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23525": {
         "type": "package"
       },
-      "Microsoft.NETCore.Platforms/1.0.1-rc2-23519": {
+      "Microsoft.NETCore.Platforms/1.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Targets": "1.0.1-rc2-23519"
+          "Microsoft.NETCore.Targets": "1.0.1-rc2-23525"
         }
       },
-      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23519": {
+      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-rc2-23519"
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-rc2-23525"
         }
       },
-      "Microsoft.NETCore.Targets/1.0.1-rc2-23519": {
+      "Microsoft.NETCore.Targets/1.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-rc2-23519"
+          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-rc2-23525"
         }
       },
-      "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23519": {
+      "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23525": {
         "type": "package"
       },
-      "Microsoft.NETCore.TestHost/1.0.0-rc2-23519": {
+      "Microsoft.NETCore.TestHost/1.0.0-rc2-23525": {
         "type": "package"
       },
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23519": {
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23525": {
         "type": "package"
       },
-      "Microsoft.VisualBasic/10.0.1-rc2-23519": {
+      "Microsoft.VisualBasic/10.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -2075,7 +2107,7 @@
           "lib/dotnet5.4/Microsoft.VisualBasic.dll": {}
         }
       },
-      "Microsoft.Win32.Primitives/4.0.1-rc2-23519": {
+      "Microsoft.Win32.Primitives/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -2084,7 +2116,7 @@
           "ref/dotnet5.4/Microsoft.Win32.Primitives.dll": {}
         }
       },
-      "Microsoft.Win32.Registry/4.0.0-rc2-23519": {
+      "Microsoft.Win32.Registry/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -2108,7 +2140,7 @@
       "ReportGenerator/2.3.4": {
         "type": "package"
       },
-      "runtime.any.System.Linq.Expressions/4.0.11-rc2-23519": {
+      "runtime.any.System.Linq.Expressions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -2136,7 +2168,7 @@
           "lib/DNXCore50/System.Linq.Expressions.dll": {}
         }
       },
-      "runtime.any.System.Private.DataContractSerialization/4.1.0-rc2-23519": {
+      "runtime.any.System.Private.DataContractSerialization/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -2153,7 +2185,7 @@
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
-          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23519",
+          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Text.Encoding.Extensions": "4.0.10",
           "System.Text.RegularExpressions": "4.0.10",
@@ -2169,7 +2201,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "runtime.any.System.Reflection.DispatchProxy/4.0.1-rc2-23519": {
+      "runtime.any.System.Reflection.DispatchProxy/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -2190,7 +2222,7 @@
           "lib/DNXCore50/System.Reflection.DispatchProxy.dll": {}
         }
       },
-      "runtime.any.System.Xml.XmlSerializer/4.0.11-rc2-23519": {
+      "runtime.any.System.Xml.XmlSerializer/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -2219,7 +2251,7 @@
           "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "runtime.win.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23519": {
+      "runtime.win.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -2232,7 +2264,7 @@
           "runtimes/win/lib/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "runtime.win.System.Text.Encoding.CodePages/4.0.1-rc2-23519": {
+      "runtime.win.System.Text.Encoding.CodePages/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -2254,7 +2286,7 @@
           "runtimes/win/lib/dotnet5.4/System.Text.Encoding.CodePages.dll": {}
         }
       },
-      "runtime.win7.Microsoft.Win32.Primitives/4.0.1-rc2-23519": {
+      "runtime.win7.Microsoft.Win32.Primitives/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20",
@@ -2267,7 +2299,7 @@
           "runtimes/win7/lib/dotnet5.4/Microsoft.Win32.Primitives.dll": {}
         }
       },
-      "runtime.win7.System.Console/4.0.0-rc2-23519": {
+      "runtime.win7.System.Console/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -2287,7 +2319,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Console.dll": {}
         }
       },
-      "runtime.win7.System.Data.SqlClient/4.0.0-rc2-23519": {
+      "runtime.win7.System.Data.SqlClient/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -2299,10 +2331,10 @@
           "System.Globalization": "4.0.10",
           "System.IO": "4.0.10",
           "System.Linq": "4.0.0",
-          "System.Net.NameResolution": "4.0.0-rc2-23519",
+          "System.Net.NameResolution": "4.0.0-rc2-23525",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-rc2-23519",
-          "System.Net.Sockets": "4.0.10-rc2-23519",
+          "System.Net.Security": "4.0.0-rc2-23525",
+          "System.Net.Sockets": "4.0.10-rc2-23525",
           "System.Reflection": "4.0.0",
           "System.Reflection.TypeExtensions": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
@@ -2310,17 +2342,17 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
-          "System.Security.Principal.Windows": "4.0.0-rc2-23519",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Text.Encoding.CodePages": "4.0.0",
           "System.Text.Encoding.Extensions": "4.0.0",
           "System.Text.RegularExpressions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.Thread": "4.0.0-rc2-23519",
-          "System.Threading.ThreadPool": "4.0.0-rc2-23519",
+          "System.Threading.Thread": "4.0.0-rc2-23525",
+          "System.Threading.ThreadPool": "4.0.0-rc2-23525",
           "System.Threading.Timer": "4.0.0",
           "System.Xml.ReaderWriter": "4.0.0"
         },
@@ -2331,7 +2363,7 @@
           "runtimes/win7/lib/DNXCore50/System.Data.SqlClient.dll": {}
         }
       },
-      "runtime.win7.System.Diagnostics.Debug/4.0.11-rc2-23519": {
+      "runtime.win7.System.Diagnostics.Debug/4.0.11-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -2340,7 +2372,7 @@
           "runtimes/win7/lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "runtime.win7.System.Diagnostics.FileVersionInfo/4.0.0-rc2-23519": {
+      "runtime.win7.System.Diagnostics.FileVersionInfo/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -2355,11 +2387,11 @@
           "runtimes/win7/lib/dotnet5.4/System.Diagnostics.FileVersionInfo.dll": {}
         }
       },
-      "runtime.win7.System.Diagnostics.Process/4.1.0-rc2-23519": {
+      "runtime.win7.System.Diagnostics.Process/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
-          "Microsoft.Win32.Registry": "4.0.0-rc2-23519",
+          "Microsoft.Win32.Registry": "4.0.0-rc2-23525",
           "System.Collections": "4.0.10",
           "System.Diagnostics.Debug": "4.0.10",
           "System.Globalization": "4.0.10",
@@ -2375,8 +2407,8 @@
           "System.Text.Encoding.Extensions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.Thread": "4.0.0-rc2-23519",
-          "System.Threading.ThreadPool": "4.0.10-rc2-23519"
+          "System.Threading.Thread": "4.0.0-rc2-23525",
+          "System.Threading.ThreadPool": "4.0.10-rc2-23525"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -2385,7 +2417,7 @@
           "runtimes/win7/lib/dotnet5.5/System.Diagnostics.Process.dll": {}
         }
       },
-      "runtime.win7.System.Globalization.Extensions/4.0.1-rc2-23519": {
+      "runtime.win7.System.Globalization.Extensions/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -2401,7 +2433,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Globalization.Extensions.dll": {}
         }
       },
-      "runtime.win7.System.IO.Compression/4.1.0-rc2-23519": {
+      "runtime.win7.System.IO.Compression/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -2423,7 +2455,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.Compression.dll": {}
         }
       },
-      "runtime.win7.System.IO.FileSystem/4.0.1-rc2-23519": {
+      "runtime.win7.System.IO.FileSystem/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -2447,7 +2479,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.FileSystem.dll": {}
         }
       },
-      "runtime.win7.System.IO.FileSystem.DriveInfo/4.0.0-rc2-23519": {
+      "runtime.win7.System.IO.FileSystem.DriveInfo/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO.FileSystem": "4.0.0",
@@ -2465,7 +2497,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
-      "runtime.win7.System.IO.FileSystem.Watcher/4.0.0-rc2-23519": {
+      "runtime.win7.System.IO.FileSystem.Watcher/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -2485,7 +2517,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.FileSystem.Watcher.dll": {}
         }
       },
-      "runtime.win7.System.IO.MemoryMappedFiles/4.0.0-rc2-23519": {
+      "runtime.win7.System.IO.MemoryMappedFiles/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -2506,7 +2538,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.MemoryMappedFiles.dll": {}
         }
       },
-      "runtime.win7.System.IO.Pipes/4.0.0-rc2-23519": {
+      "runtime.win7.System.IO.Pipes/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -2528,7 +2560,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.Pipes.dll": {}
         }
       },
-      "runtime.win7.System.Net.Http/4.0.1-rc2-23519": {
+      "runtime.win7.System.Net.Http/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -2543,7 +2575,7 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.0",
           "System.Threading.Tasks": "4.0.10"
@@ -2555,10 +2587,10 @@
           "runtimes/win7/lib/DNXCore50/System.Net.Http.dll": {}
         }
       },
-      "runtime.win7.System.Net.NameResolution/4.0.0-rc2-23519": {
+      "runtime.win7.System.Net.NameResolution/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-rc2-23519"
+          "System.Private.Networking": "4.0.1-rc2-23525"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -2567,10 +2599,10 @@
           "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
-      "runtime.win7.System.Net.NetworkInformation/4.1.0-rc2-23519": {
+      "runtime.win7.System.Net.NetworkInformation/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-rc2-23519",
+          "System.Private.Networking": "4.0.1-rc2-23525",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -2580,10 +2612,10 @@
           "lib/DNXCore50/System.Net.NetworkInformation.dll": {}
         }
       },
-      "runtime.win7.System.Net.Primitives/4.0.11-rc2-23519": {
+      "runtime.win7.System.Net.Primitives/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-rc2-23519"
+          "System.Private.Networking": "4.0.1-rc2-23525"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -2592,7 +2624,7 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "runtime.win7.System.Net.Requests/4.0.11-rc2-23519": {
+      "runtime.win7.System.Net.Requests/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -2613,10 +2645,10 @@
           "runtimes/win7/lib/dotnet5.4/System.Net.Requests.dll": {}
         }
       },
-      "runtime.win7.System.Net.Security/4.0.0-rc2-23519": {
+      "runtime.win7.System.Net.Security/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-rc2-23519"
+          "System.Private.Networking": "4.0.1-rc2-23525"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -2625,10 +2657,10 @@
           "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
-      "runtime.win7.System.Net.Sockets/4.1.0-rc2-23519": {
+      "runtime.win7.System.Net.Sockets/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-rc2-23519",
+          "System.Private.Networking": "4.0.1-rc2-23525",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -2638,7 +2670,7 @@
           "lib/DNXCore50/System.Net.Sockets.dll": {}
         }
       },
-      "runtime.win7.System.Net.WebSockets.Client/4.0.0-rc2-23519": {
+      "runtime.win7.System.Net.WebSockets.Client/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -2648,13 +2680,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-rc2-23519",
+          "System.Net.WebSockets": "4.0.0-rc2-23525",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -2666,7 +2698,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Net.WebSockets.Client.dll": {}
         }
       },
-      "runtime.win7.System.Private.Uri/4.0.1-rc2-23519": {
+      "runtime.win7.System.Private.Uri/4.0.1-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -2675,7 +2707,7 @@
           "runtimes/win7/lib/DNXCore50/System.Private.Uri.dll": {}
         }
       },
-      "runtime.win7.System.Runtime.Extensions/4.0.11-rc2-23519": {
+      "runtime.win7.System.Runtime.Extensions/4.0.11-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -2684,7 +2716,7 @@
           "lib/DNXCore50/System.Runtime.Extensions.dll": {}
         }
       },
-      "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-rc2-23519": {
+      "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -2692,7 +2724,7 @@
           "System.Runtime": "4.0.20",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.0",
           "System.Text.Encoding.Extensions": "4.0.0"
         },
@@ -2703,7 +2735,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-rc2-23519": {
+      "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -2715,7 +2747,7 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519"
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -2724,7 +2756,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-rc2-23519": {
+      "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -2738,11 +2770,11 @@
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
           "System.Runtime.Numerics": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Cng": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Csp": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Cng": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Csp": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10"
         },
@@ -2753,7 +2785,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
-      "runtime.win7.System.Threading/4.0.11-rc2-23519": {
+      "runtime.win7.System.Threading/4.0.11-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -2762,13 +2794,13 @@
           "runtimes/win7/lib/DNXCore50/System.Threading.dll": {}
         }
       },
-      "runtime.win7-x64.Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23519": {
+      "runtime.win7-x64.Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23525": {
         "type": "package",
         "native": {
           "runtimes/win7-x64/native/CoreConsole.exe": {}
         }
       },
-      "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23519": {
+      "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -2786,13 +2818,13 @@
           "runtimes/win7-x64/native/mscorrc.dll": {}
         }
       },
-      "runtime.win7-x64.Microsoft.NETCore.TestHost/1.0.0-rc2-23519": {
+      "runtime.win7-x64.Microsoft.NETCore.TestHost/1.0.0-rc2-23525": {
         "type": "package",
         "native": {
           "runtimes/win7-x64/native/CoreRun.exe": {}
         }
       },
-      "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23519": {
+      "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23525": {
         "type": "package",
         "native": {
           "runtimes/win7-x64/native/API-MS-Win-Base-Util-L1-1-0.dll": {},
@@ -2919,19 +2951,19 @@
           "runtimes/win7-x64/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll": {}
         }
       },
-      "runtime.win7-x64.System.Data.SqlClient.sni/4.0.0-rc2-23519": {
+      "runtime.win7-x64.System.Data.SqlClient.sni/4.0.0-rc2-23525": {
         "type": "package",
         "native": {
           "runtimes/win7-x64/native/sni.dll": {}
         }
       },
-      "runtime.win7-x64.System.IO.Compression.clrcompression/4.0.1-rc2-23519": {
+      "runtime.win7-x64.System.IO.Compression.clrcompression/4.0.1-rc2-23525": {
         "type": "package",
         "native": {
           "runtimes/win7-x64/native/clrcompression.dll": {}
         }
       },
-      "System.AppContext/4.0.1-rc2-23519": {
+      "System.AppContext/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -2943,10 +2975,10 @@
           "lib/DNXCore50/System.AppContext.dll": {}
         }
       },
-      "System.Collections/4.0.11-rc2-23519": {
+      "System.Collections/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Runtime": "4.0.21-rc2-23519"
+          "System.Runtime": "4.0.21-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Collections.dll": {}
@@ -2955,7 +2987,7 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Collections.Concurrent/4.0.11-rc2-23519": {
+      "System.Collections.Concurrent/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -2975,7 +3007,7 @@
           "lib/dotnet5.4/System.Collections.Concurrent.dll": {}
         }
       },
-      "System.Collections.Immutable/1.1.38-rc2-23519": {
+      "System.Collections.Immutable/1.1.38-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -2994,7 +3026,7 @@
           "lib/dotnet5.1/System.Collections.Immutable.dll": {}
         }
       },
-      "System.Collections.NonGeneric/4.0.1-rc2-23519": {
+      "System.Collections.NonGeneric/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -3011,7 +3043,7 @@
           "lib/dotnet5.4/System.Collections.NonGeneric.dll": {}
         }
       },
-      "System.Collections.Specialized/4.0.1-rc2-23519": {
+      "System.Collections.Specialized/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections.NonGeneric": "4.0.0",
@@ -3029,7 +3061,7 @@
           "lib/dotnet5.4/System.Collections.Specialized.dll": {}
         }
       },
-      "System.ComponentModel/4.0.1-rc2-23519": {
+      "System.ComponentModel/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -3041,7 +3073,7 @@
           "lib/dotnet5.4/System.ComponentModel.dll": {}
         }
       },
-      "System.ComponentModel.Annotations/4.1.0-rc2-23519": {
+      "System.ComponentModel.Annotations/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -3063,7 +3095,7 @@
           "lib/dotnet5.4/System.ComponentModel.Annotations.dll": {}
         }
       },
-      "System.ComponentModel.EventBasedAsync/4.0.11-rc2-23519": {
+      "System.ComponentModel.EventBasedAsync/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -3078,7 +3110,7 @@
           "lib/dotnet5.4/System.ComponentModel.EventBasedAsync.dll": {}
         }
       },
-      "System.Console/4.0.0-rc2-23519": {
+      "System.Console/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3088,7 +3120,7 @@
           "ref/dotnet5.4/System.Console.dll": {}
         }
       },
-      "System.Data.Common/4.0.1-rc2-23519": {
+      "System.Data.Common/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -3108,7 +3140,7 @@
           "lib/dotnet5.4/System.Data.Common.dll": {}
         }
       },
-      "System.Data.SqlClient/4.0.0-rc2-23519": {
+      "System.Data.SqlClient/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Data.Common": "4.0.0",
@@ -3122,7 +3154,7 @@
           "ref/dotnet5.4/System.Data.SqlClient.dll": {}
         }
       },
-      "System.Diagnostics.Contracts/4.0.1-rc2-23519": {
+      "System.Diagnostics.Contracts/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -3134,7 +3166,7 @@
           "lib/DNXCore50/System.Diagnostics.Contracts.dll": {}
         }
       },
-      "System.Diagnostics.Debug/4.0.11-rc2-23519": {
+      "System.Diagnostics.Debug/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -3143,7 +3175,7 @@
           "ref/dotnet5.4/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.FileVersionInfo/4.0.0-rc2-23519": {
+      "System.Diagnostics.FileVersionInfo/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -3152,7 +3184,7 @@
           "ref/dotnet5.4/System.Diagnostics.FileVersionInfo.dll": {}
         }
       },
-      "System.Diagnostics.Process/4.1.0-rc2-23519": {
+      "System.Diagnostics.Process/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3164,7 +3196,7 @@
           "ref/dotnet5.5/System.Diagnostics.Process.dll": {}
         }
       },
-      "System.Diagnostics.StackTrace/4.0.1-rc2-23519": {
+      "System.Diagnostics.StackTrace/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -3177,7 +3209,7 @@
           "lib/DNXCore50/System.Diagnostics.StackTrace.dll": {}
         }
       },
-      "System.Diagnostics.Tools/4.0.1-rc2-23519": {
+      "System.Diagnostics.Tools/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -3189,7 +3221,7 @@
           "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
         }
       },
-      "System.Diagnostics.Tracing/4.0.21-rc2-23519": {
+      "System.Diagnostics.Tracing/4.0.21-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -3201,7 +3233,7 @@
           "lib/DNXCore50/System.Diagnostics.Tracing.dll": {}
         }
       },
-      "System.Dynamic.Runtime/4.0.11-rc2-23519": {
+      "System.Dynamic.Runtime/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -3227,7 +3259,7 @@
           "lib/DNXCore50/System.Dynamic.Runtime.dll": {}
         }
       },
-      "System.Globalization/4.0.11-rc2-23519": {
+      "System.Globalization/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -3239,7 +3271,7 @@
           "lib/DNXCore50/System.Globalization.dll": {}
         }
       },
-      "System.Globalization.Calendars/4.0.1-rc2-23519": {
+      "System.Globalization.Calendars/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -3252,7 +3284,7 @@
           "lib/DNXCore50/System.Globalization.Calendars.dll": {}
         }
       },
-      "System.Globalization.Extensions/4.0.1-rc2-23519": {
+      "System.Globalization.Extensions/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -3263,7 +3295,7 @@
           "ref/dotnet5.4/System.Globalization.Extensions.dll": {}
         }
       },
-      "System.IO/4.0.11-rc2-23519": {
+      "System.IO/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20",
@@ -3277,7 +3309,7 @@
           "lib/DNXCore50/System.IO.dll": {}
         }
       },
-      "System.IO.Compression/4.1.0-rc2-23519": {
+      "System.IO.Compression/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3289,7 +3321,7 @@
           "ref/dotnet5.4/System.IO.Compression.dll": {}
         }
       },
-      "System.IO.Compression.ZipFile/4.0.1-rc2-23519": {
+      "System.IO.Compression.ZipFile/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -3308,7 +3340,7 @@
           "lib/dotnet5.4/System.IO.Compression.ZipFile.dll": {}
         }
       },
-      "System.IO.FileSystem/4.0.1-rc2-23519": {
+      "System.IO.FileSystem/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3322,7 +3354,7 @@
           "ref/dotnet5.4/System.IO.FileSystem.dll": {}
         }
       },
-      "System.IO.FileSystem.DriveInfo/4.0.0-rc2-23519": {
+      "System.IO.FileSystem.DriveInfo/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3333,7 +3365,7 @@
           "ref/dotnet5.4/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
-      "System.IO.FileSystem.Primitives/4.0.1-rc2-23519": {
+      "System.IO.FileSystem.Primitives/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -3345,7 +3377,7 @@
           "lib/dotnet5.4/System.IO.FileSystem.Primitives.dll": {}
         }
       },
-      "System.IO.FileSystem.Watcher/4.0.0-rc2-23519": {
+      "System.IO.FileSystem.Watcher/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -3354,7 +3386,7 @@
           "ref/dotnet5.4/System.IO.FileSystem.Watcher.dll": {}
         }
       },
-      "System.IO.MemoryMappedFiles/4.0.0-rc2-23519": {
+      "System.IO.MemoryMappedFiles/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO.FileSystem": "4.0.0",
@@ -3368,7 +3400,7 @@
           "ref/dotnet5.4/System.IO.MemoryMappedFiles.dll": {}
         }
       },
-      "System.IO.Pipes/4.0.0-rc2-23519": {
+      "System.IO.Pipes/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3381,7 +3413,7 @@
           "ref/dotnet5.4/System.IO.Pipes.dll": {}
         }
       },
-      "System.IO.UnmanagedMemoryStream/4.0.1-rc2-23519": {
+      "System.IO.UnmanagedMemoryStream/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -3399,7 +3431,7 @@
           "lib/dotnet5.4/System.IO.UnmanagedMemoryStream.dll": {}
         }
       },
-      "System.Linq/4.0.1-rc2-23519": {
+      "System.Linq/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -3415,7 +3447,7 @@
           "lib/dotnet5.4/System.Linq.dll": {}
         }
       },
-      "System.Linq.Expressions/4.0.11-rc2-23519": {
+      "System.Linq.Expressions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -3425,7 +3457,7 @@
           "ref/dotnet5.4/System.Linq.Expressions.dll": {}
         }
       },
-      "System.Linq.Parallel/4.0.1-rc2-23519": {
+      "System.Linq.Parallel/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -3446,7 +3478,7 @@
           "lib/dotnet5.4/System.Linq.Parallel.dll": {}
         }
       },
-      "System.Linq.Queryable/4.0.1-rc2-23519": {
+      "System.Linq.Queryable/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -3465,7 +3497,7 @@
           "lib/dotnet5.4/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-rc2-23519": {
+      "System.Net.Http/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3478,7 +3510,34 @@
           "ref/dotnet5.2/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-rc2-23519": {
+      "System.Net.Http.WinHttpHandler/4.0.0-rc2-23525": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Net.Http.WinHttpHandler.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Http.WinHttpHandler.dll": {}
+        }
+      },
+      "System.Net.NameResolution/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -3489,7 +3548,7 @@
           "ref/dotnet5.4/System.Net.NameResolution.dll": {}
         }
       },
-      "System.Net.NetworkInformation/4.1.0-rc2-23519": {
+      "System.Net.NetworkInformation/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -3500,7 +3559,7 @@
           "ref/dotnet5.4/System.Net.NetworkInformation.dll": {}
         }
       },
-      "System.Net.Primitives/4.0.11-rc2-23519": {
+      "System.Net.Primitives/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -3510,7 +3569,7 @@
           "ref/dotnet5.4/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Requests/4.0.11-rc2-23519": {
+      "System.Net.Requests/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3523,20 +3582,21 @@
           "ref/dotnet5.4/System.Net.Requests.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-rc2-23519": {
+      "System.Net.Security/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Net.Primitives": "4.0.10",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.Security.Principal": "4.0.0",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.Security.dll": {}
         }
       },
-      "System.Net.Sockets/4.1.0-rc2-23519": {
+      "System.Net.Sockets/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3548,10 +3608,10 @@
           "ref/dotnet5.4/System.Net.Sockets.dll": {}
         }
       },
-      "System.Net.Utilities/4.0.0-rc2-23519": {
+      "System.Net.Utilities/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-rc2-23519"
+          "System.Private.Networking": "4.0.1-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.Utilities.dll": {}
@@ -3560,7 +3620,7 @@
           "lib/DNXCore50/System.Net.Utilities.dll": {}
         }
       },
-      "System.Net.WebHeaderCollection/4.0.1-rc2-23519": {
+      "System.Net.WebHeaderCollection/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -3576,7 +3636,7 @@
           "lib/dotnet5.4/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-rc2-23519": {
+      "System.Net.WebSockets/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -3591,20 +3651,20 @@
           "lib/dotnet5.4/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-rc2-23519": {
+      "System.Net.WebSockets.Client/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
-          "System.Net.WebSockets": "4.0.0-rc2-23519",
+          "System.Net.WebSockets": "4.0.0-rc2-23525",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.WebSockets.Client.dll": {}
         }
       },
-      "System.Numerics.Vectors/4.1.1-rc2-23519": {
+      "System.Numerics.Vectors/4.1.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -3619,7 +3679,7 @@
           "lib/dotnet5.4/System.Numerics.Vectors.dll": {}
         }
       },
-      "System.ObjectModel/4.0.11-rc2-23519": {
+      "System.ObjectModel/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -3635,13 +3695,13 @@
           "lib/dotnet5.4/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.DataContractSerialization/4.1.0-rc2-23519": {
+      "System.Private.DataContractSerialization/4.1.0-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
         }
       },
-      "System.Private.Networking/4.0.1-rc2-23519": {
+      "System.Private.Networking/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -3660,14 +3720,14 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-rc2-23519",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23525",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-rc2-23519"
+          "System.Threading.ThreadPool": "4.0.10-rc2-23525"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -3676,53 +3736,57 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-rc2-23519": {
+      "System.Private.ServiceModel/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.11-rc2-23519",
-          "System.Collections.Concurrent": "4.0.11-rc2-23519",
-          "System.Collections.NonGeneric": "4.0.1-rc2-23519",
-          "System.Collections.Specialized": "4.0.1-rc2-23519",
-          "System.ComponentModel.EventBasedAsync": "4.0.11-rc2-23519",
-          "System.Diagnostics.Debug": "4.0.11-rc2-23519",
-          "System.Diagnostics.Tracing": "4.0.21-rc2-23519",
-          "System.Globalization": "4.0.11-rc2-23519",
-          "System.IO": "4.0.11-rc2-23519",
-          "System.IO.Compression": "4.1.0-rc2-23519",
-          "System.Linq": "4.0.1-rc2-23519",
-          "System.Linq.Expressions": "4.0.11-rc2-23519",
-          "System.Linq.Queryable": "4.0.1-rc2-23519",
-          "System.Net.Http": "4.0.1-rc2-23519",
-          "System.Net.NameResolution": "4.0.0-rc2-23519",
-          "System.Net.Primitives": "4.0.11-rc2-23519",
-          "System.Net.Security": "4.0.0-rc2-23519",
-          "System.Net.Sockets": "4.1.0-rc2-23519",
-          "System.Net.WebHeaderCollection": "4.0.1-rc2-23519",
-          "System.Net.WebSockets": "4.0.0-rc2-23519",
-          "System.Net.WebSockets.Client": "4.0.0-rc2-23519",
-          "System.ObjectModel": "4.0.11-rc2-23519",
-          "System.Reflection": "4.1.0-rc2-23519",
-          "System.Reflection.DispatchProxy": "4.0.1-rc2-23519",
-          "System.Reflection.Extensions": "4.0.1-rc2-23519",
-          "System.Reflection.Primitives": "4.0.1-rc2-23519",
-          "System.Reflection.TypeExtensions": "4.0.1-rc2-23519",
-          "System.Resources.ResourceManager": "4.0.1-rc2-23519",
-          "System.Runtime": "4.0.21-rc2-23519",
-          "System.Runtime.Extensions": "4.0.11-rc2-23519",
-          "System.Runtime.InteropServices": "4.0.21-rc2-23519",
+          "System.Collections": "4.0.11-rc2-23525",
+          "System.Collections.Concurrent": "4.0.11-rc2-23525",
+          "System.Collections.NonGeneric": "4.0.1-rc2-23525",
+          "System.Collections.Specialized": "4.0.1-rc2-23525",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-rc2-23525",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23525",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23525",
+          "System.Globalization": "4.0.11-rc2-23525",
+          "System.IO": "4.0.11-rc2-23525",
+          "System.IO.Compression": "4.1.0-rc2-23525",
+          "System.Linq": "4.0.1-rc2-23525",
+          "System.Linq.Expressions": "4.0.11-rc2-23525",
+          "System.Linq.Queryable": "4.0.1-rc2-23525",
+          "System.Net.Http": "4.0.1-rc2-23525",
+          "System.Net.Http.WinHttpHandler": "4.0.0-rc2-23525",
+          "System.Net.NameResolution": "4.0.0-rc2-23525",
+          "System.Net.Primitives": "4.0.11-rc2-23525",
+          "System.Net.Security": "4.0.0-rc2-23525",
+          "System.Net.Sockets": "4.1.0-rc2-23525",
+          "System.Net.WebHeaderCollection": "4.0.1-rc2-23525",
+          "System.Net.WebSockets": "4.0.0-rc2-23525",
+          "System.Net.WebSockets.Client": "4.0.0-rc2-23525",
+          "System.ObjectModel": "4.0.11-rc2-23525",
+          "System.Reflection": "4.1.0-rc2-23525",
+          "System.Reflection.DispatchProxy": "4.0.1-rc2-23525",
+          "System.Reflection.Extensions": "4.0.1-rc2-23525",
+          "System.Reflection.Primitives": "4.0.1-rc2-23525",
+          "System.Reflection.TypeExtensions": "4.0.1-rc2-23525",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23525",
+          "System.Runtime": "4.0.21-rc2-23525",
+          "System.Runtime.Extensions": "4.0.11-rc2-23525",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23525",
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
-          "System.Security.Claims": "4.0.1-rc2-23519",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
-          "System.Security.Principal": "4.0.1-rc2-23519",
-          "System.Security.Principal.Windows": "4.0.0-rc2-23519",
-          "System.Text.Encoding": "4.0.11-rc2-23519",
-          "System.Threading": "4.0.11-rc2-23519",
-          "System.Threading.Tasks": "4.0.11-rc2-23519",
-          "System.Threading.Timer": "4.0.1-rc2-23519",
-          "System.Xml.ReaderWriter": "4.0.11-rc2-23519",
-          "System.Xml.XmlDocument": "4.0.1-rc2-23519",
-          "System.Xml.XmlSerializer": "4.0.11-rc2-23519"
+          "System.Security.Claims": "4.0.1-rc2-23525",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.Security.Principal": "4.0.1-rc2-23525",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23525",
+          "System.Text.Encoding": "4.0.11-rc2-23525",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.11-rc2-23525",
+          "System.Threading.Tasks": "4.0.11-rc2-23525",
+          "System.Threading.Timer": "4.0.1-rc2-23525",
+          "System.Xml.ReaderWriter": "4.0.11-rc2-23525",
+          "System.Xml.XmlDocument": "4.0.1-rc2-23525",
+          "System.Xml.XmlSerializer": "4.0.11-rc2-23525"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -3731,13 +3795,13 @@
           "lib/DNXCore50/System.Private.ServiceModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.1-rc2-23519": {
+      "System.Private.Uri/4.0.1-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
         }
       },
-      "System.Reflection/4.1.0-rc2-23519": {
+      "System.Reflection/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3751,7 +3815,7 @@
           "lib/DNXCore50/System.Reflection.dll": {}
         }
       },
-      "System.Reflection.DispatchProxy/4.0.1-rc2-23519": {
+      "System.Reflection.DispatchProxy/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -3761,7 +3825,7 @@
           "ref/dotnet5.4/System.Reflection.DispatchProxy.dll": {}
         }
       },
-      "System.Reflection.Emit/4.0.1-rc2-23519": {
+      "System.Reflection.Emit/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3777,7 +3841,7 @@
           "lib/DNXCore50/System.Reflection.Emit.dll": {}
         }
       },
-      "System.Reflection.Emit.ILGeneration/4.0.1-rc2-23519": {
+      "System.Reflection.Emit.ILGeneration/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -3791,7 +3855,7 @@
           "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
         }
       },
-      "System.Reflection.Emit.Lightweight/4.0.1-rc2-23519": {
+      "System.Reflection.Emit.Lightweight/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -3806,7 +3870,7 @@
           "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll": {}
         }
       },
-      "System.Reflection.Extensions/4.0.1-rc2-23519": {
+      "System.Reflection.Extensions/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -3819,7 +3883,7 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.1.1-rc2-23519": {
+      "System.Reflection.Metadata/1.1.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -3844,7 +3908,7 @@
           "lib/dotnet5.2/System.Reflection.Metadata.dll": {}
         }
       },
-      "System.Reflection.Primitives/4.0.1-rc2-23519": {
+      "System.Reflection.Primitives/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -3856,7 +3920,7 @@
           "lib/DNXCore50/System.Reflection.Primitives.dll": {}
         }
       },
-      "System.Reflection.TypeExtensions/4.1.0-rc2-23519": {
+      "System.Reflection.TypeExtensions/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -3869,7 +3933,7 @@
           "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
         }
       },
-      "System.Resources.ReaderWriter/4.0.0-rc2-23519": {
+      "System.Resources.ReaderWriter/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -3887,7 +3951,7 @@
           "lib/DNXCore50/System.Resources.ReaderWriter.dll": {}
         }
       },
-      "System.Resources.ResourceManager/4.0.1-rc2-23519": {
+      "System.Resources.ResourceManager/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -3901,10 +3965,10 @@
           "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
         }
       },
-      "System.Runtime/4.0.21-rc2-23519": {
+      "System.Runtime/4.0.21-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.Uri": "4.0.1-rc2-23519"
+          "System.Private.Uri": "4.0.1-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Runtime.dll": {}
@@ -3913,7 +3977,7 @@
           "lib/DNXCore50/System.Runtime.dll": {}
         }
       },
-      "System.Runtime.CompilerServices.VisualC/4.0.0-rc2-23519": {
+      "System.Runtime.CompilerServices.VisualC/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -3925,7 +3989,7 @@
           "lib/DNXCore50/System.Runtime.CompilerServices.VisualC.dll": {}
         }
       },
-      "System.Runtime.Extensions/4.0.11-rc2-23519": {
+      "System.Runtime.Extensions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -3934,7 +3998,7 @@
           "ref/dotnet5.4/System.Runtime.Extensions.dll": {}
         }
       },
-      "System.Runtime.Handles/4.0.1-rc2-23519": {
+      "System.Runtime.Handles/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -3946,7 +4010,7 @@
           "lib/DNXCore50/System.Runtime.Handles.dll": {}
         }
       },
-      "System.Runtime.InteropServices/4.0.21-rc2-23519": {
+      "System.Runtime.InteropServices/4.0.21-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -3961,7 +4025,7 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23519": {
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -3970,7 +4034,7 @@
           "ref/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "System.Runtime.Loader/4.0.0-rc2-23519": {
+      "System.Runtime.Loader/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -3978,13 +4042,13 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Runtime.Loader.dll": {}
+          "ref/dotnet5.5/System.Runtime.Loader.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Runtime.Loader.dll": {}
         }
       },
-      "System.Runtime.Numerics/4.0.1-rc2-23519": {
+      "System.Runtime.Numerics/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -3999,10 +4063,10 @@
           "lib/dotnet5.4/System.Runtime.Numerics.dll": {}
         }
       },
-      "System.Runtime.Serialization.Json/4.0.1-rc2-23519": {
+      "System.Runtime.Serialization.Json/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.1.0-rc2-23519"
+          "System.Private.DataContractSerialization": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.1/System.Runtime.Serialization.Json.dll": {}
@@ -4011,7 +4075,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Json.dll": {}
         }
       },
-      "System.Runtime.Serialization.Primitives/4.1.0-rc2-23519": {
+      "System.Runtime.Serialization.Primitives/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -4024,11 +4088,11 @@
           "lib/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
         }
       },
-      "System.Runtime.Serialization.Xml/4.1.0-rc2-23519": {
+      "System.Runtime.Serialization.Xml/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.1.0-rc2-23519",
-          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23519"
+          "System.Private.DataContractSerialization": "4.1.0-rc2-23525",
+          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Runtime.Serialization.Xml.dll": {}
@@ -4037,7 +4101,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Xml.dll": {}
         }
       },
-      "System.Security.Claims/4.0.1-rc2-23519": {
+      "System.Security.Claims/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -4056,18 +4120,18 @@
           "lib/dotnet5.4/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.Algorithms/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519"
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Cng/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.Cng/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -4076,8 +4140,8 @@
           "System.Runtime.Extensions": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.0"
         },
         "compile": {
@@ -4087,7 +4151,7 @@
           "lib/dotnet5.4/System.Security.Cryptography.Cng.dll": {}
         }
       },
-      "System.Security.Cryptography.Csp/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.Csp/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -4097,9 +4161,9 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10"
         },
@@ -4110,7 +4174,7 @@
           "lib/DNXCore50/System.Security.Cryptography.Csp.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.Encoding/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -4119,7 +4183,7 @@
           "ref/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.Primitives/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -4137,19 +4201,19 @@
           "lib/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23519"
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
-      "System.Security.Principal/4.0.1-rc2-23519": {
+      "System.Security.Principal/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -4161,7 +4225,7 @@
           "lib/dotnet5.1/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-rc2-23519": {
+      "System.Security.Principal.Windows/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -4184,10 +4248,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-rc2-23519": {
+      "System.ServiceModel.Duplex/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519"
+          "System.Private.ServiceModel": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.2/System.ServiceModel.Duplex.dll": {}
@@ -4196,10 +4260,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-rc2-23519": {
+      "System.ServiceModel.Http/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519",
+          "System.Private.ServiceModel": "4.1.0-rc2-23525",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -4209,10 +4273,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.1.0-rc2-23519": {
+      "System.ServiceModel.NetTcp/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519"
+          "System.Private.ServiceModel": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.ServiceModel.NetTcp.dll": {}
@@ -4221,10 +4285,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.1.0-rc2-23519": {
+      "System.ServiceModel.Primitives/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519"
+          "System.Private.ServiceModel": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.ServiceModel.Primitives.dll": {}
@@ -4233,10 +4297,10 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
-      "System.ServiceModel.Security/4.0.1-rc2-23519": {
+      "System.ServiceModel.Security/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519"
+          "System.Private.ServiceModel": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.2/System.ServiceModel.Security.dll": {}
@@ -4245,7 +4309,7 @@
           "lib/DNXCore50/System.ServiceModel.Security.dll": {}
         }
       },
-      "System.Text.Encoding/4.0.11-rc2-23519": {
+      "System.Text.Encoding/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -4257,7 +4321,7 @@
           "lib/DNXCore50/System.Text.Encoding.dll": {}
         }
       },
-      "System.Text.Encoding.CodePages/4.0.1-rc2-23519": {
+      "System.Text.Encoding.CodePages/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -4267,7 +4331,7 @@
           "ref/dotnet5.4/System.Text.Encoding.CodePages.dll": {}
         }
       },
-      "System.Text.Encoding.Extensions/4.0.11-rc2-23519": {
+      "System.Text.Encoding.Extensions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -4280,7 +4344,7 @@
           "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
         }
       },
-      "System.Text.RegularExpressions/4.0.11-rc2-23519": {
+      "System.Text.RegularExpressions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -4297,7 +4361,7 @@
           "lib/dotnet5.4/System.Text.RegularExpressions.dll": {}
         }
       },
-      "System.Threading/4.0.11-rc2-23519": {
+      "System.Threading/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -4307,7 +4371,7 @@
           "ref/dotnet5.4/System.Threading.dll": {}
         }
       },
-      "System.Threading.Overlapped/4.0.1-rc2-23519": {
+      "System.Threading.Overlapped/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -4320,7 +4384,7 @@
           "lib/DNXCore50/System.Threading.Overlapped.dll": {}
         }
       },
-      "System.Threading.Tasks/4.0.11-rc2-23519": {
+      "System.Threading.Tasks/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -4332,7 +4396,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.Tasks.Dataflow/4.5.26-rc2-23519": {
+      "System.Threading.Tasks.Dataflow/4.5.26-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -4354,7 +4418,7 @@
           "lib/dotnet5.2/System.Threading.Tasks.Dataflow.dll": {}
         }
       },
-      "System.Threading.Tasks.Parallel/4.0.1-rc2-23519": {
+      "System.Threading.Tasks.Parallel/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections.Concurrent": "4.0.10",
@@ -4373,7 +4437,7 @@
           "lib/dotnet5.4/System.Threading.Tasks.Parallel.dll": {}
         }
       },
-      "System.Threading.Thread/4.0.0-rc2-23519": {
+      "System.Threading.Thread/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -4385,11 +4449,11 @@
           "lib/DNXCore50/System.Threading.Thread.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-rc2-23519": {
+      "System.Threading.ThreadPool/4.0.10-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
+          "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Threading.ThreadPool.dll": {}
@@ -4398,7 +4462,7 @@
           "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
-      "System.Threading.Timer/4.0.1-rc2-23519": {
+      "System.Threading.Timer/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -4410,7 +4474,7 @@
           "lib/DNXCore50/System.Threading.Timer.dll": {}
         }
       },
-      "System.Xml.ReaderWriter/4.0.11-rc2-23519": {
+      "System.Xml.ReaderWriter/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -4435,7 +4499,7 @@
           "lib/dotnet5.4/System.Xml.ReaderWriter.dll": {}
         }
       },
-      "System.Xml.XDocument/4.0.11-rc2-23519": {
+      "System.Xml.XDocument/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -4458,7 +4522,7 @@
           "lib/dotnet5.4/System.Xml.XDocument.dll": {}
         }
       },
-      "System.Xml.XmlDocument/4.0.1-rc2-23519": {
+      "System.Xml.XmlDocument/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -4479,7 +4543,7 @@
           "lib/dotnet5.4/System.Xml.XmlDocument.dll": {}
         }
       },
-      "System.Xml.XmlSerializer/4.0.11-rc2-23519": {
+      "System.Xml.XmlSerializer/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -4647,7 +4711,7 @@
       "coveralls.io/1.4.0": {
         "type": "package"
       },
-      "Microsoft.CSharp/4.0.1-rc2-23519": {
+      "Microsoft.CSharp/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -4683,147 +4747,147 @@
           "xunit.runner.console": "2.1.0"
         }
       },
-      "Microsoft.NETCore/5.0.1-rc2-23519": {
+      "Microsoft.NETCore/5.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.CSharp": "4.0.1-rc2-23519",
-          "Microsoft.NETCore.Platforms": "1.0.1-rc2-23519",
-          "Microsoft.VisualBasic": "10.0.1-rc2-23519",
-          "System.AppContext": "4.0.1-rc2-23519",
-          "System.Collections": "4.0.11-rc2-23519",
-          "System.Collections.Concurrent": "4.0.11-rc2-23519",
-          "System.Collections.Immutable": "1.1.38-rc2-23519",
-          "System.ComponentModel": "4.0.1-rc2-23519",
-          "System.ComponentModel.Annotations": "4.1.0-rc2-23519",
-          "System.Diagnostics.Debug": "4.0.11-rc2-23519",
-          "System.Diagnostics.Tools": "4.0.1-rc2-23519",
-          "System.Diagnostics.Tracing": "4.0.21-rc2-23519",
-          "System.Dynamic.Runtime": "4.0.11-rc2-23519",
-          "System.Globalization": "4.0.11-rc2-23519",
-          "System.Globalization.Calendars": "4.0.1-rc2-23519",
-          "System.Globalization.Extensions": "4.0.1-rc2-23519",
-          "System.IO": "4.0.11-rc2-23519",
-          "System.IO.Compression": "4.1.0-rc2-23519",
-          "System.IO.Compression.ZipFile": "4.0.1-rc2-23519",
-          "System.IO.FileSystem": "4.0.1-rc2-23519",
-          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23519",
-          "System.IO.UnmanagedMemoryStream": "4.0.1-rc2-23519",
-          "System.Linq": "4.0.1-rc2-23519",
-          "System.Linq.Expressions": "4.0.11-rc2-23519",
-          "System.Linq.Parallel": "4.0.1-rc2-23519",
-          "System.Linq.Queryable": "4.0.1-rc2-23519",
-          "System.Net.Http": "4.0.1-rc2-23519",
-          "System.Net.NetworkInformation": "4.1.0-rc2-23519",
-          "System.Net.Primitives": "4.0.11-rc2-23519",
-          "System.Numerics.Vectors": "4.1.1-rc2-23519",
-          "System.ObjectModel": "4.0.11-rc2-23519",
-          "System.Reflection": "4.1.0-rc2-23519",
-          "System.Reflection.DispatchProxy": "4.0.1-rc2-23519",
-          "System.Reflection.Extensions": "4.0.1-rc2-23519",
-          "System.Reflection.Metadata": "1.1.1-rc2-23519",
-          "System.Reflection.Primitives": "4.0.1-rc2-23519",
-          "System.Reflection.TypeExtensions": "4.1.0-rc2-23519",
-          "System.Resources.ResourceManager": "4.0.1-rc2-23519",
-          "System.Runtime": "4.0.21-rc2-23519",
-          "System.Runtime.Extensions": "4.0.11-rc2-23519",
-          "System.Runtime.Handles": "4.0.1-rc2-23519",
-          "System.Runtime.InteropServices": "4.0.21-rc2-23519",
-          "System.Runtime.Numerics": "4.0.1-rc2-23519",
-          "System.Security.Claims": "4.0.1-rc2-23519",
-          "System.Security.Principal": "4.0.1-rc2-23519",
-          "System.Text.Encoding": "4.0.11-rc2-23519",
-          "System.Text.Encoding.Extensions": "4.0.11-rc2-23519",
-          "System.Text.RegularExpressions": "4.0.11-rc2-23519",
-          "System.Threading": "4.0.11-rc2-23519",
-          "System.Threading.Tasks": "4.0.11-rc2-23519",
-          "System.Threading.Tasks.Dataflow": "4.5.26-rc2-23519",
-          "System.Threading.Tasks.Parallel": "4.0.1-rc2-23519",
-          "System.Threading.Timer": "4.0.1-rc2-23519",
-          "System.Xml.ReaderWriter": "4.0.11-rc2-23519",
-          "System.Xml.XDocument": "4.0.11-rc2-23519"
+          "Microsoft.CSharp": "4.0.1-rc2-23525",
+          "Microsoft.NETCore.Platforms": "1.0.1-rc2-23525",
+          "Microsoft.VisualBasic": "10.0.1-rc2-23525",
+          "System.AppContext": "4.0.1-rc2-23525",
+          "System.Collections": "4.0.11-rc2-23525",
+          "System.Collections.Concurrent": "4.0.11-rc2-23525",
+          "System.Collections.Immutable": "1.1.38-rc2-23525",
+          "System.ComponentModel": "4.0.1-rc2-23525",
+          "System.ComponentModel.Annotations": "4.1.0-rc2-23525",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23525",
+          "System.Diagnostics.Tools": "4.0.1-rc2-23525",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23525",
+          "System.Dynamic.Runtime": "4.0.11-rc2-23525",
+          "System.Globalization": "4.0.11-rc2-23525",
+          "System.Globalization.Calendars": "4.0.1-rc2-23525",
+          "System.Globalization.Extensions": "4.0.1-rc2-23525",
+          "System.IO": "4.0.11-rc2-23525",
+          "System.IO.Compression": "4.1.0-rc2-23525",
+          "System.IO.Compression.ZipFile": "4.0.1-rc2-23525",
+          "System.IO.FileSystem": "4.0.1-rc2-23525",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23525",
+          "System.IO.UnmanagedMemoryStream": "4.0.1-rc2-23525",
+          "System.Linq": "4.0.1-rc2-23525",
+          "System.Linq.Expressions": "4.0.11-rc2-23525",
+          "System.Linq.Parallel": "4.0.1-rc2-23525",
+          "System.Linq.Queryable": "4.0.1-rc2-23525",
+          "System.Net.Http": "4.0.1-rc2-23525",
+          "System.Net.NetworkInformation": "4.1.0-rc2-23525",
+          "System.Net.Primitives": "4.0.11-rc2-23525",
+          "System.Numerics.Vectors": "4.1.1-rc2-23525",
+          "System.ObjectModel": "4.0.11-rc2-23525",
+          "System.Reflection": "4.1.0-rc2-23525",
+          "System.Reflection.DispatchProxy": "4.0.1-rc2-23525",
+          "System.Reflection.Extensions": "4.0.1-rc2-23525",
+          "System.Reflection.Metadata": "1.1.1-rc2-23525",
+          "System.Reflection.Primitives": "4.0.1-rc2-23525",
+          "System.Reflection.TypeExtensions": "4.1.0-rc2-23525",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23525",
+          "System.Runtime": "4.0.21-rc2-23525",
+          "System.Runtime.Extensions": "4.0.11-rc2-23525",
+          "System.Runtime.Handles": "4.0.1-rc2-23525",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23525",
+          "System.Runtime.Numerics": "4.0.1-rc2-23525",
+          "System.Security.Claims": "4.0.1-rc2-23525",
+          "System.Security.Principal": "4.0.1-rc2-23525",
+          "System.Text.Encoding": "4.0.11-rc2-23525",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23525",
+          "System.Text.RegularExpressions": "4.0.11-rc2-23525",
+          "System.Threading": "4.0.11-rc2-23525",
+          "System.Threading.Tasks": "4.0.11-rc2-23525",
+          "System.Threading.Tasks.Dataflow": "4.5.26-rc2-23525",
+          "System.Threading.Tasks.Parallel": "4.0.1-rc2-23525",
+          "System.Threading.Timer": "4.0.1-rc2-23525",
+          "System.Xml.ReaderWriter": "4.0.11-rc2-23525",
+          "System.Xml.XDocument": "4.0.11-rc2-23525"
         }
       },
-      "Microsoft.NETCore.Console/1.0.0-rc2-23519": {
+      "Microsoft.NETCore.Console/1.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore": "5.0.1-rc2-23519",
-          "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23519",
-          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-rc2-23519",
-          "Microsoft.Win32.Primitives": "4.0.1-rc2-23519",
-          "System.ComponentModel.EventBasedAsync": "4.0.11-rc2-23519",
-          "System.Console": "4.0.0-rc2-23519",
-          "System.Data.Common": "4.0.1-rc2-23519",
-          "System.Data.SqlClient": "4.0.0-rc2-23519",
-          "System.Diagnostics.Contracts": "4.0.1-rc2-23519",
-          "System.Diagnostics.FileVersionInfo": "4.0.0-rc2-23519",
-          "System.Diagnostics.Process": "4.1.0-rc2-23519",
-          "System.Diagnostics.StackTrace": "4.0.1-rc2-23519",
-          "System.IO.FileSystem.DriveInfo": "4.0.0-rc2-23519",
-          "System.IO.FileSystem.Watcher": "4.0.0-rc2-23519",
-          "System.IO.MemoryMappedFiles": "4.0.0-rc2-23519",
-          "System.IO.Pipes": "4.0.0-rc2-23519",
-          "System.Net.NameResolution": "4.0.0-rc2-23519",
-          "System.Net.NetworkInformation": "4.1.0-rc2-23519",
-          "System.Net.Requests": "4.0.11-rc2-23519",
-          "System.Net.Security": "4.0.0-rc2-23519",
-          "System.Net.Sockets": "4.1.0-rc2-23519",
-          "System.Net.Utilities": "4.0.0-rc2-23519",
-          "System.Net.WebHeaderCollection": "4.0.1-rc2-23519",
-          "System.Net.WebSockets": "4.0.0-rc2-23519",
-          "System.Net.WebSockets.Client": "4.0.0-rc2-23519",
-          "System.Reflection.Emit": "4.0.1-rc2-23519",
-          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23519",
-          "System.Reflection.Emit.Lightweight": "4.0.1-rc2-23519",
-          "System.Resources.ReaderWriter": "4.0.0-rc2-23519",
-          "System.Runtime.CompilerServices.VisualC": "4.0.0-rc2-23519",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23519",
-          "System.Runtime.Loader": "4.0.0-rc2-23519",
-          "System.Runtime.Serialization.Json": "4.0.1-rc2-23519",
-          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23519",
-          "System.Runtime.Serialization.Xml": "4.1.0-rc2-23519",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
-          "System.ServiceModel.Duplex": "4.0.1-rc2-23519",
-          "System.ServiceModel.Http": "4.0.11-rc2-23519",
-          "System.ServiceModel.NetTcp": "4.1.0-rc2-23519",
-          "System.ServiceModel.Primitives": "4.1.0-rc2-23519",
-          "System.ServiceModel.Security": "4.0.1-rc2-23519",
-          "System.Xml.XmlSerializer": "4.0.11-rc2-23519"
+          "Microsoft.NETCore": "5.0.1-rc2-23525",
+          "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23525",
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-rc2-23525",
+          "Microsoft.Win32.Primitives": "4.0.1-rc2-23525",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-rc2-23525",
+          "System.Console": "4.0.0-rc2-23525",
+          "System.Data.Common": "4.0.1-rc2-23525",
+          "System.Data.SqlClient": "4.0.0-rc2-23525",
+          "System.Diagnostics.Contracts": "4.0.1-rc2-23525",
+          "System.Diagnostics.FileVersionInfo": "4.0.0-rc2-23525",
+          "System.Diagnostics.Process": "4.1.0-rc2-23525",
+          "System.Diagnostics.StackTrace": "4.0.1-rc2-23525",
+          "System.IO.FileSystem.DriveInfo": "4.0.0-rc2-23525",
+          "System.IO.FileSystem.Watcher": "4.0.0-rc2-23525",
+          "System.IO.MemoryMappedFiles": "4.0.0-rc2-23525",
+          "System.IO.Pipes": "4.0.0-rc2-23525",
+          "System.Net.NameResolution": "4.0.0-rc2-23525",
+          "System.Net.NetworkInformation": "4.1.0-rc2-23525",
+          "System.Net.Requests": "4.0.11-rc2-23525",
+          "System.Net.Security": "4.0.0-rc2-23525",
+          "System.Net.Sockets": "4.1.0-rc2-23525",
+          "System.Net.Utilities": "4.0.0-rc2-23525",
+          "System.Net.WebHeaderCollection": "4.0.1-rc2-23525",
+          "System.Net.WebSockets": "4.0.0-rc2-23525",
+          "System.Net.WebSockets.Client": "4.0.0-rc2-23525",
+          "System.Reflection.Emit": "4.0.1-rc2-23525",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23525",
+          "System.Reflection.Emit.Lightweight": "4.0.1-rc2-23525",
+          "System.Resources.ReaderWriter": "4.0.0-rc2-23525",
+          "System.Runtime.CompilerServices.VisualC": "4.0.0-rc2-23525",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23525",
+          "System.Runtime.Loader": "4.0.0-rc2-23525",
+          "System.Runtime.Serialization.Json": "4.0.1-rc2-23525",
+          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23525",
+          "System.Runtime.Serialization.Xml": "4.1.0-rc2-23525",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.ServiceModel.Duplex": "4.0.1-rc2-23525",
+          "System.ServiceModel.Http": "4.0.11-rc2-23525",
+          "System.ServiceModel.NetTcp": "4.1.0-rc2-23525",
+          "System.ServiceModel.Primitives": "4.1.0-rc2-23525",
+          "System.ServiceModel.Security": "4.0.1-rc2-23525",
+          "System.Xml.XmlSerializer": "4.0.11-rc2-23525"
         }
       },
-      "Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23519": {
+      "Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23525": {
         "type": "package"
       },
-      "Microsoft.NETCore.Platforms/1.0.1-rc2-23519": {
+      "Microsoft.NETCore.Platforms/1.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Targets": "1.0.1-rc2-23519"
+          "Microsoft.NETCore.Targets": "1.0.1-rc2-23525"
         }
       },
-      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23519": {
+      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-rc2-23519"
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-rc2-23525"
         }
       },
-      "Microsoft.NETCore.Targets/1.0.1-rc2-23519": {
+      "Microsoft.NETCore.Targets/1.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-rc2-23519"
+          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-rc2-23525"
         }
       },
-      "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23519": {
+      "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23525": {
         "type": "package"
       },
-      "Microsoft.NETCore.TestHost/1.0.0-rc2-23519": {
+      "Microsoft.NETCore.TestHost/1.0.0-rc2-23525": {
         "type": "package"
       },
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23519": {
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23525": {
         "type": "package"
       },
-      "Microsoft.VisualBasic/10.0.1-rc2-23519": {
+      "Microsoft.VisualBasic/10.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -4850,7 +4914,7 @@
           "lib/dotnet5.4/Microsoft.VisualBasic.dll": {}
         }
       },
-      "Microsoft.Win32.Primitives/4.0.1-rc2-23519": {
+      "Microsoft.Win32.Primitives/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -4859,7 +4923,7 @@
           "ref/dotnet5.4/Microsoft.Win32.Primitives.dll": {}
         }
       },
-      "Microsoft.Win32.Registry/4.0.0-rc2-23519": {
+      "Microsoft.Win32.Registry/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -4883,7 +4947,7 @@
       "ReportGenerator/2.3.4": {
         "type": "package"
       },
-      "runtime.any.System.Linq.Expressions/4.0.11-rc2-23519": {
+      "runtime.any.System.Linq.Expressions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -4911,7 +4975,7 @@
           "lib/DNXCore50/System.Linq.Expressions.dll": {}
         }
       },
-      "runtime.any.System.Private.DataContractSerialization/4.1.0-rc2-23519": {
+      "runtime.any.System.Private.DataContractSerialization/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -4928,7 +4992,7 @@
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
-          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23519",
+          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Text.Encoding.Extensions": "4.0.10",
           "System.Text.RegularExpressions": "4.0.10",
@@ -4944,7 +5008,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "runtime.any.System.Reflection.DispatchProxy/4.0.1-rc2-23519": {
+      "runtime.any.System.Reflection.DispatchProxy/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -4965,7 +5029,7 @@
           "lib/DNXCore50/System.Reflection.DispatchProxy.dll": {}
         }
       },
-      "runtime.any.System.Xml.XmlSerializer/4.0.11-rc2-23519": {
+      "runtime.any.System.Xml.XmlSerializer/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -4994,7 +5058,7 @@
           "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "runtime.win.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23519": {
+      "runtime.win.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -5007,7 +5071,7 @@
           "runtimes/win/lib/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "runtime.win.System.Text.Encoding.CodePages/4.0.1-rc2-23519": {
+      "runtime.win.System.Text.Encoding.CodePages/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -5029,7 +5093,7 @@
           "runtimes/win/lib/dotnet5.4/System.Text.Encoding.CodePages.dll": {}
         }
       },
-      "runtime.win7.Microsoft.Win32.Primitives/4.0.1-rc2-23519": {
+      "runtime.win7.Microsoft.Win32.Primitives/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20",
@@ -5042,7 +5106,7 @@
           "runtimes/win7/lib/dotnet5.4/Microsoft.Win32.Primitives.dll": {}
         }
       },
-      "runtime.win7.System.Console/4.0.0-rc2-23519": {
+      "runtime.win7.System.Console/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -5062,7 +5126,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Console.dll": {}
         }
       },
-      "runtime.win7.System.Data.SqlClient/4.0.0-rc2-23519": {
+      "runtime.win7.System.Data.SqlClient/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -5074,10 +5138,10 @@
           "System.Globalization": "4.0.10",
           "System.IO": "4.0.10",
           "System.Linq": "4.0.0",
-          "System.Net.NameResolution": "4.0.0-rc2-23519",
+          "System.Net.NameResolution": "4.0.0-rc2-23525",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-rc2-23519",
-          "System.Net.Sockets": "4.0.10-rc2-23519",
+          "System.Net.Security": "4.0.0-rc2-23525",
+          "System.Net.Sockets": "4.0.10-rc2-23525",
           "System.Reflection": "4.0.0",
           "System.Reflection.TypeExtensions": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
@@ -5085,17 +5149,17 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
-          "System.Security.Principal.Windows": "4.0.0-rc2-23519",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Text.Encoding.CodePages": "4.0.0",
           "System.Text.Encoding.Extensions": "4.0.0",
           "System.Text.RegularExpressions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.Thread": "4.0.0-rc2-23519",
-          "System.Threading.ThreadPool": "4.0.0-rc2-23519",
+          "System.Threading.Thread": "4.0.0-rc2-23525",
+          "System.Threading.ThreadPool": "4.0.0-rc2-23525",
           "System.Threading.Timer": "4.0.0",
           "System.Xml.ReaderWriter": "4.0.0"
         },
@@ -5106,7 +5170,7 @@
           "runtimes/win7/lib/DNXCore50/System.Data.SqlClient.dll": {}
         }
       },
-      "runtime.win7.System.Diagnostics.Debug/4.0.11-rc2-23519": {
+      "runtime.win7.System.Diagnostics.Debug/4.0.11-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -5115,7 +5179,7 @@
           "runtimes/win7/lib/DNXCore50/System.Diagnostics.Debug.dll": {}
         }
       },
-      "runtime.win7.System.Diagnostics.FileVersionInfo/4.0.0-rc2-23519": {
+      "runtime.win7.System.Diagnostics.FileVersionInfo/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -5130,11 +5194,11 @@
           "runtimes/win7/lib/dotnet5.4/System.Diagnostics.FileVersionInfo.dll": {}
         }
       },
-      "runtime.win7.System.Diagnostics.Process/4.1.0-rc2-23519": {
+      "runtime.win7.System.Diagnostics.Process/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
-          "Microsoft.Win32.Registry": "4.0.0-rc2-23519",
+          "Microsoft.Win32.Registry": "4.0.0-rc2-23525",
           "System.Collections": "4.0.10",
           "System.Diagnostics.Debug": "4.0.10",
           "System.Globalization": "4.0.10",
@@ -5150,8 +5214,8 @@
           "System.Text.Encoding.Extensions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.Thread": "4.0.0-rc2-23519",
-          "System.Threading.ThreadPool": "4.0.10-rc2-23519"
+          "System.Threading.Thread": "4.0.0-rc2-23525",
+          "System.Threading.ThreadPool": "4.0.10-rc2-23525"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -5160,7 +5224,7 @@
           "runtimes/win7/lib/dotnet5.5/System.Diagnostics.Process.dll": {}
         }
       },
-      "runtime.win7.System.Globalization.Extensions/4.0.1-rc2-23519": {
+      "runtime.win7.System.Globalization.Extensions/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -5176,7 +5240,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Globalization.Extensions.dll": {}
         }
       },
-      "runtime.win7.System.IO.Compression/4.1.0-rc2-23519": {
+      "runtime.win7.System.IO.Compression/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -5198,7 +5262,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.Compression.dll": {}
         }
       },
-      "runtime.win7.System.IO.FileSystem/4.0.1-rc2-23519": {
+      "runtime.win7.System.IO.FileSystem/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -5222,7 +5286,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.FileSystem.dll": {}
         }
       },
-      "runtime.win7.System.IO.FileSystem.DriveInfo/4.0.0-rc2-23519": {
+      "runtime.win7.System.IO.FileSystem.DriveInfo/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO.FileSystem": "4.0.0",
@@ -5240,7 +5304,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
-      "runtime.win7.System.IO.FileSystem.Watcher/4.0.0-rc2-23519": {
+      "runtime.win7.System.IO.FileSystem.Watcher/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -5260,7 +5324,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.FileSystem.Watcher.dll": {}
         }
       },
-      "runtime.win7.System.IO.MemoryMappedFiles/4.0.0-rc2-23519": {
+      "runtime.win7.System.IO.MemoryMappedFiles/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -5281,7 +5345,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.MemoryMappedFiles.dll": {}
         }
       },
-      "runtime.win7.System.IO.Pipes/4.0.0-rc2-23519": {
+      "runtime.win7.System.IO.Pipes/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -5303,7 +5367,7 @@
           "runtimes/win7/lib/dotnet5.4/System.IO.Pipes.dll": {}
         }
       },
-      "runtime.win7.System.Net.Http/4.0.1-rc2-23519": {
+      "runtime.win7.System.Net.Http/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -5318,7 +5382,7 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.0",
           "System.Threading.Tasks": "4.0.10"
@@ -5330,10 +5394,10 @@
           "runtimes/win7/lib/DNXCore50/System.Net.Http.dll": {}
         }
       },
-      "runtime.win7.System.Net.NameResolution/4.0.0-rc2-23519": {
+      "runtime.win7.System.Net.NameResolution/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-rc2-23519"
+          "System.Private.Networking": "4.0.1-rc2-23525"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -5342,10 +5406,10 @@
           "lib/DNXCore50/System.Net.NameResolution.dll": {}
         }
       },
-      "runtime.win7.System.Net.NetworkInformation/4.1.0-rc2-23519": {
+      "runtime.win7.System.Net.NetworkInformation/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-rc2-23519",
+          "System.Private.Networking": "4.0.1-rc2-23525",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -5355,10 +5419,10 @@
           "lib/DNXCore50/System.Net.NetworkInformation.dll": {}
         }
       },
-      "runtime.win7.System.Net.Primitives/4.0.11-rc2-23519": {
+      "runtime.win7.System.Net.Primitives/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-rc2-23519"
+          "System.Private.Networking": "4.0.1-rc2-23525"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -5367,7 +5431,7 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "runtime.win7.System.Net.Requests/4.0.11-rc2-23519": {
+      "runtime.win7.System.Net.Requests/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -5388,10 +5452,10 @@
           "runtimes/win7/lib/dotnet5.4/System.Net.Requests.dll": {}
         }
       },
-      "runtime.win7.System.Net.Security/4.0.0-rc2-23519": {
+      "runtime.win7.System.Net.Security/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-rc2-23519"
+          "System.Private.Networking": "4.0.1-rc2-23525"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -5400,10 +5464,10 @@
           "lib/DNXCore50/System.Net.Security.dll": {}
         }
       },
-      "runtime.win7.System.Net.Sockets/4.1.0-rc2-23519": {
+      "runtime.win7.System.Net.Sockets/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-rc2-23519",
+          "System.Private.Networking": "4.0.1-rc2-23525",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -5413,7 +5477,7 @@
           "lib/DNXCore50/System.Net.Sockets.dll": {}
         }
       },
-      "runtime.win7.System.Net.WebSockets.Client/4.0.0-rc2-23519": {
+      "runtime.win7.System.Net.WebSockets.Client/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -5423,13 +5487,13 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.10",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-rc2-23519",
+          "System.Net.WebSockets": "4.0.0-rc2-23525",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -5441,7 +5505,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Net.WebSockets.Client.dll": {}
         }
       },
-      "runtime.win7.System.Private.Uri/4.0.1-rc2-23519": {
+      "runtime.win7.System.Private.Uri/4.0.1-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -5450,7 +5514,7 @@
           "runtimes/win7/lib/DNXCore50/System.Private.Uri.dll": {}
         }
       },
-      "runtime.win7.System.Runtime.Extensions/4.0.11-rc2-23519": {
+      "runtime.win7.System.Runtime.Extensions/4.0.11-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -5459,7 +5523,7 @@
           "lib/DNXCore50/System.Runtime.Extensions.dll": {}
         }
       },
-      "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-rc2-23519": {
+      "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -5467,7 +5531,7 @@
           "System.Runtime": "4.0.20",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.0",
           "System.Text.Encoding.Extensions": "4.0.0"
         },
@@ -5478,7 +5542,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-rc2-23519": {
+      "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -5490,7 +5554,7 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519"
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -5499,7 +5563,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-rc2-23519": {
+      "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -5513,11 +5577,11 @@
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
           "System.Runtime.Numerics": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Cng": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Csp": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Cng": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Csp": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10"
         },
@@ -5528,7 +5592,7 @@
           "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
-      "runtime.win7.System.Threading/4.0.11-rc2-23519": {
+      "runtime.win7.System.Threading/4.0.11-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -5537,13 +5601,13 @@
           "runtimes/win7/lib/DNXCore50/System.Threading.dll": {}
         }
       },
-      "runtime.win7-x86.Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23519": {
+      "runtime.win7-x86.Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23525": {
         "type": "package",
         "native": {
           "runtimes/win7-x86/native/CoreConsole.exe": {}
         }
       },
-      "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23519": {
+      "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -5561,13 +5625,13 @@
           "runtimes/win7-x86/native/mscorrc.dll": {}
         }
       },
-      "runtime.win7-x86.Microsoft.NETCore.TestHost/1.0.0-rc2-23519": {
+      "runtime.win7-x86.Microsoft.NETCore.TestHost/1.0.0-rc2-23525": {
         "type": "package",
         "native": {
           "runtimes/win7-x86/native/CoreRun.exe": {}
         }
       },
-      "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23519": {
+      "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23525": {
         "type": "package",
         "native": {
           "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll": {},
@@ -5694,19 +5758,19 @@
           "runtimes/win7-x86/native/ext-ms-win-advapi32-encryptedfile-l1-1-0.dll": {}
         }
       },
-      "runtime.win7-x86.System.Data.SqlClient.sni/4.0.0-rc2-23519": {
+      "runtime.win7-x86.System.Data.SqlClient.sni/4.0.0-rc2-23525": {
         "type": "package",
         "native": {
           "runtimes/win7-x86/native/sni.dll": {}
         }
       },
-      "runtime.win7-x86.System.IO.Compression.clrcompression/4.0.1-rc2-23519": {
+      "runtime.win7-x86.System.IO.Compression.clrcompression/4.0.1-rc2-23525": {
         "type": "package",
         "native": {
           "runtimes/win7-x86/native/clrcompression.dll": {}
         }
       },
-      "System.AppContext/4.0.1-rc2-23519": {
+      "System.AppContext/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -5718,10 +5782,10 @@
           "lib/DNXCore50/System.AppContext.dll": {}
         }
       },
-      "System.Collections/4.0.11-rc2-23519": {
+      "System.Collections/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Runtime": "4.0.21-rc2-23519"
+          "System.Runtime": "4.0.21-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Collections.dll": {}
@@ -5730,7 +5794,7 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Collections.Concurrent/4.0.11-rc2-23519": {
+      "System.Collections.Concurrent/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -5750,7 +5814,7 @@
           "lib/dotnet5.4/System.Collections.Concurrent.dll": {}
         }
       },
-      "System.Collections.Immutable/1.1.38-rc2-23519": {
+      "System.Collections.Immutable/1.1.38-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -5769,7 +5833,7 @@
           "lib/dotnet5.1/System.Collections.Immutable.dll": {}
         }
       },
-      "System.Collections.NonGeneric/4.0.1-rc2-23519": {
+      "System.Collections.NonGeneric/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -5786,7 +5850,7 @@
           "lib/dotnet5.4/System.Collections.NonGeneric.dll": {}
         }
       },
-      "System.Collections.Specialized/4.0.1-rc2-23519": {
+      "System.Collections.Specialized/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections.NonGeneric": "4.0.0",
@@ -5804,7 +5868,7 @@
           "lib/dotnet5.4/System.Collections.Specialized.dll": {}
         }
       },
-      "System.ComponentModel/4.0.1-rc2-23519": {
+      "System.ComponentModel/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -5816,7 +5880,7 @@
           "lib/dotnet5.4/System.ComponentModel.dll": {}
         }
       },
-      "System.ComponentModel.Annotations/4.1.0-rc2-23519": {
+      "System.ComponentModel.Annotations/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -5838,7 +5902,7 @@
           "lib/dotnet5.4/System.ComponentModel.Annotations.dll": {}
         }
       },
-      "System.ComponentModel.EventBasedAsync/4.0.11-rc2-23519": {
+      "System.ComponentModel.EventBasedAsync/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -5853,7 +5917,7 @@
           "lib/dotnet5.4/System.ComponentModel.EventBasedAsync.dll": {}
         }
       },
-      "System.Console/4.0.0-rc2-23519": {
+      "System.Console/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -5863,7 +5927,7 @@
           "ref/dotnet5.4/System.Console.dll": {}
         }
       },
-      "System.Data.Common/4.0.1-rc2-23519": {
+      "System.Data.Common/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -5883,7 +5947,7 @@
           "lib/dotnet5.4/System.Data.Common.dll": {}
         }
       },
-      "System.Data.SqlClient/4.0.0-rc2-23519": {
+      "System.Data.SqlClient/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Data.Common": "4.0.0",
@@ -5897,7 +5961,7 @@
           "ref/dotnet5.4/System.Data.SqlClient.dll": {}
         }
       },
-      "System.Diagnostics.Contracts/4.0.1-rc2-23519": {
+      "System.Diagnostics.Contracts/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -5909,7 +5973,7 @@
           "lib/DNXCore50/System.Diagnostics.Contracts.dll": {}
         }
       },
-      "System.Diagnostics.Debug/4.0.11-rc2-23519": {
+      "System.Diagnostics.Debug/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -5918,7 +5982,7 @@
           "ref/dotnet5.4/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.FileVersionInfo/4.0.0-rc2-23519": {
+      "System.Diagnostics.FileVersionInfo/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -5927,7 +5991,7 @@
           "ref/dotnet5.4/System.Diagnostics.FileVersionInfo.dll": {}
         }
       },
-      "System.Diagnostics.Process/4.1.0-rc2-23519": {
+      "System.Diagnostics.Process/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -5939,7 +6003,7 @@
           "ref/dotnet5.5/System.Diagnostics.Process.dll": {}
         }
       },
-      "System.Diagnostics.StackTrace/4.0.1-rc2-23519": {
+      "System.Diagnostics.StackTrace/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -5952,7 +6016,7 @@
           "lib/DNXCore50/System.Diagnostics.StackTrace.dll": {}
         }
       },
-      "System.Diagnostics.Tools/4.0.1-rc2-23519": {
+      "System.Diagnostics.Tools/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -5964,7 +6028,7 @@
           "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
         }
       },
-      "System.Diagnostics.Tracing/4.0.21-rc2-23519": {
+      "System.Diagnostics.Tracing/4.0.21-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -5976,7 +6040,7 @@
           "lib/DNXCore50/System.Diagnostics.Tracing.dll": {}
         }
       },
-      "System.Dynamic.Runtime/4.0.11-rc2-23519": {
+      "System.Dynamic.Runtime/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -6002,7 +6066,7 @@
           "lib/DNXCore50/System.Dynamic.Runtime.dll": {}
         }
       },
-      "System.Globalization/4.0.11-rc2-23519": {
+      "System.Globalization/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -6014,7 +6078,7 @@
           "lib/DNXCore50/System.Globalization.dll": {}
         }
       },
-      "System.Globalization.Calendars/4.0.1-rc2-23519": {
+      "System.Globalization.Calendars/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -6027,7 +6091,7 @@
           "lib/DNXCore50/System.Globalization.Calendars.dll": {}
         }
       },
-      "System.Globalization.Extensions/4.0.1-rc2-23519": {
+      "System.Globalization.Extensions/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -6038,7 +6102,7 @@
           "ref/dotnet5.4/System.Globalization.Extensions.dll": {}
         }
       },
-      "System.IO/4.0.11-rc2-23519": {
+      "System.IO/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20",
@@ -6052,7 +6116,7 @@
           "lib/DNXCore50/System.IO.dll": {}
         }
       },
-      "System.IO.Compression/4.1.0-rc2-23519": {
+      "System.IO.Compression/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -6064,7 +6128,7 @@
           "ref/dotnet5.4/System.IO.Compression.dll": {}
         }
       },
-      "System.IO.Compression.ZipFile/4.0.1-rc2-23519": {
+      "System.IO.Compression.ZipFile/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -6083,7 +6147,7 @@
           "lib/dotnet5.4/System.IO.Compression.ZipFile.dll": {}
         }
       },
-      "System.IO.FileSystem/4.0.1-rc2-23519": {
+      "System.IO.FileSystem/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -6097,7 +6161,7 @@
           "ref/dotnet5.4/System.IO.FileSystem.dll": {}
         }
       },
-      "System.IO.FileSystem.DriveInfo/4.0.0-rc2-23519": {
+      "System.IO.FileSystem.DriveInfo/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -6108,7 +6172,7 @@
           "ref/dotnet5.4/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
-      "System.IO.FileSystem.Primitives/4.0.1-rc2-23519": {
+      "System.IO.FileSystem.Primitives/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -6120,7 +6184,7 @@
           "lib/dotnet5.4/System.IO.FileSystem.Primitives.dll": {}
         }
       },
-      "System.IO.FileSystem.Watcher/4.0.0-rc2-23519": {
+      "System.IO.FileSystem.Watcher/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -6129,7 +6193,7 @@
           "ref/dotnet5.4/System.IO.FileSystem.Watcher.dll": {}
         }
       },
-      "System.IO.MemoryMappedFiles/4.0.0-rc2-23519": {
+      "System.IO.MemoryMappedFiles/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO.FileSystem": "4.0.0",
@@ -6143,7 +6207,7 @@
           "ref/dotnet5.4/System.IO.MemoryMappedFiles.dll": {}
         }
       },
-      "System.IO.Pipes/4.0.0-rc2-23519": {
+      "System.IO.Pipes/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -6156,7 +6220,7 @@
           "ref/dotnet5.4/System.IO.Pipes.dll": {}
         }
       },
-      "System.IO.UnmanagedMemoryStream/4.0.1-rc2-23519": {
+      "System.IO.UnmanagedMemoryStream/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -6174,7 +6238,7 @@
           "lib/dotnet5.4/System.IO.UnmanagedMemoryStream.dll": {}
         }
       },
-      "System.Linq/4.0.1-rc2-23519": {
+      "System.Linq/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -6190,7 +6254,7 @@
           "lib/dotnet5.4/System.Linq.dll": {}
         }
       },
-      "System.Linq.Expressions/4.0.11-rc2-23519": {
+      "System.Linq.Expressions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -6200,7 +6264,7 @@
           "ref/dotnet5.4/System.Linq.Expressions.dll": {}
         }
       },
-      "System.Linq.Parallel/4.0.1-rc2-23519": {
+      "System.Linq.Parallel/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -6221,7 +6285,7 @@
           "lib/dotnet5.4/System.Linq.Parallel.dll": {}
         }
       },
-      "System.Linq.Queryable/4.0.1-rc2-23519": {
+      "System.Linq.Queryable/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -6240,7 +6304,7 @@
           "lib/dotnet5.4/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-rc2-23519": {
+      "System.Net.Http/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -6253,7 +6317,34 @@
           "ref/dotnet5.2/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-rc2-23519": {
+      "System.Net.Http.WinHttpHandler/4.0.0-rc2-23525": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Net.Http.WinHttpHandler.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Http.WinHttpHandler.dll": {}
+        }
+      },
+      "System.Net.NameResolution/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -6264,7 +6355,7 @@
           "ref/dotnet5.4/System.Net.NameResolution.dll": {}
         }
       },
-      "System.Net.NetworkInformation/4.1.0-rc2-23519": {
+      "System.Net.NetworkInformation/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -6275,7 +6366,7 @@
           "ref/dotnet5.4/System.Net.NetworkInformation.dll": {}
         }
       },
-      "System.Net.Primitives/4.0.11-rc2-23519": {
+      "System.Net.Primitives/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -6285,7 +6376,7 @@
           "ref/dotnet5.4/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Requests/4.0.11-rc2-23519": {
+      "System.Net.Requests/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -6298,20 +6389,21 @@
           "ref/dotnet5.4/System.Net.Requests.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-rc2-23519": {
+      "System.Net.Security/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Net.Primitives": "4.0.10",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.Security.Principal": "4.0.0",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.Security.dll": {}
         }
       },
-      "System.Net.Sockets/4.1.0-rc2-23519": {
+      "System.Net.Sockets/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -6323,10 +6415,10 @@
           "ref/dotnet5.4/System.Net.Sockets.dll": {}
         }
       },
-      "System.Net.Utilities/4.0.0-rc2-23519": {
+      "System.Net.Utilities/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-rc2-23519"
+          "System.Private.Networking": "4.0.1-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.Utilities.dll": {}
@@ -6335,7 +6427,7 @@
           "lib/DNXCore50/System.Net.Utilities.dll": {}
         }
       },
-      "System.Net.WebHeaderCollection/4.0.1-rc2-23519": {
+      "System.Net.WebHeaderCollection/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -6351,7 +6443,7 @@
           "lib/dotnet5.4/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-rc2-23519": {
+      "System.Net.WebSockets/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -6366,20 +6458,20 @@
           "lib/dotnet5.4/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-rc2-23519": {
+      "System.Net.WebSockets.Client/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
-          "System.Net.WebSockets": "4.0.0-rc2-23519",
+          "System.Net.WebSockets": "4.0.0-rc2-23525",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.WebSockets.Client.dll": {}
         }
       },
-      "System.Numerics.Vectors/4.1.1-rc2-23519": {
+      "System.Numerics.Vectors/4.1.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -6394,7 +6486,7 @@
           "lib/dotnet5.4/System.Numerics.Vectors.dll": {}
         }
       },
-      "System.ObjectModel/4.0.11-rc2-23519": {
+      "System.ObjectModel/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -6410,13 +6502,13 @@
           "lib/dotnet5.4/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.DataContractSerialization/4.1.0-rc2-23519": {
+      "System.Private.DataContractSerialization/4.1.0-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
         }
       },
-      "System.Private.Networking/4.0.1-rc2-23519": {
+      "System.Private.Networking/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -6435,14 +6527,14 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-rc2-23519",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23525",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-rc2-23519"
+          "System.Threading.ThreadPool": "4.0.10-rc2-23525"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -6451,53 +6543,57 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-rc2-23519": {
+      "System.Private.ServiceModel/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.11-rc2-23519",
-          "System.Collections.Concurrent": "4.0.11-rc2-23519",
-          "System.Collections.NonGeneric": "4.0.1-rc2-23519",
-          "System.Collections.Specialized": "4.0.1-rc2-23519",
-          "System.ComponentModel.EventBasedAsync": "4.0.11-rc2-23519",
-          "System.Diagnostics.Debug": "4.0.11-rc2-23519",
-          "System.Diagnostics.Tracing": "4.0.21-rc2-23519",
-          "System.Globalization": "4.0.11-rc2-23519",
-          "System.IO": "4.0.11-rc2-23519",
-          "System.IO.Compression": "4.1.0-rc2-23519",
-          "System.Linq": "4.0.1-rc2-23519",
-          "System.Linq.Expressions": "4.0.11-rc2-23519",
-          "System.Linq.Queryable": "4.0.1-rc2-23519",
-          "System.Net.Http": "4.0.1-rc2-23519",
-          "System.Net.NameResolution": "4.0.0-rc2-23519",
-          "System.Net.Primitives": "4.0.11-rc2-23519",
-          "System.Net.Security": "4.0.0-rc2-23519",
-          "System.Net.Sockets": "4.1.0-rc2-23519",
-          "System.Net.WebHeaderCollection": "4.0.1-rc2-23519",
-          "System.Net.WebSockets": "4.0.0-rc2-23519",
-          "System.Net.WebSockets.Client": "4.0.0-rc2-23519",
-          "System.ObjectModel": "4.0.11-rc2-23519",
-          "System.Reflection": "4.1.0-rc2-23519",
-          "System.Reflection.DispatchProxy": "4.0.1-rc2-23519",
-          "System.Reflection.Extensions": "4.0.1-rc2-23519",
-          "System.Reflection.Primitives": "4.0.1-rc2-23519",
-          "System.Reflection.TypeExtensions": "4.0.1-rc2-23519",
-          "System.Resources.ResourceManager": "4.0.1-rc2-23519",
-          "System.Runtime": "4.0.21-rc2-23519",
-          "System.Runtime.Extensions": "4.0.11-rc2-23519",
-          "System.Runtime.InteropServices": "4.0.21-rc2-23519",
+          "System.Collections": "4.0.11-rc2-23525",
+          "System.Collections.Concurrent": "4.0.11-rc2-23525",
+          "System.Collections.NonGeneric": "4.0.1-rc2-23525",
+          "System.Collections.Specialized": "4.0.1-rc2-23525",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-rc2-23525",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23525",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23525",
+          "System.Globalization": "4.0.11-rc2-23525",
+          "System.IO": "4.0.11-rc2-23525",
+          "System.IO.Compression": "4.1.0-rc2-23525",
+          "System.Linq": "4.0.1-rc2-23525",
+          "System.Linq.Expressions": "4.0.11-rc2-23525",
+          "System.Linq.Queryable": "4.0.1-rc2-23525",
+          "System.Net.Http": "4.0.1-rc2-23525",
+          "System.Net.Http.WinHttpHandler": "4.0.0-rc2-23525",
+          "System.Net.NameResolution": "4.0.0-rc2-23525",
+          "System.Net.Primitives": "4.0.11-rc2-23525",
+          "System.Net.Security": "4.0.0-rc2-23525",
+          "System.Net.Sockets": "4.1.0-rc2-23525",
+          "System.Net.WebHeaderCollection": "4.0.1-rc2-23525",
+          "System.Net.WebSockets": "4.0.0-rc2-23525",
+          "System.Net.WebSockets.Client": "4.0.0-rc2-23525",
+          "System.ObjectModel": "4.0.11-rc2-23525",
+          "System.Reflection": "4.1.0-rc2-23525",
+          "System.Reflection.DispatchProxy": "4.0.1-rc2-23525",
+          "System.Reflection.Extensions": "4.0.1-rc2-23525",
+          "System.Reflection.Primitives": "4.0.1-rc2-23525",
+          "System.Reflection.TypeExtensions": "4.0.1-rc2-23525",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23525",
+          "System.Runtime": "4.0.21-rc2-23525",
+          "System.Runtime.Extensions": "4.0.11-rc2-23525",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23525",
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
-          "System.Security.Claims": "4.0.1-rc2-23519",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
-          "System.Security.Principal": "4.0.1-rc2-23519",
-          "System.Security.Principal.Windows": "4.0.0-rc2-23519",
-          "System.Text.Encoding": "4.0.11-rc2-23519",
-          "System.Threading": "4.0.11-rc2-23519",
-          "System.Threading.Tasks": "4.0.11-rc2-23519",
-          "System.Threading.Timer": "4.0.1-rc2-23519",
-          "System.Xml.ReaderWriter": "4.0.11-rc2-23519",
-          "System.Xml.XmlDocument": "4.0.1-rc2-23519",
-          "System.Xml.XmlSerializer": "4.0.11-rc2-23519"
+          "System.Security.Claims": "4.0.1-rc2-23525",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.Security.Principal": "4.0.1-rc2-23525",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23525",
+          "System.Text.Encoding": "4.0.11-rc2-23525",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.11-rc2-23525",
+          "System.Threading.Tasks": "4.0.11-rc2-23525",
+          "System.Threading.Timer": "4.0.1-rc2-23525",
+          "System.Xml.ReaderWriter": "4.0.11-rc2-23525",
+          "System.Xml.XmlDocument": "4.0.1-rc2-23525",
+          "System.Xml.XmlSerializer": "4.0.11-rc2-23525"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -6506,13 +6602,13 @@
           "lib/DNXCore50/System.Private.ServiceModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.1-rc2-23519": {
+      "System.Private.Uri/4.0.1-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
         }
       },
-      "System.Reflection/4.1.0-rc2-23519": {
+      "System.Reflection/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -6526,7 +6622,7 @@
           "lib/DNXCore50/System.Reflection.dll": {}
         }
       },
-      "System.Reflection.DispatchProxy/4.0.1-rc2-23519": {
+      "System.Reflection.DispatchProxy/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -6536,7 +6632,7 @@
           "ref/dotnet5.4/System.Reflection.DispatchProxy.dll": {}
         }
       },
-      "System.Reflection.Emit/4.0.1-rc2-23519": {
+      "System.Reflection.Emit/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -6552,7 +6648,7 @@
           "lib/DNXCore50/System.Reflection.Emit.dll": {}
         }
       },
-      "System.Reflection.Emit.ILGeneration/4.0.1-rc2-23519": {
+      "System.Reflection.Emit.ILGeneration/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -6566,7 +6662,7 @@
           "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
         }
       },
-      "System.Reflection.Emit.Lightweight/4.0.1-rc2-23519": {
+      "System.Reflection.Emit.Lightweight/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -6581,7 +6677,7 @@
           "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll": {}
         }
       },
-      "System.Reflection.Extensions/4.0.1-rc2-23519": {
+      "System.Reflection.Extensions/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -6594,7 +6690,7 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.1.1-rc2-23519": {
+      "System.Reflection.Metadata/1.1.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -6619,7 +6715,7 @@
           "lib/dotnet5.2/System.Reflection.Metadata.dll": {}
         }
       },
-      "System.Reflection.Primitives/4.0.1-rc2-23519": {
+      "System.Reflection.Primitives/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -6631,7 +6727,7 @@
           "lib/DNXCore50/System.Reflection.Primitives.dll": {}
         }
       },
-      "System.Reflection.TypeExtensions/4.1.0-rc2-23519": {
+      "System.Reflection.TypeExtensions/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -6644,7 +6740,7 @@
           "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
         }
       },
-      "System.Resources.ReaderWriter/4.0.0-rc2-23519": {
+      "System.Resources.ReaderWriter/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -6662,7 +6758,7 @@
           "lib/DNXCore50/System.Resources.ReaderWriter.dll": {}
         }
       },
-      "System.Resources.ResourceManager/4.0.1-rc2-23519": {
+      "System.Resources.ResourceManager/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -6676,10 +6772,10 @@
           "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
         }
       },
-      "System.Runtime/4.0.21-rc2-23519": {
+      "System.Runtime/4.0.21-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.Uri": "4.0.1-rc2-23519"
+          "System.Private.Uri": "4.0.1-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Runtime.dll": {}
@@ -6688,7 +6784,7 @@
           "lib/DNXCore50/System.Runtime.dll": {}
         }
       },
-      "System.Runtime.CompilerServices.VisualC/4.0.0-rc2-23519": {
+      "System.Runtime.CompilerServices.VisualC/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -6700,7 +6796,7 @@
           "lib/DNXCore50/System.Runtime.CompilerServices.VisualC.dll": {}
         }
       },
-      "System.Runtime.Extensions/4.0.11-rc2-23519": {
+      "System.Runtime.Extensions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -6709,7 +6805,7 @@
           "ref/dotnet5.4/System.Runtime.Extensions.dll": {}
         }
       },
-      "System.Runtime.Handles/4.0.1-rc2-23519": {
+      "System.Runtime.Handles/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -6721,7 +6817,7 @@
           "lib/DNXCore50/System.Runtime.Handles.dll": {}
         }
       },
-      "System.Runtime.InteropServices/4.0.21-rc2-23519": {
+      "System.Runtime.InteropServices/4.0.21-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -6736,7 +6832,7 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23519": {
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -6745,7 +6841,7 @@
           "ref/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "System.Runtime.Loader/4.0.0-rc2-23519": {
+      "System.Runtime.Loader/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -6753,13 +6849,13 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Runtime.Loader.dll": {}
+          "ref/dotnet5.5/System.Runtime.Loader.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Runtime.Loader.dll": {}
         }
       },
-      "System.Runtime.Numerics/4.0.1-rc2-23519": {
+      "System.Runtime.Numerics/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -6774,10 +6870,10 @@
           "lib/dotnet5.4/System.Runtime.Numerics.dll": {}
         }
       },
-      "System.Runtime.Serialization.Json/4.0.1-rc2-23519": {
+      "System.Runtime.Serialization.Json/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.1.0-rc2-23519"
+          "System.Private.DataContractSerialization": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.1/System.Runtime.Serialization.Json.dll": {}
@@ -6786,7 +6882,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Json.dll": {}
         }
       },
-      "System.Runtime.Serialization.Primitives/4.1.0-rc2-23519": {
+      "System.Runtime.Serialization.Primitives/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -6799,11 +6895,11 @@
           "lib/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
         }
       },
-      "System.Runtime.Serialization.Xml/4.1.0-rc2-23519": {
+      "System.Runtime.Serialization.Xml/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.1.0-rc2-23519",
-          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23519"
+          "System.Private.DataContractSerialization": "4.1.0-rc2-23525",
+          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Runtime.Serialization.Xml.dll": {}
@@ -6812,7 +6908,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Xml.dll": {}
         }
       },
-      "System.Security.Claims/4.0.1-rc2-23519": {
+      "System.Security.Claims/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -6831,18 +6927,18 @@
           "lib/dotnet5.4/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.Algorithms/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519"
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Cng/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.Cng/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -6851,8 +6947,8 @@
           "System.Runtime.Extensions": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.0"
         },
         "compile": {
@@ -6862,7 +6958,7 @@
           "lib/dotnet5.4/System.Security.Cryptography.Cng.dll": {}
         }
       },
-      "System.Security.Cryptography.Csp/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.Csp/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -6872,9 +6968,9 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10"
         },
@@ -6885,7 +6981,7 @@
           "lib/DNXCore50/System.Security.Cryptography.Csp.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.Encoding/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -6894,7 +6990,7 @@
           "ref/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.Primitives/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -6912,19 +7008,19 @@
           "lib/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23519"
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
-      "System.Security.Principal/4.0.1-rc2-23519": {
+      "System.Security.Principal/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -6936,7 +7032,7 @@
           "lib/dotnet5.1/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-rc2-23519": {
+      "System.Security.Principal.Windows/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -6959,10 +7055,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-rc2-23519": {
+      "System.ServiceModel.Duplex/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519"
+          "System.Private.ServiceModel": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.2/System.ServiceModel.Duplex.dll": {}
@@ -6971,10 +7067,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-rc2-23519": {
+      "System.ServiceModel.Http/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519",
+          "System.Private.ServiceModel": "4.1.0-rc2-23525",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -6984,10 +7080,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.1.0-rc2-23519": {
+      "System.ServiceModel.NetTcp/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519"
+          "System.Private.ServiceModel": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.ServiceModel.NetTcp.dll": {}
@@ -6996,10 +7092,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.1.0-rc2-23519": {
+      "System.ServiceModel.Primitives/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519"
+          "System.Private.ServiceModel": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.ServiceModel.Primitives.dll": {}
@@ -7008,10 +7104,10 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
-      "System.ServiceModel.Security/4.0.1-rc2-23519": {
+      "System.ServiceModel.Security/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519"
+          "System.Private.ServiceModel": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.2/System.ServiceModel.Security.dll": {}
@@ -7020,7 +7116,7 @@
           "lib/DNXCore50/System.ServiceModel.Security.dll": {}
         }
       },
-      "System.Text.Encoding/4.0.11-rc2-23519": {
+      "System.Text.Encoding/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -7032,7 +7128,7 @@
           "lib/DNXCore50/System.Text.Encoding.dll": {}
         }
       },
-      "System.Text.Encoding.CodePages/4.0.1-rc2-23519": {
+      "System.Text.Encoding.CodePages/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -7042,7 +7138,7 @@
           "ref/dotnet5.4/System.Text.Encoding.CodePages.dll": {}
         }
       },
-      "System.Text.Encoding.Extensions/4.0.11-rc2-23519": {
+      "System.Text.Encoding.Extensions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -7055,7 +7151,7 @@
           "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
         }
       },
-      "System.Text.RegularExpressions/4.0.11-rc2-23519": {
+      "System.Text.RegularExpressions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7072,7 +7168,7 @@
           "lib/dotnet5.4/System.Text.RegularExpressions.dll": {}
         }
       },
-      "System.Threading/4.0.11-rc2-23519": {
+      "System.Threading/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -7082,7 +7178,7 @@
           "ref/dotnet5.4/System.Threading.dll": {}
         }
       },
-      "System.Threading.Overlapped/4.0.1-rc2-23519": {
+      "System.Threading.Overlapped/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -7095,7 +7191,7 @@
           "lib/DNXCore50/System.Threading.Overlapped.dll": {}
         }
       },
-      "System.Threading.Tasks/4.0.11-rc2-23519": {
+      "System.Threading.Tasks/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -7107,7 +7203,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.Tasks.Dataflow/4.5.26-rc2-23519": {
+      "System.Threading.Tasks.Dataflow/4.5.26-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -7129,7 +7225,7 @@
           "lib/dotnet5.2/System.Threading.Tasks.Dataflow.dll": {}
         }
       },
-      "System.Threading.Tasks.Parallel/4.0.1-rc2-23519": {
+      "System.Threading.Tasks.Parallel/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections.Concurrent": "4.0.10",
@@ -7148,7 +7244,7 @@
           "lib/dotnet5.4/System.Threading.Tasks.Parallel.dll": {}
         }
       },
-      "System.Threading.Thread/4.0.0-rc2-23519": {
+      "System.Threading.Thread/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -7160,11 +7256,11 @@
           "lib/DNXCore50/System.Threading.Thread.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-rc2-23519": {
+      "System.Threading.ThreadPool/4.0.10-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
+          "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Threading.ThreadPool.dll": {}
@@ -7173,7 +7269,7 @@
           "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
-      "System.Threading.Timer/4.0.1-rc2-23519": {
+      "System.Threading.Timer/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -7185,7 +7281,7 @@
           "lib/DNXCore50/System.Threading.Timer.dll": {}
         }
       },
-      "System.Xml.ReaderWriter/4.0.11-rc2-23519": {
+      "System.Xml.ReaderWriter/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7210,7 +7306,7 @@
           "lib/dotnet5.4/System.Xml.ReaderWriter.dll": {}
         }
       },
-      "System.Xml.XDocument/4.0.11-rc2-23519": {
+      "System.Xml.XDocument/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7233,7 +7329,7 @@
           "lib/dotnet5.4/System.Xml.XDocument.dll": {}
         }
       },
-      "System.Xml.XmlDocument/4.0.1-rc2-23519": {
+      "System.Xml.XmlDocument/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7254,7 +7350,7 @@
           "lib/dotnet5.4/System.Xml.XmlDocument.dll": {}
         }
       },
-      "System.Xml.XmlSerializer/4.0.11-rc2-23519": {
+      "System.Xml.XmlSerializer/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -7422,7 +7518,7 @@
       "coveralls.io/1.4.0": {
         "type": "package"
       },
-      "Microsoft.CSharp/4.0.1-rc2-23519": {
+      "Microsoft.CSharp/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7458,147 +7554,147 @@
           "xunit.runner.console": "2.1.0"
         }
       },
-      "Microsoft.NETCore/5.0.1-rc2-23519": {
+      "Microsoft.NETCore/5.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.CSharp": "4.0.1-rc2-23519",
-          "Microsoft.NETCore.Platforms": "1.0.1-rc2-23519",
-          "Microsoft.VisualBasic": "10.0.1-rc2-23519",
-          "System.AppContext": "4.0.1-rc2-23519",
-          "System.Collections": "4.0.11-rc2-23519",
-          "System.Collections.Concurrent": "4.0.11-rc2-23519",
-          "System.Collections.Immutable": "1.1.38-rc2-23519",
-          "System.ComponentModel": "4.0.1-rc2-23519",
-          "System.ComponentModel.Annotations": "4.1.0-rc2-23519",
-          "System.Diagnostics.Debug": "4.0.11-rc2-23519",
-          "System.Diagnostics.Tools": "4.0.1-rc2-23519",
-          "System.Diagnostics.Tracing": "4.0.21-rc2-23519",
-          "System.Dynamic.Runtime": "4.0.11-rc2-23519",
-          "System.Globalization": "4.0.11-rc2-23519",
-          "System.Globalization.Calendars": "4.0.1-rc2-23519",
-          "System.Globalization.Extensions": "4.0.1-rc2-23519",
-          "System.IO": "4.0.11-rc2-23519",
-          "System.IO.Compression": "4.1.0-rc2-23519",
-          "System.IO.Compression.ZipFile": "4.0.1-rc2-23519",
-          "System.IO.FileSystem": "4.0.1-rc2-23519",
-          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23519",
-          "System.IO.UnmanagedMemoryStream": "4.0.1-rc2-23519",
-          "System.Linq": "4.0.1-rc2-23519",
-          "System.Linq.Expressions": "4.0.11-rc2-23519",
-          "System.Linq.Parallel": "4.0.1-rc2-23519",
-          "System.Linq.Queryable": "4.0.1-rc2-23519",
-          "System.Net.Http": "4.0.1-rc2-23519",
-          "System.Net.NetworkInformation": "4.1.0-rc2-23519",
-          "System.Net.Primitives": "4.0.11-rc2-23519",
-          "System.Numerics.Vectors": "4.1.1-rc2-23519",
-          "System.ObjectModel": "4.0.11-rc2-23519",
-          "System.Reflection": "4.1.0-rc2-23519",
-          "System.Reflection.DispatchProxy": "4.0.1-rc2-23519",
-          "System.Reflection.Extensions": "4.0.1-rc2-23519",
-          "System.Reflection.Metadata": "1.1.1-rc2-23519",
-          "System.Reflection.Primitives": "4.0.1-rc2-23519",
-          "System.Reflection.TypeExtensions": "4.1.0-rc2-23519",
-          "System.Resources.ResourceManager": "4.0.1-rc2-23519",
-          "System.Runtime": "4.0.21-rc2-23519",
-          "System.Runtime.Extensions": "4.0.11-rc2-23519",
-          "System.Runtime.Handles": "4.0.1-rc2-23519",
-          "System.Runtime.InteropServices": "4.0.21-rc2-23519",
-          "System.Runtime.Numerics": "4.0.1-rc2-23519",
-          "System.Security.Claims": "4.0.1-rc2-23519",
-          "System.Security.Principal": "4.0.1-rc2-23519",
-          "System.Text.Encoding": "4.0.11-rc2-23519",
-          "System.Text.Encoding.Extensions": "4.0.11-rc2-23519",
-          "System.Text.RegularExpressions": "4.0.11-rc2-23519",
-          "System.Threading": "4.0.11-rc2-23519",
-          "System.Threading.Tasks": "4.0.11-rc2-23519",
-          "System.Threading.Tasks.Dataflow": "4.5.26-rc2-23519",
-          "System.Threading.Tasks.Parallel": "4.0.1-rc2-23519",
-          "System.Threading.Timer": "4.0.1-rc2-23519",
-          "System.Xml.ReaderWriter": "4.0.11-rc2-23519",
-          "System.Xml.XDocument": "4.0.11-rc2-23519"
+          "Microsoft.CSharp": "4.0.1-rc2-23525",
+          "Microsoft.NETCore.Platforms": "1.0.1-rc2-23525",
+          "Microsoft.VisualBasic": "10.0.1-rc2-23525",
+          "System.AppContext": "4.0.1-rc2-23525",
+          "System.Collections": "4.0.11-rc2-23525",
+          "System.Collections.Concurrent": "4.0.11-rc2-23525",
+          "System.Collections.Immutable": "1.1.38-rc2-23525",
+          "System.ComponentModel": "4.0.1-rc2-23525",
+          "System.ComponentModel.Annotations": "4.1.0-rc2-23525",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23525",
+          "System.Diagnostics.Tools": "4.0.1-rc2-23525",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23525",
+          "System.Dynamic.Runtime": "4.0.11-rc2-23525",
+          "System.Globalization": "4.0.11-rc2-23525",
+          "System.Globalization.Calendars": "4.0.1-rc2-23525",
+          "System.Globalization.Extensions": "4.0.1-rc2-23525",
+          "System.IO": "4.0.11-rc2-23525",
+          "System.IO.Compression": "4.1.0-rc2-23525",
+          "System.IO.Compression.ZipFile": "4.0.1-rc2-23525",
+          "System.IO.FileSystem": "4.0.1-rc2-23525",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23525",
+          "System.IO.UnmanagedMemoryStream": "4.0.1-rc2-23525",
+          "System.Linq": "4.0.1-rc2-23525",
+          "System.Linq.Expressions": "4.0.11-rc2-23525",
+          "System.Linq.Parallel": "4.0.1-rc2-23525",
+          "System.Linq.Queryable": "4.0.1-rc2-23525",
+          "System.Net.Http": "4.0.1-rc2-23525",
+          "System.Net.NetworkInformation": "4.1.0-rc2-23525",
+          "System.Net.Primitives": "4.0.11-rc2-23525",
+          "System.Numerics.Vectors": "4.1.1-rc2-23525",
+          "System.ObjectModel": "4.0.11-rc2-23525",
+          "System.Reflection": "4.1.0-rc2-23525",
+          "System.Reflection.DispatchProxy": "4.0.1-rc2-23525",
+          "System.Reflection.Extensions": "4.0.1-rc2-23525",
+          "System.Reflection.Metadata": "1.1.1-rc2-23525",
+          "System.Reflection.Primitives": "4.0.1-rc2-23525",
+          "System.Reflection.TypeExtensions": "4.1.0-rc2-23525",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23525",
+          "System.Runtime": "4.0.21-rc2-23525",
+          "System.Runtime.Extensions": "4.0.11-rc2-23525",
+          "System.Runtime.Handles": "4.0.1-rc2-23525",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23525",
+          "System.Runtime.Numerics": "4.0.1-rc2-23525",
+          "System.Security.Claims": "4.0.1-rc2-23525",
+          "System.Security.Principal": "4.0.1-rc2-23525",
+          "System.Text.Encoding": "4.0.11-rc2-23525",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23525",
+          "System.Text.RegularExpressions": "4.0.11-rc2-23525",
+          "System.Threading": "4.0.11-rc2-23525",
+          "System.Threading.Tasks": "4.0.11-rc2-23525",
+          "System.Threading.Tasks.Dataflow": "4.5.26-rc2-23525",
+          "System.Threading.Tasks.Parallel": "4.0.1-rc2-23525",
+          "System.Threading.Timer": "4.0.1-rc2-23525",
+          "System.Xml.ReaderWriter": "4.0.11-rc2-23525",
+          "System.Xml.XDocument": "4.0.11-rc2-23525"
         }
       },
-      "Microsoft.NETCore.Console/1.0.0-rc2-23519": {
+      "Microsoft.NETCore.Console/1.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore": "5.0.1-rc2-23519",
-          "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23519",
-          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-rc2-23519",
-          "Microsoft.Win32.Primitives": "4.0.1-rc2-23519",
-          "System.ComponentModel.EventBasedAsync": "4.0.11-rc2-23519",
-          "System.Console": "4.0.0-rc2-23519",
-          "System.Data.Common": "4.0.1-rc2-23519",
-          "System.Data.SqlClient": "4.0.0-rc2-23519",
-          "System.Diagnostics.Contracts": "4.0.1-rc2-23519",
-          "System.Diagnostics.FileVersionInfo": "4.0.0-rc2-23519",
-          "System.Diagnostics.Process": "4.1.0-rc2-23519",
-          "System.Diagnostics.StackTrace": "4.0.1-rc2-23519",
-          "System.IO.FileSystem.DriveInfo": "4.0.0-rc2-23519",
-          "System.IO.FileSystem.Watcher": "4.0.0-rc2-23519",
-          "System.IO.MemoryMappedFiles": "4.0.0-rc2-23519",
-          "System.IO.Pipes": "4.0.0-rc2-23519",
-          "System.Net.NameResolution": "4.0.0-rc2-23519",
-          "System.Net.NetworkInformation": "4.1.0-rc2-23519",
-          "System.Net.Requests": "4.0.11-rc2-23519",
-          "System.Net.Security": "4.0.0-rc2-23519",
-          "System.Net.Sockets": "4.1.0-rc2-23519",
-          "System.Net.Utilities": "4.0.0-rc2-23519",
-          "System.Net.WebHeaderCollection": "4.0.1-rc2-23519",
-          "System.Net.WebSockets": "4.0.0-rc2-23519",
-          "System.Net.WebSockets.Client": "4.0.0-rc2-23519",
-          "System.Reflection.Emit": "4.0.1-rc2-23519",
-          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23519",
-          "System.Reflection.Emit.Lightweight": "4.0.1-rc2-23519",
-          "System.Resources.ReaderWriter": "4.0.0-rc2-23519",
-          "System.Runtime.CompilerServices.VisualC": "4.0.0-rc2-23519",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23519",
-          "System.Runtime.Loader": "4.0.0-rc2-23519",
-          "System.Runtime.Serialization.Json": "4.0.1-rc2-23519",
-          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23519",
-          "System.Runtime.Serialization.Xml": "4.1.0-rc2-23519",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
-          "System.ServiceModel.Duplex": "4.0.1-rc2-23519",
-          "System.ServiceModel.Http": "4.0.11-rc2-23519",
-          "System.ServiceModel.NetTcp": "4.1.0-rc2-23519",
-          "System.ServiceModel.Primitives": "4.1.0-rc2-23519",
-          "System.ServiceModel.Security": "4.0.1-rc2-23519",
-          "System.Xml.XmlSerializer": "4.0.11-rc2-23519"
+          "Microsoft.NETCore": "5.0.1-rc2-23525",
+          "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23525",
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-rc2-23525",
+          "Microsoft.Win32.Primitives": "4.0.1-rc2-23525",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-rc2-23525",
+          "System.Console": "4.0.0-rc2-23525",
+          "System.Data.Common": "4.0.1-rc2-23525",
+          "System.Data.SqlClient": "4.0.0-rc2-23525",
+          "System.Diagnostics.Contracts": "4.0.1-rc2-23525",
+          "System.Diagnostics.FileVersionInfo": "4.0.0-rc2-23525",
+          "System.Diagnostics.Process": "4.1.0-rc2-23525",
+          "System.Diagnostics.StackTrace": "4.0.1-rc2-23525",
+          "System.IO.FileSystem.DriveInfo": "4.0.0-rc2-23525",
+          "System.IO.FileSystem.Watcher": "4.0.0-rc2-23525",
+          "System.IO.MemoryMappedFiles": "4.0.0-rc2-23525",
+          "System.IO.Pipes": "4.0.0-rc2-23525",
+          "System.Net.NameResolution": "4.0.0-rc2-23525",
+          "System.Net.NetworkInformation": "4.1.0-rc2-23525",
+          "System.Net.Requests": "4.0.11-rc2-23525",
+          "System.Net.Security": "4.0.0-rc2-23525",
+          "System.Net.Sockets": "4.1.0-rc2-23525",
+          "System.Net.Utilities": "4.0.0-rc2-23525",
+          "System.Net.WebHeaderCollection": "4.0.1-rc2-23525",
+          "System.Net.WebSockets": "4.0.0-rc2-23525",
+          "System.Net.WebSockets.Client": "4.0.0-rc2-23525",
+          "System.Reflection.Emit": "4.0.1-rc2-23525",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23525",
+          "System.Reflection.Emit.Lightweight": "4.0.1-rc2-23525",
+          "System.Resources.ReaderWriter": "4.0.0-rc2-23525",
+          "System.Runtime.CompilerServices.VisualC": "4.0.0-rc2-23525",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23525",
+          "System.Runtime.Loader": "4.0.0-rc2-23525",
+          "System.Runtime.Serialization.Json": "4.0.1-rc2-23525",
+          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23525",
+          "System.Runtime.Serialization.Xml": "4.1.0-rc2-23525",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.ServiceModel.Duplex": "4.0.1-rc2-23525",
+          "System.ServiceModel.Http": "4.0.11-rc2-23525",
+          "System.ServiceModel.NetTcp": "4.1.0-rc2-23525",
+          "System.ServiceModel.Primitives": "4.1.0-rc2-23525",
+          "System.ServiceModel.Security": "4.0.1-rc2-23525",
+          "System.Xml.XmlSerializer": "4.0.11-rc2-23525"
         }
       },
-      "Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23519": {
+      "Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23525": {
         "type": "package"
       },
-      "Microsoft.NETCore.Platforms/1.0.1-rc2-23519": {
+      "Microsoft.NETCore.Platforms/1.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Targets": "1.0.1-rc2-23519"
+          "Microsoft.NETCore.Targets": "1.0.1-rc2-23525"
         }
       },
-      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23519": {
+      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-rc2-23519"
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-rc2-23525"
         }
       },
-      "Microsoft.NETCore.Targets/1.0.1-rc2-23519": {
+      "Microsoft.NETCore.Targets/1.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-rc2-23519"
+          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-rc2-23525"
         }
       },
-      "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23519": {
+      "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23525": {
         "type": "package"
       },
-      "Microsoft.NETCore.TestHost/1.0.0-rc2-23519": {
+      "Microsoft.NETCore.TestHost/1.0.0-rc2-23525": {
         "type": "package"
       },
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23519": {
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23525": {
         "type": "package"
       },
-      "Microsoft.VisualBasic/10.0.1-rc2-23519": {
+      "Microsoft.VisualBasic/10.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7625,7 +7721,7 @@
           "lib/dotnet5.4/Microsoft.VisualBasic.dll": {}
         }
       },
-      "Microsoft.Win32.Primitives/4.0.1-rc2-23519": {
+      "Microsoft.Win32.Primitives/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -7640,7 +7736,7 @@
       "ReportGenerator/2.3.4": {
         "type": "package"
       },
-      "runtime.any.System.Linq.Expressions/4.0.11-rc2-23519": {
+      "runtime.any.System.Linq.Expressions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7668,7 +7764,7 @@
           "lib/DNXCore50/System.Linq.Expressions.dll": {}
         }
       },
-      "runtime.any.System.Private.DataContractSerialization/4.1.0-rc2-23519": {
+      "runtime.any.System.Private.DataContractSerialization/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7685,7 +7781,7 @@
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
-          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23519",
+          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Text.Encoding.Extensions": "4.0.10",
           "System.Text.RegularExpressions": "4.0.10",
@@ -7701,7 +7797,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "runtime.any.System.Reflection.DispatchProxy/4.0.1-rc2-23519": {
+      "runtime.any.System.Reflection.DispatchProxy/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7722,7 +7818,7 @@
           "lib/DNXCore50/System.Reflection.DispatchProxy.dll": {}
         }
       },
-      "runtime.any.System.Xml.XmlSerializer/4.0.11-rc2-23519": {
+      "runtime.any.System.Xml.XmlSerializer/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7751,7 +7847,7 @@
           "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "runtime.linux.System.Diagnostics.Process/4.1.0-rc2-23519": {
+      "runtime.linux.System.Diagnostics.Process/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -7770,7 +7866,7 @@
           "System.Text.Encoding.Extensions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-rc2-23519"
+          "System.Threading.ThreadPool": "4.0.10-rc2-23525"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -7779,7 +7875,7 @@
           "runtimes/unix/lib/dotnet5.5/System.Diagnostics.Process.dll": {}
         }
       },
-      "runtime.linux.System.IO.FileSystem/4.0.1-rc2-23519": {
+      "runtime.linux.System.IO.FileSystem/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7803,7 +7899,7 @@
           "runtimes/linux/lib/dotnet5.4/System.IO.FileSystem.dll": {}
         }
       },
-      "runtime.linux.System.IO.FileSystem.DriveInfo/4.0.0-rc2-23519": {
+      "runtime.linux.System.IO.FileSystem.DriveInfo/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7822,7 +7918,7 @@
           "runtimes/unix/lib/dotnet5.4/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
-      "runtime.linux.System.IO.FileSystem.Watcher/4.0.0-rc2-23519": {
+      "runtime.linux.System.IO.FileSystem.Watcher/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7844,7 +7940,7 @@
           "runtimes/unix/lib/dotnet5.4/System.IO.FileSystem.Watcher.dll": {}
         }
       },
-      "runtime.linux.System.IO.MemoryMappedFiles/4.0.0-rc2-23519": {
+      "runtime.linux.System.IO.MemoryMappedFiles/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -7866,7 +7962,7 @@
           "runtimes/unix/lib/dotnet5.4/System.IO.MemoryMappedFiles.dll": {}
         }
       },
-      "runtime.linux.System.Net.Http/4.0.1-rc2-23519": {
+      "runtime.linux.System.Net.Http/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -7879,7 +7975,11 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.OpenSsl": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.0",
           "System.Threading.Tasks": "4.0.10"
@@ -7891,7 +7991,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Net.Http.dll": {}
         }
       },
-      "runtime.linux.System.Net.NameResolution/4.0.0-rc2-23519": {
+      "runtime.linux.System.Net.NameResolution/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -7902,7 +8002,7 @@
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Principal.Windows": "4.0.0-rc2-23519",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23525",
           "System.Threading": "4.0.0",
           "System.Threading.Tasks": "4.0.0"
         },
@@ -7913,7 +8013,7 @@
           "runtimes/unix/lib/dnxcore50/System.Net.NameResolution.dll": {}
         }
       },
-      "runtime.linux.System.Net.NetworkInformation/4.1.0-rc2-23519": {
+      "runtime.linux.System.Net.NetworkInformation/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -7937,24 +8037,24 @@
           "runtimes/unix/lib/dotnet5.4/System.Net.NetworkInformation.dll": {}
         }
       },
-      "runtime.linux.System.Net.Sockets/4.1.0-rc2-23519": {
+      "runtime.linux.System.Net.Sockets/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
           "System.Diagnostics.Tracing": "4.0.20",
           "System.Globalization": "4.0.0",
           "System.IO": "4.0.10",
-          "System.Net.NameResolution": "4.0.0-rc2-23519",
+          "System.Net.NameResolution": "4.0.0-rc2-23525",
           "System.Net.Primitives": "4.0.10",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Principal.Windows": "4.0.0-rc2-23519",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23525",
           "System.Threading": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-rc2-23519"
+          "System.Threading.ThreadPool": "4.0.10-rc2-23525"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -7963,7 +8063,7 @@
           "runtimes/linux/lib/dotnet5.5/System.Net.Sockets.dll": {}
         }
       },
-      "runtime.linux.System.Runtime.Extensions/4.0.11-rc2-23519": {
+      "runtime.linux.System.Runtime.Extensions/4.0.11-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -7972,7 +8072,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Runtime.Extensions.dll": {}
         }
       },
-      "runtime.linux.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23519": {
+      "runtime.linux.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -7985,7 +8085,7 @@
           "runtimes/unix/lib/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "runtime.linux.System.Security.Cryptography.Algorithms/4.0.0-rc2-23519": {
+      "runtime.linux.System.Security.Cryptography.Algorithms/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -7993,7 +8093,7 @@
           "System.Runtime": "4.0.20",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.0",
           "System.Text.Encoding.Extensions": "4.0.0"
         },
@@ -8004,13 +8104,13 @@
           "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "runtime.ubuntu.14.04-x64.Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23519": {
+      "runtime.ubuntu.14.04-x64.Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23525": {
         "type": "package",
         "native": {
           "runtimes/ubuntu.14.04-x64/native/coreconsole": {}
         }
       },
-      "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23519": {
+      "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -8034,13 +8134,13 @@
           "runtimes/ubuntu.14.04-x64/native/System.Security.Cryptography.Native.so": {}
         }
       },
-      "runtime.ubuntu.14.04-x64.Microsoft.NETCore.TestHost/1.0.0-rc2-23519": {
+      "runtime.ubuntu.14.04-x64.Microsoft.NETCore.TestHost/1.0.0-rc2-23525": {
         "type": "package",
         "native": {
           "runtimes/ubuntu.14.04-x64/native/corerun": {}
         }
       },
-      "runtime.unix.Microsoft.Win32.Primitives/4.0.1-rc2-23519": {
+      "runtime.unix.Microsoft.Win32.Primitives/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20",
@@ -8053,7 +8153,7 @@
           "runtimes/unix/lib/dotnet5.4/Microsoft.Win32.Primitives.dll": {}
         }
       },
-      "runtime.unix.System.Console/4.0.0-rc2-23519": {
+      "runtime.unix.System.Console/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8077,7 +8177,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Console.dll": {}
         }
       },
-      "runtime.unix.System.Data.SqlClient/4.0.0-rc2-23519": {
+      "runtime.unix.System.Data.SqlClient/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -8089,10 +8189,10 @@
           "System.Globalization": "4.0.10",
           "System.IO": "4.0.10",
           "System.Linq": "4.0.0",
-          "System.Net.NameResolution": "4.0.0-rc2-23519",
+          "System.Net.NameResolution": "4.0.0-rc2-23525",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-rc2-23519",
-          "System.Net.Sockets": "4.1.0-rc2-23519",
+          "System.Net.Security": "4.0.0-rc2-23525",
+          "System.Net.Sockets": "4.1.0-rc2-23525",
           "System.Reflection": "4.0.0",
           "System.Reflection.TypeExtensions": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
@@ -8100,17 +8200,17 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
-          "System.Security.Principal.Windows": "4.0.0-rc2-23519",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Text.Encoding.CodePages": "4.0.0",
           "System.Text.Encoding.Extensions": "4.0.0",
           "System.Text.RegularExpressions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.Thread": "4.0.0-rc2-23519",
-          "System.Threading.ThreadPool": "4.0.10-rc2-23519",
+          "System.Threading.Thread": "4.0.0-rc2-23525",
+          "System.Threading.ThreadPool": "4.0.10-rc2-23525",
           "System.Threading.Timer": "4.0.0",
           "System.Xml.ReaderWriter": "4.0.0"
         },
@@ -8121,7 +8221,7 @@
           "runtimes/unix/lib/dotnet5.5/System.Data.SqlClient.dll": {}
         }
       },
-      "runtime.unix.System.Diagnostics.Debug/4.0.11-rc2-23519": {
+      "runtime.unix.System.Diagnostics.Debug/4.0.11-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -8130,7 +8230,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Diagnostics.Debug.dll": {}
         }
       },
-      "runtime.unix.System.Diagnostics.FileVersionInfo/4.0.0-rc2-23519": {
+      "runtime.unix.System.Diagnostics.FileVersionInfo/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -8146,7 +8246,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Diagnostics.FileVersionInfo.dll": {}
         }
       },
-      "runtime.unix.System.Globalization.Extensions/4.0.1-rc2-23519": {
+      "runtime.unix.System.Globalization.Extensions/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -8161,7 +8261,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Globalization.Extensions.dll": {}
         }
       },
-      "runtime.unix.System.IO.Compression/4.1.0-rc2-23519": {
+      "runtime.unix.System.IO.Compression/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8183,7 +8283,7 @@
           "runtimes/unix/lib/dotnet5.4/System.IO.Compression.dll": {}
         }
       },
-      "runtime.unix.System.IO.Pipes/4.0.0-rc2-23519": {
+      "runtime.unix.System.IO.Pipes/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -8204,7 +8304,7 @@
           "runtimes/unix/lib/dotnet5.4/System.IO.Pipes.dll": {}
         }
       },
-      "runtime.unix.System.Net.Primitives/4.0.11-rc2-23519": {
+      "runtime.unix.System.Net.Primitives/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -8226,7 +8326,7 @@
           "runtimes/unix/lib/dnxcore50/System.Net.Primitives.dll": {}
         }
       },
-      "runtime.unix.System.Net.Requests/4.0.11-rc2-23519": {
+      "runtime.unix.System.Net.Requests/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8247,7 +8347,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Net.Requests.dll": {}
         }
       },
-      "runtime.unix.System.Net.Security/4.0.0-rc2-23519": {
+      "runtime.unix.System.Net.Security/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -8264,17 +8364,17 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.OpenSsl": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.OpenSsl": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-rc2-23519",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-rc2-23519"
+          "System.Threading.ThreadPool": "4.0.10-rc2-23525"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -8283,7 +8383,7 @@
           "runtimes/unix/lib/dnxcore50/System.Net.Security.dll": {}
         }
       },
-      "runtime.unix.System.Net.WebSockets.Client/4.0.0-rc2-23519": {
+      "runtime.unix.System.Net.WebSockets.Client/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8291,10 +8391,10 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.0",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-rc2-23519",
+          "System.Net.WebSockets": "4.0.0-rc2-23525",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.0",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -8306,7 +8406,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Net.WebSockets.Client.dll": {}
         }
       },
-      "runtime.unix.System.Private.Uri/4.0.1-rc2-23519": {
+      "runtime.unix.System.Private.Uri/4.0.1-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -8315,7 +8415,7 @@
           "runtimes/unix/lib/dotnet5.1/System.Private.Uri.dll": {}
         }
       },
-      "runtime.unix.System.Security.Cryptography.Encoding/4.0.0-rc2-23519": {
+      "runtime.unix.System.Security.Cryptography.Encoding/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -8327,7 +8427,7 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.0"
         },
         "compile": {
@@ -8337,7 +8437,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "runtime.unix.System.Security.Cryptography.X509Certificates/4.0.0-rc2-23519": {
+      "runtime.unix.System.Security.Cryptography.X509Certificates/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8346,17 +8446,17 @@
           "System.IO": "4.0.10",
           "System.IO.FileSystem": "4.0.0",
           "System.IO.FileSystem.Primitives": "4.0.0",
-          "System.IO.FileSystem.Watcher": "4.0.0-rc2-23519",
+          "System.IO.FileSystem.Watcher": "4.0.0-rc2-23525",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
           "System.Runtime.Numerics": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.OpenSsl": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.OpenSsl": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10"
         },
@@ -8367,7 +8467,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
-      "runtime.unix.System.Text.Encoding.CodePages/4.0.1-rc2-23519": {
+      "runtime.unix.System.Text.Encoding.CodePages/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8389,7 +8489,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Text.Encoding.CodePages.dll": {}
         }
       },
-      "runtime.unix.System.Threading/4.0.11-rc2-23519": {
+      "runtime.unix.System.Threading/4.0.11-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -8398,7 +8498,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Threading.dll": {}
         }
       },
-      "System.AppContext/4.0.1-rc2-23519": {
+      "System.AppContext/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -8410,10 +8510,10 @@
           "lib/DNXCore50/System.AppContext.dll": {}
         }
       },
-      "System.Collections/4.0.11-rc2-23519": {
+      "System.Collections/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Runtime": "4.0.21-rc2-23519"
+          "System.Runtime": "4.0.21-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Collections.dll": {}
@@ -8422,7 +8522,7 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Collections.Concurrent/4.0.11-rc2-23519": {
+      "System.Collections.Concurrent/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8442,7 +8542,7 @@
           "lib/dotnet5.4/System.Collections.Concurrent.dll": {}
         }
       },
-      "System.Collections.Immutable/1.1.38-rc2-23519": {
+      "System.Collections.Immutable/1.1.38-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -8461,7 +8561,7 @@
           "lib/dotnet5.1/System.Collections.Immutable.dll": {}
         }
       },
-      "System.Collections.NonGeneric/4.0.1-rc2-23519": {
+      "System.Collections.NonGeneric/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -8478,7 +8578,7 @@
           "lib/dotnet5.4/System.Collections.NonGeneric.dll": {}
         }
       },
-      "System.Collections.Specialized/4.0.1-rc2-23519": {
+      "System.Collections.Specialized/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections.NonGeneric": "4.0.0",
@@ -8496,7 +8596,7 @@
           "lib/dotnet5.4/System.Collections.Specialized.dll": {}
         }
       },
-      "System.ComponentModel/4.0.1-rc2-23519": {
+      "System.ComponentModel/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -8508,7 +8608,7 @@
           "lib/dotnet5.4/System.ComponentModel.dll": {}
         }
       },
-      "System.ComponentModel.Annotations/4.1.0-rc2-23519": {
+      "System.ComponentModel.Annotations/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8530,7 +8630,7 @@
           "lib/dotnet5.4/System.ComponentModel.Annotations.dll": {}
         }
       },
-      "System.ComponentModel.EventBasedAsync/4.0.11-rc2-23519": {
+      "System.ComponentModel.EventBasedAsync/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -8545,7 +8645,7 @@
           "lib/dotnet5.4/System.ComponentModel.EventBasedAsync.dll": {}
         }
       },
-      "System.Console/4.0.0-rc2-23519": {
+      "System.Console/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -8555,7 +8655,7 @@
           "ref/dotnet5.4/System.Console.dll": {}
         }
       },
-      "System.Data.Common/4.0.1-rc2-23519": {
+      "System.Data.Common/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8575,7 +8675,7 @@
           "lib/dotnet5.4/System.Data.Common.dll": {}
         }
       },
-      "System.Data.SqlClient/4.0.0-rc2-23519": {
+      "System.Data.SqlClient/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Data.Common": "4.0.0",
@@ -8589,7 +8689,7 @@
           "ref/dotnet5.4/System.Data.SqlClient.dll": {}
         }
       },
-      "System.Diagnostics.Contracts/4.0.1-rc2-23519": {
+      "System.Diagnostics.Contracts/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -8601,7 +8701,7 @@
           "lib/DNXCore50/System.Diagnostics.Contracts.dll": {}
         }
       },
-      "System.Diagnostics.Debug/4.0.11-rc2-23519": {
+      "System.Diagnostics.Debug/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -8610,7 +8710,7 @@
           "ref/dotnet5.4/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.FileVersionInfo/4.0.0-rc2-23519": {
+      "System.Diagnostics.FileVersionInfo/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -8619,7 +8719,7 @@
           "ref/dotnet5.4/System.Diagnostics.FileVersionInfo.dll": {}
         }
       },
-      "System.Diagnostics.Process/4.1.0-rc2-23519": {
+      "System.Diagnostics.Process/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -8631,7 +8731,7 @@
           "ref/dotnet5.5/System.Diagnostics.Process.dll": {}
         }
       },
-      "System.Diagnostics.StackTrace/4.0.1-rc2-23519": {
+      "System.Diagnostics.StackTrace/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -8644,7 +8744,7 @@
           "lib/DNXCore50/System.Diagnostics.StackTrace.dll": {}
         }
       },
-      "System.Diagnostics.Tools/4.0.1-rc2-23519": {
+      "System.Diagnostics.Tools/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -8656,7 +8756,7 @@
           "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
         }
       },
-      "System.Diagnostics.Tracing/4.0.21-rc2-23519": {
+      "System.Diagnostics.Tracing/4.0.21-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -8668,7 +8768,7 @@
           "lib/DNXCore50/System.Diagnostics.Tracing.dll": {}
         }
       },
-      "System.Dynamic.Runtime/4.0.11-rc2-23519": {
+      "System.Dynamic.Runtime/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8694,7 +8794,7 @@
           "lib/DNXCore50/System.Dynamic.Runtime.dll": {}
         }
       },
-      "System.Globalization/4.0.11-rc2-23519": {
+      "System.Globalization/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -8706,7 +8806,7 @@
           "lib/DNXCore50/System.Globalization.dll": {}
         }
       },
-      "System.Globalization.Calendars/4.0.1-rc2-23519": {
+      "System.Globalization.Calendars/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -8719,7 +8819,7 @@
           "lib/DNXCore50/System.Globalization.Calendars.dll": {}
         }
       },
-      "System.Globalization.Extensions/4.0.1-rc2-23519": {
+      "System.Globalization.Extensions/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -8730,7 +8830,7 @@
           "ref/dotnet5.4/System.Globalization.Extensions.dll": {}
         }
       },
-      "System.IO/4.0.11-rc2-23519": {
+      "System.IO/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20",
@@ -8744,7 +8844,7 @@
           "lib/DNXCore50/System.IO.dll": {}
         }
       },
-      "System.IO.Compression/4.1.0-rc2-23519": {
+      "System.IO.Compression/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -8756,7 +8856,7 @@
           "ref/dotnet5.4/System.IO.Compression.dll": {}
         }
       },
-      "System.IO.Compression.ZipFile/4.0.1-rc2-23519": {
+      "System.IO.Compression.ZipFile/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -8775,7 +8875,7 @@
           "lib/dotnet5.4/System.IO.Compression.ZipFile.dll": {}
         }
       },
-      "System.IO.FileSystem/4.0.1-rc2-23519": {
+      "System.IO.FileSystem/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -8789,7 +8889,7 @@
           "ref/dotnet5.4/System.IO.FileSystem.dll": {}
         }
       },
-      "System.IO.FileSystem.DriveInfo/4.0.0-rc2-23519": {
+      "System.IO.FileSystem.DriveInfo/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -8800,7 +8900,7 @@
           "ref/dotnet5.4/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
-      "System.IO.FileSystem.Primitives/4.0.1-rc2-23519": {
+      "System.IO.FileSystem.Primitives/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -8812,7 +8912,7 @@
           "lib/dotnet5.4/System.IO.FileSystem.Primitives.dll": {}
         }
       },
-      "System.IO.FileSystem.Watcher/4.0.0-rc2-23519": {
+      "System.IO.FileSystem.Watcher/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -8821,7 +8921,7 @@
           "ref/dotnet5.4/System.IO.FileSystem.Watcher.dll": {}
         }
       },
-      "System.IO.MemoryMappedFiles/4.0.0-rc2-23519": {
+      "System.IO.MemoryMappedFiles/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO.FileSystem": "4.0.0",
@@ -8835,7 +8935,7 @@
           "ref/dotnet5.4/System.IO.MemoryMappedFiles.dll": {}
         }
       },
-      "System.IO.Pipes/4.0.0-rc2-23519": {
+      "System.IO.Pipes/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -8848,7 +8948,7 @@
           "ref/dotnet5.4/System.IO.Pipes.dll": {}
         }
       },
-      "System.IO.UnmanagedMemoryStream/4.0.1-rc2-23519": {
+      "System.IO.UnmanagedMemoryStream/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -8866,7 +8966,7 @@
           "lib/dotnet5.4/System.IO.UnmanagedMemoryStream.dll": {}
         }
       },
-      "System.Linq/4.0.1-rc2-23519": {
+      "System.Linq/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8882,7 +8982,7 @@
           "lib/dotnet5.4/System.Linq.dll": {}
         }
       },
-      "System.Linq.Expressions/4.0.11-rc2-23519": {
+      "System.Linq.Expressions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -8892,7 +8992,7 @@
           "ref/dotnet5.4/System.Linq.Expressions.dll": {}
         }
       },
-      "System.Linq.Parallel/4.0.1-rc2-23519": {
+      "System.Linq.Parallel/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8913,7 +9013,7 @@
           "lib/dotnet5.4/System.Linq.Parallel.dll": {}
         }
       },
-      "System.Linq.Queryable/4.0.1-rc2-23519": {
+      "System.Linq.Queryable/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -8932,7 +9032,7 @@
           "lib/dotnet5.4/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-rc2-23519": {
+      "System.Net.Http/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -8945,7 +9045,34 @@
           "ref/dotnet5.2/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-rc2-23519": {
+      "System.Net.Http.WinHttpHandler/4.0.0-rc2-23525": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Net.Http.WinHttpHandler.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Http.WinHttpHandler.dll": {}
+        }
+      },
+      "System.Net.NameResolution/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -8956,7 +9083,7 @@
           "ref/dotnet5.4/System.Net.NameResolution.dll": {}
         }
       },
-      "System.Net.NetworkInformation/4.1.0-rc2-23519": {
+      "System.Net.NetworkInformation/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -8967,7 +9094,7 @@
           "ref/dotnet5.4/System.Net.NetworkInformation.dll": {}
         }
       },
-      "System.Net.Primitives/4.0.11-rc2-23519": {
+      "System.Net.Primitives/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -8977,7 +9104,7 @@
           "ref/dotnet5.4/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Requests/4.0.11-rc2-23519": {
+      "System.Net.Requests/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -8990,20 +9117,21 @@
           "ref/dotnet5.4/System.Net.Requests.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-rc2-23519": {
+      "System.Net.Security/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Net.Primitives": "4.0.10",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.Security.Principal": "4.0.0",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.Security.dll": {}
         }
       },
-      "System.Net.Sockets/4.1.0-rc2-23519": {
+      "System.Net.Sockets/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -9015,10 +9143,10 @@
           "ref/dotnet5.4/System.Net.Sockets.dll": {}
         }
       },
-      "System.Net.Utilities/4.0.0-rc2-23519": {
+      "System.Net.Utilities/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-rc2-23519"
+          "System.Private.Networking": "4.0.1-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.Utilities.dll": {}
@@ -9027,7 +9155,7 @@
           "lib/DNXCore50/System.Net.Utilities.dll": {}
         }
       },
-      "System.Net.WebHeaderCollection/4.0.1-rc2-23519": {
+      "System.Net.WebHeaderCollection/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -9043,7 +9171,7 @@
           "lib/dotnet5.4/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-rc2-23519": {
+      "System.Net.WebSockets/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -9058,20 +9186,20 @@
           "lib/dotnet5.4/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-rc2-23519": {
+      "System.Net.WebSockets.Client/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
-          "System.Net.WebSockets": "4.0.0-rc2-23519",
+          "System.Net.WebSockets": "4.0.0-rc2-23525",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.WebSockets.Client.dll": {}
         }
       },
-      "System.Numerics.Vectors/4.1.1-rc2-23519": {
+      "System.Numerics.Vectors/4.1.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -9086,7 +9214,7 @@
           "lib/dotnet5.4/System.Numerics.Vectors.dll": {}
         }
       },
-      "System.ObjectModel/4.0.11-rc2-23519": {
+      "System.ObjectModel/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -9102,13 +9230,13 @@
           "lib/dotnet5.4/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.DataContractSerialization/4.1.0-rc2-23519": {
+      "System.Private.DataContractSerialization/4.1.0-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
         }
       },
-      "System.Private.Networking/4.0.1-rc2-23519": {
+      "System.Private.Networking/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -9127,14 +9255,14 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-rc2-23519",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23525",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-rc2-23519"
+          "System.Threading.ThreadPool": "4.0.10-rc2-23525"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -9143,53 +9271,57 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-rc2-23519": {
+      "System.Private.ServiceModel/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.11-rc2-23519",
-          "System.Collections.Concurrent": "4.0.11-rc2-23519",
-          "System.Collections.NonGeneric": "4.0.1-rc2-23519",
-          "System.Collections.Specialized": "4.0.1-rc2-23519",
-          "System.ComponentModel.EventBasedAsync": "4.0.11-rc2-23519",
-          "System.Diagnostics.Debug": "4.0.11-rc2-23519",
-          "System.Diagnostics.Tracing": "4.0.21-rc2-23519",
-          "System.Globalization": "4.0.11-rc2-23519",
-          "System.IO": "4.0.11-rc2-23519",
-          "System.IO.Compression": "4.1.0-rc2-23519",
-          "System.Linq": "4.0.1-rc2-23519",
-          "System.Linq.Expressions": "4.0.11-rc2-23519",
-          "System.Linq.Queryable": "4.0.1-rc2-23519",
-          "System.Net.Http": "4.0.1-rc2-23519",
-          "System.Net.NameResolution": "4.0.0-rc2-23519",
-          "System.Net.Primitives": "4.0.11-rc2-23519",
-          "System.Net.Security": "4.0.0-rc2-23519",
-          "System.Net.Sockets": "4.1.0-rc2-23519",
-          "System.Net.WebHeaderCollection": "4.0.1-rc2-23519",
-          "System.Net.WebSockets": "4.0.0-rc2-23519",
-          "System.Net.WebSockets.Client": "4.0.0-rc2-23519",
-          "System.ObjectModel": "4.0.11-rc2-23519",
-          "System.Reflection": "4.1.0-rc2-23519",
-          "System.Reflection.DispatchProxy": "4.0.1-rc2-23519",
-          "System.Reflection.Extensions": "4.0.1-rc2-23519",
-          "System.Reflection.Primitives": "4.0.1-rc2-23519",
-          "System.Reflection.TypeExtensions": "4.0.1-rc2-23519",
-          "System.Resources.ResourceManager": "4.0.1-rc2-23519",
-          "System.Runtime": "4.0.21-rc2-23519",
-          "System.Runtime.Extensions": "4.0.11-rc2-23519",
-          "System.Runtime.InteropServices": "4.0.21-rc2-23519",
+          "System.Collections": "4.0.11-rc2-23525",
+          "System.Collections.Concurrent": "4.0.11-rc2-23525",
+          "System.Collections.NonGeneric": "4.0.1-rc2-23525",
+          "System.Collections.Specialized": "4.0.1-rc2-23525",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-rc2-23525",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23525",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23525",
+          "System.Globalization": "4.0.11-rc2-23525",
+          "System.IO": "4.0.11-rc2-23525",
+          "System.IO.Compression": "4.1.0-rc2-23525",
+          "System.Linq": "4.0.1-rc2-23525",
+          "System.Linq.Expressions": "4.0.11-rc2-23525",
+          "System.Linq.Queryable": "4.0.1-rc2-23525",
+          "System.Net.Http": "4.0.1-rc2-23525",
+          "System.Net.Http.WinHttpHandler": "4.0.0-rc2-23525",
+          "System.Net.NameResolution": "4.0.0-rc2-23525",
+          "System.Net.Primitives": "4.0.11-rc2-23525",
+          "System.Net.Security": "4.0.0-rc2-23525",
+          "System.Net.Sockets": "4.1.0-rc2-23525",
+          "System.Net.WebHeaderCollection": "4.0.1-rc2-23525",
+          "System.Net.WebSockets": "4.0.0-rc2-23525",
+          "System.Net.WebSockets.Client": "4.0.0-rc2-23525",
+          "System.ObjectModel": "4.0.11-rc2-23525",
+          "System.Reflection": "4.1.0-rc2-23525",
+          "System.Reflection.DispatchProxy": "4.0.1-rc2-23525",
+          "System.Reflection.Extensions": "4.0.1-rc2-23525",
+          "System.Reflection.Primitives": "4.0.1-rc2-23525",
+          "System.Reflection.TypeExtensions": "4.0.1-rc2-23525",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23525",
+          "System.Runtime": "4.0.21-rc2-23525",
+          "System.Runtime.Extensions": "4.0.11-rc2-23525",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23525",
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
-          "System.Security.Claims": "4.0.1-rc2-23519",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
-          "System.Security.Principal": "4.0.1-rc2-23519",
-          "System.Security.Principal.Windows": "4.0.0-rc2-23519",
-          "System.Text.Encoding": "4.0.11-rc2-23519",
-          "System.Threading": "4.0.11-rc2-23519",
-          "System.Threading.Tasks": "4.0.11-rc2-23519",
-          "System.Threading.Timer": "4.0.1-rc2-23519",
-          "System.Xml.ReaderWriter": "4.0.11-rc2-23519",
-          "System.Xml.XmlDocument": "4.0.1-rc2-23519",
-          "System.Xml.XmlSerializer": "4.0.11-rc2-23519"
+          "System.Security.Claims": "4.0.1-rc2-23525",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.Security.Principal": "4.0.1-rc2-23525",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23525",
+          "System.Text.Encoding": "4.0.11-rc2-23525",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.11-rc2-23525",
+          "System.Threading.Tasks": "4.0.11-rc2-23525",
+          "System.Threading.Timer": "4.0.1-rc2-23525",
+          "System.Xml.ReaderWriter": "4.0.11-rc2-23525",
+          "System.Xml.XmlDocument": "4.0.1-rc2-23525",
+          "System.Xml.XmlSerializer": "4.0.11-rc2-23525"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -9198,13 +9330,13 @@
           "lib/DNXCore50/System.Private.ServiceModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.1-rc2-23519": {
+      "System.Private.Uri/4.0.1-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
         }
       },
-      "System.Reflection/4.1.0-rc2-23519": {
+      "System.Reflection/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -9218,7 +9350,7 @@
           "lib/DNXCore50/System.Reflection.dll": {}
         }
       },
-      "System.Reflection.DispatchProxy/4.0.1-rc2-23519": {
+      "System.Reflection.DispatchProxy/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -9228,7 +9360,7 @@
           "ref/dotnet5.4/System.Reflection.DispatchProxy.dll": {}
         }
       },
-      "System.Reflection.Emit/4.0.1-rc2-23519": {
+      "System.Reflection.Emit/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -9244,7 +9376,7 @@
           "lib/DNXCore50/System.Reflection.Emit.dll": {}
         }
       },
-      "System.Reflection.Emit.ILGeneration/4.0.1-rc2-23519": {
+      "System.Reflection.Emit.ILGeneration/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -9258,7 +9390,7 @@
           "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
         }
       },
-      "System.Reflection.Emit.Lightweight/4.0.1-rc2-23519": {
+      "System.Reflection.Emit.Lightweight/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -9273,7 +9405,7 @@
           "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll": {}
         }
       },
-      "System.Reflection.Extensions/4.0.1-rc2-23519": {
+      "System.Reflection.Extensions/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -9286,7 +9418,7 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.1.1-rc2-23519": {
+      "System.Reflection.Metadata/1.1.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -9311,7 +9443,7 @@
           "lib/dotnet5.2/System.Reflection.Metadata.dll": {}
         }
       },
-      "System.Reflection.Primitives/4.0.1-rc2-23519": {
+      "System.Reflection.Primitives/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -9323,7 +9455,7 @@
           "lib/DNXCore50/System.Reflection.Primitives.dll": {}
         }
       },
-      "System.Reflection.TypeExtensions/4.1.0-rc2-23519": {
+      "System.Reflection.TypeExtensions/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -9336,7 +9468,7 @@
           "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
         }
       },
-      "System.Resources.ReaderWriter/4.0.0-rc2-23519": {
+      "System.Resources.ReaderWriter/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -9354,7 +9486,7 @@
           "lib/DNXCore50/System.Resources.ReaderWriter.dll": {}
         }
       },
-      "System.Resources.ResourceManager/4.0.1-rc2-23519": {
+      "System.Resources.ResourceManager/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -9368,10 +9500,10 @@
           "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
         }
       },
-      "System.Runtime/4.0.21-rc2-23519": {
+      "System.Runtime/4.0.21-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.Uri": "4.0.1-rc2-23519"
+          "System.Private.Uri": "4.0.1-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Runtime.dll": {}
@@ -9380,7 +9512,7 @@
           "lib/DNXCore50/System.Runtime.dll": {}
         }
       },
-      "System.Runtime.CompilerServices.VisualC/4.0.0-rc2-23519": {
+      "System.Runtime.CompilerServices.VisualC/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -9392,7 +9524,7 @@
           "lib/DNXCore50/System.Runtime.CompilerServices.VisualC.dll": {}
         }
       },
-      "System.Runtime.Extensions/4.0.11-rc2-23519": {
+      "System.Runtime.Extensions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -9401,7 +9533,7 @@
           "ref/dotnet5.4/System.Runtime.Extensions.dll": {}
         }
       },
-      "System.Runtime.Handles/4.0.1-rc2-23519": {
+      "System.Runtime.Handles/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -9413,7 +9545,7 @@
           "lib/DNXCore50/System.Runtime.Handles.dll": {}
         }
       },
-      "System.Runtime.InteropServices/4.0.21-rc2-23519": {
+      "System.Runtime.InteropServices/4.0.21-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -9428,7 +9560,7 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23519": {
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -9437,7 +9569,7 @@
           "ref/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "System.Runtime.Loader/4.0.0-rc2-23519": {
+      "System.Runtime.Loader/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -9445,13 +9577,13 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Runtime.Loader.dll": {}
+          "ref/dotnet5.5/System.Runtime.Loader.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Runtime.Loader.dll": {}
         }
       },
-      "System.Runtime.Numerics/4.0.1-rc2-23519": {
+      "System.Runtime.Numerics/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -9466,10 +9598,10 @@
           "lib/dotnet5.4/System.Runtime.Numerics.dll": {}
         }
       },
-      "System.Runtime.Serialization.Json/4.0.1-rc2-23519": {
+      "System.Runtime.Serialization.Json/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.1.0-rc2-23519"
+          "System.Private.DataContractSerialization": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.1/System.Runtime.Serialization.Json.dll": {}
@@ -9478,7 +9610,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Json.dll": {}
         }
       },
-      "System.Runtime.Serialization.Primitives/4.1.0-rc2-23519": {
+      "System.Runtime.Serialization.Primitives/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -9491,11 +9623,11 @@
           "lib/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
         }
       },
-      "System.Runtime.Serialization.Xml/4.1.0-rc2-23519": {
+      "System.Runtime.Serialization.Xml/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.1.0-rc2-23519",
-          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23519"
+          "System.Private.DataContractSerialization": "4.1.0-rc2-23525",
+          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Runtime.Serialization.Xml.dll": {}
@@ -9504,7 +9636,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Xml.dll": {}
         }
       },
-      "System.Security.Claims/4.0.1-rc2-23519": {
+      "System.Security.Claims/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -9523,18 +9655,18 @@
           "lib/dotnet5.4/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.Algorithms/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519"
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.Encoding/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -9543,7 +9675,7 @@
           "ref/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.OpenSsl/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.OpenSsl/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -9554,9 +9686,9 @@
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
           "System.Runtime.Numerics": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
@@ -9566,7 +9698,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.OpenSsl.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.Primitives/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -9584,19 +9716,19 @@
           "lib/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23519"
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
-      "System.Security.Principal/4.0.1-rc2-23519": {
+      "System.Security.Principal/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -9608,7 +9740,7 @@
           "lib/dotnet5.1/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-rc2-23519": {
+      "System.Security.Principal.Windows/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -9631,10 +9763,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-rc2-23519": {
+      "System.ServiceModel.Duplex/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519"
+          "System.Private.ServiceModel": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.2/System.ServiceModel.Duplex.dll": {}
@@ -9643,10 +9775,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-rc2-23519": {
+      "System.ServiceModel.Http/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519",
+          "System.Private.ServiceModel": "4.1.0-rc2-23525",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -9656,10 +9788,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.1.0-rc2-23519": {
+      "System.ServiceModel.NetTcp/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519"
+          "System.Private.ServiceModel": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.ServiceModel.NetTcp.dll": {}
@@ -9668,10 +9800,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.1.0-rc2-23519": {
+      "System.ServiceModel.Primitives/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519"
+          "System.Private.ServiceModel": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.ServiceModel.Primitives.dll": {}
@@ -9680,10 +9812,10 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
-      "System.ServiceModel.Security/4.0.1-rc2-23519": {
+      "System.ServiceModel.Security/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519"
+          "System.Private.ServiceModel": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.2/System.ServiceModel.Security.dll": {}
@@ -9692,7 +9824,7 @@
           "lib/DNXCore50/System.ServiceModel.Security.dll": {}
         }
       },
-      "System.Text.Encoding/4.0.11-rc2-23519": {
+      "System.Text.Encoding/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -9704,7 +9836,7 @@
           "lib/DNXCore50/System.Text.Encoding.dll": {}
         }
       },
-      "System.Text.Encoding.CodePages/4.0.1-rc2-23519": {
+      "System.Text.Encoding.CodePages/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -9714,7 +9846,7 @@
           "ref/dotnet5.4/System.Text.Encoding.CodePages.dll": {}
         }
       },
-      "System.Text.Encoding.Extensions/4.0.11-rc2-23519": {
+      "System.Text.Encoding.Extensions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -9727,7 +9859,7 @@
           "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
         }
       },
-      "System.Text.RegularExpressions/4.0.11-rc2-23519": {
+      "System.Text.RegularExpressions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -9744,7 +9876,7 @@
           "lib/dotnet5.4/System.Text.RegularExpressions.dll": {}
         }
       },
-      "System.Threading/4.0.11-rc2-23519": {
+      "System.Threading/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -9754,7 +9886,7 @@
           "ref/dotnet5.4/System.Threading.dll": {}
         }
       },
-      "System.Threading.Overlapped/4.0.1-rc2-23519": {
+      "System.Threading.Overlapped/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -9767,7 +9899,7 @@
           "lib/DNXCore50/System.Threading.Overlapped.dll": {}
         }
       },
-      "System.Threading.Tasks/4.0.11-rc2-23519": {
+      "System.Threading.Tasks/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -9779,7 +9911,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.Tasks.Dataflow/4.5.26-rc2-23519": {
+      "System.Threading.Tasks.Dataflow/4.5.26-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -9801,7 +9933,7 @@
           "lib/dotnet5.2/System.Threading.Tasks.Dataflow.dll": {}
         }
       },
-      "System.Threading.Tasks.Parallel/4.0.1-rc2-23519": {
+      "System.Threading.Tasks.Parallel/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections.Concurrent": "4.0.10",
@@ -9820,7 +9952,7 @@
           "lib/dotnet5.4/System.Threading.Tasks.Parallel.dll": {}
         }
       },
-      "System.Threading.Thread/4.0.0-rc2-23519": {
+      "System.Threading.Thread/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -9832,11 +9964,11 @@
           "lib/DNXCore50/System.Threading.Thread.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-rc2-23519": {
+      "System.Threading.ThreadPool/4.0.10-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
+          "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Threading.ThreadPool.dll": {}
@@ -9845,7 +9977,7 @@
           "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
-      "System.Threading.Timer/4.0.1-rc2-23519": {
+      "System.Threading.Timer/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -9857,7 +9989,7 @@
           "lib/DNXCore50/System.Threading.Timer.dll": {}
         }
       },
-      "System.Xml.ReaderWriter/4.0.11-rc2-23519": {
+      "System.Xml.ReaderWriter/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -9882,7 +10014,7 @@
           "lib/dotnet5.4/System.Xml.ReaderWriter.dll": {}
         }
       },
-      "System.Xml.XDocument/4.0.11-rc2-23519": {
+      "System.Xml.XDocument/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -9905,7 +10037,7 @@
           "lib/dotnet5.4/System.Xml.XDocument.dll": {}
         }
       },
-      "System.Xml.XmlDocument/4.0.1-rc2-23519": {
+      "System.Xml.XmlDocument/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -9926,7 +10058,7 @@
           "lib/dotnet5.4/System.Xml.XmlDocument.dll": {}
         }
       },
-      "System.Xml.XmlSerializer/4.0.11-rc2-23519": {
+      "System.Xml.XmlSerializer/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -10094,7 +10226,7 @@
       "coveralls.io/1.4.0": {
         "type": "package"
       },
-      "Microsoft.CSharp/4.0.1-rc2-23519": {
+      "Microsoft.CSharp/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10130,147 +10262,147 @@
           "xunit.runner.console": "2.1.0"
         }
       },
-      "Microsoft.NETCore/5.0.1-rc2-23519": {
+      "Microsoft.NETCore/5.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.CSharp": "4.0.1-rc2-23519",
-          "Microsoft.NETCore.Platforms": "1.0.1-rc2-23519",
-          "Microsoft.VisualBasic": "10.0.1-rc2-23519",
-          "System.AppContext": "4.0.1-rc2-23519",
-          "System.Collections": "4.0.11-rc2-23519",
-          "System.Collections.Concurrent": "4.0.11-rc2-23519",
-          "System.Collections.Immutable": "1.1.38-rc2-23519",
-          "System.ComponentModel": "4.0.1-rc2-23519",
-          "System.ComponentModel.Annotations": "4.1.0-rc2-23519",
-          "System.Diagnostics.Debug": "4.0.11-rc2-23519",
-          "System.Diagnostics.Tools": "4.0.1-rc2-23519",
-          "System.Diagnostics.Tracing": "4.0.21-rc2-23519",
-          "System.Dynamic.Runtime": "4.0.11-rc2-23519",
-          "System.Globalization": "4.0.11-rc2-23519",
-          "System.Globalization.Calendars": "4.0.1-rc2-23519",
-          "System.Globalization.Extensions": "4.0.1-rc2-23519",
-          "System.IO": "4.0.11-rc2-23519",
-          "System.IO.Compression": "4.1.0-rc2-23519",
-          "System.IO.Compression.ZipFile": "4.0.1-rc2-23519",
-          "System.IO.FileSystem": "4.0.1-rc2-23519",
-          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23519",
-          "System.IO.UnmanagedMemoryStream": "4.0.1-rc2-23519",
-          "System.Linq": "4.0.1-rc2-23519",
-          "System.Linq.Expressions": "4.0.11-rc2-23519",
-          "System.Linq.Parallel": "4.0.1-rc2-23519",
-          "System.Linq.Queryable": "4.0.1-rc2-23519",
-          "System.Net.Http": "4.0.1-rc2-23519",
-          "System.Net.NetworkInformation": "4.1.0-rc2-23519",
-          "System.Net.Primitives": "4.0.11-rc2-23519",
-          "System.Numerics.Vectors": "4.1.1-rc2-23519",
-          "System.ObjectModel": "4.0.11-rc2-23519",
-          "System.Reflection": "4.1.0-rc2-23519",
-          "System.Reflection.DispatchProxy": "4.0.1-rc2-23519",
-          "System.Reflection.Extensions": "4.0.1-rc2-23519",
-          "System.Reflection.Metadata": "1.1.1-rc2-23519",
-          "System.Reflection.Primitives": "4.0.1-rc2-23519",
-          "System.Reflection.TypeExtensions": "4.1.0-rc2-23519",
-          "System.Resources.ResourceManager": "4.0.1-rc2-23519",
-          "System.Runtime": "4.0.21-rc2-23519",
-          "System.Runtime.Extensions": "4.0.11-rc2-23519",
-          "System.Runtime.Handles": "4.0.1-rc2-23519",
-          "System.Runtime.InteropServices": "4.0.21-rc2-23519",
-          "System.Runtime.Numerics": "4.0.1-rc2-23519",
-          "System.Security.Claims": "4.0.1-rc2-23519",
-          "System.Security.Principal": "4.0.1-rc2-23519",
-          "System.Text.Encoding": "4.0.11-rc2-23519",
-          "System.Text.Encoding.Extensions": "4.0.11-rc2-23519",
-          "System.Text.RegularExpressions": "4.0.11-rc2-23519",
-          "System.Threading": "4.0.11-rc2-23519",
-          "System.Threading.Tasks": "4.0.11-rc2-23519",
-          "System.Threading.Tasks.Dataflow": "4.5.26-rc2-23519",
-          "System.Threading.Tasks.Parallel": "4.0.1-rc2-23519",
-          "System.Threading.Timer": "4.0.1-rc2-23519",
-          "System.Xml.ReaderWriter": "4.0.11-rc2-23519",
-          "System.Xml.XDocument": "4.0.11-rc2-23519"
+          "Microsoft.CSharp": "4.0.1-rc2-23525",
+          "Microsoft.NETCore.Platforms": "1.0.1-rc2-23525",
+          "Microsoft.VisualBasic": "10.0.1-rc2-23525",
+          "System.AppContext": "4.0.1-rc2-23525",
+          "System.Collections": "4.0.11-rc2-23525",
+          "System.Collections.Concurrent": "4.0.11-rc2-23525",
+          "System.Collections.Immutable": "1.1.38-rc2-23525",
+          "System.ComponentModel": "4.0.1-rc2-23525",
+          "System.ComponentModel.Annotations": "4.1.0-rc2-23525",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23525",
+          "System.Diagnostics.Tools": "4.0.1-rc2-23525",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23525",
+          "System.Dynamic.Runtime": "4.0.11-rc2-23525",
+          "System.Globalization": "4.0.11-rc2-23525",
+          "System.Globalization.Calendars": "4.0.1-rc2-23525",
+          "System.Globalization.Extensions": "4.0.1-rc2-23525",
+          "System.IO": "4.0.11-rc2-23525",
+          "System.IO.Compression": "4.1.0-rc2-23525",
+          "System.IO.Compression.ZipFile": "4.0.1-rc2-23525",
+          "System.IO.FileSystem": "4.0.1-rc2-23525",
+          "System.IO.FileSystem.Primitives": "4.0.1-rc2-23525",
+          "System.IO.UnmanagedMemoryStream": "4.0.1-rc2-23525",
+          "System.Linq": "4.0.1-rc2-23525",
+          "System.Linq.Expressions": "4.0.11-rc2-23525",
+          "System.Linq.Parallel": "4.0.1-rc2-23525",
+          "System.Linq.Queryable": "4.0.1-rc2-23525",
+          "System.Net.Http": "4.0.1-rc2-23525",
+          "System.Net.NetworkInformation": "4.1.0-rc2-23525",
+          "System.Net.Primitives": "4.0.11-rc2-23525",
+          "System.Numerics.Vectors": "4.1.1-rc2-23525",
+          "System.ObjectModel": "4.0.11-rc2-23525",
+          "System.Reflection": "4.1.0-rc2-23525",
+          "System.Reflection.DispatchProxy": "4.0.1-rc2-23525",
+          "System.Reflection.Extensions": "4.0.1-rc2-23525",
+          "System.Reflection.Metadata": "1.1.1-rc2-23525",
+          "System.Reflection.Primitives": "4.0.1-rc2-23525",
+          "System.Reflection.TypeExtensions": "4.1.0-rc2-23525",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23525",
+          "System.Runtime": "4.0.21-rc2-23525",
+          "System.Runtime.Extensions": "4.0.11-rc2-23525",
+          "System.Runtime.Handles": "4.0.1-rc2-23525",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23525",
+          "System.Runtime.Numerics": "4.0.1-rc2-23525",
+          "System.Security.Claims": "4.0.1-rc2-23525",
+          "System.Security.Principal": "4.0.1-rc2-23525",
+          "System.Text.Encoding": "4.0.11-rc2-23525",
+          "System.Text.Encoding.Extensions": "4.0.11-rc2-23525",
+          "System.Text.RegularExpressions": "4.0.11-rc2-23525",
+          "System.Threading": "4.0.11-rc2-23525",
+          "System.Threading.Tasks": "4.0.11-rc2-23525",
+          "System.Threading.Tasks.Dataflow": "4.5.26-rc2-23525",
+          "System.Threading.Tasks.Parallel": "4.0.1-rc2-23525",
+          "System.Threading.Timer": "4.0.1-rc2-23525",
+          "System.Xml.ReaderWriter": "4.0.11-rc2-23525",
+          "System.Xml.XDocument": "4.0.11-rc2-23525"
         }
       },
-      "Microsoft.NETCore.Console/1.0.0-rc2-23519": {
+      "Microsoft.NETCore.Console/1.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore": "5.0.1-rc2-23519",
-          "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23519",
-          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-rc2-23519",
-          "Microsoft.Win32.Primitives": "4.0.1-rc2-23519",
-          "System.ComponentModel.EventBasedAsync": "4.0.11-rc2-23519",
-          "System.Console": "4.0.0-rc2-23519",
-          "System.Data.Common": "4.0.1-rc2-23519",
-          "System.Data.SqlClient": "4.0.0-rc2-23519",
-          "System.Diagnostics.Contracts": "4.0.1-rc2-23519",
-          "System.Diagnostics.FileVersionInfo": "4.0.0-rc2-23519",
-          "System.Diagnostics.Process": "4.1.0-rc2-23519",
-          "System.Diagnostics.StackTrace": "4.0.1-rc2-23519",
-          "System.IO.FileSystem.DriveInfo": "4.0.0-rc2-23519",
-          "System.IO.FileSystem.Watcher": "4.0.0-rc2-23519",
-          "System.IO.MemoryMappedFiles": "4.0.0-rc2-23519",
-          "System.IO.Pipes": "4.0.0-rc2-23519",
-          "System.Net.NameResolution": "4.0.0-rc2-23519",
-          "System.Net.NetworkInformation": "4.1.0-rc2-23519",
-          "System.Net.Requests": "4.0.11-rc2-23519",
-          "System.Net.Security": "4.0.0-rc2-23519",
-          "System.Net.Sockets": "4.1.0-rc2-23519",
-          "System.Net.Utilities": "4.0.0-rc2-23519",
-          "System.Net.WebHeaderCollection": "4.0.1-rc2-23519",
-          "System.Net.WebSockets": "4.0.0-rc2-23519",
-          "System.Net.WebSockets.Client": "4.0.0-rc2-23519",
-          "System.Reflection.Emit": "4.0.1-rc2-23519",
-          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23519",
-          "System.Reflection.Emit.Lightweight": "4.0.1-rc2-23519",
-          "System.Resources.ReaderWriter": "4.0.0-rc2-23519",
-          "System.Runtime.CompilerServices.VisualC": "4.0.0-rc2-23519",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23519",
-          "System.Runtime.Loader": "4.0.0-rc2-23519",
-          "System.Runtime.Serialization.Json": "4.0.1-rc2-23519",
-          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23519",
-          "System.Runtime.Serialization.Xml": "4.1.0-rc2-23519",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
-          "System.ServiceModel.Duplex": "4.0.1-rc2-23519",
-          "System.ServiceModel.Http": "4.0.11-rc2-23519",
-          "System.ServiceModel.NetTcp": "4.1.0-rc2-23519",
-          "System.ServiceModel.Primitives": "4.1.0-rc2-23519",
-          "System.ServiceModel.Security": "4.0.1-rc2-23519",
-          "System.Xml.XmlSerializer": "4.0.11-rc2-23519"
+          "Microsoft.NETCore": "5.0.1-rc2-23525",
+          "Microsoft.NETCore.ConsoleHost": "1.0.0-rc2-23525",
+          "Microsoft.NETCore.Runtime.CoreCLR": "1.0.1-rc2-23525",
+          "Microsoft.Win32.Primitives": "4.0.1-rc2-23525",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-rc2-23525",
+          "System.Console": "4.0.0-rc2-23525",
+          "System.Data.Common": "4.0.1-rc2-23525",
+          "System.Data.SqlClient": "4.0.0-rc2-23525",
+          "System.Diagnostics.Contracts": "4.0.1-rc2-23525",
+          "System.Diagnostics.FileVersionInfo": "4.0.0-rc2-23525",
+          "System.Diagnostics.Process": "4.1.0-rc2-23525",
+          "System.Diagnostics.StackTrace": "4.0.1-rc2-23525",
+          "System.IO.FileSystem.DriveInfo": "4.0.0-rc2-23525",
+          "System.IO.FileSystem.Watcher": "4.0.0-rc2-23525",
+          "System.IO.MemoryMappedFiles": "4.0.0-rc2-23525",
+          "System.IO.Pipes": "4.0.0-rc2-23525",
+          "System.Net.NameResolution": "4.0.0-rc2-23525",
+          "System.Net.NetworkInformation": "4.1.0-rc2-23525",
+          "System.Net.Requests": "4.0.11-rc2-23525",
+          "System.Net.Security": "4.0.0-rc2-23525",
+          "System.Net.Sockets": "4.1.0-rc2-23525",
+          "System.Net.Utilities": "4.0.0-rc2-23525",
+          "System.Net.WebHeaderCollection": "4.0.1-rc2-23525",
+          "System.Net.WebSockets": "4.0.0-rc2-23525",
+          "System.Net.WebSockets.Client": "4.0.0-rc2-23525",
+          "System.Reflection.Emit": "4.0.1-rc2-23525",
+          "System.Reflection.Emit.ILGeneration": "4.0.1-rc2-23525",
+          "System.Reflection.Emit.Lightweight": "4.0.1-rc2-23525",
+          "System.Resources.ReaderWriter": "4.0.0-rc2-23525",
+          "System.Runtime.CompilerServices.VisualC": "4.0.0-rc2-23525",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23525",
+          "System.Runtime.Loader": "4.0.0-rc2-23525",
+          "System.Runtime.Serialization.Json": "4.0.1-rc2-23525",
+          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23525",
+          "System.Runtime.Serialization.Xml": "4.1.0-rc2-23525",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.ServiceModel.Duplex": "4.0.1-rc2-23525",
+          "System.ServiceModel.Http": "4.0.11-rc2-23525",
+          "System.ServiceModel.NetTcp": "4.1.0-rc2-23525",
+          "System.ServiceModel.Primitives": "4.1.0-rc2-23525",
+          "System.ServiceModel.Security": "4.0.1-rc2-23525",
+          "System.Xml.XmlSerializer": "4.0.11-rc2-23525"
         }
       },
-      "Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23519": {
+      "Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23525": {
         "type": "package"
       },
-      "Microsoft.NETCore.Platforms/1.0.1-rc2-23519": {
+      "Microsoft.NETCore.Platforms/1.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Targets": "1.0.1-rc2-23519"
+          "Microsoft.NETCore.Targets": "1.0.1-rc2-23525"
         }
       },
-      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23519": {
+      "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-rc2-23519"
+          "Microsoft.NETCore.Windows.ApiSets": "1.0.1-rc2-23525"
         }
       },
-      "Microsoft.NETCore.Targets/1.0.1-rc2-23519": {
+      "Microsoft.NETCore.Targets/1.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-rc2-23519"
+          "Microsoft.NETCore.Targets.DNXCore": "5.0.0-rc2-23525"
         }
       },
-      "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23519": {
+      "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23525": {
         "type": "package"
       },
-      "Microsoft.NETCore.TestHost/1.0.0-rc2-23519": {
+      "Microsoft.NETCore.TestHost/1.0.0-rc2-23525": {
         "type": "package"
       },
-      "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23519": {
+      "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23525": {
         "type": "package"
       },
-      "Microsoft.VisualBasic/10.0.1-rc2-23519": {
+      "Microsoft.VisualBasic/10.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10297,7 +10429,7 @@
           "lib/dotnet5.4/Microsoft.VisualBasic.dll": {}
         }
       },
-      "Microsoft.Win32.Primitives/4.0.1-rc2-23519": {
+      "Microsoft.Win32.Primitives/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -10312,7 +10444,7 @@
       "ReportGenerator/2.3.4": {
         "type": "package"
       },
-      "runtime.any.System.Linq.Expressions/4.0.11-rc2-23519": {
+      "runtime.any.System.Linq.Expressions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10340,7 +10472,7 @@
           "lib/DNXCore50/System.Linq.Expressions.dll": {}
         }
       },
-      "runtime.any.System.Private.DataContractSerialization/4.1.0-rc2-23519": {
+      "runtime.any.System.Private.DataContractSerialization/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10357,7 +10489,7 @@
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
-          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23519",
+          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Text.Encoding.Extensions": "4.0.10",
           "System.Text.RegularExpressions": "4.0.10",
@@ -10373,7 +10505,7 @@
           "lib/DNXCore50/System.Private.DataContractSerialization.dll": {}
         }
       },
-      "runtime.any.System.Reflection.DispatchProxy/4.0.1-rc2-23519": {
+      "runtime.any.System.Reflection.DispatchProxy/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10394,7 +10526,7 @@
           "lib/DNXCore50/System.Reflection.DispatchProxy.dll": {}
         }
       },
-      "runtime.any.System.Xml.XmlSerializer/4.0.11-rc2-23519": {
+      "runtime.any.System.Xml.XmlSerializer/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10423,7 +10555,7 @@
           "lib/DNXCore50/System.Xml.XmlSerializer.dll": {}
         }
       },
-      "runtime.osx.10.10.System.Diagnostics.Process/4.1.0-rc2-23519": {
+      "runtime.osx.10.10.System.Diagnostics.Process/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -10442,7 +10574,7 @@
           "System.Text.Encoding.Extensions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-rc2-23519"
+          "System.Threading.ThreadPool": "4.0.10-rc2-23525"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -10451,7 +10583,7 @@
           "runtimes/unix/lib/dotnet5.5/System.Diagnostics.Process.dll": {}
         }
       },
-      "runtime.osx.10.10.System.IO.FileSystem/4.0.1-rc2-23519": {
+      "runtime.osx.10.10.System.IO.FileSystem/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10475,7 +10607,7 @@
           "runtimes/osx.10.10/lib/dotnet5.4/System.IO.FileSystem.dll": {}
         }
       },
-      "runtime.osx.10.10.System.IO.FileSystem.DriveInfo/4.0.0-rc2-23519": {
+      "runtime.osx.10.10.System.IO.FileSystem.DriveInfo/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10494,7 +10626,7 @@
           "runtimes/unix/lib/dotnet5.4/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
-      "runtime.osx.10.10.System.IO.FileSystem.Watcher/4.0.0-rc2-23519": {
+      "runtime.osx.10.10.System.IO.FileSystem.Watcher/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10507,7 +10639,7 @@
           "System.Runtime.InteropServices": "4.0.20",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.Thread": "4.0.0-rc2-23519"
+          "System.Threading.Thread": "4.0.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -10516,7 +10648,7 @@
           "runtimes/unix/lib/dotnet5.4/System.IO.FileSystem.Watcher.dll": {}
         }
       },
-      "runtime.osx.10.10.System.IO.MemoryMappedFiles/4.0.0-rc2-23519": {
+      "runtime.osx.10.10.System.IO.MemoryMappedFiles/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -10538,7 +10670,7 @@
           "runtimes/unix/lib/dotnet5.4/System.IO.MemoryMappedFiles.dll": {}
         }
       },
-      "runtime.osx.10.10.System.Net.Http/4.0.1-rc2-23519": {
+      "runtime.osx.10.10.System.Net.Http/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10551,7 +10683,11 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.OpenSsl": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.0",
           "System.Threading.Tasks": "4.0.10"
@@ -10563,7 +10699,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Net.Http.dll": {}
         }
       },
-      "runtime.osx.10.10.System.Net.NameResolution/4.0.0-rc2-23519": {
+      "runtime.osx.10.10.System.Net.NameResolution/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -10574,7 +10710,7 @@
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Principal.Windows": "4.0.0-rc2-23519",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23525",
           "System.Threading": "4.0.0",
           "System.Threading.Tasks": "4.0.0"
         },
@@ -10585,7 +10721,7 @@
           "runtimes/unix/lib/dnxcore50/System.Net.NameResolution.dll": {}
         }
       },
-      "runtime.osx.10.10.System.Net.NetworkInformation/4.1.0-rc2-23519": {
+      "runtime.osx.10.10.System.Net.NetworkInformation/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -10600,7 +10736,7 @@
           "System.Runtime.InteropServices": "4.0.20",
           "System.Threading": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.Thread": "4.0.0-rc2-23519"
+          "System.Threading.Thread": "4.0.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -10609,7 +10745,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Net.NetworkInformation.dll": {}
         }
       },
-      "runtime.osx.10.10.System.Net.Primitives/4.0.11-rc2-23519": {
+      "runtime.osx.10.10.System.Net.Primitives/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -10631,24 +10767,24 @@
           "runtimes/unix/lib/dnxcore50/System.Net.Primitives.dll": {}
         }
       },
-      "runtime.osx.10.10.System.Net.Sockets/4.1.0-rc2-23519": {
+      "runtime.osx.10.10.System.Net.Sockets/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
           "System.Diagnostics.Tracing": "4.0.20",
           "System.Globalization": "4.0.0",
           "System.IO": "4.0.10",
-          "System.Net.NameResolution": "4.0.0-rc2-23519",
+          "System.Net.NameResolution": "4.0.0-rc2-23525",
           "System.Net.Primitives": "4.0.10",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Principal.Windows": "4.0.0-rc2-23519",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23525",
           "System.Threading": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-rc2-23519"
+          "System.Threading.ThreadPool": "4.0.10-rc2-23525"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -10657,7 +10793,7 @@
           "runtimes/osx.10.10/lib/dotnet5.5/System.Net.Sockets.dll": {}
         }
       },
-      "runtime.osx.10.10.System.Runtime.Extensions/4.0.11-rc2-23519": {
+      "runtime.osx.10.10.System.Runtime.Extensions/4.0.11-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -10666,7 +10802,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Runtime.Extensions.dll": {}
         }
       },
-      "runtime.osx.10.10.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23519": {
+      "runtime.osx.10.10.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -10679,7 +10815,7 @@
           "runtimes/unix/lib/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "runtime.osx.10.10.System.Security.Cryptography.Algorithms/4.0.0-rc2-23519": {
+      "runtime.osx.10.10.System.Security.Cryptography.Algorithms/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -10687,7 +10823,7 @@
           "System.Runtime": "4.0.20",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.0",
           "System.Text.Encoding.Extensions": "4.0.0"
         },
@@ -10698,13 +10834,13 @@
           "runtimes/osx.10.10/lib/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "runtime.osx.10.10-x64.Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23519": {
+      "runtime.osx.10.10-x64.Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23525": {
         "type": "package",
         "native": {
           "runtimes/osx.10.10-x64/native/coreconsole": {}
         }
       },
-      "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23519": {
+      "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -10726,13 +10862,13 @@
           "runtimes/osx.10.10-x64/native/System.Security.Cryptography.Native.dylib": {}
         }
       },
-      "runtime.osx.10.10-x64.Microsoft.NETCore.TestHost/1.0.0-rc2-23519": {
+      "runtime.osx.10.10-x64.Microsoft.NETCore.TestHost/1.0.0-rc2-23525": {
         "type": "package",
         "native": {
           "runtimes/osx.10.10-x64/native/corerun": {}
         }
       },
-      "runtime.unix.Microsoft.Win32.Primitives/4.0.1-rc2-23519": {
+      "runtime.unix.Microsoft.Win32.Primitives/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20",
@@ -10745,7 +10881,7 @@
           "runtimes/unix/lib/dotnet5.4/Microsoft.Win32.Primitives.dll": {}
         }
       },
-      "runtime.unix.System.Console/4.0.0-rc2-23519": {
+      "runtime.unix.System.Console/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10769,7 +10905,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Console.dll": {}
         }
       },
-      "runtime.unix.System.Data.SqlClient/4.0.0-rc2-23519": {
+      "runtime.unix.System.Data.SqlClient/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -10781,10 +10917,10 @@
           "System.Globalization": "4.0.10",
           "System.IO": "4.0.10",
           "System.Linq": "4.0.0",
-          "System.Net.NameResolution": "4.0.0-rc2-23519",
+          "System.Net.NameResolution": "4.0.0-rc2-23525",
           "System.Net.Primitives": "4.0.10",
-          "System.Net.Security": "4.0.0-rc2-23519",
-          "System.Net.Sockets": "4.1.0-rc2-23519",
+          "System.Net.Security": "4.0.0-rc2-23525",
+          "System.Net.Sockets": "4.1.0-rc2-23525",
           "System.Reflection": "4.0.0",
           "System.Reflection.TypeExtensions": "4.0.0",
           "System.Resources.ResourceManager": "4.0.0",
@@ -10792,17 +10928,17 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
-          "System.Security.Principal.Windows": "4.0.0-rc2-23519",
+          "System.Runtime.InteropServices.RuntimeInformation": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Text.Encoding.CodePages": "4.0.0",
           "System.Text.Encoding.Extensions": "4.0.0",
           "System.Text.RegularExpressions": "4.0.10",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.Thread": "4.0.0-rc2-23519",
-          "System.Threading.ThreadPool": "4.0.10-rc2-23519",
+          "System.Threading.Thread": "4.0.0-rc2-23525",
+          "System.Threading.ThreadPool": "4.0.10-rc2-23525",
           "System.Threading.Timer": "4.0.0",
           "System.Xml.ReaderWriter": "4.0.0"
         },
@@ -10813,7 +10949,7 @@
           "runtimes/unix/lib/dotnet5.5/System.Data.SqlClient.dll": {}
         }
       },
-      "runtime.unix.System.Diagnostics.Debug/4.0.11-rc2-23519": {
+      "runtime.unix.System.Diagnostics.Debug/4.0.11-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -10822,7 +10958,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Diagnostics.Debug.dll": {}
         }
       },
-      "runtime.unix.System.Diagnostics.FileVersionInfo/4.0.0-rc2-23519": {
+      "runtime.unix.System.Diagnostics.FileVersionInfo/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -10838,7 +10974,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Diagnostics.FileVersionInfo.dll": {}
         }
       },
-      "runtime.unix.System.Globalization.Extensions/4.0.1-rc2-23519": {
+      "runtime.unix.System.Globalization.Extensions/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -10853,7 +10989,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Globalization.Extensions.dll": {}
         }
       },
-      "runtime.unix.System.IO.Compression/4.1.0-rc2-23519": {
+      "runtime.unix.System.IO.Compression/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10875,7 +11011,7 @@
           "runtimes/unix/lib/dotnet5.4/System.IO.Compression.dll": {}
         }
       },
-      "runtime.unix.System.IO.Pipes/4.0.0-rc2-23519": {
+      "runtime.unix.System.IO.Pipes/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -10896,7 +11032,7 @@
           "runtimes/unix/lib/dotnet5.4/System.IO.Pipes.dll": {}
         }
       },
-      "runtime.unix.System.Net.Requests/4.0.11-rc2-23519": {
+      "runtime.unix.System.Net.Requests/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10917,7 +11053,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Net.Requests.dll": {}
         }
       },
-      "runtime.unix.System.Net.Security/4.0.0-rc2-23519": {
+      "runtime.unix.System.Net.Security/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -10934,17 +11070,17 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.OpenSsl": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.OpenSsl": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-rc2-23519",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-rc2-23519"
+          "System.Threading.ThreadPool": "4.0.10-rc2-23525"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -10953,7 +11089,7 @@
           "runtimes/unix/lib/dnxcore50/System.Net.Security.dll": {}
         }
       },
-      "runtime.unix.System.Net.WebSockets.Client/4.0.0-rc2-23519": {
+      "runtime.unix.System.Net.WebSockets.Client/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -10961,10 +11097,10 @@
           "System.Globalization": "4.0.10",
           "System.Net.Primitives": "4.0.0",
           "System.Net.WebHeaderCollection": "4.0.0",
-          "System.Net.WebSockets": "4.0.0-rc2-23519",
+          "System.Net.WebSockets": "4.0.0-rc2-23525",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.0",
           "System.Threading": "4.0.10",
           "System.Threading.Tasks": "4.0.10"
@@ -10976,7 +11112,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Net.WebSockets.Client.dll": {}
         }
       },
-      "runtime.unix.System.Private.Uri/4.0.1-rc2-23519": {
+      "runtime.unix.System.Private.Uri/4.0.1-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -10985,7 +11121,7 @@
           "runtimes/unix/lib/dotnet5.1/System.Private.Uri.dll": {}
         }
       },
-      "runtime.unix.System.Security.Cryptography.Encoding/4.0.0-rc2-23519": {
+      "runtime.unix.System.Security.Cryptography.Encoding/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -10997,7 +11133,7 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.0"
         },
         "compile": {
@@ -11007,7 +11143,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "runtime.unix.System.Security.Cryptography.X509Certificates/4.0.0-rc2-23519": {
+      "runtime.unix.System.Security.Cryptography.X509Certificates/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11016,17 +11152,17 @@
           "System.IO": "4.0.10",
           "System.IO.FileSystem": "4.0.0",
           "System.IO.FileSystem.Primitives": "4.0.0",
-          "System.IO.FileSystem.Watcher": "4.0.0-rc2-23519",
+          "System.IO.FileSystem.Watcher": "4.0.0-rc2-23525",
           "System.Resources.ResourceManager": "4.0.0",
           "System.Runtime": "4.0.20",
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
           "System.Runtime.Numerics": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.OpenSsl": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.OpenSsl": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.10",
           "System.Threading": "4.0.10"
         },
@@ -11037,7 +11173,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
-      "runtime.unix.System.Text.Encoding.CodePages/4.0.1-rc2-23519": {
+      "runtime.unix.System.Text.Encoding.CodePages/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11059,7 +11195,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Text.Encoding.CodePages.dll": {}
         }
       },
-      "runtime.unix.System.Threading/4.0.11-rc2-23519": {
+      "runtime.unix.System.Threading/4.0.11-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dotnet/_._": {}
@@ -11068,7 +11204,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Threading.dll": {}
         }
       },
-      "System.AppContext/4.0.1-rc2-23519": {
+      "System.AppContext/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -11080,10 +11216,10 @@
           "lib/DNXCore50/System.AppContext.dll": {}
         }
       },
-      "System.Collections/4.0.11-rc2-23519": {
+      "System.Collections/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Runtime": "4.0.21-rc2-23519"
+          "System.Runtime": "4.0.21-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Collections.dll": {}
@@ -11092,7 +11228,7 @@
           "lib/DNXCore50/System.Collections.dll": {}
         }
       },
-      "System.Collections.Concurrent/4.0.11-rc2-23519": {
+      "System.Collections.Concurrent/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11112,7 +11248,7 @@
           "lib/dotnet5.4/System.Collections.Concurrent.dll": {}
         }
       },
-      "System.Collections.Immutable/1.1.38-rc2-23519": {
+      "System.Collections.Immutable/1.1.38-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -11131,7 +11267,7 @@
           "lib/dotnet5.1/System.Collections.Immutable.dll": {}
         }
       },
-      "System.Collections.NonGeneric/4.0.1-rc2-23519": {
+      "System.Collections.NonGeneric/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -11148,7 +11284,7 @@
           "lib/dotnet5.4/System.Collections.NonGeneric.dll": {}
         }
       },
-      "System.Collections.Specialized/4.0.1-rc2-23519": {
+      "System.Collections.Specialized/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections.NonGeneric": "4.0.0",
@@ -11166,7 +11302,7 @@
           "lib/dotnet5.4/System.Collections.Specialized.dll": {}
         }
       },
-      "System.ComponentModel/4.0.1-rc2-23519": {
+      "System.ComponentModel/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -11178,7 +11314,7 @@
           "lib/dotnet5.4/System.ComponentModel.dll": {}
         }
       },
-      "System.ComponentModel.Annotations/4.1.0-rc2-23519": {
+      "System.ComponentModel.Annotations/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11200,7 +11336,7 @@
           "lib/dotnet5.4/System.ComponentModel.Annotations.dll": {}
         }
       },
-      "System.ComponentModel.EventBasedAsync/4.0.11-rc2-23519": {
+      "System.ComponentModel.EventBasedAsync/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -11215,7 +11351,7 @@
           "lib/dotnet5.4/System.ComponentModel.EventBasedAsync.dll": {}
         }
       },
-      "System.Console/4.0.0-rc2-23519": {
+      "System.Console/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -11225,7 +11361,7 @@
           "ref/dotnet5.4/System.Console.dll": {}
         }
       },
-      "System.Data.Common/4.0.1-rc2-23519": {
+      "System.Data.Common/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11245,7 +11381,7 @@
           "lib/dotnet5.4/System.Data.Common.dll": {}
         }
       },
-      "System.Data.SqlClient/4.0.0-rc2-23519": {
+      "System.Data.SqlClient/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Data.Common": "4.0.0",
@@ -11259,7 +11395,7 @@
           "ref/dotnet5.4/System.Data.SqlClient.dll": {}
         }
       },
-      "System.Diagnostics.Contracts/4.0.1-rc2-23519": {
+      "System.Diagnostics.Contracts/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -11271,7 +11407,7 @@
           "lib/DNXCore50/System.Diagnostics.Contracts.dll": {}
         }
       },
-      "System.Diagnostics.Debug/4.0.11-rc2-23519": {
+      "System.Diagnostics.Debug/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -11280,7 +11416,7 @@
           "ref/dotnet5.4/System.Diagnostics.Debug.dll": {}
         }
       },
-      "System.Diagnostics.FileVersionInfo/4.0.0-rc2-23519": {
+      "System.Diagnostics.FileVersionInfo/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -11289,7 +11425,7 @@
           "ref/dotnet5.4/System.Diagnostics.FileVersionInfo.dll": {}
         }
       },
-      "System.Diagnostics.Process/4.1.0-rc2-23519": {
+      "System.Diagnostics.Process/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -11301,7 +11437,7 @@
           "ref/dotnet5.5/System.Diagnostics.Process.dll": {}
         }
       },
-      "System.Diagnostics.StackTrace/4.0.1-rc2-23519": {
+      "System.Diagnostics.StackTrace/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -11314,7 +11450,7 @@
           "lib/DNXCore50/System.Diagnostics.StackTrace.dll": {}
         }
       },
-      "System.Diagnostics.Tools/4.0.1-rc2-23519": {
+      "System.Diagnostics.Tools/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -11326,7 +11462,7 @@
           "lib/DNXCore50/System.Diagnostics.Tools.dll": {}
         }
       },
-      "System.Diagnostics.Tracing/4.0.21-rc2-23519": {
+      "System.Diagnostics.Tracing/4.0.21-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -11338,7 +11474,7 @@
           "lib/DNXCore50/System.Diagnostics.Tracing.dll": {}
         }
       },
-      "System.Dynamic.Runtime/4.0.11-rc2-23519": {
+      "System.Dynamic.Runtime/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11364,7 +11500,7 @@
           "lib/DNXCore50/System.Dynamic.Runtime.dll": {}
         }
       },
-      "System.Globalization/4.0.11-rc2-23519": {
+      "System.Globalization/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -11376,7 +11512,7 @@
           "lib/DNXCore50/System.Globalization.dll": {}
         }
       },
-      "System.Globalization.Calendars/4.0.1-rc2-23519": {
+      "System.Globalization.Calendars/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -11389,7 +11525,7 @@
           "lib/DNXCore50/System.Globalization.Calendars.dll": {}
         }
       },
-      "System.Globalization.Extensions/4.0.1-rc2-23519": {
+      "System.Globalization.Extensions/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -11400,7 +11536,7 @@
           "ref/dotnet5.4/System.Globalization.Extensions.dll": {}
         }
       },
-      "System.IO/4.0.11-rc2-23519": {
+      "System.IO/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20",
@@ -11414,7 +11550,7 @@
           "lib/DNXCore50/System.IO.dll": {}
         }
       },
-      "System.IO.Compression/4.1.0-rc2-23519": {
+      "System.IO.Compression/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -11426,7 +11562,7 @@
           "ref/dotnet5.4/System.IO.Compression.dll": {}
         }
       },
-      "System.IO.Compression.ZipFile/4.0.1-rc2-23519": {
+      "System.IO.Compression.ZipFile/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -11445,7 +11581,7 @@
           "lib/dotnet5.4/System.IO.Compression.ZipFile.dll": {}
         }
       },
-      "System.IO.FileSystem/4.0.1-rc2-23519": {
+      "System.IO.FileSystem/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -11459,7 +11595,7 @@
           "ref/dotnet5.4/System.IO.FileSystem.dll": {}
         }
       },
-      "System.IO.FileSystem.DriveInfo/4.0.0-rc2-23519": {
+      "System.IO.FileSystem.DriveInfo/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -11470,7 +11606,7 @@
           "ref/dotnet5.4/System.IO.FileSystem.DriveInfo.dll": {}
         }
       },
-      "System.IO.FileSystem.Primitives/4.0.1-rc2-23519": {
+      "System.IO.FileSystem.Primitives/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -11482,7 +11618,7 @@
           "lib/dotnet5.4/System.IO.FileSystem.Primitives.dll": {}
         }
       },
-      "System.IO.FileSystem.Watcher/4.0.0-rc2-23519": {
+      "System.IO.FileSystem.Watcher/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -11491,7 +11627,7 @@
           "ref/dotnet5.4/System.IO.FileSystem.Watcher.dll": {}
         }
       },
-      "System.IO.MemoryMappedFiles/4.0.0-rc2-23519": {
+      "System.IO.MemoryMappedFiles/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO.FileSystem": "4.0.0",
@@ -11505,7 +11641,7 @@
           "ref/dotnet5.4/System.IO.MemoryMappedFiles.dll": {}
         }
       },
-      "System.IO.Pipes/4.0.0-rc2-23519": {
+      "System.IO.Pipes/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -11518,7 +11654,7 @@
           "ref/dotnet5.4/System.IO.Pipes.dll": {}
         }
       },
-      "System.IO.UnmanagedMemoryStream/4.0.1-rc2-23519": {
+      "System.IO.UnmanagedMemoryStream/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.10",
@@ -11536,7 +11672,7 @@
           "lib/dotnet5.4/System.IO.UnmanagedMemoryStream.dll": {}
         }
       },
-      "System.Linq/4.0.1-rc2-23519": {
+      "System.Linq/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11552,7 +11688,7 @@
           "lib/dotnet5.4/System.Linq.dll": {}
         }
       },
-      "System.Linq.Expressions/4.0.11-rc2-23519": {
+      "System.Linq.Expressions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -11562,7 +11698,7 @@
           "ref/dotnet5.4/System.Linq.Expressions.dll": {}
         }
       },
-      "System.Linq.Parallel/4.0.1-rc2-23519": {
+      "System.Linq.Parallel/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11583,7 +11719,7 @@
           "lib/dotnet5.4/System.Linq.Parallel.dll": {}
         }
       },
-      "System.Linq.Queryable/4.0.1-rc2-23519": {
+      "System.Linq.Queryable/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11602,7 +11738,7 @@
           "lib/dotnet5.4/System.Linq.Queryable.dll": {}
         }
       },
-      "System.Net.Http/4.0.1-rc2-23519": {
+      "System.Net.Http/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -11615,7 +11751,34 @@
           "ref/dotnet5.2/System.Net.Http.dll": {}
         }
       },
-      "System.Net.NameResolution/4.0.0-rc2-23519": {
+      "System.Net.Http.WinHttpHandler/4.0.0-rc2-23525": {
+        "type": "package",
+        "dependencies": {
+          "Microsoft.Win32.Primitives": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Globalization": "4.0.10",
+          "System.IO": "4.0.10",
+          "System.IO.Compression": "4.0.0",
+          "System.Net.Http": "4.0.0",
+          "System.Net.Primitives": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10",
+          "System.Runtime.Handles": "4.0.0",
+          "System.Runtime.InteropServices": "4.0.20",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.Text.Encoding": "4.0.10",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet5.4/System.Net.Http.WinHttpHandler.dll": {}
+        },
+        "runtime": {
+          "lib/DNXCore50/System.Net.Http.WinHttpHandler.dll": {}
+        }
+      },
+      "System.Net.NameResolution/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -11626,7 +11789,7 @@
           "ref/dotnet5.4/System.Net.NameResolution.dll": {}
         }
       },
-      "System.Net.NetworkInformation/4.1.0-rc2-23519": {
+      "System.Net.NetworkInformation/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
@@ -11637,7 +11800,7 @@
           "ref/dotnet5.4/System.Net.NetworkInformation.dll": {}
         }
       },
-      "System.Net.Primitives/4.0.11-rc2-23519": {
+      "System.Net.Primitives/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -11647,7 +11810,7 @@
           "ref/dotnet5.4/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Requests/4.0.11-rc2-23519": {
+      "System.Net.Requests/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -11660,20 +11823,21 @@
           "ref/dotnet5.4/System.Net.Requests.dll": {}
         }
       },
-      "System.Net.Security/4.0.0-rc2-23519": {
+      "System.Net.Security/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Net.Primitives": "4.0.10",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.Security.Principal": "4.0.0",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.Security.dll": {}
         }
       },
-      "System.Net.Sockets/4.1.0-rc2-23519": {
+      "System.Net.Sockets/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -11685,10 +11849,10 @@
           "ref/dotnet5.4/System.Net.Sockets.dll": {}
         }
       },
-      "System.Net.Utilities/4.0.0-rc2-23519": {
+      "System.Net.Utilities/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-rc2-23519"
+          "System.Private.Networking": "4.0.1-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.Utilities.dll": {}
@@ -11697,7 +11861,7 @@
           "lib/DNXCore50/System.Net.Utilities.dll": {}
         }
       },
-      "System.Net.WebHeaderCollection/4.0.1-rc2-23519": {
+      "System.Net.WebHeaderCollection/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11713,7 +11877,7 @@
           "lib/dotnet5.4/System.Net.WebHeaderCollection.dll": {}
         }
       },
-      "System.Net.WebSockets/4.0.0-rc2-23519": {
+      "System.Net.WebSockets/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -11728,20 +11892,20 @@
           "lib/dotnet5.4/System.Net.WebSockets.dll": {}
         }
       },
-      "System.Net.WebSockets.Client/4.0.0-rc2-23519": {
+      "System.Net.WebSockets.Client/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Net.Primitives": "4.0.10",
-          "System.Net.WebSockets": "4.0.0-rc2-23519",
+          "System.Net.WebSockets": "4.0.0-rc2-23525",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Net.WebSockets.Client.dll": {}
         }
       },
-      "System.Numerics.Vectors/4.1.1-rc2-23519": {
+      "System.Numerics.Vectors/4.1.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -11756,7 +11920,7 @@
           "lib/dotnet5.4/System.Numerics.Vectors.dll": {}
         }
       },
-      "System.ObjectModel/4.0.11-rc2-23519": {
+      "System.ObjectModel/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -11772,13 +11936,13 @@
           "lib/dotnet5.4/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.DataContractSerialization/4.1.0-rc2-23519": {
+      "System.Private.DataContractSerialization/4.1.0-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
         }
       },
-      "System.Private.Networking/4.0.1-rc2-23519": {
+      "System.Private.Networking/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -11797,14 +11961,14 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-rc2-23519",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23525",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
           "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-rc2-23519"
+          "System.Threading.ThreadPool": "4.0.10-rc2-23525"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -11813,53 +11977,57 @@
           "lib/DNXCore50/System.Private.Networking.dll": {}
         }
       },
-      "System.Private.ServiceModel/4.1.0-rc2-23519": {
+      "System.Private.ServiceModel/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Collections": "4.0.11-rc2-23519",
-          "System.Collections.Concurrent": "4.0.11-rc2-23519",
-          "System.Collections.NonGeneric": "4.0.1-rc2-23519",
-          "System.Collections.Specialized": "4.0.1-rc2-23519",
-          "System.ComponentModel.EventBasedAsync": "4.0.11-rc2-23519",
-          "System.Diagnostics.Debug": "4.0.11-rc2-23519",
-          "System.Diagnostics.Tracing": "4.0.21-rc2-23519",
-          "System.Globalization": "4.0.11-rc2-23519",
-          "System.IO": "4.0.11-rc2-23519",
-          "System.IO.Compression": "4.1.0-rc2-23519",
-          "System.Linq": "4.0.1-rc2-23519",
-          "System.Linq.Expressions": "4.0.11-rc2-23519",
-          "System.Linq.Queryable": "4.0.1-rc2-23519",
-          "System.Net.Http": "4.0.1-rc2-23519",
-          "System.Net.NameResolution": "4.0.0-rc2-23519",
-          "System.Net.Primitives": "4.0.11-rc2-23519",
-          "System.Net.Security": "4.0.0-rc2-23519",
-          "System.Net.Sockets": "4.1.0-rc2-23519",
-          "System.Net.WebHeaderCollection": "4.0.1-rc2-23519",
-          "System.Net.WebSockets": "4.0.0-rc2-23519",
-          "System.Net.WebSockets.Client": "4.0.0-rc2-23519",
-          "System.ObjectModel": "4.0.11-rc2-23519",
-          "System.Reflection": "4.1.0-rc2-23519",
-          "System.Reflection.DispatchProxy": "4.0.1-rc2-23519",
-          "System.Reflection.Extensions": "4.0.1-rc2-23519",
-          "System.Reflection.Primitives": "4.0.1-rc2-23519",
-          "System.Reflection.TypeExtensions": "4.0.1-rc2-23519",
-          "System.Resources.ResourceManager": "4.0.1-rc2-23519",
-          "System.Runtime": "4.0.21-rc2-23519",
-          "System.Runtime.Extensions": "4.0.11-rc2-23519",
-          "System.Runtime.InteropServices": "4.0.21-rc2-23519",
+          "System.Collections": "4.0.11-rc2-23525",
+          "System.Collections.Concurrent": "4.0.11-rc2-23525",
+          "System.Collections.NonGeneric": "4.0.1-rc2-23525",
+          "System.Collections.Specialized": "4.0.1-rc2-23525",
+          "System.ComponentModel.EventBasedAsync": "4.0.11-rc2-23525",
+          "System.Diagnostics.Debug": "4.0.11-rc2-23525",
+          "System.Diagnostics.Tracing": "4.0.21-rc2-23525",
+          "System.Globalization": "4.0.11-rc2-23525",
+          "System.IO": "4.0.11-rc2-23525",
+          "System.IO.Compression": "4.1.0-rc2-23525",
+          "System.Linq": "4.0.1-rc2-23525",
+          "System.Linq.Expressions": "4.0.11-rc2-23525",
+          "System.Linq.Queryable": "4.0.1-rc2-23525",
+          "System.Net.Http": "4.0.1-rc2-23525",
+          "System.Net.Http.WinHttpHandler": "4.0.0-rc2-23525",
+          "System.Net.NameResolution": "4.0.0-rc2-23525",
+          "System.Net.Primitives": "4.0.11-rc2-23525",
+          "System.Net.Security": "4.0.0-rc2-23525",
+          "System.Net.Sockets": "4.1.0-rc2-23525",
+          "System.Net.WebHeaderCollection": "4.0.1-rc2-23525",
+          "System.Net.WebSockets": "4.0.0-rc2-23525",
+          "System.Net.WebSockets.Client": "4.0.0-rc2-23525",
+          "System.ObjectModel": "4.0.11-rc2-23525",
+          "System.Reflection": "4.1.0-rc2-23525",
+          "System.Reflection.DispatchProxy": "4.0.1-rc2-23525",
+          "System.Reflection.Extensions": "4.0.1-rc2-23525",
+          "System.Reflection.Primitives": "4.0.1-rc2-23525",
+          "System.Reflection.TypeExtensions": "4.0.1-rc2-23525",
+          "System.Resources.ResourceManager": "4.0.1-rc2-23525",
+          "System.Runtime": "4.0.21-rc2-23525",
+          "System.Runtime.Extensions": "4.0.11-rc2-23525",
+          "System.Runtime.InteropServices": "4.0.21-rc2-23525",
           "System.Runtime.Serialization.Primitives": "4.0.10",
           "System.Runtime.Serialization.Xml": "4.0.10",
-          "System.Security.Claims": "4.0.1-rc2-23519",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23519",
-          "System.Security.Principal": "4.0.1-rc2-23519",
-          "System.Security.Principal.Windows": "4.0.0-rc2-23519",
-          "System.Text.Encoding": "4.0.11-rc2-23519",
-          "System.Threading": "4.0.11-rc2-23519",
-          "System.Threading.Tasks": "4.0.11-rc2-23519",
-          "System.Threading.Timer": "4.0.1-rc2-23519",
-          "System.Xml.ReaderWriter": "4.0.11-rc2-23519",
-          "System.Xml.XmlDocument": "4.0.1-rc2-23519",
-          "System.Xml.XmlSerializer": "4.0.11-rc2-23519"
+          "System.Security.Claims": "4.0.1-rc2-23525",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23525",
+          "System.Security.Principal": "4.0.1-rc2-23525",
+          "System.Security.Principal.Windows": "4.0.0-rc2-23525",
+          "System.Text.Encoding": "4.0.11-rc2-23525",
+          "System.Text.Encoding.Extensions": "4.0.10",
+          "System.Threading": "4.0.11-rc2-23525",
+          "System.Threading.Tasks": "4.0.11-rc2-23525",
+          "System.Threading.Timer": "4.0.1-rc2-23525",
+          "System.Xml.ReaderWriter": "4.0.11-rc2-23525",
+          "System.Xml.XmlDocument": "4.0.1-rc2-23525",
+          "System.Xml.XmlSerializer": "4.0.11-rc2-23525"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -11868,13 +12036,13 @@
           "lib/DNXCore50/System.Private.ServiceModel.dll": {}
         }
       },
-      "System.Private.Uri/4.0.1-rc2-23519": {
+      "System.Private.Uri/4.0.1-rc2-23525": {
         "type": "package",
         "compile": {
           "ref/dnxcore50/_._": {}
         }
       },
-      "System.Reflection/4.1.0-rc2-23519": {
+      "System.Reflection/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -11888,7 +12056,7 @@
           "lib/DNXCore50/System.Reflection.dll": {}
         }
       },
-      "System.Reflection.DispatchProxy/4.0.1-rc2-23519": {
+      "System.Reflection.DispatchProxy/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -11898,7 +12066,7 @@
           "ref/dotnet5.4/System.Reflection.DispatchProxy.dll": {}
         }
       },
-      "System.Reflection.Emit/4.0.1-rc2-23519": {
+      "System.Reflection.Emit/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -11914,7 +12082,7 @@
           "lib/DNXCore50/System.Reflection.Emit.dll": {}
         }
       },
-      "System.Reflection.Emit.ILGeneration/4.0.1-rc2-23519": {
+      "System.Reflection.Emit.ILGeneration/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -11928,7 +12096,7 @@
           "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll": {}
         }
       },
-      "System.Reflection.Emit.Lightweight/4.0.1-rc2-23519": {
+      "System.Reflection.Emit.Lightweight/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -11943,7 +12111,7 @@
           "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll": {}
         }
       },
-      "System.Reflection.Extensions/4.0.1-rc2-23519": {
+      "System.Reflection.Extensions/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -11956,7 +12124,7 @@
           "lib/DNXCore50/System.Reflection.Extensions.dll": {}
         }
       },
-      "System.Reflection.Metadata/1.1.1-rc2-23519": {
+      "System.Reflection.Metadata/1.1.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -11981,7 +12149,7 @@
           "lib/dotnet5.2/System.Reflection.Metadata.dll": {}
         }
       },
-      "System.Reflection.Primitives/4.0.1-rc2-23519": {
+      "System.Reflection.Primitives/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -11993,7 +12161,7 @@
           "lib/DNXCore50/System.Reflection.Primitives.dll": {}
         }
       },
-      "System.Reflection.TypeExtensions/4.1.0-rc2-23519": {
+      "System.Reflection.TypeExtensions/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -12006,7 +12174,7 @@
           "lib/DNXCore50/System.Reflection.TypeExtensions.dll": {}
         }
       },
-      "System.Resources.ReaderWriter/4.0.0-rc2-23519": {
+      "System.Resources.ReaderWriter/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -12024,7 +12192,7 @@
           "lib/DNXCore50/System.Resources.ReaderWriter.dll": {}
         }
       },
-      "System.Resources.ResourceManager/4.0.1-rc2-23519": {
+      "System.Resources.ResourceManager/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.0",
@@ -12038,10 +12206,10 @@
           "lib/DNXCore50/System.Resources.ResourceManager.dll": {}
         }
       },
-      "System.Runtime/4.0.21-rc2-23519": {
+      "System.Runtime/4.0.21-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.Uri": "4.0.1-rc2-23519"
+          "System.Private.Uri": "4.0.1-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Runtime.dll": {}
@@ -12050,7 +12218,7 @@
           "lib/DNXCore50/System.Runtime.dll": {}
         }
       },
-      "System.Runtime.CompilerServices.VisualC/4.0.0-rc2-23519": {
+      "System.Runtime.CompilerServices.VisualC/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -12062,7 +12230,7 @@
           "lib/DNXCore50/System.Runtime.CompilerServices.VisualC.dll": {}
         }
       },
-      "System.Runtime.Extensions/4.0.11-rc2-23519": {
+      "System.Runtime.Extensions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.20"
@@ -12071,7 +12239,7 @@
           "ref/dotnet5.4/System.Runtime.Extensions.dll": {}
         }
       },
-      "System.Runtime.Handles/4.0.1-rc2-23519": {
+      "System.Runtime.Handles/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -12083,7 +12251,7 @@
           "lib/DNXCore50/System.Runtime.Handles.dll": {}
         }
       },
-      "System.Runtime.InteropServices/4.0.21-rc2-23519": {
+      "System.Runtime.InteropServices/4.0.21-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Reflection": "4.0.0",
@@ -12098,7 +12266,7 @@
           "lib/DNXCore50/System.Runtime.InteropServices.dll": {}
         }
       },
-      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23519": {
+      "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -12107,7 +12275,7 @@
           "ref/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "System.Runtime.Loader/4.0.0-rc2-23519": {
+      "System.Runtime.Loader/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -12115,13 +12283,13 @@
           "System.Runtime": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.1/System.Runtime.Loader.dll": {}
+          "ref/dotnet5.5/System.Runtime.Loader.dll": {}
         },
         "runtime": {
           "lib/DNXCore50/System.Runtime.Loader.dll": {}
         }
       },
-      "System.Runtime.Numerics/4.0.1-rc2-23519": {
+      "System.Runtime.Numerics/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Globalization": "4.0.10",
@@ -12136,10 +12304,10 @@
           "lib/dotnet5.4/System.Runtime.Numerics.dll": {}
         }
       },
-      "System.Runtime.Serialization.Json/4.0.1-rc2-23519": {
+      "System.Runtime.Serialization.Json/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.1.0-rc2-23519"
+          "System.Private.DataContractSerialization": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.1/System.Runtime.Serialization.Json.dll": {}
@@ -12148,7 +12316,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Json.dll": {}
         }
       },
-      "System.Runtime.Serialization.Primitives/4.1.0-rc2-23519": {
+      "System.Runtime.Serialization.Primitives/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Resources.ResourceManager": "4.0.0",
@@ -12161,11 +12329,11 @@
           "lib/dotnet5.4/System.Runtime.Serialization.Primitives.dll": {}
         }
       },
-      "System.Runtime.Serialization.Xml/4.1.0-rc2-23519": {
+      "System.Runtime.Serialization.Xml/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.DataContractSerialization": "4.1.0-rc2-23519",
-          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23519"
+          "System.Private.DataContractSerialization": "4.1.0-rc2-23525",
+          "System.Runtime.Serialization.Primitives": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Runtime.Serialization.Xml.dll": {}
@@ -12174,7 +12342,7 @@
           "lib/DNXCore50/System.Runtime.Serialization.Xml.dll": {}
         }
       },
-      "System.Security.Claims/4.0.1-rc2-23519": {
+      "System.Security.Claims/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -12193,18 +12361,18 @@
           "lib/dotnet5.4/System.Security.Claims.dll": {}
         }
       },
-      "System.Security.Cryptography.Algorithms/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.Algorithms/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
           "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519"
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
         }
       },
-      "System.Security.Cryptography.Encoding/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.Encoding/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -12213,7 +12381,7 @@
           "ref/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
         }
       },
-      "System.Security.Cryptography.OpenSsl/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.OpenSsl/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -12224,9 +12392,9 @@
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
           "System.Runtime.Numerics": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23519",
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Primitives": "4.0.0-rc2-23525",
           "System.Text.Encoding": "4.0.10"
         },
         "compile": {
@@ -12236,7 +12404,7 @@
           "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.OpenSsl.dll": {}
         }
       },
-      "System.Security.Cryptography.Primitives/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.Primitives/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -12254,19 +12422,19 @@
           "lib/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
         }
       },
-      "System.Security.Cryptography.X509Certificates/4.0.0-rc2-23519": {
+      "System.Security.Cryptography.X509Certificates/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
           "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23519",
-          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23519"
+          "System.Security.Cryptography.Algorithms": "4.0.0-rc2-23525",
+          "System.Security.Cryptography.Encoding": "4.0.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
-      "System.Security.Principal/4.0.1-rc2-23519": {
+      "System.Security.Principal/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -12278,7 +12446,7 @@
           "lib/dotnet5.1/System.Security.Principal.dll": {}
         }
       },
-      "System.Security.Principal.Windows/4.0.0-rc2-23519": {
+      "System.Security.Principal.Windows/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -12301,10 +12469,10 @@
           "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
-      "System.ServiceModel.Duplex/4.0.1-rc2-23519": {
+      "System.ServiceModel.Duplex/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519"
+          "System.Private.ServiceModel": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.2/System.ServiceModel.Duplex.dll": {}
@@ -12313,10 +12481,10 @@
           "lib/DNXCore50/System.ServiceModel.Duplex.dll": {}
         }
       },
-      "System.ServiceModel.Http/4.0.11-rc2-23519": {
+      "System.ServiceModel.Http/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519",
+          "System.Private.ServiceModel": "4.1.0-rc2-23525",
           "System.Runtime": "4.0.20"
         },
         "compile": {
@@ -12326,10 +12494,10 @@
           "lib/DNXCore50/System.ServiceModel.Http.dll": {}
         }
       },
-      "System.ServiceModel.NetTcp/4.1.0-rc2-23519": {
+      "System.ServiceModel.NetTcp/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519"
+          "System.Private.ServiceModel": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.ServiceModel.NetTcp.dll": {}
@@ -12338,10 +12506,10 @@
           "lib/DNXCore50/System.ServiceModel.NetTcp.dll": {}
         }
       },
-      "System.ServiceModel.Primitives/4.1.0-rc2-23519": {
+      "System.ServiceModel.Primitives/4.1.0-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519"
+          "System.Private.ServiceModel": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.4/System.ServiceModel.Primitives.dll": {}
@@ -12350,10 +12518,10 @@
           "lib/DNXCore50/System.ServiceModel.Primitives.dll": {}
         }
       },
-      "System.ServiceModel.Security/4.0.1-rc2-23519": {
+      "System.ServiceModel.Security/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
-          "System.Private.ServiceModel": "4.1.0-rc2-23519"
+          "System.Private.ServiceModel": "4.1.0-rc2-23525"
         },
         "compile": {
           "ref/dotnet5.2/System.ServiceModel.Security.dll": {}
@@ -12362,7 +12530,7 @@
           "lib/DNXCore50/System.ServiceModel.Security.dll": {}
         }
       },
-      "System.Text.Encoding/4.0.11-rc2-23519": {
+      "System.Text.Encoding/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -12374,7 +12542,7 @@
           "lib/DNXCore50/System.Text.Encoding.dll": {}
         }
       },
-      "System.Text.Encoding.CodePages/4.0.1-rc2-23519": {
+      "System.Text.Encoding.CodePages/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -12384,7 +12552,7 @@
           "ref/dotnet5.4/System.Text.Encoding.CodePages.dll": {}
         }
       },
-      "System.Text.Encoding.Extensions/4.0.11-rc2-23519": {
+      "System.Text.Encoding.Extensions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -12397,7 +12565,7 @@
           "lib/DNXCore50/System.Text.Encoding.Extensions.dll": {}
         }
       },
-      "System.Text.RegularExpressions/4.0.11-rc2-23519": {
+      "System.Text.RegularExpressions/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -12414,7 +12582,7 @@
           "lib/dotnet5.4/System.Text.RegularExpressions.dll": {}
         }
       },
-      "System.Threading/4.0.11-rc2-23519": {
+      "System.Threading/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -12424,7 +12592,7 @@
           "ref/dotnet5.4/System.Threading.dll": {}
         }
       },
-      "System.Threading.Overlapped/4.0.1-rc2-23519": {
+      "System.Threading.Overlapped/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -12437,7 +12605,7 @@
           "lib/DNXCore50/System.Threading.Overlapped.dll": {}
         }
       },
-      "System.Threading.Tasks/4.0.11-rc2-23519": {
+      "System.Threading.Tasks/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -12449,7 +12617,7 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       },
-      "System.Threading.Tasks.Dataflow/4.5.26-rc2-23519": {
+      "System.Threading.Tasks.Dataflow/4.5.26-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.0",
@@ -12471,7 +12639,7 @@
           "lib/dotnet5.2/System.Threading.Tasks.Dataflow.dll": {}
         }
       },
-      "System.Threading.Tasks.Parallel/4.0.1-rc2-23519": {
+      "System.Threading.Tasks.Parallel/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections.Concurrent": "4.0.10",
@@ -12490,7 +12658,7 @@
           "lib/dotnet5.4/System.Threading.Tasks.Parallel.dll": {}
         }
       },
-      "System.Threading.Thread/4.0.0-rc2-23519": {
+      "System.Threading.Thread/4.0.0-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -12502,11 +12670,11 @@
           "lib/DNXCore50/System.Threading.Thread.dll": {}
         }
       },
-      "System.Threading.ThreadPool/4.0.10-rc2-23519": {
+      "System.Threading.ThreadPool/4.0.10-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
+          "System.Runtime.Handles": "4.0.0"
         },
         "compile": {
           "ref/dotnet5.4/System.Threading.ThreadPool.dll": {}
@@ -12515,7 +12683,7 @@
           "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
-      "System.Threading.Timer/4.0.1-rc2-23519": {
+      "System.Threading.Timer/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0"
@@ -12527,7 +12695,7 @@
           "lib/DNXCore50/System.Threading.Timer.dll": {}
         }
       },
-      "System.Xml.ReaderWriter/4.0.11-rc2-23519": {
+      "System.Xml.ReaderWriter/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -12552,7 +12720,7 @@
           "lib/dotnet5.4/System.Xml.ReaderWriter.dll": {}
         }
       },
-      "System.Xml.XDocument/4.0.11-rc2-23519": {
+      "System.Xml.XDocument/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -12575,7 +12743,7 @@
           "lib/dotnet5.4/System.Xml.XDocument.dll": {}
         }
       },
-      "System.Xml.XmlDocument/4.0.1-rc2-23519": {
+      "System.Xml.XmlDocument/4.0.1-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -12596,7 +12764,7 @@
           "lib/dotnet5.4/System.Xml.XmlDocument.dll": {}
         }
       },
-      "System.Xml.XmlSerializer/4.0.11-rc2-23519": {
+      "System.Xml.XmlSerializer/4.0.11-rc2-23525": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -12786,10 +12954,10 @@
         "tools/Newtonsoft.Json.xml"
       ]
     },
-    "Microsoft.CSharp/4.0.1-rc2-23519": {
+    "Microsoft.CSharp/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G/X7CuLtWhaVLHMZqG2sD0+bI0OkVWdzOscE7rdYGhINsex0a3BaJxDdJtTjMWzfRc44mCzhP1H+UxFbWCk/cw==",
+      "sha512": "D91rVrXFwsDKd0FS0TOFy02fIwUylNl07jV1R5BZLKnwM7ArGC800eoYSiRAafzUh9prtIgh/3EGPWpf8tjuYw==",
       "files": [
         "lib/dotnet5.4/Microsoft.CSharp.dll",
         "lib/MonoAndroid10/_._",
@@ -12801,8 +12969,8 @@
         "lib/wpa81/_._",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "Microsoft.CSharp.4.0.1-rc2-23519.nupkg",
-        "Microsoft.CSharp.4.0.1-rc2-23519.nupkg.sha512",
+        "Microsoft.CSharp.4.0.1-rc2-23525.nupkg",
+        "Microsoft.CSharp.4.0.1-rc2-23525.nupkg.sha512",
         "Microsoft.CSharp.nuspec",
         "ref/dotnet5.1/de/Microsoft.CSharp.xml",
         "ref/dotnet5.1/es/Microsoft.CSharp.xml",
@@ -12881,108 +13049,108 @@
         "tools/xunit.runner.utility.desktop.pdb"
       ]
     },
-    "Microsoft.NETCore/5.0.1-rc2-23519": {
+    "Microsoft.NETCore/5.0.1-rc2-23525": {
       "type": "package",
-      "sha512": "7LbtdqQ+b5iDmvt0d3Xy930d3k1dMGpStJihsW3awPmoTPZE+8IzVamHmzjXWXQ+8NBojX6sUJZ18VLXKCQycA==",
+      "sha512": "a4KdPEHCJsNGjFrlV8aPFVTc4hAcINjPLxg2BfRPpSsmI5qvbQ4HHqPxPHWohz7AR7jaECU47NNY0IcPJjecNQ==",
       "files": [
         "_._",
-        "Microsoft.NETCore.5.0.1-rc2-23519.nupkg",
-        "Microsoft.NETCore.5.0.1-rc2-23519.nupkg.sha512",
+        "Microsoft.NETCore.5.0.1-rc2-23525.nupkg",
+        "Microsoft.NETCore.5.0.1-rc2-23525.nupkg.sha512",
         "Microsoft.NETCore.nuspec"
       ]
     },
-    "Microsoft.NETCore.Console/1.0.0-rc2-23519": {
+    "Microsoft.NETCore.Console/1.0.0-rc2-23525": {
       "type": "package",
-      "sha512": "tMZsHvETIVqGciNOkztxh2neDIEbQM/qN3qVQ0ALfVfwouabNSmgUMgeT4KYhTv6ViOFZK0KX+CqtlAum6Rr3g==",
+      "sha512": "a8sA6a6ZxmHN2nAvN49rTbNEZZ4JK6Hzr3salN3+rm9diUEaBrJ58v5MJVpF76JkUleFhtjBmGYiLliS6xjRvA==",
       "files": [
         "_._",
-        "Microsoft.NETCore.Console.1.0.0-rc2-23519.nupkg",
-        "Microsoft.NETCore.Console.1.0.0-rc2-23519.nupkg.sha512",
+        "Microsoft.NETCore.Console.1.0.0-rc2-23525.nupkg",
+        "Microsoft.NETCore.Console.1.0.0-rc2-23525.nupkg.sha512",
         "Microsoft.NETCore.Console.nuspec"
       ]
     },
-    "Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23519": {
+    "Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23525": {
       "type": "package",
-      "sha512": "3nnqul/gekpU/y1HcBBuVTMsZkR/iOVz+jJ7x6INnVNm1u3n68X3pDHxjt2MLShqwENM1l4DyeycokmKuzk/7w==",
+      "sha512": "tOESc4d5FbqyuPGWI96wqRM7JqxThWw1GeQGzFDnKXmu6xqirvIQGy/R8qlCdRbc9G/COhc8B8f6m8n4vjZp3A==",
       "files": [
-        "Microsoft.NETCore.ConsoleHost.1.0.0-rc2-23519.nupkg",
-        "Microsoft.NETCore.ConsoleHost.1.0.0-rc2-23519.nupkg.sha512",
+        "Microsoft.NETCore.ConsoleHost.1.0.0-rc2-23525.nupkg",
+        "Microsoft.NETCore.ConsoleHost.1.0.0-rc2-23525.nupkg.sha512",
         "Microsoft.NETCore.ConsoleHost.nuspec",
         "runtime.json"
       ]
     },
-    "Microsoft.NETCore.Platforms/1.0.1-rc2-23519": {
+    "Microsoft.NETCore.Platforms/1.0.1-rc2-23525": {
       "type": "package",
-      "sha512": "/FHH/Vy1YqGdUZbpDIX6J1ZuOPjGTAB3ygFHBXungOM9VeU51BWQFRUZ0UTifqSeh/ylALz9WGGhdUxorJvdDA==",
+      "sha512": "wjPRIgPADPUwigb28bqjYXVUmhqnYnsEHA0p5ZQSu8PEbgK8V1rSBYWsldkVuWdOY90HF891fsmY4pPmhhFg5w==",
       "files": [
-        "Microsoft.NETCore.Platforms.1.0.1-rc2-23519.nupkg",
-        "Microsoft.NETCore.Platforms.1.0.1-rc2-23519.nupkg.sha512",
+        "Microsoft.NETCore.Platforms.1.0.1-rc2-23525.nupkg",
+        "Microsoft.NETCore.Platforms.1.0.1-rc2-23525.nupkg.sha512",
         "Microsoft.NETCore.Platforms.nuspec",
         "runtime.json"
       ]
     },
-    "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23519": {
+    "Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23525": {
       "type": "package",
-      "sha512": "Y2b1C1YRe94oTYYHAfqNQJ/uFVoeYdmJyZsha3VzH1JpQ8+/d4dBQO3qOo/XCW1WUBiivgXJ1t5NjmbjiUrvFQ==",
+      "sha512": "qTI3LLjK3dx470qF0crensGdVUm6LQk2nrTAiRVa9jZae6S6NRLwpksoQAn/6G/haSU3ayI7caM4LCCnbZl/bQ==",
       "files": [
-        "Microsoft.NETCore.Runtime.CoreCLR.1.0.1-rc2-23519.nupkg",
-        "Microsoft.NETCore.Runtime.CoreCLR.1.0.1-rc2-23519.nupkg.sha512",
+        "Microsoft.NETCore.Runtime.CoreCLR.1.0.1-rc2-23525.nupkg",
+        "Microsoft.NETCore.Runtime.CoreCLR.1.0.1-rc2-23525.nupkg.sha512",
         "Microsoft.NETCore.Runtime.CoreCLR.nuspec",
         "runtime.json"
       ]
     },
-    "Microsoft.NETCore.Targets/1.0.1-rc2-23519": {
+    "Microsoft.NETCore.Targets/1.0.1-rc2-23525": {
       "type": "package",
-      "sha512": "+rNfb/1kPcFJ/1UHpPrwiAMQXHaTEoqc1/OBfJ8XEhtt9j4+fpjo0Psntcn94giTQiy5KbaUiY6Y6C62oyNKxA==",
+      "sha512": "u/IcE4AE4UTnyTfVJdCut6dQZ1Oy213Sgw+GMTIRd7I5TZXAREpUXUcUm4Zjz+q0v2fVG6sVWR3nyRosl66mWg==",
       "files": [
-        "Microsoft.NETCore.Targets.1.0.1-rc2-23519.nupkg",
-        "Microsoft.NETCore.Targets.1.0.1-rc2-23519.nupkg.sha512",
+        "Microsoft.NETCore.Targets.1.0.1-rc2-23525.nupkg",
+        "Microsoft.NETCore.Targets.1.0.1-rc2-23525.nupkg.sha512",
         "Microsoft.NETCore.Targets.nuspec",
         "runtime.json"
       ]
     },
-    "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23519": {
+    "Microsoft.NETCore.Targets.DNXCore/5.0.0-rc2-23525": {
       "type": "package",
-      "sha512": "q/neViI9HLp+gcLqM5YajILVZKe6Lo6dwm1XMcqos2Ba5In4+lSZ/RLAUaWUsu5cf8+5t0tKZArg3MKL+aAYWA==",
+      "sha512": "D8MaIcoGIpzfg1v0d+1pQWjcwNNPTjFAGrVLQcIoS7ATgQ4/foTZeX/6LEsBjY+4xMzGi0dkg2HcvAsrFvdt8A==",
       "files": [
-        "Microsoft.NETCore.Targets.DNXCore.5.0.0-rc2-23519.nupkg",
-        "Microsoft.NETCore.Targets.DNXCore.5.0.0-rc2-23519.nupkg.sha512",
+        "Microsoft.NETCore.Targets.DNXCore.5.0.0-rc2-23525.nupkg",
+        "Microsoft.NETCore.Targets.DNXCore.5.0.0-rc2-23525.nupkg.sha512",
         "Microsoft.NETCore.Targets.DNXCore.nuspec",
         "runtime.json"
       ]
     },
-    "Microsoft.NETCore.TestHost/1.0.0-rc2-23519": {
+    "Microsoft.NETCore.TestHost/1.0.0-rc2-23525": {
       "type": "package",
-      "sha512": "7y5fxwA6IeHgcVdoW98XSyn2+NCrs3uVe6CNltZ7ddbIVixcvSOESPJvqAe9qFOF/x/rMx9R88sQ/MgjvEBKFA==",
+      "sha512": "gI3zRi3zE7YjWvylG8wyv4vOCGv57oNAMjAMMfA3dymoJYcg5ov7yk3cHEUJF3LMUGglWQo+OwTYXPWQoABLag==",
       "files": [
-        "Microsoft.NETCore.TestHost.1.0.0-rc2-23519.nupkg",
-        "Microsoft.NETCore.TestHost.1.0.0-rc2-23519.nupkg.sha512",
+        "Microsoft.NETCore.TestHost.1.0.0-rc2-23525.nupkg",
+        "Microsoft.NETCore.TestHost.1.0.0-rc2-23525.nupkg.sha512",
         "Microsoft.NETCore.TestHost.nuspec",
         "runtime.json"
       ]
     },
-    "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23519": {
+    "Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23525": {
       "type": "package",
-      "sha512": "2TUhHE5tHueEshrJYDFY5hOFWQ5Dt356K9RmbQsTqtpfhC/cMl0nf8ToZS3dPdosrLbIVMBeiMAmDmXXjAA1BA==",
+      "sha512": "WKtb+F+rK4deLiZDLxO65LtHttiN17NvibSx0ZV7563q817iZutE4RgZbdoTTfzYzBPLoFdTdW/WiBxASV6LZQ==",
       "files": [
-        "Microsoft.NETCore.Windows.ApiSets.1.0.1-rc2-23519.nupkg",
-        "Microsoft.NETCore.Windows.ApiSets.1.0.1-rc2-23519.nupkg.sha512",
+        "Microsoft.NETCore.Windows.ApiSets.1.0.1-rc2-23525.nupkg",
+        "Microsoft.NETCore.Windows.ApiSets.1.0.1-rc2-23525.nupkg.sha512",
         "Microsoft.NETCore.Windows.ApiSets.nuspec",
         "runtime.json"
       ]
     },
-    "Microsoft.VisualBasic/10.0.1-rc2-23519": {
+    "Microsoft.VisualBasic/10.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "S4usxTdI2c0QZRLNCoYBQ1TY46oYHtgnQWjAJsNKVGopHH+mphe3jBt1jaE+ubf+Z+Uc3N5XP1c7UtaTRip3yA==",
+      "sha512": "nFb0Srnp7TYlFqb16UUTNnVbJTfX/hfPHNo/mXD6DuJmFaOp6Hkwj4UT54XyLh10s7A6opCDNG+OLlwZLHGRaQ==",
       "files": [
         "lib/dotnet5.4/Microsoft.VisualBasic.dll",
         "lib/net45/_._",
         "lib/netcore50/Microsoft.VisualBasic.dll",
         "lib/win8/_._",
         "lib/wpa81/_._",
-        "Microsoft.VisualBasic.10.0.1-rc2-23519.nupkg",
-        "Microsoft.VisualBasic.10.0.1-rc2-23519.nupkg.sha512",
+        "Microsoft.VisualBasic.10.0.1-rc2-23525.nupkg",
+        "Microsoft.VisualBasic.10.0.1-rc2-23525.nupkg.sha512",
         "Microsoft.VisualBasic.nuspec",
         "ref/dotnet5.2/de/Microsoft.VisualBasic.xml",
         "ref/dotnet5.2/es/Microsoft.VisualBasic.xml",
@@ -13011,18 +13179,18 @@
         "ref/wpa81/_._"
       ]
     },
-    "Microsoft.Win32.Primitives/4.0.1-rc2-23519": {
+    "Microsoft.Win32.Primitives/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "4VyhlUxn+FcUVGGymfEu+J/z0now+2U84IJBNeHZ67Cmjt4zogPmIrxPC7G4K3Q4F0h9bBVIGrSamORov6qFPw==",
+      "sha512": "vTu1JekYubg3Zi3n86/y5kosFCe+nBBuMMwiGR3UH6vcEkSoyBZmTJTwVGulvnwV4dHzvHlw/7q+8D4kJP0aRQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
         "lib/net46/Microsoft.Win32.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "Microsoft.Win32.Primitives.4.0.1-rc2-23519.nupkg",
-        "Microsoft.Win32.Primitives.4.0.1-rc2-23519.nupkg.sha512",
+        "Microsoft.Win32.Primitives.4.0.1-rc2-23525.nupkg",
+        "Microsoft.Win32.Primitives.4.0.1-rc2-23525.nupkg.sha512",
         "Microsoft.Win32.Primitives.nuspec",
         "ref/dotnet5.4/de/Microsoft.Win32.Primitives.xml",
         "ref/dotnet5.4/es/Microsoft.Win32.Primitives.xml",
@@ -13043,15 +13211,15 @@
         "runtime.json"
       ]
     },
-    "Microsoft.Win32.Registry/4.0.0-rc2-23519": {
+    "Microsoft.Win32.Registry/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FE9apGMrB049Orl/yCVyYvLhhQHrfJgkBwVu8LdGBsf6djal8eT0jCZaqXH4o80ZVftbBj+y5cpJkx3Mef3hzw==",
+      "sha512": "KpQmkpx5bIxbQhm62o1TrL1qCj6x4NB8k3IkKxSZHTRY05/oG0ZRen182CX8vcIB415Puo0u4BDMcHvtZzrkaw==",
       "files": [
         "lib/DNXCore50/Microsoft.Win32.Registry.dll",
         "lib/net46/Microsoft.Win32.Registry.dll",
-        "Microsoft.Win32.Registry.4.0.0-rc2-23519.nupkg",
-        "Microsoft.Win32.Registry.4.0.0-rc2-23519.nupkg.sha512",
+        "Microsoft.Win32.Registry.4.0.0-rc2-23525.nupkg",
+        "Microsoft.Win32.Registry.4.0.0-rc2-23525.nupkg.sha512",
         "Microsoft.Win32.Registry.nuspec",
         "ref/dotnet5.4/de/Microsoft.Win32.Registry.xml",
         "ref/dotnet5.4/es/Microsoft.Win32.Registry.xml",
@@ -13134,10 +13302,10 @@
         "tools/ReportGenerator.XML"
       ]
     },
-    "runtime.any.System.Linq.Expressions/4.0.11-rc2-23519": {
+    "runtime.any.System.Linq.Expressions/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8yLWlPlx3CtUM1lInsi9ODxLPe0iKRiIaGMgJUWei0cxRe15O6FyR3ZkNDWNEkciyvEpq37E7sDzihjXlUIJ3A==",
+      "sha512": "m2rDRsf1hcnaUlhKgF9op2UmADh1/5nJpfBJHkKPK46C6s2dI3LAJ0LpAIw1arW9xJDd2P//5gdvUFRGBRRang==",
       "files": [
         "lib/DNXCore50/System.Linq.Expressions.dll",
         "lib/MonoAndroid10/_._",
@@ -13150,30 +13318,30 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "ref/dotnet/_._",
-        "runtime.any.System.Linq.Expressions.4.0.11-rc2-23519.nupkg",
-        "runtime.any.System.Linq.Expressions.4.0.11-rc2-23519.nupkg.sha512",
+        "runtime.any.System.Linq.Expressions.4.0.11-rc2-23525.nupkg",
+        "runtime.any.System.Linq.Expressions.4.0.11-rc2-23525.nupkg.sha512",
         "runtime.any.System.Linq.Expressions.nuspec",
         "runtimes/aot/lib/netcore50/_._"
       ]
     },
-    "runtime.any.System.Private.DataContractSerialization/4.1.0-rc2-23519": {
+    "runtime.any.System.Private.DataContractSerialization/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "VpNkECOlKnxcuYtJgRJHYJzCciw0DV4dI2eWm87ARGRRUMwjHHMLZS/A6c7MbAsQOYrct0nlJ3wfpj/EEz0n5Q==",
+      "sha512": "XiFuG7C1k6gHK2QKp1Hf6GLhdY3SsEwpVMrhxR+sraTI+GsItIMjf4D4MxVqlwjr8INWPhiQ6V0BCAFITSiCtQ==",
       "files": [
         "lib/DNXCore50/System.Private.DataContractSerialization.dll",
         "lib/netcore50/System.Private.DataContractSerialization.dll",
         "ref/dotnet/_._",
-        "runtime.any.System.Private.DataContractSerialization.4.1.0-rc2-23519.nupkg",
-        "runtime.any.System.Private.DataContractSerialization.4.1.0-rc2-23519.nupkg.sha512",
+        "runtime.any.System.Private.DataContractSerialization.4.1.0-rc2-23525.nupkg",
+        "runtime.any.System.Private.DataContractSerialization.4.1.0-rc2-23525.nupkg.sha512",
         "runtime.any.System.Private.DataContractSerialization.nuspec",
         "runtimes/aot/lib/netcore50/_._"
       ]
     },
-    "runtime.any.System.Reflection.DispatchProxy/4.0.1-rc2-23519": {
+    "runtime.any.System.Reflection.DispatchProxy/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "YyfeqGWucaw8qqeEDHktGdgfcSJyxPPMRbu+DpDCL4RL4KhbFcpy0gCi04RrjFLdTxCgKHMoYRSHpxcnaklYbg==",
+      "sha512": "z8BztEHeQaAHIDF4+BahHUFCIG+gJ1Q6+dt4O9O/twBt17pdiwvK8mwthwFAIpaVot/GOGWrKH+a2yRV1X3O9g==",
       "files": [
         "lib/DNXCore50/System.Reflection.DispatchProxy.dll",
         "lib/MonoAndroid10/_._",
@@ -13183,16 +13351,16 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "ref/dotnet/_._",
-        "runtime.any.System.Reflection.DispatchProxy.4.0.1-rc2-23519.nupkg",
-        "runtime.any.System.Reflection.DispatchProxy.4.0.1-rc2-23519.nupkg.sha512",
+        "runtime.any.System.Reflection.DispatchProxy.4.0.1-rc2-23525.nupkg",
+        "runtime.any.System.Reflection.DispatchProxy.4.0.1-rc2-23525.nupkg.sha512",
         "runtime.any.System.Reflection.DispatchProxy.nuspec",
         "runtimes/aot/lib/netcore50/_._"
       ]
     },
-    "runtime.any.System.Xml.XmlSerializer/4.0.11-rc2-23519": {
+    "runtime.any.System.Xml.XmlSerializer/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "AF9ZAJcDvMJjutWWbaN/iLH9uxmPKYq0ZSS6+xY+wu3hoVgl5/CsLRY3GkZ/izy8JyJHKma2j2WpaU5gYHunFQ==",
+      "sha512": "eijaJjxe9aDyIWmQmUV1Z83U2nJopNpmFHTcyFhTkdTrvsX5AZHIN3ykl15PsgsSL7vFPDP6WvFYOzkknNFRgw==",
       "files": [
         "lib/DNXCore50/System.Xml.XmlSerializer.dll",
         "lib/MonoAndroid10/_._",
@@ -13205,329 +13373,329 @@
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
         "ref/dotnet/_._",
-        "runtime.any.System.Xml.XmlSerializer.4.0.11-rc2-23519.nupkg",
-        "runtime.any.System.Xml.XmlSerializer.4.0.11-rc2-23519.nupkg.sha512",
+        "runtime.any.System.Xml.XmlSerializer.4.0.11-rc2-23525.nupkg",
+        "runtime.any.System.Xml.XmlSerializer.4.0.11-rc2-23525.nupkg.sha512",
         "runtime.any.System.Xml.XmlSerializer.nuspec",
         "runtimes/aot/lib/netcore50/_._"
       ]
     },
-    "runtime.linux.System.Diagnostics.Process/4.1.0-rc2-23519": {
+    "runtime.linux.System.Diagnostics.Process/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "GRSVp3hi1dNHK4nr4AY0slHMiolmtJGKFBrGOE69ICoWCVnZc78DGENuQeOK9WZPnP4//QNdacKw0GZUsJoGCg==",
+      "sha512": "LYoDZ41pQFWabS74AEz5U0ScDB5UyMnVM8Ny/J9i5Jh9op0NzhfQI2KYwXAKUNjRObmg7Ak7WHDIe9fPkWkxJw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.Diagnostics.Process.4.1.0-rc2-23519.nupkg",
-        "runtime.linux.System.Diagnostics.Process.4.1.0-rc2-23519.nupkg.sha512",
+        "runtime.linux.System.Diagnostics.Process.4.1.0-rc2-23525.nupkg",
+        "runtime.linux.System.Diagnostics.Process.4.1.0-rc2-23525.nupkg.sha512",
         "runtime.linux.System.Diagnostics.Process.nuspec",
         "runtimes/unix/lib/dotnet5.5/System.Diagnostics.Process.dll"
       ]
     },
-    "runtime.linux.System.IO.FileSystem/4.0.1-rc2-23519": {
+    "runtime.linux.System.IO.FileSystem/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "V/HvkE8BX0qn0wbT9eE1Ne6ivIw2x+mDa+ySWbFZoWEwubz4xsOA3aydIIuuO7jJ88MN0hjSl9S0EBHYZxB4Gg==",
+      "sha512": "PaXAM7p4jup2TI77w2RJ8w7q2zIvMsn8n7w6CCHt27ODhU8cYagibZjlxlsw2Qu4bWhoHLPPqyTqv2hf/f2s5A==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.IO.FileSystem.4.0.1-rc2-23519.nupkg",
-        "runtime.linux.System.IO.FileSystem.4.0.1-rc2-23519.nupkg.sha512",
+        "runtime.linux.System.IO.FileSystem.4.0.1-rc2-23525.nupkg",
+        "runtime.linux.System.IO.FileSystem.4.0.1-rc2-23525.nupkg.sha512",
         "runtime.linux.System.IO.FileSystem.nuspec",
         "runtimes/linux/lib/dotnet5.4/System.IO.FileSystem.dll"
       ]
     },
-    "runtime.linux.System.IO.FileSystem.DriveInfo/4.0.0-rc2-23519": {
+    "runtime.linux.System.IO.FileSystem.DriveInfo/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "+0AfpqkSFqAwLLJEXpng0Z7oHpeWYFtFO7y1G+a6J1QWqgKntw9lmobqBchev5cE2LlmBWGkO6XucstC9N1T1g==",
+      "sha512": "WnFwtutN+GzTieZHLjcP9fiHNMMheT7ZvvXaFynhtwN0p9f9pOAjbcgw0HrHzh0r4KfteUxJu4tt0GhVo8AcIQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.IO.FileSystem.DriveInfo.4.0.0-rc2-23519.nupkg",
-        "runtime.linux.System.IO.FileSystem.DriveInfo.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.linux.System.IO.FileSystem.DriveInfo.4.0.0-rc2-23525.nupkg",
+        "runtime.linux.System.IO.FileSystem.DriveInfo.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.linux.System.IO.FileSystem.DriveInfo.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.IO.FileSystem.DriveInfo.dll"
       ]
     },
-    "runtime.linux.System.IO.FileSystem.Watcher/4.0.0-rc2-23519": {
+    "runtime.linux.System.IO.FileSystem.Watcher/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "0HrC8E8Cu/8EPgNEI6rDFC/o342CivMFxfxVSLLEKM9A+l0Ywxj+4045TxQfTf/7esLBefF8BhqL2m4lyK/DbA==",
+      "sha512": "MDIBfsfZvDg1dRVN6o3uXYF3o8tWmjKi7Oi+oh259u0mV+rNH8uVkr5i+PJcEa+ahb+Aq0BJfSiS1WS7BTVSaQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.IO.FileSystem.Watcher.4.0.0-rc2-23519.nupkg",
-        "runtime.linux.System.IO.FileSystem.Watcher.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.linux.System.IO.FileSystem.Watcher.4.0.0-rc2-23525.nupkg",
+        "runtime.linux.System.IO.FileSystem.Watcher.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.linux.System.IO.FileSystem.Watcher.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.IO.FileSystem.Watcher.dll"
       ]
     },
-    "runtime.linux.System.IO.MemoryMappedFiles/4.0.0-rc2-23519": {
+    "runtime.linux.System.IO.MemoryMappedFiles/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JzwCagaKjx7bzI55C+bSeEdJCid7yMtzjzyzCQ/f6hed7UgcH8nCBj7i58WadvzcsMQp7XFqySOBz5S1M5Wwcg==",
+      "sha512": "XFVl+5JUGGaJPhezva2pIsru6y0zAMbVasxTdojjRgk7Vm6rBRdtdgNZd5v8VEC56ubI5R1124fFvkU85k8WyQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.IO.MemoryMappedFiles.4.0.0-rc2-23519.nupkg",
-        "runtime.linux.System.IO.MemoryMappedFiles.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.linux.System.IO.MemoryMappedFiles.4.0.0-rc2-23525.nupkg",
+        "runtime.linux.System.IO.MemoryMappedFiles.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.linux.System.IO.MemoryMappedFiles.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.IO.MemoryMappedFiles.dll"
       ]
     },
-    "runtime.linux.System.Net.Http/4.0.1-rc2-23519": {
+    "runtime.linux.System.Net.Http/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "exvmjFXzdo+TFKXO8SYsK7ttvtp9JaOdbf/o3i+bctgzIJz6WuYIkxxgIQYMFYlUHq9yYG1/oHPit6QLXDtSVw==",
+      "sha512": "4KyrHASr9GKmAnYF/jDYiTk+c41YRaDWD7eM9+jcZYzqRSgOIxXnRystVMvNXezO/9SGHkhvlyOcVbtcjDlVTQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.Net.Http.4.0.1-rc2-23519.nupkg",
-        "runtime.linux.System.Net.Http.4.0.1-rc2-23519.nupkg.sha512",
+        "runtime.linux.System.Net.Http.4.0.1-rc2-23525.nupkg",
+        "runtime.linux.System.Net.Http.4.0.1-rc2-23525.nupkg.sha512",
         "runtime.linux.System.Net.Http.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Net.Http.dll"
       ]
     },
-    "runtime.linux.System.Net.NameResolution/4.0.0-rc2-23519": {
+    "runtime.linux.System.Net.NameResolution/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Bm3BANZXh6Xnj97N4UBzuj1fWm7n/FfZdFugCk9MrPoamzLjei9YBxt8AGMKoVLcRerlwZIUWCK9y0VFd40ZRw==",
+      "sha512": "WvZzdnEqJIXYvrXdgro1AJ5dVkc5EWPnBWITfC1UJZuft+gqJnZYCfz3egeR3v2grOLl3cCt/eritX+FWSc5ng==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.Net.NameResolution.4.0.0-rc2-23519.nupkg",
-        "runtime.linux.System.Net.NameResolution.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.linux.System.Net.NameResolution.4.0.0-rc2-23525.nupkg",
+        "runtime.linux.System.Net.NameResolution.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.linux.System.Net.NameResolution.nuspec",
         "runtimes/unix/lib/dnxcore50/System.Net.NameResolution.dll"
       ]
     },
-    "runtime.linux.System.Net.NetworkInformation/4.1.0-rc2-23519": {
+    "runtime.linux.System.Net.NetworkInformation/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OJb7xNHfvSazRRoq6l2QfLfAWlulM3llEtwHPJn4MSetp6Y6mCU1etBzO9EDNDLCyGJ57ttOKP0lINFKZJWhaQ==",
+      "sha512": "rqmcgCv8pOlgaLOShPM27Vt8OqWSU4/Hf9skbvgGqoNbyBViExgch90f8Wz5MECFmdmiY3Qe5xOgOJwMgj+E8g==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.Net.NetworkInformation.4.1.0-rc2-23519.nupkg",
-        "runtime.linux.System.Net.NetworkInformation.4.1.0-rc2-23519.nupkg.sha512",
+        "runtime.linux.System.Net.NetworkInformation.4.1.0-rc2-23525.nupkg",
+        "runtime.linux.System.Net.NetworkInformation.4.1.0-rc2-23525.nupkg.sha512",
         "runtime.linux.System.Net.NetworkInformation.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Net.NetworkInformation.dll"
       ]
     },
-    "runtime.linux.System.Net.Sockets/4.1.0-rc2-23519": {
+    "runtime.linux.System.Net.Sockets/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "tD4o9ENglhU7a0c2gox4oTEXbEZQ/cnRjhLBAw2N0O+uRJZ1eZhK29b6/QD9L6fBSXQH76EVZDP1zWtwDvxPrQ==",
+      "sha512": "NWW2rrIlp7JkcW6jEhhtCY1SeBK4C6g6BgYjrqInSJQsIiQHhz5CyVzSDSjrOfp4QvUpdpkJhIR2rRSZ4pEkCA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.Net.Sockets.4.1.0-rc2-23519.nupkg",
-        "runtime.linux.System.Net.Sockets.4.1.0-rc2-23519.nupkg.sha512",
+        "runtime.linux.System.Net.Sockets.4.1.0-rc2-23525.nupkg",
+        "runtime.linux.System.Net.Sockets.4.1.0-rc2-23525.nupkg.sha512",
         "runtime.linux.System.Net.Sockets.nuspec",
         "runtimes/linux/lib/dotnet5.5/System.Net.Sockets.dll"
       ]
     },
-    "runtime.linux.System.Runtime.Extensions/4.0.11-rc2-23519": {
+    "runtime.linux.System.Runtime.Extensions/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "5b40ki6nQEhZqybSfS39kCHM7vyppzZi3hySUZJHwCb+u3HWhNPU+WcW7xZpr0ocnbYhiRWEdeI+vmd2BI2xXw==",
+      "sha512": "Xt6ApNpB3bdLl/zP9SLTCTuQhelUtuMs5mmpI2UrJmKOIHipNreoM954NeSC13hHJZRe0cLzl3Y4QKqVPF5uTw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.Runtime.Extensions.4.0.11-rc2-23519.nupkg",
-        "runtime.linux.System.Runtime.Extensions.4.0.11-rc2-23519.nupkg.sha512",
+        "runtime.linux.System.Runtime.Extensions.4.0.11-rc2-23525.nupkg",
+        "runtime.linux.System.Runtime.Extensions.4.0.11-rc2-23525.nupkg.sha512",
         "runtime.linux.System.Runtime.Extensions.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Runtime.Extensions.dll"
       ]
     },
-    "runtime.linux.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23519": {
+    "runtime.linux.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "moTvDlvlS6iSElkPuaXPpHuCzeHh6wnDZS3vy/q15GKZrjT7RfBFlnnDcFZxAdFYiN6LVmqkNSe2ZsPNUBQ2nQ==",
+      "sha512": "tj5AowsCVAp0k1HJ2g8JPf3C8rtBcTk1yofDmbSxcTy47xyugmmkqxx7OHfdemVH6GbShttt4ePdgqQReLnadg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.Runtime.InteropServices.RuntimeInformation.4.0.0-rc2-23519.nupkg",
-        "runtime.linux.System.Runtime.InteropServices.RuntimeInformation.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.linux.System.Runtime.InteropServices.RuntimeInformation.4.0.0-rc2-23525.nupkg",
+        "runtime.linux.System.Runtime.InteropServices.RuntimeInformation.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.linux.System.Runtime.InteropServices.RuntimeInformation.nuspec",
         "runtimes/unix/lib/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll"
       ]
     },
-    "runtime.linux.System.Security.Cryptography.Algorithms/4.0.0-rc2-23519": {
+    "runtime.linux.System.Security.Cryptography.Algorithms/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "oxgk1+ppuv6MewpiGmwIM/ugLvfvw2d8qIwFMjmVC0XXMkzdkX0ks/plII5rbUySW6bswYaaTNY6mQfwYbtPhg==",
+      "sha512": "1+LT0zu6NxPfoGdWWIqbVUM0ZPrWt/q84Bech7ShLhJuknzZ6fH4PKB+N0mN5KaPLSzIXKFusVx13m9ZRkbd3Q==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.linux.System.Security.Cryptography.Algorithms.4.0.0-rc2-23519.nupkg",
-        "runtime.linux.System.Security.Cryptography.Algorithms.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.linux.System.Security.Cryptography.Algorithms.4.0.0-rc2-23525.nupkg",
+        "runtime.linux.System.Security.Cryptography.Algorithms.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.linux.System.Security.Cryptography.Algorithms.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.Algorithms.dll"
       ]
     },
-    "runtime.osx.10.10.System.Diagnostics.Process/4.1.0-rc2-23519": {
+    "runtime.osx.10.10.System.Diagnostics.Process/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "u3XhyvQiQSSpTEPVYNLurvr7Jf7Nfcz3ETfM0PALhf6cUERruOJz4LOvmHN1CDZ7baC+Um5FmvlmM0h0atDtyw==",
+      "sha512": "au8yEBrm5GY8f91HPZljuUq0GooQNWSq70gdAt9MaplQ2yvRnXtrn1UP74RpubQUqKZOFdaphnqIJAlLaoqwPg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.Diagnostics.Process.4.1.0-rc2-23519.nupkg",
-        "runtime.osx.10.10.System.Diagnostics.Process.4.1.0-rc2-23519.nupkg.sha512",
+        "runtime.osx.10.10.System.Diagnostics.Process.4.1.0-rc2-23525.nupkg",
+        "runtime.osx.10.10.System.Diagnostics.Process.4.1.0-rc2-23525.nupkg.sha512",
         "runtime.osx.10.10.System.Diagnostics.Process.nuspec",
         "runtimes/unix/lib/dotnet5.5/System.Diagnostics.Process.dll"
       ]
     },
-    "runtime.osx.10.10.System.IO.FileSystem/4.0.1-rc2-23519": {
+    "runtime.osx.10.10.System.IO.FileSystem/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "533eTQ+yOoFfpgZpJ/xQ2/PEuv8FMGYRoHoKgMydolOoA6L3B0wc+jWhKOdMEejZB38ygWctJ1fJaAwPbVJyYQ==",
+      "sha512": "+QnyW/gpW4TFXBU+gT/cbIEI5acgp+hVj9AagGFJeD3wswICYGxCgLqK1GMCi9CvwrV4SIR3p64QNwLCY27wKg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.IO.FileSystem.4.0.1-rc2-23519.nupkg",
-        "runtime.osx.10.10.System.IO.FileSystem.4.0.1-rc2-23519.nupkg.sha512",
+        "runtime.osx.10.10.System.IO.FileSystem.4.0.1-rc2-23525.nupkg",
+        "runtime.osx.10.10.System.IO.FileSystem.4.0.1-rc2-23525.nupkg.sha512",
         "runtime.osx.10.10.System.IO.FileSystem.nuspec",
         "runtimes/osx.10.10/lib/dotnet5.4/System.IO.FileSystem.dll"
       ]
     },
-    "runtime.osx.10.10.System.IO.FileSystem.DriveInfo/4.0.0-rc2-23519": {
+    "runtime.osx.10.10.System.IO.FileSystem.DriveInfo/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "st7MNy4SG2CnVb14VKv+UDNCc+iM/EE8vPcYoK4s+5lLciUUnxICNuVDxkzz35wEsMRIXosAT5fCyyuHs7N/0g==",
+      "sha512": "HmQmb0ZrifMk4dCQF/f5IlPEY92V0DpLL6zyGm3+fp8l9c9KeSFloNyaTWz1gnwIwqu3eDw9Z1Ac69CUX3Jyjg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.IO.FileSystem.DriveInfo.4.0.0-rc2-23519.nupkg",
-        "runtime.osx.10.10.System.IO.FileSystem.DriveInfo.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.osx.10.10.System.IO.FileSystem.DriveInfo.4.0.0-rc2-23525.nupkg",
+        "runtime.osx.10.10.System.IO.FileSystem.DriveInfo.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.osx.10.10.System.IO.FileSystem.DriveInfo.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.IO.FileSystem.DriveInfo.dll"
       ]
     },
-    "runtime.osx.10.10.System.IO.FileSystem.Watcher/4.0.0-rc2-23519": {
+    "runtime.osx.10.10.System.IO.FileSystem.Watcher/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JWRC12xLLv13aysn/3NrBSREpRdNj/bMy8ftfxvJ9XB8MSXpRpwdcmsrDCNZcCLKd4DhzQ9bWnLV8jr1P7wNGA==",
+      "sha512": "vFhVUqZKaKuTocIXGvYl4SqwTkVBggR99fH34tAyB5+gnroK1QztmQu5tUmx6QIZXqTYleulXESaRQE7XShy+w==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.IO.FileSystem.Watcher.4.0.0-rc2-23519.nupkg",
-        "runtime.osx.10.10.System.IO.FileSystem.Watcher.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.osx.10.10.System.IO.FileSystem.Watcher.4.0.0-rc2-23525.nupkg",
+        "runtime.osx.10.10.System.IO.FileSystem.Watcher.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.osx.10.10.System.IO.FileSystem.Watcher.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.IO.FileSystem.Watcher.dll"
       ]
     },
-    "runtime.osx.10.10.System.IO.MemoryMappedFiles/4.0.0-rc2-23519": {
+    "runtime.osx.10.10.System.IO.MemoryMappedFiles/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "dPRNeel6vWk28T/3YXD8nwlZRAxOf9Ulnh2k4QcCisE107tlsMMNt1dI/vtQtH3IEXhOODNOo2+ez7X12U9i4A==",
+      "sha512": "svjsHIL2r7jaNXWXE6YFK6QWgwbrfL6102EF9hc0pHMbyYZEEA3ebdVXpqaC4fdAjTrK6SqN4Q4LbWz9cRUASQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.IO.MemoryMappedFiles.4.0.0-rc2-23519.nupkg",
-        "runtime.osx.10.10.System.IO.MemoryMappedFiles.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.osx.10.10.System.IO.MemoryMappedFiles.4.0.0-rc2-23525.nupkg",
+        "runtime.osx.10.10.System.IO.MemoryMappedFiles.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.osx.10.10.System.IO.MemoryMappedFiles.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.IO.MemoryMappedFiles.dll"
       ]
     },
-    "runtime.osx.10.10.System.Net.Http/4.0.1-rc2-23519": {
+    "runtime.osx.10.10.System.Net.Http/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "SRGYVqKu8q5TKWNC0c0OdJHicFLKsVPVq3DZz/RBd3leocW394n9usXzB12LvwapcZ2nyuBtZBm5CrrTrpVcgw==",
+      "sha512": "ySE0EUMESO5xaIU2IyxMeSI5uzEarN4+QOSc1FlzvPThNKiFxHgpEfvrjC0jcUNK2p+gACZxwgVw7dAkgI5F1A==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.Net.Http.4.0.1-rc2-23519.nupkg",
-        "runtime.osx.10.10.System.Net.Http.4.0.1-rc2-23519.nupkg.sha512",
+        "runtime.osx.10.10.System.Net.Http.4.0.1-rc2-23525.nupkg",
+        "runtime.osx.10.10.System.Net.Http.4.0.1-rc2-23525.nupkg.sha512",
         "runtime.osx.10.10.System.Net.Http.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Net.Http.dll"
       ]
     },
-    "runtime.osx.10.10.System.Net.NameResolution/4.0.0-rc2-23519": {
+    "runtime.osx.10.10.System.Net.NameResolution/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "tBhmyAQK7FgpLm8VSVm/ijUgJB/MFYrmpgWru+v5qK8WKF7Q2KXbF6AgnEnjR62AqUxsFMupjxevd9u9WDluUw==",
+      "sha512": "XxNK+EfKHEFAwAIecgc+jd1sMskEmFJaJcB3KgqJL4DYhnOyAc6psT1J3EJXSdKovgnXXE1fXX2jjdZ/KNkJtg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.Net.NameResolution.4.0.0-rc2-23519.nupkg",
-        "runtime.osx.10.10.System.Net.NameResolution.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.osx.10.10.System.Net.NameResolution.4.0.0-rc2-23525.nupkg",
+        "runtime.osx.10.10.System.Net.NameResolution.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.osx.10.10.System.Net.NameResolution.nuspec",
         "runtimes/unix/lib/dnxcore50/System.Net.NameResolution.dll"
       ]
     },
-    "runtime.osx.10.10.System.Net.NetworkInformation/4.1.0-rc2-23519": {
+    "runtime.osx.10.10.System.Net.NetworkInformation/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Vz3RGzhITEO1A0aLCWwHXRuCVgVP4H9r+gQXbfeBTCjDEoY0Qu61DBnD+Xhm/i9iJi+dP8Qbr5aMzoJbS8b1Fg==",
+      "sha512": "YNA0B1Vc/gZaKBVGdufQF/Oi8yvB5pPYNBEMxwFgbXGP1X9AOtDhaI25it1IcSI/3qFLuG7xOjBqmRhwsrSSfQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.Net.NetworkInformation.4.1.0-rc2-23519.nupkg",
-        "runtime.osx.10.10.System.Net.NetworkInformation.4.1.0-rc2-23519.nupkg.sha512",
+        "runtime.osx.10.10.System.Net.NetworkInformation.4.1.0-rc2-23525.nupkg",
+        "runtime.osx.10.10.System.Net.NetworkInformation.4.1.0-rc2-23525.nupkg.sha512",
         "runtime.osx.10.10.System.Net.NetworkInformation.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Net.NetworkInformation.dll"
       ]
     },
-    "runtime.osx.10.10.System.Net.Primitives/4.0.11-rc2-23519": {
+    "runtime.osx.10.10.System.Net.Primitives/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "/ZFtyMzpCU34ky43MHI+8Dd8YvTmA7vtN4XPKq5R9g8/DzDVS5sJqCHazI4eNEOMeGKP/3Xnpz76xGmDyuV62g==",
+      "sha512": "fsf986aMoFxKc7alFHC/nCOTal2RZKPHBy0tOUXAMLSzKBPXmzg04hUYzlXBE4RrXL++Vha1Za86PiK0ttyc/Q==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.Net.Primitives.4.0.11-rc2-23519.nupkg",
-        "runtime.osx.10.10.System.Net.Primitives.4.0.11-rc2-23519.nupkg.sha512",
+        "runtime.osx.10.10.System.Net.Primitives.4.0.11-rc2-23525.nupkg",
+        "runtime.osx.10.10.System.Net.Primitives.4.0.11-rc2-23525.nupkg.sha512",
         "runtime.osx.10.10.System.Net.Primitives.nuspec",
         "runtimes/unix/lib/dnxcore50/System.Net.Primitives.dll"
       ]
     },
-    "runtime.osx.10.10.System.Net.Sockets/4.1.0-rc2-23519": {
+    "runtime.osx.10.10.System.Net.Sockets/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "opz1Iv+64418MPXKPuoV/eOhNF4yorar4RmAvdLMQaIBJQ/o8n7s+AK4LSInk+icv6JtRpwk+lpB4d+260ZcbA==",
+      "sha512": "wzjt4NWXV7STRksTKnRNAWBrgoJwhH1wK6nr3d3rLJqYkGHLJvd2sk0FjuXoCX4nDvL0wyK1UtgvKoD4dI9Uqw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.Net.Sockets.4.1.0-rc2-23519.nupkg",
-        "runtime.osx.10.10.System.Net.Sockets.4.1.0-rc2-23519.nupkg.sha512",
+        "runtime.osx.10.10.System.Net.Sockets.4.1.0-rc2-23525.nupkg",
+        "runtime.osx.10.10.System.Net.Sockets.4.1.0-rc2-23525.nupkg.sha512",
         "runtime.osx.10.10.System.Net.Sockets.nuspec",
         "runtimes/osx.10.10/lib/dotnet5.5/System.Net.Sockets.dll"
       ]
     },
-    "runtime.osx.10.10.System.Runtime.Extensions/4.0.11-rc2-23519": {
+    "runtime.osx.10.10.System.Runtime.Extensions/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "uGxbkgaKmeHJKnxTv4EemnrW/Ju5oVnNgCDzK47J9W6W2zZUfV77LFz1YSlaGAV/Q5IdlNGqSQJ1t5NVDGcoSQ==",
+      "sha512": "7ZA8nmiLLjv2rgNFS0oE6LR0UmQQ+fWUnXR0BUgMJZzAnNNstnGn085vzn/IACkK7SQt56PYYGW10kW2eWoWCQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.Runtime.Extensions.4.0.11-rc2-23519.nupkg",
-        "runtime.osx.10.10.System.Runtime.Extensions.4.0.11-rc2-23519.nupkg.sha512",
+        "runtime.osx.10.10.System.Runtime.Extensions.4.0.11-rc2-23525.nupkg",
+        "runtime.osx.10.10.System.Runtime.Extensions.4.0.11-rc2-23525.nupkg.sha512",
         "runtime.osx.10.10.System.Runtime.Extensions.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Runtime.Extensions.dll"
       ]
     },
-    "runtime.osx.10.10.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23519": {
+    "runtime.osx.10.10.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Wnckc6BVVPk/dnu2kQ41IKeta24QaI5PHCuGwgds2dHiA9DADEfsLjcH4GAN2Zjva+yQCjQc5SOwdwyy3YLBkg==",
+      "sha512": "tiwtFYjjhQXi5Rdb53b8yR4fxvjqsquyib67qzfX3fo9Zky+6dSM9JRpLVDVXUKcqrRYbfsvsv19LvK8Pioogg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.Runtime.InteropServices.RuntimeInformation.4.0.0-rc2-23519.nupkg",
-        "runtime.osx.10.10.System.Runtime.InteropServices.RuntimeInformation.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.osx.10.10.System.Runtime.InteropServices.RuntimeInformation.4.0.0-rc2-23525.nupkg",
+        "runtime.osx.10.10.System.Runtime.InteropServices.RuntimeInformation.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.osx.10.10.System.Runtime.InteropServices.RuntimeInformation.nuspec",
         "runtimes/unix/lib/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll"
       ]
     },
-    "runtime.osx.10.10.System.Security.Cryptography.Algorithms/4.0.0-rc2-23519": {
+    "runtime.osx.10.10.System.Security.Cryptography.Algorithms/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "hFisyUR97X7GmzaDLlJMG0XAyf1Cf8btldQuNN3Ka4DwAjTJLQqtT5kP4fPZhA0IPu3CjOLHTcc+RlhjjiP4Xw==",
+      "sha512": "CBLMwwK7Zg8hFSV867vcaAwyya7E22/7jQpa4usBKdwHJ6zKXpVcNT9ur9Pt9Q35slGjGZsLktBs1b4BXyzyyA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10.System.Security.Cryptography.Algorithms.4.0.0-rc2-23519.nupkg",
-        "runtime.osx.10.10.System.Security.Cryptography.Algorithms.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.osx.10.10.System.Security.Cryptography.Algorithms.4.0.0-rc2-23525.nupkg",
+        "runtime.osx.10.10.System.Security.Cryptography.Algorithms.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.osx.10.10.System.Security.Cryptography.Algorithms.nuspec",
         "runtimes/osx.10.10/lib/dotnet5.4/System.Security.Cryptography.Algorithms.dll"
       ]
     },
-    "runtime.osx.10.10-x64.Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23519": {
+    "runtime.osx.10.10-x64.Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23525": {
       "type": "package",
-      "sha512": "UO6EQ6qkM/6KRVEwvEE96nQiv+1oMFaQnHTMjmIkhICQJHTsPUYN2/uVfpfE8lh1gNXQcRhiNrkx2arrtYJYkQ==",
+      "sha512": "Rp70A6/E/G8kwwJxXwihWdhXgBJE/zKDWWZm4hJ7eTjznhvq8kZuNcGHOrqpAl6r6KwpNjFKCG4yS9dJJtRjmw==",
       "files": [
-        "runtime.osx.10.10-x64.Microsoft.NETCore.ConsoleHost.1.0.0-rc2-23519.nupkg",
-        "runtime.osx.10.10-x64.Microsoft.NETCore.ConsoleHost.1.0.0-rc2-23519.nupkg.sha512",
+        "runtime.osx.10.10-x64.Microsoft.NETCore.ConsoleHost.1.0.0-rc2-23525.nupkg",
+        "runtime.osx.10.10-x64.Microsoft.NETCore.ConsoleHost.1.0.0-rc2-23525.nupkg.sha512",
         "runtime.osx.10.10-x64.Microsoft.NETCore.ConsoleHost.nuspec",
         "runtimes/osx.10.10-x64/native/coreconsole"
       ]
     },
-    "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23519": {
+    "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23525": {
       "type": "package",
-      "sha512": "82h0EZdZOZ4BWbiRaH3Im/2OIcaSX9DLWUr/7cBTfRVf7jQBrm5aGKUbGx7bZiK9Cg2Hl4ZAX95JpO/lcr2yIA==",
+      "sha512": "E6ZQE3+Gh8bbAI+Fw4KyTarpdqNRsSwKPjnb1XvhW4MXSpFK6AJ0WrHf7P4wqMWtKokraXDWQheLSbcUpEUStw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-rc2-23519.nupkg",
-        "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-rc2-23519.nupkg.sha512",
+        "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-rc2-23525.nupkg",
+        "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-rc2-23525.nupkg.sha512",
         "runtime.osx.10.10-x64.Microsoft.NETCore.Runtime.CoreCLR.nuspec",
         "runtimes/osx.10.10-x64/lib/dotnet/mscorlib.dll",
         "runtimes/osx.10.10-x64/native/libcoreclr.dylib",
@@ -13544,33 +13712,33 @@
         "tools/crossgen"
       ]
     },
-    "runtime.osx.10.10-x64.Microsoft.NETCore.TestHost/1.0.0-rc2-23519": {
+    "runtime.osx.10.10-x64.Microsoft.NETCore.TestHost/1.0.0-rc2-23525": {
       "type": "package",
-      "sha512": "9gwfi06tUZK75dsM3jNwznwAiYpFQUHLhBnrtvihBVugaKOA1vPT7l4s5Vg3iry0JIKfIejNpBDcjAYRkt+nmg==",
+      "sha512": "c57vPyzs24iGOsqqvgvCgJ3HNLlUIclxeriiZah0/84P9NTY08qinj2gniOkue5oG2EbErPMLnIFemoIj23Gjg==",
       "files": [
-        "runtime.osx.10.10-x64.Microsoft.NETCore.TestHost.1.0.0-rc2-23519.nupkg",
-        "runtime.osx.10.10-x64.Microsoft.NETCore.TestHost.1.0.0-rc2-23519.nupkg.sha512",
+        "runtime.osx.10.10-x64.Microsoft.NETCore.TestHost.1.0.0-rc2-23525.nupkg",
+        "runtime.osx.10.10-x64.Microsoft.NETCore.TestHost.1.0.0-rc2-23525.nupkg.sha512",
         "runtime.osx.10.10-x64.Microsoft.NETCore.TestHost.nuspec",
         "runtimes/osx.10.10-x64/native/corerun"
       ]
     },
-    "runtime.ubuntu.14.04-x64.Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23519": {
+    "runtime.ubuntu.14.04-x64.Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23525": {
       "type": "package",
-      "sha512": "eFArYKh84B7oWpXiEcEI3unW9N38jLYi0DSUGxpbLI76YzWb7uQJx2Kdyd1xyX8l3XpnmDwsUmHzzsGW6qnp0A==",
+      "sha512": "95WnkR0rSzB+V0xls7zWBRpIcknVk7KWIw/UQYgvM70MkPKbaflD3S6OMyY4HUaEbZX1OLFA0H2FWDVXjM9VWA==",
       "files": [
-        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.ConsoleHost.1.0.0-rc2-23519.nupkg",
-        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.ConsoleHost.1.0.0-rc2-23519.nupkg.sha512",
+        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.ConsoleHost.1.0.0-rc2-23525.nupkg",
+        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.ConsoleHost.1.0.0-rc2-23525.nupkg.sha512",
         "runtime.ubuntu.14.04-x64.Microsoft.NETCore.ConsoleHost.nuspec",
         "runtimes/ubuntu.14.04-x64/native/coreconsole"
       ]
     },
-    "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23519": {
+    "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23525": {
       "type": "package",
-      "sha512": "sFvE5v3shx6+2YPH7/0hbgQa4OCaIM1CwbHTrl3kmfQ2EiXhW/oXiEDtXWJ58OsIzzSoElrRrPkOoiKqmUS8AA==",
+      "sha512": "TY15UFVCYt01Zq+t859icDjbqJybvmYRuxOGTuWs36BIghDWh9sIuDHjB1G3fUxgz53qd35NWb76VKgs7oWCQw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-rc2-23519.nupkg",
-        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-rc2-23519.nupkg.sha512",
+        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-rc2-23525.nupkg",
+        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-rc2-23525.nupkg.sha512",
         "runtime.ubuntu.14.04-x64.Microsoft.NETCore.Runtime.CoreCLR.nuspec",
         "runtimes/ubuntu.14.04-x64/lib/dotnet/mscorlib.dll",
         "runtimes/ubuntu.14.04-x64/native/libcoreclr.so",
@@ -13589,240 +13757,240 @@
         "tools/crossgen"
       ]
     },
-    "runtime.ubuntu.14.04-x64.Microsoft.NETCore.TestHost/1.0.0-rc2-23519": {
+    "runtime.ubuntu.14.04-x64.Microsoft.NETCore.TestHost/1.0.0-rc2-23525": {
       "type": "package",
-      "sha512": "MlCAuPP4WVlQ1OlIb/7lntWENytkXtERP1ijyGbR/bkkUdIFydyBdeuKWbSz00/ul3QxVp3uZb5f+iLPyaPCIQ==",
+      "sha512": "gkyme86dp+3fBBa5OcGh8EdcwxLd4K46hPWswr/Rp4YQCswhyUxZscvSuS9H3fpm9LkxB3H2ffxuQRVLtDnzfQ==",
       "files": [
-        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.TestHost.1.0.0-rc2-23519.nupkg",
-        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.TestHost.1.0.0-rc2-23519.nupkg.sha512",
+        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.TestHost.1.0.0-rc2-23525.nupkg",
+        "runtime.ubuntu.14.04-x64.Microsoft.NETCore.TestHost.1.0.0-rc2-23525.nupkg.sha512",
         "runtime.ubuntu.14.04-x64.Microsoft.NETCore.TestHost.nuspec",
         "runtimes/ubuntu.14.04-x64/native/corerun"
       ]
     },
-    "runtime.unix.Microsoft.Win32.Primitives/4.0.1-rc2-23519": {
+    "runtime.unix.Microsoft.Win32.Primitives/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "z8nAlevGVmWpYSEV+CMhAbfCPmj2BKQlbP0sE1XcK4jFSNwHp12YomZqoVftxHirx2Vjb+vXMse0qH5DmL4N+A==",
+      "sha512": "XC/1/YQQrfooXhOKCRBkdXKOILUf8vMiutSajP9IB/zRNGdN8tVzT+Frrc0fRD2Jfs2DhxmLW+kQYFnTaIcUWg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.Microsoft.Win32.Primitives.4.0.1-rc2-23519.nupkg",
-        "runtime.unix.Microsoft.Win32.Primitives.4.0.1-rc2-23519.nupkg.sha512",
+        "runtime.unix.Microsoft.Win32.Primitives.4.0.1-rc2-23525.nupkg",
+        "runtime.unix.Microsoft.Win32.Primitives.4.0.1-rc2-23525.nupkg.sha512",
         "runtime.unix.Microsoft.Win32.Primitives.nuspec",
         "runtimes/unix/lib/dotnet5.4/Microsoft.Win32.Primitives.dll"
       ]
     },
-    "runtime.unix.System.Console/4.0.0-rc2-23519": {
+    "runtime.unix.System.Console/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "5eFOweb10N3YkkOXauCejKJTzqhr2bqSXTq/zfS+FwzjRkgNoklMS14TTt1ukzvZ4YMoGU4WGmvaEoEWbGLahQ==",
+      "sha512": "Y5oNPBxFARG9VvdN7npAzT74Dpm4iPdeX6DdcXd7sHS+rRXhpXWnnuuQk4hqS2EetU5It3jrwiRoJYU4YeNPSw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Console.4.0.0-rc2-23519.nupkg",
-        "runtime.unix.System.Console.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.unix.System.Console.4.0.0-rc2-23525.nupkg",
+        "runtime.unix.System.Console.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.unix.System.Console.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Console.dll"
       ]
     },
-    "runtime.unix.System.Data.SqlClient/4.0.0-rc2-23519": {
+    "runtime.unix.System.Data.SqlClient/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "HLiHrUpo0fQKdjdQwVjDRHVMg+0oVHYBoXOFZ6x6GgzWdQvKY1GEIC4E7s5lBPtEOqMkgXQg3rCwJ7/RLo57Vw==",
+      "sha512": "BO54QPVbHPL46A5kd2JY89YRmT8XioZ5nojTfRavKN+kovHp/vPvViaf97+w7IiW93A7pW8KsPBI40hZRAp01w==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Data.SqlClient.4.0.0-rc2-23519.nupkg",
-        "runtime.unix.System.Data.SqlClient.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.unix.System.Data.SqlClient.4.0.0-rc2-23525.nupkg",
+        "runtime.unix.System.Data.SqlClient.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.unix.System.Data.SqlClient.nuspec",
         "runtimes/unix/lib/dotnet5.5/System.Data.SqlClient.dll"
       ]
     },
-    "runtime.unix.System.Diagnostics.Debug/4.0.11-rc2-23519": {
+    "runtime.unix.System.Diagnostics.Debug/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "p/Bruef09afNiXeYMPAFAFTF75E0U2xhXp8jtwjTXe2AHwwa33rRUMKtFUXCvY1loa4YuMWA88oeUImdqoLxeA==",
+      "sha512": "71UEnXk4Q5lyIPxlsRFblo3GIn75N5rDO6N6+XZkyesMylZjccX6O2kSTb7iURIJy3ZbBvMUovO3ZXazHYWa0A==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Diagnostics.Debug.4.0.11-rc2-23519.nupkg",
-        "runtime.unix.System.Diagnostics.Debug.4.0.11-rc2-23519.nupkg.sha512",
+        "runtime.unix.System.Diagnostics.Debug.4.0.11-rc2-23525.nupkg",
+        "runtime.unix.System.Diagnostics.Debug.4.0.11-rc2-23525.nupkg.sha512",
         "runtime.unix.System.Diagnostics.Debug.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Diagnostics.Debug.dll"
       ]
     },
-    "runtime.unix.System.Diagnostics.FileVersionInfo/4.0.0-rc2-23519": {
+    "runtime.unix.System.Diagnostics.FileVersionInfo/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8wq6pNDPvdVYaK1umjIN6fQjJ5ly6+6OAc/4LfhMBO9PwuXjTAXpeXZFIjrfnaY4WQ0afqmw5CymEnlZ5ZgZew==",
+      "sha512": "TiJvoif+/dEOzPNO970LvLEOtYM1Q09e6o9nzgp3i5HnIUUnMJD0MtW6vXjdzVQs5Ocu8zQSgl5VNA39NXIMMQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Diagnostics.FileVersionInfo.4.0.0-rc2-23519.nupkg",
-        "runtime.unix.System.Diagnostics.FileVersionInfo.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.unix.System.Diagnostics.FileVersionInfo.4.0.0-rc2-23525.nupkg",
+        "runtime.unix.System.Diagnostics.FileVersionInfo.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.unix.System.Diagnostics.FileVersionInfo.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Diagnostics.FileVersionInfo.dll"
       ]
     },
-    "runtime.unix.System.Globalization.Extensions/4.0.1-rc2-23519": {
+    "runtime.unix.System.Globalization.Extensions/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "GaGyYyMeIG3Hl5P1I2+N563wGzHqfTvV7MmvxOoBfgo4+uSLAl3SMczfEEKk067rVnt8VBP+CP6pNSbIfWMTig==",
+      "sha512": "w3S5sHL2wJuo/Teg+kzri6oJ+dc/79Dzq5W9k20/DSUydVxNVsftXB2ENBhu5Vn40E/clk9kBU/POyI6uG+NqA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Globalization.Extensions.4.0.1-rc2-23519.nupkg",
-        "runtime.unix.System.Globalization.Extensions.4.0.1-rc2-23519.nupkg.sha512",
+        "runtime.unix.System.Globalization.Extensions.4.0.1-rc2-23525.nupkg",
+        "runtime.unix.System.Globalization.Extensions.4.0.1-rc2-23525.nupkg.sha512",
         "runtime.unix.System.Globalization.Extensions.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Globalization.Extensions.dll"
       ]
     },
-    "runtime.unix.System.IO.Compression/4.1.0-rc2-23519": {
+    "runtime.unix.System.IO.Compression/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bgQ+lEVPQaQMeXuUkl974dEwnAiF/diyZZec1cgT1KeJu8BxdK3uONiSQ3MgJ+a9NfngqOmAReU9wR+1E4qZiw==",
+      "sha512": "I2CQm1zDpe5LgvEuxqgn6rqOIshypjjJW3aH78mf8uJxDoE+CdT9o6RK5zWB0NTySfqOEmRNGAVcZY08G9Kv1g==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.IO.Compression.4.1.0-rc2-23519.nupkg",
-        "runtime.unix.System.IO.Compression.4.1.0-rc2-23519.nupkg.sha512",
+        "runtime.unix.System.IO.Compression.4.1.0-rc2-23525.nupkg",
+        "runtime.unix.System.IO.Compression.4.1.0-rc2-23525.nupkg.sha512",
         "runtime.unix.System.IO.Compression.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.IO.Compression.dll"
       ]
     },
-    "runtime.unix.System.IO.Pipes/4.0.0-rc2-23519": {
+    "runtime.unix.System.IO.Pipes/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "SVIMfDrwMD6EwVu2hOn/oVoHFD1gh0fZnDs+21Ogd5Cwpj/486qK/0HVLpIdX2L1Uhhazp5bhTFF34DWgbdw9A==",
+      "sha512": "Eu/9NxxY52DnL5FiJmC68w1mCN8+Uqau2JaP6Hti6nuzOrqTh/GLBtLNiptv6j9Wq1Og6w+GUdSHusT6n5AzOg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.IO.Pipes.4.0.0-rc2-23519.nupkg",
-        "runtime.unix.System.IO.Pipes.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.unix.System.IO.Pipes.4.0.0-rc2-23525.nupkg",
+        "runtime.unix.System.IO.Pipes.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.unix.System.IO.Pipes.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.IO.Pipes.dll"
       ]
     },
-    "runtime.unix.System.Net.Primitives/4.0.11-rc2-23519": {
+    "runtime.unix.System.Net.Primitives/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2s+EFhSB7aj8Nb7fe5EXsSacnA4AwKcRMZcBaYf1KBeDj2J4qznlIHUHrByP4lEp7ZrTAsGtbu8Hjdys6U/ljQ==",
+      "sha512": "NizQDS7mGja8IBtYX1JtPZPE/XLXq4zUb8GiZiHtiq/Qo7SG9/iOucGGNwodsWFHdA/W8A2mkGxK2b+vnsQ6lA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Net.Primitives.4.0.11-rc2-23519.nupkg",
-        "runtime.unix.System.Net.Primitives.4.0.11-rc2-23519.nupkg.sha512",
+        "runtime.unix.System.Net.Primitives.4.0.11-rc2-23525.nupkg",
+        "runtime.unix.System.Net.Primitives.4.0.11-rc2-23525.nupkg.sha512",
         "runtime.unix.System.Net.Primitives.nuspec",
         "runtimes/unix/lib/dnxcore50/System.Net.Primitives.dll"
       ]
     },
-    "runtime.unix.System.Net.Requests/4.0.11-rc2-23519": {
+    "runtime.unix.System.Net.Requests/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "7p7V2Qvs72lfTFvBh+HYbDXGzptOp35SXNuyItQv+s90o1aZmVPJWjCTkYCnTw6vfyNJfYEiiGr8DZH9/ftMPQ==",
+      "sha512": "mnfMIwVrTGgaxkaTLmSEV2Us30+Oa4YCJN0jaZeFJp1hpwcxe/KeOLMY2jXbXkBkz4o42Q9TuwygIDhV/yFEXg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Net.Requests.4.0.11-rc2-23519.nupkg",
-        "runtime.unix.System.Net.Requests.4.0.11-rc2-23519.nupkg.sha512",
+        "runtime.unix.System.Net.Requests.4.0.11-rc2-23525.nupkg",
+        "runtime.unix.System.Net.Requests.4.0.11-rc2-23525.nupkg.sha512",
         "runtime.unix.System.Net.Requests.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Net.Requests.dll"
       ]
     },
-    "runtime.unix.System.Net.Security/4.0.0-rc2-23519": {
+    "runtime.unix.System.Net.Security/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "7ONyPeNUgpPkhnbEEe6Pb2QgeawdMGXbkUAscFzzizgHbImveohdOROLxAwkWRUBu/4pqvWeUqPcUXzPC4M+VA==",
+      "sha512": "g8Xj34/agaPUOwO8kfGgXISx5QY68wsOQO6s5HqklbVGJoSBzguuEfDyYjTykC32H7UoeW01jzxuVIDBuOJtpQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Net.Security.4.0.0-rc2-23519.nupkg",
-        "runtime.unix.System.Net.Security.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.unix.System.Net.Security.4.0.0-rc2-23525.nupkg",
+        "runtime.unix.System.Net.Security.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.unix.System.Net.Security.nuspec",
         "runtimes/unix/lib/dnxcore50/System.Net.Security.dll"
       ]
     },
-    "runtime.unix.System.Net.WebSockets.Client/4.0.0-rc2-23519": {
+    "runtime.unix.System.Net.WebSockets.Client/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "UjBw0ZC1jmy8cayG4eQ7ps3K0x1b2w+ovehd6RcHXT+udwAJt9wdqRvg9QZaAYvw5GxoSO+7ci2GUd3/YTSFLw==",
+      "sha512": "Xa96WRyCZnH1AzS5+AUXad6lZ2AyV4d5WiKJeQq9T+iVgcTQDhAGBcy38GgA+7WACbfvkBhh8mmI6THdBiYbaA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Net.WebSockets.Client.4.0.0-rc2-23519.nupkg",
-        "runtime.unix.System.Net.WebSockets.Client.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.unix.System.Net.WebSockets.Client.4.0.0-rc2-23525.nupkg",
+        "runtime.unix.System.Net.WebSockets.Client.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.unix.System.Net.WebSockets.Client.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Net.WebSockets.Client.dll"
       ]
     },
-    "runtime.unix.System.Private.Uri/4.0.1-rc2-23519": {
+    "runtime.unix.System.Private.Uri/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ftx0Gfzv/UUOiSK/qEfe/LtQtXqhIAwSBidbpkfHtEhcNpxHdwGwZzMRX6JzAkLHWjAOifhUv9bJKILp9SiD0w==",
+      "sha512": "L+vIdWWr13SstxDwh3loOAELui5gHVawj+zOgjIlPIIVAa3QkwYb45SR6TiOs9fkSGnQO6rLC8hDCOjcvjRpxw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Private.Uri.4.0.1-rc2-23519.nupkg",
-        "runtime.unix.System.Private.Uri.4.0.1-rc2-23519.nupkg.sha512",
+        "runtime.unix.System.Private.Uri.4.0.1-rc2-23525.nupkg",
+        "runtime.unix.System.Private.Uri.4.0.1-rc2-23525.nupkg.sha512",
         "runtime.unix.System.Private.Uri.nuspec",
         "runtimes/unix/lib/dotnet5.1/System.Private.Uri.dll"
       ]
     },
-    "runtime.unix.System.Security.Cryptography.Encoding/4.0.0-rc2-23519": {
+    "runtime.unix.System.Security.Cryptography.Encoding/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "H5xzMTtiF/gXdDCrGFlTzepg/zpOXbW9yfMnY3bAzWzfMQH1MVTna2vbwPzJFuoehAZbVZ5YMpWAM50Lq1TO/g==",
+      "sha512": "8Wcw1Yn223U8elKcHdJVMOZ+nkXLGo+kEw8wau0IXLiN6XXeYnhG83dKkQ+UrIF7bGr0Mg1KrXiIkle/Hk8bPQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Security.Cryptography.Encoding.4.0.0-rc2-23519.nupkg",
-        "runtime.unix.System.Security.Cryptography.Encoding.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.unix.System.Security.Cryptography.Encoding.4.0.0-rc2-23525.nupkg",
+        "runtime.unix.System.Security.Cryptography.Encoding.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.unix.System.Security.Cryptography.Encoding.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.Encoding.dll"
       ]
     },
-    "runtime.unix.System.Security.Cryptography.X509Certificates/4.0.0-rc2-23519": {
+    "runtime.unix.System.Security.Cryptography.X509Certificates/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "MdwlbGtdhmhKiIfIk+9KQwU1fvttjcVE4QQFM4XpR5QINc/nik0dlIhYWoofm0NxbSJP9cCKxoktVb3kIIrr+Q==",
+      "sha512": "hTcORhMtGQbyTzfKbXR6g1MYSQc0+zNbYHleIAW7wEowTDnIrz2kKeWucGB/2rJfWwohx8vuCUJzbJKuihU/1g==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Security.Cryptography.X509Certificates.4.0.0-rc2-23519.nupkg",
-        "runtime.unix.System.Security.Cryptography.X509Certificates.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.unix.System.Security.Cryptography.X509Certificates.4.0.0-rc2-23525.nupkg",
+        "runtime.unix.System.Security.Cryptography.X509Certificates.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.unix.System.Security.Cryptography.X509Certificates.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.X509Certificates.dll"
       ]
     },
-    "runtime.unix.System.Text.Encoding.CodePages/4.0.1-rc2-23519": {
+    "runtime.unix.System.Text.Encoding.CodePages/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "UsPEgFrNawaMn/hLKiCoQglZGMEGsowMKxiE+bpW7o5VV9UrlrRHVShtAYYT5OTSOv8LXGDTLlujKOm/lIetgA==",
+      "sha512": "Xgbunp+hl4nOVE3NfwU5Mb2p8cdkJwTNZUWPSiUO6u4g0fri2QHRjbDt9CIgU9onwREYAEJECSCCRIdkEjTRHA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Text.Encoding.CodePages.4.0.1-rc2-23519.nupkg",
-        "runtime.unix.System.Text.Encoding.CodePages.4.0.1-rc2-23519.nupkg.sha512",
+        "runtime.unix.System.Text.Encoding.CodePages.4.0.1-rc2-23525.nupkg",
+        "runtime.unix.System.Text.Encoding.CodePages.4.0.1-rc2-23525.nupkg.sha512",
         "runtime.unix.System.Text.Encoding.CodePages.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Text.Encoding.CodePages.dll"
       ]
     },
-    "runtime.unix.System.Threading/4.0.11-rc2-23519": {
+    "runtime.unix.System.Threading/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "0Mv0GrzADQJxJ7zFAnO+tLN9leivJp0KIAbcIbvjAIN3sTjeX5nxIzDjAJlrbr2A6C9isaYi7epLGD926GGuTQ==",
+      "sha512": "BsAPay24hKPb2W8/1VCzEOnm94sQsT9kp+lCZcrvPNndikhsidrfjB0OPnJSo8uhaHXfwAz4uCEXhpAywlkwrA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.unix.System.Threading.4.0.11-rc2-23519.nupkg",
-        "runtime.unix.System.Threading.4.0.11-rc2-23519.nupkg.sha512",
+        "runtime.unix.System.Threading.4.0.11-rc2-23525.nupkg",
+        "runtime.unix.System.Threading.4.0.11-rc2-23525.nupkg.sha512",
         "runtime.unix.System.Threading.nuspec",
         "runtimes/unix/lib/dotnet5.4/System.Threading.dll"
       ]
     },
-    "runtime.win.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23519": {
+    "runtime.win.System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "vN22e/gkWMWy5TlrLG5llQ48E37QudiWJykLC64plg7i7xuKu1kdDA7q7LcMzvHIAie6rel66nurgnuYS/W0oQ==",
+      "sha512": "H8lMtaHAPFEjWCfOZyPwN7ctkAxC3vN65x+gzaUfcPBLrHMLaqT3qsNy5H3c66oFGt3NOCm4WEYlvjeYjd8/sQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win.System.Runtime.InteropServices.RuntimeInformation.4.0.0-rc2-23519.nupkg",
-        "runtime.win.System.Runtime.InteropServices.RuntimeInformation.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.win.System.Runtime.InteropServices.RuntimeInformation.4.0.0-rc2-23525.nupkg",
+        "runtime.win.System.Runtime.InteropServices.RuntimeInformation.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.win.System.Runtime.InteropServices.RuntimeInformation.nuspec",
         "runtimes/win/lib/dotnet5.1/System.Runtime.InteropServices.RuntimeInformation.dll"
       ]
     },
-    "runtime.win.System.Text.Encoding.CodePages/4.0.1-rc2-23519": {
+    "runtime.win.System.Text.Encoding.CodePages/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "rIo1MtNq7F78ThEONHJGPv40TbT47yD+HCP3tFexHklbJInZhvyIzBOObVg/u/8c3dJo0eKpGfuPcmm8zk+LFg==",
+      "sha512": "08bbbHOxR66eebeq5AMj/Is/TOuoy4PqaBvcUcj08uiDuGldC1yQRVAgAuFx9MADG7YvdRdlUcPPiuvW4pLz5g==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win.System.Text.Encoding.CodePages.4.0.1-rc2-23519.nupkg",
-        "runtime.win.System.Text.Encoding.CodePages.4.0.1-rc2-23519.nupkg.sha512",
+        "runtime.win.System.Text.Encoding.CodePages.4.0.1-rc2-23525.nupkg",
+        "runtime.win.System.Text.Encoding.CodePages.4.0.1-rc2-23525.nupkg.sha512",
         "runtime.win.System.Text.Encoding.CodePages.nuspec",
         "runtimes/win/lib/dotnet5.4/System.Text.Encoding.CodePages.dll",
         "runtimes/win/lib/netcore50/System.Text.Encoding.CodePages.dll",
@@ -13831,41 +13999,41 @@
         "runtimes/win/lib/wpa81/_._"
       ]
     },
-    "runtime.win7.Microsoft.Win32.Primitives/4.0.1-rc2-23519": {
+    "runtime.win7.Microsoft.Win32.Primitives/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "w4TfepasDnOlPW1QCjxQV09Pk7e9EQbM6dMdKFX82/tM1Ff+8g/T5JXFmhcc1yobgx+ji2y46Uh9kn559dgeIA==",
+      "sha512": "w86NgKsKP/5l7w5PYKvSOZyMyPmqOryEjKoZrwtcHb+CRn8bf9JNNQgn24KASBMq3GQFzDslXp0biT1pxhreeg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.Microsoft.Win32.Primitives.4.0.1-rc2-23519.nupkg",
-        "runtime.win7.Microsoft.Win32.Primitives.4.0.1-rc2-23519.nupkg.sha512",
+        "runtime.win7.Microsoft.Win32.Primitives.4.0.1-rc2-23525.nupkg",
+        "runtime.win7.Microsoft.Win32.Primitives.4.0.1-rc2-23525.nupkg.sha512",
         "runtime.win7.Microsoft.Win32.Primitives.nuspec",
         "runtimes/win7/lib/dotnet5.4/Microsoft.Win32.Primitives.dll",
         "runtimes/win7/lib/net/_._"
       ]
     },
-    "runtime.win7.System.Console/4.0.0-rc2-23519": {
+    "runtime.win7.System.Console/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "HdUziKdEDxQxVltxCqy3zBw98bXfL3vv1OjX79dTej2nO6NCAo4t1WgNW2iYH+nH8FgnfaTkcZ3kWmnFiO2FeQ==",
+      "sha512": "61pTms2XLekse3lSpQ5fvs98Rgs1ydk18TgPmy6fq9jfP2uuLWyRbxul1Kb/keI3BygVabUvwly9Bjg0Vu94jQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Console.4.0.0-rc2-23519.nupkg",
-        "runtime.win7.System.Console.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.Console.4.0.0-rc2-23525.nupkg",
+        "runtime.win7.System.Console.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.win7.System.Console.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.Console.dll",
         "runtimes/win7/lib/net/_._"
       ]
     },
-    "runtime.win7.System.Data.SqlClient/4.0.0-rc2-23519": {
+    "runtime.win7.System.Data.SqlClient/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "bdcJAfpRLrhGQOYDTDrz87N/U2USjzDfzOyakkj5gD/n3peI/TE6EfCvl0Gn2eecuW9wVUkXmuoA+cMpCj7k3w==",
+      "sha512": "kRz7kfEC5KvUM5ijJLLLf9Lw2dvGULI8Lr+kCveUl0VpgcTB/ug6eZkrUC5MKDOm1+85KiVq6udtPmvlDTSEug==",
       "files": [
         "lib/net/_._",
         "ref/dotnet/_._",
-        "runtime.win7.System.Data.SqlClient.4.0.0-rc2-23519.nupkg",
-        "runtime.win7.System.Data.SqlClient.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.Data.SqlClient.4.0.0-rc2-23525.nupkg",
+        "runtime.win7.System.Data.SqlClient.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.win7.System.Data.SqlClient.nuspec",
         "runtimes/win7/lib/DNXCore50/System.Data.SqlClient.dll",
         "runtimes/win7/lib/win8/_._",
@@ -13873,28 +14041,28 @@
         "runtimes/win7/lib/wpa81/_._"
       ]
     },
-    "runtime.win7.System.Diagnostics.Debug/4.0.11-rc2-23519": {
+    "runtime.win7.System.Diagnostics.Debug/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n1Poti3x31pqiOekPvYjdw4OUlCT1byrxHlkKwr12ysGM5t1QQonAJXQYCBFrrCNphxwT0PbWYzST3j2Sf+9kw==",
+      "sha512": "6txhz00DQayySs37jFHBE7C0O5dpTmlZrCxJLDdukcyKpHnyhNCOEKz6r+93mFeziRY6Lf4f3K7XgnvN/1vPJQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Diagnostics.Debug.4.0.11-rc2-23519.nupkg",
-        "runtime.win7.System.Diagnostics.Debug.4.0.11-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.Diagnostics.Debug.4.0.11-rc2-23525.nupkg",
+        "runtime.win7.System.Diagnostics.Debug.4.0.11-rc2-23525.nupkg.sha512",
         "runtime.win7.System.Diagnostics.Debug.nuspec",
         "runtimes/win7/lib/DNXCore50/System.Diagnostics.Debug.dll",
         "runtimes/win7/lib/netcore50/System.Diagnostics.Debug.dll",
         "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll"
       ]
     },
-    "runtime.win7.System.Diagnostics.FileVersionInfo/4.0.0-rc2-23519": {
+    "runtime.win7.System.Diagnostics.FileVersionInfo/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "KEuNUwthzr93zr7VtLzJQIOYp+FhIcX+P65vMovTe388dCQlA+VnxjwEO6iXleB4Vpnjojwp5xNhVBgis3+QgA==",
+      "sha512": "LUDn11ZTLsxoYI5zVIpr0MnQlZVqbax0KN08lhpmRqPRWE17eWQ6/04jVEhkGAt6mhRudYnTcP+AJLyzwszIiQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Diagnostics.FileVersionInfo.4.0.0-rc2-23519.nupkg",
-        "runtime.win7.System.Diagnostics.FileVersionInfo.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.Diagnostics.FileVersionInfo.4.0.0-rc2-23525.nupkg",
+        "runtime.win7.System.Diagnostics.FileVersionInfo.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.win7.System.Diagnostics.FileVersionInfo.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.Diagnostics.FileVersionInfo.dll",
         "runtimes/win7/lib/net/_._",
@@ -13904,14 +14072,14 @@
         "runtimes/win7/lib/wpa81/_._"
       ]
     },
-    "runtime.win7.System.Diagnostics.Process/4.1.0-rc2-23519": {
+    "runtime.win7.System.Diagnostics.Process/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lc5F3+nIA0CWWVLXu0TDeJtXHOzJlkJzO2m+z8g/6xE3ePZWYoojr4fF4onslD0aKnCEgQhSGA+iDlv0fZ3RGQ==",
+      "sha512": "tQ1MZrCOo3esTt+vjuDBhQNBVn2O+cn7I4ZbDQlARppQJrzCqgbEZtPPRHHQNokOJsGk8RJvGy8VzjiMbjFCUg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Diagnostics.Process.4.1.0-rc2-23519.nupkg",
-        "runtime.win7.System.Diagnostics.Process.4.1.0-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.Diagnostics.Process.4.1.0-rc2-23525.nupkg",
+        "runtime.win7.System.Diagnostics.Process.4.1.0-rc2-23525.nupkg.sha512",
         "runtime.win7.System.Diagnostics.Process.nuspec",
         "runtimes/win7/lib/dotnet5.5/System.Diagnostics.Process.dll",
         "runtimes/win7/lib/net/_._",
@@ -13921,27 +14089,27 @@
         "runtimes/win7/lib/wpa81/_._"
       ]
     },
-    "runtime.win7.System.Globalization.Extensions/4.0.1-rc2-23519": {
+    "runtime.win7.System.Globalization.Extensions/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "wLMYawZx5qCknKXco9r86tvwaGk6Gi4XILByQSkqB8/KBfJnalnQdmBTA1BfUaVpkndIW3F6TxqT/bfb+iKRYQ==",
+      "sha512": "KjAFrVUkamkrAYajk+bpM5qhZ5UzAMVS1jlR4fW6keFk8ltp57PfivcBGRDbQDhCMzUVIjEFQ5RHXIsLOgpZHg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Globalization.Extensions.4.0.1-rc2-23519.nupkg",
-        "runtime.win7.System.Globalization.Extensions.4.0.1-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.Globalization.Extensions.4.0.1-rc2-23525.nupkg",
+        "runtime.win7.System.Globalization.Extensions.4.0.1-rc2-23525.nupkg.sha512",
         "runtime.win7.System.Globalization.Extensions.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.Globalization.Extensions.dll",
         "runtimes/win7/lib/net/_._"
       ]
     },
-    "runtime.win7.System.IO.Compression/4.1.0-rc2-23519": {
+    "runtime.win7.System.IO.Compression/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "7Rc+QxouDbm70q8OVIeibxAYKBoWxnzi7nukjoeurbhYMGuM081c/gi+Vc/zVzrCuh3BFjI/2tUYhNOOUk0TLg==",
+      "sha512": "M/pRg7E0EiHTn9SvNUzadDiSP57xNvDpM+Nq5r1azKbaoy7PcngzmnYrhlE8gjYYzgBegWVWcKEH7TqMHenj3A==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.IO.Compression.4.1.0-rc2-23519.nupkg",
-        "runtime.win7.System.IO.Compression.4.1.0-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.IO.Compression.4.1.0-rc2-23525.nupkg",
+        "runtime.win7.System.IO.Compression.4.1.0-rc2-23525.nupkg.sha512",
         "runtime.win7.System.IO.Compression.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.IO.Compression.dll",
         "runtimes/win7/lib/net/_._",
@@ -13951,14 +14119,14 @@
         "runtimes/win7/lib/wpa81/_._"
       ]
     },
-    "runtime.win7.System.IO.FileSystem/4.0.1-rc2-23519": {
+    "runtime.win7.System.IO.FileSystem/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "LagrXkrYejnTe60Z7HqwY4HYciODVUBtJiD0i1TbIRZOtQ3//Ff+ECqDy3fiLLfxPZJZw5PnI5/A2WF3giZUNg==",
+      "sha512": "Rk2nN279viCiNX+a05TDaZAWxtp1Kl/NytR4jT75dM24niwhNtLVpDq3mZ6L8AV0lSnkd6UeHhMOrcbMhoiHyg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.IO.FileSystem.4.0.1-rc2-23519.nupkg",
-        "runtime.win7.System.IO.FileSystem.4.0.1-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.IO.FileSystem.4.0.1-rc2-23525.nupkg",
+        "runtime.win7.System.IO.FileSystem.4.0.1-rc2-23525.nupkg.sha512",
         "runtime.win7.System.IO.FileSystem.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.IO.FileSystem.dll",
         "runtimes/win7/lib/net/_._",
@@ -13968,14 +14136,14 @@
         "runtimes/win7/lib/wpa81/_._"
       ]
     },
-    "runtime.win7.System.IO.FileSystem.DriveInfo/4.0.0-rc2-23519": {
+    "runtime.win7.System.IO.FileSystem.DriveInfo/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "17PB1cTJblveLDwyM+e1D3Vka8RgRPnRD+UBsl51z0YlymYwe6mUTuP31UrZpF3Zs6RCKSpyXTebDdPE/5LwPA==",
+      "sha512": "g3qF37hdYxeMdvAhRxO0fvvhvbyWcyZmTv5FrC4fy8FQUspNJx4BpD1EUfPSTeM3dOtrKwX8SfR62qNFKM0jbA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.IO.FileSystem.DriveInfo.4.0.0-rc2-23519.nupkg",
-        "runtime.win7.System.IO.FileSystem.DriveInfo.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.IO.FileSystem.DriveInfo.4.0.0-rc2-23525.nupkg",
+        "runtime.win7.System.IO.FileSystem.DriveInfo.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.win7.System.IO.FileSystem.DriveInfo.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.IO.FileSystem.DriveInfo.dll",
         "runtimes/win7/lib/net/_._",
@@ -13985,14 +14153,14 @@
         "runtimes/win7/lib/wpa81/_._"
       ]
     },
-    "runtime.win7.System.IO.FileSystem.Watcher/4.0.0-rc2-23519": {
+    "runtime.win7.System.IO.FileSystem.Watcher/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "yWqJMwsoqurH3PV77n1ULaKW8kAA8N1cqySPvMtTkO4e4Qp1LliQHAJvvMaTB4mMOShY1UJYPXnL5yJKyH5j8A==",
+      "sha512": "P7gihPiu9v9V9TzAmY/+9532/HOIRTyViksJFf+08dRz882ugN96vR8halkcr+1kP2PvYEr35rNCp2ZffrWzHg==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.IO.FileSystem.Watcher.4.0.0-rc2-23519.nupkg",
-        "runtime.win7.System.IO.FileSystem.Watcher.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.IO.FileSystem.Watcher.4.0.0-rc2-23525.nupkg",
+        "runtime.win7.System.IO.FileSystem.Watcher.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.win7.System.IO.FileSystem.Watcher.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.IO.FileSystem.Watcher.dll",
         "runtimes/win7/lib/net/_._",
@@ -14002,14 +14170,14 @@
         "runtimes/win7/lib/wpa81/_._"
       ]
     },
-    "runtime.win7.System.IO.MemoryMappedFiles/4.0.0-rc2-23519": {
+    "runtime.win7.System.IO.MemoryMappedFiles/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "3qxEjID/5K0wnyQ5uVbxbyGLPALcbE3NT2+s9BFQLZBa/elF03GyHLl2NJ+2xoOr3QGov4IWBz5pu7DNt2QqMg==",
+      "sha512": "AkDeO4FBNbnr6T9JVpfXgS91kiP84hBdAPftpJ2VN1nTr+XeNU4EgY5blVDRKeqjy8QNku9fmL5c5zPM76qtBQ==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.IO.MemoryMappedFiles.4.0.0-rc2-23519.nupkg",
-        "runtime.win7.System.IO.MemoryMappedFiles.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.IO.MemoryMappedFiles.4.0.0-rc2-23525.nupkg",
+        "runtime.win7.System.IO.MemoryMappedFiles.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.win7.System.IO.MemoryMappedFiles.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.IO.MemoryMappedFiles.dll",
         "runtimes/win7/lib/net/_._",
@@ -14019,223 +14187,224 @@
         "runtimes/win7/lib/wpa81/_._"
       ]
     },
-    "runtime.win7.System.IO.Pipes/4.0.0-rc2-23519": {
+    "runtime.win7.System.IO.Pipes/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "l/xNm2RdKuMdeuH/DO3X9N0UrUJxieMiD27JgA3JaM+ONoi2YAYYjX2aQ5nOtBVaJ+3bTCbrBPu2suYOd6jY9Q==",
+      "sha512": "BCd3bnf3Seb3GqHmGNcaZc9lgpg4dVRmH7CtNv+Br0oDLiT8WdTiFJ1/Wv7+vT8gicQ8paXkLGxVu86tquDa2Q==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.IO.Pipes.4.0.0-rc2-23519.nupkg",
-        "runtime.win7.System.IO.Pipes.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.IO.Pipes.4.0.0-rc2-23525.nupkg",
+        "runtime.win7.System.IO.Pipes.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.win7.System.IO.Pipes.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.IO.Pipes.dll",
         "runtimes/win7/lib/net/_._",
         "runtimes/win7/lib/netcore50/_._"
       ]
     },
-    "runtime.win7.System.Net.Http/4.0.1-rc2-23519": {
+    "runtime.win7.System.Net.Http/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "wg4pa/zoptNVoy3b7luv8YEqBVyWXB8Nec3i8IkjMnkc5yTjmJ6PAznXN+hCksZs1r0JIioCLJ2BKLVpuNt+Jg==",
+      "sha512": "w+SIJazlftdQDqqTdjgMiIL21YRNXNEjV3isNJYNrOSGpZGFUlO5Q7GHfjq7cjtmtHoqZ/i1Oj/orbIP/ZwU6w==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Net.Http.4.0.1-rc2-23519.nupkg",
-        "runtime.win7.System.Net.Http.4.0.1-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.Net.Http.4.0.1-rc2-23525.nupkg",
+        "runtime.win7.System.Net.Http.4.0.1-rc2-23525.nupkg.sha512",
         "runtime.win7.System.Net.Http.nuspec",
         "runtimes/win7/lib/DNXCore50/System.Net.Http.dll",
         "runtimes/win7/lib/netcore50/System.Net.Http.dll"
       ]
     },
-    "runtime.win7.System.Net.NameResolution/4.0.0-rc2-23519": {
+    "runtime.win7.System.Net.NameResolution/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "rQH9ZaH/y72lNz5tTC6EPUxgvQswSn4277XeHoFl7F7pClJrkMmGZaFrN1RyXp41DVU+tSkrjf1F72ZfcythJg==",
+      "sha512": "SnH1EgmbXzY+kL3GfWjEfqTkVzAMqz5RGgRH/TjfQoz50scKkrT7t0Z5MDC8yecW+7ZMkB5w0be9H6F08v/LNQ==",
       "files": [
         "lib/DNXCore50/System.Net.NameResolution.dll",
         "ref/dotnet/_._",
-        "runtime.win7.System.Net.NameResolution.4.0.0-rc2-23519.nupkg",
-        "runtime.win7.System.Net.NameResolution.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.Net.NameResolution.4.0.0-rc2-23525.nupkg",
+        "runtime.win7.System.Net.NameResolution.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.win7.System.Net.NameResolution.nuspec"
       ]
     },
-    "runtime.win7.System.Net.NetworkInformation/4.1.0-rc2-23519": {
+    "runtime.win7.System.Net.NetworkInformation/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "NKU0L7Z/m7v3sYzrxN+aWC4L5Hq2sb7ju17GR7fCfnpcEA01xABL2VKCmt4ZkS3TzGw0Vwds2TJ8qt8oXnBwPQ==",
+      "sha512": "JY7y7HQZTJfF4IWH7KvOrHW9jrVd0w5qudZXtmAYAQEj5qnQvJUTPbp06pyKhkbHEAMXzNSVX02oV2nPRMdOpw==",
       "files": [
         "lib/DNXCore50/System.Net.NetworkInformation.dll",
         "lib/netcore50/System.Net.NetworkInformation.dll",
         "ref/dotnet/_._",
-        "runtime.win7.System.Net.NetworkInformation.4.1.0-rc2-23519.nupkg",
-        "runtime.win7.System.Net.NetworkInformation.4.1.0-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.Net.NetworkInformation.4.1.0-rc2-23525.nupkg",
+        "runtime.win7.System.Net.NetworkInformation.4.1.0-rc2-23525.nupkg.sha512",
         "runtime.win7.System.Net.NetworkInformation.nuspec",
         "runtimes/win7/lib/net/_._"
       ]
     },
-    "runtime.win7.System.Net.Primitives/4.0.11-rc2-23519": {
+    "runtime.win7.System.Net.Primitives/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "t5fXDmbTPzIKw/T3duwvoVq1GnfkdrDVl+SdmOnA8SPAcLD3vSfFtFE/7bA7yri5Oq4UBAuGAWZu3ZMO+u5xcw==",
+      "sha512": "fQXiEWBBAf85oQrn/PhE5h0x1Bz2MsQLzFnsmPHXK3F52aCXSfA8XG7d9/P4M635T6YuZz4Hl4RmJdFYoO84Ww==",
       "files": [
         "lib/DNXCore50/System.Net.Primitives.dll",
         "ref/dotnet/_._",
-        "runtime.win7.System.Net.Primitives.4.0.11-rc2-23519.nupkg",
-        "runtime.win7.System.Net.Primitives.4.0.11-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.Net.Primitives.4.0.11-rc2-23525.nupkg",
+        "runtime.win7.System.Net.Primitives.4.0.11-rc2-23525.nupkg.sha512",
         "runtime.win7.System.Net.Primitives.nuspec",
         "runtimes/win7/lib/netcore50/System.Net.Primitives.dll"
       ]
     },
-    "runtime.win7.System.Net.Requests/4.0.11-rc2-23519": {
+    "runtime.win7.System.Net.Requests/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "rhDDTsyNeh2WshybNIFGUreSncnyv2SPnLJYl1UcIaFjGoXie6kPEozYgGNQXERQkL/lIH0qUKRKVy5JFzv/qw==",
+      "sha512": "MU3ZIB6E4Sk6MJ9csnb/X6oD0dMr9QlEl5gduvZOTJBF2v9hrbcgb5DHvPjTW7cxyWEe38rIQywYObX37J+7+w==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Net.Requests.4.0.11-rc2-23519.nupkg",
-        "runtime.win7.System.Net.Requests.4.0.11-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.Net.Requests.4.0.11-rc2-23525.nupkg",
+        "runtime.win7.System.Net.Requests.4.0.11-rc2-23525.nupkg.sha512",
         "runtime.win7.System.Net.Requests.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.Net.Requests.dll",
         "runtimes/win7/lib/net/_._"
       ]
     },
-    "runtime.win7.System.Net.Security/4.0.0-rc2-23519": {
+    "runtime.win7.System.Net.Security/4.0.0-rc2-23525": {
       "type": "package",
-      "sha512": "+uLBJy+kEWVCEaIBQ59p3hmDC6Ci4ZXkNRwQSvQCpIkOW1nZkR14aSAGp4UTGOa4KwmNM14CGaLRhvs2CTRjfw==",
+      "serviceable": true,
+      "sha512": "1M4FtHXwB2Xb2h0wXQZyK9VuDGW4IHjImoYxY6h4MIia0xiIhlnnFb9MjzOTuErU2Xuh732b4lKPgAq/3idT5A==",
       "files": [
         "lib/DNXCore50/System.Net.Security.dll",
         "ref/dotnet/_._",
-        "runtime.win7.System.Net.Security.4.0.0-rc2-23519.nupkg",
-        "runtime.win7.System.Net.Security.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.Net.Security.4.0.0-rc2-23525.nupkg",
+        "runtime.win7.System.Net.Security.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.win7.System.Net.Security.nuspec"
       ]
     },
-    "runtime.win7.System.Net.Sockets/4.1.0-rc2-23519": {
+    "runtime.win7.System.Net.Sockets/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Eh/MWBdD1ifFy0bS4XUtvEAMmjynDuKKwtPjRqIoVMPZqI1vPJJpYCzEZ6y/qGHTdz7YIzFRxooksb6brCSV4g==",
+      "sha512": "llKUmUqa5QgyKstmVz5jkMLkxVB6rL5DAqyw2O2oZSeA9G+D1gCqxrzVXROCrU3uPTA9oF2krxYercJDBzBZmg==",
       "files": [
         "lib/DNXCore50/System.Net.Sockets.dll",
         "lib/netcore50/System.Net.Sockets.dll",
         "ref/dotnet/_._",
-        "runtime.win7.System.Net.Sockets.4.1.0-rc2-23519.nupkg",
-        "runtime.win7.System.Net.Sockets.4.1.0-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.Net.Sockets.4.1.0-rc2-23525.nupkg",
+        "runtime.win7.System.Net.Sockets.4.1.0-rc2-23525.nupkg.sha512",
         "runtime.win7.System.Net.Sockets.nuspec",
         "runtimes/win7/lib/net/_._"
       ]
     },
-    "runtime.win7.System.Net.WebSockets.Client/4.0.0-rc2-23519": {
+    "runtime.win7.System.Net.WebSockets.Client/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "RRkyUTwVWGAE8sskGfwbvFQyzhfktHGNLtugQf7m3Hz55prFbC6K9sXtxeZEIJlMcbraOVK02FZfhHMvIYGMew==",
+      "sha512": "T2ck7xshtRDH7eqxVDgop0PtQacdMW5on9YEVXFf7TRM0Fp1urk1c1I7emNgG8Rf1VSCSu04mFApxBqou24QVA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Net.WebSockets.Client.4.0.0-rc2-23519.nupkg",
-        "runtime.win7.System.Net.WebSockets.Client.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.Net.WebSockets.Client.4.0.0-rc2-23525.nupkg",
+        "runtime.win7.System.Net.WebSockets.Client.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.win7.System.Net.WebSockets.Client.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.Net.WebSockets.Client.dll",
         "runtimes/win7/lib/net/_._",
         "runtimes/win7/lib/netcore50/System.Net.WebSockets.Client.dll"
       ]
     },
-    "runtime.win7.System.Private.Uri/4.0.1-rc2-23519": {
+    "runtime.win7.System.Private.Uri/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "1s1vWphPagDN2XNU0mEMk68NgyBzQ/6ltuQqD0k7pR16VNC9i9aEAHS09LWMchjPhKhfzVMK4nPvMZbe0WSY3w==",
+      "sha512": "Yd7I9NfwfowCfjj6Tjysb2eqIp6oAkdk4VjG/vHfMoFs3wxPxVH8yOyjeUaW3miwQjfIo8e6PwtZvNdkRRsrkA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Private.Uri.4.0.1-rc2-23519.nupkg",
-        "runtime.win7.System.Private.Uri.4.0.1-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.Private.Uri.4.0.1-rc2-23525.nupkg",
+        "runtime.win7.System.Private.Uri.4.0.1-rc2-23525.nupkg.sha512",
         "runtime.win7.System.Private.Uri.nuspec",
         "runtimes/win7/lib/DNXCore50/System.Private.Uri.dll",
         "runtimes/win7/lib/netcore50/System.Private.Uri.dll",
         "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll"
       ]
     },
-    "runtime.win7.System.Runtime.Extensions/4.0.11-rc2-23519": {
+    "runtime.win7.System.Runtime.Extensions/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8R97K9SzwmQx1oZFfn75a4RmlO9Ztgt/AkSGJsa6O4IB0z6+y2u9DO8xD2STkKxkbEMqTm11UPXssbKAxZstPw==",
+      "sha512": "o9yhni1ibV4TZ8pDXnGWrbdYUN0vDTqjC08fBoNF/iHtg4m5TNATIaEVDXOF1ny1ymyfZE/6VRC7m2twuWD/+A==",
       "files": [
         "lib/DNXCore50/System.Runtime.Extensions.dll",
         "lib/netcore50/System.Runtime.Extensions.dll",
         "ref/dotnet/_._",
-        "runtime.win7.System.Runtime.Extensions.4.0.11-rc2-23519.nupkg",
-        "runtime.win7.System.Runtime.Extensions.4.0.11-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.Runtime.Extensions.4.0.11-rc2-23525.nupkg",
+        "runtime.win7.System.Runtime.Extensions.4.0.11-rc2-23525.nupkg.sha512",
         "runtime.win7.System.Runtime.Extensions.nuspec",
         "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll"
       ]
     },
-    "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-rc2-23519": {
+    "runtime.win7.System.Security.Cryptography.Algorithms/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Ap9guK2uVMxdbzYidzqCrLSDe1hUYWzJ4bTIRuebRWJQMAKW6vqNMfROA+xOjhykFFbjv1SVsg/jh2g5yHXx5w==",
+      "sha512": "OZghF4dY+gj/IhXj1FOrlDI//lEb0q9/Y/5GPftSotrk/sDRMpiflbAzVziNCkvOnDPowaU+kayZGCLU9zMRqA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Security.Cryptography.Algorithms.4.0.0-rc2-23519.nupkg",
-        "runtime.win7.System.Security.Cryptography.Algorithms.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.Security.Cryptography.Algorithms.4.0.0-rc2-23525.nupkg",
+        "runtime.win7.System.Security.Cryptography.Algorithms.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.win7.System.Security.Cryptography.Algorithms.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.Algorithms.dll",
         "runtimes/win7/lib/net/_._"
       ]
     },
-    "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-rc2-23519": {
+    "runtime.win7.System.Security.Cryptography.Encoding/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "XCyNPBVf5WDw6POaNBoSZb4ChpkNMfg1cnCVRtjHxfJ6OwVwwhtBlymYObxw8cGn0U3Cz44JOewJ/7kyYhV9AA==",
+      "sha512": "fwjrSecPvxUhksPU8iIxjY8z5akm/KqTTCUWEETuka9WkaFCU1ktrqJI/UJrn+ImXBv87MbLYBblixdAYAr75g==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Security.Cryptography.Encoding.4.0.0-rc2-23519.nupkg",
-        "runtime.win7.System.Security.Cryptography.Encoding.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.Security.Cryptography.Encoding.4.0.0-rc2-23525.nupkg",
+        "runtime.win7.System.Security.Cryptography.Encoding.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.win7.System.Security.Cryptography.Encoding.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.Encoding.dll",
         "runtimes/win7/lib/net/_._"
       ]
     },
-    "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-rc2-23519": {
+    "runtime.win7.System.Security.Cryptography.X509Certificates/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "eTV/jF1bIopFz8v9TyyN3AGeLAdOpDgl87fNEcYrJOoWEkSx4+01vcfbLVkN57Vi5DW4MWyaI/Ok4Z5EcNVQcg==",
+      "sha512": "MstJY/cwJg4HYbUk+z+m8r1Ffw14Nsm8DD7QNxtNfXI99eFfvjDhn7ur8S7m5nTBk23EPsUfN9VAFESXTrv2fw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Security.Cryptography.X509Certificates.4.0.0-rc2-23519.nupkg",
-        "runtime.win7.System.Security.Cryptography.X509Certificates.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.Security.Cryptography.X509Certificates.4.0.0-rc2-23525.nupkg",
+        "runtime.win7.System.Security.Cryptography.X509Certificates.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.win7.System.Security.Cryptography.X509Certificates.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.Security.Cryptography.X509Certificates.dll",
         "runtimes/win7/lib/net/_._",
         "runtimes/win7/lib/netcore50/System.Security.Cryptography.X509Certificates.dll"
       ]
     },
-    "runtime.win7.System.Threading/4.0.11-rc2-23519": {
+    "runtime.win7.System.Threading/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "aAJLwf3AoW0qTWPnC/SDX/yqzcBZ2FJrsbySOR2CI7UqpE1XlDy7BGKm+d9S8Ux+J1+oUa3oBchgtvkl70ROlQ==",
+      "sha512": "gYFmKqjSPB2E2PpyEehCvovB6pPiRJbw04DwViGE7FGyrE0J9VsdeFTeIpzWcKiTg5pzdlvmUg100MIxfYWrjA==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Threading.4.0.11-rc2-23519.nupkg",
-        "runtime.win7.System.Threading.4.0.11-rc2-23519.nupkg.sha512",
+        "runtime.win7.System.Threading.4.0.11-rc2-23525.nupkg",
+        "runtime.win7.System.Threading.4.0.11-rc2-23525.nupkg.sha512",
         "runtime.win7.System.Threading.nuspec",
         "runtimes/win7/lib/DNXCore50/System.Threading.dll",
         "runtimes/win7/lib/netcore50/System.Threading.dll",
         "runtimes/win8-aot/lib/netcore50/System.Threading.dll"
       ]
     },
-    "runtime.win7-x64.Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23519": {
+    "runtime.win7-x64.Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23525": {
       "type": "package",
-      "sha512": "2HuO0W6nZipp0mGgtn2aTe92XL38JjlkqttP4O8oVcoMV+jJ8WC4dg1IMIZ688R4rRD7MUDzFX3+w+8K0IqIgA==",
+      "sha512": "VRCbAZoyDCJnId2Co8e1O1L8k6FY/3DiW03WysHRB62lOJTR1SU2PyOE88I0Y7WIt7NtH4kii9So2ZAEuwe7vA==",
       "files": [
-        "runtime.win7-x64.Microsoft.NETCore.ConsoleHost.1.0.0-rc2-23519.nupkg",
-        "runtime.win7-x64.Microsoft.NETCore.ConsoleHost.1.0.0-rc2-23519.nupkg.sha512",
+        "runtime.win7-x64.Microsoft.NETCore.ConsoleHost.1.0.0-rc2-23525.nupkg",
+        "runtime.win7-x64.Microsoft.NETCore.ConsoleHost.1.0.0-rc2-23525.nupkg.sha512",
         "runtime.win7-x64.Microsoft.NETCore.ConsoleHost.nuspec",
         "runtimes/win7-x64/native/CoreConsole.exe"
       ]
     },
-    "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23519": {
+    "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23525": {
       "type": "package",
-      "sha512": "6Gwnh3YR3O7QFzdeT3tnPfIIFC5uYQP5buwq5W/wXYjFbV4blCooUJzXzAbbm0+CjJkN9ZpX6fKAftxemNTFHw==",
+      "sha512": "qvtmJYA9gsb1P1thaEZ6GJnsQTW/neP9r91NnttKf7VFxJUOSf7RxzHmc7b3T4FY8zE0ESYgFPI6+pYUbZU9+g==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-rc2-23519.nupkg",
-        "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-rc2-23519.nupkg.sha512",
+        "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-rc2-23525.nupkg",
+        "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-rc2-23525.nupkg.sha512",
         "runtime.win7-x64.Microsoft.NETCore.Runtime.CoreCLR.nuspec",
         "runtimes/win7-x64/lib/dotnet/mscorlib.ni.dll",
         "runtimes/win7-x64/native/clretwrc.dll",
@@ -14249,22 +14418,22 @@
         "tools/sos.dll"
       ]
     },
-    "runtime.win7-x64.Microsoft.NETCore.TestHost/1.0.0-rc2-23519": {
+    "runtime.win7-x64.Microsoft.NETCore.TestHost/1.0.0-rc2-23525": {
       "type": "package",
-      "sha512": "pUKyupgXxWzw+Z/xnqTJrWdy9f+guW3MlEJ+9P72vsw5yp2JyGsUZXYqO1CjeHucX6Hs/4ZlFiJ2Mcxuo5cqzg==",
+      "sha512": "QFwuDQMs2mAkTj9DZEUZi+3gFdXOdFJmErXivMFf7BgMZ183yZkwyLc6hwCnSXHADJpiTSKuCp/U/H2tgQxCeQ==",
       "files": [
-        "runtime.win7-x64.Microsoft.NETCore.TestHost.1.0.0-rc2-23519.nupkg",
-        "runtime.win7-x64.Microsoft.NETCore.TestHost.1.0.0-rc2-23519.nupkg.sha512",
+        "runtime.win7-x64.Microsoft.NETCore.TestHost.1.0.0-rc2-23525.nupkg",
+        "runtime.win7-x64.Microsoft.NETCore.TestHost.1.0.0-rc2-23525.nupkg.sha512",
         "runtime.win7-x64.Microsoft.NETCore.TestHost.nuspec",
         "runtimes/win7-x64/native/CoreRun.exe"
       ]
     },
-    "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23519": {
+    "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23525": {
       "type": "package",
-      "sha512": "NKG1uM5G4sdKkGvn2mcBa4D7QWYh8fx9ycDXZFVQYH8+HLLvjjcf2hZ2071S152id8QCBVYrpnUZk+uSVR3MwQ==",
+      "sha512": "V1tkLjlDHNS+DyalpMGppXa8QASMhpMqvNQhyxtLKwJ+sG2M2eHYkGNZLJM8bDJ+C/FJC7hswqyH40htHzJFkA==",
       "files": [
-        "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets.1.0.1-rc2-23519.nupkg",
-        "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets.1.0.1-rc2-23519.nupkg.sha512",
+        "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets.1.0.1-rc2-23525.nupkg",
+        "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets.1.0.1-rc2-23525.nupkg.sha512",
         "runtime.win7-x64.Microsoft.NETCore.Windows.ApiSets.nuspec",
         "runtimes/win10-x64/native/_._",
         "runtimes/win7-x64/native/API-MS-Win-Base-Util-L1-1-0.dll",
@@ -14425,44 +14594,44 @@
         "runtimes/win8-x64/native/api-ms-win-service-private-l1-1-1.dll"
       ]
     },
-    "runtime.win7-x64.System.Data.SqlClient.sni/4.0.0-rc2-23519": {
+    "runtime.win7-x64.System.Data.SqlClient.sni/4.0.0-rc2-23525": {
       "type": "package",
-      "sha512": "cBfaQ3GlEwzpmn0xJG+PhliHPJp9mCvLVvf2J1OoPCpExFLtKjFxWZlC9Zk6bS1GgkIYrYCVLgGSXVWYLb+vpg==",
+      "sha512": "E/BinrBgWJYSDrOpS3AI8KfQIOiWzWB8NIpUO6FX/S/hUdxMBWKIiXnRGxzdvckE+1tPObDrMndkGzNbP2mwNg==",
       "files": [
-        "runtime.win7-x64.System.Data.SqlClient.sni.4.0.0-rc2-23519.nupkg",
-        "runtime.win7-x64.System.Data.SqlClient.sni.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.win7-x64.System.Data.SqlClient.sni.4.0.0-rc2-23525.nupkg",
+        "runtime.win7-x64.System.Data.SqlClient.sni.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.win7-x64.System.Data.SqlClient.sni.nuspec",
         "runtimes/win7-x64/native/sni.dll"
       ]
     },
-    "runtime.win7-x64.System.IO.Compression.clrcompression/4.0.1-rc2-23519": {
+    "runtime.win7-x64.System.IO.Compression.clrcompression/4.0.1-rc2-23525": {
       "type": "package",
-      "sha512": "o+MSWT3nHGUsRyK8JMhN/5SB5H7iPkgEvhqmDsoPcbKNZLrdDf7tJjeCub0BT1WIngIWYrW2o7WaQz70vsnhrQ==",
+      "sha512": "Pdja7Sk5Bx9R85JcayBdkIUAFJhpF0xQ3wnMb0yQa1E6ZILcC9elMlHGl+nf8ATnoS5bdAPMOoWvXgNIol9zLg==",
       "files": [
-        "runtime.win7-x64.System.IO.Compression.clrcompression.4.0.1-rc2-23519.nupkg",
-        "runtime.win7-x64.System.IO.Compression.clrcompression.4.0.1-rc2-23519.nupkg.sha512",
+        "runtime.win7-x64.System.IO.Compression.clrcompression.4.0.1-rc2-23525.nupkg",
+        "runtime.win7-x64.System.IO.Compression.clrcompression.4.0.1-rc2-23525.nupkg.sha512",
         "runtime.win7-x64.System.IO.Compression.clrcompression.nuspec",
         "runtimes/win10-x64/native/ClrCompression.dll",
         "runtimes/win7-x64/native/clrcompression.dll"
       ]
     },
-    "runtime.win7-x86.Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23519": {
+    "runtime.win7-x86.Microsoft.NETCore.ConsoleHost/1.0.0-rc2-23525": {
       "type": "package",
-      "sha512": "SPAs0+9jb8s92kS7hPhPsOPngBVUeMTvuspWR58FIPu16aqZ1++ntml22+9rCnt/qhd6Uj9q+uEQAZ+hHhRbYw==",
+      "sha512": "5ALQMpp2ZQCWIf0U4MILh1ebJbqMB3qgPEgxKkaSSGomiVd7ZN0Mf+70ZPTVHw8tA6P7Bd+mq2V9HWWCwNcbBw==",
       "files": [
-        "runtime.win7-x86.Microsoft.NETCore.ConsoleHost.1.0.0-rc2-23519.nupkg",
-        "runtime.win7-x86.Microsoft.NETCore.ConsoleHost.1.0.0-rc2-23519.nupkg.sha512",
+        "runtime.win7-x86.Microsoft.NETCore.ConsoleHost.1.0.0-rc2-23525.nupkg",
+        "runtime.win7-x86.Microsoft.NETCore.ConsoleHost.1.0.0-rc2-23525.nupkg.sha512",
         "runtime.win7-x86.Microsoft.NETCore.ConsoleHost.nuspec",
         "runtimes/win7-x86/native/CoreConsole.exe"
       ]
     },
-    "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23519": {
+    "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR/1.0.1-rc2-23525": {
       "type": "package",
-      "sha512": "8zHZaBAlGvTqP/RClNbnOedgJlj3bG5DzfTHKnGN2kEi9E2vNWyGBp6X61eXaNnFpAKre5cc3mCd+DaXwBzw3g==",
+      "sha512": "RghxtHfAddpdGijgxToMNdv+ltU5zERfly1/HEjCfnvgVl+iolmRqNGNYEs0Z5BYMrqzMCfqER/+tlFXsnQoLw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-rc2-23519.nupkg",
-        "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-rc2-23519.nupkg.sha512",
+        "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-rc2-23525.nupkg",
+        "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR.1.0.1-rc2-23525.nupkg.sha512",
         "runtime.win7-x86.Microsoft.NETCore.Runtime.CoreCLR.nuspec",
         "runtimes/win7-x86/lib/dotnet/mscorlib.ni.dll",
         "runtimes/win7-x86/native/clretwrc.dll",
@@ -14476,22 +14645,22 @@
         "tools/sos.dll"
       ]
     },
-    "runtime.win7-x86.Microsoft.NETCore.TestHost/1.0.0-rc2-23519": {
+    "runtime.win7-x86.Microsoft.NETCore.TestHost/1.0.0-rc2-23525": {
       "type": "package",
-      "sha512": "Pwt817MwcTEuTJVWmnhzXvSkLrzVLa1gPf16RlOLh10suuZeUdeVBBHxKijo7/SXR8meJutPrlgV7yfRVd34IA==",
+      "sha512": "ySAMFvl/k9yrNc0u1tYt+92KRZIR7RFOOnpWl5Vov24V3YIaGbgfRyNRNKEaY8BEa0H+aXquQwsDey1mAekSEA==",
       "files": [
-        "runtime.win7-x86.Microsoft.NETCore.TestHost.1.0.0-rc2-23519.nupkg",
-        "runtime.win7-x86.Microsoft.NETCore.TestHost.1.0.0-rc2-23519.nupkg.sha512",
+        "runtime.win7-x86.Microsoft.NETCore.TestHost.1.0.0-rc2-23525.nupkg",
+        "runtime.win7-x86.Microsoft.NETCore.TestHost.1.0.0-rc2-23525.nupkg.sha512",
         "runtime.win7-x86.Microsoft.NETCore.TestHost.nuspec",
         "runtimes/win7-x86/native/CoreRun.exe"
       ]
     },
-    "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23519": {
+    "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets/1.0.1-rc2-23525": {
       "type": "package",
-      "sha512": "LfRB96qg/pq29ZFs1qQaHlz5C1Rw4JdwBaXHNb8mjJ6+WZCF9yJ2o8lnxPDs4w7HdjRsE+ryxBkgA/k2BL67Ng==",
+      "sha512": "orphuu8topcXbJzhbAg9DP5A6AuC7oca7OKwlv74cE7zKT9GfYADr5aw/JbNkLescFs6UWMR1wNHDJOXTl80jw==",
       "files": [
-        "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets.1.0.1-rc2-23519.nupkg",
-        "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets.1.0.1-rc2-23519.nupkg.sha512",
+        "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets.1.0.1-rc2-23525.nupkg",
+        "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets.1.0.1-rc2-23525.nupkg.sha512",
         "runtime.win7-x86.Microsoft.NETCore.Windows.ApiSets.nuspec",
         "runtimes/win10-x86/native/_._",
         "runtimes/win7-x86/native/API-MS-Win-Base-Util-L1-1-0.dll",
@@ -14652,31 +14821,31 @@
         "runtimes/win8-x86/native/api-ms-win-service-private-l1-1-1.dll"
       ]
     },
-    "runtime.win7-x86.System.Data.SqlClient.sni/4.0.0-rc2-23519": {
+    "runtime.win7-x86.System.Data.SqlClient.sni/4.0.0-rc2-23525": {
       "type": "package",
-      "sha512": "83oMykWiM8hBun79TobREDenft3uO7Al74eyfJPoXbLcU7gFvP9ZBXqkk8NLSRJuzFeEEyHBB4GfenLtcdT6ug==",
+      "sha512": "1VeHGatCiWkre6/vBj0NCebdHO0XqYiqmYAernADF3mNEFF6mdIOPY4HcmMIBJcF/rtaBVAZSquMCMeHuCGqug==",
       "files": [
-        "runtime.win7-x86.System.Data.SqlClient.sni.4.0.0-rc2-23519.nupkg",
-        "runtime.win7-x86.System.Data.SqlClient.sni.4.0.0-rc2-23519.nupkg.sha512",
+        "runtime.win7-x86.System.Data.SqlClient.sni.4.0.0-rc2-23525.nupkg",
+        "runtime.win7-x86.System.Data.SqlClient.sni.4.0.0-rc2-23525.nupkg.sha512",
         "runtime.win7-x86.System.Data.SqlClient.sni.nuspec",
         "runtimes/win7-x86/native/sni.dll"
       ]
     },
-    "runtime.win7-x86.System.IO.Compression.clrcompression/4.0.1-rc2-23519": {
+    "runtime.win7-x86.System.IO.Compression.clrcompression/4.0.1-rc2-23525": {
       "type": "package",
-      "sha512": "G2F2VMQZouYnnMcS+uAopjPQ3/ynXK6z6BbvUjtzShzBIgtTS3gbvSISo9GAOHjA6ckKllZFSoTfpesDpbkxkA==",
+      "sha512": "4lagzf0U7BGPxqtcPXb1DatzbR6zvCJwjksY6XCMDSMLUVixz+/feQri1k1J0WwH25lN/lh6m0rTFYAJAb2Zfg==",
       "files": [
-        "runtime.win7-x86.System.IO.Compression.clrcompression.4.0.1-rc2-23519.nupkg",
-        "runtime.win7-x86.System.IO.Compression.clrcompression.4.0.1-rc2-23519.nupkg.sha512",
+        "runtime.win7-x86.System.IO.Compression.clrcompression.4.0.1-rc2-23525.nupkg",
+        "runtime.win7-x86.System.IO.Compression.clrcompression.4.0.1-rc2-23525.nupkg.sha512",
         "runtime.win7-x86.System.IO.Compression.clrcompression.nuspec",
         "runtimes/win10-x86/native/ClrCompression.dll",
         "runtimes/win7-x86/native/clrcompression.dll"
       ]
     },
-    "System.AppContext/4.0.1-rc2-23519": {
+    "System.AppContext/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "kuioxvVE9TdzLbSSw/07ovtyy5cNfplDuA7mJZ3DKBTc/tG4BCd0/w+vRAR+RNGd3CNgIp0Yfy63Sl1anUjuTQ==",
+      "sha512": "1AErxnp8ORCt1JmFgddMK5xYzIgfFE8yPRXXLRAHv43Dj6oHGsdE0sz4eB+lBkbLrzd+MWd/FJc6/t0It6qJxw==",
       "files": [
         "lib/DNXCore50/System.AppContext.dll",
         "lib/MonoAndroid10/_._",
@@ -14701,15 +14870,15 @@
         "ref/net46/System.AppContext.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.AppContext.4.0.1-rc2-23519.nupkg",
-        "System.AppContext.4.0.1-rc2-23519.nupkg.sha512",
+        "System.AppContext.4.0.1-rc2-23525.nupkg",
+        "System.AppContext.4.0.1-rc2-23525.nupkg.sha512",
         "System.AppContext.nuspec"
       ]
     },
-    "System.Collections/4.0.11-rc2-23519": {
+    "System.Collections/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "lne604hwPj/RBcKCiI9FUunDe+KX6B+p+ijsjCb9fvuDSVW7C31cimbExXGgbLydrmYlkDWNpqnOhVnYZiYkXw==",
+      "sha512": "xJmMbyH4afnSkGiOhTiSyAWL6j45yYDG3l63D3peganrFKvzln1ks7SGfERzBEPqKFHBDoJ7TlRpJQp40wJNUA==",
       "files": [
         "lib/DNXCore50/System.Collections.dll",
         "lib/MonoAndroid10/_._",
@@ -14763,15 +14932,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
-        "System.Collections.4.0.11-rc2-23519.nupkg",
-        "System.Collections.4.0.11-rc2-23519.nupkg.sha512",
+        "System.Collections.4.0.11-rc2-23525.nupkg",
+        "System.Collections.4.0.11-rc2-23525.nupkg.sha512",
         "System.Collections.nuspec"
       ]
     },
-    "System.Collections.Concurrent/4.0.11-rc2-23519": {
+    "System.Collections.Concurrent/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "zjCzo48tz3MPbyZPJBfaBXiKKTfveA3CqNTYGOvb8XlWqipjvCg+VQ1Dwy6iZ2XgO6wIjoKmLK+s7fSAG3fseA==",
+      "sha512": "rJUILubHbGrHU1CNoZwUpJQjTL5XgG7BNT5hwQbN9fNLIWh/8t6jqUNE6pGoEg/N/l8vBeFXwfVnzrjAlFfTHA==",
       "files": [
         "lib/dotnet5.4/System.Collections.Concurrent.dll",
         "lib/MonoAndroid10/_._",
@@ -14822,29 +14991,29 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Collections.Concurrent.4.0.11-rc2-23519.nupkg",
-        "System.Collections.Concurrent.4.0.11-rc2-23519.nupkg.sha512",
+        "System.Collections.Concurrent.4.0.11-rc2-23525.nupkg",
+        "System.Collections.Concurrent.4.0.11-rc2-23525.nupkg.sha512",
         "System.Collections.Concurrent.nuspec"
       ]
     },
-    "System.Collections.Immutable/1.1.38-rc2-23519": {
+    "System.Collections.Immutable/1.1.38-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "FyKvqXYvvauXhT77+KW3WysO8y7QvnqaZ3E2Ma2t0V2lEFDODPi6XwNRsCcn48EFG+NdEMxmV7P11F39/Pcktw==",
+      "sha512": "D7Rms4xeaQwV6BdPBPEN4Di64VRPKF7MgaodKyUKI2OL15Uhe1+WBwmEhiLv1VAO/lCryIzzhegf3k8OPZYJvw==",
       "files": [
         "lib/dotnet5.1/System.Collections.Immutable.dll",
         "lib/dotnet5.1/System.Collections.Immutable.xml",
         "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.dll",
         "lib/portable-net45+win8+wp8+wpa81/System.Collections.Immutable.xml",
-        "System.Collections.Immutable.1.1.38-rc2-23519.nupkg",
-        "System.Collections.Immutable.1.1.38-rc2-23519.nupkg.sha512",
+        "System.Collections.Immutable.1.1.38-rc2-23525.nupkg",
+        "System.Collections.Immutable.1.1.38-rc2-23525.nupkg.sha512",
         "System.Collections.Immutable.nuspec"
       ]
     },
-    "System.Collections.NonGeneric/4.0.1-rc2-23519": {
+    "System.Collections.NonGeneric/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "t7IE2j0cXH6BWiuDwMTd3gTP5RpFs62ymNMjR0lQ/igdW0qVf7p7WCJbRdSjvWZ1wz5cM/xSsL0+t1aznlRvAw==",
+      "sha512": "B4/jo1I3ZcNeMfBdr84PLpv6UXyjbYtVLB8SBHzGaM4VbMctxYaMsFpL2DhBh26Bt2opKOdESr52vrFBI7sk6w==",
       "files": [
         "lib/dotnet5.4/System.Collections.NonGeneric.dll",
         "lib/MonoAndroid10/_._",
@@ -14868,15 +15037,15 @@
         "ref/net46/System.Collections.NonGeneric.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Collections.NonGeneric.4.0.1-rc2-23519.nupkg",
-        "System.Collections.NonGeneric.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Collections.NonGeneric.4.0.1-rc2-23525.nupkg",
+        "System.Collections.NonGeneric.4.0.1-rc2-23525.nupkg.sha512",
         "System.Collections.NonGeneric.nuspec"
       ]
     },
-    "System.Collections.Specialized/4.0.1-rc2-23519": {
+    "System.Collections.Specialized/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "XsgNnvSwuFlJhaH9QlzqN04t7i5eaDLdnfO1MHFW9K3adYLVtvb29zTa3v9FJ8AHjFbdVK/SyowpHym3okuFmQ==",
+      "sha512": "181sGCjQuQoCKX4AHfiUF1z1OId3wPIWV4TzZUHqbDDiRV8W7byGLwDU/FsnyWrGiaonBl4jONsigdNvkipPiA==",
       "files": [
         "lib/dotnet5.4/System.Collections.Specialized.dll",
         "lib/MonoAndroid10/_._",
@@ -14900,15 +15069,15 @@
         "ref/net46/System.Collections.Specialized.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Collections.Specialized.4.0.1-rc2-23519.nupkg",
-        "System.Collections.Specialized.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Collections.Specialized.4.0.1-rc2-23525.nupkg",
+        "System.Collections.Specialized.4.0.1-rc2-23525.nupkg.sha512",
         "System.Collections.Specialized.nuspec"
       ]
     },
-    "System.ComponentModel/4.0.1-rc2-23519": {
+    "System.ComponentModel/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "tj6+RM61FahRQXz1u4C4aO4eRv5WsYSiEj2xqGHI5ttp1tgNg7nTXc2nMfgUuiN44jQhei7wNMU97G6+PSkPhg==",
+      "sha512": "QJ3RnKbTPqJ64NH+VQ15URBa0XlJHUdM6whX1C12nLhdJ48c4P1lMpJCWHxPbUJuj4MCn+0eAqUxi4UZ/hzokA==",
       "files": [
         "lib/dotnet5.4/System.ComponentModel.dll",
         "lib/net45/_._",
@@ -14942,15 +15111,15 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "System.ComponentModel.4.0.1-rc2-23519.nupkg",
-        "System.ComponentModel.4.0.1-rc2-23519.nupkg.sha512",
+        "System.ComponentModel.4.0.1-rc2-23525.nupkg",
+        "System.ComponentModel.4.0.1-rc2-23525.nupkg.sha512",
         "System.ComponentModel.nuspec"
       ]
     },
-    "System.ComponentModel.Annotations/4.1.0-rc2-23519": {
+    "System.ComponentModel.Annotations/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "x+dcEhc03Po9Dgxm9Z9CKgeOypMPR0WkqDS9cUotxaQ4I6SnPCRdrEwO3uJdyNSPGdeZZ5JCyzVFkqP7dspBSg==",
+      "sha512": "awi3i86IirYxlQFJXzLOzFP077W8hmgb+ggG7fPH0qejq+SygNsdEWHj2oN80KXa3F9NmgHovhoxBVBseT/cuw==",
       "files": [
         "lib/dotnet5.4/System.ComponentModel.Annotations.dll",
         "lib/MonoAndroid10/_._",
@@ -15001,15 +15170,15 @@
         "ref/win8/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ComponentModel.Annotations.4.1.0-rc2-23519.nupkg",
-        "System.ComponentModel.Annotations.4.1.0-rc2-23519.nupkg.sha512",
+        "System.ComponentModel.Annotations.4.1.0-rc2-23525.nupkg",
+        "System.ComponentModel.Annotations.4.1.0-rc2-23525.nupkg.sha512",
         "System.ComponentModel.Annotations.nuspec"
       ]
     },
-    "System.ComponentModel.EventBasedAsync/4.0.11-rc2-23519": {
+    "System.ComponentModel.EventBasedAsync/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "3RE32XDSxcngDwMoLz6yu0n5ry0a92rbw96EmFXxZR6PrYGZhGiGQuNOp2yL88grjc8+plmcAFQ/rD2neKghxA==",
+      "sha512": "jyoufjblo7+s10prYv8qi8u1w1ZorOieb0LkOoIirrfJJRx7akTw1i0wB6wAEEWNVfRTTSNX7cc6i+IXe+EgEw==",
       "files": [
         "lib/dotnet5.4/System.ComponentModel.EventBasedAsync.dll",
         "lib/MonoAndroid10/_._",
@@ -15062,15 +15231,15 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ComponentModel.EventBasedAsync.4.0.11-rc2-23519.nupkg",
-        "System.ComponentModel.EventBasedAsync.4.0.11-rc2-23519.nupkg.sha512",
+        "System.ComponentModel.EventBasedAsync.4.0.11-rc2-23525.nupkg",
+        "System.ComponentModel.EventBasedAsync.4.0.11-rc2-23525.nupkg.sha512",
         "System.ComponentModel.EventBasedAsync.nuspec"
       ]
     },
-    "System.Console/4.0.0-rc2-23519": {
+    "System.Console/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "kcV3vk5iNVYL5Bj2cHjeC2ySZIHkARUaPdkkW4Vg93BWmK31p2XjsTMNEsZASthda7gRJF7yrSASjmoYSt7syg==",
+      "sha512": "ayoM54TltBsmGiH4U4vq4OukgUWesBraaMpaRlA1epjQgDVIVCrtSCsUr603ICPJqU2EdpX4/rFnQFys0DEtqg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15094,15 +15263,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Console.4.0.0-rc2-23519.nupkg",
-        "System.Console.4.0.0-rc2-23519.nupkg.sha512",
+        "System.Console.4.0.0-rc2-23525.nupkg",
+        "System.Console.4.0.0-rc2-23525.nupkg.sha512",
         "System.Console.nuspec"
       ]
     },
-    "System.Data.Common/4.0.1-rc2-23519": {
+    "System.Data.Common/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Cw1CKerQ+iriGkjkxjUBmaBPXjXQ1YGjU3x4DHzqN4B3TUIzOh42khuohVF34dgDNK7NDpOahAbg3PGg5EVdxg==",
+      "sha512": "Ito7lgYXvl7+EJCGXRGioWTms0RuauMraoKsq5sHDV30tLsrNL950SOF1oDkhOX0Wqr5t6ik/FryH0hQAcQ61A==",
       "files": [
         "lib/dotnet5.4/System.Data.Common.dll",
         "lib/MonoAndroid10/_._",
@@ -15126,15 +15295,15 @@
         "ref/net46/System.Data.Common.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Data.Common.4.0.1-rc2-23519.nupkg",
-        "System.Data.Common.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Data.Common.4.0.1-rc2-23525.nupkg",
+        "System.Data.Common.4.0.1-rc2-23525.nupkg.sha512",
         "System.Data.Common.nuspec"
       ]
     },
-    "System.Data.SqlClient/4.0.0-rc2-23519": {
+    "System.Data.SqlClient/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "WJ+ENfLt/F3dVrOdqlmyY9M+0fK8G/azOHFX10YgDtAYHECpj486oU34Sh18jwkvWn53blI3TAAWl4qE06Idqg==",
+      "sha512": "afUFSDlbNUCPdroghqousIgBQZ86lZ3kNsY62+jBAA2avIslnLAmpsTXLDAGJ9k9dHaZGGPf1dcepceTcqJjGA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15158,15 +15327,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Data.SqlClient.4.0.0-rc2-23519.nupkg",
-        "System.Data.SqlClient.4.0.0-rc2-23519.nupkg.sha512",
+        "System.Data.SqlClient.4.0.0-rc2-23525.nupkg",
+        "System.Data.SqlClient.4.0.0-rc2-23525.nupkg.sha512",
         "System.Data.SqlClient.nuspec"
       ]
     },
-    "System.Diagnostics.Contracts/4.0.1-rc2-23519": {
+    "System.Diagnostics.Contracts/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "mTkx5Wv+ZEWGye3wcbRH5UecTkF7VPm+n9U/0Ixu5J84yPFeFb1W4D0J6EpDCaAUQomZl48n4KvyfLG+M2g5oQ==",
+      "sha512": "uhZEFk/Gp276noaTo3R2xwQsrA/k0Sq3O/ov4D4Io4OHmCzXwRXOk24y9J/ZgwuSn0PMaoxiYH7knPvgPeYMTQ==",
       "files": [
         "lib/DNXCore50/System.Diagnostics.Contracts.dll",
         "lib/net45/_._",
@@ -15201,15 +15370,15 @@
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
-        "System.Diagnostics.Contracts.4.0.1-rc2-23519.nupkg",
-        "System.Diagnostics.Contracts.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Diagnostics.Contracts.4.0.1-rc2-23525.nupkg",
+        "System.Diagnostics.Contracts.4.0.1-rc2-23525.nupkg.sha512",
         "System.Diagnostics.Contracts.nuspec"
       ]
     },
-    "System.Diagnostics.Debug/4.0.11-rc2-23519": {
+    "System.Diagnostics.Debug/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Bl1vGktRteEdKH1eXjxhef1BnuErr8Kn+evskU9OVErBLjd60bZcnWr+HUS9K3n1vmWlwruc9glyQif7qiOGMA==",
+      "sha512": "T/wq74JBg48B5FU5R1bOW0cTyclAXL5GAqF/jehLxM65Sc8cNmJ8GMAQvjmmIa6mwmRF27U63Gs1UeiV0QtkjQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15261,15 +15430,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Diagnostics.Debug.4.0.11-rc2-23519.nupkg",
-        "System.Diagnostics.Debug.4.0.11-rc2-23519.nupkg.sha512",
+        "System.Diagnostics.Debug.4.0.11-rc2-23525.nupkg",
+        "System.Diagnostics.Debug.4.0.11-rc2-23525.nupkg.sha512",
         "System.Diagnostics.Debug.nuspec"
       ]
     },
-    "System.Diagnostics.FileVersionInfo/4.0.0-rc2-23519": {
+    "System.Diagnostics.FileVersionInfo/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "m1G5gHUDGifL6tK3UXRT6Ac9NjzHccF1HRf5KM74RWUYlnLC9CvBSzGDJzIds3NCJDOADNm7hz8AxVh2VjdZTg==",
+      "sha512": "JmeYHfaTvPpwa+HmazAiH0Rpu+x4QJDStUCF/IiNEGVVq1IE/nVdqJg3+eeOgr4pdr4I6unbRc6nWh5nvnhg1A==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15293,15 +15462,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Diagnostics.FileVersionInfo.4.0.0-rc2-23519.nupkg",
-        "System.Diagnostics.FileVersionInfo.4.0.0-rc2-23519.nupkg.sha512",
+        "System.Diagnostics.FileVersionInfo.4.0.0-rc2-23525.nupkg",
+        "System.Diagnostics.FileVersionInfo.4.0.0-rc2-23525.nupkg.sha512",
         "System.Diagnostics.FileVersionInfo.nuspec"
       ]
     },
-    "System.Diagnostics.Process/4.1.0-rc2-23519": {
+    "System.Diagnostics.Process/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "PXJlMWrL9DQJ2GYiN9b2+EZeDqz0EpHKTjU4G7TxSUThqQt5lNkb5x4jFuxrWK/45zJ74KIPsH4nei3G8IxcIQ==",
+      "sha512": "taHrkCNmbRw32tSB4VwTFecO61EQ4V+qkgdzkZaXQsZeO6cCZ7MRglnBlPhdnUBzX30CmdeSmgpuElOTF3Mdrw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15338,15 +15507,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Diagnostics.Process.4.1.0-rc2-23519.nupkg",
-        "System.Diagnostics.Process.4.1.0-rc2-23519.nupkg.sha512",
+        "System.Diagnostics.Process.4.1.0-rc2-23525.nupkg",
+        "System.Diagnostics.Process.4.1.0-rc2-23525.nupkg.sha512",
         "System.Diagnostics.Process.nuspec"
       ]
     },
-    "System.Diagnostics.StackTrace/4.0.1-rc2-23519": {
+    "System.Diagnostics.StackTrace/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "7+xjiVLYx9WwXAfuRHtJHQLG9WSCUIB39IV9nLrpBJwuLo/EFJ8bAc9xtRMk3snA2GBvsT7tgfQtb+wpFnkEtA==",
+      "sha512": "PGYnviu3fGe8kseJAVMjVbFS2rwJ1QmGUJdNB/TTfj4pFodisoJRvLw3RIKTKiW2WbwXPy7leB14+MGqIRUPRA==",
       "files": [
         "lib/DNXCore50/System.Diagnostics.StackTrace.dll",
         "lib/MonoAndroid10/_._",
@@ -15372,15 +15541,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Diagnostics.StackTrace.dll",
-        "System.Diagnostics.StackTrace.4.0.1-rc2-23519.nupkg",
-        "System.Diagnostics.StackTrace.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Diagnostics.StackTrace.4.0.1-rc2-23525.nupkg",
+        "System.Diagnostics.StackTrace.4.0.1-rc2-23525.nupkg.sha512",
         "System.Diagnostics.StackTrace.nuspec"
       ]
     },
-    "System.Diagnostics.Tools/4.0.1-rc2-23519": {
+    "System.Diagnostics.Tools/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Z7L/VIQCtYt4P/Evv4wmp44D+kyxlcNK8QJByfhBwICCqUZY2CMJf5KXhDoatoHos3ZACOG6a9CywZK99qKVcA==",
+      "sha512": "Bh9ra6Wpewj2XAkbCjrSemxNqLqCCoAO/1+l/RQZuQlSZ2v9x/bpnA6IEgan8JX35gJpGJc1rmgAdQl2KFpWwA==",
       "files": [
         "lib/DNXCore50/System.Diagnostics.Tools.dll",
         "lib/net45/_._",
@@ -15415,15 +15584,15 @@
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
-        "System.Diagnostics.Tools.4.0.1-rc2-23519.nupkg",
-        "System.Diagnostics.Tools.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Diagnostics.Tools.4.0.1-rc2-23525.nupkg",
+        "System.Diagnostics.Tools.4.0.1-rc2-23525.nupkg.sha512",
         "System.Diagnostics.Tools.nuspec"
       ]
     },
-    "System.Diagnostics.Tracing/4.0.21-rc2-23519": {
+    "System.Diagnostics.Tracing/4.0.21-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ztR7SnfeDvzYIuKeCHfvC07aRGGQ+wUG/xfBtv5ZQrBXWe2B++u6KZDOgP8dBQIfl/rhoymSPZbTSvAwkGk/iw==",
+      "sha512": "8Ig1eiAmYUbhniRIO58L8tQLSpeXKaXt9ky21kC7BUwzeS2ypiG3PtxTNwUe8H/LNCfCGjRCxwtEsDNZ0zH7RA==",
       "files": [
         "lib/DNXCore50/System.Diagnostics.Tracing.dll",
         "lib/MonoAndroid10/_._",
@@ -15486,15 +15655,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tracing.dll",
-        "System.Diagnostics.Tracing.4.0.21-rc2-23519.nupkg",
-        "System.Diagnostics.Tracing.4.0.21-rc2-23519.nupkg.sha512",
+        "System.Diagnostics.Tracing.4.0.21-rc2-23525.nupkg",
+        "System.Diagnostics.Tracing.4.0.21-rc2-23525.nupkg.sha512",
         "System.Diagnostics.Tracing.nuspec"
       ]
     },
-    "System.Dynamic.Runtime/4.0.11-rc2-23519": {
+    "System.Dynamic.Runtime/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "EEZZbcQ0/vm+fk+gF7ZKj/vMevdcHs9rwnJ6dKle3ORAhcv8q0EXqK1sF/jWvj0GO/DVsRxsGQPm6BBrhuXldQ==",
+      "sha512": "+OMQBIOXgovK8BPkqIFi95NRT+bYiHaixL3WwPVohqex4Hp4UuEYsJPS91ljtEkBMYO8a34B2FeSRqecWOCMLg==",
       "files": [
         "lib/DNXCore50/System.Dynamic.Runtime.dll",
         "lib/MonoAndroid10/_._",
@@ -15548,15 +15717,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Dynamic.Runtime.dll",
-        "System.Dynamic.Runtime.4.0.11-rc2-23519.nupkg",
-        "System.Dynamic.Runtime.4.0.11-rc2-23519.nupkg.sha512",
+        "System.Dynamic.Runtime.4.0.11-rc2-23525.nupkg",
+        "System.Dynamic.Runtime.4.0.11-rc2-23525.nupkg.sha512",
         "System.Dynamic.Runtime.nuspec"
       ]
     },
-    "System.Globalization/4.0.11-rc2-23519": {
+    "System.Globalization/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "XRWQ327g3mi22yZyeLWtI4OYGzKoG0YgcBFXhkWggxIIe8W3nOMG4DVBqUEnUKw9Of5xZ+rTXbmOZNSM2ik4lA==",
+      "sha512": "oy7h7UsvcRRdmRL0vzNHwCSqQVP6Np80oRKRPJplTFtpfxnjj1O7nkkxl0So7nQnSE6lrE4a5SH7dFAjEH6Ncg==",
       "files": [
         "lib/DNXCore50/System.Globalization.dll",
         "lib/MonoAndroid10/_._",
@@ -15610,15 +15779,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
-        "System.Globalization.4.0.11-rc2-23519.nupkg",
-        "System.Globalization.4.0.11-rc2-23519.nupkg.sha512",
+        "System.Globalization.4.0.11-rc2-23525.nupkg",
+        "System.Globalization.4.0.11-rc2-23525.nupkg.sha512",
         "System.Globalization.nuspec"
       ]
     },
-    "System.Globalization.Calendars/4.0.1-rc2-23519": {
+    "System.Globalization.Calendars/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "6HuIVtag5pgPcXamxwuPxO2bzvuXQU7DF4EWZACQ7p50zRjlA1wzBkfAigH+fwVKsh0ezOE8+xNeYwV2LO+BYg==",
+      "sha512": "eihNYdFXSPPNzguVv7e87k/BELRgckzcTZOadv6kmeRj8ZkVDqRHm8+r43OxhTS3qS0hLz0yIuyz7yOtARNxYg==",
       "files": [
         "lib/DNXCore50/System.Globalization.Calendars.dll",
         "lib/MonoAndroid10/_._",
@@ -15644,15 +15813,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Globalization.Calendars.dll",
-        "System.Globalization.Calendars.4.0.1-rc2-23519.nupkg",
-        "System.Globalization.Calendars.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Globalization.Calendars.4.0.1-rc2-23525.nupkg",
+        "System.Globalization.Calendars.4.0.1-rc2-23525.nupkg.sha512",
         "System.Globalization.Calendars.nuspec"
       ]
     },
-    "System.Globalization.Extensions/4.0.1-rc2-23519": {
+    "System.Globalization.Extensions/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "QTIBuSJwZAPwTxNTUZ/1RgXsgVHfLP3czThHmKCfzpMby/zfrHgmKCTzEHvH74PRl9fIqFhHcj2Fi1C9/5RdMw==",
+      "sha512": "WcX9wVjeAPI6Aiuz0UGdIS7abeu/XQRm0yK/ff8nr7cJn5wx69ACoF0/SHkfB1HrW4WDUQiKzgRpE8DDl6VSDw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15676,15 +15845,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Globalization.Extensions.4.0.1-rc2-23519.nupkg",
-        "System.Globalization.Extensions.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Globalization.Extensions.4.0.1-rc2-23525.nupkg",
+        "System.Globalization.Extensions.4.0.1-rc2-23525.nupkg.sha512",
         "System.Globalization.Extensions.nuspec"
       ]
     },
-    "System.IO/4.0.11-rc2-23519": {
+    "System.IO/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "uVzAQIjmBvUmqtd7Ajydp+JguIud3QW4dFQ7IPPzbau5sfZe99IL74c2xHAhWE6O/6MZN4dFeuUl5GaZ2muZNw==",
+      "sha512": "Brlv6E7ndUEBPH28OXf9EULgyMXTu6I3+NwbXiVneltgClANm/tmjZIAvJZpkCW2WQPMxRgaJlhngXqaYOM4ww==",
       "files": [
         "lib/DNXCore50/System.IO.dll",
         "lib/MonoAndroid10/_._",
@@ -15738,15 +15907,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.IO.dll",
-        "System.IO.4.0.11-rc2-23519.nupkg",
-        "System.IO.4.0.11-rc2-23519.nupkg.sha512",
+        "System.IO.4.0.11-rc2-23525.nupkg",
+        "System.IO.4.0.11-rc2-23525.nupkg.sha512",
         "System.IO.nuspec"
       ]
     },
-    "System.IO.Compression/4.1.0-rc2-23519": {
+    "System.IO.Compression/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2JK7ANhlKQDcE81r8/i9GHsJdgIqpoc7X1VByodXcw74jnKdhXfFe5NR9/odmN9p8HzY1NMCsPd/zyj1kqMHKg==",
+      "sha512": "QpUw8KvDwaUqgFfVQlOlC9nNR6kOP43+SD9eKulS3kKPMwzWTua96bAG6oqrl71a8tzMCi6fGtSxP/PSZkxfTA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15798,15 +15967,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.IO.Compression.4.1.0-rc2-23519.nupkg",
-        "System.IO.Compression.4.1.0-rc2-23519.nupkg.sha512",
+        "System.IO.Compression.4.1.0-rc2-23525.nupkg",
+        "System.IO.Compression.4.1.0-rc2-23525.nupkg.sha512",
         "System.IO.Compression.nuspec"
       ]
     },
-    "System.IO.Compression.ZipFile/4.0.1-rc2-23519": {
+    "System.IO.Compression.ZipFile/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "GvvM5NHQI0E31CaDPdVwU2clEdQTwsusIUl2obxXQM1cGZworGIILwiyUsA2I5YKUUnBv+nLZmbc7wnGkCMfuA==",
+      "sha512": "gq7h6bt97aPFWQNvsQ51p7e1BAkxSofaHWqGRFk4xweNrnob1o9D2ZADkiHfb9EWsxd7Cv3lss/xg/NbczM7FA==",
       "files": [
         "lib/dotnet5.4/System.IO.Compression.ZipFile.dll",
         "lib/MonoAndroid10/_._",
@@ -15830,15 +15999,15 @@
         "ref/net46/System.IO.Compression.ZipFile.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.IO.Compression.ZipFile.4.0.1-rc2-23519.nupkg",
-        "System.IO.Compression.ZipFile.4.0.1-rc2-23519.nupkg.sha512",
+        "System.IO.Compression.ZipFile.4.0.1-rc2-23525.nupkg",
+        "System.IO.Compression.ZipFile.4.0.1-rc2-23525.nupkg.sha512",
         "System.IO.Compression.ZipFile.nuspec"
       ]
     },
-    "System.IO.FileSystem/4.0.1-rc2-23519": {
+    "System.IO.FileSystem/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "U9xYw3/+QV/AOMduFbo8rkQsm0y6ufvGfruRpZJeYxNRyh4uxyapAfm875MFYch8l1EdgSk4b7mwRSa7Muox+A==",
+      "sha512": "5x8A7ETeRtOmeqfUr36T20yJR+JHkd9M8275UTOyUylO1RRFDdIDiNYeCnZlFJpDCFMDxDa6g8OgiWYxJzAqfw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15862,15 +16031,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.IO.FileSystem.4.0.1-rc2-23519.nupkg",
-        "System.IO.FileSystem.4.0.1-rc2-23519.nupkg.sha512",
+        "System.IO.FileSystem.4.0.1-rc2-23525.nupkg",
+        "System.IO.FileSystem.4.0.1-rc2-23525.nupkg.sha512",
         "System.IO.FileSystem.nuspec"
       ]
     },
-    "System.IO.FileSystem.DriveInfo/4.0.0-rc2-23519": {
+    "System.IO.FileSystem.DriveInfo/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "GtJdAJjmtVSBFX5i/pesVxgiTZIZA9dx8Nt3M+Ey+vXJK2GXMfQFw2mXwayvg/n1AcnLAJa0pvnytnydm36dog==",
+      "sha512": "CJUox/KuHtgGW2VPrrlItK+sd1ilYYaZBH8rGXt8fllHBoKT35UrjFe4WwChkf6OM/S+wWBqhn10nUh75cH0Ww==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15894,15 +16063,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.IO.FileSystem.DriveInfo.4.0.0-rc2-23519.nupkg",
-        "System.IO.FileSystem.DriveInfo.4.0.0-rc2-23519.nupkg.sha512",
+        "System.IO.FileSystem.DriveInfo.4.0.0-rc2-23525.nupkg",
+        "System.IO.FileSystem.DriveInfo.4.0.0-rc2-23525.nupkg.sha512",
         "System.IO.FileSystem.DriveInfo.nuspec"
       ]
     },
-    "System.IO.FileSystem.Primitives/4.0.1-rc2-23519": {
+    "System.IO.FileSystem.Primitives/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "vc/DaI0kcOOAfrMqCBRVStUyqZh6hFmXIQy/SghS5wsvbo/lfrg2982wZ49Th/j56Ujh4ZhlRT41iXCuCv4JfQ==",
+      "sha512": "fV65b2r3pwlWSSWApSrYxGKCYNmAinm+Oesaq29llzw0MrxhzltVGCV+ck4LPcAbrTr4vU6gXe0xtg26lWa5Uw==",
       "files": [
         "lib/dotnet5.4/System.IO.FileSystem.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -15926,15 +16095,15 @@
         "ref/net46/System.IO.FileSystem.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.IO.FileSystem.Primitives.4.0.1-rc2-23519.nupkg",
-        "System.IO.FileSystem.Primitives.4.0.1-rc2-23519.nupkg.sha512",
+        "System.IO.FileSystem.Primitives.4.0.1-rc2-23525.nupkg",
+        "System.IO.FileSystem.Primitives.4.0.1-rc2-23525.nupkg.sha512",
         "System.IO.FileSystem.Primitives.nuspec"
       ]
     },
-    "System.IO.FileSystem.Watcher/4.0.0-rc2-23519": {
+    "System.IO.FileSystem.Watcher/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "seCWxet0vlVRVWqx/VBJZB/0nt8iUDeFrj9bmk/nSAUqeCkHrE8qWyfUNlLBL41HVY4kDkVDeRypkyBTSlyPYg==",
+      "sha512": "uR9aLtA94ZLN205daRhvvvWVy1GwvqhsHpkvTQAgtAjbX5oZgR4VrOzNVubWjmKTTU8fZluxzL4oiNLqqzxqjA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15958,15 +16127,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.IO.FileSystem.Watcher.4.0.0-rc2-23519.nupkg",
-        "System.IO.FileSystem.Watcher.4.0.0-rc2-23519.nupkg.sha512",
+        "System.IO.FileSystem.Watcher.4.0.0-rc2-23525.nupkg",
+        "System.IO.FileSystem.Watcher.4.0.0-rc2-23525.nupkg.sha512",
         "System.IO.FileSystem.Watcher.nuspec"
       ]
     },
-    "System.IO.MemoryMappedFiles/4.0.0-rc2-23519": {
+    "System.IO.MemoryMappedFiles/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "yw0u8dXNI+ZeNjX8N7Hvaw5YdFFXVkGChvays5Vbr6SNcdQbGi50azSgkqaG62wO7l9rzPtxtvk5ltUu5kXuJw==",
+      "sha512": "nPfGjsL1Ml17g//8aXDNHt1A1TM3tzYYd+NwmJSUB5Nlddr6FCSSsdtfdcVkLn8a/1ly6IcVKi8tJIsbNrLq4g==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -15990,15 +16159,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.IO.MemoryMappedFiles.4.0.0-rc2-23519.nupkg",
-        "System.IO.MemoryMappedFiles.4.0.0-rc2-23519.nupkg.sha512",
+        "System.IO.MemoryMappedFiles.4.0.0-rc2-23525.nupkg",
+        "System.IO.MemoryMappedFiles.4.0.0-rc2-23525.nupkg.sha512",
         "System.IO.MemoryMappedFiles.nuspec"
       ]
     },
-    "System.IO.Pipes/4.0.0-rc2-23519": {
+    "System.IO.Pipes/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "+pADh5gZtHNgWRg7J4jlvid1oivitypxzJnv5pYeMvi88M3gnBw3y6WDZjYyb1Xp6acyQcbYkIBavauF3nssdQ==",
+      "sha512": "jEp/SNFuWo0VMaqY2oCfUrRfHmHxeftx7iIPT2hEZI8t19c3hm8MJ6CTlsbbWg4aarP5kKclaO+y7YXM/EIGwQ==",
       "files": [
         "lib/net46/System.IO.Pipes.dll",
         "ref/dotnet5.4/de/System.IO.Pipes.xml",
@@ -16014,15 +16183,15 @@
         "ref/dotnet5.4/zh-hant/System.IO.Pipes.xml",
         "ref/net46/System.IO.Pipes.dll",
         "runtime.json",
-        "System.IO.Pipes.4.0.0-rc2-23519.nupkg",
-        "System.IO.Pipes.4.0.0-rc2-23519.nupkg.sha512",
+        "System.IO.Pipes.4.0.0-rc2-23525.nupkg",
+        "System.IO.Pipes.4.0.0-rc2-23525.nupkg.sha512",
         "System.IO.Pipes.nuspec"
       ]
     },
-    "System.IO.UnmanagedMemoryStream/4.0.1-rc2-23519": {
+    "System.IO.UnmanagedMemoryStream/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "zpblH404F41GPQ8gXOozDzkVphx+CmmtTw0fAOLmw8WvNHPdkFOtXtD97GB5jJq8z7a3asNpk/en5iTQaMX9PA==",
+      "sha512": "mAtMhHPUuZo0+1baYCCRNjoN6GyG117OcXzmFbWvwwRTHYwU1ZEXlLuXcjjG4LTlFVaLB0//QVrbjq6rpHPFzQ==",
       "files": [
         "lib/dotnet5.4/System.IO.UnmanagedMemoryStream.dll",
         "lib/MonoAndroid10/_._",
@@ -16046,15 +16215,15 @@
         "ref/net46/System.IO.UnmanagedMemoryStream.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.IO.UnmanagedMemoryStream.4.0.1-rc2-23519.nupkg",
-        "System.IO.UnmanagedMemoryStream.4.0.1-rc2-23519.nupkg.sha512",
+        "System.IO.UnmanagedMemoryStream.4.0.1-rc2-23525.nupkg",
+        "System.IO.UnmanagedMemoryStream.4.0.1-rc2-23525.nupkg.sha512",
         "System.IO.UnmanagedMemoryStream.nuspec"
       ]
     },
-    "System.Linq/4.0.1-rc2-23519": {
+    "System.Linq/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "T5zZIpnWnSd9uT3+9nFlQxWH9NfQFdS+ogLUXf6SQv4thHolrqxToQ6F6+EHONpZgCKWyNPTE8vBsDFghcRjQg==",
+      "sha512": "nxeyB3ycuQRIyRb/EVh+IEBN4heKR5LGo3+NvQl0/nJs/nIJym4Yb+pqHjhMAFwv9L7KoUIanhg1uRES7+IaQQ==",
       "files": [
         "lib/dotnet5.4/System.Linq.dll",
         "lib/net45/_._",
@@ -16088,15 +16257,15 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "System.Linq.4.0.1-rc2-23519.nupkg",
-        "System.Linq.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Linq.4.0.1-rc2-23525.nupkg",
+        "System.Linq.4.0.1-rc2-23525.nupkg.sha512",
         "System.Linq.nuspec"
       ]
     },
-    "System.Linq.Expressions/4.0.11-rc2-23519": {
+    "System.Linq.Expressions/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "7nbIhlGhGY6nRO3uEMZxkQaoOCHD+iN4yDqt0HKTEzaUXNQ006dRFuQodAvDPi16S2ZYTabnsKoDYVz8nlIE4A==",
+      "sha512": "nUZs+huGwB8yM+RhJSCP1pDooGAjVhe2kEzSu2M7I8A9kwOF8WFgmMDwhfvW8UdnvcEVMbmtM9VtAYoZIBLs4w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -16148,15 +16317,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Linq.Expressions.4.0.11-rc2-23519.nupkg",
-        "System.Linq.Expressions.4.0.11-rc2-23519.nupkg.sha512",
+        "System.Linq.Expressions.4.0.11-rc2-23525.nupkg",
+        "System.Linq.Expressions.4.0.11-rc2-23525.nupkg.sha512",
         "System.Linq.Expressions.nuspec"
       ]
     },
-    "System.Linq.Parallel/4.0.1-rc2-23519": {
+    "System.Linq.Parallel/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "b8MxBuFRI8cmrZKtDiDQun0Aseec/m3o1wAkijAGA2+YX5qVfhNaDbWmzyDj7jF/mHA4pEfa4uBDrFz05/AO5Q==",
+      "sha512": "SspTDB0PzXUHjbsp6pGhj8DqDoeZ+PX8mQ9ODfmt9b+eRLgyHyopbWeJIZ0RQ2VrnRlsZProwMXF6f+Adp22Bg==",
       "files": [
         "lib/dotnet5.4/System.Linq.Parallel.dll",
         "lib/net45/_._",
@@ -16188,15 +16357,15 @@
         "ref/netcore50/zh-hant/System.Linq.Parallel.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
-        "System.Linq.Parallel.4.0.1-rc2-23519.nupkg",
-        "System.Linq.Parallel.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Linq.Parallel.4.0.1-rc2-23525.nupkg",
+        "System.Linq.Parallel.4.0.1-rc2-23525.nupkg.sha512",
         "System.Linq.Parallel.nuspec"
       ]
     },
-    "System.Linq.Queryable/4.0.1-rc2-23519": {
+    "System.Linq.Queryable/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Gxxzvi0uTUVaESLZNXAi3y4tpJeu/JmdM8BD5TaBCKhxx9xizsdsDvKl+mglZkWlat51fiEnNED2eZ04sLsNUg==",
+      "sha512": "YfhFw7mvugNL5AyUiZgt0ylV2bEuuQ/+ZMSlW2q7Uey/desTT/JstyThb9E32v9569nFGNfVTqmiuRKucNzsxQ==",
       "files": [
         "lib/dotnet5.4/System.Linq.Queryable.dll",
         "lib/net45/_._",
@@ -16230,15 +16399,15 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "System.Linq.Queryable.4.0.1-rc2-23519.nupkg",
-        "System.Linq.Queryable.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Linq.Queryable.4.0.1-rc2-23525.nupkg",
+        "System.Linq.Queryable.4.0.1-rc2-23525.nupkg.sha512",
         "System.Linq.Queryable.nuspec"
       ]
     },
-    "System.Net.Http/4.0.1-rc2-23519": {
+    "System.Net.Http/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "wXQKyBYjahhBoCNiNXeaizwQZaWrmNY8JPcw4bnOE7wB0850/Ft6cFFEGGxiADUuEHP+QlVXlmDAzmWFSER3Hw==",
+      "sha512": "K2wn1DPOHDH2l3M4+PEkdO5rIugAGNl/zq2pawWAgW3I4osAsHAna2RqAlGhUe46iFITg9WcKGwrMw++uj0zww==",
       "files": [
         "lib/net45/_._",
         "lib/win8/_._",
@@ -16269,15 +16438,38 @@
         "ref/win8/_._",
         "ref/wpa81/_._",
         "runtime.json",
-        "System.Net.Http.4.0.1-rc2-23519.nupkg",
-        "System.Net.Http.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Net.Http.4.0.1-rc2-23525.nupkg",
+        "System.Net.Http.4.0.1-rc2-23525.nupkg.sha512",
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.NameResolution/4.0.0-rc2-23519": {
+    "System.Net.Http.WinHttpHandler/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "34nI1H+jLIg3ArGOOV0JuLncPcmkYQF7XXjNRn2XafgYNQg9BM9Hf3JFmIcU8hbafLkuxSuqy3KUejXbz2u6yQ==",
+      "sha512": "ge2skn8EFujrfLri9/3GlDClBz2W7r6t0wZqEgtAtPbY8MK/NiwtV+1G1FimjSSTWkoO1K45K57l5D3/N5MJgg==",
+      "files": [
+        "lib/DNXCore50/System.Net.Http.WinHttpHandler.dll",
+        "lib/net46/System.Net.Http.WinHttpHandler.dll",
+        "ref/dotnet5.4/de/System.Net.Http.WinHttpHandler.xml",
+        "ref/dotnet5.4/es/System.Net.Http.WinHttpHandler.xml",
+        "ref/dotnet5.4/fr/System.Net.Http.WinHttpHandler.xml",
+        "ref/dotnet5.4/it/System.Net.Http.WinHttpHandler.xml",
+        "ref/dotnet5.4/ja/System.Net.Http.WinHttpHandler.xml",
+        "ref/dotnet5.4/ko/System.Net.Http.WinHttpHandler.xml",
+        "ref/dotnet5.4/ru/System.Net.Http.WinHttpHandler.xml",
+        "ref/dotnet5.4/System.Net.Http.WinHttpHandler.dll",
+        "ref/dotnet5.4/System.Net.Http.WinHttpHandler.xml",
+        "ref/dotnet5.4/zh-hans/System.Net.Http.WinHttpHandler.xml",
+        "ref/dotnet5.4/zh-hant/System.Net.Http.WinHttpHandler.xml",
+        "System.Net.Http.WinHttpHandler.4.0.0-rc2-23525.nupkg",
+        "System.Net.Http.WinHttpHandler.4.0.0-rc2-23525.nupkg.sha512",
+        "System.Net.Http.WinHttpHandler.nuspec"
+      ]
+    },
+    "System.Net.NameResolution/4.0.0-rc2-23525": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "7e0dTbKNPzMiNd/op//TPe2j7ssP4oQuHsaNpomy3B3CXwI9iMjXQK4PF8ftrkMWubUmjynHEZhf6gDcLIVxFA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -16301,15 +16493,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NameResolution.4.0.0-rc2-23519.nupkg",
-        "System.Net.NameResolution.4.0.0-rc2-23519.nupkg.sha512",
+        "System.Net.NameResolution.4.0.0-rc2-23525.nupkg",
+        "System.Net.NameResolution.4.0.0-rc2-23525.nupkg.sha512",
         "System.Net.NameResolution.nuspec"
       ]
     },
-    "System.Net.NetworkInformation/4.1.0-rc2-23519": {
+    "System.Net.NetworkInformation/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "7sjJu+656BGVkh7q/TRi+YuURYCM3NbJZ5Q5py6xUhshSHPMG1BaF7BWBCW4JyAyGip1JHPh+qbIsDVZi7IC5w==",
+      "sha512": "JdvgaKgLPeuGqMNp0Bfz6QoiilpZiq+1ZkogXWuBcZ40EQDJNaVxLnWjp+fgqqCIgThnHVgt875hhu0eAa8csg==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -16363,15 +16555,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.NetworkInformation.4.1.0-rc2-23519.nupkg",
-        "System.Net.NetworkInformation.4.1.0-rc2-23519.nupkg.sha512",
+        "System.Net.NetworkInformation.4.1.0-rc2-23525.nupkg",
+        "System.Net.NetworkInformation.4.1.0-rc2-23525.nupkg.sha512",
         "System.Net.NetworkInformation.nuspec"
       ]
     },
-    "System.Net.Primitives/4.0.11-rc2-23519": {
+    "System.Net.Primitives/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ST8BWjbFkor3oGhDtaBBQElnEjLvcQq9fQrR6/NFZh09aikNLc1sAUSVK8GA0PSqKJ8ORk4xJvfKDP8e4PM1Hg==",
+      "sha512": "tPl7aprrM0gnQa24GbIy+Swf+9+hEj+oy1I+OkeG/flSEGT3mCtrSAgfmLCr1FmN9lfn9XKkCgPYh8wJC2g8+w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -16434,15 +16626,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.Primitives.4.0.11-rc2-23519.nupkg",
-        "System.Net.Primitives.4.0.11-rc2-23519.nupkg.sha512",
+        "System.Net.Primitives.4.0.11-rc2-23525.nupkg",
+        "System.Net.Primitives.4.0.11-rc2-23525.nupkg.sha512",
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Requests/4.0.11-rc2-23519": {
+    "System.Net.Requests/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "QIJsMXeX87+JA5H/sOdY9/hubq1eH5G4RxFwPa58Swo6f8q/oAUwYFgU1UJcsZRbWsKJ4nA6ZzGjetumq11EEg==",
+      "sha512": "RPkYW8G7FRdfNPM+MnxkLgjdV8ATiSLUc5EpOtZ9n5cMV0qsLFy0j29Tu7ABniG83iTcf9ySkWHwEUQElBG43A==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -16505,14 +16697,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.Requests.4.0.11-rc2-23519.nupkg",
-        "System.Net.Requests.4.0.11-rc2-23519.nupkg.sha512",
+        "System.Net.Requests.4.0.11-rc2-23525.nupkg",
+        "System.Net.Requests.4.0.11-rc2-23525.nupkg.sha512",
         "System.Net.Requests.nuspec"
       ]
     },
-    "System.Net.Security/4.0.0-rc2-23519": {
+    "System.Net.Security/4.0.0-rc2-23525": {
       "type": "package",
-      "sha512": "G0obUVsv8IZB4Xy1a9HRBFo8WzSMJRTbq4R3xXRxo1dTjpNKYagLqPo+TVEeHZ5ZutzSu49xiEIdidJzcF0/ow==",
+      "serviceable": true,
+      "sha512": "gwEksPO3scOJ9i7HDluP36tUp06yF1ElbRbl2uaPS+nyHuf+LpU7hjQ/oJY+ze6JHhJVfv1ipUc0p8ryw2z8Vw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -16536,15 +16729,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.Security.4.0.0-rc2-23519.nupkg",
-        "System.Net.Security.4.0.0-rc2-23519.nupkg.sha512",
+        "System.Net.Security.4.0.0-rc2-23525.nupkg",
+        "System.Net.Security.4.0.0-rc2-23525.nupkg.sha512",
         "System.Net.Security.nuspec"
       ]
     },
-    "System.Net.Sockets/4.1.0-rc2-23519": {
+    "System.Net.Sockets/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2y06+kyQ9vbHLxINZjCkcvAtTnt6dx7sCxEkJUOuBgK07lWzZrge1GdLiSbHlOxxTnsA5hBBlc6bP44kml9zvA==",
+      "sha512": "hEzL4QtWYFMRxWVWUHvip570T+q9Lgmlsk3Yrhao1ZIum1EKl3MkV89C/h8X1zFnS209XUq0ziGQMANAlBHPew==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -16568,15 +16761,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.Sockets.4.1.0-rc2-23519.nupkg",
-        "System.Net.Sockets.4.1.0-rc2-23519.nupkg.sha512",
+        "System.Net.Sockets.4.1.0-rc2-23525.nupkg",
+        "System.Net.Sockets.4.1.0-rc2-23525.nupkg.sha512",
         "System.Net.Sockets.nuspec"
       ]
     },
-    "System.Net.Utilities/4.0.0-rc2-23519": {
+    "System.Net.Utilities/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "a1lEq+U7ARhTaIaNqQBfFuwaH5xIJ96Z7dTwQ7xvgHL3KwAkYlzRWeWCosD3ankLfpmH+VycxkSkUekhXYQNEw==",
+      "sha512": "iflEO+lzs5NDYfCug5OHzQcrsL9gLx+j9FDkXHeuxQFUlzDyH28tcxnDr26ZDPLT+tYCHn0X47H0IeVkXRmLVg==",
       "files": [
         "lib/DNXCore50/System.Net.Utilities.dll",
         "lib/MonoAndroid10/_._",
@@ -16600,15 +16793,15 @@
         "ref/net46/System.Net.Utilities.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.Utilities.4.0.0-rc2-23519.nupkg",
-        "System.Net.Utilities.4.0.0-rc2-23519.nupkg.sha512",
+        "System.Net.Utilities.4.0.0-rc2-23525.nupkg",
+        "System.Net.Utilities.4.0.0-rc2-23525.nupkg.sha512",
         "System.Net.Utilities.nuspec"
       ]
     },
-    "System.Net.WebHeaderCollection/4.0.1-rc2-23519": {
+    "System.Net.WebHeaderCollection/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "c73SJ3QRV+XqxoAhbvZOLFOB+VqNgj9op/bkmX9H/MEntC4BM/YYGfPoYYZQ6UjwhT58HEoeDA4IpdbLmuwSLg==",
+      "sha512": "WqSkoXBGkSYRohtzw/JDmYY2YBnUcmiN6jkHBwo6klron1bvGmaQIZIn5I+SdjpkRKJ4aZ5I/nhtnhKoyYVF5Q==",
       "files": [
         "lib/dotnet5.4/System.Net.WebHeaderCollection.dll",
         "lib/MonoAndroid10/_._",
@@ -16632,15 +16825,15 @@
         "ref/net46/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebHeaderCollection.4.0.1-rc2-23519.nupkg",
-        "System.Net.WebHeaderCollection.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Net.WebHeaderCollection.4.0.1-rc2-23525.nupkg",
+        "System.Net.WebHeaderCollection.4.0.1-rc2-23525.nupkg.sha512",
         "System.Net.WebHeaderCollection.nuspec"
       ]
     },
-    "System.Net.WebSockets/4.0.0-rc2-23519": {
+    "System.Net.WebSockets/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ei0KfthiDpiW7wvw7EQT2V3EbZC3kEMxpW4C+V8DXpArNGU/kPEpAgL71YknWE8DC4rbZfc28YRlC2hBV068pg==",
+      "sha512": "QykOhQUn7S0rJYPbKflEWOf3Cpr6Ku5UhGmJY5s14t0g14H/5ibVg3KuLySGYvrRmxxx7s6Ydx/b7AcuwDA9hQ==",
       "files": [
         "lib/dotnet5.4/System.Net.WebSockets.dll",
         "lib/MonoAndroid10/_._",
@@ -16664,14 +16857,15 @@
         "ref/net46/System.Net.WebSockets.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Net.WebSockets.4.0.0-rc2-23519.nupkg",
-        "System.Net.WebSockets.4.0.0-rc2-23519.nupkg.sha512",
+        "System.Net.WebSockets.4.0.0-rc2-23525.nupkg",
+        "System.Net.WebSockets.4.0.0-rc2-23525.nupkg.sha512",
         "System.Net.WebSockets.nuspec"
       ]
     },
-    "System.Net.WebSockets.Client/4.0.0-rc2-23519": {
+    "System.Net.WebSockets.Client/4.0.0-rc2-23525": {
       "type": "package",
-      "sha512": "RTw1JXt1SAKXp4MzetJRpOcFw5vhO7lO0vURPbaAEzrmcW9Fl6kL+bf0OiGP7r2iVsNsfi34XXfuueLLbQ/hwg==",
+      "serviceable": true,
+      "sha512": "Abbcg8X+YnLBYkrwdhUkHmnQ3THyLnN/morOYlK44L4WRhRZjRihb4Z6EzyOX+7+gZUhitUX/gJK282BFvh4bQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -16695,15 +16889,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.WebSockets.Client.4.0.0-rc2-23519.nupkg",
-        "System.Net.WebSockets.Client.4.0.0-rc2-23519.nupkg.sha512",
+        "System.Net.WebSockets.Client.4.0.0-rc2-23525.nupkg",
+        "System.Net.WebSockets.Client.4.0.0-rc2-23525.nupkg.sha512",
         "System.Net.WebSockets.Client.nuspec"
       ]
     },
-    "System.Numerics.Vectors/4.1.1-rc2-23519": {
+    "System.Numerics.Vectors/4.1.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "UOglGg3tlcBwem8aPI6U2TT6fWehLc1/eAlfNEEYKjJ3b3yQ5tN/U4QELPU5AFY3s4I5ykIGEUW7s30tAndxsg==",
+      "sha512": "in5WMxAP6rcl5+tCsVSWf2+ASv0HiTRrI0IyhEkwc/xL7SmhB2M2nSjXIjdI2Ti5+swmhrRjvUtMioTHpyGpGA==",
       "files": [
         "lib/dotnet5.4/System.Numerics.Vectors.dll",
         "lib/MonoAndroid10/_._",
@@ -16720,15 +16914,15 @@
         "ref/net46/System.Numerics.Vectors.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Numerics.Vectors.4.1.1-rc2-23519.nupkg",
-        "System.Numerics.Vectors.4.1.1-rc2-23519.nupkg.sha512",
+        "System.Numerics.Vectors.4.1.1-rc2-23525.nupkg",
+        "System.Numerics.Vectors.4.1.1-rc2-23525.nupkg.sha512",
         "System.Numerics.Vectors.nuspec"
       ]
     },
-    "System.ObjectModel/4.0.11-rc2-23519": {
+    "System.ObjectModel/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "K7K17lYJw85SEQnX37xGrtSNTU/TnQCcNFZfj5lqsRKJV4Mti0x3oAmiY6BxEfg0FY2jAuyQYFOZvNzfirx4cQ==",
+      "sha512": "IJJ5i3tnyDWnrjK3GH81Bu3I+ie/MyKr7/V/LjYkVpKHlTaT1EdjLX40CqXaw3ObgqkLqSYz6iRJKaYkmGesXg==",
       "files": [
         "lib/dotnet5.4/System.ObjectModel.dll",
         "lib/MonoAndroid10/_._",
@@ -16781,67 +16975,67 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ObjectModel.4.0.11-rc2-23519.nupkg",
-        "System.ObjectModel.4.0.11-rc2-23519.nupkg.sha512",
+        "System.ObjectModel.4.0.11-rc2-23525.nupkg",
+        "System.ObjectModel.4.0.11-rc2-23525.nupkg.sha512",
         "System.ObjectModel.nuspec"
       ]
     },
-    "System.Private.DataContractSerialization/4.1.0-rc2-23519": {
+    "System.Private.DataContractSerialization/4.1.0-rc2-23525": {
       "type": "package",
-      "sha512": "0xXAPGcxvxfvoc2Olw6acHFqc855zShSGLh5kLlcyXL1v8SReBqhpnsCJSQL/cN1QDdCnghqgq+yfyLvt30KmA==",
+      "sha512": "K9zKJUfFhCQijQgcbp6UNe1LCOjX8hjDfe/JfCZHaWN7VWUwLkPXMapgaLp8gxoMVpds3ieQjHiQoqr4Gf56LQ==",
       "files": [
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
         "runtime.json",
-        "System.Private.DataContractSerialization.4.1.0-rc2-23519.nupkg",
-        "System.Private.DataContractSerialization.4.1.0-rc2-23519.nupkg.sha512",
+        "System.Private.DataContractSerialization.4.1.0-rc2-23525.nupkg",
+        "System.Private.DataContractSerialization.4.1.0-rc2-23525.nupkg.sha512",
         "System.Private.DataContractSerialization.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-rc2-23519": {
+    "System.Private.Networking/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "wg60js/HFJw7470eanYs2myS/KsQzqcYN8JPf5ugkGC6DBOwJ2CxuWSVNG5yci9z7zkkXu7F9bvnG3mX+WzkdQ==",
+      "sha512": "rFFUD0mYPaIgxiQTv6+RQ2Sx4fwtGNIFdga4hyJ2BJ6lgidfuyWgx0NcU5YxH7DyuYcZAVOCvC9sIeQHGMtR8w==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-rc2-23519.nupkg",
-        "System.Private.Networking.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Private.Networking.4.0.1-rc2-23525.nupkg",
+        "System.Private.Networking.4.0.1-rc2-23525.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
-    "System.Private.ServiceModel/4.1.0-rc2-23519": {
+    "System.Private.ServiceModel/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "btNVKYvSrW1EBmP0+Bu9e0Bo35qheno0OP2aX4GX53z3KFoJWq8lBz74G3q9xeLMAMGjDTa0P4Z0zRdmwRsbLQ==",
+      "sha512": "NrbZBR4FaW5IWCY03oU63f6AARtrZRAmhz9quao9pvRJGzEPzm4tDszwkCy5ZAFuwiE1Q0qvldJ8sm/a8xU+6g==",
       "files": [
         "lib/DNXCore50/System.Private.ServiceModel.dll",
         "lib/netcore50/System.Private.ServiceModel.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.ServiceModel.4.1.0-rc2-23519.nupkg",
-        "System.Private.ServiceModel.4.1.0-rc2-23519.nupkg.sha512",
+        "System.Private.ServiceModel.4.1.0-rc2-23525.nupkg",
+        "System.Private.ServiceModel.4.1.0-rc2-23525.nupkg.sha512",
         "System.Private.ServiceModel.nuspec"
       ]
     },
-    "System.Private.Uri/4.0.1-rc2-23519": {
+    "System.Private.Uri/4.0.1-rc2-23525": {
       "type": "package",
-      "sha512": "E5HAXgHHeuWghyLT6JQHWUTw4wCs9HuBwOPGwKFEuL5ODJ/RznOUB9Gzso6cJVJwaYWVE5ic9qE1Ly3UFqOwYg==",
+      "sha512": "9O1jOYVClAKxhxDI134YlAN0Zg0FtFuMccSeHmbuqnXy3WiwvALMz5asSYM6pTtzMmLchRPVyG/RLlMWxbyxsw==",
       "files": [
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
         "runtime.json",
-        "System.Private.Uri.4.0.1-rc2-23519.nupkg",
-        "System.Private.Uri.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Private.Uri.4.0.1-rc2-23525.nupkg",
+        "System.Private.Uri.4.0.1-rc2-23525.nupkg.sha512",
         "System.Private.Uri.nuspec"
       ]
     },
-    "System.Reflection/4.1.0-rc2-23519": {
+    "System.Reflection/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "5ojAc+YIYLRbmb+9f1OizaQzRR7ZTnbTnjbKxtbBo8zVcWBP/04qivLd4Ah1KuNS05KYdlG2ycXpUMyHin5QUQ==",
+      "sha512": "NC5bqbghdHXHQTTRNpN0/t16Iw0tEzzzmLM+pU/nf86IBXuQJhz9gmbDZjbrKgQDLRbKJutzBQG+9pKMKNhwwg==",
       "files": [
         "lib/DNXCore50/System.Reflection.dll",
         "lib/MonoAndroid10/_._",
@@ -16897,15 +17091,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
-        "System.Reflection.4.1.0-rc2-23519.nupkg",
-        "System.Reflection.4.1.0-rc2-23519.nupkg.sha512",
+        "System.Reflection.4.1.0-rc2-23525.nupkg",
+        "System.Reflection.4.1.0-rc2-23525.nupkg.sha512",
         "System.Reflection.nuspec"
       ]
     },
-    "System.Reflection.DispatchProxy/4.0.1-rc2-23519": {
+    "System.Reflection.DispatchProxy/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "kP8miRInKNj0LhWlW7h8QjfC+X4PJmIhON28c/Gsr6lGJasHavwDerHa/0QGSUJ02pQYMunbkKd4hO3r/2IqWA==",
+      "sha512": "A/O/uwm/5t1fAUUqrVljCr4KYIVcdMcVjmu8yME1ZCOy5Lz3UggbNk1HuzD+EPWuEnctNnHeL1PDuKV3iRlfOA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -16927,15 +17121,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Reflection.DispatchProxy.4.0.1-rc2-23519.nupkg",
-        "System.Reflection.DispatchProxy.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Reflection.DispatchProxy.4.0.1-rc2-23525.nupkg",
+        "System.Reflection.DispatchProxy.4.0.1-rc2-23525.nupkg.sha512",
         "System.Reflection.DispatchProxy.nuspec"
       ]
     },
-    "System.Reflection.Emit/4.0.1-rc2-23519": {
+    "System.Reflection.Emit/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "hffudAJa58dFM2sm2B9fT6kyobMN7Ii4U6RngDrDX6l4AARQTd+WvsyiuYEGlQl8qYTQE7XGR7x+/xJkNA+dXQ==",
+      "sha512": "TwJEe1ecGUBSnuwbK/5Otg240Pkusu1SykDl1ZlmiqyL2RbmvKIMe//OcaaVajaq5IZI9XdSPqVIvhTzYHHQig==",
       "files": [
         "lib/DNXCore50/System.Reflection.Emit.dll",
         "lib/MonoAndroid10/_._",
@@ -16957,15 +17151,15 @@
         "ref/net45/_._",
         "ref/xamarinmac20/_._",
         "runtimes/aot/lib/netcore50/_._",
-        "System.Reflection.Emit.4.0.1-rc2-23519.nupkg",
-        "System.Reflection.Emit.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Reflection.Emit.4.0.1-rc2-23525.nupkg",
+        "System.Reflection.Emit.4.0.1-rc2-23525.nupkg.sha512",
         "System.Reflection.Emit.nuspec"
       ]
     },
-    "System.Reflection.Emit.ILGeneration/4.0.1-rc2-23519": {
+    "System.Reflection.Emit.ILGeneration/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "9cHdDujGuZq4YJK5610LXZsTxphySvVZzYCAwBNRb8QmcpLJbIqBtAPVF+39AyyX05I+P5Y3jx7brkGvAjm5EA==",
+      "sha512": "YiWbt6foeT42BP+WsxawRNfBAIiRrNJ46WXA8eQUZ1NXobmmGkTcWTBXG6PGms4rLZjCelJcZ0ecpVXXbbxpmg==",
       "files": [
         "lib/DNXCore50/System.Reflection.Emit.ILGeneration.dll",
         "lib/net45/_._",
@@ -16985,15 +17179,15 @@
         "ref/net45/_._",
         "ref/wp80/_._",
         "runtimes/aot/lib/netcore50/_._",
-        "System.Reflection.Emit.ILGeneration.4.0.1-rc2-23519.nupkg",
-        "System.Reflection.Emit.ILGeneration.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Reflection.Emit.ILGeneration.4.0.1-rc2-23525.nupkg",
+        "System.Reflection.Emit.ILGeneration.4.0.1-rc2-23525.nupkg.sha512",
         "System.Reflection.Emit.ILGeneration.nuspec"
       ]
     },
-    "System.Reflection.Emit.Lightweight/4.0.1-rc2-23519": {
+    "System.Reflection.Emit.Lightweight/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "G/wmC8EvwB4OchizauvgI3N8LYHm/3+mVDOMKrPALG6GCOaP11FwAK4yrh8LFFL3+1NiJek71EXcdvamQ+ciow==",
+      "sha512": "yemFBcrKv5b9UFu3dY0eFpzGan6arWNeecvD4Nvbua9OMqJTy9JevZw3S8tpFd84LLxJ8PuWdp7eylTjkHas5w==",
       "files": [
         "lib/DNXCore50/System.Reflection.Emit.Lightweight.dll",
         "lib/net45/_._",
@@ -17013,15 +17207,15 @@
         "ref/net45/_._",
         "ref/wp80/_._",
         "runtimes/aot/lib/netcore50/_._",
-        "System.Reflection.Emit.Lightweight.4.0.1-rc2-23519.nupkg",
-        "System.Reflection.Emit.Lightweight.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Reflection.Emit.Lightweight.4.0.1-rc2-23525.nupkg",
+        "System.Reflection.Emit.Lightweight.4.0.1-rc2-23525.nupkg.sha512",
         "System.Reflection.Emit.Lightweight.nuspec"
       ]
     },
-    "System.Reflection.Extensions/4.0.1-rc2-23519": {
+    "System.Reflection.Extensions/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "HUx3jdxCnjfyDgO9XGhEEHZFSja66X5ERpL9uQkCux6x38dLRFwac5rDxkALWP0DtR3OdeuVreKi2EVkeYXPyw==",
+      "sha512": "S2zlLFK7KGY+vmP2idf9baP1vd3FSRhiRrDpzaDu57f0mqsMuXkbbtqxSncaN8SzvHbLu1OSp1ERiwSzCtcskw==",
       "files": [
         "lib/DNXCore50/System.Reflection.Extensions.dll",
         "lib/net45/_._",
@@ -17056,29 +17250,29 @@
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
-        "System.Reflection.Extensions.4.0.1-rc2-23519.nupkg",
-        "System.Reflection.Extensions.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Reflection.Extensions.4.0.1-rc2-23525.nupkg",
+        "System.Reflection.Extensions.4.0.1-rc2-23525.nupkg.sha512",
         "System.Reflection.Extensions.nuspec"
       ]
     },
-    "System.Reflection.Metadata/1.1.1-rc2-23519": {
+    "System.Reflection.Metadata/1.1.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "920s1w7OHpOeWEq2FzvTSt+2ncr7IZnbvQCHYfgJP4I7IpmeXxPRYm5QzKO1ZMwINoP6wuS5Wx5DHcjPbtD+PA==",
+      "sha512": "R93+wYCDwy18JEOalW40BywZEknDmsemKgUWQQFhAq3zR23FK7a2qpslmZ5bxf4u/8zPWZ/swcRSSxpAOAPx5g==",
       "files": [
         "lib/dotnet5.2/System.Reflection.Metadata.dll",
         "lib/dotnet5.2/System.Reflection.Metadata.xml",
         "lib/portable-net45+win8/System.Reflection.Metadata.dll",
         "lib/portable-net45+win8/System.Reflection.Metadata.xml",
-        "System.Reflection.Metadata.1.1.1-rc2-23519.nupkg",
-        "System.Reflection.Metadata.1.1.1-rc2-23519.nupkg.sha512",
+        "System.Reflection.Metadata.1.1.1-rc2-23525.nupkg",
+        "System.Reflection.Metadata.1.1.1-rc2-23525.nupkg.sha512",
         "System.Reflection.Metadata.nuspec"
       ]
     },
-    "System.Reflection.Primitives/4.0.1-rc2-23519": {
+    "System.Reflection.Primitives/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "SkdP7oWwNKIcKQidVhck4E9R2tShdEkqzjK/eIRePklolymdy6z7aDCMt8qL2YTPN8e/AE2YTZ+4Ij/QKg0jSw==",
+      "sha512": "X8JDi0Uf6lWpSDZuNLHwN1eXYb1HckS1sVRaUhIwblilxtiHdbVPnpRVBpcIVSAqzxayC/ID3M1vsadCOd7raA==",
       "files": [
         "lib/DNXCore50/System.Reflection.Primitives.dll",
         "lib/net45/_._",
@@ -17113,15 +17307,15 @@
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
-        "System.Reflection.Primitives.4.0.1-rc2-23519.nupkg",
-        "System.Reflection.Primitives.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Reflection.Primitives.4.0.1-rc2-23525.nupkg",
+        "System.Reflection.Primitives.4.0.1-rc2-23525.nupkg.sha512",
         "System.Reflection.Primitives.nuspec"
       ]
     },
-    "System.Reflection.TypeExtensions/4.1.0-rc2-23519": {
+    "System.Reflection.TypeExtensions/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gxg4Vj6J+mtMjV2HThpEqkgf5zdih9iGdupp7BWdphjcB7Ud4nFEYn9x9f5RF3sD7wqDaJPDe2b3DxsNWvlkwg==",
+      "sha512": "iQcaPIkQezVXqmP5hP8vaYWs5xH0qborO0e+9Tv1jlBIZUp8tufZHYl/7tnQPjEJnkn4RaipQdszRxzwrv63pg==",
       "files": [
         "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
         "lib/MonoAndroid10/_._",
@@ -17147,15 +17341,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
-        "System.Reflection.TypeExtensions.4.1.0-rc2-23519.nupkg",
-        "System.Reflection.TypeExtensions.4.1.0-rc2-23519.nupkg.sha512",
+        "System.Reflection.TypeExtensions.4.1.0-rc2-23525.nupkg",
+        "System.Reflection.TypeExtensions.4.1.0-rc2-23525.nupkg.sha512",
         "System.Reflection.TypeExtensions.nuspec"
       ]
     },
-    "System.Resources.ReaderWriter/4.0.0-rc2-23519": {
+    "System.Resources.ReaderWriter/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "hCrqq0ZEjtMb6eBeB8RRphbQbAfMoBFrhp9yoUO6nAgu9atwUVLSgq8slDkMZSYP0OwJF8XFeK0f3qWa4a7Lmw==",
+      "sha512": "MwTCAAQSLA4c2khUE5LFPNP1hJuIJtu08y8knROargQJitCuYfHf7Q1OlDSmggPXK31SSiHXWb716Q/zvjul8w==",
       "files": [
         "lib/DNXCore50/System.Resources.ReaderWriter.dll",
         "lib/MonoAndroid10/_._",
@@ -17179,15 +17373,15 @@
         "ref/net46/System.Resources.ReaderWriter.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Resources.ReaderWriter.4.0.0-rc2-23519.nupkg",
-        "System.Resources.ReaderWriter.4.0.0-rc2-23519.nupkg.sha512",
+        "System.Resources.ReaderWriter.4.0.0-rc2-23525.nupkg",
+        "System.Resources.ReaderWriter.4.0.0-rc2-23525.nupkg.sha512",
         "System.Resources.ReaderWriter.nuspec"
       ]
     },
-    "System.Resources.ResourceManager/4.0.1-rc2-23519": {
+    "System.Resources.ResourceManager/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "8hWSoivfcJm+hhFQWd69huYB0e8ZiwEaeX0I5DFRLNV4jyheW1r9ypCJA3kbVwL5u/nXSyhLsBy8rVRZCZ3jUg==",
+      "sha512": "Pp+0DOwNu+L6fYGLejweNbbxXYW9EZTA9UpVBLvWTAldWsTWQ15J1LYuDIULWP3G2JBnKDtzZzQj4VIjzW4zxQ==",
       "files": [
         "lib/DNXCore50/System.Resources.ResourceManager.dll",
         "lib/net45/_._",
@@ -17222,15 +17416,15 @@
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
-        "System.Resources.ResourceManager.4.0.1-rc2-23519.nupkg",
-        "System.Resources.ResourceManager.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Resources.ResourceManager.4.0.1-rc2-23525.nupkg",
+        "System.Resources.ResourceManager.4.0.1-rc2-23525.nupkg.sha512",
         "System.Resources.ResourceManager.nuspec"
       ]
     },
-    "System.Runtime/4.0.21-rc2-23519": {
+    "System.Runtime/4.0.21-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "WOWXeUEju/nvb5Asix8X3+zNRG/LlJOsFtUJ85PCGTxMzR6yjv+1dFj57y04DysTk+cKTgc0JQGRxqAGDkjjYQ==",
+      "sha512": "LycbvHHYEuhrvcrwJ7JW1uKOXWUSC1gMn+M5zCTMYRrBomqYJnUu2Ej+oNJZibV4pdvjOSNdnLRBjy0VS0pJHQ==",
       "files": [
         "lib/DNXCore50/System.Runtime.dll",
         "lib/MonoAndroid10/_._",
@@ -17295,15 +17489,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
-        "System.Runtime.4.0.21-rc2-23519.nupkg",
-        "System.Runtime.4.0.21-rc2-23519.nupkg.sha512",
+        "System.Runtime.4.0.21-rc2-23525.nupkg",
+        "System.Runtime.4.0.21-rc2-23525.nupkg.sha512",
         "System.Runtime.nuspec"
       ]
     },
-    "System.Runtime.CompilerServices.VisualC/4.0.0-rc2-23519": {
+    "System.Runtime.CompilerServices.VisualC/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "SX25rR+sIOn33Sjr68IMQcNnnQkEl36AqTz4DFFkIRYXkPnqXLA118G6OGcZhNKKjBhe57IMf4ynbXfTNDAI6w==",
+      "sha512": "iUw8YaDAtN1KU12j/Re3S0Lz8TX8/8e9GRa23j91L8nnCI3BIgfzAPgAiKj7eQXHNAwyNBYIf0hWghHZri3zvw==",
       "files": [
         "lib/DNXCore50/System.Runtime.CompilerServices.VisualC.dll",
         "lib/MonoAndroid10/_._",
@@ -17327,15 +17521,15 @@
         "ref/net46/System.Runtime.CompilerServices.VisualC.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Runtime.CompilerServices.VisualC.4.0.0-rc2-23519.nupkg",
-        "System.Runtime.CompilerServices.VisualC.4.0.0-rc2-23519.nupkg.sha512",
+        "System.Runtime.CompilerServices.VisualC.4.0.0-rc2-23525.nupkg",
+        "System.Runtime.CompilerServices.VisualC.4.0.0-rc2-23525.nupkg.sha512",
         "System.Runtime.CompilerServices.VisualC.nuspec"
       ]
     },
-    "System.Runtime.Extensions/4.0.11-rc2-23519": {
+    "System.Runtime.Extensions/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "H9i/sDcxbvhygX+aOsulyBBgIOdsJfmrXPEwwe3VhADZl8CY3rE6LVP52/193J6kep2HHh1VJKK62KORfPOwKg==",
+      "sha512": "R6crzqPfrw8M1hohRtO9ae8CngdmbmB6DLMt4asm0KiP7i4ufliJcGRpn++mxJwPYgiLw757t1KN5sBDnyvvkw==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -17387,15 +17581,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Runtime.Extensions.4.0.11-rc2-23519.nupkg",
-        "System.Runtime.Extensions.4.0.11-rc2-23519.nupkg.sha512",
+        "System.Runtime.Extensions.4.0.11-rc2-23525.nupkg",
+        "System.Runtime.Extensions.4.0.11-rc2-23525.nupkg.sha512",
         "System.Runtime.Extensions.nuspec"
       ]
     },
-    "System.Runtime.Handles/4.0.1-rc2-23519": {
+    "System.Runtime.Handles/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "nLY7xxMwRvbzVxxRqOEUflK2rnUtowLYbVKrXFpvgfVRkWIRXjdqudBxsvM+wa8pKv4tXZMlQMfT8PxzQ2Ev4g==",
+      "sha512": "Sp0niOVVPZ27d8MH3Lg5YUriQ0QtXdUA6fuJMno7piccMdLapI5OGe9tk7yiX3npG9eDtJoehdehuPyjBvfBoA==",
       "files": [
         "lib/DNXCore50/System.Runtime.Handles.dll",
         "lib/MonoAndroid10/_._",
@@ -17421,15 +17615,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Runtime.Handles.dll",
-        "System.Runtime.Handles.4.0.1-rc2-23519.nupkg",
-        "System.Runtime.Handles.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Runtime.Handles.4.0.1-rc2-23525.nupkg",
+        "System.Runtime.Handles.4.0.1-rc2-23525.nupkg.sha512",
         "System.Runtime.Handles.nuspec"
       ]
     },
-    "System.Runtime.InteropServices/4.0.21-rc2-23519": {
+    "System.Runtime.InteropServices/4.0.21-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "5cWxFSHHi39IREKZK7E97D0Lkx0pWPIT5ZO8ZI40GXwR00JEHe6k5hzsNhHpC1cG2w6B2tmMd5Xfqr3tCCTKsg==",
+      "sha512": "rWJNPZVqqjGxOhwWLdDh20vbH1OHXMqydO2QDO2vJApFCKEgyR2ySG2w6Ls665jGeUYzT2mQ+ZGTkcyzKOJdyg==",
       "files": [
         "lib/DNXCore50/System.Runtime.InteropServices.dll",
         "lib/MonoAndroid10/_._",
@@ -17492,15 +17686,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Runtime.InteropServices.dll",
-        "System.Runtime.InteropServices.4.0.21-rc2-23519.nupkg",
-        "System.Runtime.InteropServices.4.0.21-rc2-23519.nupkg.sha512",
+        "System.Runtime.InteropServices.4.0.21-rc2-23525.nupkg",
+        "System.Runtime.InteropServices.4.0.21-rc2-23525.nupkg.sha512",
         "System.Runtime.InteropServices.nuspec"
       ]
     },
-    "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23519": {
+    "System.Runtime.InteropServices.RuntimeInformation/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "JQv8oobe6k0WSmRvk9C6dqck6Tn5u6HOspSZo/OP3RGv/pkaJAjstPVwnrYJBsiQbkU12FHvAv2wrKL35wwJUg==",
+      "sha512": "Ha25KM/Db3dmbZz9UWgn7ChGPmqFHLDyWTxuvoJtaUq8ziwTW4hP0tlUfEKZBa3FwEB6Nero7VLX4h0TQs0k6Q==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -17512,37 +17706,37 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Runtime.InteropServices.RuntimeInformation.4.0.0-rc2-23519.nupkg",
-        "System.Runtime.InteropServices.RuntimeInformation.4.0.0-rc2-23519.nupkg.sha512",
+        "System.Runtime.InteropServices.RuntimeInformation.4.0.0-rc2-23525.nupkg",
+        "System.Runtime.InteropServices.RuntimeInformation.4.0.0-rc2-23525.nupkg.sha512",
         "System.Runtime.InteropServices.RuntimeInformation.nuspec"
       ]
     },
-    "System.Runtime.Loader/4.0.0-rc2-23519": {
+    "System.Runtime.Loader/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "54ZIqEuUMpYLCaQll6y9ztMXNjqahvGsjk4DSPn/VukyfydBeUN8JMBugI6tAuK/GuP+7g8AMekBk/LBPzb+vA==",
+      "sha512": "IRM2zf64YMEAG7ZaHtwdHDU6OCVObDrX82xuXPa9V5EIMpxMWC4SU68aQKCHQg/YP3bcm0z3FWFXX21UbrZL4Q==",
       "files": [
         "lib/DNXCore50/System.Runtime.Loader.dll",
-        "ref/dotnet5.1/de/System.Runtime.Loader.xml",
-        "ref/dotnet5.1/es/System.Runtime.Loader.xml",
-        "ref/dotnet5.1/fr/System.Runtime.Loader.xml",
-        "ref/dotnet5.1/it/System.Runtime.Loader.xml",
-        "ref/dotnet5.1/ja/System.Runtime.Loader.xml",
-        "ref/dotnet5.1/ko/System.Runtime.Loader.xml",
-        "ref/dotnet5.1/ru/System.Runtime.Loader.xml",
-        "ref/dotnet5.1/System.Runtime.Loader.dll",
-        "ref/dotnet5.1/System.Runtime.Loader.xml",
-        "ref/dotnet5.1/zh-hans/System.Runtime.Loader.xml",
-        "ref/dotnet5.1/zh-hant/System.Runtime.Loader.xml",
-        "System.Runtime.Loader.4.0.0-rc2-23519.nupkg",
-        "System.Runtime.Loader.4.0.0-rc2-23519.nupkg.sha512",
+        "ref/dotnet5.5/de/System.Runtime.Loader.xml",
+        "ref/dotnet5.5/es/System.Runtime.Loader.xml",
+        "ref/dotnet5.5/fr/System.Runtime.Loader.xml",
+        "ref/dotnet5.5/it/System.Runtime.Loader.xml",
+        "ref/dotnet5.5/ja/System.Runtime.Loader.xml",
+        "ref/dotnet5.5/ko/System.Runtime.Loader.xml",
+        "ref/dotnet5.5/ru/System.Runtime.Loader.xml",
+        "ref/dotnet5.5/System.Runtime.Loader.dll",
+        "ref/dotnet5.5/System.Runtime.Loader.xml",
+        "ref/dotnet5.5/zh-hans/System.Runtime.Loader.xml",
+        "ref/dotnet5.5/zh-hant/System.Runtime.Loader.xml",
+        "System.Runtime.Loader.4.0.0-rc2-23525.nupkg",
+        "System.Runtime.Loader.4.0.0-rc2-23525.nupkg.sha512",
         "System.Runtime.Loader.nuspec"
       ]
     },
-    "System.Runtime.Numerics/4.0.1-rc2-23519": {
+    "System.Runtime.Numerics/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "QRhIsYbDQDOQg8MixenDTwUGtf7am99Msmd0UayBFaYDvunfubF2lPsz3Qrx5DwujlOYVYaoBAgw8fZ89D8A4w==",
+      "sha512": "5yuepZn0yhE6P/4gs8YogTiAz+oEbHYUT2c5pOESOdGVD66l2VV0bG3YlHn30G/6Vzqzcwsr+e38tiPUFdvC0Q==",
       "files": [
         "lib/dotnet5.4/System.Runtime.Numerics.dll",
         "lib/net45/_._",
@@ -17574,15 +17768,15 @@
         "ref/netcore50/zh-hant/System.Runtime.Numerics.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
-        "System.Runtime.Numerics.4.0.1-rc2-23519.nupkg",
-        "System.Runtime.Numerics.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Runtime.Numerics.4.0.1-rc2-23525.nupkg",
+        "System.Runtime.Numerics.4.0.1-rc2-23525.nupkg.sha512",
         "System.Runtime.Numerics.nuspec"
       ]
     },
-    "System.Runtime.Serialization.Json/4.0.1-rc2-23519": {
+    "System.Runtime.Serialization.Json/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ORttzKwtgNHabHOyK6O+NPTIaPJqQaPeaFN6L02D0ZHeh7svevlEOnZiDGshDChuHgMcdWO0EStDj8dLfTdStA==",
+      "sha512": "PhPGZjodpT3+u5V1tyq1ZWsoGgwo7ohRLjIHrhF3bpzr201Z+7Kp0bHJ8wCQMCetWmA3tNwslPOMRBZbySvDtw==",
       "files": [
         "lib/DNXCore50/System.Runtime.Serialization.Json.dll",
         "lib/net45/_._",
@@ -17617,15 +17811,15 @@
         "ref/wp80/_._",
         "ref/wpa81/_._",
         "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Json.dll",
-        "System.Runtime.Serialization.Json.4.0.1-rc2-23519.nupkg",
-        "System.Runtime.Serialization.Json.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Runtime.Serialization.Json.4.0.1-rc2-23525.nupkg",
+        "System.Runtime.Serialization.Json.4.0.1-rc2-23525.nupkg.sha512",
         "System.Runtime.Serialization.Json.nuspec"
       ]
     },
-    "System.Runtime.Serialization.Primitives/4.1.0-rc2-23519": {
+    "System.Runtime.Serialization.Primitives/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "OvuZtq8EYsYIASmZK0U8CEKQwSZ5f7hZmW/08YnlG+WA7NmnTqWAuYAI4xX+Dq8Ui71i/JO37musGdntbTqlQQ==",
+      "sha512": "LSBvw+32BRYIyZFeigVNTwTdTRSZHymJyqVZl6qD3RNy7YMxE/ny7BfyTROKlxZLrfhJLeuUqnR7f2IsTFxuow==",
       "files": [
         "lib/dotnet5.4/System.Runtime.Serialization.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -17678,15 +17872,15 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Runtime.Serialization.Primitives.4.1.0-rc2-23519.nupkg",
-        "System.Runtime.Serialization.Primitives.4.1.0-rc2-23519.nupkg.sha512",
+        "System.Runtime.Serialization.Primitives.4.1.0-rc2-23525.nupkg",
+        "System.Runtime.Serialization.Primitives.4.1.0-rc2-23525.nupkg.sha512",
         "System.Runtime.Serialization.Primitives.nuspec"
       ]
     },
-    "System.Runtime.Serialization.Xml/4.1.0-rc2-23519": {
+    "System.Runtime.Serialization.Xml/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "v9T2z5pDFJGliS3vWJfJSLIcqwS0ocYJLpNDBiB+RVkCGfiPx4jELx/rPoKZV/qPh/umTuqNkOG3LqeZyOeAhA==",
+      "sha512": "rp9ZmrGXS/3Kbg2wJ0xPuzgR3SaIbU7FaGeQqG060HwMBSt69ykzu4Tyu/tGR5gZ9Z8MXkPuBfEQP4F2BnrWIA==",
       "files": [
         "lib/DNXCore50/System.Runtime.Serialization.Xml.dll",
         "lib/MonoAndroid10/_._",
@@ -17740,15 +17934,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Runtime.Serialization.Xml.dll",
-        "System.Runtime.Serialization.Xml.4.1.0-rc2-23519.nupkg",
-        "System.Runtime.Serialization.Xml.4.1.0-rc2-23519.nupkg.sha512",
+        "System.Runtime.Serialization.Xml.4.1.0-rc2-23525.nupkg",
+        "System.Runtime.Serialization.Xml.4.1.0-rc2-23525.nupkg.sha512",
         "System.Runtime.Serialization.Xml.nuspec"
       ]
     },
-    "System.Security.Claims/4.0.1-rc2-23519": {
+    "System.Security.Claims/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Aw2wASvi9hzF/Z868JEt0Yaka3eHieAXDu+8OKe6nW1/e1aGXbM1gnI+13TTqebZhmB2j4ceUjrXs0cdPzG0Aw==",
+      "sha512": "QQRiGO33X/l9n5rikQfRoHPtX+0k4m3dxWFIZyH+63qsshU7S89QqmVsEjFYhHhEtsTbiKdkyNKrqTA7aj9XPQ==",
       "files": [
         "lib/dotnet5.4/System.Security.Claims.dll",
         "lib/MonoAndroid10/_._",
@@ -17772,15 +17966,15 @@
         "ref/net46/System.Security.Claims.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Claims.4.0.1-rc2-23519.nupkg",
-        "System.Security.Claims.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Security.Claims.4.0.1-rc2-23525.nupkg",
+        "System.Security.Claims.4.0.1-rc2-23525.nupkg.sha512",
         "System.Security.Claims.nuspec"
       ]
     },
-    "System.Security.Cryptography.Algorithms/4.0.0-rc2-23519": {
+    "System.Security.Cryptography.Algorithms/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "oSmdWGbSQJum4moyrjV4ow0Kelsw0m8rdDf9unZ0E7FvpcrqVeBB+CETstzdUFJoSr8w3oyyHzJ9Uz1Thf/ATA==",
+      "sha512": "YG9pKBlPiXYSElZ2Yz8K9WuKO9/pjiypOZC44Ovjh8LUFBRCrMoikR3MQBefkqc4pQPDcY42YowcjkvfNU31Ew==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -17794,29 +17988,29 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-rc2-23519.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-rc2-23519.nupkg.sha512",
+        "System.Security.Cryptography.Algorithms.4.0.0-rc2-23525.nupkg",
+        "System.Security.Cryptography.Algorithms.4.0.0-rc2-23525.nupkg.sha512",
         "System.Security.Cryptography.Algorithms.nuspec"
       ]
     },
-    "System.Security.Cryptography.Cng/4.0.0-rc2-23519": {
+    "System.Security.Cryptography.Cng/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "y0Ugncp+9/mFjQ7o4iLMirGr+JiI+dKUBGIHqAYEQSzX7BY1Sklmh/Qj9q04wXTqk3rbZULtcYiXx53QAPXRWQ==",
+      "sha512": "H4fSJsMPMOM5SmfTMJ9AD0CgYshIPYnCf+2gJ9px0eg/Xjm9Q6JsVpTgbl6osdgXWNlwA45voiq4DRsniku5eg==",
       "files": [
         "lib/dotnet5.4/System.Security.Cryptography.Cng.dll",
         "lib/net46/System.Security.Cryptography.Cng.dll",
         "ref/dotnet5.4/System.Security.Cryptography.Cng.dll",
         "ref/net46/System.Security.Cryptography.Cng.dll",
-        "System.Security.Cryptography.Cng.4.0.0-rc2-23519.nupkg",
-        "System.Security.Cryptography.Cng.4.0.0-rc2-23519.nupkg.sha512",
+        "System.Security.Cryptography.Cng.4.0.0-rc2-23525.nupkg",
+        "System.Security.Cryptography.Cng.4.0.0-rc2-23525.nupkg.sha512",
         "System.Security.Cryptography.Cng.nuspec"
       ]
     },
-    "System.Security.Cryptography.Csp/4.0.0-rc2-23519": {
+    "System.Security.Cryptography.Csp/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gQOxKWfSfS0JBa94FHASZRGvyc48eN/GSGTrqwY5+uzFIWjP5XVIlk7GAcW5Yv910XBLRNXyktTPgrw7WegIXg==",
+      "sha512": "5s7Sz0yUhfBjnJxIZdKxtM/WevPg36jnaUHFji4SFDYFHLkiV6xrEP8HhemZqW5ix7IfiaCDKqGBOceugqxarQ==",
       "files": [
         "lib/DNXCore50/System.Security.Cryptography.Csp.dll",
         "lib/MonoAndroid10/_._",
@@ -17830,15 +18024,15 @@
         "ref/net46/System.Security.Cryptography.Csp.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Csp.4.0.0-rc2-23519.nupkg",
-        "System.Security.Cryptography.Csp.4.0.0-rc2-23519.nupkg.sha512",
+        "System.Security.Cryptography.Csp.4.0.0-rc2-23525.nupkg",
+        "System.Security.Cryptography.Csp.4.0.0-rc2-23525.nupkg.sha512",
         "System.Security.Cryptography.Csp.nuspec"
       ]
     },
-    "System.Security.Cryptography.Encoding/4.0.0-rc2-23519": {
+    "System.Security.Cryptography.Encoding/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "mTYygdKxOiI0OrRTZ7SoUts5NcBk6/+Hx5s1cHJWRUIp3KFEl4Zc1vmIQVDEFMqtqB1kGJBHeJSTIEIC0E4OWg==",
+      "sha512": "w7S6YFfl1dDdfm2dEJVsKBGBgB65CD/AyEzPXrPladnuUl4AJffUIAGf9MnWbUR//qraMUaTluzWQmUs6bE5KA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -17862,27 +18056,27 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-rc2-23519.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-rc2-23519.nupkg.sha512",
+        "System.Security.Cryptography.Encoding.4.0.0-rc2-23525.nupkg",
+        "System.Security.Cryptography.Encoding.4.0.0-rc2-23525.nupkg.sha512",
         "System.Security.Cryptography.Encoding.nuspec"
       ]
     },
-    "System.Security.Cryptography.OpenSsl/4.0.0-rc2-23519": {
+    "System.Security.Cryptography.OpenSsl/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Esyc4QKBFluMHAEzeg7kEp4cRUHX7HHYOB01LAeDIUO9p9bEu8qxrk1kz/VYehMX9qYvV0JpZHLbwPxIlJiyGQ==",
+      "sha512": "FgOKuJAe474txCIZMgsEpEbsPtMD6Wk7ifvn6w78h0d+eGyacB2cEWBfK+Mga6bE2UKr25z72sloBgoE5OWmUA==",
       "files": [
         "ref/dotnet5.4/System.Security.Cryptography.OpenSsl.dll",
         "runtimes/unix/lib/dotnet5.4/System.Security.Cryptography.OpenSsl.dll",
-        "System.Security.Cryptography.OpenSsl.4.0.0-rc2-23519.nupkg",
-        "System.Security.Cryptography.OpenSsl.4.0.0-rc2-23519.nupkg.sha512",
+        "System.Security.Cryptography.OpenSsl.4.0.0-rc2-23525.nupkg",
+        "System.Security.Cryptography.OpenSsl.4.0.0-rc2-23525.nupkg.sha512",
         "System.Security.Cryptography.OpenSsl.nuspec"
       ]
     },
-    "System.Security.Cryptography.Primitives/4.0.0-rc2-23519": {
+    "System.Security.Cryptography.Primitives/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "SKpz8rfeFlCBoGBmxavLd51zIUBZKaldVRnqW22AkWQOQPlc1XHj/gOKwkDfg80K0b4+s2FcTOu7M67bOGA5ig==",
+      "sha512": "4XctVVQ8Ma2eDOiWjE6iUo44unjourG7k5Zr91Bm74DpMVEn3+lmZj9pJn3cthp/WgpRRJXaQRfE7mKEiEUjog==",
       "files": [
         "lib/dotnet5.4/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -17896,15 +18090,15 @@
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-rc2-23519.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-rc2-23519.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-rc2-23525.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-rc2-23525.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
       ]
     },
-    "System.Security.Cryptography.X509Certificates/4.0.0-rc2-23519": {
+    "System.Security.Cryptography.X509Certificates/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "uTuTDGr+tOFafSycB03dLTdhAUbCOJQVp8HrzZDNIY+xwlmugRMF4BS2LDWSn7JhbG4oHymjcnkX5Jpq7K4WJg==",
+      "sha512": "Xzho0jNobWUb3UZtos0Pv/WI6PzBTOxLrisrgKE3xsZhKtevpThJ+1g1OhegeSy5cDpFy0x8bw8sr8qzumNBXQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -17928,15 +18122,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-rc2-23519.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-rc2-23519.nupkg.sha512",
+        "System.Security.Cryptography.X509Certificates.4.0.0-rc2-23525.nupkg",
+        "System.Security.Cryptography.X509Certificates.4.0.0-rc2-23525.nupkg.sha512",
         "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
-    "System.Security.Principal/4.0.1-rc2-23519": {
+    "System.Security.Principal/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "XTl2QBfPPRdi37RsvHathVi71UV3j16nDWHfB56Zen9D7a/iv5Vp1H54NAZUazsidVtpFDX+mhWNhucjK8hs5A==",
+      "sha512": "Xw8pvBLIpmqA1TOK2FNI9sORMgxtcrqP+XGI/pKiny7iu0G+jKeQUQqd/qWCNjT0BGougN+a4ygXzMCFGp7Mog==",
       "files": [
         "lib/dotnet5.1/System.Security.Principal.dll",
         "lib/net45/_._",
@@ -17970,15 +18164,15 @@
         "ref/win8/_._",
         "ref/wp80/_._",
         "ref/wpa81/_._",
-        "System.Security.Principal.4.0.1-rc2-23519.nupkg",
-        "System.Security.Principal.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Security.Principal.4.0.1-rc2-23525.nupkg",
+        "System.Security.Principal.4.0.1-rc2-23525.nupkg.sha512",
         "System.Security.Principal.nuspec"
       ]
     },
-    "System.Security.Principal.Windows/4.0.0-rc2-23519": {
+    "System.Security.Principal.Windows/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "zKxyBUt9zJwWhUH080b23/DY+bDuSAdazopGzOcjasB4s0mrxmdTpbMuKJQrP3BJAzVl9UwaGUSzxg+vhVA59Q==",
+      "sha512": "KtP4Puquvt2hjR7gRGQqkJzwlhRsmlsah1hfDcrarByrcuUMn7Yp2aO0uQ+nA8iZqTz+pXfoPlWnmZA5rGqJ6w==",
       "files": [
         "lib/DNXCore50/System.Security.Principal.Windows.dll",
         "lib/net46/System.Security.Principal.Windows.dll",
@@ -17994,15 +18188,15 @@
         "ref/dotnet5.4/zh-hans/System.Security.Principal.Windows.xml",
         "ref/dotnet5.4/zh-hant/System.Security.Principal.Windows.xml",
         "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-rc2-23519.nupkg",
-        "System.Security.Principal.Windows.4.0.0-rc2-23519.nupkg.sha512",
+        "System.Security.Principal.Windows.4.0.0-rc2-23525.nupkg",
+        "System.Security.Principal.Windows.4.0.0-rc2-23525.nupkg.sha512",
         "System.Security.Principal.Windows.nuspec"
       ]
     },
-    "System.ServiceModel.Duplex/4.0.1-rc2-23519": {
+    "System.ServiceModel.Duplex/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "o+kxgM9dD9uWfamnHvzBD8fSZcBCctSV43IV/d1ovbSYDXSXw+UB4ssrQl9K9x+wc86NKHxwcXGD4r6erdbcUQ==",
+      "sha512": "U0ZuD7q1zGDhLhEgNih+88LrLlpjg+Iu7cUrwyBqqLZTj5NgWM4hcc8oHcyvuci3XBml+N9OttZSYPAfMloBJA==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Duplex.dll",
         "lib/net45/_._",
@@ -18032,15 +18226,15 @@
         "ref/netcore50/zh-hans/System.ServiceModel.Duplex.xml",
         "ref/netcore50/zh-hant/System.ServiceModel.Duplex.xml",
         "ref/win8/_._",
-        "System.ServiceModel.Duplex.4.0.1-rc2-23519.nupkg",
-        "System.ServiceModel.Duplex.4.0.1-rc2-23519.nupkg.sha512",
+        "System.ServiceModel.Duplex.4.0.1-rc2-23525.nupkg",
+        "System.ServiceModel.Duplex.4.0.1-rc2-23525.nupkg.sha512",
         "System.ServiceModel.Duplex.nuspec"
       ]
     },
-    "System.ServiceModel.Http/4.0.11-rc2-23519": {
+    "System.ServiceModel.Http/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "gYaBSfvixaBI1kXE43Kg0KRyodfsu0bbGNnth1RhIOXXkrc6hcZEJ7J/mbwALUvScvfe3rOWMx03braGM3dlmg==",
+      "sha512": "i2MWIqRza6J8dG+oj1GX4AVgsEarA0Tj/qW//UF2XwbveWI11i0esCDc9vJFWr34b1V/+g+VZjWdMXGsFR9ukw==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Http.dll",
         "lib/MonoAndroid10/_._",
@@ -18102,15 +18296,15 @@
         "ref/wp80/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.ServiceModel.Http.4.0.11-rc2-23519.nupkg",
-        "System.ServiceModel.Http.4.0.11-rc2-23519.nupkg.sha512",
+        "System.ServiceModel.Http.4.0.11-rc2-23525.nupkg",
+        "System.ServiceModel.Http.4.0.11-rc2-23525.nupkg.sha512",
         "System.ServiceModel.Http.nuspec"
       ]
     },
-    "System.ServiceModel.NetTcp/4.1.0-rc2-23519": {
+    "System.ServiceModel.NetTcp/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "ZTS11bszgwSt0e1ZgPgWxd0pyQYp5RlETHB3YV+X5+q9fMFmRtzgb6IqoN5YdtT/JZKUwk3vFCWJOmaklMWE+g==",
+      "sha512": "pLkbDSQMlRKqpMdkeoxrOM0ab8CKGPVaNY0nwcSwt0LUbMYtr2lMhOBEQmic4cTauxdxiyk8tWa3RVX7Zkme/Q==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.NetTcp.dll",
         "lib/net45/_._",
@@ -18153,15 +18347,15 @@
         "ref/netcore50/zh-hans/System.ServiceModel.NetTcp.xml",
         "ref/netcore50/zh-hant/System.ServiceModel.NetTcp.xml",
         "ref/win8/_._",
-        "System.ServiceModel.NetTcp.4.1.0-rc2-23519.nupkg",
-        "System.ServiceModel.NetTcp.4.1.0-rc2-23519.nupkg.sha512",
+        "System.ServiceModel.NetTcp.4.1.0-rc2-23525.nupkg",
+        "System.ServiceModel.NetTcp.4.1.0-rc2-23525.nupkg.sha512",
         "System.ServiceModel.NetTcp.nuspec"
       ]
     },
-    "System.ServiceModel.Primitives/4.1.0-rc2-23519": {
+    "System.ServiceModel.Primitives/4.1.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "1cmNWz16uUir3Z8NCmhYsnXoHJ7TZPP17Ka63uDcdWnO52mCyT4tfTT7NnthWQFsxH4fvvfcEtD186xB710g5w==",
+      "sha512": "QZWjcAeO3gBSFmq6G2G3KUiQTRlz1Av6k2bZEo07WPDgBHgbnAaJ4XGr4GmCmqdZNulL8gGq6DXcUvdu86NSoQ==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Primitives.dll",
         "lib/net45/_._",
@@ -18217,15 +18411,15 @@
         "ref/netcore50/zh-hant/System.ServiceModel.Primitives.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "System.ServiceModel.Primitives.4.1.0-rc2-23519.nupkg",
-        "System.ServiceModel.Primitives.4.1.0-rc2-23519.nupkg.sha512",
+        "System.ServiceModel.Primitives.4.1.0-rc2-23525.nupkg",
+        "System.ServiceModel.Primitives.4.1.0-rc2-23525.nupkg.sha512",
         "System.ServiceModel.Primitives.nuspec"
       ]
     },
-    "System.ServiceModel.Security/4.0.1-rc2-23519": {
+    "System.ServiceModel.Security/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "/nkfwh2ugu5bTrXXf+6ZemiR6ZaqaUafHAelxKcEjWluavleta8vmAIwWSJb7X9UJEGbPyGeXEd7Wv+JDbNdtw==",
+      "sha512": "F/CKorSfitabnWF+y16+4h5PLWM0CdCMwCJY+9zKhSrHnEaUgloXNBuBsH+aUEs3HJxnnPblkRAWgcudcDZJBA==",
       "files": [
         "lib/DNXCore50/System.ServiceModel.Security.dll",
         "lib/net45/_._",
@@ -18268,15 +18462,15 @@
         "ref/netcore50/zh-hant/System.ServiceModel.Security.xml",
         "ref/win8/_._",
         "ref/wp80/_._",
-        "System.ServiceModel.Security.4.0.1-rc2-23519.nupkg",
-        "System.ServiceModel.Security.4.0.1-rc2-23519.nupkg.sha512",
+        "System.ServiceModel.Security.4.0.1-rc2-23525.nupkg",
+        "System.ServiceModel.Security.4.0.1-rc2-23525.nupkg.sha512",
         "System.ServiceModel.Security.nuspec"
       ]
     },
-    "System.Text.Encoding/4.0.11-rc2-23519": {
+    "System.Text.Encoding/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "DIrxUx1Ax7S9bncAMv40dwQ9ZKJIIeNYTO7teOAlkkkHcTcPaURKODwlttbXRLpeSyFI0MGPR1UL9D/LTes4HQ==",
+      "sha512": "M1k26o4qE9PGxYyO0Q17houEVrE+iPk8wnnA1Z+sbWGRTeXZxWCKEr7K6yH9GXaV/zcNAPM4KM5RAnuHAN5QdQ==",
       "files": [
         "lib/DNXCore50/System.Text.Encoding.dll",
         "lib/MonoAndroid10/_._",
@@ -18330,15 +18524,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
-        "System.Text.Encoding.4.0.11-rc2-23519.nupkg",
-        "System.Text.Encoding.4.0.11-rc2-23519.nupkg.sha512",
+        "System.Text.Encoding.4.0.11-rc2-23525.nupkg",
+        "System.Text.Encoding.4.0.11-rc2-23525.nupkg.sha512",
         "System.Text.Encoding.nuspec"
       ]
     },
-    "System.Text.Encoding.CodePages/4.0.1-rc2-23519": {
+    "System.Text.Encoding.CodePages/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "21Xqs8DL0XjcpPrJkbNp8PspDeWGe8IfSd5fbjvnnF5BFP14EZVMUhtSd2+5OTl4hvvKNqsdGVp+zqRjcOTwxA==",
+      "sha512": "q2QjitPdvKXcXpJriVQowBtxAeRQxSgCcopXMNU92vkl55P7YvI1w8yFb3nCLLXbCtFlV+Fh7GYTK0VI2E7AgQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -18360,15 +18554,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Text.Encoding.CodePages.4.0.1-rc2-23519.nupkg",
-        "System.Text.Encoding.CodePages.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Text.Encoding.CodePages.4.0.1-rc2-23525.nupkg",
+        "System.Text.Encoding.CodePages.4.0.1-rc2-23525.nupkg.sha512",
         "System.Text.Encoding.CodePages.nuspec"
       ]
     },
-    "System.Text.Encoding.Extensions/4.0.11-rc2-23519": {
+    "System.Text.Encoding.Extensions/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "h2oh52D/t1Ro+8MlKKtdIFriNbSFP0GWVpXndq61qOjCCDRDSKt+qYJtYDGGdpN7ln6dmudnxwyBMsVjN1y56g==",
+      "sha512": "o1PMN49JtyrAhSCsJSQfmcnFOBRSeIr3FmHqLLo/dt84KFNX+vdZ0TYRlAt/crvRMZ+cojGaoTvQ6+4bw6u+XA==",
       "files": [
         "lib/DNXCore50/System.Text.Encoding.Extensions.dll",
         "lib/MonoAndroid10/_._",
@@ -18422,15 +18616,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.Extensions.dll",
-        "System.Text.Encoding.Extensions.4.0.11-rc2-23519.nupkg",
-        "System.Text.Encoding.Extensions.4.0.11-rc2-23519.nupkg.sha512",
+        "System.Text.Encoding.Extensions.4.0.11-rc2-23525.nupkg",
+        "System.Text.Encoding.Extensions.4.0.11-rc2-23525.nupkg.sha512",
         "System.Text.Encoding.Extensions.nuspec"
       ]
     },
-    "System.Text.RegularExpressions/4.0.11-rc2-23519": {
+    "System.Text.RegularExpressions/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "Nt9sn8yvUHnzhCcB5X8F+5I5F/lv7JxHPTh6W0jhaceOFBl4mHhetDL1E/u1IPoveQIh1QSVo00Uk+lwE1Jf2g==",
+      "sha512": "M1JdxnEZ1Mnv6jro+SvVI2ldrEEYhqP7LdhcX0uGm94q1Mg46Y9P27l6g1yz+Qgy2b3oi3tky5aF8+2VJwTuUA==",
       "files": [
         "lib/dotnet5.4/System.Text.RegularExpressions.dll",
         "lib/MonoAndroid10/_._",
@@ -18483,15 +18677,15 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Text.RegularExpressions.4.0.11-rc2-23519.nupkg",
-        "System.Text.RegularExpressions.4.0.11-rc2-23519.nupkg.sha512",
+        "System.Text.RegularExpressions.4.0.11-rc2-23525.nupkg",
+        "System.Text.RegularExpressions.4.0.11-rc2-23525.nupkg.sha512",
         "System.Text.RegularExpressions.nuspec"
       ]
     },
-    "System.Threading/4.0.11-rc2-23519": {
+    "System.Threading/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "n4/qz4RH1fs8GEjPQIUkiena1V5qVPoDwoQxd7/NfcLCG+yy3jnwGrCL4yYlOlioj62s8YqkJmmB9NihWNzIfA==",
+      "sha512": "Vb+NknoSeJKz8FT6nCpDfjtZGOQOfoQAmi/kZxeXgdKwppTMp+Ytv5yqvvnYQDtBQcO3OnrnxUDg8WMTtU/v6w==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -18543,8 +18737,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Threading.4.0.11-rc2-23519.nupkg",
-        "System.Threading.4.0.11-rc2-23519.nupkg.sha512",
+        "System.Threading.4.0.11-rc2-23525.nupkg",
+        "System.Threading.4.0.11-rc2-23525.nupkg.sha512",
         "System.Threading.nuspec"
       ]
     },
@@ -18573,10 +18767,10 @@
         "System.Threading.Overlapped.nuspec"
       ]
     },
-    "System.Threading.Overlapped/4.0.1-rc2-23519": {
+    "System.Threading.Overlapped/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "6DMlo7lTLwH51wY8P05eZDUVs4y/1penPGSNg3bzPOVrmxUJgwBCXebgRjbtBa7QtX1/lLXUKGOau1xSj2uHcQ==",
+      "sha512": "MCDlnSFlNJ0gH2kKE1qV96jOQErULnMXySr++sD/6yIymRXiwl0GYFdv6Tq+qhHRYD9+QEcm/8jG+i1eK7IubQ==",
       "files": [
         "lib/DNXCore50/System.Threading.Overlapped.dll",
         "lib/net46/System.Threading.Overlapped.dll",
@@ -18593,15 +18787,15 @@
         "ref/dotnet5.4/zh-hans/System.Threading.Overlapped.xml",
         "ref/dotnet5.4/zh-hant/System.Threading.Overlapped.xml",
         "ref/net46/System.Threading.Overlapped.dll",
-        "System.Threading.Overlapped.4.0.1-rc2-23519.nupkg",
-        "System.Threading.Overlapped.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Threading.Overlapped.4.0.1-rc2-23525.nupkg",
+        "System.Threading.Overlapped.4.0.1-rc2-23525.nupkg.sha512",
         "System.Threading.Overlapped.nuspec"
       ]
     },
-    "System.Threading.Tasks/4.0.11-rc2-23519": {
+    "System.Threading.Tasks/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "NFTNdkMCSYfxRBLx/hppmuCEhZoAYLfDjp/T7z19K9bedOR9avPpoKHrPuOJSCqWSxXSSezKJIO49ROmEiZcXg==",
+      "sha512": "AnTRum7I9zd11FK9QxLsCWmt0VyxWyJjj2b/dFCQIFXh9iOPCkApf4sDcgRN7c6e/97CZSGHIKCvTO/zxeuGcA==",
       "files": [
         "lib/DNXCore50/System.Threading.Tasks.dll",
         "lib/MonoAndroid10/_._",
@@ -18655,15 +18849,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
-        "System.Threading.Tasks.4.0.11-rc2-23519.nupkg",
-        "System.Threading.Tasks.4.0.11-rc2-23519.nupkg.sha512",
+        "System.Threading.Tasks.4.0.11-rc2-23525.nupkg",
+        "System.Threading.Tasks.4.0.11-rc2-23525.nupkg.sha512",
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.Tasks.Dataflow/4.5.26-rc2-23519": {
+    "System.Threading.Tasks.Dataflow/4.5.26-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "h0JyMjHSuZD62Swrp1QPuoeE8rMoQiD6Ro7jCxFDybhpJzETrO1msW1XCOyzbqQS5nJjudbPdsiPuvSw5Ui2cg==",
+      "sha512": "3HP/YYzZtUc4RW3p1bpZjDF9Hs9F4bdC54f9aXZC7o/UPkhkQMehAcebiWzj86P/aoOcrEsgC1YmN2zxAmkslg==",
       "files": [
         "lib/dotnet5.2/System.Threading.Tasks.Dataflow.dll",
         "lib/dotnet5.2/System.Threading.Tasks.Dataflow.XML",
@@ -18671,15 +18865,15 @@
         "lib/portable-net45+win8+wp8+wpa81/System.Threading.Tasks.Dataflow.XML",
         "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.dll",
         "lib/portable-net45+win8+wpa81/System.Threading.Tasks.Dataflow.XML",
-        "System.Threading.Tasks.Dataflow.4.5.26-rc2-23519.nupkg",
-        "System.Threading.Tasks.Dataflow.4.5.26-rc2-23519.nupkg.sha512",
+        "System.Threading.Tasks.Dataflow.4.5.26-rc2-23525.nupkg",
+        "System.Threading.Tasks.Dataflow.4.5.26-rc2-23525.nupkg.sha512",
         "System.Threading.Tasks.Dataflow.nuspec"
       ]
     },
-    "System.Threading.Tasks.Parallel/4.0.1-rc2-23519": {
+    "System.Threading.Tasks.Parallel/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "miB24ZTw24oYddir7ybqGRXLBZ6k9tr+0d40pjt2ly+xFXZ7snFhCLg54PN5pMuzDM/cBxd5BBE7R28y6Pn6VQ==",
+      "sha512": "EJLT+ffbbDDLVQKx5fU2EajiEaGg3VQF1WqzcG5rBkgY/fPTAR8f4RkSAXiUCj5RVZupehT6qBIn466GfL6TMQ==",
       "files": [
         "lib/dotnet5.4/System.Threading.Tasks.Parallel.dll",
         "lib/net45/_._",
@@ -18711,15 +18905,15 @@
         "ref/netcore50/zh-hant/System.Threading.Tasks.Parallel.xml",
         "ref/win8/_._",
         "ref/wpa81/_._",
-        "System.Threading.Tasks.Parallel.4.0.1-rc2-23519.nupkg",
-        "System.Threading.Tasks.Parallel.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Threading.Tasks.Parallel.4.0.1-rc2-23525.nupkg",
+        "System.Threading.Tasks.Parallel.4.0.1-rc2-23525.nupkg.sha512",
         "System.Threading.Tasks.Parallel.nuspec"
       ]
     },
-    "System.Threading.Thread/4.0.0-rc2-23519": {
+    "System.Threading.Thread/4.0.0-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "HWbXrWl/DH+ta49hwEO/pypeiqLk8YOfwgT/IfNKuQnLS6XWHAFbP4xc+/yVG0+L60OLb4+mEU2K7icczd2UPA==",
+      "sha512": "ZruaC91XdYWBdCf1YZv0sfET0hGLn/6c/ykwOWIIF4T6PBUEFNlSsG8Kwc/+ewOx6tv3Lbe2RlRplc6FnG74dw==",
       "files": [
         "lib/DNXCore50/System.Threading.Thread.dll",
         "lib/MonoAndroid10/_._",
@@ -18743,15 +18937,15 @@
         "ref/net46/System.Threading.Thread.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.Thread.4.0.0-rc2-23519.nupkg",
-        "System.Threading.Thread.4.0.0-rc2-23519.nupkg.sha512",
+        "System.Threading.Thread.4.0.0-rc2-23525.nupkg",
+        "System.Threading.Thread.4.0.0-rc2-23525.nupkg.sha512",
         "System.Threading.Thread.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-rc2-23519": {
+    "System.Threading.ThreadPool/4.0.10-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "IXApp3iQtwuRLDJfd2+xsouso9yoxAOwAiifzYevwketGSZSQD5QtzkDL27e786f5Hn066leYCUCtqXPeJttYA==",
+      "sha512": "MPJw65JnL5aAku+ZgE3yOlx9XdSOhFFbS2fB+fKACZisR8AyMUu+80XqVtujnf4GAoI3LlO88TJq9ijyyI+1hA==",
       "files": [
         "lib/DNXCore50/System.Threading.ThreadPool.dll",
         "lib/MonoAndroid10/_._",
@@ -18775,15 +18969,15 @@
         "ref/net46/System.Threading.ThreadPool.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-rc2-23519.nupkg",
-        "System.Threading.ThreadPool.4.0.10-rc2-23519.nupkg.sha512",
+        "System.Threading.ThreadPool.4.0.10-rc2-23525.nupkg",
+        "System.Threading.ThreadPool.4.0.10-rc2-23525.nupkg.sha512",
         "System.Threading.ThreadPool.nuspec"
       ]
     },
-    "System.Threading.Timer/4.0.1-rc2-23519": {
+    "System.Threading.Timer/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "P3iQJJUBUa5WlhT69SoLVMEdxXlQ6BsEufwzuMncCHLk1393BFgA39s406q7I9cqihiEDLs7vQvkU0meki33qA==",
+      "sha512": "vbkQ82Mxunz4O+DyiR4fLwvN1aCt8JXfub+qeHqZriIUj0xZhrftC938B6vZCeuklmIHNd46RuM0N3eq4jKyrw==",
       "files": [
         "lib/DNXCore50/System.Threading.Timer.dll",
         "lib/net451/_._",
@@ -18816,15 +19010,15 @@
         "ref/win81/_._",
         "ref/wpa81/_._",
         "runtimes/win8-aot/lib/netcore50/System.Threading.Timer.dll",
-        "System.Threading.Timer.4.0.1-rc2-23519.nupkg",
-        "System.Threading.Timer.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Threading.Timer.4.0.1-rc2-23525.nupkg",
+        "System.Threading.Timer.4.0.1-rc2-23525.nupkg.sha512",
         "System.Threading.Timer.nuspec"
       ]
     },
-    "System.Xml.ReaderWriter/4.0.11-rc2-23519": {
+    "System.Xml.ReaderWriter/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "I606h1JlAug8z2h3Wu6GC5A7jdHx4xkliPdnhPtrt6yPnSRlkEAyAcG21GVRIvmJbyK7hxmg98Ikd3YwR+/Chg==",
+      "sha512": "EIqBwHgtF3eA90r2N2bG9PwYFKt/D8G+/+alpQc7hQezo+XzoyaR8uxqRBVf0t2rKqpyQ3JewfMgeS/0o2uxEw==",
       "files": [
         "lib/dotnet5.4/System.Xml.ReaderWriter.dll",
         "lib/MonoAndroid10/_._",
@@ -18877,15 +19071,15 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Xml.ReaderWriter.4.0.11-rc2-23519.nupkg",
-        "System.Xml.ReaderWriter.4.0.11-rc2-23519.nupkg.sha512",
+        "System.Xml.ReaderWriter.4.0.11-rc2-23525.nupkg",
+        "System.Xml.ReaderWriter.4.0.11-rc2-23525.nupkg.sha512",
         "System.Xml.ReaderWriter.nuspec"
       ]
     },
-    "System.Xml.XDocument/4.0.11-rc2-23519": {
+    "System.Xml.XDocument/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "hVd5smJPqvijN2dEJixMuCCS2fmGz6jTJxzjUQjveElgqM54DOm0KvHT81OB72jPW80OVt4p8dquCJnu0JZZNw==",
+      "sha512": "wSy82fA10MuX184Tra7ZXdfA+snT5Kg/Fjk6l06HuXQ4iIh7mK/l43/kUTttWvI8s4vlnov2Rc36bp4tlSIsSQ==",
       "files": [
         "lib/dotnet5.4/System.Xml.XDocument.dll",
         "lib/MonoAndroid10/_._",
@@ -18938,15 +19132,15 @@
         "ref/wpa81/_._",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Xml.XDocument.4.0.11-rc2-23519.nupkg",
-        "System.Xml.XDocument.4.0.11-rc2-23519.nupkg.sha512",
+        "System.Xml.XDocument.4.0.11-rc2-23525.nupkg",
+        "System.Xml.XDocument.4.0.11-rc2-23525.nupkg.sha512",
         "System.Xml.XDocument.nuspec"
       ]
     },
-    "System.Xml.XmlDocument/4.0.1-rc2-23519": {
+    "System.Xml.XmlDocument/4.0.1-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "7WQi53VwcVOvWK7nLoB/CgUm6AzKgus3agY7KBICTk+q/vKRYZ0BHpBxCdeVj/GVe3AfAJT6X5WS918g9+uoJw==",
+      "sha512": "Zr6Xs130BWHNp5OFA1rxVSsqwqeo6sb80Dk/dsV8lxIuEa33Ut0ZB9oBPrOAwmDa3jF9zDRTc9HO1nd7BZOsyA==",
       "files": [
         "lib/dotnet5.4/System.Xml.XmlDocument.dll",
         "lib/MonoAndroid10/_._",
@@ -18970,15 +19164,15 @@
         "ref/net46/System.Xml.XmlDocument.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Xml.XmlDocument.4.0.1-rc2-23519.nupkg",
-        "System.Xml.XmlDocument.4.0.1-rc2-23519.nupkg.sha512",
+        "System.Xml.XmlDocument.4.0.1-rc2-23525.nupkg",
+        "System.Xml.XmlDocument.4.0.1-rc2-23525.nupkg.sha512",
         "System.Xml.XmlDocument.nuspec"
       ]
     },
-    "System.Xml.XmlSerializer/4.0.11-rc2-23519": {
+    "System.Xml.XmlSerializer/4.0.11-rc2-23525": {
       "type": "package",
       "serviceable": true,
-      "sha512": "i6ZnITpR5bvgn1Q7YwMPdOdltQVVF6aAYV4LproiZXS1xO+yDms05Hq5r/yHB/4/6bxQhYb1uXHSRTNOwHr1Sg==",
+      "sha512": "tWLqQPfWeKJEFpsZ0NYQY1GtyqLwDEma2c9vcGYlZoRvwYtvptrowzXb6LUYebx+y6KUsKr6rxGcU0LNPL2/dQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -19030,8 +19224,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Xml.XmlSerializer.4.0.11-rc2-23519.nupkg",
-        "System.Xml.XmlSerializer.4.0.11-rc2-23519.nupkg.sha512",
+        "System.Xml.XmlSerializer.4.0.11-rc2-23525.nupkg",
+        "System.Xml.XmlSerializer.4.0.11-rc2-23525.nupkg.sha512",
         "System.Xml.XmlSerializer.nuspec"
       ]
     },
@@ -19208,10 +19402,10 @@
   },
   "projectFileDependencyGroups": {
     "": [
-      "Microsoft.NETCore.Platforms >= 1.0.1-rc2-23519",
-      "Microsoft.NETCore.TestHost >= 1.0.0-rc2-23519",
-      "Microsoft.NETCore.Console >= 1.0.0-rc2-23519",
-      "System.IO.Compression >= 4.1.0-rc2-23519",
+      "Microsoft.NETCore.Platforms >= 1.0.1-rc2-23525",
+      "Microsoft.NETCore.TestHost >= 1.0.0-rc2-23525",
+      "Microsoft.NETCore.Console >= 1.0.0-rc2-23525",
+      "System.IO.Compression >= 4.1.0-rc2-23525",
       "coveralls.io >= 1.4.0",
       "OpenCover >= 4.6.166",
       "ReportGenerator >= 2.3.4",

--- a/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
+++ b/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
@@ -35,17 +35,6 @@
       <Name>System.Net.Requests</Name>
       <Project>{5EE76DCC-9FD5-47FD-AB45-BD0F0857740F}</Project>
     </ProjectReference>
-    <!--
-        TODO: Temporary fix.
-        Current PR introduces a backward-incompatible change in System.Net.Http.Native. Owing to the way tests are run on CI, this change will result in
-        crash when System.Net.Requests.Tests are run. The following is a temporary work around and will be removed as soon as the dlls and native libraries
-        get in sync
-    -->
-    <ProjectReference Include="..\..\System.Net.Http\src\System.Net.Http.csproj">
-      <Name>System.Net.Http</Name>
-      <Project>{1D422B1D-D7C4-41B9-862D-EB3D98DF37DE}</Project>
-    </ProjectReference>
-
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Net.Requests/tests/project.lock.json
+++ b/src/System.Net.Requests/tests/project.lock.json
@@ -189,7 +189,7 @@
           "lib/DNXCore50/System.Net.Http.dll": {}
         }
       },
-      "System.Net.Primitives/4.0.11-beta-23509": {
+      "System.Net.Primitives/4.0.11-beta-23516": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -199,7 +199,7 @@
           "ref/dotnet5.4/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Requests/4.0.11-beta-23509": {
+      "System.Net.Requests/4.0.11-beta-23516": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -503,7 +503,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00119": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00122": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -543,10 +543,10 @@
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
         }
       },
-      "runtime.win7.System.Net.Primitives/4.0.11-beta-23509": {
+      "runtime.win7.System.Net.Primitives/4.0.11-beta-23516": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23509"
+          "System.Private.Networking": "4.0.1-beta-23516"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -555,7 +555,7 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "runtime.win7.System.Net.Requests/4.0.11-beta-23509": {
+      "runtime.win7.System.Net.Requests/4.0.11-beta-23516": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -828,7 +828,7 @@
           "lib/DNXCore50/System.Net.Http.dll": {}
         }
       },
-      "System.Net.Primitives/4.0.11-beta-23509": {
+      "System.Net.Primitives/4.0.11-beta-23516": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -838,7 +838,7 @@
           "ref/dotnet5.4/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Requests/4.0.11-beta-23509": {
+      "System.Net.Requests/4.0.11-beta-23516": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -875,7 +875,7 @@
           "ref/dotnet/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23509": {
+      "System.Private.Networking/4.0.1-beta-23516": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -894,14 +894,11 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23509",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23509",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23516",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23509",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23509"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -1036,46 +1033,7 @@
           "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "System.Security.Claims/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Globalization": "4.0.0",
-          "System.IO": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Security.Principal": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Security.Claims.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/System.Security.Claims.dll": {}
-        }
-      },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23509": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23509"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
-        }
-      },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23509": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
-        }
-      },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23509": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23516": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -1087,22 +1045,10 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
+          "ref/dotnet5.1/System.Security.Cryptography.Primitives.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
-        }
-      },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23509": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23509",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23509"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
       "System.Security.Principal/4.0.0": {
@@ -1115,29 +1061,6 @@
         },
         "runtime": {
           "lib/dotnet/System.Security.Principal.dll": {}
-        }
-      },
-      "System.Security.Principal.Windows/4.0.0-beta-23509": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Reflection": "4.0.10",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Runtime.Handles": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Claims": "4.0.0",
-          "System.Security.Principal": "4.0.0",
-          "System.Text.Encoding": "4.0.10",
-          "System.Threading": "4.0.10"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Principal.Windows.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
       "System.Text.Encoding/4.0.10": {
@@ -1210,19 +1133,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23509": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "xunit/2.1.0": {
@@ -1320,7 +1230,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00119": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00122": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -1360,10 +1270,10 @@
           "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
         }
       },
-      "runtime.win7.System.Net.Primitives/4.0.11-beta-23509": {
+      "runtime.win7.System.Net.Primitives/4.0.11-beta-23516": {
         "type": "package",
         "dependencies": {
-          "System.Private.Networking": "4.0.1-beta-23509"
+          "System.Private.Networking": "4.0.1-beta-23516"
         },
         "compile": {
           "ref/dotnet/_._": {}
@@ -1372,7 +1282,7 @@
           "lib/DNXCore50/System.Net.Primitives.dll": {}
         }
       },
-      "runtime.win7.System.Net.Requests/4.0.11-beta-23509": {
+      "runtime.win7.System.Net.Requests/4.0.11-beta-23516": {
         "type": "package",
         "dependencies": {
           "System.Collections": "4.0.10",
@@ -1645,7 +1555,7 @@
           "lib/DNXCore50/System.Net.Http.dll": {}
         }
       },
-      "System.Net.Primitives/4.0.11-beta-23509": {
+      "System.Net.Primitives/4.0.11-beta-23516": {
         "type": "package",
         "dependencies": {
           "System.Runtime": "4.0.0",
@@ -1655,7 +1565,7 @@
           "ref/dotnet5.4/System.Net.Primitives.dll": {}
         }
       },
-      "System.Net.Requests/4.0.11-beta-23509": {
+      "System.Net.Requests/4.0.11-beta-23516": {
         "type": "package",
         "dependencies": {
           "System.IO": "4.0.0",
@@ -1692,7 +1602,7 @@
           "ref/dotnet/System.ObjectModel.dll": {}
         }
       },
-      "System.Private.Networking/4.0.1-beta-23509": {
+      "System.Private.Networking/4.0.1-beta-23516": {
         "type": "package",
         "dependencies": {
           "Microsoft.Win32.Primitives": "4.0.0",
@@ -1711,14 +1621,11 @@
           "System.Runtime.Extensions": "4.0.10",
           "System.Runtime.Handles": "4.0.0",
           "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23509",
-          "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23509",
+          "System.Security.Cryptography.Primitives": "4.0.0-beta-23516",
           "System.Security.Principal": "4.0.0",
-          "System.Security.Principal.Windows": "4.0.0-beta-23509",
           "System.Threading": "4.0.10",
           "System.Threading.Overlapped": "4.0.0",
-          "System.Threading.Tasks": "4.0.10",
-          "System.Threading.ThreadPool": "4.0.10-beta-23509"
+          "System.Threading.Tasks": "4.0.10"
         },
         "compile": {
           "ref/dnxcore50/_._": {}
@@ -1853,46 +1760,7 @@
           "lib/dotnet/System.Runtime.InteropServices.RuntimeInformation.dll": {}
         }
       },
-      "System.Security.Claims/4.0.0": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.0",
-          "System.Globalization": "4.0.0",
-          "System.IO": "4.0.0",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Security.Principal": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet/System.Security.Claims.dll": {}
-        },
-        "runtime": {
-          "lib/dotnet/System.Security.Claims.dll": {}
-        }
-      },
-      "System.Security.Cryptography.Algorithms/4.0.0-beta-23509": {
-        "type": "package",
-        "dependencies": {
-          "System.IO": "4.0.0",
-          "System.Runtime": "4.0.0",
-          "System.Security.Cryptography.Primitives": "4.0.0-beta-23509"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.Algorithms.dll": {}
-        }
-      },
-      "System.Security.Cryptography.Encoding/4.0.0-beta-23509": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.Encoding.dll": {}
-        }
-      },
-      "System.Security.Cryptography.Primitives/4.0.0-beta-23509": {
+      "System.Security.Cryptography.Primitives/4.0.0-beta-23516": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.0",
@@ -1904,22 +1772,10 @@
           "System.Threading.Tasks": "4.0.0"
         },
         "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
+          "ref/dotnet5.1/System.Security.Cryptography.Primitives.dll": {}
         },
         "runtime": {
           "lib/dotnet5.4/System.Security.Cryptography.Primitives.dll": {}
-        }
-      },
-      "System.Security.Cryptography.X509Certificates/4.0.0-beta-23509": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.Handles": "4.0.0",
-          "System.Security.Cryptography.Algorithms": "4.0.0-beta-23509",
-          "System.Security.Cryptography.Encoding": "4.0.0-beta-23509"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Cryptography.X509Certificates.dll": {}
         }
       },
       "System.Security.Principal/4.0.0": {
@@ -1932,29 +1788,6 @@
         },
         "runtime": {
           "lib/dotnet/System.Security.Principal.dll": {}
-        }
-      },
-      "System.Security.Principal.Windows/4.0.0-beta-23509": {
-        "type": "package",
-        "dependencies": {
-          "System.Collections": "4.0.0",
-          "System.Diagnostics.Debug": "4.0.10",
-          "System.Reflection": "4.0.10",
-          "System.Resources.ResourceManager": "4.0.0",
-          "System.Runtime": "4.0.20",
-          "System.Runtime.Extensions": "4.0.0",
-          "System.Runtime.Handles": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.20",
-          "System.Security.Claims": "4.0.0",
-          "System.Security.Principal": "4.0.0",
-          "System.Text.Encoding": "4.0.10",
-          "System.Threading": "4.0.10"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Security.Principal.Windows.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Security.Principal.Windows.dll": {}
         }
       },
       "System.Text.Encoding/4.0.10": {
@@ -2027,19 +1860,6 @@
         },
         "runtime": {
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
-        }
-      },
-      "System.Threading.ThreadPool/4.0.10-beta-23509": {
-        "type": "package",
-        "dependencies": {
-          "System.Runtime": "4.0.0",
-          "System.Runtime.InteropServices": "4.0.0"
-        },
-        "compile": {
-          "ref/dotnet5.4/System.Threading.ThreadPool.dll": {}
-        },
-        "runtime": {
-          "lib/DNXCore50/System.Threading.ThreadPool.dll": {}
         }
       },
       "xunit/2.1.0": {
@@ -2137,7 +1957,7 @@
           "lib/dotnet/xunit.execution.dotnet.dll": {}
         }
       },
-      "xunit.netcore.extensions/1.0.0-prerelease-00119": {
+      "xunit.netcore.extensions/1.0.0-prerelease-00122": {
         "type": "package",
         "dependencies": {
           "System.Diagnostics.Debug": "4.0.10",
@@ -2197,27 +2017,27 @@
         "ref/xamarinmac20/_._"
       ]
     },
-    "runtime.win7.System.Net.Primitives/4.0.11-beta-23509": {
+    "runtime.win7.System.Net.Primitives/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "6xz036vLhnMn16ZY854alpHjF7/lAdQSEViFHFDIPE6lwjBZHmEp41K/s5Xo7I7y6pZsAAmqF6vCNlh9SsJlLg==",
+      "sha512": "WmcWc3b5xNFdik+yWrFPy/WWwsfNAdMebJNzVqbPd4OlVQ7TWhO7VR5TN2M+3Ji0OAV9scHZ6atCWyBycz6+nA==",
       "files": [
         "lib/DNXCore50/System.Net.Primitives.dll",
         "ref/dotnet/_._",
-        "runtime.win7.System.Net.Primitives.4.0.11-beta-23509.nupkg",
-        "runtime.win7.System.Net.Primitives.4.0.11-beta-23509.nupkg.sha512",
+        "runtime.win7.System.Net.Primitives.4.0.11-beta-23516.nupkg",
+        "runtime.win7.System.Net.Primitives.4.0.11-beta-23516.nupkg.sha512",
         "runtime.win7.System.Net.Primitives.nuspec",
         "runtimes/win7/lib/netcore50/System.Net.Primitives.dll"
       ]
     },
-    "runtime.win7.System.Net.Requests/4.0.11-beta-23509": {
+    "runtime.win7.System.Net.Requests/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "/5LyKgp6cHiIxJne3FgVnl2utfs9dmad9pzA+qXMc35Y/E+RLG3MdXFeLDMgIpKEusKtr4MnRgMRSidd6KJmSw==",
+      "sha512": "mqWBQUhXhzkiwb+zVUuKg+wswJUsnQtZkFtz6eISw8vWNXA9i2jkzYjU3pjjIVmtdopnhle9YaS4a/w4OuWGLw==",
       "files": [
         "ref/dotnet/_._",
-        "runtime.win7.System.Net.Requests.4.0.11-beta-23509.nupkg",
-        "runtime.win7.System.Net.Requests.4.0.11-beta-23509.nupkg.sha512",
+        "runtime.win7.System.Net.Requests.4.0.11-beta-23516.nupkg",
+        "runtime.win7.System.Net.Requests.4.0.11-beta-23516.nupkg.sha512",
         "runtime.win7.System.Net.Requests.nuspec",
         "runtimes/win7/lib/dotnet5.4/System.Net.Requests.dll",
         "runtimes/win7/lib/net/_._"
@@ -2805,10 +2625,10 @@
         "System.Net.Http.nuspec"
       ]
     },
-    "System.Net.Primitives/4.0.11-beta-23509": {
+    "System.Net.Primitives/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "2v/BuSqfIFQbR/69jXAEtWhtlfY7D/2uNfGpxXTai7Rbp9FGM46CCFKMG4qfQCeLjIaqa1/NOuTnLTRGUxJIJQ==",
+      "sha512": "e6bYgPSmo1n/+Ccef2OxFm5gyvhGvw/+Zvsh09iOfLNOutr/2ker4IsxC+3VMVDZc/3/glc4iOfuB5x59HzzHQ==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2871,15 +2691,15 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.Primitives.4.0.11-beta-23509.nupkg",
-        "System.Net.Primitives.4.0.11-beta-23509.nupkg.sha512",
+        "System.Net.Primitives.4.0.11-beta-23516.nupkg",
+        "System.Net.Primitives.4.0.11-beta-23516.nupkg.sha512",
         "System.Net.Primitives.nuspec"
       ]
     },
-    "System.Net.Requests/4.0.11-beta-23509": {
+    "System.Net.Requests/4.0.11-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "/rT+jZLxJRDrR0wt7fg+2LtsgzSsKYqDck64fj2dnnxKBHSao4cZoP/H3ibNMgyNZjg0AXxHH5GfjOJYKinHIg==",
+      "sha512": "zbUdLNiGM7m0JgHcADonPXuz5DJq/WkK6NoHyQNkRt9dbBrYQ0CSg3PQX1qTLQyAuOKKhWOXuZ5gMyOA0t0AzA==",
       "files": [
         "lib/MonoAndroid10/_._",
         "lib/MonoTouch10/_._",
@@ -2942,8 +2762,8 @@
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
         "runtime.json",
-        "System.Net.Requests.4.0.11-beta-23509.nupkg",
-        "System.Net.Requests.4.0.11-beta-23509.nupkg.sha512",
+        "System.Net.Requests.4.0.11-beta-23516.nupkg",
+        "System.Net.Requests.4.0.11-beta-23516.nupkg.sha512",
         "System.Net.Requests.nuspec"
       ]
     },
@@ -3027,17 +2847,17 @@
         "System.ObjectModel.nuspec"
       ]
     },
-    "System.Private.Networking/4.0.1-beta-23509": {
+    "System.Private.Networking/4.0.1-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "UCT1KbRKwYRK8mcsMLEGE51Co4DgRK9kvykv0PvmZjivAIuE3uJe2mla4xXgand6hRLYhR6G5tg/4Fm26/I6gg==",
+      "sha512": "x1STivE/maJG95AY82H5A7K5LbEOj4hzjGEGt2p1oEM4NIG0HBqXFauWHRRRQDZI0851wjBwgxHNid/56hHOhg==",
       "files": [
         "lib/DNXCore50/System.Private.Networking.dll",
         "lib/netcore50/System.Private.Networking.dll",
         "ref/dnxcore50/_._",
         "ref/netcore50/_._",
-        "System.Private.Networking.4.0.1-beta-23509.nupkg",
-        "System.Private.Networking.4.0.1-beta-23509.nupkg.sha512",
+        "System.Private.Networking.4.0.1-beta-23516.nupkg",
+        "System.Private.Networking.4.0.1-beta-23516.nupkg.sha512",
         "System.Private.Networking.nuspec"
       ]
     },
@@ -3347,96 +3167,10 @@
         "System.Runtime.InteropServices.RuntimeInformation.nuspec"
       ]
     },
-    "System.Security.Claims/4.0.0": {
+    "System.Security.Cryptography.Primitives/4.0.0-beta-23516": {
       "type": "package",
       "serviceable": true,
-      "sha512": "94NFR/7JN3YdyTH7hl2iSvYmdA8aqShriTHectcK+EbizT71YczMaG6LuqJBQP/HWo66AQyikYYM9aw+4EzGXg==",
-      "files": [
-        "lib/dotnet/System.Security.Claims.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Security.Claims.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet/de/System.Security.Claims.xml",
-        "ref/dotnet/es/System.Security.Claims.xml",
-        "ref/dotnet/fr/System.Security.Claims.xml",
-        "ref/dotnet/it/System.Security.Claims.xml",
-        "ref/dotnet/ja/System.Security.Claims.xml",
-        "ref/dotnet/ko/System.Security.Claims.xml",
-        "ref/dotnet/ru/System.Security.Claims.xml",
-        "ref/dotnet/System.Security.Claims.dll",
-        "ref/dotnet/System.Security.Claims.xml",
-        "ref/dotnet/zh-hans/System.Security.Claims.xml",
-        "ref/dotnet/zh-hant/System.Security.Claims.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Security.Claims.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Security.Claims.4.0.0.nupkg",
-        "System.Security.Claims.4.0.0.nupkg.sha512",
-        "System.Security.Claims.nuspec"
-      ]
-    },
-    "System.Security.Cryptography.Algorithms/4.0.0-beta-23509": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "YBUhZnerH9puSUZJo1PEG0U8wGbGWCnfC2KgoUytRjOw7YlCX4CgS5CzumnPr+zEeEfH/A2O9RzEksqsNeJO1Q==",
-      "files": [
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Security.Cryptography.Algorithms.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet5.4/System.Security.Cryptography.Algorithms.dll",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Security.Cryptography.Algorithms.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "runtime.json",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23509.nupkg",
-        "System.Security.Cryptography.Algorithms.4.0.0-beta-23509.nupkg.sha512",
-        "System.Security.Cryptography.Algorithms.nuspec"
-      ]
-    },
-    "System.Security.Cryptography.Encoding/4.0.0-beta-23509": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "IB1ldLksggECahCRdw7zH1EeifdnlYsInHuekdgzv2gfct2GYKPk1R5KrmqLo1ZIS8ac6bhY0AclbEX3QNxuIA==",
-      "files": [
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Security.Cryptography.Encoding.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet5.4/de/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.4/es/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.4/fr/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.4/it/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.4/ja/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.4/ko/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.4/ru/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.4/System.Security.Cryptography.Encoding.dll",
-        "ref/dotnet5.4/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.4/zh-hans/System.Security.Cryptography.Encoding.xml",
-        "ref/dotnet5.4/zh-hant/System.Security.Cryptography.Encoding.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Security.Cryptography.Encoding.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "runtime.json",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23509.nupkg",
-        "System.Security.Cryptography.Encoding.4.0.0-beta-23509.nupkg.sha512",
-        "System.Security.Cryptography.Encoding.nuspec"
-      ]
-    },
-    "System.Security.Cryptography.Primitives/4.0.0-beta-23509": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "4av3kVaRkbTUEeDSvW312Y/hehNFapnaFfGnQyGkuQ4e5n5ux5sdnoFrDZfOsBSbHuhaRraBB5ITsVLdQD0lNQ==",
+      "sha512": "ztiLIQf2hl0ljLzaUeCx5tk+TU8TrHwrEatuKgSl2KoZXxeOCeXnB+oE07xQO7RnnMlPLtX7/ucHQtteh9du7A==",
       "files": [
         "lib/dotnet5.4/System.Security.Cryptography.Primitives.dll",
         "lib/MonoAndroid10/_._",
@@ -3444,47 +3178,15 @@
         "lib/net46/System.Security.Cryptography.Primitives.dll",
         "lib/xamarinios10/_._",
         "lib/xamarinmac20/_._",
-        "ref/dotnet5.4/System.Security.Cryptography.Primitives.dll",
+        "ref/dotnet5.1/System.Security.Cryptography.Primitives.dll",
         "ref/MonoAndroid10/_._",
         "ref/MonoTouch10/_._",
         "ref/net46/System.Security.Cryptography.Primitives.dll",
         "ref/xamarinios10/_._",
         "ref/xamarinmac20/_._",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23509.nupkg",
-        "System.Security.Cryptography.Primitives.4.0.0-beta-23509.nupkg.sha512",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23516.nupkg",
+        "System.Security.Cryptography.Primitives.4.0.0-beta-23516.nupkg.sha512",
         "System.Security.Cryptography.Primitives.nuspec"
-      ]
-    },
-    "System.Security.Cryptography.X509Certificates/4.0.0-beta-23509": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "OuSdB1Nkb6WKLUObTeDnlfRKFrOJ0/d/F6vcLezLs67X3o61EQ+sXTY1oFR00WLFSXOF5X4G/uXwDZh/3PIiyQ==",
-      "files": [
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Security.Cryptography.X509Certificates.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet5.4/de/System.Security.Cryptography.X509Certificates.xml",
-        "ref/dotnet5.4/es/System.Security.Cryptography.X509Certificates.xml",
-        "ref/dotnet5.4/fr/System.Security.Cryptography.X509Certificates.xml",
-        "ref/dotnet5.4/it/System.Security.Cryptography.X509Certificates.xml",
-        "ref/dotnet5.4/ja/System.Security.Cryptography.X509Certificates.xml",
-        "ref/dotnet5.4/ko/System.Security.Cryptography.X509Certificates.xml",
-        "ref/dotnet5.4/ru/System.Security.Cryptography.X509Certificates.xml",
-        "ref/dotnet5.4/System.Security.Cryptography.X509Certificates.dll",
-        "ref/dotnet5.4/System.Security.Cryptography.X509Certificates.xml",
-        "ref/dotnet5.4/zh-hans/System.Security.Cryptography.X509Certificates.xml",
-        "ref/dotnet5.4/zh-hant/System.Security.Cryptography.X509Certificates.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Security.Cryptography.X509Certificates.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "runtime.json",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23509.nupkg",
-        "System.Security.Cryptography.X509Certificates.4.0.0-beta-23509.nupkg.sha512",
-        "System.Security.Cryptography.X509Certificates.nuspec"
       ]
     },
     "System.Security.Principal/4.0.0": {
@@ -3518,30 +3220,6 @@
         "System.Security.Principal.4.0.0.nupkg",
         "System.Security.Principal.4.0.0.nupkg.sha512",
         "System.Security.Principal.nuspec"
-      ]
-    },
-    "System.Security.Principal.Windows/4.0.0-beta-23509": {
-      "type": "package",
-      "serviceable": true,
-      "sha512": "boE9PSE0jXjPIxlxTH7nYlL09Pxn3asXSiqpfTyVNc8ZV8EtjGjDIze4QB2tCx7jSfdh3R3hLJoI38cu08qFOA==",
-      "files": [
-        "lib/DNXCore50/System.Security.Principal.Windows.dll",
-        "lib/net46/System.Security.Principal.Windows.dll",
-        "ref/dotnet5.4/de/System.Security.Principal.Windows.xml",
-        "ref/dotnet5.4/es/System.Security.Principal.Windows.xml",
-        "ref/dotnet5.4/fr/System.Security.Principal.Windows.xml",
-        "ref/dotnet5.4/it/System.Security.Principal.Windows.xml",
-        "ref/dotnet5.4/ja/System.Security.Principal.Windows.xml",
-        "ref/dotnet5.4/ko/System.Security.Principal.Windows.xml",
-        "ref/dotnet5.4/ru/System.Security.Principal.Windows.xml",
-        "ref/dotnet5.4/System.Security.Principal.Windows.dll",
-        "ref/dotnet5.4/System.Security.Principal.Windows.xml",
-        "ref/dotnet5.4/zh-hans/System.Security.Principal.Windows.xml",
-        "ref/dotnet5.4/zh-hant/System.Security.Principal.Windows.xml",
-        "ref/net46/System.Security.Principal.Windows.dll",
-        "System.Security.Principal.Windows.4.0.0-beta-23509.nupkg",
-        "System.Security.Principal.Windows.4.0.0-beta-23509.nupkg.sha512",
-        "System.Security.Principal.Windows.nuspec"
       ]
     },
     "System.Text.Encoding/4.0.10": {
@@ -3751,37 +3429,6 @@
         "System.Threading.Tasks.nuspec"
       ]
     },
-    "System.Threading.ThreadPool/4.0.10-beta-23509": {
-      "type": "package",
-      "sha512": "3dB9aKVCiV7WcgOvgG21aG/JKBveZRzfk6KiTTdAnuZT1PPFNFCodkT0oZ9MFV9sxiUjJZO+RESqKRH5ehnaPQ==",
-      "files": [
-        "lib/DNXCore50/System.Threading.ThreadPool.dll",
-        "lib/MonoAndroid10/_._",
-        "lib/MonoTouch10/_._",
-        "lib/net46/System.Threading.ThreadPool.dll",
-        "lib/xamarinios10/_._",
-        "lib/xamarinmac20/_._",
-        "ref/dotnet5.4/de/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.4/es/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.4/fr/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.4/it/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.4/ja/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.4/ko/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.4/ru/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.4/System.Threading.ThreadPool.dll",
-        "ref/dotnet5.4/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.4/zh-hans/System.Threading.ThreadPool.xml",
-        "ref/dotnet5.4/zh-hant/System.Threading.ThreadPool.xml",
-        "ref/MonoAndroid10/_._",
-        "ref/MonoTouch10/_._",
-        "ref/net46/System.Threading.ThreadPool.dll",
-        "ref/xamarinios10/_._",
-        "ref/xamarinmac20/_._",
-        "System.Threading.ThreadPool.4.0.10-beta-23509.nupkg",
-        "System.Threading.ThreadPool.4.0.10-beta-23509.nupkg.sha512",
-        "System.Threading.ThreadPool.nuspec"
-      ]
-    },
     "xunit/2.1.0": {
       "type": "package",
       "sha512": "u/7VQSOSXa7kSG4iK6Lcn7RqKZQ3hk7cnyMNVMpXHSP0RI5VQEtc44hvkG3LyWOVsx1dhUDD3rPAHAxyOUDQJw==",
@@ -3899,14 +3546,14 @@
         "xunit.extensibility.execution.nuspec"
       ]
     },
-    "xunit.netcore.extensions/1.0.0-prerelease-00119": {
+    "xunit.netcore.extensions/1.0.0-prerelease-00122": {
       "type": "package",
       "serviceable": true,
-      "sha512": "oCniHZ9M9IVdGV3iInQDEja2mK+i+r9MyJzH1/gLD8drExfVuvYc1QuzOer9eu0GPZxPRsP/K9MiGR1vC555HQ==",
+      "sha512": "eSQ1Jo09hXNAFL+JfcqiiN7+GuOO78RZoXd0darX4V0xYopw0sbe/wxTy54fXE2TvlQj9l7943j5FN2Psz9TWA==",
       "files": [
         "lib/dotnet/Xunit.NetCore.Extensions.dll",
-        "xunit.netcore.extensions.1.0.0-prerelease-00119.nupkg",
-        "xunit.netcore.extensions.1.0.0-prerelease-00119.nupkg.sha512",
+        "xunit.netcore.extensions.1.0.0-prerelease-00122.nupkg",
+        "xunit.netcore.extensions.1.0.0-prerelease-00122.nupkg.sha512",
         "xunit.netcore.extensions.nuspec"
       ]
     }


### PR DESCRIPTION
It was temporarily using a P2P reference while we were waiting for the packages to be updated with a new shim that it depends on.  Now that the new packages are available, removing the workaround and updating the project.lock.json and the test-runtime to pick up the fix.

Replaces #4634 
cc: @CIPop, @kapilash, @pgavlin 