### PR TITLE
Avoid enumerator allocations in SortedSet<T>.SetEquals

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -1648,8 +1648,8 @@ namespace System.Collections.Generic
             SortedSet<T> asSorted = other as SortedSet<T>;
             if (asSorted != null && AreComparersEqual(this, asSorted))
             {
-                IEnumerator<T> mine = this.GetEnumerator();
-                IEnumerator<T> theirs = asSorted.GetEnumerator();
+                Enumerator mine = GetEnumerator();
+                Enumerator theirs = asSorted.GetEnumerator();
                 bool mineEnded = !mine.MoveNext();
                 bool theirsEnded = !theirs.MoveNext();
                 while (!mineEnded && !theirsEnded)


### PR DESCRIPTION
Avoid unnecessary boxing of the struct enumerators.