### PR TITLE
Enabling Globalization tests that currently pass on Unix.

### DIFF
--- a/src/System.Globalization/tests/CompareInfo.cs
+++ b/src/System.Globalization/tests/CompareInfo.cs
@@ -11,7 +11,6 @@ public partial class CompareInfoTests
     [InlineData("")]
     [InlineData("en")]
     [InlineData("en-US")]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
     public static void GetCompareInfo(string localeName)
     {
         CompareInfo ci = CompareInfo.GetCompareInfo(localeName);
@@ -361,7 +360,6 @@ public partial class CompareInfoTests
     }
 
     [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
     public static void EqualsAndHashCode()
     {
         CompareInfo ciInvariantFromCultureInfo = CultureInfo.InvariantCulture.CompareInfo;

--- a/src/System.Globalization/tests/CompareInfo/CompareInfoCompare.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoCompare.cs
@@ -16,19 +16,15 @@ namespace System.Globalization.Tests
         public void Test1() { TestOrd(CultureInfo.InvariantCulture, "\u3042", "\u30A1", 1, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test2() { TestOrd(CultureInfo.InvariantCulture, "\u3042", "\u30A2", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test3() { TestOrd(CultureInfo.InvariantCulture, "\u3042", "\uFF71", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test4() { TestOrd(CultureInfo.InvariantCulture, "\u304D\u3083", "\u30AD\u30E3", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test5() { TestOrd(CultureInfo.InvariantCulture, "\u304D\u3083", "\u30AD\u3083", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
@@ -41,42 +37,33 @@ namespace System.Globalization.Tests
         public void Test8() { TestOrd(CultureInfo.InvariantCulture, "a", "A", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test9() { TestOrd(CultureInfo.InvariantCulture, "a", "\uFF41", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test10() { TestOrd(CultureInfo.InvariantCulture, "ABCDE", "\uFF21\uFF22\uFF23\uFF24\uFF25", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test11() { TestOrd(CultureInfo.InvariantCulture, "ABCDE", "\uFF21\uFF22\uFF23D\uFF25", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test12() { TestOrd(CultureInfo.InvariantCulture, "ABCDE", "a\uFF22\uFF23D\uFF25", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test13() { TestOrd(CultureInfo.InvariantCulture, "ABCDE", "\uFF41\uFF42\uFF23D\uFF25", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
         public void Test14() { TestOrd(CultureInfo.InvariantCulture, "\u6FA4", "\u6CA2", 1, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test15() { TestOrd(CultureInfo.InvariantCulture, "\u3070\u3073\u3076\u3079\u307C", "\u30D0\u30D3\u30D6\u30D9\u30DC", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test16() { TestOrd(CultureInfo.InvariantCulture, "\u3070\u3073\u3076\u3079\u307C", "\u30D0\u30D3\u3076\u30D9\u30DC", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test17() { TestOrd(CultureInfo.InvariantCulture, "\u3070\u3073\u3076\u3079\u307C", "\u30D0\u30D3\u3076\u30D9\uFF8E\uFF9E", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test18() { TestOrd(CultureInfo.InvariantCulture, "\u3070\u3073\uFF8C\uFF9E\uFF8D\uFF9E\u307C", "\u30D0\u30D3\u3076\u30D9\uFF8E\uFF9E", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
@@ -95,7 +82,6 @@ namespace System.Globalization.Tests
         public void Test23() { TestOrd(CultureInfo.InvariantCulture, "\u3071\u3074\u30D7\u307A", "\uFF8B\uFF9F\uFF8C\uFF9F", -1, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test24() { TestOrd(CultureInfo.InvariantCulture, "\u3070\u30DC\uFF8C\uFF9E\uFF8D\uFF9E\u307C", "\u3070\uFF8E\uFF9E\u30D6", 1, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
@@ -120,35 +106,27 @@ namespace System.Globalization.Tests
         public void Test31() { TestOrd(CultureInfo.InvariantCulture, "\u3060", "\u305F", 1, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test32() { TestOrd(CultureInfo.InvariantCulture, "\u3060", "\uFF80\uFF9E", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test33() { TestOrd(CultureInfo.InvariantCulture, "\u3060", "\u30C0", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test34() { TestOrd(CultureInfo.InvariantCulture, "\u30C7\u30BF\u30D9\u30B9", "\uFF83\uFF9E\uFF80\uFF8D\uFF9E\uFF7D", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test35() { TestOrd(CultureInfo.InvariantCulture, "\u30C7", "\uFF83\uFF9E", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test36() { TestOrd(CultureInfo.InvariantCulture, "\u30C7\u30BF", "\uFF83\uFF9E\uFF80", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test37() { TestOrd(CultureInfo.InvariantCulture, "\u30C7\u30BF\u30D9", "\uFF83\uFF9E\uFF80\uFF8D\uFF9E", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test38() { TestOrd(CultureInfo.InvariantCulture, "\u30BF", "\uFF80", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test39() { TestOrd(CultureInfo.InvariantCulture, "\uFF83\uFF9E\uFF70\uFF80\uFF8D\uFF9E\uFF70\uFF7D", "\u3067\u30FC\u305F\u3079\u30FC\u3059", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
@@ -167,19 +145,15 @@ namespace System.Globalization.Tests
         public void Test44() { TestOrd(CultureInfo.InvariantCulture, "", "'", -1, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test45() { TestOrd(CultureInfo.InvariantCulture, "\u4E00", "\uFF11", 1, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test46() { TestOrd(CultureInfo.InvariantCulture, "\u2160", "\uFF11", 1, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test47() { TestOrd(CultureInfo.InvariantCulture, "0", "\uFF10", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test48() { TestOrd(CultureInfo.InvariantCulture, "10", "1\uFF10", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
@@ -192,7 +166,6 @@ namespace System.Globalization.Tests
         public void Test51() { TestOrd(CultureInfo.InvariantCulture, "9999\uFF191010", "1\uFF10", 1, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test52() { TestOrd(CultureInfo.InvariantCulture, "'\u3000'", "' '", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
@@ -200,19 +173,15 @@ namespace System.Globalization.Tests
         public void Test53() { TestOrd(CultureInfo.InvariantCulture, "'\u3000'", "''", 1, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test54() { TestOrd(CultureInfo.InvariantCulture, "\uFF1B", ";", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test55() { TestOrd(CultureInfo.InvariantCulture, "\uFF08", "(", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test56() { TestOrd(CultureInfo.InvariantCulture, "\u30FC", "\uFF70", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test57() { TestOrd(CultureInfo.InvariantCulture, "\u30FC", "\uFF0D", 1, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
@@ -225,15 +194,12 @@ namespace System.Globalization.Tests
         public void Test60() { TestOrd(CultureInfo.InvariantCulture, "\u30FC", "\u2010", 1, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test61() { TestOrd(CultureInfo.InvariantCulture, "/", "\uFF0F", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test62() { TestOrd(CultureInfo.InvariantCulture, "'", "\uFF07", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test63() { TestOrd(CultureInfo.InvariantCulture, "\"", "\uFF02", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
@@ -263,7 +229,6 @@ namespace System.Globalization.Tests
         public void Test70() { Test(CultureInfo.InvariantCulture, "\u3044", "I", 1, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test71() { Test(CultureInfo.InvariantCulture, "a", "A", -1, CompareOptions.None); }
 
         [Fact]
@@ -279,7 +244,6 @@ namespace System.Globalization.Tests
         public void Test75() { Test(CultureInfo.InvariantCulture, new string('a', 5555), new string('a', 5554) + "b", -1, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test76() { Test(CultureInfo.InvariantCulture, "ABCDE", "\uFF41\uFF42\uFF23D\uFF25", 1, CompareOptions.None); }
 
         [Fact]
@@ -317,7 +281,6 @@ namespace System.Globalization.Tests
         public void Test86() { Test(CultureInfo.InvariantCulture, "\u3071\u3074\u30D7\u307A", "\uFF8B\uFF9F\uFF8C\uFF9F", -1, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test87() { Test(CultureInfo.InvariantCulture, "\u3070\u30DC\uFF8C\uFF9E\uFF8D\uFF9E\u307C", "\u3070\uFF8E\uFF9E\u30D6", 1, CompareOptions.None); }
 
         [Fact]
@@ -389,11 +352,9 @@ namespace System.Globalization.Tests
         public void Test107() { Test(CultureInfo.InvariantCulture, "", "'", -1, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test108() { Test(CultureInfo.InvariantCulture, "\u4E00", "\uFF11", 1, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test109() { Test(CultureInfo.InvariantCulture, "\u2160", "\uFF11", 1, CompareOptions.None); }
 
         [Fact]
@@ -429,7 +390,6 @@ namespace System.Globalization.Tests
         public void Test119() { Test(CultureInfo.InvariantCulture, "\u30FC", "\uFF70", 0, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test120() { Test(CultureInfo.InvariantCulture, "\u30FC", "\uFF0D", 1, CompareOptions.None); }
 
         [Fact]
@@ -464,14 +424,12 @@ namespace System.Globalization.Tests
         public void Test130() { TestOrd(CultureInfo.InvariantCulture, "dzsdzs", "ddzs", 1, CompareOptions.Ordinal); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test131() { Test(new CultureInfo("tr-TR"), "i", "I", 1, CompareOptions.IgnoreCase); }
 
         [Fact]
         public void Test132() { Test(CultureInfo.InvariantCulture, "i", "I", 0, CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test133() { Test(new CultureInfo("tr-TR"), "i", "\u0130", 0, CompareOptions.IgnoreCase); }
 
         [Fact]
@@ -481,7 +439,6 @@ namespace System.Globalization.Tests
         public void Test135() { Test(new CultureInfo("tr-TR"), "i", "I", 1, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test136() { Test(CultureInfo.InvariantCulture, "i", "I", -1, CompareOptions.None); }
 
         [Fact]
@@ -491,14 +448,12 @@ namespace System.Globalization.Tests
         public void Test138() { Test(CultureInfo.InvariantCulture, "i", "\u0130", -1, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test139() { Test(CultureInfo.InvariantCulture, "\u00C0", "A\u0300", 0, CompareOptions.None); }
 
         [Fact]
         public void Test140() { TestOrd(CultureInfo.InvariantCulture, "\u00C0", "A\u0300", 1, CompareOptions.Ordinal); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test141() { Test(CultureInfo.InvariantCulture, "\u00C0", "a\u0300", 0, CompareOptions.IgnoreCase); }
 
         [Fact]
@@ -526,19 +481,16 @@ namespace System.Globalization.Tests
         public void Test147()
         {
             char unassignedUnicode = GetNextUnassignedUnicode();
-            Test(CultureInfo.InvariantCulture, "FooBar", "Foo" +unassignedUnicode +"Bar", 0, CompareOptions.IgnoreNonSpace);
+            Test(CultureInfo.InvariantCulture, "FooBar", "Foo" + unassignedUnicode + "Bar", 0, CompareOptions.IgnoreNonSpace);
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test148()
         {
-            char unassignedUnicode = GetNextUnassignedUnicode();
-            Test(CultureInfo.InvariantCulture, "FooBA\u0300R", "Foo" +unassignedUnicode +"B\u00C0R", 0, CompareOptions.IgnoreNonSpace);
+            Test(CultureInfo.InvariantCulture, "FooBA\u0300R", "FooB\u00C0R", 0, CompareOptions.IgnoreNonSpace);
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test149() { Test(CultureInfo.InvariantCulture, "Test's", "Tests", 0, CompareOptions.IgnoreSymbols); }
 
         [Fact]
@@ -562,6 +514,18 @@ namespace System.Globalization.Tests
 
         [Fact]
         public void Test156() { Test(CultureInfo.InvariantCulture, new string('a', 5555), new string('a', 5555), 0, CompareOptions.None); }
+
+        [Fact]
+        public void Test157() { Test(CultureInfo.InvariantCulture, "foobar", "FooB\u00C0R", 0, CompareOptions.IgnoreNonSpace | CompareOptions.IgnoreCase); }
+
+        [Fact]
+        public void Test158() { Test(CultureInfo.InvariantCulture, "foobar", "FooB\u00C0R", -1, CompareOptions.IgnoreNonSpace); }
+
+        [Fact]
+        public void Test159() { Test(CultureInfo.InvariantCulture, "\uFF66", "\u30F2", 0, CompareOptions.IgnoreWidth); }
+
+        [Fact]
+        public void Test160() { Test(CultureInfo.InvariantCulture, "\uFF66", "\u30F2", 1, CompareOptions.IgnoreCase); }
 
         [Theory]
         [InlineData(null, 0, 0, null, 0, 0, 0)]
@@ -624,11 +588,11 @@ namespace System.Globalization.Tests
             CompareInfo ci = culture.CompareInfo;
             int i = ci.Compare(str1, str2, options);
             i = Math.Sign(i);
-            Assert.Equal(i, expected);
+            Assert.Equal(expected, i);
 
             i = ci.Compare(str2, str1, options);
             i = Math.Sign(i);
-            Assert.Equal(i, (0 - expected));
+            Assert.Equal((0 - expected), i);
         }
         
         private char GetNextUnassignedUnicode()

--- a/src/System.Globalization/tests/CompareInfo/CompareInfoCompare.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoCompare.cs
@@ -3,12 +3,22 @@
 
 using System;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Globalization.Tests
 {
     public class CompareInfoCompare
     {
+        private static bool s_isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        // on windows hiragana characters sort after katakana. on ICU, it is the opposite
+        private static int s_expectedHiraganaToKatakanaCompare = s_isWindows ? 1 : -1;
+
+        // on windows, all halfwidth characters sort before fullwidth characters.
+        // on ICU, half and fullwidth characters that aren't in the "Halfwidth and fullwidth forms" block U+FF00-U+FFEF
+        // sort before the corresponding characters that are in the block U+FF00-U+FFEF
+        private static int s_expectedHalfToFullFormsComparison = s_isWindows ? -1 : 1;
+
         private const string c_SoftHyphen = "\u00AD";
 
         [Fact]
@@ -203,24 +213,19 @@ namespace System.Globalization.Tests
         public void Test63() { TestOrd(CultureInfo.InvariantCulture, "\"", "\uFF02", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
-        public void Test64() { Test(CultureInfo.InvariantCulture, "\u3042", "\u30A1", 1, CompareOptions.None); }
+        public void Test64() { Test(CultureInfo.InvariantCulture, "\u3042", "\u30A1", s_expectedHiraganaToKatakanaCompare, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
-        public void Test65() { Test(CultureInfo.InvariantCulture, "\u3042", "\u30A2", 1, CompareOptions.None); }
+        public void Test65() { Test(CultureInfo.InvariantCulture, "\u3042", "\u30A2", s_expectedHiraganaToKatakanaCompare, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
-        public void Test66() { Test(CultureInfo.InvariantCulture, "\u3042", "\uFF71", 1, CompareOptions.None); }
+        public void Test66() { Test(CultureInfo.InvariantCulture, "\u3042", "\uFF71", s_expectedHiraganaToKatakanaCompare, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
-        public void Test67() { Test(CultureInfo.InvariantCulture, "\u304D\u3083", "\u30AD\u30E3", 1, CompareOptions.None); }
+        public void Test67() { Test(CultureInfo.InvariantCulture, "\u304D\u3083", "\u30AD\u30E3", s_expectedHiraganaToKatakanaCompare, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
-        public void Test68() { Test(CultureInfo.InvariantCulture, "\u304D\u3083", "\u30AD\u3083", 1, CompareOptions.None); }
+        public void Test68() { Test(CultureInfo.InvariantCulture, "\u304D\u3083", "\u30AD\u3083", s_expectedHiraganaToKatakanaCompare, CompareOptions.None); }
 
         [Fact]
         public void Test69() { Test(CultureInfo.InvariantCulture, "\u304D \u3083", "\u30AD\u3083", -1, CompareOptions.None); }
@@ -250,20 +255,16 @@ namespace System.Globalization.Tests
         public void Test77() { Test(CultureInfo.InvariantCulture, "\u6FA4", "\u6CA2", 1, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
-        public void Test78() { Test(CultureInfo.InvariantCulture, "\u3070\u3073\u3076\u3079\u307C", "\u30D0\u30D3\u30D6\u30D9\u30DC", 1, CompareOptions.None); }
+        public void Test78() { Test(CultureInfo.InvariantCulture, "\u3070\u3073\u3076\u3079\u307C", "\u30D0\u30D3\u30D6\u30D9\u30DC", s_expectedHiraganaToKatakanaCompare, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
-        public void Test79() { Test(CultureInfo.InvariantCulture, "\u3070\u3073\u3076\u3079\u307C", "\u30D0\u30D3\u3076\u30D9\u30DC", 1, CompareOptions.None); }
+        public void Test79() { Test(CultureInfo.InvariantCulture, "\u3070\u3073\u3076\u3079\u307C", "\u30D0\u30D3\u3076\u30D9\u30DC", s_expectedHiraganaToKatakanaCompare, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
-        public void Test80() { Test(CultureInfo.InvariantCulture, "\u3070\u3073\u3076\u3079\u307C", "\u30D0\u30D3\u3076\u30D9\uFF8E\uFF9E", 1, CompareOptions.None); }
+        public void Test80() { Test(CultureInfo.InvariantCulture, "\u3070\u3073\u3076\u3079\u307C", "\u30D0\u30D3\u3076\u30D9\uFF8E\uFF9E", s_expectedHiraganaToKatakanaCompare, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
-        public void Test81() { Test(CultureInfo.InvariantCulture, "\u3070\u3073\uFF8C\uFF9E\uFF8D\uFF9E\u307C", "\u30D0\u30D3\u3076\u30D9\uFF8E\uFF9E", 1, CompareOptions.None); }
+        public void Test81() { Test(CultureInfo.InvariantCulture, "\u3070\u3073\uFF8C\uFF9E\uFF8D\uFF9E\u307C", "\u30D0\u30D3\u3076\u30D9\uFF8E\uFF9E", s_expectedHiraganaToKatakanaCompare, CompareOptions.None); }
 
         [Fact]
         public void Test82() { Test(CultureInfo.InvariantCulture, "\u3070\u3073\uFF8C\uFF9E\uFF8D\uFF9E\u307C", "\uFF8E\uFF9E", -1, CompareOptions.None); }
@@ -305,12 +306,10 @@ namespace System.Globalization.Tests
         public void Test94() { Test(CultureInfo.InvariantCulture, "\u3060", "\u305F", 1, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
-        public void Test95() { Test(CultureInfo.InvariantCulture, "\u3060", "\uFF80\uFF9E", 1, CompareOptions.None); }
+        public void Test95() { Test(CultureInfo.InvariantCulture, "\u3060", "\uFF80\uFF9E", s_expectedHiraganaToKatakanaCompare, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
-        public void Test96() { Test(CultureInfo.InvariantCulture, "\u3060", "\u30C0", 1, CompareOptions.None); }
+        public void Test96() { Test(CultureInfo.InvariantCulture, "\u3060", "\u30C0", s_expectedHiraganaToKatakanaCompare, CompareOptions.None); }
 
         [Fact]
         [ActiveIssue(846, PlatformID.AnyUnix)]
@@ -522,10 +521,63 @@ namespace System.Globalization.Tests
         public void Test158() { Test(CultureInfo.InvariantCulture, "foobar", "FooB\u00C0R", -1, CompareOptions.IgnoreNonSpace); }
 
         [Fact]
-        public void Test159() { Test(CultureInfo.InvariantCulture, "\uFF66", "\u30F2", 0, CompareOptions.IgnoreWidth); }
+        public void Test159() { Test(CultureInfo.InvariantCulture, "\uFF9E", "\u3099", 0, CompareOptions.IgnoreCase); }
 
         [Fact]
-        public void Test160() { Test(CultureInfo.InvariantCulture, "\uFF66", "\u30F2", 1, CompareOptions.IgnoreCase); }
+        public void Test160() { Test(CultureInfo.InvariantCulture, "\uFF9E", "\u3099", 0, CompareOptions.IgnoreNonSpace); }
+
+        [Fact]
+        public void Test161() { Test(CultureInfo.InvariantCulture, "\u20A9", "\uFFE6", 0, CompareOptions.IgnoreWidth); }
+
+        [Fact]
+        public void Test162() { Test(CultureInfo.InvariantCulture, "\u20A9", "\uFFE6", -1, CompareOptions.IgnoreCase); }
+
+        [Fact]
+        public void Test163() { Test(CultureInfo.InvariantCulture, "\u20A9", "\uFFE6", -1, CompareOptions.None); }
+
+        [Fact]
+        public void Test164() { Test(CultureInfo.InvariantCulture, "\u0021", "\uFF01", 0, CompareOptions.IgnoreSymbols); }
+
+        [Fact]
+        [ActiveIssue(4907, PlatformID.AnyUnix)]
+        public void Test165() { Test(CultureInfo.InvariantCulture, "\u00A2", "\uFFE0", 0, CompareOptions.IgnoreSymbols); }
+
+        [Fact]
+        [ActiveIssue(4907, PlatformID.AnyUnix)]
+        public void Test166() { Test(CultureInfo.InvariantCulture, "$", "&", 0, CompareOptions.IgnoreSymbols); }
+
+        [Fact]
+        public void Test167() { Test(CultureInfo.InvariantCulture, "\uFF65", "\u30FB", 0, CompareOptions.IgnoreSymbols); }
+
+        [Fact]
+        public void Test168() { Test(CultureInfo.InvariantCulture, "\u0021", "\uFF01", 0, CompareOptions.IgnoreWidth); }
+
+        [Fact]
+        public void Test169() { Test(CultureInfo.InvariantCulture, "\u0021", "\uFF01", -1, CompareOptions.None); }
+
+        [Fact]
+        public void Test170() { Test(CultureInfo.InvariantCulture, "\uFF66", "\u30F2", 0, CompareOptions.IgnoreWidth); }
+
+        [Fact]
+        public void Test171() { Test(CultureInfo.InvariantCulture, "\uFF66", "\u30F2", s_expectedHalfToFullFormsComparison, CompareOptions.IgnoreSymbols); }
+
+        [Fact]
+        public void Test172() { Test(CultureInfo.InvariantCulture, "\uFF66", "\u30F2", s_expectedHalfToFullFormsComparison, CompareOptions.IgnoreCase); }
+
+        [Fact]
+        public void Test173() { Test(CultureInfo.InvariantCulture, "\uFF66", "\u30F2", s_expectedHalfToFullFormsComparison, CompareOptions.IgnoreNonSpace); }
+
+        [Fact]
+        public void Test174() { Test(CultureInfo.InvariantCulture, "\uFF66", "\u30F2", s_expectedHalfToFullFormsComparison, CompareOptions.None); }
+
+        [Fact]
+        public void Test175() { Test(CultureInfo.InvariantCulture, "\u3060", "\u30C0", 0, CompareOptions.IgnoreKanaType); }
+
+        [Fact]
+        public void Test176() { Test(CultureInfo.InvariantCulture, "\u3060", "\u30C0", s_expectedHiraganaToKatakanaCompare, CompareOptions.IgnoreCase); }
+
+        [Fact]
+        public void Test177() { Test(CultureInfo.InvariantCulture, "c", "C", -1, CompareOptions.IgnoreKanaType); }
 
         [Theory]
         [InlineData(null, 0, 0, null, 0, 0, 0)]
@@ -594,7 +646,7 @@ namespace System.Globalization.Tests
             i = Math.Sign(i);
             Assert.Equal((0 - expected), i);
         }
-        
+
         private char GetNextUnassignedUnicode()
         {
             for (char ch = '\uFFFF'; ch > '\u0000'; ch++)

--- a/src/System.Globalization/tests/CompareInfo/CompareInfoIndexOf.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoIndexOf.cs
@@ -59,14 +59,12 @@ namespace System.Globalization.Tests
         public void Test15() { Test(CultureInfo.InvariantCulture, "foobardzsdzs", "rddzs", -1, CompareOptions.Ordinal); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test16() { Test(s_turkish, "Hi", "I", -1, CompareOptions.IgnoreCase); }
 
         [Fact]
         public void Test17() { Test(CultureInfo.InvariantCulture, "Hi", "I", 1, CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test18() { Test(s_turkish, "Hi", "\u0130", 1, CompareOptions.IgnoreCase); }
 
         [Fact]
@@ -85,14 +83,12 @@ namespace System.Globalization.Tests
         public void Test23() { Test(CultureInfo.InvariantCulture, "Hi", "\u0130", -1, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test24() { Test(CultureInfo.InvariantCulture, "Exhibit \u00C0", "A\u0300", 8, CompareOptions.None); }
 
         [Fact]
         public void Test25() { Test(CultureInfo.InvariantCulture, "Exhibit \u00C0", "A\u0300", -1, CompareOptions.Ordinal); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test26() { Test(CultureInfo.InvariantCulture, "Exhibit \u00C0", "a\u0300", 8, CompareOptions.IgnoreCase); }
 
         [Fact]
@@ -124,16 +120,13 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test33()
         {
-            char unassignedUnicode = GetNextUnassignedUnicode();
-            Test(CultureInfo.InvariantCulture, "TestFooBA\u0300R", "Foo" + unassignedUnicode + "B\u00C0R", 4, CompareOptions.IgnoreNonSpace);
+            Test(CultureInfo.InvariantCulture, "TestFooBA\u0300R", "FooB\u00C0R", 4, CompareOptions.IgnoreNonSpace);
         }
 
         //   Now IgnoreSymbols will not consider the ' ' as a Symbol
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test34() { Test(CultureInfo.InvariantCulture, "More Test's", "Tests", 5, CompareOptions.IgnoreSymbols); }
 
         [Fact]

--- a/src/System.Globalization/tests/CompareInfo/CompareInfoIsPrefix.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoIsPrefix.cs
@@ -59,14 +59,12 @@ namespace System.Globalization.Tests
         public void Test15() { Test(CultureInfo.InvariantCulture, "dzsdzsfoobar", "ddzsf", false, CompareOptions.Ordinal); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void Test16() { Test(s_turkish, "interesting", "I", false, CompareOptions.IgnoreCase); }
 
         [Fact]
         public void Test17() { Test(CultureInfo.InvariantCulture, "interesting", "I", true, CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void Test18() { Test(s_turkish, "interesting", "\u0130", true, CompareOptions.IgnoreCase); }
 
         [Fact]
@@ -85,14 +83,12 @@ namespace System.Globalization.Tests
         public void Test23() { Test(CultureInfo.InvariantCulture, "interesting", "\u0130", false, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void Test24() { Test(CultureInfo.InvariantCulture, "\u00C0nimal", "A\u0300", true, CompareOptions.None); }
 
         [Fact]
         public void Test25() { Test(CultureInfo.InvariantCulture, "\u00C0nimal", "A\u0300", false, CompareOptions.Ordinal); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void Test26() { Test(CultureInfo.InvariantCulture, "\u00C0nimal", "a\u0300", true, CompareOptions.IgnoreCase); }
 
         [Fact]
@@ -124,15 +120,12 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void Test33()
         {
-            char unassignedUnicode = GetNextUnassignedUnicode();
-            Test(CultureInfo.InvariantCulture, "FooBA\u0300R", "Foo" + unassignedUnicode + "B\u00C0R", true, CompareOptions.IgnoreNonSpace);
+            Test(CultureInfo.InvariantCulture, "FooBA\u0300R", "FooB\u00C0R", true, CompareOptions.IgnoreNonSpace);
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void Test34() { Test(CultureInfo.InvariantCulture, "Test's can be interesting", "Tests", true, CompareOptions.IgnoreSymbols); }
 
         [Fact]

--- a/src/System.Globalization/tests/CompareInfo/CompareInfoIsSuffix.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoIsSuffix.cs
@@ -59,14 +59,12 @@ namespace System.Globalization.Tests
         public void Test15() { Test(CultureInfo.InvariantCulture, "foobardzsdzs", "rddzs", false, CompareOptions.Ordinal); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void Test16() { Test(s_turkish, "Hi", "I", false, CompareOptions.IgnoreCase); }
 
         [Fact]
         public void Test17() { Test(CultureInfo.InvariantCulture, "Hi", "I", true, CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void Test18() { Test(s_turkish, "Hi", "\u0130", true, CompareOptions.IgnoreCase); }
 
         [Fact]
@@ -85,14 +83,12 @@ namespace System.Globalization.Tests
         public void Test23() { Test(CultureInfo.InvariantCulture, "Hi", "\u0130", false, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void Test24() { Test(CultureInfo.InvariantCulture, "Exhibit \u00C0", "A\u0300", true, CompareOptions.None); }
 
         [Fact]
         public void Test25() { Test(CultureInfo.InvariantCulture, "Exhibit \u00C0", "A\u0300", false, CompareOptions.Ordinal); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void Test26() { Test(CultureInfo.InvariantCulture, "Exhibit \u00C0", "a\u0300", true, CompareOptions.IgnoreCase); }
 
         [Fact]
@@ -124,15 +120,12 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void Test33()
         {
-            char unassignedUnicode = GetNextUnassignedUnicode();
-            Test(CultureInfo.InvariantCulture, "FooBA\u0300R", "Foo" + unassignedUnicode + "B\u00C0R", true, CompareOptions.IgnoreNonSpace);
+            Test(CultureInfo.InvariantCulture, "FooBA\u0300R", "FooB\u00C0R", true, CompareOptions.IgnoreNonSpace);
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
         public void Test34() { Test(CultureInfo.InvariantCulture, "More Test's", "Tests", true, CompareOptions.IgnoreSymbols); }
 
         [Fact]

--- a/src/System.Globalization/tests/CompareInfo/CompareInfoLastIndexOf.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoLastIndexOf.cs
@@ -59,14 +59,12 @@ namespace System.Globalization.Tests
         public void Test15() { Test(CultureInfo.InvariantCulture, "foobardzsdzs", "rddzs", -1, CompareOptions.Ordinal); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test16() { Test(s_turkish, "Hi", "I", -1, CompareOptions.IgnoreCase); }
 
         [Fact]
         public void Test17() { Test(CultureInfo.InvariantCulture, "Hi", "I", 1, CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test18() { Test(s_turkish, "Hi", "\u0130", 1, CompareOptions.IgnoreCase); }
 
         [Fact]
@@ -85,14 +83,12 @@ namespace System.Globalization.Tests
         public void Test23() { Test(CultureInfo.InvariantCulture, "Hi", "\u0130", -1, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test24() { Test(CultureInfo.InvariantCulture, "Exhibit \u00C0", "A\u0300", 8, CompareOptions.None); }
 
         [Fact]
         public void Test25() { Test(CultureInfo.InvariantCulture, "Exhibit \u00C0", "A\u0300", -1, CompareOptions.Ordinal); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test26() { Test(CultureInfo.InvariantCulture, "Exhibit \u00C0", "a\u0300", 8, CompareOptions.IgnoreCase); }
 
         [Fact]
@@ -124,15 +120,12 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test33()
         {
-            char unassignedUnicode = GetNextUnassignedUnicode();
-            Test(CultureInfo.InvariantCulture, "TestFooBA\u0300R", "Foo" + unassignedUnicode + "B\u00C0R", 4, CompareOptions.IgnoreNonSpace);
+            Test(CultureInfo.InvariantCulture, "TestFooBA\u0300R", "FooB\u00C0R", 4, CompareOptions.IgnoreNonSpace);
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test34() { Test(CultureInfo.InvariantCulture, "More Test's", "Tests", 5, CompareOptions.IgnoreSymbols); }
 
         [Fact]

--- a/src/System.Globalization/tests/CompareInfo/compareinfo.cs
+++ b/src/System.Globalization/tests/CompareInfo/compareinfo.cs
@@ -10,7 +10,6 @@ namespace System.Globalization.Tests
     public class CompareInfoTest
     {
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void TestCompareInfo()
         {
             CompareInfo ciENG = CompareInfo.GetCompareInfo("en-US");
@@ -74,7 +73,6 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void CompareInfoIndexTest2()
         {
             // Creates CompareInfo for the InvariantCulture.

--- a/src/System.Globalization/tests/CultureInfo/CultureInfoCompareInfo.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoCompareInfo.cs
@@ -29,7 +29,6 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void TestCompareInfoName()
         {
             string expectedName = "en-US";
@@ -39,7 +38,6 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void TestCompareInfoNameWithInvariant()
         {
             string expectedName = "";

--- a/src/System.Globalization/tests/CultureInfo/CultureInfoGetHashCode.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoGetHashCode.cs
@@ -10,7 +10,6 @@ namespace System.Globalization.Tests
     public class CultureInfoGetHashCode
     {
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void PosTest1()
         {
             CultureInfo myCultureInfo = new CultureInfo("en-US");
@@ -22,7 +21,6 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void PosTest2()
         {
             CultureInfo myCultureInfo = new CultureInfo("en");
@@ -34,7 +32,6 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void PosTest3()
         {
             CultureInfo myCultureInfo = CultureInfo.InvariantCulture;


### PR DESCRIPTION
After https://github.com/dotnet/coreclr/pull/2196 is merged, these tests will now be passing. This can't be merged until the corresponding coreclr PR is merged.

Note: I changed 1 set of tests for the following reasoning:
I removed the "unassigned" unicode character in the tests because the tests directly above them were already testing for "unassigned" unicode characters and ICU behavior differs from Windows behavior - Windows ignores unassigned characters, ICU doesn't.

@ellismg @stephentoub @tarekgh 

I'm not sure I fixed all these tests with my current PR, but I went through all ActiveIssue #846 tests and enabled any test that passed on my machine.