### PR TITLE
Add other library builds for System.Linq.Expressions project.

### DIFF
--- a/src/System.Linq.Expressions/src/Facade/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/Facade/System.Linq.Expressions.csproj
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Linq.Expressions</AssemblyName>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <ProjectJson>..\project.json</ProjectJson>
+    <ProjectLockJson>..\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU' " />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" />
+    <TargetingPackReference Include="System.Core" />
+  </ItemGroup>
+  
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.builds
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.builds
@@ -3,7 +3,16 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Linq.Expressions.csproj">
-      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+      <AdditionalProperties>TargetGroup=</AdditionalProperties> 
+    </Project>
+    <Project Include="System.Linq.Expressions.csproj">
+      <AdditionalProperties>TargetGroup=netcore50aot</AdditionalProperties>
+    </Project>
+    <Project Include="System.Linq.Expressions.csproj">
+      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties> 
+    </Project>
+    <Project Include="Facade\System.Linq.Expressions.csproj">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -6,21 +6,32 @@
     <FeatureInterpret>true</FeatureInterpret>
   </PropertyGroup>
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{AEF718E9-D4FC-418F-A7AE-ED6B2C7B3787}</ProjectGuid>
-    <OutputType>Library</OutputType>
     <AssemblyName>System.Linq.Expressions</AssemblyName>
     <RootNamespace>System.Linq.Expressions</RootNamespace>
     <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <IsInterpreting Condition="'$(PackageTargetFramework)' == 'netcore50'">true</IsInterpreting>
     <DefineConstants Condition=" '$(IsInterpreting)' != 'true' ">$(DefineConstants);FEATURE_COMPILE</DefineConstants>
     <DefineConstants Condition=" '$(FeatureInterpret)' == 'true' ">$(DefineConstants);FEATURE_INTERPRET</DefineConstants>
   </PropertyGroup>
+
   <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
+    <ProjectJson>netcore50aot\project.json</ProjectJson>
+    <ProjectLockJson>netcore50aot\project.lock.json</ProjectLockJson>
+    <DefineConstants>$(DefineConstants);FEATURE_DYNAMIC_DELEGATE</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
+    <EmbeddedResource Include="Resources\$(AssemblyName).rd.xml" />
+    <TargetingPackReference Include="System.Private.CoreLib.DynamicDelegate" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
       <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>

--- a/src/System.Linq.Expressions/src/netcore50aot/project.json
+++ b/src/System.Linq.Expressions/src/netcore50aot/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23530",
     "System.Collections": "4.0.10",
     "System.Diagnostics.Contracts": "4.0.0",
     "System.Diagnostics.Debug": "4.0.10",
@@ -9,27 +10,17 @@
     "System.Linq": "4.0.0",
     "System.ObjectModel": "4.0.10",
     "System.Reflection": "4.0.10",
-    "System.Reflection.Emit": "4.0.0",
-    "System.Reflection.Emit.ILGeneration": "4.0.0",
-    "System.Reflection.Emit.Lightweight": "4.0.0",
     "System.Reflection.Extensions": "4.0.0",
     "System.Reflection.Primitives": "4.0.0",
     "System.Reflection.TypeExtensions": "4.0.0",
     "System.Resources.ResourceManager": "4.0.0",
     "System.Runtime": "4.0.20",
     "System.Runtime.Extensions": "4.0.10",
+    "System.Text.Encoding": "4.0.10",
     "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10"
   },
   "frameworks": {
-    "dnxcore50": {
-        "dependencies": {
-        }
-    },
-    "net46": {
-        "dependencies": {
-           "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
-        }
-    }
+    "netcore50": {}
   }
 }

