### PR TITLE
Fix terminfo tests to not assume specific files exist

### DIFF
--- a/src/System.Console/tests/TermInfo.cs
+++ b/src/System.Console/tests/TermInfo.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -14,6 +13,8 @@ public class TermInfo
     [PlatformSpecific(PlatformID.AnyUnix)]
     public void VerifyInstalledTermInfosParse()
     {
+        bool foundAtLeastOne = false;
+
         string[] locations = GetFieldValueOnObject<string[]>("_terminfoLocations", null, typeof(Console).GetTypeInfo().Assembly.GetType("System.ConsolePal+TermInfo+Database"));
         foreach (string location in locations)
         {
@@ -23,6 +24,8 @@ public class TermInfo
             foreach (string term in Directory.EnumerateFiles(location, "*", SearchOption.AllDirectories))
             {
                 if (term.ToUpper().Contains("README")) continue;
+                foundAtLeastOne = true;
+
                 object info = CreateTermColorInfo(ReadTermInfoDatabase(Path.GetFileName(term)));
 
                 if (!string.IsNullOrEmpty(GetForegroundFormat(info)))
@@ -36,120 +39,36 @@ public class TermInfo
                 }
             }
         }
+
+        Assert.True(foundAtLeastOne, "Didn't find any terminfo files");
     }
 
-    // Note that we cannot use a Theory here due using unprintable characters and a bug in xunit where the runner errors
-    // out while trying to generate a report and printing the character (bug #380 on xunit)
-    private void TermInfoVerification(string termToTest, string expectedForeground, string expectedBackground, int colorValue)
-    {
-        object info = CreateTermColorInfo(ReadTermInfoDatabase(termToTest));
-        Assert.Equal(expectedForeground, EvaluateParameterizedStrings(GetForegroundFormat(info), colorValue));
-        Assert.Equal(expectedBackground, EvaluateParameterizedStrings(GetBackgroundFormat(info), colorValue));
-    }
-
-    [Fact]
+    [Theory]
     [PlatformSpecific(PlatformID.AnyUnix)]
