### PR TITLE
Add TargetGroup support into dir.props

### DIFF
--- a/Documentation/coding-guidelines/project-guidelines.md
+++ b/Documentation/coding-guidelines/project-guidelines.md
@@ -1,0 +1,116 @@
+#Library Project guidelines
+Library projects should use the fllowing directory layout.
+```
+src\<Library Name>\src - Contains the source code for the library. 
+src\<Library Name>\ref - Contains any refernce assembly projects for the library
+src\<Library Name>\tests - Contains the test code for a library
+```
+In the src directory for a library there should be only **one** `.csproj` file that contains any information necessary to build the library in various configurartions (see [Configurations](project-configuration-conventions)). The src directory should also contain exactly **one** `.builds` file which contains all the valid configurations that a library should be built for (see [.builds file](project-.builds-file)). In some cases there might be a Facade subdirectory under src with a .csproj (see [Facades Projects](facades-projects)). 
+
+
+##Build Pivots
+Below is a list of all the various options we pivot the project builds on.
+
+- **Architecture:** x86, x64, ARM, ARM64
+- **Flavor:** Debug, Release
+- **OS:** Windows_NT, Linux, OSX, FreeBSD
+- **Platform Runtimes:** NetFx (aka CLR/Desktop), CoreCLR, NetNative (aka MRT/AOT)
+- **Target Frameworks:** NetFx (aka Desktop), .NETCore (aka Store/UWP), DNXCore (aka ASP.NET vNext), netstandard(aka dotnet/Portable)
+- **Version:** Potentially multiple versions at the same time.
+
+##Full Repo build pass
+**Build Parameters:** *Flavor, Architecture, OS*<BR/>
+For each combination of build parameters there should be a full build pass over the entire repo. For each OS the build pass should be performed on that OS.
+
+##Project build pass
+**Project Parameters:** *Platform Runtime, Target Framework, Version*<BR/>
+These are optional for specific projects and don't require a full build pass but instead should be scoped to individual projects within the most appropriate full build pass.
+
+#Project configuration conventions
+For each unique configuration needed for a given library project a configuration property group should be added to the project so it can be selected and built in VS and also clearly identify the various configurations.<BR/>
+`<PropertyGroup Condition="'$(Configuration)|$(Platform)' == '$(<OSGroup>_<TargetGroup>_<ConfigurationGroup>)|$(Platform)'">`
+
+- `$(Platform) -> AnyCPU* | x86 | x64 | ARM | ARM64`
+- `$(Configuration) -> $(OSGroup)_$(TargetGroup)_$(ConfigurationGroup)`
+- `$(OSGroup) -> [Empty]* | Windows | Linux | OSX | FreeBSD`
+- `$(TargetGroup) -> [Empty]* | <TargetFrameworkMoniker> | <RuntimeIdentifier> | <Version> | <TFM><RID>`
+ - `$(PackageTargetFramework) -> netstandard | netcore50 | net46 | dnxcore50`
+ - `$(PackageTargetRuntime) -> aot`
+ - For more information on various targets see also [.NET Platform Standard](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/standard-platform.md)
+- `$(ConfigurationGroup) -> Debug* | Release`
+<BR/>`*` -> *default values*
+
+####*Examples*
+Project configurations for a pure IL library project which targets the defaults.
+```
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+```
+Project configurations with a unique implementation for each OS
+```
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'FreeBSD_Debug|AnyCPU " />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'FreeBSD_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'OSX_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'OSX_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
+```
+Project configurations that are unique for a few different target frameworks and runtimes
+```
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+```
+## Project .builds file
+To drive the Project build pass we have a *.builds project that will multiplex the various optional build parameters we have for all the various configurtions within a given build pass.
+
+Below is an example for System.Linq.Expressions where it only builds for the windows full build passes and needs a unique build for various target frameworks.
+```
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
+    <Project Include="System.Linq.Expressions.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties> 
+    </Project>
+    <Project Include="System.Linq.Expressions.csproj">
+      <AdditionalProperties>TargetGroup=netcore50aot</AdditionalProperties>
+    </Project>
+    <Project Include="System.Linq.Expressions.csproj">
+      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties> 
+    </Project>
+    <Project Include="Facade\System.Linq.Expressions.csproj">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+```
+##Facades Projects
+Facade projects are unique in that they don't have any code and instead are generated by finding a contract reference assembly with the matching identity and generating type forwards for all the types to where they live in the implementation assemblies (aka facade seeds). There are also partial facades which contain some type forwards as well as some code definitions. Ideally all the various build configurations would be contained in the one csproj file per library but given the unique nature of facades and the fact they are usually a complete fork of everything in the project file it is recommended to create a matching csproj under a Facade directory (<library>\src\Facade\<library>.csproj) and reference that from your .builds file, as in the System.Linq.Expressions example.
+
+TODO: Fill in more information about the required properties for creatng a facade project.
+
+##Defines for code #ifdefs
+Configuration base defines should match the name of the configurtion that is needs the fork in code. So either $(Platform), $(OSGroup), $(ConfigurationGroup), $(TargetGroup). These should only be used as a last resort and we should prefer using partial classes or configuration specific cs files for any necessary forking (see [File naming convention](file-naming-convention)).
+
+Feature based defines should be named like `FEATURE_[FeatureName]`. These can unique to a given library project or potentially shared (via name) across multiple projects.
+
+
+##File naming convention
+
+`<class name>.<group>.cs`
+
+Where `<group>` is:
+- Windows/Linux/Unix/Osx - For files specific to a given OS
+- WinRT - For files that are have unique WinRT dependencies
+- Target Runtime
+ - NetFx - Files specific for the full .NET Framework/CLR runtime
+ - CoreCLR - Files specific to the CoreCLR runtime
+ - NETNative - Files specific to the .NET Native runtime (MRT) or toolchain.

