### PR TITLE
Optimize Queue<T>'s constructor

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -31,7 +31,6 @@ namespace System.Collections.Generic
 
         private const int MinimumGrow = 4;
         private const int GrowFactor = 200;  // double each time
-        private const int DefaultCapacity = 4;
 
         // Creates a queue with room for capacity objects. The default initial
         // capacity and grow factor are used.
@@ -61,15 +60,8 @@ namespace System.Collections.Generic
             if (collection == null)
                 throw new ArgumentNullException("collection");
 
-            _array = new T[DefaultCapacity];
-
-            using (IEnumerator<T> en = collection.GetEnumerator())
-            {
-                while (en.MoveNext())
-                {
-                    Enqueue(en.Current);
-                }
-            }
+            _array = EnumerableHelpers.ToArray(collection, out _size);
+            _tail = (_size == _array.Length) ? 0 : _size;
         }
 
 


### PR DESCRIPTION
Instead of enumerating through the `IEnumerable<T>` directly, use `EnumerableHelpers.ToArray`, which has optimizations for collections that implement `ICollection<T>`.

Note, this is technically a minor behavior change as previously the collection's enumerator would always be used, but now `ICollection<T>.Count` and `ICollection<T>.CopyTo` will be used if the collection implements `ICollection<T>`.

As such, @stephentoub held off on adding this optimization to `Queue<T>` when simplifying `Stack<T>`'s similar constructor (which already had the `ICollection`-based optimization) in #1955:

> (It's not clear to me why Queue doesn't have the same IColection-related logic; probably just an oversight, but I didn't want to change its behavior with the additional ICollection check.)

Since then we've added similar optimizations elsewhere, so it seems like it'd be worth doing for `Queue<T>`, making it consistent with `Stack<T>` and `List<T>`'s behavior.