### PR TITLE
Reduce number of checks in most calls to TypeUtils.ValidateType()

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/TypeUtils.cs
@@ -41,13 +41,9 @@ namespace System.Dynamic.Utils
             if (type != typeof(void))
             {
                 // A check to avoid a bunch of reflection (currently not supported) during cctor
-                if (type.GetTypeInfo().IsGenericTypeDefinition)
-                {
-                    throw Error.TypeIsGeneric(type);
-                }
                 if (type.GetTypeInfo().ContainsGenericParameters)
                 {
-                    throw Error.TypeContainsGenericParameters(type);
+                    throw type.GetTypeInfo().IsGenericTypeDefinition ? Error.TypeIsGeneric(type) : Error.TypeContainsGenericParameters(type);
                 }
             }
         }


### PR DESCRIPTION
TypeUtils.ValidateType(Type) checks first IsGenericTypeDefinition
and then ContainsGenericParameters, throwing a different error in
either case. Since IsGenericTypeDefinition entails
ContainsGenericParameters, and since the most common case would be
that neither are true, we can check ContainsGenericParameters first,
only checking IsGenericTypeDefinition if that is true, to determine
which exception to throw.

The result is a micro-opt to a method called in several factory
methods.