### PR TITLE
Avoid enumerator allocations inside KeyedCollection<TKey, TItem>

### DIFF
--- a/src/System.ObjectModel/src/System/Collections/ObjectModel/KeyedCollection.cs
+++ b/src/System.ObjectModel/src/System/Collections/ObjectModel/KeyedCollection.cs
@@ -25,6 +25,8 @@ namespace System.Collections.ObjectModel
 
 
         protected KeyedCollection(IEqualityComparer<TKey> comparer, int dictionaryCreationThreshold)
+            : base(new List<TItem>()) // Be explicit about the use of List<T> so we can foreach over
+                                      // Items internally without enumerator allocations.
         {
             if (comparer == null)
             {
@@ -43,6 +45,19 @@ namespace System.Collections.ObjectModel
 
             _comparer = comparer;
             _threshold = dictionaryCreationThreshold;
+        }
+
+        /// <summary>
+        /// Enables the use of foreach internally without allocations using <see cref="List{T}"/>'s struct enumerator.
+        /// </summary>
+        new private List<TItem> Items
+        {
+            get
+            {
+                Debug.Assert(base.Items is List<TItem>);
+
+                return (List<TItem>)base.Items;
+            }
         }
 
         public IEqualityComparer<TKey> Comparer


### PR DESCRIPTION
Methods on `KeyedCollection<TKey, TItem>` will internally loop over `Items` using foreach before the dictionary threshold is reached. `Items` is a protected (non-virtual) property defined on the base `Collection<T>` class and typed as `IList<T>`. This means `KeyedCollection<TKey, TValue>` members like `Contains` and `Item[TKey]` allocate an enumerator when looping over `Items`.

We can avoid the enumerator allocations inside `KeyedCollection<TKey, TValue>` by providing a new private `Items` property that is typed as `List<T>` instead of `IList<T>`, so that `List<T>`'s struct enumerator is used, which avoids the enumerator heap allocation and also avoids interface dispatch.

`KeyedCollection<TKey, TItem>`'s constructors call the default `Collection<T>` constructor which already initializes `Items` to an instance of `List<T>`, so this change is just being explicit about the use of `List<T>` for `Items` inside `KeyedCollection<TKey, TItem>`.