### PR TITLE
Fix corruption when FD_SETSIZE larger than expected

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.FdSet.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.FdSet.cs
@@ -2,34 +2,54 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
 {
     internal static partial class Sys
     {
-        public unsafe struct FdSet
+        [DllImport(Libraries.SystemNative)]
+        private static extern int FdSetSize();
+
+        private static readonly int FD_SETSIZE_BITS = FdSetSize();
+
+        private const int BitsPerByte = 8;
+        private static readonly int FD_SETSIZE_BYTES = FD_SETSIZE_BITS / BitsPerByte;
+
+        internal static readonly int FD_SETSIZE_UINTS = FD_SETSIZE_BYTES / sizeof(uint);
+
+        internal static unsafe void FD_SET(int fd, uint* fdset)
         {
-            const int FDSET_MAX_FDS = 1024;
-            const int FDSET_NFD_BITS = FDSET_MAX_FDS / (8 * sizeof(uint));
-
-            private fixed uint _bits[FDSET_MAX_FDS / FDSET_NFD_BITS];
-  
-            public void Set(int fd)
+            if (fd >= FD_SETSIZE_BITS)
             {
-                fixed (uint* bits = _bits)
-                {
-                    bits[fd / FDSET_NFD_BITS] |= (1u << (fd % FDSET_NFD_BITS));
-                }
+                ThrowInvalidFileDescriptor(fd);
             }
+            Debug.Assert(fdset != null);
 
-            public bool IsSet(int fd)
+            fdset[fd / FD_SETSIZE_UINTS] |= (1u << (fd % FD_SETSIZE_UINTS));
+        }
+
+        internal static unsafe bool FD_ISSET(int fd, uint* fdset)
+        {
+            if (fd >= FD_SETSIZE_BITS)
             {
-                fixed (uint* bits = _bits)
-                {
-                    return (bits[fd / FDSET_NFD_BITS] & (1U << (fd % FDSET_NFD_BITS))) != 0;
-                }
+                ThrowInvalidFileDescriptor(fd);
             }
+            Debug.Assert(fdset != null);
+
+            return (fdset[fd / FD_SETSIZE_UINTS] & (1u << (fd % FD_SETSIZE_UINTS))) != 0;
+        }
+
+        internal static unsafe void FD_ZERO(uint* fdset)
+        {
+            Debug.Assert(fdset != null);
+            Interop.Sys.MemSet(fdset, 0, (UIntPtr)FD_SETSIZE_BYTES);
+        }
+
+        private static void ThrowInvalidFileDescriptor(int fd)
+        {
+            throw new ArgumentOutOfRangeException("fd", fd, SR.net_InvalidSocketHandle);
         }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MemSet.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MemSet.cs
@@ -9,6 +9,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative)]
-        internal static extern unsafe Error Select(int fdCount, uint* readFds, uint* writeFds, uint* errorFds, int microseconds, int* selected);
+        internal static extern unsafe void* MemSet(void *s, int c, UIntPtr n);
     }
 }

--- a/src/Native/System.Native/CMakeLists.txt
+++ b/src/Native/System.Native/CMakeLists.txt
@@ -6,6 +6,7 @@ set(NATIVE_SOURCES
     pal_interfaceaddresses.cpp
     pal_io.cpp
     pal_maphardwaretype.cpp
+    pal_memory.cpp
     pal_mount.cpp
     pal_networking.cpp
     pal_networkstatistics.cpp

--- a/src/Native/System.Native/pal_memory.cpp
+++ b/src/Native/System.Native/pal_memory.cpp
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "pal_memory.h"
+#include <string.h>
+
+extern "C" void* MemSet(void *s, int c, uintptr_t n)
+{
+    return memset(s, c, static_cast<size_t>(n));
+}

--- a/src/Native/System.Native/pal_memory.h
+++ b/src/Native/System.Native/pal_memory.h
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "pal_types.h"
+
+/**
+ * Fills memory with a set byte. Implemented as shim to memset(3).
+ *
+ * Returns a pointer to the memory.
+ */
+extern "C" void* MemSet(void *s, int c, uintptr_t n);

--- a/src/Native/System.Native/pal_networking.h
+++ b/src/Native/System.Native/pal_networking.h
@@ -283,19 +283,6 @@ struct MessageHeader
     int32_t ControlBufferLen;
     int32_t Flags;
 };
