### PR TITLE
Fix pipelining in System.Net.Http on CentOS

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.VersionInfo.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.VersionInfo.cs
@@ -12,6 +12,7 @@ internal static partial class Interop
         internal static extern bool GetCurlVersionInfo(
             out int age,
             [MarshalAs(UnmanagedType.Bool)] out bool supportsSsl,
-            [MarshalAs(UnmanagedType.Bool)] out bool supportsAutoDecompression);
+            [MarshalAs(UnmanagedType.Bool)] out bool supportsAutoDecompression,
+            [MarshalAs(UnmanagedType.Bool)] out bool supportsHttp2Multiplexing);
     }
 }

--- a/src/Native/System.Net.Http.Native/pal_versioninfo.cpp
+++ b/src/Native/System.Net.Http.Native/pal_versioninfo.cpp
@@ -1,15 +1,20 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#include "pal_config.h"
 #include "pal_versioninfo.h"
 
 #include <curl/curl.h>
 
-extern "C" int32_t GetCurlVersionInfo(int32_t* age, int32_t* supportsSsl, int32_t* supportsAutoDecompression)
+extern "C" int32_t GetCurlVersionInfo(
+    int32_t* age, 
+    int32_t* supportsSsl, 
+    int32_t* supportsAutoDecompression,
+    int32_t* supportsHttp2Multiplexing)
 {
     curl_version_info_data* versionInfo = curl_version_info(CURLVERSION_NOW);
 
-    if (!versionInfo || !age || !supportsSsl || !supportsAutoDecompression)
+    if (!versionInfo || !age || !supportsSsl || !supportsAutoDecompression || !supportsHttp2Multiplexing)
     {
         if (age)
             *age = 0;
@@ -17,6 +22,8 @@ extern "C" int32_t GetCurlVersionInfo(int32_t* age, int32_t* supportsSsl, int32_
             *supportsSsl = 0;
         if (supportsAutoDecompression)
             *supportsAutoDecompression = 0;
+        if (supportsHttp2Multiplexing)
+            *supportsHttp2Multiplexing = 0;
 
         return 0;
     }
@@ -24,6 +31,12 @@ extern "C" int32_t GetCurlVersionInfo(int32_t* age, int32_t* supportsSsl, int32_
     *age = versionInfo->age;
     *supportsSsl = (versionInfo->features & CURL_VERSION_SSL) == CURL_VERSION_SSL;
     *supportsAutoDecompression = (versionInfo->features & CURL_VERSION_LIBZ) == CURL_VERSION_LIBZ;
+    *supportsHttp2Multiplexing =
+#if HAVE_CURLPIPE_MULTIPLEX
+        (versionInfo->features & CURL_VERSION_HTTP2) == CURL_VERSION_HTTP2;
+#else
+        0;
+#endif
 
     return 1;
 }

--- a/src/Native/System.Net.Http.Native/pal_versioninfo.h
+++ b/src/Native/System.Net.Http.Native/pal_versioninfo.h
@@ -10,4 +10,8 @@ Gets the curl version information.
 
 Returns 1 upon success, otherwise 0.
 */
-extern "C" int32_t GetCurlVersionInfo(int32_t* age, int32_t* supportsSsl, int32_t* supportsAutoDecompression);
+extern "C" int32_t GetCurlVersionInfo(
+    int32_t* age, 
+    int32_t* supportsSsl, 
+    int32_t* supportsAutoDecompression,
+    int32_t* supportsHttp2Multiplexing);

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -43,6 +43,7 @@ namespace System.Net.Http
 
         private readonly static bool s_supportsAutomaticDecompression;
         private readonly static bool s_supportsSSL;
+        private readonly static bool s_supportsHttp2Multiplexing;
 
         private readonly MultiAgent _agent = new MultiAgent();
         private volatile bool _anyOperationStarted;
@@ -69,7 +70,11 @@ namespace System.Net.Http
             // curl_global_init call handled by Interop.LibCurl's cctor
 
             int age;
-            if (!Interop.Http.GetCurlVersionInfo(out age, out s_supportsSSL, out s_supportsAutomaticDecompression))
+            if (!Interop.Http.GetCurlVersionInfo(
+                out age, 
+                out s_supportsSSL, 
+                out s_supportsAutomaticDecompression, 
+                out s_supportsHttp2Multiplexing))
             {
                 throw new InvalidOperationException(SR.net_http_unix_https_libcurl_no_versioninfo);  
             }

--- a/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
+++ b/src/System.Net.Requests/tests/System.Net.Requests.Tests.csproj
@@ -38,6 +38,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- TODO: Temporary workaround.  This PR introduces a backward-incompatible change in System.Net.Http.Native. 
+         Due to how tests are run in CI, this results in a crash when the System.Net.Requests.Tests are run. The 
+         following is a temporary work around and will be removed as soon as the dlls and native libraries get in sync. -->	
+    <ProjectReference Include="..\..\System.Net.Http\src\System.Net.Http.csproj">		
+        <Name>System.Net.Http</Name>		
+        <Project>{1D422B1D-D7C4-41B9-862D-EB3D98DF37DE}</Project>		
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />


### PR DESCRIPTION
My previous change to add HTTP/2 multiplexing broke some System.Net.Http functionality on CentOS, or more specifically when using an old version of libcurl that's in our CentOS 7.1 image.

That version of libcurl is from before HTTP/2 multiplexing was introduced.  When multiplexing was added to libcurl, one of the existing libcurl functions (curl_multi_setopt) was changed such that if you were to pass in the HTTP/2 multiplexing option (which didn't exist at the time), due to the way the method was implemented, you'd end up opting in to HTTP 1.1 pipelining rather than having the option just be ignored.  This is not the desired behavior and ends up breaking behaviors where we issue multiple HTTP 1.1 calls on the same multi handle concurrently.

This fix exposes from the native shim whether we're using a version of libcurl that supports HTTP/2 and that knows about the multiplexing option, and only configures the multi handle for multiplexing in that case.

Fixes #4801
cc: @kapilash, @ellismg, @eerhardt 