### PR TITLE
Optimize ObservableCollection<T>'s constructor

### DIFF
--- a/src/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs
+++ b/src/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs
@@ -43,27 +43,14 @@ namespace System.Collections.ObjectModel
         /// same order they are read by the enumerator of the collection.
         /// </remarks>
         /// <exception cref="ArgumentNullException"> collection is a null reference </exception>
-        public ObservableCollection(IEnumerable<T> collection)
+        public ObservableCollection(IEnumerable<T> collection) : base(CreateCopy(collection)) { }
+
+        private static List<T> CreateCopy(IEnumerable<T> collection)
         {
             if (collection == null)
                 throw new ArgumentNullException("collection");
 
-            CopyFrom(collection);
-        }
-
-        private void CopyFrom(IEnumerable<T> collection)
-        {
-            IList<T> items = Items;
-            if (collection != null && items != null)
-            {
-                using (IEnumerator<T> enumerator = collection.GetEnumerator())
-                {
-                    while (enumerator.MoveNext())
-                    {
-                        items.Add(enumerator.Current);
-                    }
-                }
-            }
+            return new List<T>(collection);
         }
 
         #endregion Constructors

--- a/src/System.ObjectModel/tests/ObservableCollection/ObservableCollection_ConstructorAndPropertyTests.cs
+++ b/src/System.ObjectModel/tests/ObservableCollection/ObservableCollection_ConstructorAndPropertyTests.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using Xunit;
 
 namespace System.Collections.ObjectModel.Tests
@@ -18,58 +19,47 @@ namespace System.Collections.ObjectModel.Tests
         [Fact]
         public static void ParameterlessConstructorTest()
         {
-            ObservableCollection<String> col = new ObservableCollection<String>();
-            Assert.NotNull(col);
+            var col = new ObservableCollection<string>();
             Assert.Equal(0, col.Count);
+            Assert.Empty(col);
         }
 
         /// <summary>
-        /// Tests that the Ienumerable constructor can take Ienumerable with items
-        /// and empty Ienumerable.
+        /// Tests that the IEnumerable constructor can various IEnumerables with items.
+        /// </summary>
+        [Theory]
+        [MemberData("Collections")]
+        public static void IEnumerableConstructorTest(IEnumerable<string> collection)
+        {
+            var actual = new ObservableCollection<string>(collection);
+            Assert.Equal(collection, actual);
+        }
+
+        public static readonly object[][] Collections =
+        {
+            new object[] { new string[] { "one", "two", "three" } },
+            new object[] { new List<string> { "one", "two", "three" } },
+            new object[] { new Collection<string> { "one", "two", "three" } },
+            new object[] { Enumerable.Range(1, 3).Select(i => i.ToString()) },
+            new object[] { CreateIteratorCollection() }
+        };
+
+        private static IEnumerable<string> CreateIteratorCollection()
+        {
+            yield return "one";
+            yield return "two";
+            yield return "three";
+        }
+
+        /// <summary>
+        /// Tests that the IEnumerable constructor can take an empty IEnumerable.
         /// </summary>
         [Fact]
-        public static void IEnumerableConstructorTest()
+        public static void IEnumerableConstructorTest_Empty()
         {
-            // Creating ObservableCollection with IEnumerable.
-            string[] expectedCol = { "one", "two", "three" };
-            ObservableCollection<String> actualCol = new ObservableCollection<String>((IEnumerable<String>)expectedCol);
-            Assert.NotNull(actualCol);
-            Assert.Equal(expectedCol.Length, actualCol.Count);
-
-            for (int i = 0; i < actualCol.Count; i++)
-            {
-                string item = actualCol[i];
-                bool contains = false;
-                for (int j = 0; j < expectedCol.Length; j++)
-                {
-                    if (item.Equals(expectedCol[j]))
-                    {
-                        contains = true;
-                        break;
-                    }
-                }
-                Assert.True(contains);
-            }
-
-            for (int i = 0; i < expectedCol.Length; i++)
-            {
-                string item = expectedCol[i];
-                bool contains = false;
-                for (int j = 0; j < actualCol.Count; j++)
-                {
-                    if (item.Equals(actualCol[j]))
-                    {
-                        contains = true;
-                        break;
-                    }
-                }
-                Assert.True(contains);
-            }
-
-            // Creating ObservableCollection with empty IEnumerable.
-            actualCol = new ObservableCollection<string>(new string[] { });
-            Assert.Equal(0, actualCol.Count);
-            Assert.Empty(actualCol);
+            var col = new ObservableCollection<string>(new string[] { });
+            Assert.Equal(0, col.Count);
+            Assert.Empty(col);
         }
 
         /// <summary>