--- a/src/System.Linq.Expressions/src/netcore50aot/project.lock.json
+++ b/src/System.Linq.Expressions/src/netcore50aot/project.lock.json
@@ -1,0 +1,1615 @@
+{
+  "locked": false,
+  "version": 2,
+  "targets": {
+    ".NETCore,Version=v5.0": {
+      "Microsoft.TargetingPack.Private.NetNative/1.0.0-rc2-23530": {
+        "type": "package",
+        "compile": {
+          "ref/netcore50/System.Private.CompatQuirks.dll": {},
+          "ref/netcore50/System.Private.CoreLib.dll": {},
+          "ref/netcore50/System.Private.CoreLib.DynamicDelegate.dll": {},
+          "ref/netcore50/System.Private.CoreLib.InteropServices.dll": {},
+          "ref/netcore50/System.Private.DataContractSerialization.dll": {},
+          "ref/netcore50/System.Private.DeveloperExperience.AppX.dll": {},
+          "ref/netcore50/System.Private.DeveloperExperience.Console.dll": {},
+          "ref/netcore50/System.Private.Interop.dll": {},
+          "ref/netcore50/System.Private.PortableServiceModelThunks.dll": {},
+          "ref/netcore50/System.Private.PortableThunks.dll": {},
+          "ref/netcore50/System.Private.Reflection.Core.dll": {},
+          "ref/netcore50/System.Private.Reflection.dll": {},
+          "ref/netcore50/System.Private.Reflection.Execution.dll": {},
+          "ref/netcore50/System.Private.Reflection.Metadata.dll": {},
+          "ref/netcore50/System.Private.ServiceModel.dll": {},
+          "ref/netcore50/System.Private.StackTraceGenerator.dll": {},
+          "ref/netcore50/System.Private.Threading.dll": {},
+          "ref/netcore50/System.Private.TypeLoader.dll": {},
+          "ref/netcore50/System.Private.WinRTInterop.CoreLib.dll": {},
+          "ref/netcore50/windows.winmd": {}
+        }
+      },
+      "System.Collections/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Collections.dll": {}
+        }
+      },
+      "System.Diagnostics.Contracts/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/netcore50/System.Diagnostics.Contracts.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Diagnostics.Contracts.dll": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/netcore50/System.Diagnostics.Tools.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Diagnostics.Tools.dll": {}
+        }
+      },
+      "System.Globalization/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Globalization.dll": {}
+        }
+      },
+      "System.IO/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.IO.dll": {}
+        }
+      },
+      "System.Linq/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/netcore50/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Linq.dll": {}
+        }
+      },
+      "System.ObjectModel/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.ObjectModel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ObjectModel.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/netcore50/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Private.Uri.dll": {}
+        }
+      },
+      "System.Reflection/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Extensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/netcore50/System.Reflection.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Reflection.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Reflection.TypeExtensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/netcore50/System.Resources.ResourceManager.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.0.20": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Uri": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Text.Encoding.Extensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Text.Encoding.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/wpa81/_._": {}
+        }
+      },
+      "System.Threading/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Threading.Tasks.dll": {}
+        }
+      }
+    },
+    ".NETCore,Version=v5.0/win7-x86": {
+      "Microsoft.TargetingPack.Private.NetNative/1.0.0-rc2-23530": {
+        "type": "package",
+        "compile": {
+          "ref/netcore50/System.Private.CompatQuirks.dll": {},
+          "ref/netcore50/System.Private.CoreLib.dll": {},
+          "ref/netcore50/System.Private.CoreLib.DynamicDelegate.dll": {},
+          "ref/netcore50/System.Private.CoreLib.InteropServices.dll": {},
+          "ref/netcore50/System.Private.DataContractSerialization.dll": {},
+          "ref/netcore50/System.Private.DeveloperExperience.AppX.dll": {},
+          "ref/netcore50/System.Private.DeveloperExperience.Console.dll": {},
+          "ref/netcore50/System.Private.Interop.dll": {},
+          "ref/netcore50/System.Private.PortableServiceModelThunks.dll": {},
+          "ref/netcore50/System.Private.PortableThunks.dll": {},
+          "ref/netcore50/System.Private.Reflection.Core.dll": {},
+          "ref/netcore50/System.Private.Reflection.dll": {},
+          "ref/netcore50/System.Private.Reflection.Execution.dll": {},
+          "ref/netcore50/System.Private.Reflection.Metadata.dll": {},
+          "ref/netcore50/System.Private.ServiceModel.dll": {},
+          "ref/netcore50/System.Private.StackTraceGenerator.dll": {},
+          "ref/netcore50/System.Private.Threading.dll": {},
+          "ref/netcore50/System.Private.TypeLoader.dll": {},
+          "ref/netcore50/System.Private.WinRTInterop.CoreLib.dll": {},
+          "ref/netcore50/windows.winmd": {}
+        }
+      },
+      "System.Collections/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Collections.dll": {}
+        }
+      },
+      "System.Diagnostics.Contracts/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/netcore50/System.Diagnostics.Contracts.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Diagnostics.Contracts.dll": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/netcore50/System.Diagnostics.Tools.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Diagnostics.Tools.dll": {}
+        }
+      },
+      "System.Globalization/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Globalization.dll": {}
+        }
+      },
+      "System.IO/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.IO.dll": {}
+        }
+      },
+      "System.Linq/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/netcore50/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Linq.dll": {}
+        }
+      },
+      "System.ObjectModel/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.ObjectModel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ObjectModel.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/netcore50/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Private.Uri.dll": {}
+        }
+      },
+      "System.Reflection/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Extensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/netcore50/System.Reflection.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Reflection.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Reflection.TypeExtensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/netcore50/System.Resources.ResourceManager.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.0.20": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Uri": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Text.Encoding.Extensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Text.Encoding.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/wpa81/_._": {}
+        }
+      },
+      "System.Threading/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Threading.Tasks.dll": {}
+        }
+      }
+    },
+    ".NETCore,Version=v5.0/win7-x64": {
+      "Microsoft.TargetingPack.Private.NetNative/1.0.0-rc2-23530": {
+        "type": "package",
+        "compile": {
+          "ref/netcore50/System.Private.CompatQuirks.dll": {},
+          "ref/netcore50/System.Private.CoreLib.dll": {},
+          "ref/netcore50/System.Private.CoreLib.DynamicDelegate.dll": {},
+          "ref/netcore50/System.Private.CoreLib.InteropServices.dll": {},
+          "ref/netcore50/System.Private.DataContractSerialization.dll": {},
+          "ref/netcore50/System.Private.DeveloperExperience.AppX.dll": {},
+          "ref/netcore50/System.Private.DeveloperExperience.Console.dll": {},
+          "ref/netcore50/System.Private.Interop.dll": {},
+          "ref/netcore50/System.Private.PortableServiceModelThunks.dll": {},
+          "ref/netcore50/System.Private.PortableThunks.dll": {},
+          "ref/netcore50/System.Private.Reflection.Core.dll": {},
+          "ref/netcore50/System.Private.Reflection.dll": {},
+          "ref/netcore50/System.Private.Reflection.Execution.dll": {},
+          "ref/netcore50/System.Private.Reflection.Metadata.dll": {},
+          "ref/netcore50/System.Private.ServiceModel.dll": {},
+          "ref/netcore50/System.Private.StackTraceGenerator.dll": {},
+          "ref/netcore50/System.Private.Threading.dll": {},
+          "ref/netcore50/System.Private.TypeLoader.dll": {},
+          "ref/netcore50/System.Private.WinRTInterop.CoreLib.dll": {},
+          "ref/netcore50/windows.winmd": {}
+        }
+      },
+      "System.Collections/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.0",
+          "System.Threading": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Collections.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Collections.dll": {}
+        }
+      },
+      "System.Diagnostics.Contracts/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/netcore50/System.Diagnostics.Contracts.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Diagnostics.Contracts.dll": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Diagnostics.Debug.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Diagnostics.Debug.dll": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/netcore50/System.Diagnostics.Tools.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Diagnostics.Tools.dll": {}
+        }
+      },
+      "System.Globalization/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Globalization.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Globalization.dll": {}
+        }
+      },
+      "System.IO/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Text.Encoding": "4.0.10",
+          "System.Text.Encoding.Extensions": "4.0.0",
+          "System.Threading": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.IO.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.IO.dll": {}
+        }
+      },
+      "System.Linq/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/netcore50/System.Linq.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Linq.dll": {}
+        }
+      },
+      "System.ObjectModel/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Collections": "4.0.10",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Threading": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.ObjectModel.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/System.ObjectModel.dll": {}
+        }
+      },
+      "System.Private.Uri/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/netcore50/_._": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Private.Uri.dll": {}
+        }
+      },
+      "System.Reflection/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.IO": "4.0.0",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.dll": {}
+        }
+      },
+      "System.Reflection.Extensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Reflection.TypeExtensions": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/netcore50/System.Reflection.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.Extensions.dll": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Reflection.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.Primitives.dll": {}
+        }
+      },
+      "System.Reflection.TypeExtensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Diagnostics.Contracts": "4.0.0",
+          "System.Diagnostics.Debug": "4.0.10",
+          "System.Linq": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Reflection.Primitives": "4.0.0",
+          "System.Resources.ResourceManager": "4.0.0",
+          "System.Runtime": "4.0.20",
+          "System.Runtime.Extensions": "4.0.10"
+        },
+        "compile": {
+          "ref/dotnet/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Globalization": "4.0.0",
+          "System.Reflection": "4.0.10",
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/netcore50/System.Resources.ResourceManager.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Resources.ResourceManager.dll": {}
+        }
+      },
+      "System.Runtime/4.0.20": {
+        "type": "package",
+        "dependencies": {
+          "System.Private.Uri": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Runtime.dll": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/System.Runtime.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Runtime.Extensions.dll": {}
+        }
+      },
+      "System.Text.Encoding/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Text.Encoding.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Text.Encoding.dll": {}
+        }
+      },
+      "System.Text.Encoding.Extensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Text.Encoding": "4.0.0"
+        },
+        "compile": {
+          "ref/netcore50/System.Text.Encoding.Extensions.dll": {}
+        },
+        "runtime": {
+          "lib/wpa81/_._": {}
+        }
+      },
+      "System.Threading/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0",
+          "System.Threading.Tasks": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Threading.dll": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.10": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.0"
+        },
+        "compile": {
+          "ref/dotnet/System.Threading.Tasks.dll": {}
+        },
+        "runtime": {
+          "lib/netcore50/System.Threading.Tasks.dll": {}
+        }
+      }
+    }
+  },
+  "libraries": {
+    "Microsoft.TargetingPack.Private.NetNative/1.0.0-rc2-23530": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "YbsxqchoOlgvdu+0j4Dn5H76lTy3KwMd6aPMFIeOTL0Mtcnq8HLABG0ko9160YhOr+xbRgbVXVGwfI0nxfFEzg==",
+      "files": [
+        "Microsoft.TargetingPack.Private.NetNative.1.0.0-rc2-23530.nupkg",
+        "Microsoft.TargetingPack.Private.NetNative.1.0.0-rc2-23530.nupkg.sha512",
+        "Microsoft.TargetingPack.Private.NetNative.nuspec",
+        "ref/netcore50/System.Private.CompatQuirks.dll",
+        "ref/netcore50/System.Private.CoreLib.dll",
+        "ref/netcore50/System.Private.CoreLib.DynamicDelegate.dll",
+        "ref/netcore50/System.Private.CoreLib.InteropServices.dll",
+        "ref/netcore50/System.Private.DataContractSerialization.dll",
+        "ref/netcore50/System.Private.DeveloperExperience.AppX.dll",
+        "ref/netcore50/System.Private.DeveloperExperience.Console.dll",
+        "ref/netcore50/System.Private.Interop.dll",
+        "ref/netcore50/System.Private.PortableServiceModelThunks.dll",
+        "ref/netcore50/System.Private.PortableThunks.dll",
+        "ref/netcore50/System.Private.Reflection.Core.dll",
+        "ref/netcore50/System.Private.Reflection.dll",
+        "ref/netcore50/System.Private.Reflection.Execution.dll",
+        "ref/netcore50/System.Private.Reflection.Metadata.dll",
+        "ref/netcore50/System.Private.ServiceModel.dll",
+        "ref/netcore50/System.Private.StackTraceGenerator.dll",
+        "ref/netcore50/System.Private.Threading.dll",
+        "ref/netcore50/System.Private.TypeLoader.dll",
+        "ref/netcore50/System.Private.WinRTInterop.CoreLib.dll",
+        "ref/netcore50/windows.winmd"
+      ]
+    },
+    "System.Collections/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "ux6ilcZZjV/Gp7JEZpe+2V1eTueq6NuoGRM3eZCFuPM25hLVVgCRuea6STW8hvqreIOE59irJk5/ovpA5xQipw==",
+      "files": [
+        "lib/DNXCore50/System.Collections.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Collections.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Collections.xml",
+        "ref/dotnet/es/System.Collections.xml",
+        "ref/dotnet/fr/System.Collections.xml",
+        "ref/dotnet/it/System.Collections.xml",
+        "ref/dotnet/ja/System.Collections.xml",
+        "ref/dotnet/ko/System.Collections.xml",
+        "ref/dotnet/ru/System.Collections.xml",
+        "ref/dotnet/System.Collections.dll",
+        "ref/dotnet/System.Collections.xml",
+        "ref/dotnet/zh-hans/System.Collections.xml",
+        "ref/dotnet/zh-hant/System.Collections.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Collections.dll",
+        "System.Collections.4.0.10.nupkg",
+        "System.Collections.4.0.10.nupkg.sha512",
+        "System.Collections.nuspec"
+      ]
+    },
+    "System.Diagnostics.Contracts/4.0.0": {
+      "type": "package",
+      "sha512": "lMc7HNmyIsu0pKTdA4wf+FMq5jvouUd+oUpV4BdtyqoV0Pkbg9u/7lTKFGqpjZRQosWHq1+B32Lch2wf4AmloA==",
+      "files": [
+        "lib/DNXCore50/System.Diagnostics.Contracts.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Diagnostics.Contracts.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/es/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/fr/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/it/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/ja/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/ko/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/ru/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/System.Diagnostics.Contracts.dll",
+        "ref/dotnet/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Contracts.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Contracts.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Diagnostics.Contracts.dll",
+        "ref/netcore50/System.Diagnostics.Contracts.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Contracts.dll",
+        "System.Diagnostics.Contracts.4.0.0.nupkg",
+        "System.Diagnostics.Contracts.4.0.0.nupkg.sha512",
+        "System.Diagnostics.Contracts.nuspec"
+      ]
+    },
+    "System.Diagnostics.Debug/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "pi2KthuvI2LWV2c2V+fwReDsDiKpNl040h6DcwFOb59SafsPT/V1fCy0z66OKwysurJkBMmp5j5CBe3Um+ub0g==",
+      "files": [
+        "lib/DNXCore50/System.Diagnostics.Debug.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Diagnostics.Debug.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Diagnostics.Debug.xml",
+        "ref/dotnet/es/System.Diagnostics.Debug.xml",
+        "ref/dotnet/fr/System.Diagnostics.Debug.xml",
+        "ref/dotnet/it/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ja/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ko/System.Diagnostics.Debug.xml",
+        "ref/dotnet/ru/System.Diagnostics.Debug.xml",
+        "ref/dotnet/System.Diagnostics.Debug.dll",
+        "ref/dotnet/System.Diagnostics.Debug.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Debug.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Debug.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Debug.dll",
+        "System.Diagnostics.Debug.4.0.10.nupkg",
+        "System.Diagnostics.Debug.4.0.10.nupkg.sha512",
+        "System.Diagnostics.Debug.nuspec"
+      ]
+    },
+    "System.Diagnostics.Tools/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "uw5Qi2u5Cgtv4xv3+8DeB63iaprPcaEHfpeJqlJiLjIVy6v0La4ahJ6VW9oPbJNIjcavd24LKq0ctT9ssuQXsw==",
+      "files": [
+        "lib/DNXCore50/System.Diagnostics.Tools.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Diagnostics.Tools.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Diagnostics.Tools.xml",
+        "ref/dotnet/es/System.Diagnostics.Tools.xml",
+        "ref/dotnet/fr/System.Diagnostics.Tools.xml",
+        "ref/dotnet/it/System.Diagnostics.Tools.xml",
+        "ref/dotnet/ja/System.Diagnostics.Tools.xml",
+        "ref/dotnet/ko/System.Diagnostics.Tools.xml",
+        "ref/dotnet/ru/System.Diagnostics.Tools.xml",
+        "ref/dotnet/System.Diagnostics.Tools.dll",
+        "ref/dotnet/System.Diagnostics.Tools.xml",
+        "ref/dotnet/zh-hans/System.Diagnostics.Tools.xml",
+        "ref/dotnet/zh-hant/System.Diagnostics.Tools.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Diagnostics.Tools.dll",
+        "ref/netcore50/System.Diagnostics.Tools.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Diagnostics.Tools.dll",
+        "System.Diagnostics.Tools.4.0.0.nupkg",
+        "System.Diagnostics.Tools.4.0.0.nupkg.sha512",
+        "System.Diagnostics.Tools.nuspec"
+      ]
+    },
+    "System.Globalization/4.0.10": {
+      "type": "package",
+      "sha512": "kzRtbbCNAxdafFBDogcM36ehA3th8c1PGiz8QRkZn8O5yMBorDHSK8/TGJPYOaCS5zdsGk0u9qXHnW91nqy7fw==",
+      "files": [
+        "lib/DNXCore50/System.Globalization.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Globalization.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Globalization.xml",
+        "ref/dotnet/es/System.Globalization.xml",
+        "ref/dotnet/fr/System.Globalization.xml",
+        "ref/dotnet/it/System.Globalization.xml",
+        "ref/dotnet/ja/System.Globalization.xml",
+        "ref/dotnet/ko/System.Globalization.xml",
+        "ref/dotnet/ru/System.Globalization.xml",
+        "ref/dotnet/System.Globalization.dll",
+        "ref/dotnet/System.Globalization.xml",
+        "ref/dotnet/zh-hans/System.Globalization.xml",
+        "ref/dotnet/zh-hant/System.Globalization.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Globalization.dll",
+        "System.Globalization.4.0.10.nupkg",
+        "System.Globalization.4.0.10.nupkg.sha512",
+        "System.Globalization.nuspec"
+      ]
+    },
+    "System.IO/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "kghf1CeYT+W2lw8a50/GxFz5HR9t6RkL4BvjxtTp1NxtEFWywnMA9W8FH/KYXiDNThcw9u/GOViDON4iJFGXIQ==",
+      "files": [
+        "lib/DNXCore50/System.IO.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.IO.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.IO.xml",
+        "ref/dotnet/es/System.IO.xml",
+        "ref/dotnet/fr/System.IO.xml",
+        "ref/dotnet/it/System.IO.xml",
+        "ref/dotnet/ja/System.IO.xml",
+        "ref/dotnet/ko/System.IO.xml",
+        "ref/dotnet/ru/System.IO.xml",
+        "ref/dotnet/System.IO.dll",
+        "ref/dotnet/System.IO.xml",
+        "ref/dotnet/zh-hans/System.IO.xml",
+        "ref/dotnet/zh-hant/System.IO.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.IO.dll",
+        "System.IO.4.0.10.nupkg",
+        "System.IO.4.0.10.nupkg.sha512",
+        "System.IO.nuspec"
+      ]
+    },
+    "System.Linq/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "r6Hlc+ytE6m/9UBr+nNRRdoJEWjoeQiT3L3lXYFDHoXk3VYsRBCDNXrawcexw7KPLaH0zamQLiAb6avhZ50cGg==",
+      "files": [
+        "lib/dotnet/System.Linq.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Linq.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Linq.xml",
+        "ref/dotnet/es/System.Linq.xml",
+        "ref/dotnet/fr/System.Linq.xml",
+        "ref/dotnet/it/System.Linq.xml",
+        "ref/dotnet/ja/System.Linq.xml",
+        "ref/dotnet/ko/System.Linq.xml",
+        "ref/dotnet/ru/System.Linq.xml",
+        "ref/dotnet/System.Linq.dll",
+        "ref/dotnet/System.Linq.xml",
+        "ref/dotnet/zh-hans/System.Linq.xml",
+        "ref/dotnet/zh-hant/System.Linq.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Linq.dll",
+        "ref/netcore50/System.Linq.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "System.Linq.4.0.0.nupkg",
+        "System.Linq.4.0.0.nupkg.sha512",
+        "System.Linq.nuspec"
+      ]
+    },
+    "System.ObjectModel/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "Djn1wb0vP662zxbe+c3mOhvC4vkQGicsFs1Wi0/GJJpp3Eqp+oxbJ+p2Sx3O0efYueggAI5SW+BqEoczjfr1cA==",
+      "files": [
+        "lib/dotnet/System.ObjectModel.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.ObjectModel.xml",
+        "ref/dotnet/es/System.ObjectModel.xml",
+        "ref/dotnet/fr/System.ObjectModel.xml",
+        "ref/dotnet/it/System.ObjectModel.xml",
+        "ref/dotnet/ja/System.ObjectModel.xml",
+        "ref/dotnet/ko/System.ObjectModel.xml",
+        "ref/dotnet/ru/System.ObjectModel.xml",
+        "ref/dotnet/System.ObjectModel.dll",
+        "ref/dotnet/System.ObjectModel.xml",
+        "ref/dotnet/zh-hans/System.ObjectModel.xml",
+        "ref/dotnet/zh-hant/System.ObjectModel.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.ObjectModel.4.0.10.nupkg",
+        "System.ObjectModel.4.0.10.nupkg.sha512",
+        "System.ObjectModel.nuspec"
+      ]
+    },
+    "System.Private.Uri/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "CtuxaCKcRIvPcsqquVl3mPp79EDZPMr2UogfiFCxCs+t2z1VjbpQsKNs1GHZ8VQetqbk1mr0V1yAfMe6y8CHDA==",
+      "files": [
+        "lib/DNXCore50/System.Private.Uri.dll",
+        "lib/netcore50/System.Private.Uri.dll",
+        "ref/dnxcore50/_._",
+        "ref/netcore50/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Private.Uri.dll",
+        "System.Private.Uri.4.0.0.nupkg",
+        "System.Private.Uri.4.0.0.nupkg.sha512",
+        "System.Private.Uri.nuspec"
+      ]
+    },
+    "System.Reflection/4.0.10": {
+      "type": "package",
+      "sha512": "WZ+4lEE4gqGx6mrqLhSiW4oi6QLPWwdNjzhhTONmhELOrW8Cw9phlO9tltgvRUuQUqYtBiliFwhO5S5fCJElVw==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Reflection.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Reflection.xml",
+        "ref/dotnet/es/System.Reflection.xml",
+        "ref/dotnet/fr/System.Reflection.xml",
+        "ref/dotnet/it/System.Reflection.xml",
+        "ref/dotnet/ja/System.Reflection.xml",
+        "ref/dotnet/ko/System.Reflection.xml",
+        "ref/dotnet/ru/System.Reflection.xml",
+        "ref/dotnet/System.Reflection.dll",
+        "ref/dotnet/System.Reflection.xml",
+        "ref/dotnet/zh-hans/System.Reflection.xml",
+        "ref/dotnet/zh-hant/System.Reflection.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.dll",
+        "System.Reflection.4.0.10.nupkg",
+        "System.Reflection.4.0.10.nupkg.sha512",
+        "System.Reflection.nuspec"
+      ]
+    },
+    "System.Reflection.Extensions/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "dbYaZWCyFAu1TGYUqR2n+Q+1casSHPR2vVW0WVNkXpZbrd2BXcZ7cpvpu9C98CTHtNmyfMWCLpCclDqly23t6A==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.Extensions.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Extensions.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Reflection.Extensions.xml",
+        "ref/dotnet/es/System.Reflection.Extensions.xml",
+        "ref/dotnet/fr/System.Reflection.Extensions.xml",
+        "ref/dotnet/it/System.Reflection.Extensions.xml",
+        "ref/dotnet/ja/System.Reflection.Extensions.xml",
+        "ref/dotnet/ko/System.Reflection.Extensions.xml",
+        "ref/dotnet/ru/System.Reflection.Extensions.xml",
+        "ref/dotnet/System.Reflection.Extensions.dll",
+        "ref/dotnet/System.Reflection.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Extensions.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Reflection.Extensions.dll",
+        "ref/netcore50/System.Reflection.Extensions.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Extensions.dll",
+        "System.Reflection.Extensions.4.0.0.nupkg",
+        "System.Reflection.Extensions.4.0.0.nupkg.sha512",
+        "System.Reflection.Extensions.nuspec"
+      ]
+    },
+    "System.Reflection.Primitives/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "n9S0XpKv2ruc17FSnaiX6nV47VfHTZ1wLjKZlAirUZCvDQCH71mVp+Ohabn0xXLh5pK2PKp45HCxkqu5Fxn/lA==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.Primitives.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Reflection.Primitives.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Reflection.Primitives.xml",
+        "ref/dotnet/es/System.Reflection.Primitives.xml",
+        "ref/dotnet/fr/System.Reflection.Primitives.xml",
+        "ref/dotnet/it/System.Reflection.Primitives.xml",
+        "ref/dotnet/ja/System.Reflection.Primitives.xml",
+        "ref/dotnet/ko/System.Reflection.Primitives.xml",
+        "ref/dotnet/ru/System.Reflection.Primitives.xml",
+        "ref/dotnet/System.Reflection.Primitives.dll",
+        "ref/dotnet/System.Reflection.Primitives.xml",
+        "ref/dotnet/zh-hans/System.Reflection.Primitives.xml",
+        "ref/dotnet/zh-hant/System.Reflection.Primitives.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Reflection.Primitives.dll",
+        "ref/netcore50/System.Reflection.Primitives.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.Primitives.dll",
+        "System.Reflection.Primitives.4.0.0.nupkg",
+        "System.Reflection.Primitives.4.0.0.nupkg.sha512",
+        "System.Reflection.Primitives.nuspec"
+      ]
+    },
+    "System.Reflection.TypeExtensions/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "YRM/msNAM86hdxPyXcuZSzmTO0RQFh7YMEPBLTY8cqXvFPYIx2x99bOyPkuU81wRYQem1c1HTkImQ2DjbOBfew==",
+      "files": [
+        "lib/DNXCore50/System.Reflection.TypeExtensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/System.Reflection.TypeExtensions.dll",
+        "lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/es/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/fr/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/it/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/ja/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/ko/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/ru/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/System.Reflection.TypeExtensions.dll",
+        "ref/dotnet/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/zh-hans/System.Reflection.TypeExtensions.xml",
+        "ref/dotnet/zh-hant/System.Reflection.TypeExtensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/System.Reflection.TypeExtensions.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Reflection.TypeExtensions.dll",
+        "System.Reflection.TypeExtensions.4.0.0.nupkg",
+        "System.Reflection.TypeExtensions.4.0.0.nupkg.sha512",
+        "System.Reflection.TypeExtensions.nuspec"
+      ]
+    },
+    "System.Resources.ResourceManager/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "qmqeZ4BJgjfU+G2JbrZt4Dk1LsMxO4t+f/9HarNY6w8pBgweO6jT+cknUH7c3qIrGvyUqraBhU45Eo6UtA0fAw==",
+      "files": [
+        "lib/DNXCore50/System.Resources.ResourceManager.dll",
+        "lib/net45/_._",
+        "lib/netcore50/System.Resources.ResourceManager.dll",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "ref/dotnet/de/System.Resources.ResourceManager.xml",
+        "ref/dotnet/es/System.Resources.ResourceManager.xml",
+        "ref/dotnet/fr/System.Resources.ResourceManager.xml",
+        "ref/dotnet/it/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ja/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ko/System.Resources.ResourceManager.xml",
+        "ref/dotnet/ru/System.Resources.ResourceManager.xml",
+        "ref/dotnet/System.Resources.ResourceManager.dll",
+        "ref/dotnet/System.Resources.ResourceManager.xml",
+        "ref/dotnet/zh-hans/System.Resources.ResourceManager.xml",
+        "ref/dotnet/zh-hant/System.Resources.ResourceManager.xml",
+        "ref/net45/_._",
+        "ref/netcore50/System.Resources.ResourceManager.dll",
+        "ref/netcore50/System.Resources.ResourceManager.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Resources.ResourceManager.dll",
+        "System.Resources.ResourceManager.4.0.0.nupkg",
+        "System.Resources.ResourceManager.4.0.0.nupkg.sha512",
+        "System.Resources.ResourceManager.nuspec"
+      ]
+    },
+    "System.Runtime/4.0.20": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "X7N/9Bz7jVPorqdVFO86ns1sX6MlQM+WTxELtx+Z4VG45x9+LKmWH0GRqjgKprUnVuwmfB9EJ9DQng14Z7/zwg==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.xml",
+        "ref/dotnet/es/System.Runtime.xml",
+        "ref/dotnet/fr/System.Runtime.xml",
+        "ref/dotnet/it/System.Runtime.xml",
+        "ref/dotnet/ja/System.Runtime.xml",
+        "ref/dotnet/ko/System.Runtime.xml",
+        "ref/dotnet/ru/System.Runtime.xml",
+        "ref/dotnet/System.Runtime.dll",
+        "ref/dotnet/System.Runtime.xml",
+        "ref/dotnet/zh-hans/System.Runtime.xml",
+        "ref/dotnet/zh-hant/System.Runtime.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.dll",
+        "System.Runtime.4.0.20.nupkg",
+        "System.Runtime.4.0.20.nupkg.sha512",
+        "System.Runtime.nuspec"
+      ]
+    },
+    "System.Runtime.Extensions/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "5dsEwf3Iml7d5OZeT20iyOjT+r+okWpN7xI2v+R4cgd3WSj4DeRPTvPFjDpacbVW4skCAZ8B9hxXJYgkCFKJ1A==",
+      "files": [
+        "lib/DNXCore50/System.Runtime.Extensions.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Runtime.Extensions.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Runtime.Extensions.xml",
+        "ref/dotnet/es/System.Runtime.Extensions.xml",
+        "ref/dotnet/fr/System.Runtime.Extensions.xml",
+        "ref/dotnet/it/System.Runtime.Extensions.xml",
+        "ref/dotnet/ja/System.Runtime.Extensions.xml",
+        "ref/dotnet/ko/System.Runtime.Extensions.xml",
+        "ref/dotnet/ru/System.Runtime.Extensions.xml",
+        "ref/dotnet/System.Runtime.Extensions.dll",
+        "ref/dotnet/System.Runtime.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Runtime.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Runtime.Extensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Runtime.Extensions.dll",
+        "System.Runtime.Extensions.4.0.10.nupkg",
+        "System.Runtime.Extensions.4.0.10.nupkg.sha512",
+        "System.Runtime.Extensions.nuspec"
+      ]
+    },
+    "System.Text.Encoding/4.0.10": {
+      "type": "package",
+      "sha512": "fNlSFgy4OuDlJrP9SFFxMlaLazq6ipv15sU5TiEgg9UCVnA/OgoVUfymFp4AOk1jOkW5SVxWbeeIUptcM+m/Vw==",
+      "files": [
+        "lib/DNXCore50/System.Text.Encoding.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Text.Encoding.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Text.Encoding.xml",
+        "ref/dotnet/es/System.Text.Encoding.xml",
+        "ref/dotnet/fr/System.Text.Encoding.xml",
+        "ref/dotnet/it/System.Text.Encoding.xml",
+        "ref/dotnet/ja/System.Text.Encoding.xml",
+        "ref/dotnet/ko/System.Text.Encoding.xml",
+        "ref/dotnet/ru/System.Text.Encoding.xml",
+        "ref/dotnet/System.Text.Encoding.dll",
+        "ref/dotnet/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hans/System.Text.Encoding.xml",
+        "ref/dotnet/zh-hant/System.Text.Encoding.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Text.Encoding.dll",
+        "System.Text.Encoding.4.0.10.nupkg",
+        "System.Text.Encoding.4.0.10.nupkg.sha512",
+        "System.Text.Encoding.nuspec"
+      ]
+    },
+    "System.Text.Encoding.Extensions/4.0.0": {
+      "type": "package",
+      "sha512": "FktA77+2DC0S5oRhgM569pbzFrcA45iQpYiI7+YKl68B6TfI2N5TQbXqSWlh2YXKoFXHi2RFwPMha2lxiFJZ6A==",
+      "files": [
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net45/_._",
+        "lib/win8/_._",
+        "lib/wp80/_._",
+        "lib/wpa81/_._",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "License.rtf",
+        "ref/dotnet/de/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/es/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/fr/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/it/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/ja/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/ko/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/ru/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/System.Text.Encoding.Extensions.dll",
+        "ref/dotnet/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/zh-hans/System.Text.Encoding.Extensions.xml",
+        "ref/dotnet/zh-hant/System.Text.Encoding.Extensions.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net45/_._",
+        "ref/netcore50/de/System.Text.Encoding.Extensions.xml",
+        "ref/netcore50/es/System.Text.Encoding.Extensions.xml",
+        "ref/netcore50/fr/System.Text.Encoding.Extensions.xml",
+        "ref/netcore50/it/System.Text.Encoding.Extensions.xml",
+        "ref/netcore50/ja/System.Text.Encoding.Extensions.xml",
+        "ref/netcore50/ko/System.Text.Encoding.Extensions.xml",
+        "ref/netcore50/ru/System.Text.Encoding.Extensions.xml",
+        "ref/netcore50/System.Text.Encoding.Extensions.dll",
+        "ref/netcore50/System.Text.Encoding.Extensions.xml",
+        "ref/netcore50/zh-hans/System.Text.Encoding.Extensions.xml",
+        "ref/netcore50/zh-hant/System.Text.Encoding.Extensions.xml",
+        "ref/win8/_._",
+        "ref/wp80/_._",
+        "ref/wpa81/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "System.Text.Encoding.Extensions.4.0.0.nupkg",
+        "System.Text.Encoding.Extensions.4.0.0.nupkg.sha512",
+        "System.Text.Encoding.Extensions.nuspec"
+      ]
+    },
+    "System.Threading/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "0w6pRxIEE7wuiOJeKabkDgeIKmqf4ER1VNrs6qFwHnooEE78yHwi/bKkg5Jo8/pzGLm0xQJw0nEmPXt1QBAIUA==",
+      "files": [
+        "lib/DNXCore50/System.Threading.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Threading.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Threading.xml",
+        "ref/dotnet/es/System.Threading.xml",
+        "ref/dotnet/fr/System.Threading.xml",
+        "ref/dotnet/it/System.Threading.xml",
+        "ref/dotnet/ja/System.Threading.xml",
+        "ref/dotnet/ko/System.Threading.xml",
+        "ref/dotnet/ru/System.Threading.xml",
+        "ref/dotnet/System.Threading.dll",
+        "ref/dotnet/System.Threading.xml",
+        "ref/dotnet/zh-hans/System.Threading.xml",
+        "ref/dotnet/zh-hant/System.Threading.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.dll",
+        "System.Threading.4.0.10.nupkg",
+        "System.Threading.4.0.10.nupkg.sha512",
+        "System.Threading.nuspec"
+      ]
+    },
+    "System.Threading.Tasks/4.0.10": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "NOwJGDfk79jR0bnzosbXLVD/PdI8KzBeESoa3CofEM5v9R5EBfcI0Jyf18stx+0IYV9okmDIDxVtxq9TbnR9bQ==",
+      "files": [
+        "lib/DNXCore50/System.Threading.Tasks.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/_._",
+        "lib/netcore50/System.Threading.Tasks.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "ref/dotnet/de/System.Threading.Tasks.xml",
+        "ref/dotnet/es/System.Threading.Tasks.xml",
+        "ref/dotnet/fr/System.Threading.Tasks.xml",
+        "ref/dotnet/it/System.Threading.Tasks.xml",
+        "ref/dotnet/ja/System.Threading.Tasks.xml",
+        "ref/dotnet/ko/System.Threading.Tasks.xml",
+        "ref/dotnet/ru/System.Threading.Tasks.xml",
+        "ref/dotnet/System.Threading.Tasks.dll",
+        "ref/dotnet/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hans/System.Threading.Tasks.xml",
+        "ref/dotnet/zh-hant/System.Threading.Tasks.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/_._",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._",
+        "runtimes/win8-aot/lib/netcore50/System.Threading.Tasks.dll",
+        "System.Threading.Tasks.4.0.10.nupkg",
+        "System.Threading.Tasks.4.0.10.nupkg.sha512",
+        "System.Threading.Tasks.nuspec"
+      ]
+    }
+  },
+  "projectFileDependencyGroups": {
+    "": [
+      "Microsoft.TargetingPack.Private.NetNative >= 1.0.0-rc2-23530",
+      "System.Collections >= 4.0.10",
+      "System.Diagnostics.Contracts >= 4.0.0",
+      "System.Diagnostics.Debug >= 4.0.10",
+      "System.Diagnostics.Tools >= 4.0.0",
+      "System.Globalization >= 4.0.10",
+      "System.IO >= 4.0.10",
+      "System.Linq >= 4.0.0",
+      "System.ObjectModel >= 4.0.10",
+      "System.Reflection >= 4.0.10",
+      "System.Reflection.Extensions >= 4.0.0",
+      "System.Reflection.Primitives >= 4.0.0",
+      "System.Reflection.TypeExtensions >= 4.0.0",
+      "System.Resources.ResourceManager >= 4.0.0",
+      "System.Runtime >= 4.0.20",
+      "System.Runtime.Extensions >= 4.0.10",
+      "System.Text.Encoding >= 4.0.10",
+      "System.Threading >= 4.0.10",
+      "System.Threading.Tasks >= 4.0.10"
+    ],
+    ".NETCore,Version=v5.0": []
+  }
+}