--- a/dir.props
+++ b/dir.props
@@ -144,6 +144,12 @@
     -->
     <SkipBuildPackages>true</SkipBuildPackages>
   </PropertyGroup>
+  
+  <PropertyGroup>
+    <!-- By default make all libraries to be AnyCPU but individual projects can override it if they need to -->
+    <Platform>AnyCPU</Platform>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
 
   <!-- 
   Projects that have no OS-specific implementations just use Debug and Release for $(Configuration).
@@ -151,48 +157,147 @@
   if the code is the same between some OS's (so if you have some project that just calls POSIX APIs, we still have
   OSX_[Debug|Release] and Linux_[Debug|Release] configurations.  We do this so that we place all the output under
   a single binary folder and can have a similar experience between the command line and Visual Studio.
-  
-  Since now have multiple *Debug and *Release configurations, ConfigurationGroup is set to Debug for any of the
-  debug configurations, and to Release for any of the release configurations.
   -->
 
-  <!-- Set default Configuration and Platform -->
-  <PropertyGroup>
-    <Platform Condition="'$(Platform)'==''">AnyCPU</Platform>
+  <!-- 
+  If Configuration is empty that means we are not being built in VS and so folks need to explicitly pass the different
+  values for $(ConfigurationGroup), $(TargetGroup), or $(OSGroup) or accept the defaults for them.
+  -->
+  <PropertyGroup Condition="'$(Configuration)'==''">
+    <ConfigurationGroup Condition="'$(ConfigurationGroup)'==''">Debug</ConfigurationGroup>
+    <Configuration>$(ConfigurationGroup)</Configuration>
+    <Configuration Condition="'$(TargetGroup)'!=''">$(TargetGroup)_$(Configuration)</Configuration>
+    <Configuration Condition="'$(OSGroup)'!='' and '$(OSGroup)'!='Windows_NT'">$(OSGroup)_$(Configuration)</Configuration>
+  </PropertyGroup>
 