-
-// FdSet constants.
-enum
-{
-    PAL_FDSET_MAX_FDS = 1024,
-    PAL_FDSET_NFD_BITS = 8 * sizeof(uint32_t)
-};
-
-struct FdSet
-{
-    uint32_t Bits[PAL_FDSET_MAX_FDS / PAL_FDSET_NFD_BITS];
-};
-
 struct SocketEvent
 {
     uintptr_t Data;      // User data for this event
@@ -403,8 +390,10 @@ extern "C" Error SetSockOpt(
 
 extern "C" Error Socket(int32_t addressFamily, int32_t socketType, int32_t protocolType, int32_t* createdSocket);
 
+extern "C" int32_t FdSetSize();
+
 extern "C" Error Select(
-    int32_t fdCount, FdSet* readFdSet, FdSet* writeFdSet, FdSet* errorFdSet, int32_t microseconds, int32_t* selected);
+    int32_t fdCount, uint32_t* readFdSet, uint32_t* writeFdSet, uint32_t* errorFdSet, int32_t microseconds, int32_t* selected);
 
 extern "C" Error GetBytesAvailable(int32_t socket, int32_t* available);
 

--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -379,6 +379,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Listen.cs">
       <Link>Interop\Unix\System.Native\Interop.Listen.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.MemSet.cs">
+      <Link>Interop\Unix\System.Native\Interop.MemSet.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.MessageHeader.cs">
       <Link>Interop\Unix\System.Native\Interop.MessageHeader.cs</Link>
     </Compile>

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -1185,27 +1185,29 @@ namespace System.Net.Sockets
 
         public static unsafe SocketError Poll(SafeCloseSocket handle, int microseconds, SelectMode mode, out bool status)
         {
-            var fdSet = new Interop.Sys.FdSet();
-            fdSet.Set(handle.FileDescriptor);
+            uint* fdSet = stackalloc uint[Interop.Sys.FD_SETSIZE_UINTS];
+            Interop.Sys.FD_ZERO(fdSet);
+
+            Interop.Sys.FD_SET(handle.FileDescriptor, fdSet);
 
             int fdCount = 0;
-            Interop.Sys.FdSet* readFds = null;
-            Interop.Sys.FdSet* writeFds = null;
-            Interop.Sys.FdSet* errorFds = null;
+            uint* readFds = null;
+            uint* writeFds = null;
+            uint* errorFds = null;
             switch (mode)
             {
                 case SelectMode.SelectRead:
-                    readFds = &fdSet;
+                    readFds = fdSet;
                     fdCount = handle.FileDescriptor + 1;
                     break;
 
                 case SelectMode.SelectWrite:
-                    writeFds = &fdSet;
+                    writeFds = fdSet;
                     fdCount = handle.FileDescriptor + 1;
                     break;
 
                 case SelectMode.SelectError:
-                    errorFds = &fdSet;
+                    errorFds = fdSet;
                     fdCount = handle.FileDescriptor + 1;
                     break;
             }
@@ -1218,35 +1220,35 @@ namespace System.Net.Sockets
                 return GetSocketErrorForErrorCode(err);
             }
 
-            status = fdSet.IsSet(handle.FileDescriptor);
+            status = Interop.Sys.FD_ISSET(handle.FileDescriptor, fdSet);
             return SocketError.Success;
         }
 
         public static unsafe SocketError Select(IList checkRead, IList checkWrite, IList checkError, int microseconds)
         {
-            var readSet = new Interop.Sys.FdSet();
-            int maxReadFd = Socket.FillFdSetFromSocketList(ref readSet, checkRead);
+            uint* readSet = stackalloc uint[Interop.Sys.FD_SETSIZE_UINTS];
+            int maxReadFd = Socket.FillFdSetFromSocketList(readSet, checkRead);
 
-            var writeSet = new Interop.Sys.FdSet();
-            int maxWriteFd = Socket.FillFdSetFromSocketList(ref writeSet, checkWrite);
+            uint* writeSet = stackalloc uint[Interop.Sys.FD_SETSIZE_UINTS];
+            int maxWriteFd = Socket.FillFdSetFromSocketList(writeSet, checkWrite);
 
-            var errorSet = new Interop.Sys.FdSet();
-            int maxErrorFd = Socket.FillFdSetFromSocketList(ref errorSet, checkError);
+            uint* errorSet = stackalloc uint[Interop.Sys.FD_SETSIZE_UINTS];
+            int maxErrorFd = Socket.FillFdSetFromSocketList(errorSet, checkError);
 
             int fdCount = 0;
-            Interop.Sys.FdSet* readFds = null;
-            Interop.Sys.FdSet* writeFds = null;
-            Interop.Sys.FdSet* errorFds = null;
+            uint* readFds = null;
+            uint* writeFds = null;
+            uint* errorFds = null;
 
             if (maxReadFd != 0)
             {
-                readFds = &readSet;
+                readFds = readSet;
                 fdCount = maxReadFd;
             }
 
             if (maxWriteFd != 0)
             {
-                writeFds = &writeSet;
+                writeFds = writeSet;
                 if (maxWriteFd > fdCount)
                 {
                     fdCount = maxWriteFd;
@@ -1255,7 +1257,7 @@ namespace System.Net.Sockets
 
             if (maxErrorFd != 0)
             {
-                errorFds = &errorSet;
+                errorFds = errorSet;
                 if (maxErrorFd > fdCount)
                 {
                     fdCount = maxErrorFd;
@@ -1272,9 +1274,9 @@ namespace System.Net.Sockets
                 return GetSocketErrorForErrorCode(err);
             }
 
-            Socket.FilterSocketListUsingFdSet(ref readSet, checkRead);
-            Socket.FilterSocketListUsingFdSet(ref writeSet, checkWrite);
-            Socket.FilterSocketListUsingFdSet(ref errorSet, checkError);
+            Socket.FilterSocketListUsingFdSet(readSet, checkRead);
+            Socket.FilterSocketListUsingFdSet(writeSet, checkWrite);
+            Socket.FilterSocketListUsingFdSet(errorSet, checkError);
 
             return SocketError.Success;
         }


### PR DESCRIPTION
The expected FD_SETSIZE for Select is currently hardcoded to be 1024.  While common, this is not required, and many servers will have this limit increased.  With the current hardcoded value, if a file descriptor comes in beyond the limit, we end up corrupting memory.

This commit fixes it by making the limit in managed code dynamic, supplied via a call to the native shim to return the actual value of FD_SETSIZE so that the managed and native expectations match.

cc: @pgavlin, @sergiy-k 