### PR TITLE
Fix CurlHandler to allow empty headers in redirect

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -346,7 +346,7 @@ namespace System.Net.Http
                 }
             }
 
-            private void SetRequestHeaders()
+            internal void SetRequestHeaders()
             {
                 HttpContentHeaders contentHeaders = null;
                 if (_requestMessage.Content != null)

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -604,6 +604,9 @@ namespace System.Net.Http
                     state.SetCookieOption(forwardUri);
                 }
             }
+
+            // set the headers again. This is a workaround for libcurl's limitation in handling headers with empty values
+            state.SetRequestHeaders();
         }
 
         private static void SetChunkedModeForSend(HttpRequestMessage request)

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -31,6 +31,13 @@ namespace System.Net.Http.Functional.Tests
         public readonly static object[][] EchoServers = HttpTestServers.EchoServers;
         public readonly static object[][] VerifyUploadServers = HttpTestServers.VerifyUploadServers;
         public readonly static object[][] CompressedServers = HttpTestServers.CompressedServers;
+        public readonly static object[][] HeaderValueAndUris = {
+            new object[] { "X-CustomHeader", "x-value", HttpTestServers.RemoteEchoServer },
+            new object[] { "X-Cust-Header-NoValue", "" , HttpTestServers.RemoteEchoServer },
+            new object[] { "X-CustomHeader", "x-value", HttpTestServers.RedirectUriForDestinationUri(false, HttpTestServers.RemoteEchoServer, -1) },
+            new object[] { "X-Cust-Header-NoValue", "" , HttpTestServers.RedirectUriForDestinationUri(false, HttpTestServers.RemoteEchoServer, -1) },
+        };
+
 
         // Standard HTTP methods defined in RFC7231: http://tools.ietf.org/html/rfc7231#section-4.3
         //     "GET", "HEAD", "POST", "PUT", "DELETE", "OPTIONS", "TRACE"
@@ -365,15 +372,13 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [Theory]
-        [InlineData("X-Cust-Header", "x-value")]
-        [InlineData("X-Cust-Header-NoValue", "")]
-        public async Task GetAsync_RequestHeadersAddCustomHeaders_HeaderAndValueSent(string name, string value)
+        [Theory, MemberData("HeaderValueAndUris")]
+        public async Task GetAsync_RequestHeadersAddCustomHeaders_HeaderAndValueSent(string name, string value, Uri uri)
         {
             using (var client = new HttpClient())
             {
                 client.DefaultRequestHeaders.Add(name, value);
-                using (HttpResponseMessage httpResponse = await client.GetAsync(HttpTestServers.RemoteEchoServer))
+                using (HttpResponseMessage httpResponse = await client.GetAsync(uri))
                 {
                     Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
                     string responseText = await httpResponse.Content.ReadAsStringAsync();


### PR DESCRIPTION
libcurl does not pass empty headers in case of a redirect uri. This results in discrepancy between CurlHandler and WinHttpHandler. To work around this, we set the request headers again in response to a redirect from the server.