### PR TITLE
Add osx.10.9 to runtimes.json

### DIFF
--- a/pkg/Microsoft.NETCore.Platforms/runtime.json
+++ b/pkg/Microsoft.NETCore.Platforms/runtime.json
@@ -144,6 +144,13 @@
             "#import": [ "osx", "unix-x64" ]
         },
 
+        "osx.10.9": {
+            "#import": [ "osx" ]
+        },
+        "osx.10.9-x64": {
+            "#import": [ "osx.10.9", "osx-x64" ]
+        },
+
         "osx.10.10": {
             "#import": [ "osx" ]
         },


### PR DESCRIPTION
Resolves package restore issues on OSX 10.9