### PR TITLE
[NetworkInformation] Detect when /etc/resolv.conf does not exist on Unix

### DIFF
--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPInterfaceProperties.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/UnixIPInterfaceProperties.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Sockets;
 
@@ -38,11 +39,44 @@ namespace System.Net.NetworkInformation
             }
         }
 
-        public override bool IsDnsEnabled { get { return DnsAddresses.Count > 0; } }
+        public override bool IsDnsEnabled
+        {
+            get
+            {
+                if (_dnsAddresses == null)
+                {
+                    throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+                }
 
-        public sealed override string DnsSuffix { get { return _dnsSuffix; } }
+                return _dnsAddresses.Count > 0;
+            }
+        }
 
-        public sealed override IPAddressCollection DnsAddresses { get { return _dnsAddresses; } }
+        public sealed override string DnsSuffix
+        {
+            get
+            {
+                if (_dnsSuffix == null)
+                {
+                    throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+                }
+
+                return _dnsSuffix;
+            }
+        }
+
+        public sealed override IPAddressCollection DnsAddresses
+        {
+            get
+            {
+                if (_dnsAddresses == null)
+                {
+                    throw new PlatformNotSupportedException(SR.net_InformationUnavailableOnPlatform);
+                }
+
+                return _dnsAddresses;
+            }
+        }
 
         private static UnicastIPAddressInformationCollection GetUnicastAddresses(UnixNetworkInterface uni)
         {
@@ -71,13 +105,27 @@ namespace System.Net.NetworkInformation
 
         private static string GetDnsSuffix()
         {
-            return StringParsingHelpers.ParseDnsSuffixFromResolvConfFile(NetworkFiles.EtcResolvConfFile);
+            try
+            {
+                return StringParsingHelpers.ParseDnsSuffixFromResolvConfFile(NetworkFiles.EtcResolvConfFile);
+            }
+            catch (FileNotFoundException)
+            {
+                return null;
+            }
         }
 
         private static IPAddressCollection GetDnsAddresses()
         {
-            List<IPAddress> internalAddresses = StringParsingHelpers.ParseDnsAddressesFromResolvConfFile(NetworkFiles.EtcResolvConfFile);
-            return new InternalIPAddressCollection(internalAddresses);
+            try
+            {
+                List<IPAddress> internalAddresses = StringParsingHelpers.ParseDnsAddressesFromResolvConfFile(NetworkFiles.EtcResolvConfFile);
+                return new InternalIPAddressCollection(internalAddresses);
+            }
+            catch (FileNotFoundException)
+            {
+                return null;
+            }
         }
     }
 }

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_OSX.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/IPInterfacePropertiesTest_OSX.cs
@@ -36,14 +36,19 @@ namespace System.Net.NetworkInformation.Tests
 
                 Assert.Throws<PlatformNotSupportedException>(() => ipProperties.DhcpServerAddresses);
 
-                Assert.NotNull(ipProperties.DnsAddresses);
-                _log.WriteLine("- Dns Addresses: " + ipProperties.DnsAddresses.Count);
-                foreach (IPAddress dns in ipProperties.DnsAddresses)
+                try
                 {
-                    _log.WriteLine("-- " + dns.ToString());
+                    Assert.NotNull(ipProperties.DnsAddresses);
+                    _log.WriteLine("- Dns Addresses: " + ipProperties.DnsAddresses.Count);
+                    foreach (IPAddress dns in ipProperties.DnsAddresses)
+                    {
+                        _log.WriteLine("-- " + dns.ToString());
+                    }
+                    Assert.NotNull(ipProperties.DnsSuffix);
+                    _log.WriteLine("- Dns Suffix: " + ipProperties.DnsSuffix);
                 }
-                Assert.NotNull(ipProperties.DnsSuffix);
-                _log.WriteLine("- Dns Suffix: " + ipProperties.DnsSuffix);
+                // If /etc/resolv.conf does not exist, DNS values cannot be retrieved.
+                catch (PlatformNotSupportedException) { }
 
                 Assert.NotNull(ipProperties.GatewayAddresses);
                 _log.WriteLine("- Gateway Addresses: " + ipProperties.GatewayAddresses.Count);


### PR DESCRIPTION
Right now if the user does not have /etc/resolv.conf on their machine, the constructor for UnixIPInterfaceProperties will throw an exception when it tries to open that file. Instead, detect that state and just throw a PlatformNotSupportedException when one of the properties relying on that information is accessed, with a message stating that the information is unavailable.

Fixes #4699 