### PR TITLE
Prohibit LoopExpression with same label for break and continue.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -879,6 +879,13 @@ namespace System.Linq.Expressions
         {
             return new InvalidOperationException(Strings.LabelTargetAlreadyDefined(p0));
         }
+        /// ArgumentException with message like "Cannot redefine label '{0}' in an inner block."
+        /// </summary>
+        internal static Exception LabelTargetDuplicateArguments(object p0)
+        {
+            return new ArgumentException(Strings.LabelTargetAlreadyDefined(p0));
+        }
+        /// <summary>
         /// <summary>
         /// InvalidOperationException with message like "Cannot jump to undefined label '{0}'."
         /// </summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LoopExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LoopExpression.cs
@@ -127,7 +127,11 @@ namespace System.Linq.Expressions
         public static LoopExpression Loop(Expression body, LabelTarget @break, LabelTarget @continue)
         {
             RequiresCanRead(body, "body");
-            if (@continue != null && @continue.Type != typeof(void)) throw Error.LabelTypeMustBeVoid();
+            if (@continue != null)
+            {
+                if (@continue.Type != (typeof(void))) throw Error.LabelTypeMustBeVoid();
+                if (@continue == @break) throw Error.LabelTargetDuplicateArguments(@continue.Name);
+            }
             return new LoopExpression(body, @break, @continue);
         }
     }

--- a/src/System.Linq.Expressions/tests/Block/BlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/BlockTests.cs
@@ -161,5 +161,12 @@ namespace Tests.ExpressionCompiler.Block
                 );
             Assert.NotSame(block, new ParameterChangingVisitor().Visit(block));
         }
+
+        [Fact]
+        public static void CannotCreateLoopWithSameLabelForBreakAndContinue()
+        {
+            LabelTarget target = Expression.Label();
+            Assert.Throws<ArgumentException>(() => Expression.Loop(Expression.Empty(), target, target));
+        }
     }
 }


### PR DESCRIPTION
Fixes #4298