### PR TITLE
Use Origin getter where applicable.

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
@@ -304,7 +304,7 @@ namespace System.Collections.Immutable
             Requires.NotNullAllowStructs(key, "key");
             Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
-            var result = Add(key, value, KeyCollisionBehavior.ThrowIfValueDifferent, new MutationInput(this));
+            var result = Add(key, value, KeyCollisionBehavior.ThrowIfValueDifferent, this.Origin);
             return result.Finalize(this);
         }
 
@@ -331,7 +331,7 @@ namespace System.Collections.Immutable
             Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
             Contract.Ensures(!Contract.Result<ImmutableDictionary<TKey, TValue>>().IsEmpty);
 
-            var result = Add(key, value, KeyCollisionBehavior.SetValue, new MutationInput(this));
+            var result = Add(key, value, KeyCollisionBehavior.SetValue, this.Origin);
             return result.Finalize(this);
         }
 
@@ -360,7 +360,7 @@ namespace System.Collections.Immutable
             Requires.NotNullAllowStructs(key, "key");
             Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
-            var result = Remove(key, new MutationInput(this));
+            var result = Remove(key, this.Origin);
             return result.Finalize(this);
         }
 
@@ -404,7 +404,7 @@ namespace System.Collections.Immutable
         public bool ContainsKey(TKey key)
         {
             Requires.NotNullAllowStructs(key, "key");
-            return ContainsKey(key, new MutationInput(this));
+            return ContainsKey(key, this.Origin);
         }
 
         /// <summary>


### PR DESCRIPTION
Use Origin instead of manully creating a MutationInput from this. This change
makes the code more consistent because Origin getter is already used in other
places.