-    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
-    <ConfigurationGroup Condition="$(Configuration.EndsWith('Debug'))">Debug</ConfigurationGroup>
-    <ConfigurationGroup Condition="$(Configuration.EndsWith('Release'))">Release</ConfigurationGroup>
-    <ConfigurationGroup Condition="'$(ConfigurationGroup)'==''">$(Configuration)</ConfigurationGroup>
+  <!--
+  If Configuration is set then someone explicitly passed it in or we building from VS. In either case
+  default $(ConfigurationGroup), $(TargetGroup), or $(OSGroup) from the Configuration if they aren't
+  already explicitly set.
+  -->
+  <PropertyGroup Condition="'$(Configuration)'!=''">
+    <ConfigurationGroup Condition="'$(ConfigurationGroup)'=='' and $(Configuration.EndsWith('Debug'))">Debug</ConfigurationGroup>
+    <ConfigurationGroup Condition="'$(ConfigurationGroup)'=='' and $(Configuration.EndsWith('Release'))">Release</ConfigurationGroup>
+    <ConfigurationGroup Condition="'$(ConfigurationGroup)'==''">Debug</ConfigurationGroup>
 
     <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('Windows'))">Windows_NT</OSGroup>
     <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('Linux'))">Linux</OSGroup>
     <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('OSX'))">OSX</OSGroup>
     <OSGroup Condition="'$(OSGroup)'=='' and $(Configuration.StartsWith('FreeBSD'))">FreeBSD</OSGroup>
     <OSGroup Condition="'$(OSGroup)'==''">Windows_NT</OSGroup>
+
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('netcore50aot'))">netcore50aot</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('netcore50'))">netcore50</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('dnxcore50'))">dnxcore50</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('net46'))">net46</TargetGroup>
   </PropertyGroup>
 
   <!-- Set up Default symbol and optimization for Configuration -->
-  <PropertyGroup Condition="'$(ConfigurationGroup)' == 'Debug'">
-    <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
-    <Optimize Condition="'$(Optimize)' == ''">false</Optimize>
-    <DebugType Condition="'$(DebugType)' == ''">full</DebugType>
-    <DefineConstants>$(DefineConstants),DEBUG,TRACE</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(ConfigurationGroup)' == 'Release'">
-    <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
-    <Optimize Condition="'$(Optimize)' == ''">true</Optimize>
-    <DebugType Condition="'$(DebugType)' == ''">pdbonly</DebugType>
-    <DefineConstants>$(DefineConstants),TRACE</DefineConstants>
+  <Choose>
+    <When Condition="'$(ConfigurationGroup)'=='Debug'">
+      <PropertyGroup>
+        <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
+        <Optimize Condition="'$(Optimize)' == ''">false</Optimize>
+        <DebugType Condition="'$(DebugType)' == ''">full</DebugType>
+        <DefineConstants>$(DefineConstants),DEBUG,TRACE</DefineConstants>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(ConfigurationGroup)' == 'Release'">
+      <PropertyGroup>
+        <DebugSymbols Condition="'$(DebugSymbols)' == ''">true</DebugSymbols>
+        <Optimize Condition="'$(Optimize)' == ''">true</Optimize>
+        <DebugType Condition="'$(DebugType)' == ''">pdbonly</DebugType>
+        <DefineConstants>$(DefineConstants),TRACE</DefineConstants>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <ConfigurationErrorMsg>$(ConfigurationErrorMsg);Unknown ConfigurationGroup [$(ConfigurationGroup)] specificed in your project.</ConfigurationErrorMsg>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <!-- Setup properties per OSGroup -->
+  <Choose>
+    <When Condition="'$(OSGroup)'=='Windows_NT'">
+      <PropertyGroup>
+        <TargetsWindows>true</TargetsWindows>
+        <TestNugetRuntimeId>win7-x64</TestNugetRuntimeId>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(OSGroup)'=='Linux'">
+      <PropertyGroup>
+        <TargetsUnix>true</TargetsUnix>
+        <TargetsLinux>true</TargetsLinux>
+        <TestNugetRuntimeId>ubuntu.14.04-x64</TestNugetRuntimeId>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(OSGroup)'=='OSX'">
+      <PropertyGroup>
+        <TargetsUnix>true</TargetsUnix>
+        <TargetsOSX>true</TargetsOSX>
+        <TestNugetRuntimeId>osx.10.10-x64</TestNugetRuntimeId>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(OSGroup)'=='FreeBSD'">
+      <PropertyGroup>
+        <TargetsUnix>true</TargetsUnix>
+        <TargetsFreeBSD>true</TargetsFreeBSD>
+        <TestNugetRuntimeId>ubuntu.14.04-x64</TestNugetRuntimeId>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <ConfigurationErrorMsg>$(ConfigurationErrorMsg);Unknown OSGroup [$(OSGroup)] specificed in your project.</ConfigurationErrorMsg>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+
+  <PropertyGroup>
+    <TargetsUnknownUnix Condition="'$(TargetsUnix)' == 'true' AND '$(OSGroup)' != 'FreeBSD' AND '$(OSGroup)' != 'Linux' AND '$(OSGroup)' != 'OSX'">true</TargetsUnknownUnix>
   </PropertyGroup>
 
