### PR TITLE
Non-indexer Expression.Property should reject indexers.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
@@ -39,18 +39,22 @@ namespace System.Linq.Expressions
             _expression = expression;
         }
 
+        internal static PropertyExpression Make(Expression expression, PropertyInfo property)
+        {
+            Debug.Assert(property != null);
+            return new PropertyExpression(expression, property);
+        }
+
+        internal static FieldExpression Make(Expression expression, FieldInfo field)
+        {
+            Debug.Assert(field != null);
+            return new FieldExpression(expression, field);
+        }
+
         internal static MemberExpression Make(Expression expression, MemberInfo member)
         {
             FieldInfo fi = member as FieldInfo;
-            if (fi != null)
-            {
-                return new FieldExpression(expression, fi);
-            }
-            else
-            {
-                PropertyInfo pi = (PropertyInfo)member;
-                return new PropertyExpression(expression, pi);
-            }
+            return fi == null ? (MemberExpression)Make(expression, (PropertyInfo)member) : Make(expression, fi);
         }
 
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
@@ -276,11 +276,24 @@ namespace System.Linq.Expressions
         {
             ContractUtils.RequiresNotNull(property, "property");
 
-            MethodInfo mi = property.GetGetMethod(true) ?? property.GetSetMethod(true);
+            MethodInfo mi = property.GetGetMethod(true);
 
             if (mi == null)
             {
-                throw Error.PropertyDoesNotHaveAccessor(property);
+                mi = property.GetSetMethod(true);
+
+                if (mi == null)
+                {
+                    throw Error.PropertyDoesNotHaveAccessor(property);
+                }
+                else if (mi.GetParametersCached().Length != 1)
+                {
+                    throw Error.IncorrectNumberOfMethodCallArguments(mi);
+                }
+            }
+            else if (mi.GetParametersCached().Length != 0)
+            {
+                throw Error.IncorrectNumberOfMethodCallArguments(mi);
             }
 
             if (mi.IsStatic)
@@ -296,6 +309,7 @@ namespace System.Linq.Expressions
                     throw Error.PropertyNotDefinedForType(property, expression.Type);
                 }
             }
+
             return MemberExpression.Make(expression, property);
         }
 

--- a/src/System.Linq.Expressions/tests/ExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/ExpressionTests.cs
@@ -308,7 +308,6 @@ namespace System.Linq.Expressions.Tests
             get
             {
                 yield return Expression.Property(null, typeof(ExpressionTests), "Unreadable");
-                yield return Expression.Property(Expression.Constant(new UnreadableIndexableClass()), "Item");
                 yield return Expression.Property(Expression.Constant(new UnreadableIndexableClass()), "Item", Expression.Constant(0));
             }
         }
@@ -326,7 +325,6 @@ namespace System.Linq.Expressions.Tests
             get
             {
                 yield return Expression.Property(null, typeof(ExpressionTests), "Unreadable");
-                yield return Expression.Property(Expression.Constant(new UnreadableIndexableClass()), "Item");
                 yield return Expression.Property(Expression.Constant(new UnreadableIndexableClass()), "Item", Expression.Constant(0));
                 yield return Expression.Field(null, typeof(ExpressionTests), "TestField");
                 yield return Expression.Parameter(typeof(int));
@@ -338,7 +336,6 @@ namespace System.Linq.Expressions.Tests
             get
             {
                 yield return Expression.Property(null, typeof(ExpressionTests), "Unwritable");
-                yield return Expression.Property(Expression.Constant(new UnwritableIndexableClass()), "Item");
                 yield return Expression.Property(Expression.Constant(new UnwritableIndexableClass()), "Item", Expression.Constant(0));
                 yield return Expression.Field(null, typeof(ExpressionTests), "TestConstant");
                 yield return Expression.Field(null, typeof(ExpressionTests), "TestInitOnlyField");

--- a/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
+++ b/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
@@ -2,12 +2,22 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
 {
     public static class MemberAccessTests
     {
+        private class UnreadableIndexableClass
+        {
+            public int this[int index]
+            {
+                set { }
+            }
+        }
+
         [Fact]
         public static void CheckMemberAccessStructInstanceFieldTest()
         {
@@ -290,6 +300,18 @@ namespace System.Linq.Expressions.Tests
             Func<int> f = e.Compile();
 
             Assert.Throws<NullReferenceException>(() => f());
+        }
+
+        [Fact]
+        public static void AccessIndexedPropertyWithoutIndex()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Property(Expression.Default(typeof(List<int>)), typeof(List<int>).GetProperty("Item")));
+        }
+
+        [Fact]
+        public static void AccessIndexedPropertyWithoutIndexWriteOnly()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Property(Expression.Default(typeof(UnreadableIndexableClass)), typeof(UnreadableIndexableClass).GetProperty("Item")));
         }
     }
 }


### PR DESCRIPTION
Fixes #4375 

Also, in the affected code-path it makes one of the two calls to `MemberExpression.Make()` that cast from `PropertyInfo` or `FieldInfo` to `MemberInfo` in making the call, just to have that method detect which type it is to cast back and call correct constructor.

Add overloads for `PropertyInfo` or `FieldInfo` to allow this to be skipped.