### PR TITLE
Shims should use intptr_t for file descriptors.

### DIFF
--- a/src/Common/src/Interop/Linux/System.Native/Interop.INotify.cs
+++ b/src/Common/src/Interop/Linux/System.Native/Interop.INotify.cs
@@ -4,21 +4,22 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static extern int INotifyInit();
+        internal static extern SafeFileHandle INotifyInit();
 
         [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static extern int INotifyAddWatch(int fd, string pathName, uint mask);
+        internal static extern int INotifyAddWatch(SafeFileHandle fd, string pathName, uint mask);
 
         [DllImport(Libraries.SystemNative, SetLastError = true, EntryPoint = "INotifyRemoveWatch")]
-        private static extern int INotifyRemoveWatch_private(int fd, int wd);
+        private static extern int INotifyRemoveWatch_private(SafeFileHandle fd, int wd);
 
-        internal static int INotifyRemoveWatch(int fd, int wd)
+        internal static int INotifyRemoveWatch(SafeFileHandle fd, int wd)
         {
             int result = INotifyRemoveWatch_private(fd, wd);
             if (result < 0)

--- a/src/Common/src/Interop/Unix/Interop.IOErrors.cs
+++ b/src/Common/src/Interop/Unix/Interop.IOErrors.cs
@@ -51,15 +51,15 @@ internal static partial class Interop
     }
 
     /// <summary>
-    /// Validates the result of system call that returns a non-zero pointer on success
-    /// and a zero pointer on failure.
+    /// Validates the result of system call that returns greater than or equal to 0 on success
+    /// and less than 0 on failure, with errno set to the error code.
     /// If the system call failed due to interruption (EINTR), true is returned and 
     /// the caller should (usually) retry. If the system call failed for any other reason, 
     /// an exception is thrown. Otherwise, the system call succeeded, and false is returned.
     /// </summary>
-    internal static bool CheckIoPtr(IntPtr ptr, string path = null, bool isDirectory = false)
+    internal static bool CheckIo(IntPtr ptr, string path = null, bool isDirectory = false, Func<ErrorInfo, ErrorInfo> errorRewriter = null)
     {
-        return CheckIo(ptr == IntPtr.Zero ? -1 : 0, path, isDirectory);
+        return CheckIo((long)ptr, path, isDirectory, errorRewriter);
     }
 
     /// <summary>

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Close.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Close.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
@@ -8,6 +9,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static extern int Close(int fd);
+        internal static extern int Close(IntPtr fd);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Dup.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Dup.cs
@@ -1,13 +1,15 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static extern int Dup(int oldfd);
+        internal static extern IntPtr Dup(SafeFileHandle oldfd);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.FLock.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.FLock.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {
@@ -17,6 +18,13 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static extern int FLock(int fd, LockOperations operation);
+        internal static extern int FLock(SafeFileHandle fd, LockOperations operation);
+
+        /// <summary>
+        /// Exposing this for SafeFileHandle.ReleaseHandle() to call.
+        /// Normal callers should use FLock(SafeFileHandle fd).
+        /// </summary>
+        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        internal static extern int FLock(IntPtr fd, LockOperations operation);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.FTruncate.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.FTruncate.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static extern int FTruncate(int fd, long length);
+        internal static extern int FTruncate(SafeFileHandle fd, long length);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Fcntl.Pipe.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Fcntl.Pipe.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        internal static class Fcntl
+        {
+            internal static readonly bool CanGetSetPipeSz = (FcntlCanGetSetPipeSz() != 0);
+
+            [DllImport(Libraries.SystemNative, EntryPoint="FcntlGetPipeSz", SetLastError=true)]
+            internal static extern int GetPipeSz(SafePipeHandle fd);
+
+            [DllImport(Libraries.SystemNative, EntryPoint="FcntlSetPipeSz", SetLastError=true)]
+            internal static extern int SetPipeSz(SafePipeHandle fd, int size);
+
+            [DllImport(Libraries.SystemNative)]
+            private static extern int FcntlCanGetSetPipeSz();
+        }
+    }
+}

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Fcntl.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Fcntl.cs
@@ -10,22 +10,8 @@ internal static partial class Interop
     {
         internal static class Fcntl
         {
-            internal static readonly bool CanGetSetPipeSz = (FcntlCanGetSetPipeSz() != 0);
-
-            [DllImport(Libraries.SystemNative, EntryPoint="FcntlGetPipeSz", SetLastError=true)]
-            internal static extern int GetPipeSz(int fd);
-
-            [DllImport(Libraries.SystemNative, EntryPoint="FcntlSetPipeSz", SetLastError=true)]
-            internal static extern int SetPipeSz(int fd, int size);
-
-            [DllImport(Libraries.SystemNative)]
-            private static extern int FcntlCanGetSetPipeSz();
-
-            [DllImport(Libraries.SystemNative, EntryPoint="FcntlGetIsNonBlocking", SetLastError=true)]
-            internal static extern int GetIsNonBlocking(int fd);
-
             [DllImport(Libraries.SystemNative, EntryPoint="FcntlSetIsNonBlocking", SetLastError=true)]
-            internal static extern int SetIsNonBlocking(int fd, int isNonBlocking);
+            internal static extern int SetIsNonBlocking(IntPtr fd, int isNonBlocking);
         }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.FileDescriptors.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.FileDescriptors.cs
@@ -10,9 +10,14 @@ internal static partial class Interop
     {
         internal static class FileDescriptors
         {
-            internal static readonly SafeFileHandle STDIN_FILENO = new SafeFileHandle((IntPtr)0, false);
-            internal static readonly SafeFileHandle STDOUT_FILENO = new SafeFileHandle((IntPtr)1, false);
-            internal static readonly SafeFileHandle STDERR_FILENO = new SafeFileHandle((IntPtr)2, false);
+            internal static readonly SafeFileHandle STDIN_FILENO = CreateFileHandle(0);
+            internal static readonly SafeFileHandle STDOUT_FILENO = CreateFileHandle(1);
+            internal static readonly SafeFileHandle STDERR_FILENO = CreateFileHandle(2);
+
+            private static SafeFileHandle CreateFileHandle(int fileNumber)
+            {
+                return new SafeFileHandle((IntPtr)fileNumber, ownsHandle: false);
+            }
         }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.FileDescriptors.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.FileDescriptors.cs
@@ -1,15 +1,18 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
+using Microsoft.Win32.SafeHandles;
+
 internal static partial class Interop
 {
     internal static partial class Sys
     {
         internal static class FileDescriptors
         {
-            internal const int STDIN_FILENO = 0;
-            internal const int STDOUT_FILENO = 1;
-            internal const int STDERR_FILENO = 2;
+            internal static readonly SafeFileHandle STDIN_FILENO = new SafeFileHandle((IntPtr)0, false);
+            internal static readonly SafeFileHandle STDOUT_FILENO = new SafeFileHandle((IntPtr)1, false);
+            internal static readonly SafeFileHandle STDERR_FILENO = new SafeFileHandle((IntPtr)2, false);
         }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.IsATty.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.IsATty.cs
@@ -3,12 +3,13 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static extern bool IsATty(int fd);
+        internal static extern bool IsATty(SafeFileHandle fd);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.LSeek.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.LSeek.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {
@@ -16,6 +16,6 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static extern long LSeek(int fd, long offset, SeekWhence whence);
+        internal static extern long LSeek(SafeFileHandle fd, long offset, SeekWhence whence);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MMap.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MMap.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {
@@ -31,6 +32,6 @@ internal static partial class Interop
         internal static extern IntPtr MMap(
             IntPtr addr, ulong len, 
             MemoryMappedProtections prot, MemoryMappedFlags flags,
-            int fd, long offset);
+            SafeFileHandle fd, long offset);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MksTemps.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MksTemps.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
@@ -8,7 +9,7 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static extern int MksTemps(
+        internal static extern IntPtr MksTemps(
             byte[] template, 
             int suffixlen);
     }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Open.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Open.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Runtime.InteropServices;
 
 internal static partial class Interop
@@ -8,6 +9,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static extern int Open(string filename, OpenFlags flags, int mode);
+        internal static extern IntPtr Open(string filename, OpenFlags flags, int mode);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Poll.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Poll.cs
@@ -21,10 +21,9 @@ internal static partial class Interop
 
         internal struct PollEvent
         {
-            internal IntPtr FileDescriptor;      // The file descriptor to poll
+            internal int FileDescriptor;         // The file descriptor to poll
             internal PollEvents Events;          // The events to poll for
             internal PollEvents TriggeredEvents; // The events that occurred which triggered the poll
-            private readonly int __padding;
         }
 
         /// <summary>
@@ -55,7 +54,7 @@ internal static partial class Interop
 
                 var pollEvent = new PollEvent
                 {
-                    FileDescriptor = fd.DangerousGetHandle(),
+                    FileDescriptor = fd.DangerousGetHandle().ToInt32(),
                     Events = events,
                 };
 

--- a/src/Common/src/Interop/Unix/System.Native/Interop.PosixFAdvise.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.PosixFAdvise.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {
@@ -30,6 +30,6 @@ internal static partial class Interop
         /// Returns 0 on success; otherwise, the error code is returned
         /// </returns>
         [DllImport(Libraries.SystemNative, SetLastError = false /* this is explicitly called out in the man page */)]
-        internal static extern int PosixFAdvise(int fd, long offset, long length, FileAdvice advice);
+        internal static extern int PosixFAdvise(SafeFileHandle fd, long offset, long length, FileAdvice advice);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Read.Pipe.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Read.Pipe.cs
@@ -19,6 +19,6 @@ internal static partial class Interop
         /// Note - on fail. the position of the stream may change depending on the platform; consult man 2 read for more info
         /// </returns>
         [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static unsafe extern int Read(SafeFileHandle fd, byte* buffer, int count);
+        internal static unsafe extern int Read(SafePipeHandle fd, byte* buffer, int count);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.ShmOpen.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ShmOpen.cs
@@ -2,13 +2,14 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static extern int ShmOpen(string name, OpenFlags flags, int mode);
+        internal static extern SafeFileHandle ShmOpen(string name, OpenFlags flags, int mode);
 
         [DllImport(Libraries.SystemNative, SetLastError = true)]
         internal static extern int ShmUnlink(string name);

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Stat.Pipe.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Stat.Pipe.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 
@@ -9,6 +10,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static extern int FSync(SafeFileHandle fd);
+        internal static extern int FStat(SafePipeHandle fd, out FileStatus output);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Stat.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Stat.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {
@@ -45,7 +46,7 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static extern int FStat(int fd, out FileStatus output);
+        internal static extern int FStat(SafeFileHandle fd, out FileStatus output);
 
         [DllImport(Libraries.SystemNative, SetLastError = true)]
         internal static extern int Stat(string path, out FileStatus output);

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Write.Pipe.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Write.Pipe.cs
@@ -18,6 +18,6 @@ internal static partial class Interop
         /// Returns the number of bytes written on success; otherwise, returns -1 and sets errno
         /// </returns>
         [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static unsafe extern int Write(SafeFileHandle fd, byte* buffer, int bufferSize);
+        internal static unsafe extern int Write(SafePipeHandle fd, byte* buffer, int bufferSize);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Multi.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Multi.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {
@@ -23,7 +24,7 @@ internal static partial class Interop
         [DllImport(Libraries.HttpNative)]
         public static extern CURLMcode MultiWait(
             SafeCurlMultiHandle multiHandle,
-            int extraFileDescriptor,
+            SafeFileHandle extraFileDescriptor,
             out bool isExtraFileDescriptorActive,
             out bool isTimeout);
 

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -18,6 +18,11 @@ namespace Microsoft.Win32.SafeHandles
         {
         }
 
+        public SafeFileHandle(IntPtr preexistingHandle, bool ownsHandle) : this(ownsHandle)
+        {
+            SetHandle(preexistingHandle);
+        }
+
         /// <summary>Opens the specified file with the requested flags and mode.</summary>
         /// <param name="path">The path to the file.</param>
         /// <param name="flags">The flags with which to open the file.</param>
@@ -35,7 +40,7 @@ namespace Microsoft.Win32.SafeHandles
             bool enoentDueToDirectory = (flags & Interop.Sys.OpenFlags.O_CREAT) != 0;
 
             // Open the file. 
-            int fd;
+            IntPtr fd;
             while (Interop.CheckIo(fd = Interop.Sys.Open(path, flags, mode), path, isDirectory: enoentDueToDirectory,
                 errorRewriter: e => (e.Error == Interop.Error.EISDIR) ? Interop.Error.EACCES.Info() : e)) ;
             handle.SetHandle(fd);
@@ -43,7 +48,7 @@ namespace Microsoft.Win32.SafeHandles
             // Make sure it's not a directory; we do this after opening it once we have a file descriptor 
             // to avoid race conditions.
             Interop.Sys.FileStatus status;
-            if (Interop.Sys.FStat(fd, out status) != 0)
+            if (Interop.Sys.FStat(handle, out status) != 0)
             {
                 handle.Dispose();
                 throw Interop.GetExceptionForIoErrno(Interop.Sys.GetLastErrorInfo(), path);
@@ -63,38 +68,31 @@ namespace Microsoft.Win32.SafeHandles
         /// with Marshal.GetLastWin32Error() set to the error code.
         /// </param>
         /// <returns>The created SafeFileHandle.</returns>
-        internal static SafeFileHandle Open(Func<int> fdFunc)
+        internal static SafeFileHandle Open(Func<IntPtr> fdFunc)
         {
             var handle = new SafeFileHandle(ownsHandle: true);
-            int fd;
+            IntPtr fd;
             while (Interop.CheckIo(fd = fdFunc())) ;
             handle.SetHandle(fd);
+            Debug.Assert(!handle.IsInvalid, "File descriptor is invalid");
             return handle;
-        }
-
-        private void SetHandle(int fd)
-        {
-            SetHandle((IntPtr)fd);
-            Debug.Assert(!IsInvalid, "File descriptor is invalid");
         }
 
         [System.Security.SecurityCritical]
         protected override bool ReleaseHandle()
         {
-            int fd = (int)handle;
-
             // When the SafeFileHandle was opened, we likely issued an flock on the created descriptor in order to add 
             // an advisory lock.  This lock should be removed via closing the file descriptor, but close can be
             // interrupted, and we don't retry closes.  As such, we could end up leaving the file locked,
             // which could prevent subsequent usage of the file until this process dies.  To avoid that, we proactively
             // try to release the lock before we close the handle. (If it's not locked, there's no behavioral
             // problem trying to unlock it.)
-            Interop.Sys.FLock(fd, Interop.Sys.LockOperations.LOCK_UN); // ignore any errors
+            Interop.Sys.FLock(handle, Interop.Sys.LockOperations.LOCK_UN); // ignore any errors
 
             // Close the descriptor. Although close is documented to potentially fail with EINTR, we never want
             // to retry, as the descriptor could actually have been closed, been subsequently reassigned, and
             // be in use elsewhere in the process.  Instead, we simply check whether the call was successful.
-            int result = Interop.Sys.Close(fd);
+            int result = Interop.Sys.Close(handle);
 #if DEBUG
             if (result != 0)
             {

--- a/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/Common/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -13,6 +13,10 @@ namespace Microsoft.Win32.SafeHandles
         /// <summary>A handle value of -1.</summary>
         private static readonly IntPtr s_invalidHandle = new IntPtr(-1);
 
+        private SafeFileHandle() : this(ownsHandle: true)
+        {
+        }
+
         private SafeFileHandle(bool ownsHandle)
             : base(s_invalidHandle, ownsHandle)
         {

--- a/src/Common/src/System/Diagnostics/Debug.Unix.cs
+++ b/src/Common/src/System/Diagnostics/Debug.Unix.cs
@@ -90,7 +90,7 @@ namespace System.Diagnostics
                             int totalBytesWritten = 0;
                             while (bufCount > 0)
                             {
-                                int bytesWritten = Interop.Sys.Write((int)fileHandle.DangerousGetHandle(), buf + totalBytesWritten, bufCount);
+                                int bytesWritten = Interop.Sys.Write(fileHandle, buf + totalBytesWritten, bufCount);
                                 if (bytesWritten < 0)
                                 {
                                     if (Interop.Sys.GetLastErrorInfo().Error == Interop.Error.EINTR)

--- a/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
@@ -121,7 +121,7 @@ namespace System.Net.Sockets
                 {
                     GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") Following 'blockable' branch.");
 
-                    errorCode = Interop.Sys.Close((int)handle);
+                    errorCode = Interop.Sys.Close(handle);
                     if (errorCode == -1)
                     {
                         errorCode = (int)Interop.Sys.GetLastError();
@@ -145,11 +145,11 @@ namespace System.Net.Sockets
 
                     // The socket must be non-blocking with a linger timeout set.
                     // We have to set the socket to blocking.
-                    errorCode = Interop.Sys.Fcntl.SetIsNonBlocking((int)handle, 0);
+                    errorCode = Interop.Sys.Fcntl.SetIsNonBlocking(handle, 0);
                     if (errorCode == 0)
                     {
                         // The socket successfully made blocking; retry the close().
-                        errorCode = Interop.Sys.Close((int)handle);
+                        errorCode = Interop.Sys.Close(handle);
 
                         GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") close()#2:" + errorCode.ToString());
 #if DEBUG
@@ -184,7 +184,7 @@ namespace System.Net.Sockets
                     return SocketPal.GetSocketErrorForErrorCode((Interop.Error)errorCode);
                 }
 
-                errorCode = Interop.Sys.Close((int)handle);
+                errorCode = Interop.Sys.Close(handle);
 #if DEBUG
                 _closeSocketHandle = handle;
                 _closeSocketResult = SocketPal.GetSocketErrorForErrorCode((Interop.Error)errorCode);
@@ -213,10 +213,10 @@ namespace System.Net.Sockets
 
                     // The socket was created successfully; make it non-blocking and enable
                     // IPV6_V6ONLY by default for AF_INET6 sockets.
-                    int err = Interop.Sys.Fcntl.SetIsNonBlocking(fd, 1);
+                    int err = Interop.Sys.Fcntl.SetIsNonBlocking((IntPtr)fd, 1);
                     if (err != 0)
                     {
-                        Interop.Sys.Close(fd);
+                        Interop.Sys.Close((IntPtr)fd);
                         fd = -1;
                         errorCode = SocketError.SocketError;
                     }
@@ -226,7 +226,7 @@ namespace System.Net.Sockets
                         error = Interop.Sys.SetSockOpt(fd, SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, (byte*)&on, sizeof(int));
                         if (error != Interop.Error.SUCCESS)
                         {
-                            Interop.Sys.Close(fd);
+                            Interop.Sys.Close((IntPtr)fd);
                             fd = -1;
                             errorCode = SocketPal.GetSocketErrorForErrorCode(error);
                         }

--- a/src/Common/src/System/Net/SocketProtocolSupportPal.Unix.cs
+++ b/src/Common/src/System/Net/SocketProtocolSupportPal.Unix.cs
@@ -64,7 +64,7 @@ namespace System.Net
             {
                 if (socket != -1)
                 {
-                    Interop.Sys.Close(socket);
+                    Interop.Sys.Close((IntPtr)socket);
                 }
             }
         }

--- a/src/Native/Common/pal_config.h.in
+++ b/src/Native/Common/pal_config.h.in
@@ -45,6 +45,7 @@
 #cmakedefine01 HAVE_CURLPIPE_MULTIPLEX
 #cmakedefine01 HAVE_TCP_H_TCPSTATE_ENUM
 #cmakedefine01 HAVE_TCP_FSM_H
+#cmakedefine01 HAVE_OPEN_MAX
 
 // Mac OS X has stat64, but it is deprecated since plain stat now
 // provides the same 64-bit aware struct when targeting OS X > 10.5

--- a/src/Native/Common/pal_utilities.h
+++ b/src/Native/Common/pal_utilities.h
@@ -130,3 +130,11 @@ inline static int ToFileDescriptor(intptr_t fd)
     return static_cast<int>(fd);
 }
 
+/**
+* Converts an intptr_t to a file descriptor.
+* intptr_t is the type used to marshal file descriptors so we can use SafeHandles effectively.
+*/
+inline static int ToFileDescriptorUnchecked(intptr_t fd)
+{
+    return static_cast<int>(fd);
+}

--- a/src/Native/Common/pal_utilities.h
+++ b/src/Native/Common/pal_utilities.h
@@ -13,6 +13,10 @@
 #include <string.h>
 #include <type_traits>
 
+#if HAVE_OPEN_MAX
+#include <sys/syslimits.h>
+#endif
+
 /**
  * ResultOf<T> is shorthand for typename std::result_of<T>::type.
  * Equivalent to C++14 std::result_of_t.
@@ -110,3 +114,19 @@ inline void SafeStringCopy(char* destination, int32_t destinationSize, const cha
         SafeStringCopy(destination, unsignedSize, source);
     }
 }
+
+/**
+* Converts an intptr_t to a file descriptor.
+* intptr_t is the type used to marshal file descriptors so we can use SafeHandles effectively.
+*/
+inline static int ToFileDescriptor(intptr_t fd)
+{
+#if HAVE_OPEN_MAX
+    assert(0 <= fd && fd <= OPEN_MAX);
+#else
+    assert(0 <= fd && fd <= INT32_MAX);
+#endif
+
+    return static_cast<int>(fd);
+}
+

--- a/src/Native/System.Native/pal_console.cpp
+++ b/src/Native/System.Native/pal_console.cpp
@@ -37,8 +37,7 @@ extern "C" int32_t GetWindowSize(WinSize* windowSize)
 
 extern "C" int32_t IsATty(intptr_t fd)
 {
-    assert(INT32_MIN <= fd && fd <= INT32_MAX);
-    return isatty(static_cast<int>(fd));
+    return isatty(ToFileDescriptor(fd));
 }
 
 static bool g_initialized = false;

--- a/src/Native/System.Native/pal_console.cpp
+++ b/src/Native/System.Native/pal_console.cpp
@@ -35,9 +35,10 @@ extern "C" int32_t GetWindowSize(WinSize* windowSize)
 #endif
 }
 
-extern "C" int32_t IsATty(int fd)
+extern "C" int32_t IsATty(intptr_t fd)
 {
-    return isatty(fd);
+    assert(INT32_MIN <= fd && fd <= INT32_MAX);
+    return isatty(static_cast<int>(fd));
 }
 
 static bool g_initialized = false;

--- a/src/Native/System.Native/pal_console.h
+++ b/src/Native/System.Native/pal_console.h
@@ -29,7 +29,7 @@ extern "C" int32_t GetWindowSize(WinSize* windowsSize);
  * Returns 1 if the file descriptor is referring to a terminal;
  * otherwise returns 0 and sets errno.
  */
-extern "C" int32_t IsATty(int filedes);
+extern "C" int32_t IsATty(intptr_t fd);
 
 /**
  * Initializes the console for use by System.Console.

--- a/src/Native/System.Native/pal_io.cpp
+++ b/src/Native/System.Native/pal_io.cpp
@@ -127,12 +127,6 @@ static_assert(PAL_IN_EXCL_UNLINK == IN_EXCL_UNLINK, "");
 static_assert(PAL_IN_ISDIR == IN_ISDIR, "");
 #endif
 
-inline static int ToFileDescriptor(intptr_t fd)
-{
-    assert(INT32_MIN <= fd && fd <= INT32_MAX);
-    return static_cast<int>(fd);
-}
-
 static void ConvertFileStatus(const struct stat_& src, FileStatus* dst)
 {
     dst->Flags = FILESTATUS_FLAGS_NONE;
@@ -719,7 +713,7 @@ extern "C" Error Poll(PollEvent* pollEvents, uint32_t eventCount, int32_t millis
     for (uint32_t i = 0; i < eventCount; i++)
     {
         const PollEvent& event = pollEvents[i];
-        pollfds[i] = { .fd = ToFileDescriptor(event.FileDescriptor), .events = event.Events, .revents = 0 };
+        pollfds[i] = { .fd = event.FileDescriptor, .events = event.Events, .revents = 0 };
     }
 
     int rv = poll(pollfds, static_cast<nfds_t>(eventCount), milliseconds);

--- a/src/Native/System.Native/pal_io.cpp
+++ b/src/Native/System.Native/pal_io.cpp
@@ -570,7 +570,8 @@ extern "C" void* MMap(void* address,
         return nullptr;
     }
 
-    void* ret = mmap(address, static_cast<size_t>(length), protection, flags, ToFileDescriptor(fd), offset);
+    // Use ToFileDescriptorUnchecked to allow -1 to be passed for the file descriptor, since managed code explicitly uses -1
+    void* ret = mmap(address, static_cast<size_t>(length), protection, flags, ToFileDescriptorUnchecked(fd), offset);
     if (ret == MAP_FAILED)
     {
         return nullptr;

--- a/src/Native/System.Native/pal_io.h
+++ b/src/Native/System.Native/pal_io.h
@@ -252,9 +252,10 @@ struct DirectoryEntry
  */
 struct PollEvent
 {
-    int32_t    FileDescriptor;  // The file descriptor to poll
+    intptr_t   FileDescriptor;  // The file descriptor to poll
     PollEvents Events;          // The events to poll for
     PollEvents TriggeredEvents; // The events that triggered the poll
+    int32_t __padding;
 };
 
 /**
@@ -278,11 +279,11 @@ enum NotifyEvents : int32_t
 };
 
 /**
- * Get file status from a decriptor. Implemented as shim to fstat(2).
+ * Get file status from a descriptor. Implemented as shim to fstat(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C" int32_t FStat(int32_t fd, FileStatus* output);
+extern "C" int32_t FStat(intptr_t fd, FileStatus* output);
 
 /**
  * Get file status from a full path. Implemented as shim to stat(2).
@@ -303,21 +304,21 @@ extern "C" int32_t LStat(const char* path, FileStatus* output);
  *
  * Returns file descriptor or -1 for failure. Sets errno on failure.
  */
-extern "C" int32_t Open(const char* path, int32_t flags, int32_t mode);
+extern "C" intptr_t Open(const char* path, int32_t flags, int32_t mode);
 
 /**
  * Close a file descriptor. Implemented as shim to open(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C" int32_t Close(int32_t fd);
+extern "C" int32_t Close(intptr_t fd);
 
 /**
  * Duplicates a file descriptor.
  *
  * Returns the duplication descriptor for success, -1 for failure. Sets errno on failure.
  */
-extern "C" int32_t Dup(int32_t oldfd);
+extern "C" intptr_t Dup(intptr_t oldfd);
 
 /**
  * Delete an entry from the file system. Implemented as shim to unlink(2).
@@ -331,7 +332,7 @@ extern "C" int32_t Unlink(const char* path);
  *
  * Returns file descriptor or -1 on fiailure. Sets errno on failure.
  */
-extern "C" int32_t ShmOpen(const char* name, int32_t flags, int32_t mode);
+extern "C" intptr_t ShmOpen(const char* name, int32_t flags, int32_t mode);
 
 /**
  * Unlink a shared memory object. Implemented as shim to shm_unlink(3).
@@ -389,7 +390,7 @@ extern "C" int32_t FcntlCanGetSetPipeSz();
  *
  * NOTE: Some platforms do not support this operation and will always fail with errno = ENOTSUP.
  */
-extern "C" int32_t FcntlGetPipeSz(int32_t fd);
+extern "C" int32_t FcntlGetPipeSz(intptr_t fd);
 
 /**
  * Sets the capacity of a pipe.
@@ -398,21 +399,14 @@ extern "C" int32_t FcntlGetPipeSz(int32_t fd);
  *
  * NOTE: Some platforms do not support this operation and will always fail with errno = ENOTSUP.
  */
-extern "C" int32_t FcntlSetPipeSz(int32_t fd, int32_t size);
-
-/**
- * Indicates whether or not a file descriptor is non-blocking.
- *
- * Returns 1 for true, 0 for false, and -1 for failure. Sets errno for failure.
- */
-extern "C" int32_t FcntlGetIsNonBlocking(int32_t fd);
+extern "C" int32_t FcntlSetPipeSz(intptr_t fd, int32_t size);
 
 /**
  * Sets whether or not a file descriptor is non-blocking.
  *
  * Returns 0 for success, -1 for failure. Sets errno for failure.
  */
-extern "C" int32_t FcntlSetIsNonBlocking(int32_t fd, int32_t isNonBlocking);
+extern "C" int32_t FcntlSetIsNonBlocking(intptr_t fd, int32_t isNonBlocking);
 
 /**
  * Create a directory. Implemented as a shim to mkdir(2).
@@ -440,14 +434,14 @@ extern "C" int32_t MkFifo(const char* path, int32_t mode);
  *
  * Returns 0 for success; on fail, -1 is returned and errno is set.
  */
-extern "C" int32_t FSync(int32_t fd);
+extern "C" int32_t FSync(intptr_t fd);
 
 /**
  * Changes the advisory lock status on a given File Descriptor
  *
  * Returns 0 on success; otherwise, -1 is returned and errno is set
  */
-extern "C" int32_t FLock(int32_t fd, LockOperations operation);
+extern "C" int32_t FLock(intptr_t fd, LockOperations operation);
 
 /**
  * Changes the current working directory to be the specified path.
@@ -478,7 +472,7 @@ extern "C" int32_t FnMatch(const char* pattern, const char* path, FnMatchFlags f
  * On success, the resulting offet, in bytes, from the begining of the stream; otherwise,
  * returns -1 and errno is set.
  */
-extern "C" int64_t LSeek(int32_t fd, int64_t offset, SeekWhence whence);
+extern "C" int64_t LSeek(intptr_t fd, int64_t offset, SeekWhence whence);
 
 /**
  * Creates a hard-link at link pointing to source.
@@ -493,7 +487,7 @@ extern "C" int32_t Link(const char* source, const char* linkTarget);
  *
  * Returns a valid File Descriptor on success; otherwise, returns -1 and errno is set.
  */
-extern "C" int32_t MksTemps(char* pathTemplate, int32_t suffixLength);
+extern "C" intptr_t MksTemps(char* pathTemplate, int32_t suffixLength);
 
 /**
  * Map file or device into memory. Implemented as shim to mmap(2).
@@ -507,7 +501,7 @@ extern "C" void* MMap(void* address,
                       uint64_t length,
                       int32_t protection, // bitwise OR of PAL_PROT_*
                       int32_t flags,      // bitwise OR of PAL_MAP_*, but PRIVATE and SHARED are mutually exclusive.
-                      int32_t fd,
+                      intptr_t fd,
                       int64_t offset);
 
 /**
@@ -568,7 +562,7 @@ extern "C" int64_t SysConf(SysConfName name);
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C" int32_t FTruncate(int32_t fd, int64_t length);
+extern "C" int32_t FTruncate(intptr_t fd, int64_t length);
 
 /**
  * Examines one or more file descriptors for the specified state(s) and blocks until the state(s) occur or the timeout
@@ -585,7 +579,7 @@ extern "C" Error Poll(PollEvent* pollEvents, uint32_t eventCount, int32_t millis
  *
  * Returns 0 on success; otherwise, the error code is returned and errno is NOT set.
  */
-extern "C" int32_t PosixFAdvise(int32_t fd, int64_t offset, int64_t length, FileAdvice advice);
+extern "C" int32_t PosixFAdvise(intptr_t fd, int64_t offset, int64_t length, FileAdvice advice);
 
 /**
  * Reads the number of bytes specified into the provided buffer from the specified, opened file descriptor.
@@ -594,7 +588,7 @@ extern "C" int32_t PosixFAdvise(int32_t fd, int64_t offset, int64_t length, File
  *
  * Note - on fail. the position of the stream may change depending on the platform; consult man 2 read for more info
  */
-extern "C" int32_t Read(int32_t fd, void* buffer, int32_t bufferSize);
+extern "C" int32_t Read(intptr_t fd, void* buffer, int32_t bufferSize);
 
 /**
  * Takes a path to a symbolic link and attempts to place the link target path into the buffer. If the buffer is too
@@ -629,7 +623,7 @@ extern "C" void Sync();
  *
  * Returns the number of bytes written on success; otherwise, returns -1 and sets errno
  */
-extern "C" int32_t Write(int32_t fd, const void* buffer, int32_t bufferSize);
+extern "C" int32_t Write(intptr_t fd, const void* buffer, int32_t bufferSize);
 
 /**
 * Initializes a new inotify instance and returns a file
@@ -638,7 +632,7 @@ extern "C" int32_t Write(int32_t fd, const void* buffer, int32_t bufferSize);
 * Returns a new file descriptor on success.
 * On error, -1 is returned, and errno is set to indicate the error.
 */
-extern "C" int32_t INotifyInit();
+extern "C" intptr_t INotifyInit();
 
 /**
 * Adds a new watch, or modifies an existing watch,
@@ -647,7 +641,7 @@ extern "C" int32_t INotifyInit();
 * Returns a nonnegative watch descriptor on success.
 * On error -1 is returned and errno is set appropriately.
 */
-extern "C" int32_t INotifyAddWatch(int32_t fd, const char* pathName, uint32_t mask);
+extern "C" int32_t INotifyAddWatch(intptr_t fd, const char* pathName, uint32_t mask);
 
 /**
 * Removes the watch associated with the watch descriptor wd
@@ -655,4 +649,4 @@ extern "C" int32_t INotifyAddWatch(int32_t fd, const char* pathName, uint32_t ma
 *
 * Returns 0 on success, or -1 if an error occurred (in which case, errno is set appropriately).
 */
-extern "C" int32_t INotifyRemoveWatch(int32_t fd, int32_t wd);
+extern "C" int32_t INotifyRemoveWatch(intptr_t fd, int32_t wd);

--- a/src/Native/System.Native/pal_io.h
+++ b/src/Native/System.Native/pal_io.h
@@ -252,10 +252,9 @@ struct DirectoryEntry
  */
 struct PollEvent
 {
-    intptr_t   FileDescriptor;  // The file descriptor to poll
+    int32_t    FileDescriptor;  // The file descriptor to poll
     PollEvents Events;          // The events to poll for
     PollEvents TriggeredEvents; // The events that triggered the poll
-    int32_t __padding;
 };
 
 /**

--- a/src/Native/System.Net.Http.Native/pal_multi.cpp
+++ b/src/Native/System.Net.Http.Native/pal_multi.cpp
@@ -3,6 +3,7 @@
 
 #include "pal_config.h"
 #include "pal_multi.h"
+#include "pal_utilities.h"
 
 #include <assert.h>
 
@@ -43,14 +44,14 @@ extern "C" int32_t MultiRemoveHandle(CURLM* multiHandle, CURL* easyHandle)
     return curl_multi_remove_handle(multiHandle, easyHandle);
 }
 
-extern "C" int32_t MultiWait(CURLM* multiHandle, int32_t extraFileDescriptor, int32_t* isExtraFileDescriptorActive, int32_t* isTimeout)
+extern "C" int32_t MultiWait(CURLM* multiHandle, intptr_t extraFileDescriptor, int32_t* isExtraFileDescriptorActive, int32_t* isTimeout)
 {
     assert(isExtraFileDescriptorActive != nullptr);
     assert(isTimeout != nullptr);
 
     curl_waitfd extraFds =
     {
-        .fd = extraFileDescriptor,
+        .fd = ToFileDescriptor(extraFileDescriptor),
         .events = CURL_WAIT_POLLIN,
         .revents = 0
     };

--- a/src/Native/System.Net.Http.Native/pal_multi.h
+++ b/src/Native/System.Net.Http.Native/pal_multi.h
@@ -70,7 +70,7 @@ Returns CURLM_OK on success, otherwise an error code.
 isExtraFileDescriptorActive is set to a value indicating whether extraFileDescriptor has new data received.
 isTimeout is set to a value indicating whether a timeout was encountered before any file descriptors had events occur.
 */
-extern "C" int32_t MultiWait(CURLM* multiHandle, int32_t extraFileDescriptor, int32_t* isExtraFileDescriptorActive, int32_t* isTimeout);
+extern "C" int32_t MultiWait(CURLM* multiHandle, intptr_t extraFileDescriptor, int32_t* isExtraFileDescriptorActive, int32_t* isTimeout);
 
 /*
 Reads/writes available data from each easy handle.

--- a/src/Native/configure.cmake
+++ b/src/Native/configure.cmake
@@ -312,6 +312,11 @@ check_cxx_source_compiles(
     "
     HAVE_CURLPIPE_MULTIPLEX)
 
+check_symbol_exists(
+    OPEN_MAX
+    "sys/syslimits.h"
+    HAVE_OPEN_MAX)
+
 set (CMAKE_REQUIRED_LIBRARIES)
 
 configure_file(

--- a/src/System.Console/src/System/TermInfo.cs
+++ b/src/System.Console/src/System/TermInfo.cs
@@ -212,7 +212,7 @@ namespace System
             private static bool TryOpen(string filePath, out SafeFileHandle fd)
             {
                 IntPtr tmpFd;
-                while ((int)(tmpFd = Interop.Sys.Open(filePath, Interop.Sys.OpenFlags.O_RDONLY, 0)) < 0)
+                while ((long)(tmpFd = Interop.Sys.Open(filePath, Interop.Sys.OpenFlags.O_RDONLY, 0)) < 0)
                 {
                     // Don't throw in this case, as we'll be polling multiple locations looking for the file.
                     // But we still want to retry if the open is interrupted by a signal.

--- a/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
+++ b/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
@@ -14,6 +14,14 @@
       <Name>System.IO.FileSystem.Watcher</Name>
       <Private>True</Private>
     </ProjectReference>
+    <!-- TODO: Temporary workaround.  This PR introduces a change in System.IO.FileSystem to enable SafeFileHandles
+         to be returned from a P/Invoke. Due to how tests are run in CI, this results in a MissingMethodException 
+         when the System.IO.FileSystem.Watcher.Tests are run. The following is a temporary work around and will be removed as 
+         soon as the dlls get in sync. -->
+    <ProjectReference Include="..\..\System.IO.FileSystem\src\System.IO.FileSystem.csproj">
+      <Name>System.IO.FileSystem</Name>
+      <Project>{879C23DC-D828-4DFB-8E92-ABBC11B71035}</Project>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="FileSystemWatcher.Changed.cs" />

--- a/src/System.IO.FileSystem/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
+++ b/src/System.IO.FileSystem/src/Microsoft/Win32/SafeHandles/SafeFileHandle.Unix.cs
@@ -11,11 +11,6 @@ namespace Microsoft.Win32.SafeHandles
 {
     public sealed partial class SafeFileHandle : SafeHandle
     {
-        public SafeFileHandle(IntPtr preexistingHandle, bool ownsHandle) : this(ownsHandle)
-        {
-            SetHandle(preexistingHandle);
-        }
-
         internal bool? IsAsync { get; set; }
     }
 }

--- a/src/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
+++ b/src/System.IO.MemoryMappedFiles/tests/System.IO.MemoryMappedFiles.Tests.csproj
@@ -48,6 +48,14 @@
       <Project>{16EE5522-F387-4C9E-9EF2-B5134B043F37}</Project>
       <Name>System.IO.MemoryMappedFiles</Name>
     </ProjectReference>
+    <!-- TODO: Temporary workaround.  This PR introduces a change in System.IO.FileSystem to enable SafeFileHandles
+         to be returned from a P/Invoke. Due to how tests are run in CI, this results in a MissingMethodException 
+         when the System.IO.MemoryMappedFiles.Tests are run. The following is a temporary work around and will be removed as 
+         soon as the dlls get in sync. -->
+    <ProjectReference Include="..\..\System.IO.FileSystem\src\System.IO.FileSystem.csproj">
+      <Name>System.IO.FileSystem</Name>
+      <Project>{879C23DC-D828-4DFB-8E92-ABBC11B71035}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.Pipes/src/Microsoft/Win32/SafeHandles/SafePipeHandle.Unix.cs
+++ b/src/System.IO.Pipes/src/Microsoft/Win32/SafeHandles/SafePipeHandle.Unix.cs
@@ -19,21 +19,16 @@ namespace Microsoft.Win32.SafeHandles
         /// <returns>A SafeFileHandle for the opened file.</returns>
         internal static SafePipeHandle Open(string path, Interop.Sys.OpenFlags flags, int mode)
         {
-            // SafePipeHandle wraps a file descriptor rather than a pointer, and a file descriptor is always 4 bytes
-            // rather than being pointer sized, which means we can't utilize the runtime's ability to marshal safe handles.
             // Ideally this would be a constrained execution region, but we don't have access to PrepareConstrainedRegions.
-            // We still use a finally block to house the code that opens the file and stores the handle in hopes
-            // of making it as non-interruptable as possible.  The SafePipeHandle is also allocated first to avoid
-            // the allocation after getting the file descriptor but before storing it.
+            // The SafePipeHandle is allocated first to avoid the allocation after getting the file descriptor but before storing it.
             SafePipeHandle handle = new SafePipeHandle();
-            try { }
-            finally
-            {
-                int fd;
-                while (Interop.CheckIo(fd = Interop.Sys.Open(path, flags, mode))) ;
-                Debug.Assert(fd >= 0);
-                handle.SetHandle((IntPtr)fd);
-            }
+
+            IntPtr fd;
+            while (Interop.CheckIo(fd = Interop.Sys.Open(path, flags, mode))) ;
+
+            handle.SetHandle(fd);
+            Debug.Assert(!handle.IsInvalid);
+
             return handle;
         }
 
@@ -42,9 +37,8 @@ namespace Microsoft.Win32.SafeHandles
             // Close the handle. Although close is documented to potentially fail with EINTR, we never want
             // to retry, as the descriptor could actually have been closed, been subsequently reassigned, and
             // be in use elsewhere in the process.  Instead, we simply check whether the call was successful.
-            int fd = (int)handle;
-            Debug.Assert(fd >= 0);
-            return Interop.Sys.Close(fd) == 0;
+            Debug.Assert(!this.IsInvalid);
+            return Interop.Sys.Close(handle) == 0;
         }
 
         public override bool IsInvalid

--- a/src/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -158,8 +158,8 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Close.cs">
       <Link>Common\Interop\Unix\Interop.Close.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Fcntl.cs">
-      <Link>Common\Interop\Unix\Interop.Fcntl.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Fcntl.Pipe.cs">
+      <Link>Common\Interop\Unix\Interop.Fcntl.Pipe.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.FLock.cs">
       <Link>Common\Interop\Unix\Interop.FLock.cs</Link>
@@ -188,17 +188,20 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Poll.cs">
       <Link>Common\Interop\Unix\Interop.Poll.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Read.cs">
-      <Link>Common\Interop\Unix\Interop.Read.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Read.Pipe.cs">
+      <Link>Common\Interop\Unix\Interop.Read.Pipe.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Unlink.cs">
       <Link>Common\Interop\Unix\Interop.Unlink.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Write.cs">
-      <Link>Common\Interop\Unix\Interop.Write.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Write.Pipe.cs">
+      <Link>Common\Interop\Unix\Interop.Write.Pipe.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Stat.cs">
       <Link>Common\Interop\Unix\Interop.Stat.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Stat.Pipe.cs">
+      <Link>Common\Interop\Unix\Interop.Stat.Pipe.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\IO\PersistedFiles.Names.Unix.cs">
       <Link>Common\System\IO\PersistedFiles.Names.Unix.cs</Link>

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -361,8 +361,8 @@ namespace System.IO.Pipes
                             // We want to wait for data to be available on either the pipe we want to read from
                             // or on the cancellation pipe, which would signal a cancellation request.
                             Interop.Sys.PollEvent* events = stackalloc Interop.Sys.PollEvent[2];
-                            events[0] = new Interop.Sys.PollEvent { FileDescriptor = fd.DangerousGetHandle(), Events = Interop.Sys.PollEvents.POLLIN };
-                            events[1] = new Interop.Sys.PollEvent { FileDescriptor = cancellationFd, Events = Interop.Sys.PollEvents.POLLIN };
+                            events[0] = new Interop.Sys.PollEvent { FileDescriptor = (int)fd.DangerousGetHandle(), Events = Interop.Sys.PollEvents.POLLIN };
+                            events[1] = new Interop.Sys.PollEvent { FileDescriptor = (int)cancellationFd, Events = Interop.Sys.PollEvents.POLLIN };
 
                             // Some systems (at least OS X) appear to have a race condition in poll with FIFOs where the poll can 
                             // end up not noticing writes of greater than the internal buffer size.  Restarting the poll causes it 

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -361,8 +361,8 @@ namespace System.IO.Pipes
                             // We want to wait for data to be available on either the pipe we want to read from
                             // or on the cancellation pipe, which would signal a cancellation request.
                             Interop.Sys.PollEvent* events = stackalloc Interop.Sys.PollEvent[2];
-                            events[0] = new Interop.Sys.PollEvent { FileDescriptor = fd, Events = Interop.Sys.PollEvents.POLLIN };
-                            events[1] = new Interop.Sys.PollEvent { FileDescriptor = (int)cancellationFd, Events = Interop.Sys.PollEvents.POLLIN };
+                            events[0] = new Interop.Sys.PollEvent { FileDescriptor = fd.DangerousGetHandle(), Events = Interop.Sys.PollEvents.POLLIN };
+                            events[1] = new Interop.Sys.PollEvent { FileDescriptor = cancellationFd, Events = Interop.Sys.PollEvents.POLLIN };
 
                             // Some systems (at least OS X) appear to have a race condition in poll with FIFOs where the poll can 
                             // end up not noticing writes of greater than the internal buffer size.  Restarting the poll causes it 
@@ -498,19 +498,8 @@ namespace System.IO.Pipes
             CancellationTokenRegistration reg = cancellationToken.Register(s =>
             {
                 SafePipeHandle sendRef = (SafePipeHandle)s;
-                bool gotSendRef = false;
-                try
-                {
-                    sendRef.DangerousAddRef(ref gotSendRef);
-                    int fd = (int)sendRef.DangerousGetHandle();
                     byte b = 1;
-                    while (Interop.CheckIo((int)Interop.Sys.Write(fd, &b, 1))) ;
-                }
-                finally
-                {
-                    if (gotSendRef)
-                        sendRef.DangerousRelease();
-                }
+                while (Interop.CheckIo(Interop.Sys.Write(sendRef, &b, 1))) ;
             }, send);
 
             // Return a disposable struct that will unregister the cancellation registration
@@ -570,43 +559,27 @@ namespace System.IO.Pipes
         /// </remarks>
         private long SysCall(
             SafePipeHandle handle,
-            Func<int, IntPtr, int, IntPtr, long> sysCall,
+            Func<SafePipeHandle, IntPtr, int, IntPtr, long> sysCall,
             IntPtr arg1 = default(IntPtr), int arg2 = default(int), IntPtr arg3 = default(IntPtr))
         {
-            bool gotRefOnHandle = false;
-            try
+            Debug.Assert(!handle.IsInvalid);
+
+            while (true)
             {
-                // Get the file descriptor from the handle.  We increment the ref count to help
-                // ensure it's not closed out from under us.
-                handle.DangerousAddRef(ref gotRefOnHandle);
-                Debug.Assert(gotRefOnHandle);
-                int fd = (int)handle.DangerousGetHandle();
-                Debug.Assert(fd >= 0);
-
-                while (true)
+                long result = sysCall(handle, arg1, arg2, arg3);
+                if (result == -1)
                 {
-                    long result = sysCall(fd, arg1, arg2, arg3);
-                    if (result == -1)
-                    {
-                        Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();
+                    Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();
 
-                        if (errorInfo.Error == Interop.Error.EINTR)
-                            continue;
+                    if (errorInfo.Error == Interop.Error.EINTR)
+                        continue;
 
-                        if (errorInfo.Error == Interop.Error.EPIPE)
-                            State = PipeState.Broken;
+                    if (errorInfo.Error == Interop.Error.EPIPE)
+                        State = PipeState.Broken;
 
-                        throw Interop.GetExceptionForIoErrno(errorInfo);
-                    }
-                    return result;
+                    throw Interop.GetExceptionForIoErrno(errorInfo);
                 }
-            }
-            finally
-            {
-                if (gotRefOnHandle)
-                {
-                    handle.DangerousRelease();
-                }
+                return result;
             }
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -294,7 +294,7 @@ namespace System.Net.Http
                         // Wait for more things to do.
                         bool isWakeupRequestedPipeActive;
                         bool isTimeout;
-                        ThrowIfCURLMError(Interop.Http.MultiWait(multiHandle, (int)_wakeupRequestedPipeFd.DangerousGetHandle(), out isWakeupRequestedPipeActive, out isTimeout));
+                        ThrowIfCURLMError(Interop.Http.MultiWait(multiHandle, _wakeupRequestedPipeFd, out isWakeupRequestedPipeActive, out isTimeout));
                         if (isWakeupRequestedPipeActive)
                         {
                             // We woke up (at least in part) because a wake-up was requested.  

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -521,7 +521,7 @@ namespace System.Net.Sockets
                 Debug.Assert(fd != -1);
 
                 // If the accept completed successfully, ensure that the accepted socket is non-blocking.
-                int err = Interop.Sys.Fcntl.SetIsNonBlocking(fd, 1);
+                int err = Interop.Sys.Fcntl.SetIsNonBlocking((IntPtr)fd, 1);
                 if (err == 0)
                 {
                     socketAddressLen = sockAddrLen;
@@ -532,7 +532,7 @@ namespace System.Net.Sockets
                 {
                     errorCode = GetSocketErrorForErrorCode(Interop.Sys.GetLastError());
                     acceptedFd = -1;
-                    Interop.Sys.Close(fd);
+                    Interop.Sys.Close((IntPtr)fd);
                 }
 
                 return true;

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.CoreCLR.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.CoreCLR.csproj
@@ -117,16 +117,16 @@
       <Link>Common\Interop\Unix\System.Native\Interop.Close.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetCwd.cs">
-      <Link>Common\Interop\Unix\libc\Interop.GetCwd.cs</Link>
+      <Link>Common\Interop\Unix\System.Native\Interop.GetCwd.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetTimestamp.cs">
-      <Link>Common\Interop\Unix\libc\Interop.GetTimestamp.cs</Link>
+      <Link>Common\Interop\Unix\System.Native\Interop.GetTimestamp.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.MksTemps.cs">
-      <Link>Common\Interop\Unix\libc\Interop.MksTemps.cs</Link>
+      <Link>Common\Interop\Unix\System.Native\Interop.MksTemps.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.PathConf.cs">
-      <Link>Common\Interop\Unix\libc\Interop.PathConf.cs</Link>
+      <Link>Common\Interop\Unix\System.Native\Interop.PathConf.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs">
       <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Initialization.cs</Link>

--- a/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
@@ -93,7 +93,7 @@ namespace System.IO
             byte[] name = Encoding.UTF8.GetBytes(template);
 
             // Create, open, and close the temp file.
-            int fd;
+            IntPtr fd;
             Interop.CheckIo(fd = Interop.Sys.MksTemps(name, SuffixByteLength));
             Interop.Sys.Close(fd); // ignore any errors from close; nothing to do if cleanup isn't possible
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/DirectoryBasedStoreProvider.cs
@@ -475,12 +475,8 @@ namespace Internal.Cryptography.Pal
                 Interop.Sys.Permissions.S_IRGRP |
                 Interop.Sys.Permissions.S_IWGRP;
 
-            // NOTE: no need to call DangerousAddRef here, since the FileStream is 
-            // held open outside of this method
-            int fileDescriptor = (int)stream.SafeFileHandle.DangerousGetHandle();
-
             Interop.Sys.FileStatus stat;
-            if (Interop.Sys.FStat(fileDescriptor, out stat) != 0)
+            if (Interop.Sys.FStat(stream.SafeFileHandle, out stat) != 0)
             {
                 Interop.ErrorInfo error = Interop.Sys.GetLastErrorInfo();
                 throw new CryptographicException(


### PR DESCRIPTION
Changing all file descriptors used in System.Native to use intptr_t instead of int32_t.  This way we can marshal SafeHandles without having to add DangerousAddRef/Release code.

Fix #2904.

@nguerrera @stephentoub @sokket 

@pgavlin - can you take a look at the Sockets changes?