--- a/src/System.Linq.Expressions/src/project.lock.json
+++ b/src/System.Linq.Expressions/src/project.lock.json
@@ -288,6 +288,386 @@
         }
       }
     },
+    ".NETFramework,Version=v4.6": {
+      "Microsoft.TargetingPack.NETFramework.v4.6/1.0.0-rc2-23530": {
+        "type": "package",
+        "compile": {
+          "ref/net46/Accessibility.dll": {},
+          "ref/net46/CustomMarshalers.dll": {},
+          "ref/net46/ISymWrapper.dll": {},
+          "ref/net46/Microsoft.Activities.Build.dll": {},
+          "ref/net46/Microsoft.Build.Conversion.v4.0.dll": {},
+          "ref/net46/Microsoft.Build.dll": {},
+          "ref/net46/Microsoft.Build.Engine.dll": {},
+          "ref/net46/Microsoft.Build.Framework.dll": {},
+          "ref/net46/Microsoft.Build.Tasks.v4.0.dll": {},
+          "ref/net46/Microsoft.Build.Utilities.v4.0.dll": {},
+          "ref/net46/Microsoft.CSharp.dll": {},
+          "ref/net46/Microsoft.JScript.dll": {},
+          "ref/net46/Microsoft.VisualBasic.Compatibility.Data.dll": {},
+          "ref/net46/Microsoft.VisualBasic.Compatibility.dll": {},
+          "ref/net46/Microsoft.VisualBasic.dll": {},
+          "ref/net46/Microsoft.VisualC.dll": {},
+          "ref/net46/Microsoft.VisualC.STLCLR.dll": {},
+          "ref/net46/mscorlib.dll": {},
+          "ref/net46/PresentationBuildTasks.dll": {},
+          "ref/net46/PresentationCore.dll": {},
+          "ref/net46/PresentationFramework.Aero.dll": {},
+          "ref/net46/PresentationFramework.Aero2.dll": {},
+          "ref/net46/PresentationFramework.AeroLite.dll": {},
+          "ref/net46/PresentationFramework.Classic.dll": {},
+          "ref/net46/PresentationFramework.dll": {},
+          "ref/net46/PresentationFramework.Luna.dll": {},
+          "ref/net46/PresentationFramework.Royale.dll": {},
+          "ref/net46/ReachFramework.dll": {},
+          "ref/net46/sysglobl.dll": {},
+          "ref/net46/System.Activities.Core.Presentation.dll": {},
+          "ref/net46/System.Activities.dll": {},
+          "ref/net46/System.Activities.DurableInstancing.dll": {},
+          "ref/net46/System.Activities.Presentation.dll": {},
+          "ref/net46/System.AddIn.Contract.dll": {},
+          "ref/net46/System.AddIn.dll": {},
+          "ref/net46/System.Collections.Concurrent.dll": {},
+          "ref/net46/System.Collections.dll": {},
+          "ref/net46/System.ComponentModel.Annotations.dll": {},
+          "ref/net46/System.ComponentModel.Composition.dll": {},
+          "ref/net46/System.ComponentModel.Composition.Registration.dll": {},
+          "ref/net46/System.ComponentModel.DataAnnotations.dll": {},
+          "ref/net46/System.ComponentModel.dll": {},
+          "ref/net46/System.ComponentModel.EventBasedAsync.dll": {},
+          "ref/net46/System.Configuration.dll": {},
+          "ref/net46/System.Configuration.Install.dll": {},
+          "ref/net46/System.Core.dll": {},
+          "ref/net46/System.Data.DataSetExtensions.dll": {},
+          "ref/net46/System.Data.dll": {},
+          "ref/net46/System.Data.Entity.Design.dll": {},
+          "ref/net46/System.Data.Entity.dll": {},
+          "ref/net46/System.Data.Linq.dll": {},
+          "ref/net46/System.Data.OracleClient.dll": {},
+          "ref/net46/System.Data.Services.Client.dll": {},
+          "ref/net46/System.Data.Services.Design.dll": {},
+          "ref/net46/System.Data.Services.dll": {},
+          "ref/net46/System.Data.SqlXml.dll": {},
+          "ref/net46/System.Deployment.dll": {},
+          "ref/net46/System.Design.dll": {},
+          "ref/net46/System.Device.dll": {},
+          "ref/net46/System.Diagnostics.Contracts.dll": {},
+          "ref/net46/System.Diagnostics.Debug.dll": {},
+          "ref/net46/System.Diagnostics.Tools.dll": {},
+          "ref/net46/System.Diagnostics.Tracing.dll": {},
+          "ref/net46/System.DirectoryServices.AccountManagement.dll": {},
+          "ref/net46/System.DirectoryServices.dll": {},
+          "ref/net46/System.DirectoryServices.Protocols.dll": {},
+          "ref/net46/System.dll": {},
+          "ref/net46/System.Drawing.Design.dll": {},
+          "ref/net46/System.Drawing.dll": {},
+          "ref/net46/System.Dynamic.dll": {},
+          "ref/net46/System.Dynamic.Runtime.dll": {},
+          "ref/net46/System.EnterpriseServices.dll": {},
+          "ref/net46/System.EnterpriseServices.Thunk.dll": {},
+          "ref/net46/System.EnterpriseServices.Wrapper.dll": {},
+          "ref/net46/System.Globalization.dll": {},
+          "ref/net46/System.IdentityModel.dll": {},
+          "ref/net46/System.IdentityModel.Selectors.dll": {},
+          "ref/net46/System.IdentityModel.Services.dll": {},
+          "ref/net46/System.IO.Compression.dll": {},
+          "ref/net46/System.IO.Compression.FileSystem.dll": {},
+          "ref/net46/System.IO.dll": {},
+          "ref/net46/System.IO.Log.dll": {},
+          "ref/net46/System.Linq.dll": {},
+          "ref/net46/System.Linq.Expressions.dll": {},
+          "ref/net46/System.Linq.Parallel.dll": {},
+          "ref/net46/System.Linq.Queryable.dll": {},
+          "ref/net46/System.Management.dll": {},
+          "ref/net46/System.Management.Instrumentation.dll": {},
+          "ref/net46/System.Messaging.dll": {},
+          "ref/net46/System.Net.dll": {},
+          "ref/net46/System.Net.Http.dll": {},
+          "ref/net46/System.Net.Http.WebRequest.dll": {},
+          "ref/net46/System.Net.NetworkInformation.dll": {},
+          "ref/net46/System.Net.Primitives.dll": {},
+          "ref/net46/System.Net.Requests.dll": {},
+          "ref/net46/System.Net.WebHeaderCollection.dll": {},
+          "ref/net46/System.Numerics.dll": {},
+          "ref/net46/System.Numerics.Vectors.dll": {},
+          "ref/net46/System.ObjectModel.dll": {},
+          "ref/net46/System.Printing.dll": {},
+          "ref/net46/System.Reflection.Context.dll": {},
+          "ref/net46/System.Reflection.dll": {},
+          "ref/net46/System.Reflection.Emit.dll": {},
+          "ref/net46/System.Reflection.Emit.ILGeneration.dll": {},
+          "ref/net46/System.Reflection.Emit.Lightweight.dll": {},
+          "ref/net46/System.Reflection.Extensions.dll": {},
+          "ref/net46/System.Reflection.Primitives.dll": {},
+          "ref/net46/System.Resources.ResourceManager.dll": {},
+          "ref/net46/System.Runtime.Caching.dll": {},
+          "ref/net46/System.Runtime.dll": {},
+          "ref/net46/System.Runtime.DurableInstancing.dll": {},
+          "ref/net46/System.Runtime.Extensions.dll": {},
+          "ref/net46/System.Runtime.Handles.dll": {},
+          "ref/net46/System.Runtime.InteropServices.dll": {},
+          "ref/net46/System.Runtime.InteropServices.WindowsRuntime.dll": {},
+          "ref/net46/System.Runtime.Numerics.dll": {},
+          "ref/net46/System.Runtime.Remoting.dll": {},
+          "ref/net46/System.Runtime.Serialization.dll": {},
+          "ref/net46/System.Runtime.Serialization.Formatters.Soap.dll": {},
+          "ref/net46/System.Runtime.Serialization.Json.dll": {},
+          "ref/net46/System.Runtime.Serialization.Primitives.dll": {},
+          "ref/net46/System.Runtime.Serialization.Xml.dll": {},
+          "ref/net46/System.Security.dll": {},
+          "ref/net46/System.Security.Principal.dll": {},
+          "ref/net46/System.ServiceModel.Activation.dll": {},
+          "ref/net46/System.ServiceModel.Activities.dll": {},
+          "ref/net46/System.ServiceModel.Channels.dll": {},
+          "ref/net46/System.ServiceModel.Discovery.dll": {},
+          "ref/net46/System.ServiceModel.dll": {},
+          "ref/net46/System.ServiceModel.Duplex.dll": {},
+          "ref/net46/System.ServiceModel.Http.dll": {},
+          "ref/net46/System.ServiceModel.NetTcp.dll": {},
+          "ref/net46/System.ServiceModel.Primitives.dll": {},
+          "ref/net46/System.ServiceModel.Routing.dll": {},
+          "ref/net46/System.ServiceModel.Security.dll": {},
+          "ref/net46/System.ServiceModel.Web.dll": {},
+          "ref/net46/System.ServiceProcess.dll": {},
+          "ref/net46/System.Speech.dll": {},
+          "ref/net46/System.Text.Encoding.dll": {},
+          "ref/net46/System.Text.Encoding.Extensions.dll": {},
+          "ref/net46/System.Text.RegularExpressions.dll": {},
+          "ref/net46/System.Threading.dll": {},
+          "ref/net46/System.Threading.Tasks.dll": {},
+          "ref/net46/System.Threading.Tasks.Parallel.dll": {},
+          "ref/net46/System.Threading.Timer.dll": {},
+          "ref/net46/System.Transactions.dll": {},
+          "ref/net46/System.Web.Abstractions.dll": {},
+          "ref/net46/System.Web.ApplicationServices.dll": {},
+          "ref/net46/System.Web.DataVisualization.Design.dll": {},
+          "ref/net46/System.Web.DataVisualization.dll": {},
+          "ref/net46/System.Web.dll": {},
+          "ref/net46/System.Web.DynamicData.Design.dll": {},
+          "ref/net46/System.Web.DynamicData.dll": {},
+          "ref/net46/System.Web.Entity.Design.dll": {},
+          "ref/net46/System.Web.Entity.dll": {},
+          "ref/net46/System.Web.Extensions.Design.dll": {},
+          "ref/net46/System.Web.Extensions.dll": {},
+          "ref/net46/System.Web.Mobile.dll": {},
+          "ref/net46/System.Web.RegularExpressions.dll": {},
+          "ref/net46/System.Web.Routing.dll": {},
+          "ref/net46/System.Web.Services.dll": {},
+          "ref/net46/System.Windows.Controls.Ribbon.dll": {},
+          "ref/net46/System.Windows.dll": {},
+          "ref/net46/System.Windows.Forms.DataVisualization.Design.dll": {},
+          "ref/net46/System.Windows.Forms.DataVisualization.dll": {},
+          "ref/net46/System.Windows.Forms.dll": {},
+          "ref/net46/System.Windows.Input.Manipulations.dll": {},
+          "ref/net46/System.Windows.Presentation.dll": {},
+          "ref/net46/System.Workflow.Activities.dll": {},
+          "ref/net46/System.Workflow.ComponentModel.dll": {},
+          "ref/net46/System.Workflow.Runtime.dll": {},
+          "ref/net46/System.WorkflowServices.dll": {},
+          "ref/net46/System.Xaml.dll": {},
+          "ref/net46/System.Xml.dll": {},
+          "ref/net46/System.Xml.Linq.dll": {},
+          "ref/net46/System.Xml.ReaderWriter.dll": {},
+          "ref/net46/System.Xml.Serialization.dll": {},
+          "ref/net46/System.Xml.XDocument.dll": {},
+          "ref/net46/System.Xml.XmlSerializer.dll": {},
+          "ref/net46/UIAutomationClient.dll": {},
+          "ref/net46/UIAutomationClientsideProviders.dll": {},
+          "ref/net46/UIAutomationProvider.dll": {},
+          "ref/net46/UIAutomationTypes.dll": {},
+          "ref/net46/WindowsBase.dll": {},
+          "ref/net46/WindowsFormsIntegration.dll": {},
+          "ref/net46/XamlBuildTask.dll": {}
+        }
+      },
+      "System.Collections/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Diagnostics.Contracts/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Globalization/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.IO/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Linq/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.ObjectModel/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Reflection/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Reflection.Emit/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Reflection.Emit.Lightweight/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Reflection.Extensions/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Reflection.TypeExtensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "frameworkAssemblies": [
+          "mscorlib"
+        ],
+        "compile": {
+          "ref/net46/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "lib/net46/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Runtime/4.0.20": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Threading/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      }
+    },
     "DNXCore,Version=v5.0/win7-x86": {
       "System.Collections/4.0.10": {
         "type": "package",
@@ -859,9 +1239,964 @@
           "lib/DNXCore50/System.Threading.Tasks.dll": {}
         }
       }
