### PR TITLE
Fixing a deadlock issue in the OS X FileSystemWatcher

### DIFF
--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
@@ -76,22 +76,8 @@ namespace System.IO
                 // Make sure there's a loop to clear
                 if (_watcherRunLoop != IntPtr.Zero)
                 {
-                    // Stop the RunLoop and wait for the thread to exit gracefully
+                    // Stop the background Thread from pumping FS events
                     Interop.RunLoop.CFRunLoopStop(_watcherRunLoop);
-                    _watcherThread.Join();
-                    _watcherRunLoop = IntPtr.Zero;
-                }
-
-                // Clean up the EventStream, if it exists
-                if (!_eventStream.IsInvalid)
-                {
-                    _eventStream = new SafeEventStreamHandle(IntPtr.Zero);
-                }             
-
-                // Cleanup the callback
-                if (_callback != null)
-                {
-                    _callback = null;
                 }
             }
         }
@@ -223,6 +209,10 @@ namespace System.IO
                 Interop.EventStream.FSEventStreamUnscheduleFromRunLoop(_eventStream, _watcherRunLoop, Interop.RunLoop.kCFRunLoopDefaultMode);
                 OnError(new ErrorEventArgs(new IOException(SR.EventStream_FailedToStart, Marshal.GetLastWin32Error())));
             }
+
+            _eventStream = new SafeEventStreamHandle(IntPtr.Zero);
+            _watcherRunLoop = IntPtr.Zero;
+            _callback = null;
         }
 
         private void FileSystemEventCallback( 

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.unit.cs
@@ -518,4 +518,39 @@ public class FileSystemWatcherTests
         }
     }
 
+    [Fact]
+    public static void FileSystemWatcher_StopCalledOnBackgroundThreadDoesNotDeadlock()
+    {
+        // Check the case where Stop or Dispose (they do the same thing) is called from 
+        // a FSW event callback and make sure we don't Thread.Join to deadlock
+        using (var dir = Utility.CreateTestDirectory())
+        {
+            FileSystemWatcher watcher = new FileSystemWatcher();
+            AutoResetEvent are = new AutoResetEvent(false);
+
+            FileSystemEventHandler callback = (sender, arg) => {
+                watcher.Dispose();
+                are.Set();
+            };
+
+            // Attach the FSW to the existing structure
+            watcher.Path = Path.GetFullPath(dir.Path);
+            watcher.Filter = "*";
+            watcher.NotifyFilter = NotifyFilters.FileName | NotifyFilters.Size;
+            watcher.Changed += callback;
+
+            using (var file = File.Create(Path.Combine(dir.Path, "testfile.txt")))
+            {
+                watcher.EnableRaisingEvents = true;
+
+                // Change the nested file and verify we get the changed event
+                byte[] bt = new byte[4096];
+                file.Write(bt, 0, bt.Length);
+                file.Flush();
+            }
+
+            are.WaitOne();
+        }
+    }
+
 }


### PR DESCRIPTION
Fixing a deadlock issue in the OS X FileSystemWatcher
If the FSW was Stopped or Disposed from within an Event Callback
then the cleanup thread would try to Join on itself, causing a deadlock

/cc: @stephentoub @victorhurdugaci 