@@ -78,7 +68,7 @@ namespace System.Collections.ObjectModel.Tests
         [Fact]
         public static void IEnumerableConstructorTest_Negative()
         {
-            Assert.Throws<ArgumentNullException>(() => new ObservableCollection<string>(null));
+            Assert.Throws<ArgumentNullException>("collection", () => new ObservableCollection<string>(null));
         }
 
         /// <summary>
@@ -87,8 +77,7 @@ namespace System.Collections.ObjectModel.Tests
         [Fact]
         public static void ItemTestSet()
         {
-            Guid[] anArray = { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
-            ObservableCollection<Guid> col = new ObservableCollection<Guid>((IEnumerable<Guid>)anArray);
+            var col = new ObservableCollection<Guid>(new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() });
             for (int i = 0; i < col.Count; ++i)
             {
                 Guid guid = Guid.NewGuid();
@@ -97,46 +86,24 @@ namespace System.Collections.ObjectModel.Tests
             }
         }
 
-        /// <summary>
-        /// Tests that:
-        /// ArgumentOutOfRangeException is thrown when the Index is >= collection.Count
-        /// or Index < 0.
-        /// </summary>
-        [Fact]
-        public static void ItemTestSet_Negative()
+        [Theory]
+        [InlineData(0, 0)]
+        [InlineData(3, int.MinValue)]
+        [InlineData(3, -1)]
+        [InlineData(3, 3)]
+        [InlineData(3, 4)]
+        [InlineData(3, int.MaxValue)]
+        public static void ItemTestSet_Negative_InvalidIndex(int size, int index)
         {
-            // Negative index.
-            Guid[] anArray = { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
-            ObservableCollection<Guid> col = new ObservableCollection<Guid>((IEnumerable<Guid>)anArray);
-            int[] iArrInvalidValues = new Int32[] { -1, -2, -100, -1000, -10000, -100000, -1000000, -10000000, -100000000, -1000000000, Int32.MinValue };
-            Guid guid = Guid.Empty;
-            foreach (var index in iArrInvalidValues)
-            {
-                Assert.Throws<ArgumentOutOfRangeException>(() => guid = col[index]);
-            }
-
-            // Index not in the array.
-            anArray = new Guid[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
-            col = new ObservableCollection<Guid>((IEnumerable<Guid>)anArray);
-            guid = Guid.Empty;
-            int[] iArrLargeValues = new Int32[] { col.Count, Int32.MaxValue, Int32.MaxValue / 2, Int32.MaxValue / 10 };
-            foreach (var index in iArrLargeValues)
-            {
-                Assert.Throws<ArgumentOutOfRangeException>(() => guid = col[index]);
-            }
-
-            // Index not in the array when collection is empty.
-            col = new ObservableCollection<Guid>(new Guid[] { });
-            guid = Guid.Empty;
-            Assert.Throws<ArgumentOutOfRangeException>(() => guid = col[0]);
+            var col = new ObservableCollection<int>(new int[size]);
+            Assert.Throws<ArgumentOutOfRangeException>(() => col[index]);
         }
 
         // ICollection<T>.IsReadOnly
         [Fact]
         public static void IsReadOnlyTest()
         {
-            Guid[] anArray = { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() };
-            ObservableCollection<Guid> col = new ObservableCollection<Guid>((IEnumerable<Guid>)anArray);
+            var col = new ObservableCollection<Guid>(new[] { Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid() });
             Assert.False(((ICollection<Guid>)col).IsReadOnly);
         }
 
@@ -146,6 +113,5 @@ namespace System.Collections.ObjectModel.Tests
             DebuggerAttributes.ValidateDebuggerDisplayReferences(new ObservableCollection<int>());
             DebuggerAttributes.ValidateDebuggerTypeProxyProperties(new ObservableCollection<int>());
         }
-
     }
 }


### PR DESCRIPTION
Instead of enumerating through the `IEnumerable<T>` directly, make use of the `List<T>` constructor that takes an `IEnumerable<T>`, which has optimizations for collections that implement `ICollection<T>`.

Also, cleaned up the `ObservableCollection<T>` constructor/property tests.

Note, this is technically a minor behavior change as previously the collection's enumerator would always be used, but now `ICollection<T>.Count` and `ICollection<T>.CopyTo` will be used if the collection implements `ICollection<T>`.