### PR TITLE
Add ALPN support to SslStream

### DIFF
--- a/src/Common/src/Interop/Unix/libssl/ApplicationProtocolContext.cs
+++ b/src/Common/src/Interop/Unix/libssl/ApplicationProtocolContext.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Net
+{
+    internal enum ApplicationProtocolNegotiationStatus
+    {
+        None = 0,
+        Success,
+        SelectedClientOnly
+    }
+
+    internal enum ApplicationProtocolNegotiationExt
+    {
+        None = 0,
+        NPN,
+        ALPN
+    }
+
+    internal class ApplicationProtocolContext
+    {
+        public ApplicationProtocolNegotiationStatus NegotiationStatus = ApplicationProtocolNegotiationStatus.None;
+        public ApplicationProtocolNegotiationExt NegotiationExtension = ApplicationProtocolNegotiationExt.None;
+
+        public string GetProtocolId()
+        {
+            return null;
+        }
+    }
+}

--- a/src/Common/src/Interop/Unix/libssl/ApplicationProtocols.cs
+++ b/src/Common/src/Interop/Unix/libssl/ApplicationProtocols.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Net
+{
+    internal struct ApplicationProtocols
+    {
+        public static byte[] ToByteArray(string[] applicationProtocols)
+        {
+            return new byte[0];
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/SChannel/Interop.SecurityStatus.cs
+++ b/src/Common/src/Interop/Windows/SChannel/Interop.SecurityStatus.cs
@@ -46,7 +46,8 @@ internal static partial class Interop
         SecurityQosFailed = unchecked((int)0x80090332),
         SmartcardLogonRequired = unchecked((int)0x8009033E),
         UnsupportedPreauth = unchecked((int)0x80090343),
-        BadBinding = unchecked((int)0x80090346)
+        BadBinding = unchecked((int)0x80090346),
+        ApplicationProtocolMismatch = unchecked((int)0x80090367)
     }
 
 #if TRACE_VERBOSE

--- a/src/Common/src/Interop/Windows/secur32/ApplicationProtocolContext.cs
+++ b/src/Common/src/Interop/Windows/secur32/ApplicationProtocolContext.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+namespace System.Net
+{
+    internal enum ApplicationProtocolNegotiationStatus
+    {
+        None = 0,
+        Success,
+        SelectedClientOnly
+    }
+
+    internal enum ApplicationProtocolNegotiationExt
+    {
+        None = 0,
+        NPN,
+        ALPN
+    }
+
+    // SecPkgContext_ApplicationProtocol
+    [StructLayout(LayoutKind.Sequential,CharSet = CharSet.Ansi)]
+    internal class ApplicationProtocolContext
+    {
+        private const int MAX_PROTOCOL_ID_SIZE = 0xFF;
+        public ApplicationProtocolNegotiationStatus NegotiationStatus;
+        public ApplicationProtocolNegotiationExt NegotiationExtension;
+        public byte ProtocolIdSize;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = MAX_PROTOCOL_ID_SIZE)]
+        public char[] ProtocolId;
+
+        public string GetProtocolId()
+        {
+            return new string(ProtocolId, 0, ProtocolIdSize);
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/secur32/ApplicationProtocols.cs
+++ b/src/Common/src/Interop/Windows/secur32/ApplicationProtocols.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace System.Net
+{
+    // _SEC_APPLICATION_PROTOCOLS
+    [StructLayout(LayoutKind.Sequential,Pack = 1)]
+    internal struct ApplicationProtocols
+    {
+        private static readonly int ProtocolListOffset = Marshal.SizeOf<ApplicationProtocols>();
+        private static readonly int ProtocolListConstSize = ProtocolListOffset - (int)Marshal.OffsetOf<ApplicationProtocols>("ProtocolExtenstionType");
+        public uint ProtocolListsSize;
+        public ApplicationProtocolNegotiationExt ProtocolExtenstionType;
+        public short ProtocolListSize;
+
+        public static unsafe byte[] ToByteArray(string[] applicationProtocols)
+        {
+            long protocolListSize = 0;
+            foreach (string applicationProtocol in applicationProtocols)
+            {
+                if (string.IsNullOrEmpty(applicationProtocol)) throw new ArgumentException(SR.net_ssl_app_protocols_invalid, "applicationProtocols");
+                if (applicationProtocol.Length > byte.MaxValue) throw new ArgumentException(SR.net_ssl_app_protocols_invalid, "applicationProtocols");       
+                protocolListSize += applicationProtocol.Length + 1;
+                if (protocolListSize > short.MaxValue)
+                    throw new ArgumentException(SR.net_ssl_app_protocols_invalid, "applicationProtocols");
+            }
+
+            ApplicationProtocols protocols = new ApplicationProtocols();
+            protocols.ProtocolListsSize = (uint)(ProtocolListConstSize + protocolListSize);
+            protocols.ProtocolExtenstionType = ApplicationProtocolNegotiationExt.ALPN;
+            protocols.ProtocolListSize = (short)protocolListSize;
+
+            byte[] buffer = new byte[ProtocolListOffset + protocolListSize];
+            fixed (byte* bufferPtr = buffer)
+            {
+                Marshal.StructureToPtr(protocols, new IntPtr(bufferPtr), false);
+                byte* protocolList = bufferPtr + ProtocolListOffset;
+                foreach (string applicationProtocol in applicationProtocols)
+                {
+                    *(protocolList++) = (byte)applicationProtocol.Length;
+                    fixed (char* protocolPtr = applicationProtocol)
+                    {
+                        Encoding.ASCII.GetBytes(protocolPtr, applicationProtocol.Length, protocolList, applicationProtocol.Length);
+                    }
+                    protocolList += applicationProtocol.Length;
+                }
+            }
+            return buffer;
+        }
+    }
+}

--- a/src/Common/src/Interop/Windows/secur32/Interop.SSPI.cs
+++ b/src/Common/src/Interop/Windows/secur32/Interop.SSPI.cs
@@ -79,6 +79,7 @@ internal static partial class Interop
             UniqueBindings = 0x19,
             EndpointBindings = 0x1A,
             ClientSpecifiedSpn = 0x1B, // SECPKG_ATTR_CLIENT_SPECIFIED_TARGET = 27
+            ApplicationProtocol = 0x23, // SECPKG_ATTR_APPLICATION_PROTOCOL = 35
             RemoteCertificate = 0x53,
             LocalCertificate = 0x54,
             RootStore = 0x55,

--- a/src/Common/src/Interop/Windows/secur32/SSPIWrapper.cs
+++ b/src/Common/src/Interop/Windows/secur32/SSPIWrapper.cs
@@ -561,6 +561,10 @@ namespace System.Net
                     nativeBlockSize = Marshal.SizeOf<SslConnectionInfo>();
                     break;
 
+                case Interop.Secur32.ContextAttribute.ApplicationProtocol:
+                    nativeBlockSize = Marshal.SizeOf<ApplicationProtocolContext>();
+                    break;
+
                 default:
                     throw new ArgumentException(SR.Format(SR.net_invalid_enum, "ContextAttribute"), "contextAttribute");
             }
@@ -625,6 +629,17 @@ namespace System.Net
                     case Interop.Secur32.ContextAttribute.ConnectionInfo:
                         attribute = new SslConnectionInfo(nativeBuffer);
                         break;
+
+                    case Interop.Secur32.ContextAttribute.ApplicationProtocol:
+                        unsafe
+                        {
+                            fixed (void* ptr = nativeBuffer)
+                            {
+                                attribute = Marshal.PtrToStructure<ApplicationProtocolContext>(new IntPtr(ptr));
+                            }
+                        }
+                        break;
+
                     default:
                         // Will return null.
                         break;

--- a/src/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/System.Net.Security/ref/System.Net.Security.cs
@@ -99,6 +99,7 @@ namespace System.Net.Security
         public override bool IsSigned { get { return default(bool); } }
         public virtual System.Security.Authentication.ExchangeAlgorithmType KeyExchangeAlgorithm { get { return default(System.Security.Authentication.ExchangeAlgorithmType); } }
         public virtual int KeyExchangeStrength { get { return default(int); } }
+        public virtual string NegotiatedApplicationProtocol { get { return default(string); } }
         public override long Length { get { return default(long); } }
         public virtual System.Security.Cryptography.X509Certificates.X509Certificate LocalCertificate { get { return default(System.Security.Cryptography.X509Certificates.X509Certificate); } }
         public override long Position { get { return default(long); } set { } }
@@ -109,12 +110,16 @@ namespace System.Net.Security
         public override int WriteTimeout { get { return default(int); } set { } }
         public virtual void AuthenticateAsClient(string targetHost) { }
         public virtual void AuthenticateAsClient(string targetHost, System.Security.Cryptography.X509Certificates.X509CertificateCollection clientCertificates, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation) { }
+        public virtual void AuthenticateAsClient(string targetHost, System.Security.Cryptography.X509Certificates.X509CertificateCollection clientCertificates, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation, string[] applicationProtocols) { }
         public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(string targetHost) { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(string targetHost, System.Security.Cryptography.X509Certificates.X509CertificateCollection clientCertificates, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation) { return default(System.Threading.Tasks.Task); }
+        public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(string targetHost, System.Security.Cryptography.X509Certificates.X509CertificateCollection clientCertificates, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation, string[] applicationProtocols) { return default(System.Threading.Tasks.Task); }
         public virtual void AuthenticateAsServer(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate) { }
         public virtual void AuthenticateAsServer(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate, bool clientCertificateRequired, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation) { }
+        public virtual void AuthenticateAsServer(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate, bool clientCertificateRequired, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation, string[] applicationProtocols) { }
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate) { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate, bool clientCertificateRequired, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation) { return default(System.Threading.Tasks.Task); }
+        public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate, bool clientCertificateRequired, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation, string[] applicationProtocols) { return default(System.Threading.Tasks.Task); }
         public override void Flush() { }
         public override int Read(byte[] buffer, int offset, int count) { return default(int); }
         public override long Seek(long offset, System.IO.SeekOrigin origin) { return default(long); }

--- a/src/System.Net.Security/src/Resources/Strings.resx
+++ b/src/System.Net.Security/src/Resources/Strings.resx
@@ -177,6 +177,9 @@
   <data name="net_ssl_io_no_server_cert" xml:space="preserve">
     <value>The server mode SSL must use a certificate with the associated private key.</value>
   </data>
+  <data name="net_ssl_app_protocols_invalid" xml:space="preserve">
+    <value>The application protocol list content is invalid</value>
+  </data>
   <data name="net_auth_reauth" xml:space="preserve">
     <value>This operation is not allowed on a security context that has already been authenticated.</value>
   </data>

--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -206,6 +206,12 @@
     <Compile Include="$(CommonPath)\Interop\Windows\secur32\StreamSizes.cs">
       <Link>Common\Interop\Windows\secur32\StreamSizes.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\secur32\ApplicationProtocolContext.cs">
+      <Link>Common\Interop\Windows\secur32\ApplicationProtocolContext.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\secur32\ApplicationProtocols.cs">
+      <Link>Common\Interop\Windows\secur32\ApplicationProtocols.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="System\Net\SslStreamPal.Unix.cs" />
@@ -222,6 +228,12 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libssl\SslConnectionInfo.cs">
       <Link>Common\Interop\Unix\libssl\SslConnectionInfo.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libssl\ApplicationProtocolContext.cs">
+      <Link>Common\Interop\Unix\libssl\ApplicationProtocolContext.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\libssl\ApplicationProtocols.cs">
+      <Link>Common\Interop\Unix\libssl\ApplicationProtocols.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libssl\Interop.OpenSsl.cs">
       <Link>Common\Interop\Unix\libssl\Interop.OpenSsl.cs</Link>

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslState.cs
@@ -88,13 +88,13 @@ namespace System.Net.Security
         //
         //
         //
-        internal void ValidateCreateContext(bool isServer, string targetHost, SslProtocols enabledSslProtocols, X509Certificate serverCertificate, X509CertificateCollection clientCertificates, bool remoteCertRequired, bool checkCertRevocationStatus)
+        internal void ValidateCreateContext(bool isServer, string targetHost, SslProtocols enabledSslProtocols, X509Certificate serverCertificate, X509CertificateCollection clientCertificates, bool remoteCertRequired, bool checkCertRevocationStatus, string[] applicationProtocols)
         {
             ValidateCreateContext(isServer, targetHost, enabledSslProtocols, serverCertificate, clientCertificates, remoteCertRequired,
-                                   checkCertRevocationStatus, !isServer);
+                                   checkCertRevocationStatus, !isServer, applicationProtocols);
         }
 
