### PR TITLE
Remove duplication in Queue<T> & Stack<T> enumerators

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -437,17 +437,7 @@ namespace System.Collections.Generic
 
             Object System.Collections.IEnumerator.Current
             {
-                get
-                {
-                    if (_index < 0)
-                    {
-                        if (_index == -1)
-                            throw new InvalidOperationException(SR.InvalidOperation_EnumNotStarted);
-                        else
-                            throw new InvalidOperationException(SR.InvalidOperation_EnumEnded);
-                    }
-                    return _currentElement;
-                }
+                get { return Current; }
             }
 
             void System.Collections.IEnumerator.Reset()

--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -325,12 +325,7 @@ namespace System.Collections.Generic
 
             Object System.Collections.IEnumerator.Current
             {
-                get
-                {
-                    if (_index == -2) throw new InvalidOperationException(SR.InvalidOperation_EnumNotStarted);
-                    if (_index == -1) throw new InvalidOperationException(SR.InvalidOperation_EnumEnded);
-                    return _currentElement;
-                }
+                get { return Current; }
             }
 
             void System.Collections.IEnumerator.Reset()


### PR DESCRIPTION
Change `IEnumerator.Current` to simply return `Current`, instead of having duplicate code in both properties.