### PR TITLE
Fix a compilation error in native FreeBSD build

### DIFF
--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -2006,7 +2006,7 @@ Select(int32_t fdCount, uint32_t* readFdSet, uint32_t* writeFdSet, uint32_t* err
         return PAL_EFAULT;
     }
 
-    if (fdCount < 0 || fdCount >= FD_SETSIZE || microseconds < -1)
+    if (fdCount < 0 || static_cast<uint32_t>(fdCount) >= FD_SETSIZE || microseconds < -1)
     {
         return PAL_EINVAL;
     }


### PR DESCRIPTION
"error: comparison of integers of different signs: 'int32_t' (aka 'int') and 'unsigned int' [-Werror,-Wsign-compare]"

cc: @mmitche 