### PR TITLE
Fixing issues in OS X FSW regarding a Dispose Deadlock and failing UTs

### DIFF
--- a/src/Common/src/Interop/OSX/Interop.EventStream.cs
+++ b/src/Common/src/Interop/OSX/Interop.EventStream.cs
@@ -29,6 +29,7 @@ internal static partial class Interop
         [Flags]
         internal enum FSEventStreamEventFlags : uint
         {
+            /* flags when creating the stream. */
             kFSEventStreamEventFlagNone                 = 0x00000000,
             kFSEventStreamEventFlagMustScanSubDirs      = 0x00000001,
             kFSEventStreamEventFlagUserDropped          = 0x00000002,
@@ -37,8 +38,8 @@ internal static partial class Interop
             kFSEventStreamEventFlagHistoryDone          = 0x00000010,
             kFSEventStreamEventFlagRootChanged          = 0x00000020,
             kFSEventStreamEventFlagMount                = 0x00000040,
-            kFSEventStreamEventFlagUnmount              = 0x00000080, /* These flags are only set if you specified the FileEvents */
-            /* flags when creating the stream. */
+            kFSEventStreamEventFlagUnmount              = 0x00000080,
+            /* These flags are only set if you specified the FileEvents */
             kFSEventStreamEventFlagItemCreated          = 0x00000100,
             kFSEventStreamEventFlagItemRemoved          = 0x00000200,
             kFSEventStreamEventFlagItemInodeMetaMod     = 0x00000400,
@@ -49,7 +50,10 @@ internal static partial class Interop
             kFSEventStreamEventFlagItemXattrMod         = 0x00008000,
             kFSEventStreamEventFlagItemIsFile           = 0x00010000,
             kFSEventStreamEventFlagItemIsDir            = 0x00020000,
-            kFSEventStreamEventFlagItemIsSymlink        = 0x00040000
+            kFSEventStreamEventFlagItemIsSymlink        = 0x00040000,
+            kFSEventStreamEventFlagOwnEvent             = 0x00080000,
+            kFSEventStreamEventFlagItemIsHardlink       = 0x00100000,
+            kFSEventStreamEventFlagItemIsLastHardlink   = 0x00200000,
         }
 
         /// <summary>

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs
@@ -26,41 +26,25 @@ namespace System.IO
 
         private void StartRaisingEvents()
         {
-            // Make sure the Start and Stop can be called from different threads and don't 
-            // stomp on the other's operation. We use the _syncLock instead of the
-            // RunLoop or StreamRef because IntPtrs are value types and can't be locked
-            lock (_syncLock)
+            // Don't start another instance if one is already runnings
+            if (_cancellation != null)
             {
-                // Always re-create the filter flags when start is called since they could have changed
-                if ((_notifyFilters & (NotifyFilters.Attributes | NotifyFilters.CreationTime | NotifyFilters.LastAccess | NotifyFilters.LastWrite | NotifyFilters.Size)) != 0)
-                {
-                    _filterFlags = Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemInodeMetaMod  | 
-                                   Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemFinderInfoMod |
-                                   Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemModified      |
-                                   Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemChangeOwner;
-                }
-                if ((_notifyFilters & NotifyFilters.Security) != 0)
-                {
-                    _filterFlags |= Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemChangeOwner | Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemXattrMod;
-                }
-                if ((_notifyFilters & NotifyFilters.DirectoryName) != 0)
-                {
-                    _filterFlags |= Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemIsDir |
-                                    Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemIsSymlink |
-                                    Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemCreated |
-                                    Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemRemoved |
-                                    Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemRenamed;
-                }
-                if ((_notifyFilters & NotifyFilters.FileName) != 0)
-                {
-                    _filterFlags |= Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemIsFile |
-                                    Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemIsSymlink |
-                                    Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemCreated |
-                                    Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemRemoved |
-                                    Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemRenamed;
-                }
+                return;
+            }
 
-                CreateStreamAndStartWatcher();
+            try
+            {
+                CancellationTokenSource cancellation = new CancellationTokenSource();
+                RunningInstance instance = new RunningInstance(this, _directory, _includeSubdirectories, TranslateFlags(_notifyFilters), cancellation.Token);
+                _enabled = true;
+                _cancellation = cancellation;
+                instance.Start();
+            }
+            catch
+            {
+                _enabled = false;
+                _cancellation = null;
+                throw;
             }
         }
 
