### PR TITLE
Fix WebException constructor parameters to match Desktop naming

### DIFF
--- a/src/System.Net.Requests/ref/System.Net.Requests.cs
+++ b/src/System.Net.Requests/ref/System.Net.Requests.cs
@@ -56,8 +56,8 @@ namespace System.Net
     {
         public WebException() { }
         public WebException(string message) { }
-        public WebException(string message, System.Exception inner) { }
-        public WebException(string message, System.Exception inner, System.Net.WebExceptionStatus status, System.Net.WebResponse response) { }
+        public WebException(string message, System.Exception innerException) { }
+        public WebException(string message, System.Exception innerException, System.Net.WebExceptionStatus status, System.Net.WebResponse response) { }
         public WebException(string message, System.Net.WebExceptionStatus status) { }
         public System.Net.WebResponse Response { get { return default(System.Net.WebResponse); } }
         public System.Net.WebExceptionStatus Status { get { return default(System.Net.WebExceptionStatus); } }

--- a/src/System.Net.Requests/src/System/Net/WebException.cs
+++ b/src/System.Net.Requests/src/System/Net/WebException.cs
@@ -23,8 +23,8 @@ namespace System.Net
         {
         }
 
-        public WebException(string message, Exception inner) :
-            this(message, inner, DefaultStatus, null)
+        public WebException(string message, Exception innerException) :
+            this(message, innerException, DefaultStatus, null)
         {
         }
 
@@ -34,17 +34,17 @@ namespace System.Net
         }
 
         public WebException(string message,
-                            Exception inner,
+                            Exception innerException,
                             WebExceptionStatus status,
                             WebResponse response) :
-            base(message, inner)
+            base(message, innerException)
         {
             _status = status;
             _response = response;
 
-            if (inner != null)
+            if (innerException != null)
             {
-                HResult = inner.HResult;
+                HResult = innerException.HResult;
             }
         }
 


### PR DESCRIPTION
As per the System.Net.* API review dotnet/apireviews#21 fixing the
parameter name used for the inner exception in the WebException
constructor overloads to match the name used in .NET Framework (Desktop).

Part of #4732