### PR TITLE
Avoid Console-based allocations when typing on Unix

### DIFF
--- a/src/Common/src/System/Text/StringOrCharArray.cs
+++ b/src/Common/src/System/Text/StringOrCharArray.cs
@@ -1,0 +1,178 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace System.Text
+{
+    /// <summary>
+    /// Discrimated union of a string and a char array/offset/count.  Enables looking up
+    /// a portion of a char array as a key in a dictionary of string keys without having to
+    /// allocate/copy the chars into a new string.  This comes at the expense of an extra
+    /// reference field + two Int32s per key in the size of the dictionary's Entry array.
+    /// </summary>
+    internal struct StringOrCharArray : IEquatable<StringOrCharArray>
+    {
+        public readonly string String;
+
+        public readonly char[] CharArray;
+        public readonly int CharArrayOffset;
+        public readonly int CharArrayCount;
+
+        public StringOrCharArray(string s)
+        {
+            String = s;
+
+            CharArray = null;
+            CharArrayOffset = 0;
+            CharArrayCount = 0;
+
+            DebugValidate();
+        }
+
+        public StringOrCharArray(char[] charArray, int charArrayIndex, int charArrayOffset)
+        {
+            String = null;
+
+            CharArray = charArray;
+            CharArrayOffset = charArrayIndex;
+            CharArrayCount = charArrayOffset;
+
+            DebugValidate();
+        }
+
+        public static implicit operator StringOrCharArray(string value)
+        {
+            return new StringOrCharArray(value);
+        }
+
+        public int Length
+        {
+            get
+            {
+                DebugValidate();
+                return String != null ? String.Length : CharArrayCount;
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return
+                obj is StringOrCharArray &&
+                Equals((StringOrCharArray)obj);
+        }
+
+        public unsafe bool Equals(StringOrCharArray other)
+        {
+            this.DebugValidate();
+            other.DebugValidate();
+
+            if (this.String != null)
+            {
+                // String vs String
+                if (other.String != null)
+                {
+                    return StringComparer.Ordinal.Equals(this.String, other.String);
+                }
+
+                // String vs CharArray
+                if (this.String.Length != other.CharArrayCount)
+                    return false;
+
+                for (int i = 0; i < this.String.Length; i++)
+                {
+                    if (this.String[i] != other.CharArray[other.CharArrayOffset + i])
+                        return false;
+                }
+
+                return true;
+            }
+
+            // CharArray vs CharArray
+            if (other.CharArray != null)
+            {
+                if (this.CharArrayCount != other.CharArrayCount)
+                    return false;
+
+                for (int i = 0; i < this.CharArrayCount; i++)
+                {
+                    if (this.CharArray[this.CharArrayOffset + i] != other.CharArray[other.CharArrayOffset + i])
+                        return false;
+                }
+
+                return true;
+            }
+
+            // CharArray vs String
+            if (this.CharArrayCount != other.String.Length)
+                return false;
+
+            for (int i = 0; i < this.CharArrayCount; i++)
+            {
+                if (this.CharArray[this.CharArrayOffset + i] != other.String[i])
+                    return false;
+            }
+
+            return true;
+        }
+
+        public override unsafe int GetHashCode()
+        {
+            DebugValidate();
+
+            if (String != null)
+            {
+                fixed (char* s = String)
+                {
+                    return GetHashCode(s, String.Length);
+                }
+            }
+            else
+            {
+                fixed (char* s = CharArray)
+                {
+                    return GetHashCode(s + CharArrayOffset, CharArrayCount);
+                }
+            }
+        }
+
+        private static unsafe int GetHashCode(char* s, int count)
+        {
+            // This hash code is a simplified version of some of the code in String, 
+            // when not using randomized hash codes.  We don't use string's GetHashCode
+            // because we need to be able to use the exact same algorithms on a char[].
+            // As such, this should not be used anywhere there are concerns around
+            // hash-based attacks that would require a better code.
+
+            int hash1 = (5381 << 16) + 5381;
+            int hash2 = hash1;
+
+            for (int i = 0; i < count; ++i)
+            {
+                int c = *s++;
+                hash1 = ((hash1 << 5) + hash1) ^ c;
+
+                if (++i >= count)
+                    break;
+
+                c = *s++;
+                hash2 = ((hash2 << 5) + hash2) ^ c;
+            }
+
+            return hash1 + (hash2 * 1566083941);
+        }
+
+        [Conditional("DEBUG")]
+        private void DebugValidate()
+        {
+            Debug.Assert((String != null) ^ (CharArray != null));
+
+            if (CharArray != null)
+            {
+                Debug.Assert(CharArrayCount >= 0);
+                Debug.Assert(CharArrayOffset >= 0);
+                Debug.Assert(CharArrayOffset <= CharArray.Length - CharArrayCount);
+            }
+        }
+    }
+}

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -130,6 +130,9 @@
     <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
       <Link>Common\System\IO\StringBuilderCache.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Text\StringOrCharArray.cs">
+      <Link>Common\System\Text\StringOrCharArray.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -571,14 +571,14 @@ namespace System
         {
             int unprocessedCharCount = endIndex - startIndex;
 
-            if (unprocessedCharCount >= TerminalKeyInfo.Instance.MinKeyLength)
+            int minRange = TerminalKeyInfo.Instance.MinKeyLength;
+            if (unprocessedCharCount >= minRange)
             {
-                int minRange = TerminalKeyInfo.Instance.MinKeyLength;
                 int maxRange = Math.Min(unprocessedCharCount, TerminalKeyInfo.Instance.MaxKeyLength);
 
                 for (int i = maxRange; i >= minRange; i--)
                 {
-                    string currentString = new string(givenChars, startIndex, i);
+                    var currentString = new StringOrCharArray(givenChars, startIndex, i);
 
                     // Check if the string prefix matches.
                     if (TerminalKeyInfo.Instance.KeyFormatToConsoleKey.TryGetValue(currentString, out key))
@@ -775,7 +775,7 @@ namespace System
             /// The dictionary of keystring to ConsoleKeyInfo.
             /// Only some members of the ConsoleKeyInfo are used; in particular, the actual char is ignored.
             /// </summary>
-            public Dictionary<string, ConsoleKeyInfo> KeyFormatToConsoleKey;
+            public Dictionary<StringOrCharArray, ConsoleKeyInfo> KeyFormatToConsoleKey;
             /// <summary> Max key length </summary>
             public int MaxKeyLength;
             /// <summary> Min key length </summary>
@@ -816,7 +816,7 @@ namespace System
 
             private TerminalKeyInfo(TermInfo.Database db)
             {
-                KeyFormatToConsoleKey = new Dictionary<string, ConsoleKeyInfo>();
+                KeyFormatToConsoleKey = new Dictionary<StringOrCharArray, ConsoleKeyInfo>();
                 MaxKeyLength = MinKeyLength = 0;
                 KeypadXmit = string.Empty;
 


### PR DESCRIPTION
The Console implementation on Unix relies on a dictionary from string to ConsoleKeyInfo to determine whether a given character sequence represents a special known sequence that should be converted into a particular ConsoleKeyInfo, e.g. the escape sequence that represents an arrow key.  As typing happens, a buffer of characters fills up, and then strings are created from that buffer to determine whether they match anything in the dictionary.  This means we incur one ore more allocations any time a lookup needs to happen.

This commit adds a new internal struct type, StringOrCharArray, that is a discriminated union of a String and of a char[]/offset/index tuple.  This is then used as the key in the dictionary, which lets us look up a character sequence with zero allocations.  It comes at the expense of needing to store a few extra fields for each key in the dictionary, but given the number of keys we need to store (~100), this is a good tradeoff compared to needing to allocate/copy each string one or more times (depending on the length) each time we evaluate a special sequence.

(I experimented with other data structures, including several trie variations, and this approach yielded the best performance, both in memory consumption and in throughput.)

cc: @pallavit, @ellismg 