-  <!-- Provide defaults for TestNugetRuntimeId -->
-  <PropertyGroup Condition="'$(TestNugetRuntimeId)'== ''">
-    <TestNugetRuntimeId Condition="'$(OSGroup)'=='Windows_NT'">win7-x64</TestNugetRuntimeId>
-    <TestNugetRuntimeId Condition="'$(OSGroup)'=='Linux'">ubuntu.14.04-x64</TestNugetRuntimeId>
-    <TestNugetRuntimeId Condition="'$(OSGroup)'=='OSX'">osx.10.10-x64</TestNugetRuntimeId>
-    <TestNugetRuntimeId Condition="'$(OSGroup)'=='FreeBSD'">ubuntu.14.04-x64</TestNugetRuntimeId>
-  </PropertyGroup>
+  <!-- Setup properties per TargetGroup -->
+  <Choose>
+    <When Condition="'$(TargetGroup)'==''">
+      <PropertyGroup>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(TargetGroup)'=='netcore50'">
+      <PropertyGroup>
+        <PackageTargetFramework>netcore50</PackageTargetFramework>
+        <TargetingPackNugetPackageId>Microsoft.TargetingPack.Private.NetNative</TargetingPackNugetPackageId>
+        <NuGetTargetMoniker>.NETCore,Version=v5.0</NuGetTargetMoniker>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(TargetGroup)'=='netcore50aot'">
+      <PropertyGroup>
+        <PackageTargetFramework>netcore50</PackageTargetFramework>
+        <PackageTargetRuntime>aot</PackageTargetRuntime>
+        <TargetingPackNugetPackageId>Microsoft.TargetingPack.Private.NetNative</TargetingPackNugetPackageId>
+        <NuGetTargetMoniker>.NETCore,Version=v5.0</NuGetTargetMoniker>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(TargetGroup)'=='dnxcore50'">
+      <PropertyGroup>
+        <PackageTargetFramework>dnxcore50</PackageTargetFramework>
+        <TargetingPackNugetPackageId>Microsoft.TargetingPack.Private.CoreCLR</TargetingPackNugetPackageId>
+        <NuGetTargetMoniker>DNXCore,Version=v5.0</NuGetTargetMoniker>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(TargetGroup)'=='net46'">
+      <PropertyGroup>
+        <PackageTargetFramework>net46</PackageTargetFramework>
+        <TargetingPackNugetPackageId>Microsoft.TargetingPack.NETFramework.v4.6</TargetingPackNugetPackageId>
+        <NuGetTargetMoniker>.NETFramework,Version=v4.6</NuGetTargetMoniker>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <ConfigurationErrorMsg>$(ConfigurationErrorMsg);Unknown TargetGroup [$(TargetGroup)] specificed in your project.</ConfigurationErrorMsg>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
 
   <!-- Provide defaults for ToolNugetRuntimeId -->
   <PropertyGroup Condition="'$(ToolNugetRuntimeId)'== ''">
@@ -233,37 +338,18 @@
   <!-- Set up the default output and intermediate paths -->
   <PropertyGroup>
     <OSPlatformConfig>$(OSGroup).$(Platform).$(ConfigurationGroup)</OSPlatformConfig>