+    },
+    ".NETFramework,Version=v4.6/win7-x86": {
+      "Microsoft.TargetingPack.NETFramework.v4.6/1.0.0-rc2-23530": {
+        "type": "package",
+        "compile": {
+          "ref/net46/Accessibility.dll": {},
+          "ref/net46/CustomMarshalers.dll": {},
+          "ref/net46/ISymWrapper.dll": {},
+          "ref/net46/Microsoft.Activities.Build.dll": {},
+          "ref/net46/Microsoft.Build.Conversion.v4.0.dll": {},
+          "ref/net46/Microsoft.Build.dll": {},
+          "ref/net46/Microsoft.Build.Engine.dll": {},
+          "ref/net46/Microsoft.Build.Framework.dll": {},
+          "ref/net46/Microsoft.Build.Tasks.v4.0.dll": {},
+          "ref/net46/Microsoft.Build.Utilities.v4.0.dll": {},
+          "ref/net46/Microsoft.CSharp.dll": {},
+          "ref/net46/Microsoft.JScript.dll": {},
+          "ref/net46/Microsoft.VisualBasic.Compatibility.Data.dll": {},
+          "ref/net46/Microsoft.VisualBasic.Compatibility.dll": {},
+          "ref/net46/Microsoft.VisualBasic.dll": {},
+          "ref/net46/Microsoft.VisualC.dll": {},
+          "ref/net46/Microsoft.VisualC.STLCLR.dll": {},
+          "ref/net46/mscorlib.dll": {},
+          "ref/net46/PresentationBuildTasks.dll": {},
+          "ref/net46/PresentationCore.dll": {},
+          "ref/net46/PresentationFramework.Aero.dll": {},
+          "ref/net46/PresentationFramework.Aero2.dll": {},
+          "ref/net46/PresentationFramework.AeroLite.dll": {},
+          "ref/net46/PresentationFramework.Classic.dll": {},
+          "ref/net46/PresentationFramework.dll": {},
+          "ref/net46/PresentationFramework.Luna.dll": {},
+          "ref/net46/PresentationFramework.Royale.dll": {},
+          "ref/net46/ReachFramework.dll": {},
+          "ref/net46/sysglobl.dll": {},
+          "ref/net46/System.Activities.Core.Presentation.dll": {},
+          "ref/net46/System.Activities.dll": {},
+          "ref/net46/System.Activities.DurableInstancing.dll": {},
+          "ref/net46/System.Activities.Presentation.dll": {},
+          "ref/net46/System.AddIn.Contract.dll": {},
+          "ref/net46/System.AddIn.dll": {},
+          "ref/net46/System.Collections.Concurrent.dll": {},
+          "ref/net46/System.Collections.dll": {},
+          "ref/net46/System.ComponentModel.Annotations.dll": {},
+          "ref/net46/System.ComponentModel.Composition.dll": {},
+          "ref/net46/System.ComponentModel.Composition.Registration.dll": {},
+          "ref/net46/System.ComponentModel.DataAnnotations.dll": {},
+          "ref/net46/System.ComponentModel.dll": {},
+          "ref/net46/System.ComponentModel.EventBasedAsync.dll": {},
+          "ref/net46/System.Configuration.dll": {},
+          "ref/net46/System.Configuration.Install.dll": {},
+          "ref/net46/System.Core.dll": {},
+          "ref/net46/System.Data.DataSetExtensions.dll": {},
+          "ref/net46/System.Data.dll": {},
+          "ref/net46/System.Data.Entity.Design.dll": {},
+          "ref/net46/System.Data.Entity.dll": {},
+          "ref/net46/System.Data.Linq.dll": {},
+          "ref/net46/System.Data.OracleClient.dll": {},
+          "ref/net46/System.Data.Services.Client.dll": {},
+          "ref/net46/System.Data.Services.Design.dll": {},
+          "ref/net46/System.Data.Services.dll": {},
+          "ref/net46/System.Data.SqlXml.dll": {},
+          "ref/net46/System.Deployment.dll": {},
+          "ref/net46/System.Design.dll": {},
+          "ref/net46/System.Device.dll": {},
+          "ref/net46/System.Diagnostics.Contracts.dll": {},
+          "ref/net46/System.Diagnostics.Debug.dll": {},
+          "ref/net46/System.Diagnostics.Tools.dll": {},
+          "ref/net46/System.Diagnostics.Tracing.dll": {},
+          "ref/net46/System.DirectoryServices.AccountManagement.dll": {},
+          "ref/net46/System.DirectoryServices.dll": {},
+          "ref/net46/System.DirectoryServices.Protocols.dll": {},
+          "ref/net46/System.dll": {},
+          "ref/net46/System.Drawing.Design.dll": {},
+          "ref/net46/System.Drawing.dll": {},
+          "ref/net46/System.Dynamic.dll": {},
+          "ref/net46/System.Dynamic.Runtime.dll": {},
+          "ref/net46/System.EnterpriseServices.dll": {},
+          "ref/net46/System.EnterpriseServices.Thunk.dll": {},
+          "ref/net46/System.EnterpriseServices.Wrapper.dll": {},
+          "ref/net46/System.Globalization.dll": {},
+          "ref/net46/System.IdentityModel.dll": {},
+          "ref/net46/System.IdentityModel.Selectors.dll": {},
+          "ref/net46/System.IdentityModel.Services.dll": {},
+          "ref/net46/System.IO.Compression.dll": {},
+          "ref/net46/System.IO.Compression.FileSystem.dll": {},
+          "ref/net46/System.IO.dll": {},
+          "ref/net46/System.IO.Log.dll": {},
+          "ref/net46/System.Linq.dll": {},
+          "ref/net46/System.Linq.Expressions.dll": {},
+          "ref/net46/System.Linq.Parallel.dll": {},
+          "ref/net46/System.Linq.Queryable.dll": {},
+          "ref/net46/System.Management.dll": {},
+          "ref/net46/System.Management.Instrumentation.dll": {},
+          "ref/net46/System.Messaging.dll": {},
+          "ref/net46/System.Net.dll": {},
+          "ref/net46/System.Net.Http.dll": {},
+          "ref/net46/System.Net.Http.WebRequest.dll": {},
+          "ref/net46/System.Net.NetworkInformation.dll": {},
+          "ref/net46/System.Net.Primitives.dll": {},
+          "ref/net46/System.Net.Requests.dll": {},
+          "ref/net46/System.Net.WebHeaderCollection.dll": {},
+          "ref/net46/System.Numerics.dll": {},
+          "ref/net46/System.Numerics.Vectors.dll": {},
+          "ref/net46/System.ObjectModel.dll": {},
+          "ref/net46/System.Printing.dll": {},
+          "ref/net46/System.Reflection.Context.dll": {},
+          "ref/net46/System.Reflection.dll": {},
+          "ref/net46/System.Reflection.Emit.dll": {},
+          "ref/net46/System.Reflection.Emit.ILGeneration.dll": {},
+          "ref/net46/System.Reflection.Emit.Lightweight.dll": {},
+          "ref/net46/System.Reflection.Extensions.dll": {},
+          "ref/net46/System.Reflection.Primitives.dll": {},
+          "ref/net46/System.Resources.ResourceManager.dll": {},
+          "ref/net46/System.Runtime.Caching.dll": {},
+          "ref/net46/System.Runtime.dll": {},
+          "ref/net46/System.Runtime.DurableInstancing.dll": {},
+          "ref/net46/System.Runtime.Extensions.dll": {},
+          "ref/net46/System.Runtime.Handles.dll": {},
+          "ref/net46/System.Runtime.InteropServices.dll": {},
+          "ref/net46/System.Runtime.InteropServices.WindowsRuntime.dll": {},
+          "ref/net46/System.Runtime.Numerics.dll": {},
+          "ref/net46/System.Runtime.Remoting.dll": {},
+          "ref/net46/System.Runtime.Serialization.dll": {},
+          "ref/net46/System.Runtime.Serialization.Formatters.Soap.dll": {},
+          "ref/net46/System.Runtime.Serialization.Json.dll": {},
+          "ref/net46/System.Runtime.Serialization.Primitives.dll": {},
+          "ref/net46/System.Runtime.Serialization.Xml.dll": {},
+          "ref/net46/System.Security.dll": {},
+          "ref/net46/System.Security.Principal.dll": {},
+          "ref/net46/System.ServiceModel.Activation.dll": {},
+          "ref/net46/System.ServiceModel.Activities.dll": {},
+          "ref/net46/System.ServiceModel.Channels.dll": {},
+          "ref/net46/System.ServiceModel.Discovery.dll": {},
+          "ref/net46/System.ServiceModel.dll": {},
+          "ref/net46/System.ServiceModel.Duplex.dll": {},
+          "ref/net46/System.ServiceModel.Http.dll": {},
+          "ref/net46/System.ServiceModel.NetTcp.dll": {},
+          "ref/net46/System.ServiceModel.Primitives.dll": {},
+          "ref/net46/System.ServiceModel.Routing.dll": {},
+          "ref/net46/System.ServiceModel.Security.dll": {},
+          "ref/net46/System.ServiceModel.Web.dll": {},
+          "ref/net46/System.ServiceProcess.dll": {},
+          "ref/net46/System.Speech.dll": {},
+          "ref/net46/System.Text.Encoding.dll": {},
+          "ref/net46/System.Text.Encoding.Extensions.dll": {},
+          "ref/net46/System.Text.RegularExpressions.dll": {},
+          "ref/net46/System.Threading.dll": {},
+          "ref/net46/System.Threading.Tasks.dll": {},
+          "ref/net46/System.Threading.Tasks.Parallel.dll": {},
+          "ref/net46/System.Threading.Timer.dll": {},
+          "ref/net46/System.Transactions.dll": {},
+          "ref/net46/System.Web.Abstractions.dll": {},
+          "ref/net46/System.Web.ApplicationServices.dll": {},
+          "ref/net46/System.Web.DataVisualization.Design.dll": {},
+          "ref/net46/System.Web.DataVisualization.dll": {},
+          "ref/net46/System.Web.dll": {},
+          "ref/net46/System.Web.DynamicData.Design.dll": {},
+          "ref/net46/System.Web.DynamicData.dll": {},
+          "ref/net46/System.Web.Entity.Design.dll": {},
+          "ref/net46/System.Web.Entity.dll": {},
+          "ref/net46/System.Web.Extensions.Design.dll": {},
+          "ref/net46/System.Web.Extensions.dll": {},
+          "ref/net46/System.Web.Mobile.dll": {},
+          "ref/net46/System.Web.RegularExpressions.dll": {},
+          "ref/net46/System.Web.Routing.dll": {},
+          "ref/net46/System.Web.Services.dll": {},
+          "ref/net46/System.Windows.Controls.Ribbon.dll": {},
+          "ref/net46/System.Windows.dll": {},
+          "ref/net46/System.Windows.Forms.DataVisualization.Design.dll": {},
+          "ref/net46/System.Windows.Forms.DataVisualization.dll": {},
+          "ref/net46/System.Windows.Forms.dll": {},
+          "ref/net46/System.Windows.Input.Manipulations.dll": {},
+          "ref/net46/System.Windows.Presentation.dll": {},
+          "ref/net46/System.Workflow.Activities.dll": {},
+          "ref/net46/System.Workflow.ComponentModel.dll": {},
+          "ref/net46/System.Workflow.Runtime.dll": {},
+          "ref/net46/System.WorkflowServices.dll": {},
+          "ref/net46/System.Xaml.dll": {},
+          "ref/net46/System.Xml.dll": {},
+          "ref/net46/System.Xml.Linq.dll": {},
+          "ref/net46/System.Xml.ReaderWriter.dll": {},
+          "ref/net46/System.Xml.Serialization.dll": {},
+          "ref/net46/System.Xml.XDocument.dll": {},
+          "ref/net46/System.Xml.XmlSerializer.dll": {},
+          "ref/net46/UIAutomationClient.dll": {},
+          "ref/net46/UIAutomationClientsideProviders.dll": {},
+          "ref/net46/UIAutomationProvider.dll": {},
+          "ref/net46/UIAutomationTypes.dll": {},
+          "ref/net46/WindowsBase.dll": {},
+          "ref/net46/WindowsFormsIntegration.dll": {},
+          "ref/net46/XamlBuildTask.dll": {}
+        }
+      },
+      "System.Collections/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Diagnostics.Contracts/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Globalization/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.IO/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Linq/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.ObjectModel/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Reflection/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Reflection.Emit/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Reflection.Emit.Lightweight/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Reflection.Extensions/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Reflection.TypeExtensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "frameworkAssemblies": [
+          "mscorlib"
+        ],
+        "compile": {
+          "ref/net46/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "lib/net46/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Runtime/4.0.20": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Threading/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      }
+    },
+    ".NETFramework,Version=v4.6/win7-x64": {
+      "Microsoft.TargetingPack.NETFramework.v4.6/1.0.0-rc2-23530": {
+        "type": "package",
+        "compile": {
+          "ref/net46/Accessibility.dll": {},
+          "ref/net46/CustomMarshalers.dll": {},
+          "ref/net46/ISymWrapper.dll": {},
+          "ref/net46/Microsoft.Activities.Build.dll": {},
+          "ref/net46/Microsoft.Build.Conversion.v4.0.dll": {},
+          "ref/net46/Microsoft.Build.dll": {},
+          "ref/net46/Microsoft.Build.Engine.dll": {},
+          "ref/net46/Microsoft.Build.Framework.dll": {},
+          "ref/net46/Microsoft.Build.Tasks.v4.0.dll": {},
+          "ref/net46/Microsoft.Build.Utilities.v4.0.dll": {},
+          "ref/net46/Microsoft.CSharp.dll": {},
+          "ref/net46/Microsoft.JScript.dll": {},
+          "ref/net46/Microsoft.VisualBasic.Compatibility.Data.dll": {},
+          "ref/net46/Microsoft.VisualBasic.Compatibility.dll": {},
+          "ref/net46/Microsoft.VisualBasic.dll": {},
+          "ref/net46/Microsoft.VisualC.dll": {},
+          "ref/net46/Microsoft.VisualC.STLCLR.dll": {},
+          "ref/net46/mscorlib.dll": {},
+          "ref/net46/PresentationBuildTasks.dll": {},
+          "ref/net46/PresentationCore.dll": {},
+          "ref/net46/PresentationFramework.Aero.dll": {},
+          "ref/net46/PresentationFramework.Aero2.dll": {},
+          "ref/net46/PresentationFramework.AeroLite.dll": {},
+          "ref/net46/PresentationFramework.Classic.dll": {},
+          "ref/net46/PresentationFramework.dll": {},
+          "ref/net46/PresentationFramework.Luna.dll": {},
+          "ref/net46/PresentationFramework.Royale.dll": {},
+          "ref/net46/ReachFramework.dll": {},
+          "ref/net46/sysglobl.dll": {},
+          "ref/net46/System.Activities.Core.Presentation.dll": {},
+          "ref/net46/System.Activities.dll": {},
+          "ref/net46/System.Activities.DurableInstancing.dll": {},
+          "ref/net46/System.Activities.Presentation.dll": {},
+          "ref/net46/System.AddIn.Contract.dll": {},
+          "ref/net46/System.AddIn.dll": {},
+          "ref/net46/System.Collections.Concurrent.dll": {},
+          "ref/net46/System.Collections.dll": {},
+          "ref/net46/System.ComponentModel.Annotations.dll": {},
+          "ref/net46/System.ComponentModel.Composition.dll": {},
+          "ref/net46/System.ComponentModel.Composition.Registration.dll": {},
+          "ref/net46/System.ComponentModel.DataAnnotations.dll": {},
+          "ref/net46/System.ComponentModel.dll": {},
+          "ref/net46/System.ComponentModel.EventBasedAsync.dll": {},
+          "ref/net46/System.Configuration.dll": {},
+          "ref/net46/System.Configuration.Install.dll": {},
+          "ref/net46/System.Core.dll": {},
+          "ref/net46/System.Data.DataSetExtensions.dll": {},
+          "ref/net46/System.Data.dll": {},
+          "ref/net46/System.Data.Entity.Design.dll": {},
+          "ref/net46/System.Data.Entity.dll": {},
+          "ref/net46/System.Data.Linq.dll": {},
+          "ref/net46/System.Data.OracleClient.dll": {},
+          "ref/net46/System.Data.Services.Client.dll": {},
+          "ref/net46/System.Data.Services.Design.dll": {},
+          "ref/net46/System.Data.Services.dll": {},
+          "ref/net46/System.Data.SqlXml.dll": {},
+          "ref/net46/System.Deployment.dll": {},
+          "ref/net46/System.Design.dll": {},
+          "ref/net46/System.Device.dll": {},
+          "ref/net46/System.Diagnostics.Contracts.dll": {},
+          "ref/net46/System.Diagnostics.Debug.dll": {},
+          "ref/net46/System.Diagnostics.Tools.dll": {},
+          "ref/net46/System.Diagnostics.Tracing.dll": {},
+          "ref/net46/System.DirectoryServices.AccountManagement.dll": {},
+          "ref/net46/System.DirectoryServices.dll": {},
+          "ref/net46/System.DirectoryServices.Protocols.dll": {},
+          "ref/net46/System.dll": {},
+          "ref/net46/System.Drawing.Design.dll": {},
+          "ref/net46/System.Drawing.dll": {},
+          "ref/net46/System.Dynamic.dll": {},
+          "ref/net46/System.Dynamic.Runtime.dll": {},
+          "ref/net46/System.EnterpriseServices.dll": {},
+          "ref/net46/System.EnterpriseServices.Thunk.dll": {},
+          "ref/net46/System.EnterpriseServices.Wrapper.dll": {},
+          "ref/net46/System.Globalization.dll": {},
+          "ref/net46/System.IdentityModel.dll": {},
+          "ref/net46/System.IdentityModel.Selectors.dll": {},
+          "ref/net46/System.IdentityModel.Services.dll": {},
+          "ref/net46/System.IO.Compression.dll": {},
+          "ref/net46/System.IO.Compression.FileSystem.dll": {},
+          "ref/net46/System.IO.dll": {},
+          "ref/net46/System.IO.Log.dll": {},
+          "ref/net46/System.Linq.dll": {},
+          "ref/net46/System.Linq.Expressions.dll": {},
+          "ref/net46/System.Linq.Parallel.dll": {},
+          "ref/net46/System.Linq.Queryable.dll": {},
+          "ref/net46/System.Management.dll": {},
+          "ref/net46/System.Management.Instrumentation.dll": {},
+          "ref/net46/System.Messaging.dll": {},
+          "ref/net46/System.Net.dll": {},
+          "ref/net46/System.Net.Http.dll": {},
+          "ref/net46/System.Net.Http.WebRequest.dll": {},
+          "ref/net46/System.Net.NetworkInformation.dll": {},
+          "ref/net46/System.Net.Primitives.dll": {},
+          "ref/net46/System.Net.Requests.dll": {},
+          "ref/net46/System.Net.WebHeaderCollection.dll": {},
+          "ref/net46/System.Numerics.dll": {},
+          "ref/net46/System.Numerics.Vectors.dll": {},
+          "ref/net46/System.ObjectModel.dll": {},
+          "ref/net46/System.Printing.dll": {},
+          "ref/net46/System.Reflection.Context.dll": {},
+          "ref/net46/System.Reflection.dll": {},
+          "ref/net46/System.Reflection.Emit.dll": {},
+          "ref/net46/System.Reflection.Emit.ILGeneration.dll": {},
+          "ref/net46/System.Reflection.Emit.Lightweight.dll": {},
+          "ref/net46/System.Reflection.Extensions.dll": {},
+          "ref/net46/System.Reflection.Primitives.dll": {},
+          "ref/net46/System.Resources.ResourceManager.dll": {},
+          "ref/net46/System.Runtime.Caching.dll": {},
+          "ref/net46/System.Runtime.dll": {},
+          "ref/net46/System.Runtime.DurableInstancing.dll": {},
+          "ref/net46/System.Runtime.Extensions.dll": {},
+          "ref/net46/System.Runtime.Handles.dll": {},
+          "ref/net46/System.Runtime.InteropServices.dll": {},
+          "ref/net46/System.Runtime.InteropServices.WindowsRuntime.dll": {},
+          "ref/net46/System.Runtime.Numerics.dll": {},
+          "ref/net46/System.Runtime.Remoting.dll": {},
+          "ref/net46/System.Runtime.Serialization.dll": {},
+          "ref/net46/System.Runtime.Serialization.Formatters.Soap.dll": {},
+          "ref/net46/System.Runtime.Serialization.Json.dll": {},
+          "ref/net46/System.Runtime.Serialization.Primitives.dll": {},
+          "ref/net46/System.Runtime.Serialization.Xml.dll": {},
+          "ref/net46/System.Security.dll": {},
+          "ref/net46/System.Security.Principal.dll": {},
+          "ref/net46/System.ServiceModel.Activation.dll": {},
+          "ref/net46/System.ServiceModel.Activities.dll": {},
+          "ref/net46/System.ServiceModel.Channels.dll": {},
+          "ref/net46/System.ServiceModel.Discovery.dll": {},
+          "ref/net46/System.ServiceModel.dll": {},
+          "ref/net46/System.ServiceModel.Duplex.dll": {},
+          "ref/net46/System.ServiceModel.Http.dll": {},
+          "ref/net46/System.ServiceModel.NetTcp.dll": {},
+          "ref/net46/System.ServiceModel.Primitives.dll": {},
+          "ref/net46/System.ServiceModel.Routing.dll": {},
+          "ref/net46/System.ServiceModel.Security.dll": {},
+          "ref/net46/System.ServiceModel.Web.dll": {},
+          "ref/net46/System.ServiceProcess.dll": {},
+          "ref/net46/System.Speech.dll": {},
+          "ref/net46/System.Text.Encoding.dll": {},
+          "ref/net46/System.Text.Encoding.Extensions.dll": {},
+          "ref/net46/System.Text.RegularExpressions.dll": {},
+          "ref/net46/System.Threading.dll": {},
+          "ref/net46/System.Threading.Tasks.dll": {},
+          "ref/net46/System.Threading.Tasks.Parallel.dll": {},
+          "ref/net46/System.Threading.Timer.dll": {},
+          "ref/net46/System.Transactions.dll": {},
+          "ref/net46/System.Web.Abstractions.dll": {},
+          "ref/net46/System.Web.ApplicationServices.dll": {},
+          "ref/net46/System.Web.DataVisualization.Design.dll": {},
+          "ref/net46/System.Web.DataVisualization.dll": {},
+          "ref/net46/System.Web.dll": {},
+          "ref/net46/System.Web.DynamicData.Design.dll": {},
+          "ref/net46/System.Web.DynamicData.dll": {},
+          "ref/net46/System.Web.Entity.Design.dll": {},
+          "ref/net46/System.Web.Entity.dll": {},
+          "ref/net46/System.Web.Extensions.Design.dll": {},
+          "ref/net46/System.Web.Extensions.dll": {},
+          "ref/net46/System.Web.Mobile.dll": {},
+          "ref/net46/System.Web.RegularExpressions.dll": {},
+          "ref/net46/System.Web.Routing.dll": {},
+          "ref/net46/System.Web.Services.dll": {},
+          "ref/net46/System.Windows.Controls.Ribbon.dll": {},
+          "ref/net46/System.Windows.dll": {},
+          "ref/net46/System.Windows.Forms.DataVisualization.Design.dll": {},
+          "ref/net46/System.Windows.Forms.DataVisualization.dll": {},
+          "ref/net46/System.Windows.Forms.dll": {},
+          "ref/net46/System.Windows.Input.Manipulations.dll": {},
+          "ref/net46/System.Windows.Presentation.dll": {},
+          "ref/net46/System.Workflow.Activities.dll": {},
+          "ref/net46/System.Workflow.ComponentModel.dll": {},
+          "ref/net46/System.Workflow.Runtime.dll": {},
+          "ref/net46/System.WorkflowServices.dll": {},
+          "ref/net46/System.Xaml.dll": {},
+          "ref/net46/System.Xml.dll": {},
+          "ref/net46/System.Xml.Linq.dll": {},
+          "ref/net46/System.Xml.ReaderWriter.dll": {},
+          "ref/net46/System.Xml.Serialization.dll": {},
+          "ref/net46/System.Xml.XDocument.dll": {},
+          "ref/net46/System.Xml.XmlSerializer.dll": {},
+          "ref/net46/UIAutomationClient.dll": {},
+          "ref/net46/UIAutomationClientsideProviders.dll": {},
+          "ref/net46/UIAutomationProvider.dll": {},
+          "ref/net46/UIAutomationTypes.dll": {},
+          "ref/net46/WindowsBase.dll": {},
+          "ref/net46/WindowsFormsIntegration.dll": {},
+          "ref/net46/XamlBuildTask.dll": {}
+        }
+      },
+      "System.Collections/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Diagnostics.Contracts/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Diagnostics.Debug/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Diagnostics.Tools/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Globalization/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.IO/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Linq/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.ObjectModel/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Reflection/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Reflection.Emit/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Reflection.Emit.ILGeneration/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Reflection.Emit.Lightweight/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Reflection.Extensions/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Reflection.Primitives/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Reflection.TypeExtensions/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Reflection": "4.0.0",
+          "System.Runtime": "4.0.0"
+        },
+        "frameworkAssemblies": [
+          "mscorlib"
+        ],
+        "compile": {
+          "ref/net46/System.Reflection.TypeExtensions.dll": {}
+        },
+        "runtime": {
+          "lib/net46/System.Reflection.TypeExtensions.dll": {}
+        }
+      },
+      "System.Resources.ResourceManager/4.0.0": {
+        "type": "package",
+        "compile": {
+          "ref/net45/_._": {}
+        },
+        "runtime": {
+          "lib/net45/_._": {}
+        }
+      },
+      "System.Runtime/4.0.20": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Runtime.Extensions/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Threading/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      },
+      "System.Threading.Tasks/4.0.10": {
+        "type": "package",
+        "compile": {
+          "ref/net46/_._": {}
+        },
+        "runtime": {
+          "lib/net46/_._": {}
+        }
+      }
     }
   },
   "libraries": {
+    "Microsoft.TargetingPack.NETFramework.v4.6/1.0.0-rc2-23530": {
+      "type": "package",
+      "sha512": "qhZEnZLXtOGsSWkG7ozjU/sYCLIBlkKSue99fckT6Ty5v9htDythPLfAJrzHOUwDkBQ7oRPBCryeDE/E1fwnCg==",
+      "files": [
+        "Microsoft.TargetingPack.NETFramework.v4.6.1.0.0-rc2-23530.nupkg",
+        "Microsoft.TargetingPack.NETFramework.v4.6.1.0.0-rc2-23530.nupkg.sha512",
+        "Microsoft.TargetingPack.NETFramework.v4.6.nuspec",
+        "ref/net46/Accessibility.dll",
+        "ref/net46/CustomMarshalers.dll",
+        "ref/net46/ISymWrapper.dll",
+        "ref/net46/Microsoft.Activities.Build.dll",
+        "ref/net46/Microsoft.Build.Conversion.v4.0.dll",
+        "ref/net46/Microsoft.Build.dll",
+        "ref/net46/Microsoft.Build.Engine.dll",
+        "ref/net46/Microsoft.Build.Framework.dll",
+        "ref/net46/Microsoft.Build.Tasks.v4.0.dll",
+        "ref/net46/Microsoft.Build.Utilities.v4.0.dll",
+        "ref/net46/Microsoft.CSharp.dll",
+        "ref/net46/Microsoft.JScript.dll",
+        "ref/net46/Microsoft.VisualBasic.Compatibility.Data.dll",
+        "ref/net46/Microsoft.VisualBasic.Compatibility.dll",
+        "ref/net46/Microsoft.VisualBasic.dll",
+        "ref/net46/Microsoft.VisualC.dll",
+        "ref/net46/Microsoft.VisualC.STLCLR.dll",
+        "ref/net46/mscorlib.dll",
+        "ref/net46/PresentationBuildTasks.dll",
+        "ref/net46/PresentationCore.dll",
+        "ref/net46/PresentationFramework.Aero.dll",
+        "ref/net46/PresentationFramework.Aero2.dll",
+        "ref/net46/PresentationFramework.AeroLite.dll",
+        "ref/net46/PresentationFramework.Classic.dll",
+        "ref/net46/PresentationFramework.dll",
+        "ref/net46/PresentationFramework.Luna.dll",
+        "ref/net46/PresentationFramework.Royale.dll",
+        "ref/net46/ReachFramework.dll",
+        "ref/net46/sysglobl.dll",
+        "ref/net46/System.Activities.Core.Presentation.dll",
+        "ref/net46/System.Activities.dll",
+        "ref/net46/System.Activities.DurableInstancing.dll",
+        "ref/net46/System.Activities.Presentation.dll",
+        "ref/net46/System.AddIn.Contract.dll",
+        "ref/net46/System.AddIn.dll",
+        "ref/net46/System.Collections.Concurrent.dll",
+        "ref/net46/System.Collections.dll",
+        "ref/net46/System.ComponentModel.Annotations.dll",
+        "ref/net46/System.ComponentModel.Composition.dll",
+        "ref/net46/System.ComponentModel.Composition.Registration.dll",
+        "ref/net46/System.ComponentModel.DataAnnotations.dll",
+        "ref/net46/System.ComponentModel.dll",
+        "ref/net46/System.ComponentModel.EventBasedAsync.dll",
+        "ref/net46/System.Configuration.dll",
+        "ref/net46/System.Configuration.Install.dll",
+        "ref/net46/System.Core.dll",
+        "ref/net46/System.Data.DataSetExtensions.dll",
+        "ref/net46/System.Data.dll",
+        "ref/net46/System.Data.Entity.Design.dll",
+        "ref/net46/System.Data.Entity.dll",
+        "ref/net46/System.Data.Linq.dll",
+        "ref/net46/System.Data.OracleClient.dll",
+        "ref/net46/System.Data.Services.Client.dll",
+        "ref/net46/System.Data.Services.Design.dll",
+        "ref/net46/System.Data.Services.dll",
+        "ref/net46/System.Data.SqlXml.dll",
+        "ref/net46/System.Deployment.dll",
+        "ref/net46/System.Design.dll",
+        "ref/net46/System.Device.dll",
+        "ref/net46/System.Diagnostics.Contracts.dll",
+        "ref/net46/System.Diagnostics.Debug.dll",
+        "ref/net46/System.Diagnostics.Tools.dll",
+        "ref/net46/System.Diagnostics.Tracing.dll",
+        "ref/net46/System.DirectoryServices.AccountManagement.dll",
+        "ref/net46/System.DirectoryServices.dll",
+        "ref/net46/System.DirectoryServices.Protocols.dll",
+        "ref/net46/System.dll",
+        "ref/net46/System.Drawing.Design.dll",
+        "ref/net46/System.Drawing.dll",
+        "ref/net46/System.Dynamic.dll",
+        "ref/net46/System.Dynamic.Runtime.dll",
+        "ref/net46/System.EnterpriseServices.dll",
+        "ref/net46/System.EnterpriseServices.Thunk.dll",
+        "ref/net46/System.EnterpriseServices.Wrapper.dll",
+        "ref/net46/System.Globalization.dll",
+        "ref/net46/System.IdentityModel.dll",
+        "ref/net46/System.IdentityModel.Selectors.dll",
+        "ref/net46/System.IdentityModel.Services.dll",
+        "ref/net46/System.IO.Compression.dll",
+        "ref/net46/System.IO.Compression.FileSystem.dll",
+        "ref/net46/System.IO.dll",
+        "ref/net46/System.IO.Log.dll",
+        "ref/net46/System.Linq.dll",
+        "ref/net46/System.Linq.Expressions.dll",
+        "ref/net46/System.Linq.Parallel.dll",
+        "ref/net46/System.Linq.Queryable.dll",
+        "ref/net46/System.Management.dll",
+        "ref/net46/System.Management.Instrumentation.dll",
+        "ref/net46/System.Messaging.dll",
+        "ref/net46/System.Net.dll",
+        "ref/net46/System.Net.Http.dll",
+        "ref/net46/System.Net.Http.WebRequest.dll",
+        "ref/net46/System.Net.NetworkInformation.dll",
+        "ref/net46/System.Net.Primitives.dll",
+        "ref/net46/System.Net.Requests.dll",
+        "ref/net46/System.Net.WebHeaderCollection.dll",
+        "ref/net46/System.Numerics.dll",
+        "ref/net46/System.Numerics.Vectors.dll",
+        "ref/net46/System.ObjectModel.dll",
+        "ref/net46/System.Printing.dll",
+        "ref/net46/System.Reflection.Context.dll",
+        "ref/net46/System.Reflection.dll",
+        "ref/net46/System.Reflection.Emit.dll",
+        "ref/net46/System.Reflection.Emit.ILGeneration.dll",
+        "ref/net46/System.Reflection.Emit.Lightweight.dll",
+        "ref/net46/System.Reflection.Extensions.dll",
+        "ref/net46/System.Reflection.Primitives.dll",
+        "ref/net46/System.Resources.ResourceManager.dll",
+        "ref/net46/System.Runtime.Caching.dll",
+        "ref/net46/System.Runtime.dll",
+        "ref/net46/System.Runtime.DurableInstancing.dll",
+        "ref/net46/System.Runtime.Extensions.dll",
+        "ref/net46/System.Runtime.Handles.dll",
+        "ref/net46/System.Runtime.InteropServices.dll",
+        "ref/net46/System.Runtime.InteropServices.WindowsRuntime.dll",
+        "ref/net46/System.Runtime.Numerics.dll",
+        "ref/net46/System.Runtime.Remoting.dll",
+        "ref/net46/System.Runtime.Serialization.dll",
+        "ref/net46/System.Runtime.Serialization.Formatters.Soap.dll",
+        "ref/net46/System.Runtime.Serialization.Json.dll",
+        "ref/net46/System.Runtime.Serialization.Primitives.dll",
+        "ref/net46/System.Runtime.Serialization.Xml.dll",
+        "ref/net46/System.Security.dll",
+        "ref/net46/System.Security.Principal.dll",
+        "ref/net46/System.ServiceModel.Activation.dll",
+        "ref/net46/System.ServiceModel.Activities.dll",
+        "ref/net46/System.ServiceModel.Channels.dll",
+        "ref/net46/System.ServiceModel.Discovery.dll",
+        "ref/net46/System.ServiceModel.dll",
+        "ref/net46/System.ServiceModel.Duplex.dll",
+        "ref/net46/System.ServiceModel.Http.dll",
+        "ref/net46/System.ServiceModel.NetTcp.dll",
+        "ref/net46/System.ServiceModel.Primitives.dll",
+        "ref/net46/System.ServiceModel.Routing.dll",
+        "ref/net46/System.ServiceModel.Security.dll",
+        "ref/net46/System.ServiceModel.Web.dll",
+        "ref/net46/System.ServiceProcess.dll",
+        "ref/net46/System.Speech.dll",
+        "ref/net46/System.Text.Encoding.dll",
+        "ref/net46/System.Text.Encoding.Extensions.dll",
+        "ref/net46/System.Text.RegularExpressions.dll",
+        "ref/net46/System.Threading.dll",
+        "ref/net46/System.Threading.Tasks.dll",
+        "ref/net46/System.Threading.Tasks.Parallel.dll",
+        "ref/net46/System.Threading.Timer.dll",
+        "ref/net46/System.Transactions.dll",
+        "ref/net46/System.Web.Abstractions.dll",
+        "ref/net46/System.Web.ApplicationServices.dll",
+        "ref/net46/System.Web.DataVisualization.Design.dll",
+        "ref/net46/System.Web.DataVisualization.dll",
+        "ref/net46/System.Web.dll",
+        "ref/net46/System.Web.DynamicData.Design.dll",
+        "ref/net46/System.Web.DynamicData.dll",
+        "ref/net46/System.Web.Entity.Design.dll",
+        "ref/net46/System.Web.Entity.dll",
+        "ref/net46/System.Web.Extensions.Design.dll",
+        "ref/net46/System.Web.Extensions.dll",
+        "ref/net46/System.Web.Mobile.dll",
+        "ref/net46/System.Web.RegularExpressions.dll",
+        "ref/net46/System.Web.Routing.dll",
+        "ref/net46/System.Web.Services.dll",
+        "ref/net46/System.Windows.Controls.Ribbon.dll",
+        "ref/net46/System.Windows.dll",
+        "ref/net46/System.Windows.Forms.DataVisualization.Design.dll",
+        "ref/net46/System.Windows.Forms.DataVisualization.dll",
+        "ref/net46/System.Windows.Forms.dll",
+        "ref/net46/System.Windows.Input.Manipulations.dll",
+        "ref/net46/System.Windows.Presentation.dll",
+        "ref/net46/System.Workflow.Activities.dll",
+        "ref/net46/System.Workflow.ComponentModel.dll",
+        "ref/net46/System.Workflow.Runtime.dll",
+        "ref/net46/System.WorkflowServices.dll",
+        "ref/net46/System.Xaml.dll",
+        "ref/net46/System.Xml.dll",
+        "ref/net46/System.Xml.Linq.dll",
+        "ref/net46/System.Xml.ReaderWriter.dll",
+        "ref/net46/System.Xml.Serialization.dll",
+        "ref/net46/System.Xml.XDocument.dll",
+        "ref/net46/System.Xml.XmlSerializer.dll",
+        "ref/net46/UIAutomationClient.dll",
+        "ref/net46/UIAutomationClientsideProviders.dll",
+        "ref/net46/UIAutomationProvider.dll",
+        "ref/net46/UIAutomationTypes.dll",
+        "ref/net46/WindowsBase.dll",
+        "ref/net46/WindowsFormsIntegration.dll",
+        "ref/net46/XamlBuildTask.dll"
+      ]
+    },
     "System.Collections/4.0.10": {
       "type": "package",
       "serviceable": true,
@@ -1601,6 +2936,9 @@
       "System.Threading >= 4.0.10",
       "System.Threading.Tasks >= 4.0.10"
     ],
-    "DNXCore,Version=v5.0": []
+    "DNXCore,Version=v5.0": [],
+    ".NETFramework,Version=v4.6": [
+      "Microsoft.TargetingPack.NETFramework.v4.6 >= 1.0.0-rc2-23530"
+    ]
   }
 }


### PR DESCRIPTION
Convert System.Linq.Expresions library project to follow the new guidelines at https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/project-guidelines.md and enable building of the other flavors of this library (netcore50, netcore50aot, net46, etc). 

cc @VSadov @mellinoe 