@@ -68,31 +52,11 @@ namespace System.IO
         {
             _enabled = false;
 
-            // Make sure the Start and Stop can be called from different threads and don't 
-            // stomp on the other's operation. We use the _syncLock instead of the
-            // RunLoop or StreamRef because IntPtrs are value types and can't be locked
-            lock (_syncLock)
+            CancellationTokenSource token = _cancellation;
+            if (token != null)
             {
-                // Make sure there's a loop to clear
-                if (_watcherRunLoop != IntPtr.Zero)
-                {
-                    // Stop the RunLoop and wait for the thread to exit gracefully
-                    Interop.RunLoop.CFRunLoopStop(_watcherRunLoop);
-                    _watcherThread.Join();
-                    _watcherRunLoop = IntPtr.Zero;
-                }
-
-                // Clean up the EventStream, if it exists
-                if (!_eventStream.IsInvalid)
-                {
-                    _eventStream = new SafeEventStreamHandle(IntPtr.Zero);
-                }             
-
-                // Cleanup the callback
-                if (_callback != null)
-                {
-                    _callback = null;
-                }
+                _cancellation = null;
+                token.Cancel();
             }
         }
 
@@ -100,49 +64,113 @@ namespace System.IO
         // ---- PAL layer ends here ----
         // -----------------------------
 
