### PR TITLE
Minor changes to the Poll() shim.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.Poll.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Poll.cs
@@ -8,54 +8,54 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        internal enum PollFlags : short
+        internal enum PollEvents : short
         {
-            POLLIN   = 0x0001,  /* any readable data available */
-            POLLOUT  = 0x0004,  /* data can be written without blocked */
-            POLLERR  = 0x0008,  /* an error occurred */
-            POLLHUP  = 0x0010,  /* the file descriptor hung up */
-            POLLNVAL = 0x0020,  /* the requested events were invalid */
+            POLLNONE = 0x0000,  // No events occurred.
+            POLLIN   = 0x0001,  // any readable data available
+            POLLOUT  = 0x0004,  // data can be written without blocked
+            POLLERR  = 0x0008,  // an error occurred
+            POLLHUP  = 0x0010,  // the file descriptor hung up
+            POLLNVAL = 0x0020,  // the requested events were invalid
         }
 
-        internal struct PollFD
+        internal struct PollEvent
         {
-            internal int        FD;     // The file descriptor to poll
-            internal PollFlags  Events;    // The events to poll for
-            internal PollFlags  REvents;     // The events that occurred which triggered the poll
+            internal int FileDescriptor;         // The file descriptor to poll
+            internal PollEvents Events;          // The events to poll for
+            internal PollEvents TriggeredEvents; // The events that occurred which triggered the poll
         }
 
         /// <summary>
         /// Polls a set of file descriptors for signals and returns what signals have been set
         /// </summary>
-        /// <param name="pollData">A pointer to pollfd structs to look for</param>
-        /// <param name="numberOfPollFds">The number of entries in pollData</param>
+        /// <param name="pollEvents">A list of PollEvent entries</param>
+        /// <param name="numberOfPollFds">The number of entries in pollEvents</param>
         /// <param name="timeout">The amount of time to wait; -1 for infinite, 0 for immediate return, and a positive number is the number of milliseconds</param>
-        /// <returns>
-        /// Returns a positive number (which is the number of structures with nonzero revent files), 0 for a timeout or no 
-        /// descriptors were ready, or -1 on error.
-        /// </returns>
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static unsafe extern int Poll(PollFD* pollData, uint numberOfPollFds, int timeout);
+        /// <param name="triggered">The number of events triggered (i.e. the number of entries in pollEvents with a non-zero TriggeredEvents). May be zero in the event of a timeout.</param>
+        /// <returns>An error or Error.SUCCESS.</returns>
+        [DllImport(Libraries.SystemNative)]
+        internal static unsafe extern Error Poll(PollEvent* pollEvents, uint eventCount, int timeout, uint* triggered);
 
         /// <summary>
         /// Polls a File Descriptor for the passed in flags.
         /// </summary>
         /// <param name="fd">The descriptor to poll</param>
-        /// <param name="flags">The flags to poll for</param>
+        /// <param name="events">The events to poll for</param>
         /// <param name="timeout">The amount of time to wait; -1 for infinite, 0 for immediate return, and a positive number is the number of milliseconds</param>
-        /// <param name="resultFlags">The flags that were returned by the poll call</param>
-        /// <returns>
-        /// Returns a positive number (which is the number of structures with nonzero revent files), 0 for a timeout or no 
-        /// descriptors were ready, or -1 on error.
-        /// </returns>
-        internal static unsafe int Poll(int fd, PollFlags flags, int timeout, out PollFlags resultFlags)
+        /// <param name="triggered">The events that were returned by the poll call. May be PollEvents.POLLNONE in the case of a timeout.</param>
+        /// <returns>An error or Error.SUCCESS.</returns>
+        internal static unsafe Error Poll(int fd, PollEvents events, int timeout, out PollEvents triggered)
         {
-            PollFD pfd = default(PollFD);
-            pfd.FD = fd;
-            pfd.Events = flags;
-            int result = Poll(&pfd, 1, timeout);
-            resultFlags = pfd.REvents;
-            return result;
+            var pollEvent = new PollEvent
+            {
+                FileDescriptor = fd,
+                Events = events,
+            };
+
+            uint unused;
+            Error err = Poll(&pollEvent, 1, timeout, &unused);
+            triggered = pollEvent.TriggeredEvents;
+            return err;
         }
     }
 }

