### PR TITLE
Don't throw when Expression.VisitBlock() changes only variables.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -222,6 +222,7 @@ namespace System.Linq.Expressions
 
         internal override BlockExpression Rewrite(ReadOnlyCollection<ParameterExpression> variables, Expression[] args)
         {
+            Debug.Assert(args != null);
             Debug.Assert(args.Length == 2);
             Debug.Assert(variables == null || variables.Count == 0);
 
@@ -267,6 +268,7 @@ namespace System.Linq.Expressions
 
         internal override BlockExpression Rewrite(ReadOnlyCollection<ParameterExpression> variables, Expression[] args)
         {
+            Debug.Assert(args != null);
             Debug.Assert(args.Length == 3);
             Debug.Assert(variables == null || variables.Count == 0);
 
@@ -314,6 +316,7 @@ namespace System.Linq.Expressions
 
         internal override BlockExpression Rewrite(ReadOnlyCollection<ParameterExpression> variables, Expression[] args)
         {
+            Debug.Assert(args != null);
             Debug.Assert(args.Length == 4);
             Debug.Assert(variables == null || variables.Count == 0);
 
@@ -363,6 +366,7 @@ namespace System.Linq.Expressions
 
         internal override BlockExpression Rewrite(ReadOnlyCollection<ParameterExpression> variables, Expression[] args)
         {
+            Debug.Assert(args != null);
             Debug.Assert(args.Length == 5);
             Debug.Assert(variables == null || variables.Count == 0);
 
@@ -404,6 +408,7 @@ namespace System.Linq.Expressions
         internal override BlockExpression Rewrite(ReadOnlyCollection<ParameterExpression> variables, Expression[] args)
         {
             Debug.Assert(variables == null || variables.Count == 0);
+            Debug.Assert(args != null);
 
             return new BlockN(args);
         }
@@ -465,6 +470,11 @@ namespace System.Linq.Expressions
         private object _body;
 
         internal Scope1(IList<ParameterExpression> variables, Expression body)
+            : this(variables, (object)body)
+        {
+        }
+
+        private Scope1(IList<ParameterExpression> variables, object body)
             : base(variables)
         {
             _body = body;
@@ -494,6 +504,12 @@ namespace System.Linq.Expressions
 
         internal override BlockExpression Rewrite(ReadOnlyCollection<ParameterExpression> variables, Expression[] args)
         {
+            if (args == null)
+            {
+                Debug.Assert(variables.Count == VariableCount);
+                ValidateVariables(variables, "variables");
+                return new Scope1(variables, _body);
+            }
             Debug.Assert(args.Length == 1);
             Debug.Assert(variables == null || variables.Count == VariableCount);
 
@@ -509,6 +525,11 @@ namespace System.Linq.Expressions
             : base(variables)
         {
             _body = body;
+        }
+
+        protected IList<Expression> Body
+        {
+            get { return _body; }
         }
 
         internal override Expression GetExpression(int index)
@@ -531,6 +552,12 @@ namespace System.Linq.Expressions
 
         internal override BlockExpression Rewrite(ReadOnlyCollection<ParameterExpression> variables, Expression[] args)
         {
+            if (args == null)
+            {
+                Debug.Assert(variables.Count == VariableCount);
+                ValidateVariables(variables, "variables");
+                return new ScopeN(variables, _body);
+            }
             Debug.Assert(args.Length == ExpressionCount);
             Debug.Assert(variables == null || variables.Count == VariableCount);
 
@@ -555,6 +582,12 @@ namespace System.Linq.Expressions
 
         internal override BlockExpression Rewrite(ReadOnlyCollection<ParameterExpression> variables, Expression[] args)
         {
+            if (args == null)
+            {
+                Debug.Assert(variables.Count == VariableCount);
+                ValidateVariables(variables, "variables");
+                return new ScopeWithType(variables, Body, _type);
+            }
             Debug.Assert(args.Length == ExpressionCount);
             Debug.Assert(variables == null || variables.Count == VariableCount);
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionVisitor.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ExpressionVisitor.cs
@@ -230,7 +230,8 @@ namespace System.Linq.Expressions
             {
                 return node;
             }
-            else
+
+            if (nodes != null)
             {
                 for (int i = 0; i < count; i++)
                 {

--- a/src/System.Linq.Expressions/tests/Block/BlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/BlockTests.cs
@@ -121,5 +121,45 @@ namespace Tests.ExpressionCompiler.Block
         }
 
         #endregion
+
+        private class ParameterChangingVisitor : ExpressionVisitor
+        {
+            protected override Expression VisitParameter(ParameterExpression node)
+            {
+                return Expression.Parameter(node.IsByRef ? node.Type.MakeByRefType() : node.Type, node.Name);
+            }
+        }
+
+        [Fact]
+        public static void VisitChangingOnlyParmeters()
+        {
+            var block = Expression.Block(
+                new[] { Expression.Parameter(typeof(int)), Expression.Parameter(typeof(string)) },
+                Expression.Empty()
+                );
+            Assert.NotSame(block, new ParameterChangingVisitor().Visit(block));
+        }
+
+        [Fact]
+        public static void VisitChangingOnlyParmetersMultiStatementBody()
+        {
+            var block = Expression.Block(
+                new[] { Expression.Parameter(typeof(int)), Expression.Parameter(typeof(string)) },
+                Expression.Empty(),
+                Expression.Empty()
+                );
+            Assert.NotSame(block, new ParameterChangingVisitor().Visit(block));
+        }
+
+        [Fact]
+        public static void VisitChangingOnlyParmetersTyped()
+        {
+            var block = Expression.Block(
+                typeof(object),
+                new[] { Expression.Parameter(typeof(int)), Expression.Parameter(typeof(string)) },
+                Expression.Constant("")
+                );
+            Assert.NotSame(block, new ParameterChangingVisitor().Visit(block));
+        }
     }
 }


### PR DESCRIPTION
Currently if an ExpressionVisitor changes the variables of a block visited with VisitBlock(), but not any of the nodes in its body, the call to VisitBlock() will then throw a NullReferenceException. Fix this.

Fixes #4400

This change allows null to be passed to the args argument of BlockExpression.Rewrite(). Add asserts that this has not happened to all subclasses which don't have variables.

Add private constructor to Scope1 allowing direct reuse of _body reducing allocations in this case.

Add protected property to ScopeN allowing read-only access of body list, again so allocations can be reduced in this case.

Add tests that cover this for all overrides of BlockExpression that can have more than zero variables.