-        // Flags used to create the event stream
-        private const Interop.EventStream.FSEventStreamCreateFlags EventStreamFlags = (Interop.EventStream.FSEventStreamCreateFlags.kFSEventStreamCreateFlagFileEvents | 
+        private CancellationTokenSource _cancellation;
+
+        private static Interop.EventStream.FSEventStreamEventFlags TranslateFlags(NotifyFilters flagsToTranslate)
+        {
+            Interop.EventStream.FSEventStreamEventFlags flags = 0;
+
+            // Always re-create the filter flags when start is called since they could have changed
+            if ((flagsToTranslate & (NotifyFilters.Attributes | NotifyFilters.CreationTime | NotifyFilters.LastAccess | NotifyFilters.LastWrite | NotifyFilters.Size)) != 0)
+            {
+                flags = Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemInodeMetaMod  | 
+                               Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemFinderInfoMod |
+                               Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemModified      |
+                               Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemChangeOwner;
+            }
+            if ((flagsToTranslate & NotifyFilters.Security) != 0)
+            {
+                flags |= Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemChangeOwner | Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemXattrMod;
+            }
+            if ((flagsToTranslate & NotifyFilters.DirectoryName) != 0)
+            {
+                flags |= Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemIsDir |
+                                Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemIsSymlink |
+                                Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemCreated |
+                                Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemRemoved |
+                                Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemRenamed;
+            }
+            if ((flagsToTranslate & NotifyFilters.FileName) != 0)
+            {
+                flags |= Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemIsFile |
+                                Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemIsSymlink |
+                                Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemCreated |
+                                Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemRemoved |
+                                Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemRenamed;
+            }
+
+            return flags;
+        }
+
+        private sealed class RunningInstance
+        {
+            // Flags used to create the event stream
+            private const Interop.EventStream.FSEventStreamCreateFlags EventStreamFlags = (Interop.EventStream.FSEventStreamCreateFlags.kFSEventStreamCreateFlagFileEvents | 
                                                                                         Interop.EventStream.FSEventStreamCreateFlags.kFSEventStreamCreateFlagNoDefer   | 
                                                                                         Interop.EventStream.FSEventStreamCreateFlags.kFSEventStreamCreateFlagWatchRoot);
 
-        // The user can input relative paths, which can muck with our path comparisons. Save off the 
-        // actual full path so we can use it for comparing
-        private string _fullDirectory = String.Empty;
+            // Weak reference to the associated watcher. A weak reference is used so that the FileSystemWatcher may be collected and finalized,
+            // causing an active operation to be torn down.
+            private readonly WeakReference<FileSystemWatcher> _weakWatcher;
 
-        // The bitmask of events that we want to send to the user
-        private Interop.EventStream.FSEventStreamEventFlags _filterFlags = 0;
+            // The user can input relative paths, which can muck with our path comparisons. Save off the 
+            // actual full path so we can use it for comparing
+            private string _fullDirectory;
 
-        // The EventStream to listen for events on
-        private SafeEventStreamHandle _eventStream = new SafeEventStreamHandle(IntPtr.Zero);
+            // Boolean if we allow events from nested folders
+            private bool _includeChildren;
 
-        // The background thread to use to monitor events
-        private Thread _watcherThread = null;
+            // The bitmask of events that we want to send to the user
+            private Interop.EventStream.FSEventStreamEventFlags _filterFlags;
 
-        // A reference to the RunLoop that we can use to start or stop a Watcher
-        private CFRunLoopRef _watcherRunLoop = IntPtr.Zero;
+            // The EventStream to listen for events on
+            private SafeEventStreamHandle _eventStream;
 
-        // Since all variables are IntPtr, Strings, or change references, using this in our locks
-        private readonly object _syncLock = new object();
+            // A reference to the RunLoop that we can use to start or stop a Watcher
+            private CFRunLoopRef _watcherRunLoop;
 
-        // Callback delegate for the EventStream events 
-        private Interop.EventStream.FSEventStreamCallback _callback = null;
+            // Callback delegate for the EventStream events 
+            private Interop.EventStream.FSEventStreamCallback _callback;
 
-        // Use an event to try to prevent StartRaisingEvents from returning before the
-        // RunLoop actually begins. This will mitigate a race condition where the watcher
-        // thread hasn't completed initialization and stop is called before the RunLoop even starts.
-        private readonly AutoResetEvent _runLoopStartedEvent = new AutoResetEvent(false);
+            // Token to monitor for cancellation requests, upon which processing is stopped and all
+            // state is cleaned up.
+            private readonly CancellationToken _cancellationToken;
 
-        private void CreateStreamAndStartWatcher()
-        {
-            Debug.Assert(_eventStream.IsInvalid);
-            Debug.Assert(_watcherRunLoop == IntPtr.Zero);
-            Debug.Assert(_callback == null);
+            // Calling RunLoopStop multiple times SegFaults so protect the call to it
+            private bool _stopping;
 
-            // Make sure we only do this if there is a valid directory
-            if (String.IsNullOrEmpty(_directory) == false)
+            internal RunningInstance(
+                FileSystemWatcher watcher,
+                string directory,
+                bool includeChildren,
+                Interop.EventStream.FSEventStreamEventFlags filter,
+                CancellationToken cancelToken)
             {
-                _fullDirectory = System.IO.Path.GetFullPath(_directory);
+                Debug.Assert(string.IsNullOrEmpty(directory) == false);
+                Debug.Assert(!cancelToken.IsCancellationRequested);
 
+                _weakWatcher = new WeakReference<FileSystemWatcher>(watcher);
+                _fullDirectory = System.IO.Path.GetFullPath(directory);
+                _includeChildren = includeChildren;
+                _filterFlags = filter;
+                _cancellationToken = cancelToken;
+                _cancellationToken.Register(obj => ((RunningInstance)obj).CancellationCallback(), this);
+                _stopping = false;
+            }
+
+            private void CancellationCallback()
+            {
+                if (!_stopping)
+                {
+                    _stopping = true;
+
+                    // Stop the FS event message pump
+                    Interop.RunLoop.CFRunLoopStop(_watcherRunLoop);
+                }
+            }
+
+            internal void Start()
+            {
                 // Get the path to watch and verify we created the CFStringRef
                 SafeCreateHandle path = Interop.CoreFoundation.CFStringCreateWithCString(_fullDirectory);
                 if (path.IsInvalid)
@@ -181,234 +209,234 @@ namespace System.IO
                     throw Interop.GetExceptionForIoErrno(Interop.Sys.GetLastErrorInfo(), _fullDirectory, true);
                 }
 
-                _enabled = true;
-
                 // Create and start our watcher thread then wait for the thread to initialize and start 
                 // the RunLoop. We wait for that to prevent this function from returning before the RunLoop
                 // has a chance to start so that any callers won't race with the background thread's initialization
                 // and calling Stop, which would attempt to stop a RunLoop that hasn't started yet.
-                _watcherThread = new Thread(new ThreadStart(WatchForFileSystemEventsThreadStart));
-                _watcherThread.Start();
-                _runLoopStartedEvent.WaitOne();
+                var runLoopStarted = new ManualResetEventSlim();
+                new Thread(WatchForFileSystemEventsThreadStart) { IsBackground = true }.Start(runLoopStarted);
+                runLoopStarted.Wait();
             }
-        }
 
-        private void WatchForFileSystemEventsThreadStart()
-        {
-            // Get this thread's RunLoop
-            _watcherRunLoop = Interop.RunLoop.CFRunLoopGetCurrent();
-            Debug.Assert(_watcherRunLoop != IntPtr.Zero);
-
-            // Schedule the EventStream to run on the thread's RunLoop
-            Interop.EventStream.FSEventStreamScheduleWithRunLoop(_eventStream, _watcherRunLoop, Interop.RunLoop.kCFRunLoopDefaultMode);
-            if (Interop.EventStream.FSEventStreamStart(_eventStream))
+            private void WatchForFileSystemEventsThreadStart(object arg)
             {
-                // Notify the StartRaisingEvents call that we are initialized and about to start
-                // so that it can return and avoid a race-condition around multiple threads calling Stop and Start
-                _runLoopStartedEvent.Set();
+                var runLoopStarted = (ManualResetEventSlim)arg;
 
-                // Start the OS X RunLoop (a blocking call) that will pump file system changes into the callback function
-                Interop.RunLoop.CFRunLoopRun();
+                // Get this thread's RunLoop
+                _watcherRunLoop = Interop.RunLoop.CFRunLoopGetCurrent();
+                Debug.Assert(_watcherRunLoop != IntPtr.Zero);
 
-                // When we get here, we've requested to stop so cleanup the EventStream and unschedule from the RunLoop
-                Interop.EventStream.FSEventStreamStop(_eventStream);
-                Interop.EventStream.FSEventStreamUnscheduleFromRunLoop(_eventStream, _watcherRunLoop, Interop.RunLoop.kCFRunLoopDefaultMode);
-            }
-            else
-            {
-                // We failed and need to release the caller so the OnError event can be processed
-                _runLoopStartedEvent.Set();
+                // Schedule the EventStream to run on the thread's RunLoop
+                Interop.EventStream.FSEventStreamScheduleWithRunLoop(_eventStream, _watcherRunLoop, Interop.RunLoop.kCFRunLoopDefaultMode);
 
-                // An error occurred while trying to start the run loop so fail out
-                Interop.EventStream.FSEventStreamUnscheduleFromRunLoop(_eventStream, _watcherRunLoop, Interop.RunLoop.kCFRunLoopDefaultMode);
-                OnError(new ErrorEventArgs(new IOException(SR.EventStream_FailedToStart, Marshal.GetLastWin32Error())));
-            }
-        }
-
-        private void FileSystemEventCallback( 
-            FSEventStreamRef streamRef, 
-            IntPtr clientCallBackInfo, 
-            size_t numEvents, 
-            String[] eventPaths, 
-            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]
-            Interop.EventStream.FSEventStreamEventFlags[] eventFlags,
-            [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]
-            FSEventStreamEventId[] eventIds)
-        {
-            Debug.Assert((numEvents.ToInt32() == eventPaths.Length) && (numEvents.ToInt32() == eventFlags.Length) && (numEvents.ToInt32() == eventIds.Length));
-
-            // Since renames come in pairs, when we find the first we need to search for the next one. Once we find it, we'll add it to this
-            // list so when the for-loop comes across it, we'll skip it since it's already been processed as part of the original of the pair.
-            List<FSEventStreamEventId> handledRenameEvents = null;
-
-            for (long i = 0; i < numEvents.ToInt32(); i++)
-            {
-                // We need to special case the root path for pattern matching, so cache the path this way in case it is the root
-                // and use it for pattern matching. We'll go back to the eventPaths[i] to get the actual path for notifications
-                string path = eventPaths[i];
-                if (path.Equals(_fullDirectory, StringComparison.OrdinalIgnoreCase))
+                try
                 {
-                    path += "/.";
-                }
+                    bool started = Interop.EventStream.FSEventStreamStart(_eventStream);
 
-                // First, we should check if this event should kick off a re-scan since we can't really rely on anything after this point if that is true
-                if (ShouldRescanOccur(eventFlags[i]))
-                {
-                    OnError(new ErrorEventArgs(new IOException(SR.FSW_BufferOverflow, (int)eventFlags[i])));
-                    break;
-                }
-                else if ((handledRenameEvents != null) && (handledRenameEvents.Contains(eventIds[i])))
-                {
-                    // If this event is the second in a rename pair then skip it
-                    continue;
-                }
-                else if ((DoesPathPassNameFilter(path)) && ((_filterFlags & eventFlags[i]) != 0))
-                {
-                    // The base FileSystemWatcher does a match check against the relative path before combining with 
-                    // the root dir; however, null is special cased to signify the root dir, so check if we should use that.
-                    string relativePath = null;
-                    if (eventPaths[i].Equals(_fullDirectory, StringComparison.OrdinalIgnoreCase) == false)
+                    // Notify the StartRaisingEvents call that we are initialized and about to start
+                    // so that it can return and avoid a race-condition around multiple threads calling Stop and Start
+                    runLoopStarted.Set();
+
+                    if (started)
                     {
-                        // Check if the event path, with the root directory removed, begins with a / and
-                        // if so, remove it; otherwise, just remove the root path (which contains a trailing /)
-                        if (eventPaths[i][_fullDirectory.Length] == '/')
-                        {
-                            relativePath = eventPaths[i].Remove(0, _fullDirectory.Length + 1);
-                        }
-                        else
-                        {
-                            relativePath = eventPaths[i].Remove(0, _fullDirectory.Length);
-                        }
-                    }
+                        // Start the OS X RunLoop (a blocking call) that will pump file system changes into the callback function
+                        Interop.RunLoop.CFRunLoopRun();
 
-                    // Check if this is a rename
-                    if (IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemRenamed))
-                    {
-                        // Find the rename that is paired to this rename, which should be the next rename in the list
-                        long pairedId = FindRenameChangePairedChange(i, eventPaths, eventFlags, eventIds);
-                        if (pairedId == long.MinValue)
-                        {
-                            // Getting here means we have a rename without a pair, meaning it should be a create for the 
-                            // move from unwatched folder to watcher folder scenario or a move from the watcher folder out.
-                            // Check if the item exists on disk to check which it is
-                            if (DoesItemExist(eventPaths[i], IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemIsFile)))
-                            {
-                                NotifyFileSystemEventArgs(WatcherChangeTypes.Created, relativePath);
-                            }
-                            else
-                            {
-                                NotifyFileSystemEventArgs(WatcherChangeTypes.Deleted, relativePath);
-                            }
-                        }
-                        else
-                        {
-                            // Remove the base directory prefix (including trailing / that OS X adds) and 
-                            // add the paired event to the list of events to skip and notify the user of the rename
-                            string newPathRelativeName = eventPaths[pairedId].Remove(0, _fullDirectory.Length + 1);
-                            NotifyRenameEventArgs(WatcherChangeTypes.Renamed, newPathRelativeName, relativePath);
-
-                            // Create a new list, if necessary, and add the event
-                            if (handledRenameEvents == null)
-                            {
-                                handledRenameEvents = new List<FSEventStreamEventId>();
-                            }
-                            handledRenameEvents.Add(eventIds[pairedId]);
-                        }
+                        // When we get here, we've requested to stop so cleanup the EventStream and unschedule from the RunLoop
+                        Interop.EventStream.FSEventStreamStop(_eventStream);
                     }
                     else
                     {
-                        // OS X is wonky where it can give back kFSEventStreamEventFlagItemCreated and kFSEventStreamEventFlagItemRemoved
-                        // for the same item. The only option we have is to stat and see if the item exists; if so send created, otherwise send deleted.
-                        if ((IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemCreated)) ||
-                            (IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemRemoved)))
+                        // Try to get the Watcher to raise the error event; if we can't do that, just silently exist since the watcher is gone anyway
+                        FileSystemWatcher watcher;
+                        if (_weakWatcher.TryGetTarget(out watcher))
                         {
-                            if (DoesItemExist(eventPaths[i], IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemIsFile)))
+                            // An error occurred while trying to start the run loop so fail out
+                            watcher.OnError(new ErrorEventArgs(new IOException(SR.EventStream_FailedToStart, Marshal.GetLastWin32Error())));
+                        }
+                    }
+                }
+                finally
+                {
+                    // Always unschedule the RunLoop before cleaning up
+                    Interop.EventStream.FSEventStreamUnscheduleFromRunLoop(_eventStream, _watcherRunLoop, Interop.RunLoop.kCFRunLoopDefaultMode);
+                }
+            }
+
+            private void FileSystemEventCallback( 
+                FSEventStreamRef streamRef, 
+                IntPtr clientCallBackInfo, 
+                size_t numEvents, 
+                String[] eventPaths, 
+                [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]
+                Interop.EventStream.FSEventStreamEventFlags[] eventFlags,
+                [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]
+                FSEventStreamEventId[] eventIds)
+            {
+                Debug.Assert((numEvents.ToInt32() == eventPaths.Length) && (numEvents.ToInt32() == eventFlags.Length) && (numEvents.ToInt32() == eventIds.Length));
+
+                // Try to get the actual watcher from our weak reference.  We maintain a weak reference most of the time
+                // so as to avoid a rooted cycle that would prevent our processing loop from ever ending
+                // if the watcher is dropped by the user without being disposed. If we can't get the watcher,
+                // there's nothing more to do (we can't raise events), so bail.
+                FileSystemWatcher watcher;
+                if (!_weakWatcher.TryGetTarget(out watcher))
+                {
+                    CancellationCallback();
+                    return;
+                }
+
+                // Since renames come in pairs, when we find the first we need to search for the next one. Once we find it, we'll add it to this
+                // list so when the for-loop comes across it, we'll skip it since it's already been processed as part of the original of the pair.
+                List<FSEventStreamEventId> handledRenameEvents = null;
+
+                for (long i = 0; i < numEvents.ToInt32(); i++)
+                {
+                    // Match Windows and don't notify us about changes to the Root folder
+                    string path = eventPaths[i];
+                    if (path.Equals(_fullDirectory, StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    // First, we should check if this event should kick off a re-scan since we can't really rely on anything after this point if that is true
+                    if (ShouldRescanOccur(eventFlags[i]))
+                    {
+                        watcher.OnError(new ErrorEventArgs(new IOException(SR.FSW_BufferOverflow, (int)eventFlags[i])));
+                        break;
+                    }
+                    else if ((handledRenameEvents != null) && (handledRenameEvents.Contains(eventIds[i])))
+                    {
+                        // If this event is the second in a rename pair then skip it
+                        continue;
+                    }
+                    else if ((CheckIfPathIsNested(path)) && ((_filterFlags & eventFlags[i]) != 0))
+                    {
+                        // The base FileSystemWatcher does a match check against the relative path before combining with 
+                        // the root dir; however, null is special cased to signify the root dir, so check if we should use that.
+                        string relativePath = null;
+                        if (eventPaths[i].Equals(_fullDirectory, StringComparison.OrdinalIgnoreCase) == false)
+                        {
+                            // Check if the event path, with the root directory removed, begins with a / and
+                            // if so, remove it; otherwise, just remove the root path (which contains a trailing /)
+                            relativePath = eventPaths[i].Remove(0, _fullDirectory.Length + (eventPaths[i][_fullDirectory.Length] == '/' ? 1 : 0));
+                        }
+
+                        // Check if this is a rename
+                        if (IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemRenamed))
+                        {
+                            // Find the rename that is paired to this rename, which should be the next rename in the list
+                            long pairedId = FindRenameChangePairedChange(i, eventPaths, eventFlags, eventIds);
+                            if (pairedId == long.MinValue)
                             {
-                                NotifyFileSystemEventArgs(WatcherChangeTypes.Created, relativePath);
+                                // Getting here means we have a rename without a pair, meaning it should be a create for the 
+                                // move from unwatched folder to watcher folder scenario or a move from the watcher folder out.
+                                // Check if the item exists on disk to check which it is
+                                WatcherChangeTypes wct = DoesItemExist(eventPaths[i], IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemIsFile)) ?
+                                    WatcherChangeTypes.Created : 
+                                    WatcherChangeTypes.Deleted;
+                                watcher.NotifyFileSystemEventArgs(wct, relativePath);
                             }
                             else
                             {
-                                NotifyFileSystemEventArgs(WatcherChangeTypes.Deleted, relativePath);
+                                // Remove the base directory prefix (including trailing / that OS X adds) and 
+                                // add the paired event to the list of events to skip and notify the user of the rename
+                                string newPathRelativeName = eventPaths[pairedId].Remove(0, _fullDirectory.Length + 1);
+                                watcher.NotifyRenameEventArgs(WatcherChangeTypes.Renamed, newPathRelativeName, relativePath);
+
+                                // Create a new list, if necessary, and add the event
+                                if (handledRenameEvents == null)
+                                {
+                                    handledRenameEvents = new List<FSEventStreamEventId>();
+                                }
+                                handledRenameEvents.Add(eventIds[pairedId]);
                             }
                         }
-
-                        if (IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemInodeMetaMod) ||
+                        else
+                        {
+                            // OS X is wonky where it can give back kFSEventStreamEventFlagItemCreated and kFSEventStreamEventFlagItemRemoved
+                            // for the same item. The only option we have is to stat and see if the item exists; if so send created, otherwise send deleted.
+                            if ((IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemCreated)) ||
+                                (IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemRemoved)))
+                            {
+                                WatcherChangeTypes wct = DoesItemExist(eventPaths[i], IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemIsFile)) ?
+                                    WatcherChangeTypes.Created : 
+                                    WatcherChangeTypes.Deleted;
+                                watcher.NotifyFileSystemEventArgs(wct, relativePath);
+                            }
+    
+                            if (IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemInodeMetaMod) ||
                             IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemModified) ||
                             IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemFinderInfoMod) ||
                             IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemChangeOwner) ||
                             IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemXattrMod))