--- a/src/Native/System.Native/pal_io.h
+++ b/src/Native/System.Native/pal_io.h
@@ -214,7 +214,7 @@ enum SysConfName : int32_t
  * Constants passed to and from poll describing what to poll for and what
  * kind of data was received from poll.
  */
-enum PollFlags : int16_t
+enum PollEvents : int16_t
 {
     PAL_POLLIN = 0x0001,   /* any readable data available */
     PAL_POLLOUT = 0x0004,  /* data can be written without blocked */
@@ -250,11 +250,11 @@ struct DirectoryEntry
 /**
  * Our intermediate pollfd struct to normalize the data types
  */
-struct PollFD
+struct PollEvent
 {
-    int32_t FD;      // The file descriptor to poll
-    int16_t Events;  // The events to poll for
-    int16_t REvents; // The events that occurred which triggered the poll
+    int32_t    FileDescriptor;  // The file descriptor to poll
+    PollEvents Events;          // The events to poll for
+    PollEvents TriggeredEvents; // The events that triggered the poll
 };
 
 /**
@@ -574,10 +574,10 @@ extern "C" int32_t FTruncate(int32_t fd, int64_t length);
  * Examines one or more file descriptors for the specified state(s) and blocks until the state(s) occur or the timeout
  * ellapses.
  *
- * Returns the number of descriptors ready, if any; if the timeout ellapses, returns 0; otherwise, returns -1 and errno
- * is set.
+ * Returns an error or PAL_SUCCESS. `triggered` is set to the number of ready descriptors if any. The number of
+ * triggered descriptors may be zero in the event of a timeout.
  */
-extern "C" int32_t Poll(PollFD* pollData, uint32_t numberOfPollFds, int32_t timeout);
+extern "C" Error Poll(PollEvent* pollEvents, uint32_t eventCount, int32_t milliseconds, uint32_t* triggered);
 
 /**
  * Notifies the OS kernel that the specified file will be accessed in a particular way soon; this allows the kernel to

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
@@ -665,7 +665,7 @@ namespace System.IO
                                 // so we will send a DELETE for this event and a CREATE when the MOVED_TO is eventually processed.
                                 if (_bufferPos == _bufferAvailable)
                                 {
-                                    int pollResult;
+                                    Interop.Sys.PollEvents events;
                                     bool gotRef = false;
                                     try
                                     {
@@ -680,8 +680,7 @@ namespace System.IO
                                         // that's actually what's needed (otherwise it'd be fine to block indefinitely waiting
                                         // for the next event to arrive).
                                         const int MillisecondsTimeout = 2;
-                                        Interop.Sys.PollFlags resultFlags;
-                                        pollResult = Interop.Sys.Poll(_inotifyHandle.DangerousGetHandle().ToInt32(), Interop.Sys.PollFlags.POLLIN, MillisecondsTimeout, out resultFlags);
+                                        Interop.Sys.Poll(_inotifyHandle.DangerousGetHandle().ToInt32(), Interop.Sys.PollEvents.POLLIN, MillisecondsTimeout, out events);
                                     }
                                     finally
                                     {
@@ -692,7 +691,7 @@ namespace System.IO
                                     }
 
                                     // If we error or don't have any signaled handles, send the deleted event
-                                    if (pollResult <= 0)
+                                    if (events == Interop.Sys.PollEvents.POLLNONE)
                                     {
                                         // There isn't any more data in the queue so this is a deleted event
                                         watcher.NotifyFileSystemEventArgs(WatcherChangeTypes.Deleted, expandedName);


### PR DESCRIPTION
- Minor cosmetic changes to the Poll() datatypes
- Change the Poll() shim to return an Error instead of an errno.
  The number of triggered file descriptors is now an output
  parameter.
- Fix the implementation of Poll() to handle > 2 poll events.

This change is preparing for a future change that will move
Socket.{Select,Poll} to use `poll` instead of `select`.