+    <TargetOutputRelPath Condition="'$(TargetGroup)'!=''">$(TargetGroup)\</TargetOutputRelPath>
 
     <BaseOutputPath Condition="'$(BaseOutputPath)'==''">$(BinDir)</BaseOutputPath>
-    <OutputPath Condition="'$(OutputPath)'==''">$(BaseOutputPath)$(OSPlatformConfig)\$(MSBuildProjectName)\</OutputPath>
+    <OutputPath Condition="'$(OutputPath)'==''">$(BaseOutputPath)$(OSPlatformConfig)\$(MSBuildProjectName)\$(TargetOutputRelPath)</OutputPath>
 
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'==''">$(ObjDir)</BaseIntermediateOutputPath>
     <IntermediateOutputRootPath Condition="'$(IntermediateOutputRootPath)' == ''">$(BaseIntermediateOutputPath)$(OSPlatformConfig)\</IntermediateOutputRootPath>
-    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(IntermediateOutputRootPath)$(MSBuildProjectName)\</IntermediateOutputPath>
+    <IntermediateOutputPath Condition="'$(IntermediateOutputPath)' == ''">$(IntermediateOutputRootPath)$(MSBuildProjectName)\$(TargetOutputRelPath)</IntermediateOutputPath>
 
     <TestPath Condition="'$(TestPath)'==''">$(TestWorkingDir)$(OSPlatformConfig)\$(MSBuildProjectName)\</TestPath>
 
     <PackagesBasePath Condition="'$(PackagesBasePath)'==''">$(BinDir)$(OSPlatformConfig)</PackagesBasePath>
-  </PropertyGroup>
-
-  <!-- Set up common target properties that we use to conditionally include sources -->
-  <PropertyGroup>
-    <TargetsWindows Condition="'$(OSGroup)' == 'Windows_NT'">true</TargetsWindows>
-    <TargetsUnix Condition="'$(TargetsWindows)' != 'true'">true</TargetsUnix>
-
-    <TargetsLinux Condition="'$(OSGroup)' == 'Linux'">true</TargetsLinux>
-    <TargetsOSX Condition="'$(OSGroup)' == 'OSX'">true</TargetsOSX>
-    <TargetsFreeBSD Condition="'$(OSGroup)' == 'FreeBSD'">true</TargetsFreeBSD>
-    <TargetsUnknownUnix Condition="'$(TargetsUnix)' == 'true' AND '$(OSGroup)' != 'FreeBSD' AND '$(OSGroup)' != 'Linux' AND '$(OSGroup)' != 'OSX'">true</TargetsUnknownUnix>
-  </PropertyGroup>
-  <!-- Make some assumptions based on TargetsPlatform -->
-  <PropertyGroup Condition="'$(UseUnixPackageTargetRuntimeDefaults)' == 'true' OR '$(UsePackageTargetRuntimeDefaults)' == 'true'">
-    <PackageTargetRuntime Condition=" '$(TargetsLinux)' == 'true'  AND '$(PackageTargetRuntime)' == ''">linux</PackageTargetRuntime>
-    <PackageTargetRuntime Condition=" '$(TargetsOSX)' == 'true'  AND '$(PackageTargetRuntime)' == ''">osx</PackageTargetRuntime>
-    <PackageTargetRuntime Condition=" '$(TargetsUnix)' == 'true' AND '$(PackageTargetRuntime)' == ''">unix</PackageTargetRuntime>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(UseWindowsPackageTargetRuntimeDefault)' == 'true' OR '$(UsePackageTargetRuntimeDefaults)' == 'true'">
-    <PackageTargetRuntime Condition=" '$(TargetsWindows)' == 'true' AND '$(PackageTargetRuntime)' == ''">win7</PackageTargetRuntime>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This change is an initial go add supporting our new projects that need
to build for more target frameworks like netcore50/netcore50aot/etc.

It shouldn't have any impact on the existing projects or defaults but
will enable us to open source our other cross-compiled projects.

I plan to add a supporting md file that describes our build conventions as well. It is currently a work in progress.

cc @mellinoe @ericstj @ellismg @stephentoub 