### PR TITLE
Don't hardcode Version.ToString length in FVI

### DIFF
--- a/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Unix.cs
+++ b/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Unix.cs
@@ -73,11 +73,11 @@ namespace System.Diagnostics
             // Set the product version based on the assembly's version (this may be overwritten 
             // later in the method).
             Version productVersion = assemblyDefinition.Version;
-            _productVersion = productVersion.ToString(4);
+            _productVersion = productVersion.ToString();
             _productMajor = productVersion.Major;
             _productMinor = productVersion.Minor;
-            _productBuild = productVersion.Build;
-            _productPrivate = productVersion.Revision;
+            _productBuild = productVersion.Build != -1 ? productVersion.Build : 0;
+            _productPrivate = productVersion.Revision != -1 ? productVersion.Revision : 0;
 
             // "Language Neutral" is used on Win32 for unknown language identifiers.
             _language = "Language Neutral";
@@ -128,11 +128,11 @@ namespace System.Diagnostics
                         Version v;
                         if (Version.TryParse(versionString, out v))
                         {
-                            _fileVersion = v.ToString(4);
+                            _fileVersion = v.ToString();
                             _fileMajor = v.Major;
                             _fileMinor = v.Minor;
-                            _fileBuild = v.Build;
-                            _filePrivate = v.Revision;
+                            _fileBuild = v.Build != -1 ? v.Build : 0;
+                            _filePrivate = v.Revision != -1 ? v.Revision : 0;
 
                             // When the managed compiler sees an [AssemblyVersion(...)] attribute, it uses that to set 
                             // both the assembly version and the product version in the Win32 resources. If it doesn't 


### PR DESCRIPTION
If Build or Revision isn't set, Version.ToString(4) will throw.  We instead just use the default ToString() overload, which will internally call ToString(2), ToString(3), or ToString(4) based on how many parts are actually defined in the version.

Fixes https://github.com/dotnet/corefx/issues/4727
cc: @pallavit 

@mjrousos, can you help verify this fixes your issue (and doesn't introduce others)?