-        internal void ValidateCreateContext(bool isServer, string targetHost, SslProtocols enabledSslProtocols, X509Certificate serverCertificate, X509CertificateCollection clientCertificates, bool remoteCertRequired, bool checkCertRevocationStatus, bool checkCertName)
+        internal void ValidateCreateContext(bool isServer, string targetHost, SslProtocols enabledSslProtocols, X509Certificate serverCertificate, X509CertificateCollection clientCertificates, bool remoteCertRequired, bool checkCertRevocationStatus, bool checkCertName, string[] applicationProtocols)
         {
             //
             // We don't support SSL alerts right now, hence any exception is fatal and cannot be retried.
@@ -143,7 +143,7 @@ namespace System.Net.Security
             try
             {
                 _context = new SecureChannel(targetHost, isServer, enabledSslProtocols, serverCertificate, clientCertificates, remoteCertRequired,
-                                                                 checkCertName, checkCertRevocationStatus, _encryptionPolicy, _certSelectionDelegate);
+                                                                 checkCertName, checkCertRevocationStatus, _encryptionPolicy, _certSelectionDelegate, applicationProtocols);
             }
             catch (Win32Exception e)
             {
@@ -377,6 +377,15 @@ namespace System.Net.Security
                 }
 
                 return ret;
+            }
+        }
+
+        internal string NegotiatedApplicationProtocol
+        {
+            get
+            {
+                CheckThrow(true);
+                return Context.NegotiatedApplicationProtocol;
             }
         }
 

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslStream.cs
@@ -103,20 +103,25 @@ namespace System.Net.Security
         //
         public virtual void AuthenticateAsClient(string targetHost)
         {
-            AuthenticateAsClient(targetHost, new X509CertificateCollection(), SecurityProtocol.DefaultSecurityProtocols, false);
+            AuthenticateAsClient(targetHost, new X509CertificateCollection(), SecurityProtocol.DefaultSecurityProtocols, false, null);
         }
 
         public virtual void AuthenticateAsClient(string targetHost, X509CertificateCollection clientCertificates, SslProtocols enabledSslProtocols, bool checkCertificateRevocation)
         {
+            AuthenticateAsClient(targetHost, clientCertificates, enabledSslProtocols, checkCertificateRevocation, null);
+        }
+
+        public virtual void AuthenticateAsClient(string targetHost, X509CertificateCollection clientCertificates, SslProtocols enabledSslProtocols, bool checkCertificateRevocation, string[] applicationProtocols)
+        {
             SecurityProtocol.ThrowOnNotAllowed(enabledSslProtocols);
 
-            _sslState.ValidateCreateContext(false, targetHost, enabledSslProtocols, null, clientCertificates, true, checkCertificateRevocation);
+            _sslState.ValidateCreateContext(false, targetHost, enabledSslProtocols, null, clientCertificates, true, checkCertificateRevocation, applicationProtocols);
             _sslState.ProcessAuthentication(null);
         }
 
         internal virtual IAsyncResult BeginAuthenticateAsClient(string targetHost, AsyncCallback asyncCallback, object asyncState)
         {
-            return BeginAuthenticateAsClient(targetHost, new X509CertificateCollection(), SecurityProtocol.DefaultSecurityProtocols, false,
+            return BeginAuthenticateAsClient(targetHost, new X509CertificateCollection(), SecurityProtocol.DefaultSecurityProtocols, false, null,
                                            asyncCallback, asyncState);
         }
 
@@ -124,7 +129,16 @@ namespace System.Net.Security
                                                             SslProtocols enabledSslProtocols, bool checkCertificateRevocation,
                                                             AsyncCallback asyncCallback, object asyncState)
         {
-            _sslState.ValidateCreateContext(false, targetHost, enabledSslProtocols, null, clientCertificates, true, checkCertificateRevocation);
+            return BeginAuthenticateAsClient(targetHost, clientCertificates, enabledSslProtocols, checkCertificateRevocation, null,
+                                           asyncCallback, asyncState);
+        }
+
+        internal virtual IAsyncResult BeginAuthenticateAsClient(string targetHost, X509CertificateCollection clientCertificates,
+                                                            SslProtocols enabledSslProtocols, bool checkCertificateRevocation,
+                                                            string[] applicationProtocols,
+                                                            AsyncCallback asyncCallback, object asyncState)
+        {
+            _sslState.ValidateCreateContext(false, targetHost, enabledSslProtocols, null, clientCertificates, true, checkCertificateRevocation, applicationProtocols);
 
             LazyAsyncResult result = new LazyAsyncResult(_sslState, asyncState, asyncCallback);
             _sslState.ProcessAuthentication(result);
@@ -141,22 +155,28 @@ namespace System.Net.Security
         //
         public virtual void AuthenticateAsServer(X509Certificate serverCertificate)
         {
-            AuthenticateAsServer(serverCertificate, false, SecurityProtocol.DefaultSecurityProtocols, false);
+            AuthenticateAsServer(serverCertificate, false, SecurityProtocol.DefaultSecurityProtocols, false, null);
         }
 
         public virtual void AuthenticateAsServer(X509Certificate serverCertificate, bool clientCertificateRequired,
                                                SslProtocols enabledSslProtocols, bool checkCertificateRevocation)
         {
+            AuthenticateAsServer(serverCertificate, clientCertificateRequired, enabledSslProtocols, checkCertificateRevocation, null);
+        }
+
+        public virtual void AuthenticateAsServer(X509Certificate serverCertificate, bool clientCertificateRequired,
+                                               SslProtocols enabledSslProtocols, bool checkCertificateRevocation, string[] applicationProtocols)
+        {
             SecurityProtocol.ThrowOnNotAllowed(enabledSslProtocols);
 
-            _sslState.ValidateCreateContext(true, string.Empty, enabledSslProtocols, serverCertificate, null, clientCertificateRequired, checkCertificateRevocation);
+            _sslState.ValidateCreateContext(true, string.Empty, enabledSslProtocols, serverCertificate, null, clientCertificateRequired, checkCertificateRevocation, applicationProtocols);
             _sslState.ProcessAuthentication(null);
         }
 
         internal virtual IAsyncResult BeginAuthenticateAsServer(X509Certificate serverCertificate, AsyncCallback asyncCallback, object asyncState)
 
         {
-            return BeginAuthenticateAsServer(serverCertificate, false, SecurityProtocol.DefaultSecurityProtocols, false,
+            return BeginAuthenticateAsServer(serverCertificate, false, SecurityProtocol.DefaultSecurityProtocols, false, null,
                                                           asyncCallback,
                                                             asyncState);
         }
@@ -166,7 +186,18 @@ namespace System.Net.Security
                                                             AsyncCallback asyncCallback,
                                                             object asyncState)
         {
-            _sslState.ValidateCreateContext(true, string.Empty, enabledSslProtocols, serverCertificate, null, clientCertificateRequired, checkCertificateRevocation);
+            return BeginAuthenticateAsServer(serverCertificate, clientCertificateRequired, enabledSslProtocols, checkCertificateRevocation, null,
+                                                          asyncCallback,
+                                                            asyncState);
+        }
+
+        internal virtual IAsyncResult BeginAuthenticateAsServer(X509Certificate serverCertificate, bool clientCertificateRequired,
+                                                            SslProtocols enabledSslProtocols, bool checkCertificateRevocation,
+                                                            string[] applicationProtocols,
+                                                            AsyncCallback asyncCallback,
+                                                            object asyncState)
+        {
+            _sslState.ValidateCreateContext(true, string.Empty, enabledSslProtocols, serverCertificate, null, clientCertificateRequired, checkCertificateRevocation, applicationProtocols);
             LazyAsyncResult result = new LazyAsyncResult(_sslState, asyncState, asyncCallback);
             _sslState.ProcessAuthentication(result);
             return result;
@@ -203,6 +234,13 @@ namespace System.Net.Security
             return Task.Factory.FromAsync((callback, state) => BeginAuthenticateAsClient(targetHost, clientCertificates, enabledSslProtocols, checkCertificateRevocation, callback, state), EndAuthenticateAsClient, null);
         }
 
+        public virtual Task AuthenticateAsClientAsync(string targetHost, X509CertificateCollection clientCertificates, SslProtocols enabledSslProtocols, bool checkCertificateRevocation, string[] applicationProtocols)
+        {
+            SecurityProtocol.ThrowOnNotAllowed(enabledSslProtocols);
+
+            return Task.Factory.FromAsync((callback, state) => BeginAuthenticateAsClient(targetHost, clientCertificates, enabledSslProtocols, checkCertificateRevocation, applicationProtocols, callback, state), EndAuthenticateAsClient, null);
+        }
+
         public virtual Task AuthenticateAsServerAsync(X509Certificate serverCertificate)
         {
             return Task.Factory.FromAsync(BeginAuthenticateAsServer, EndAuthenticateAsServer, serverCertificate, null);
@@ -213,6 +251,13 @@ namespace System.Net.Security
             SecurityProtocol.ThrowOnNotAllowed(enabledSslProtocols);
 
             return Task.Factory.FromAsync((callback, state) => BeginAuthenticateAsServer(serverCertificate, clientCertificateRequired, enabledSslProtocols, checkCertificateRevocation, callback, state), EndAuthenticateAsServer, null);
+        }
+
+        public virtual Task AuthenticateAsServerAsync(X509Certificate serverCertificate, bool clientCertificateRequired, SslProtocols enabledSslProtocols, bool checkCertificateRevocation, string[] applicationProtocols)
+        {
+            SecurityProtocol.ThrowOnNotAllowed(enabledSslProtocols);
+
+            return Task.Factory.FromAsync((callback, state) => BeginAuthenticateAsServer(serverCertificate, clientCertificateRequired, enabledSslProtocols, checkCertificateRevocation, applicationProtocols, callback, state), EndAuthenticateAsServer, null);
         }
         #endregion
 
@@ -343,6 +388,14 @@ namespace System.Net.Security
             get
             {
                 return _sslState.KeyExchangeStrength;
+            }
+        }
+
+        public virtual string NegotiatedApplicationProtocol
+        {
+            get
+            {
+                return _sslState.NegotiatedApplicationProtocol;
             }
         }
 