-                        {
-                            // Everything else is a modification
-                            NotifyFileSystemEventArgs(WatcherChangeTypes.Changed, relativePath);
+                            {
+                                // Everything else is a modification
+                                watcher.NotifyFileSystemEventArgs(WatcherChangeTypes.Changed, relativePath);
+                            }
                         }
                     }
                 }
             }
-        }
 
-        private bool ShouldRescanOccur(Interop.EventStream.FSEventStreamEventFlags flags)
-        {
-            // Check if any bit is set that signals that the caller should rescan
-            return (IsFlagSet(flags, Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagMustScanSubDirs) ||
-                    IsFlagSet(flags, Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagUserDropped)     ||
-                    IsFlagSet(flags, Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagKernelDropped)   ||
-                    IsFlagSet(flags, Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagRootChanged)     ||
-                    IsFlagSet(flags, Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagMount)           ||
-                    IsFlagSet(flags, Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagUnmount));
-        }
-
-        private bool DoesPathPassNameFilter(string eventPath)
-        {
-            bool doesPathPass = true;
-            
-            // If we shouldn't include subdirectories, check if this path's parent is the watch directory
-            if (_includeSubdirectories == false)
+            private bool ShouldRescanOccur(Interop.EventStream.FSEventStreamEventFlags flags)
             {
-                // Check if the parent is the root. If so, then we'll continue processing based on the name.
-                // If it isn't, then this will be set to false and we'll skip the name processing since it's irrelevant.
-                string parent = System.IO.Path.GetDirectoryName(eventPath);
-                doesPathPass = (parent.Equals(_fullDirectory, StringComparison.OrdinalIgnoreCase));
+                // Check if any bit is set that signals that the caller should rescan
+                return (IsFlagSet(flags, Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagMustScanSubDirs) ||
+                        IsFlagSet(flags, Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagUserDropped)     ||
+                        IsFlagSet(flags, Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagKernelDropped)   ||
+                        IsFlagSet(flags, Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagRootChanged)     ||
+                        IsFlagSet(flags, Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagMount)           ||
+                        IsFlagSet(flags, Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagUnmount));
             }
 
-            if (doesPathPass)
+            private bool CheckIfPathIsNested(string eventPath)
             {
-                // Check if the name fits the pattern
-                doesPathPass = MatchPattern(eventPath);
-            }
+                bool doesPathPass = true;
 
-            return doesPathPass;
-        }
-
-        private long FindRenameChangePairedChange(
-            long currentIndex, 
-            String[] eventPaths,
-            Interop.EventStream.FSEventStreamEventFlags[] eventFlags,
-            FSEventStreamEventId[] eventIds)
-        {
-            // Start at one past the current index and try to find the next Rename item, which should be the old path.
-            for (long i = currentIndex + 1; i < eventPaths.Length; i++)
-            {
-                if (IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemRenamed))
+                // If we shouldn't include subdirectories, check if this path's parent is the watch directory
+                if (_includeChildren == false)
                 {
-                    // We found match, stop looking
-                    return i;
+                    // Check if the parent is the root. If so, then we'll continue processing based on the name.
+                    // If it isn't, then this will be set to false and we'll skip the name processing since it's irrelevant.
+                    string parent = System.IO.Path.GetDirectoryName(eventPath);
+                    doesPathPass = (parent.Equals(_fullDirectory, StringComparison.OrdinalIgnoreCase));
                 }
+
+                return doesPathPass;
             }
 