-    public void Xterm256ColorDefault()
+    [InlineData("xterm-256color", "\u001B\u005B\u00330m", "\u001B\u005B\u00340m", 0)]
+    [InlineData("xterm-256color", "\u001B\u005B\u00331m", "\u001B\u005B\u00341m", 1)]
+    [InlineData("xterm-256color", "\u001B\u005B90m", "\u001B\u005B100m", 8)]
+    [InlineData("screen", "\u001B\u005B\u00330m", "\u001B\u005B\u00340m", 0)]
+    [InlineData("screen", "\u001B\u005B\u00332m", "\u001B\u005B\u00342m", 2)]
+    [InlineData("screen", "\u001B\u005B\u00339m", "\u001B\u005B\u00349m", 9)]
+    [InlineData("Eterm", "\u001B\u005B\u00330m", "\u001B\u005B\u00340m", 0)]
+    [InlineData("Eterm", "\u001B\u005B\u00333m", "\u001B\u005B\u00343m", 3)]
+    [InlineData("Eterm", "\u001B\u005B\u003310m", "\u001B\u005B\u003410m", 10)]
+    [InlineData("wsvt25", "\u001B\u005B\u00330m", "\u001B\u005B\u00340m", 0)]
+    [InlineData("wsvt25", "\u001B\u005B\u00334m", "\u001B\u005B\u00344m", 4)]
+    [InlineData("wsvt25", "\u001B\u005B\u003311m", "\u001B\u005B\u003411m", 11)]
+    [InlineData("mach-color", "\u001B\u005B\u00330m", "\u001B\u005B\u00340m", 0)]
+    [InlineData("mach-color", "\u001B\u005B\u00335m", "\u001B\u005B\u00345m", 5)]
+    [InlineData("mach-color", "\u001B\u005B\u003312m", "\u001B\u005B\u003412m", 12)]
+    public void TermInfoVerification(string termToTest, string expectedForeground, string expectedBackground, int colorValue)
     {
-        TermInfoVerification("xterm-256color", "\u001B\u005B\u00330m", "\u001B\u005B\u00340m", 0);
-    }
-
-    [Fact]
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    public void Xterm256ColorLight()
-    {
-        TermInfoVerification("xterm-256color", "\u001B\u005B\u00331m", "\u001B\u005B\u00341m", 1);
-    }
-
-    [Fact]
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    public void Xterm256ColorDark()
-    {
-        TermInfoVerification("xterm-256color", "\u001B\u005B90m", "\u001B\u005B100m", 8);
-    }
-
-    [Fact]
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    public void ScreenTermDefault()
-    {
-        TermInfoVerification("screen", "\u001B\u005B\u00330m", "\u001B\u005B\u00340m", 0);
-    }
-
-    [Fact]
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    public void ScreenTermLight()
-    {
-        TermInfoVerification("screen", "\u001B\u005B\u00332m", "\u001B\u005B\u00342m", 2);
-    }
-
-    [Fact]
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    public void ScreenTermDark()
-    {
-        TermInfoVerification("screen", "\u001B\u005B\u00339m", "\u001B\u005B\u00349m", 9);
-    }
-
-    [Fact]
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    public void EtermDefault()
-    {
-        TermInfoVerification("Eterm", "\u001B\u005B\u00330m", "\u001B\u005B\u00340m", 0);
-    }
-
-    [Fact]
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    public void EtermLight()
-    {
-        TermInfoVerification("Eterm", "\u001B\u005B\u00333m", "\u001B\u005B\u00343m", 3);
-    }
-
-    [Fact]
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    public void EtermDark()
-    {
-        TermInfoVerification("Eterm", "\u001B\u005B\u003310m", "\u001B\u005B\u003410m", 10);
-    }
-
-    [Fact]
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    public void Wsvt25TermDefault()
-    {
-        TermInfoVerification("wsvt25", "\u001B\u005B\u00330m", "\u001B\u005B\u00340m", 0);
-    }
-
-    [Fact]
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    public void Wsvt25TermLight()
-    {
-        TermInfoVerification("wsvt25", "\u001B\u005B\u00334m", "\u001B\u005B\u00344m", 4);
-    }
-
-    [Fact]
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    public void Wsvt25TermDark()
-    {
-        TermInfoVerification("wsvt25", "\u001B\u005B\u003311m", "\u001B\u005B\u003411m", 11);
-    }
-
-    [Fact]
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    public void MachColorTermDefault()
-    {
-        TermInfoVerification("mach-color", "\u001B\u005B\u00330m", "\u001B\u005B\u00340m", 0);
-    }
-
-    [Fact]
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    public void MachColorTermLight()
-    {
-        TermInfoVerification("mach-color", "\u001B\u005B\u00335m", "\u001B\u005B\u00345m", 5);
-    }
-
-    [Fact]
-    [PlatformSpecific(PlatformID.AnyUnix)]
-    public void MachColorTermDark()
-    {
-        TermInfoVerification("mach-color", "\u001B\u005B\u003312m", "\u001B\u005B\u003412m", 12);
+        object db = ReadTermInfoDatabase(termToTest);
+        if (db != null)
+        {
+            object info = CreateTermColorInfo(db);
+            Assert.Equal(expectedForeground, EvaluateParameterizedStrings(GetForegroundFormat(info), colorValue));
+            Assert.Equal(expectedBackground, EvaluateParameterizedStrings(GetBackgroundFormat(info), colorValue));
+        }
     }
 
     [Fact]


### PR DESCRIPTION
The terminfo tests assume that a specific set of terminfo definition files exist; they do on Ubuntu, CentOS, and OS X, but not all of them do on openSUSE, resulting in test failures.  This commit just makes them optional, bailing out of the test if the file isn't found.  It also cleans up some code to use a theory, now that the bug that was preventing a theory from being used originally has been fixed.

Fixes #4681 
cc: @sokket