### PR TITLE
Cleanup IdentityReferenceCollection's enumerator

### DIFF
--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/IRCollection.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/IRCollection.cs
@@ -422,7 +422,7 @@ namespace System.Security.Principal
         {
             get
             {
-                return _collection.Identities[_current];
+                return Current;
             }
         }
 
@@ -430,7 +430,7 @@ namespace System.Security.Principal
         {
             get
             {
-                return ((IEnumerator)this).Current as IdentityReference;
+                return _collection.Identities[_current];
             }
         }
 


### PR DESCRIPTION
Swap the implementations of `Current` and `IEnumerator.Current` to avoid having to use casts in `Current`'s implementation.