### PR TITLE
Bump dev/metadata version to 1.3

### DIFF
--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -14,7 +14,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <NoWarn>1591</NoWarn>
     <CLSCompliant>false</CLSCompliant>
-    <AssemblyVersion>1.2.0.0</AssemblyVersion>
+    <AssemblyVersion>1.3.0.0</AssemblyVersion>
     <PackageTargetFramework>dotnet5.2</PackageTargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">


### PR DESCRIPTION
Master will move to 1.2 and acquire SignatureDecoder and MetadataWriter

dev/metadata, still has CustomAttributeDecoder and TypeNameParser which need further refactoring and testing, so bump dev version to 1.3.