-            return long.MinValue;
-        }
+            private long FindRenameChangePairedChange(
+                long currentIndex, 
+                String[] eventPaths,
+                Interop.EventStream.FSEventStreamEventFlags[] eventFlags,
+                FSEventStreamEventId[] eventIds)
+            {
+                // Start at one past the current index and try to find the next Rename item, which should be the old path.
+                for (long i = currentIndex + 1; i < eventPaths.Length; i++)
+                {
+                    if (IsFlagSet(eventFlags[i], Interop.EventStream.FSEventStreamEventFlags.kFSEventStreamEventFlagItemRenamed))
+                    {
+                        // We found match, stop looking
+                        return i;
+                    }
+                }
 
-        private static bool IsFlagSet(Interop.EventStream.FSEventStreamEventFlags flags, Interop.EventStream.FSEventStreamEventFlags value)
-        {
-            return (value & flags) == value;
-        }
+                return long.MinValue;
+            }
 
-        private static bool DoesItemExist(string path, bool isFile)
-        {
-            if (isFile)
-                return File.Exists(path);
-            else
-                return Directory.Exists(path);
+            private static bool IsFlagSet(Interop.EventStream.FSEventStreamEventFlags flags, Interop.EventStream.FSEventStreamEventFlags value)
+            {
+                return (value & flags) == value;
+            }
+
+            private static bool DoesItemExist(string path, bool isFile)
+            {
+                if (isFile)
+                    return File.Exists(path);
+                else
+                    return Directory.Exists(path);
+            }
         }
     }
 }


### PR DESCRIPTION
Refactoring the OS X FileSystemWatcher to more match the Linux implementation by using an internal Instance class in order to allow each instance to clean itself up without causing side effects to other instances during rapid start-stop-start scenarios. This refactor fixes issue #4738
    
/cc @stephentoub 