--- a/src/System.Net.Security/src/System/Net/SecurityBufferType.cs
+++ b/src/System.Net.Security/src/System/Net/SecurityBufferType.cs
@@ -17,6 +17,7 @@ namespace System.Net.Security
         Stream = 0x0A,
         ChannelBindings = 0x0E,
         TargetHost = 0x10,
+        ApplicationProtocols = 0x12,
         ReadOnlyFlag = unchecked((int)0x80000000),
         ReadOnlyWithChecksum = 0x10000000
     }

--- a/src/System.Net.Security/src/System/Net/SecurityStatusPal.cs
+++ b/src/System.Net.Security/src/System/Net/SecurityStatusPal.cs
@@ -46,6 +46,7 @@ namespace System.Net
         SecurityQosFailed,
         SmartcardLogonRequired,
         UnsupportedPreauth,
-        BadBinding
+        BadBinding,
+        ApplicationProtocolMismatch
     }
 }

--- a/src/System.Net.Security/src/System/Net/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/SslStreamPal.Unix.cs
@@ -28,6 +28,13 @@ namespace System.Net
             return HandshakeInternal(credential, ref context, inputBuffer, outputBuffer, true, remoteCertRequired);
         }
 
+        public static SecurityStatusPal AcceptSecurityContext(SafeFreeCredentials credential,
+            ref SafeDeleteContext context, SecurityBuffer[] inputBuffers, SecurityBuffer outputBuffer,
+            bool remoteCertRequired)
+        {
+            return HandshakeInternal(credential, ref context, inputBuffers[0], outputBuffer, true, remoteCertRequired);
+        }
+
         public static SecurityStatusPal InitializeSecurityContext(ref SafeFreeCredentials credential, ref SafeDeleteContext context,
             string targetName, SecurityBuffer inputBuffer, SecurityBuffer outputBuffer)
         {        
@@ -79,6 +86,11 @@ namespace System.Net
         public static void QueryContextConnectionInfo(SafeDeleteContext securityContext, out SslConnectionInfo connectionInfo)
         {
             connectionInfo = new SslConnectionInfo(securityContext.SslContext);
+        }
+
+        public static void QueryContextApplicationProtocol(SafeDeleteContext securityContext, out ApplicationProtocolContext applicationProtocolContext)
+        {
+            applicationProtocolContext = null;
         }
 
         private static SecurityStatusPal HandshakeInternal(SafeFreeCredentials credential, ref SafeDeleteContext context,

--- a/src/System.Net.Security/tests/FunctionalTests/ApplicationProtocolNegotiationTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ApplicationProtocolNegotiationTest.cs
@@ -1,0 +1,202 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace System.Net.Security.Tests
+{
+    public class ApplicationProtocolNegotiationTest
+    {
+        private readonly TimeSpan TestTimeoutSpan = TimeSpan.FromMilliseconds(TestConfiguration.PassingTestTimeoutMilliseconds);
+        private const int ApplicationProtocolMismatchCode = unchecked((int) 0x80090367);
+
+        // The following method is invoked by the RemoteCertificateValidationDelegate.
+        public bool AllowAnyServerCertificate(
+              object sender,
+              X509Certificate certificate,
+              X509Chain chain,
+              SslPolicyErrors sslPolicyErrors)
+        {
+            return true;  // allow everything
+        }
+
+        [Fact]
+        public void ApplicationProtocolNegotiation_ProtocolListEmpty_Throw()
+        {
+            MockNetwork network = new MockNetwork();
+
+            using (var clientStream = new FakeNetworkStream(false, network))
+            using (var client = new SslStream(clientStream, false, AllowAnyServerCertificate))
+            {
+                X509Certificate2 certificate = TestConfiguration.GetServerCertificate();
+                // Exception thrown by SChannel
+                Assert.Throws<AuthenticationException>(() => client.AuthenticateAsClient(certificate.Subject, new X509CertificateCollection(), SslProtocols.Tls12, false, new string[] {}));
+            }
+        }
+
+        [Fact]
+        public void ApplicationProtocolNegotiation_ProtocolNull_Throw()
+        {
+            MockNetwork network = new MockNetwork();
+
+            using (var clientStream = new FakeNetworkStream(false, network))
+            using (var client = new SslStream(clientStream, false, AllowAnyServerCertificate))
+            {
+                X509Certificate2 certificate = TestConfiguration.GetServerCertificate();
+                string[] protocolList = new string[] { null };
+                Assert.Throws<ArgumentException>(() => client.AuthenticateAsClient(certificate.Subject, new X509CertificateCollection(), SslProtocols.Tls12, false, protocolList));
+            }
+        }
+
+        [Fact]
+        public void ApplicationProtocolNegotiation_ProtocolEmpty_Throw()
+        {
+            MockNetwork network = new MockNetwork();
+
+            using (var clientStream = new FakeNetworkStream(false, network))
+            using (var client = new SslStream(clientStream, false, AllowAnyServerCertificate))
+            {
+                X509Certificate2 certificate = TestConfiguration.GetServerCertificate();
+                string[] protocolList = new string[] { "" };
+                Assert.Throws<ArgumentException>(() => client.AuthenticateAsClient(certificate.Subject, new X509CertificateCollection(), SslProtocols.Tls12, false, protocolList));
+            }
+        }
+
+        [Fact]
+        public void ApplicationProtocolNegotiation_ProtocolLongerThan255_Throw()
+        {
+            MockNetwork network = new MockNetwork();
+
+            using (var clientStream = new FakeNetworkStream(false, network))
+            using (var client = new SslStream(clientStream, false, AllowAnyServerCertificate))
+            {
+                X509Certificate2 certificate = TestConfiguration.GetServerCertificate();
+                string[] protocolList = new string[] {"".PadRight(256, 'A')};
+                Assert.Throws<ArgumentException>(() => client.AuthenticateAsClient(certificate.Subject, new X509CertificateCollection(), SslProtocols.Tls12, false, protocolList));
+            }
+        }
+
+        [Fact]
+        public void ApplicationProtocolNegotiation_ProtocolListLongerThan32k_Throw()
+        {
+            MockNetwork network = new MockNetwork();
+
+            using (var clientStream = new FakeNetworkStream(false, network))
+            using (var client = new SslStream(clientStream, false, AllowAnyServerCertificate))
+            {
+                X509Certificate2 certificate = TestConfiguration.GetServerCertificate();
+                string[] protocolList = Enumerable.Range(0, 128).Select(number => number.ToString("D3").PadRight(255, 'A')).ToArray();
+                Assert.Throws<ArgumentException>(() => client.AuthenticateAsClient(certificate.Subject, new X509CertificateCollection(), SslProtocols.Tls12, false, protocolList));
+            }
+        }
+
+        [Fact]
+        public void ApplicationProtocolNegotiation_MatchExists_Connect()
+        {
+            MockNetwork network = new MockNetwork();
+
+            using (var clientStream = new FakeNetworkStream(false, network))
+            using (var serverStream = new FakeNetworkStream(true, network))
+            using (var client = new SslStream(clientStream, false, AllowAnyServerCertificate))
+            using (var server = new SslStream(serverStream))
+            {
+                X509Certificate2 certificate = TestConfiguration.GetServerCertificate();
+                Task[] auth = new Task[2];
+                auth[0] = client.AuthenticateAsClientAsync(certificate.Subject, new X509CertificateCollection(), SslProtocols.Tls12, false, new[] { "h2", "http/1.1" });
+                auth[1] = server.AuthenticateAsServerAsync(certificate, false, SslProtocols.Tls12, false, new[] { "test", "h2" });
+                bool finished = Task.WaitAll(auth, TestTimeoutSpan);
+                Assert.True(finished, "Handshake completed in the allotted time");
+                Assert.True("h2" == client.NegotiatedApplicationProtocol, "Negotiated application protocol on client should be h2");
+                Assert.True("h2" == server.NegotiatedApplicationProtocol, "Negotiated application protocol on server should be h2");
+            }
+        }
+
+        [Fact]
+        public void ApplicationProtocolNegotiation_NoMatch_ServerThrow()
+        {
+            MockNetwork network = new MockNetwork();
+
+            using (var clientStream = new FakeNetworkStream(false, network))
+            using (var serverStream = new FakeNetworkStream(true, network))
+            using (var client = new SslStream(clientStream, false, AllowAnyServerCertificate))
+            {
+                Task[] auth = new Task[2];
+                using (var server = new SslStream(serverStream, false))
+                {
+                    X509Certificate2 certificate = TestConfiguration.GetServerCertificate();
+                    auth[0] = client.AuthenticateAsClientAsync(certificate.Subject, new X509CertificateCollection(), SslProtocols.Tls12, false, new[] { "h2" });
+                    auth[1] = server.AuthenticateAsServerAsync(certificate, false, SslProtocols.Tls12, false, new[] { "http/1.1" });
+
+                    AuthenticationException exception = Assert.Throws<AuthenticationException>(() => auth[1].GetAwaiter().GetResult());
+                    Assert.True(exception.InnerException is Win32Exception, "Server authenticate inner exception should be of type Win32Exception");
+                    Assert.True(((Win32Exception)exception.InnerException).NativeErrorCode == ApplicationProtocolMismatchCode, "Server authenticate error code should be ApplicationProtocolMismatch");
+                }
+                Assert.Throws<IOException>(() => auth[0].GetAwaiter().GetResult());
+            }
+        }
+
+        [Fact]
+        public void ApplicationProtocolNegotiation_ServerRequestedOnly_Connect()
+        {
+            MockNetwork network = new MockNetwork();
+
+            using (var clientStream = new FakeNetworkStream(false, network))
+            using (var serverStream = new FakeNetworkStream(true, network))
+            using (var client = new SslStream(clientStream, false, AllowAnyServerCertificate))
+            using (var server = new SslStream(serverStream))
+            {
+                X509Certificate2 certificate = TestConfiguration.GetServerCertificate();
+                Task[] auth = new Task[2];
+                auth[0] = client.AuthenticateAsClientAsync(certificate.Subject, new X509CertificateCollection(), SslProtocols.Tls12, false);
+                auth[1] = server.AuthenticateAsServerAsync(certificate, false, SslProtocols.Tls12, false, new[] { "h2" });
+
+                bool finished = Task.WaitAll(auth, TestTimeoutSpan);
+                Assert.True(finished, "Handshake completed in the allotted time");
+                Assert.True(null == client.NegotiatedApplicationProtocol, "Negotiated protocol value on client should be null");
+                Assert.True(null == server.NegotiatedApplicationProtocol, "Negotiated protocol value on server should be null");
+            }
+        }
+
+        [Fact]
+        public void ApplicationProtocolNegotiation_ClientRequestedOnly_Connect()
+        {
+            MockNetwork network = new MockNetwork();
+
+            using (var clientStream = new FakeNetworkStream(false, network))
+            using (var serverStream = new FakeNetworkStream(true, network))
+            using (var client = new SslStream(clientStream, false, AllowAnyServerCertificate))
+            using (var server = new SslStream(serverStream))
+            {
+                X509Certificate2 certificate = TestConfiguration.GetServerCertificate();
+                Task[] auth = new Task[2];
+                auth[0] = client.AuthenticateAsClientAsync(certificate.Subject, new X509CertificateCollection(), SslProtocols.Tls12, false, new[] { "h2" });
+                auth[1] = server.AuthenticateAsServerAsync(certificate, false, SslProtocols.Tls12, false);
+
+                bool finished = Task.WaitAll(auth, TestTimeoutSpan);
+                Assert.True(finished, "Handshake completed in the allotted time");
+                Assert.True(null == client.NegotiatedApplicationProtocol, "Negotiated protocol value on client should be null");
+                Assert.True(null == server.NegotiatedApplicationProtocol, "Negotiated protocol value on server should be null");
+            }
+        }
+
+        [Fact]
+        public void ApplicationProtocolNegotiation_BeforeHandshakeComplete_NegotiatedApplicationProtocolThrows()
+        {
+            MockNetwork network = new MockNetwork();
+
+            using (var clientStream = new FakeNetworkStream(false, network))
+            using (var client = new SslStream(clientStream, false, AllowAnyServerCertificate))
+            {
+                X509Certificate2 certificate = TestConfiguration.GetServerCertificate();
+                client.AuthenticateAsClientAsync(certificate.Subject, new X509CertificateCollection(), SslProtocols.Tls12, false, new[] { "h2" });
+                Assert.Throws<InvalidOperationException>(() => client.NegotiatedApplicationProtocol);
+            }
+        }
+    }
+}

--- a/src/System.Net.Security/tests/FunctionalTests/FakeNetworkStream.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/FakeNetworkStream.cs
@@ -91,6 +91,12 @@ namespace System.Net.Security.Tests
             _network.WriteFrame(_isServer, innerBuffer);
         }
 
+        protected override void Dispose(bool disposing)
+        {
+            _network.WriteFrame(_isServer, new byte[0]);
+            base.Dispose(disposing);
+        }
+
         private void UpdateReadStream()
         {
             if (_readStream != null && (_readStream.Position < _readStream.Length))

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -12,6 +12,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
+    <Compile Include="ApplicationProtocolNegotiationTest.cs" />
     <Compile Include="CertificateChainValidation.cs" />
     <Compile Include="CertificateValidationClientServer.cs" />
     <Compile Include="CertificateValidationRemoteServer.cs" />

--- a/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslState.cs
+++ b/src/System.Net.Security/tests/UnitTests/Fakes/FakeSslState.cs
@@ -20,7 +20,7 @@ namespace System.Net.Security
         //
         //
         //
-        internal void ValidateCreateContext(bool isServer, string targetHost, SslProtocols enabledSslProtocols, X509Certificate serverCertificate, X509CertificateCollection clientCertificates, bool remoteCertRequired, bool checkCertRevocationStatus)
+        internal void ValidateCreateContext(bool isServer, string targetHost, SslProtocols enabledSslProtocols, X509Certificate serverCertificate, X509CertificateCollection clientCertificates, bool remoteCertRequired, bool checkCertRevocationStatus, string[] applicationProtocols)
         {
         }
 
@@ -125,6 +125,14 @@ namespace System.Net.Security
             get
             {
                 return 0;
+            }
+        }
+
+        internal string NegotiatedApplicationProtocol
+        {
+            get
+            {
+                return null; 
             }
         }
 


### PR DESCRIPTION
Support for passing ALPN application protocol list to SChannel
and querying for the negotiated protocol post handshake on client
and server.