### PR TITLE
Fix native code to build on 32 bit platforms

### DIFF
--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -28,6 +28,7 @@ if (CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL am
     add_definitions(-DBIT64=1)
 elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l)
     add_definitions(-DBIT32=1)
+    add_definitions(-D_FILE_OFFSET_BITS=64)
     # Because we don't use CMAKE_C_COMPILER/CMAKE_CXX_COMPILER to use clang
     # we have to set the triple by adding a compiler argument
     add_compile_options(-target armv7-linux-gnueabihf)

--- a/src/Native/System.Native/pal_process.cpp
+++ b/src/Native/System.Native/pal_process.cpp
@@ -436,7 +436,7 @@ extern "C" int32_t SchedSetAffinity(int32_t pid, intptr_t* mask)
     intptr_t bits = *mask; 
     for (int cpu = 0; cpu < maxCpu; cpu++)
     {
-        if ((bits & (1u << cpu)) != 0)
+        if ((bits & static_cast<intptr_t>(1u << cpu)) != 0)
         {
             CPU_SET(cpu, &set);
         }

--- a/src/Native/System.Native/pal_time.cpp
+++ b/src/Native/System.Native/pal_time.cpp
@@ -20,8 +20,8 @@ enum
 
 static void ConvertUTimBuf(const UTimBuf& pal, utimbuf& native)
 {
-    native.actime = pal.AcTime;
-    native.modtime = pal.ModTime;
+    native.actime = static_cast<time_t>(pal.AcTime);
+    native.modtime = static_cast<time_t>(pal.ModTime);
 }
 
 extern "C" int32_t UTime(const char* path, UTimBuf* times)

--- a/src/Native/System.Net.Http.Native/pal_easy.cpp
+++ b/src/Native/System.Net.Http.Native/pal_easy.cpp
@@ -178,19 +178,19 @@ extern "C" void RegisterSeekCallback(CURL* curl, SeekCallback callback, void* us
 static size_t write_callback(char* buffer, size_t size, size_t nitems, void* instream)
 {
     CallbackHandle* handle = static_cast<CallbackHandle*>(instream);
-    return handle->writeCallback(reinterpret_cast<uint8_t*>(buffer), size, nitems, handle->writeUserPointer);
+    return static_cast<size_t>(handle->writeCallback(reinterpret_cast<uint8_t*>(buffer), size, nitems, handle->writeUserPointer));
 }
 
 static size_t read_callback(char* buffer, size_t size, size_t nitems, void* instream)
 {
     CallbackHandle* handle = static_cast<CallbackHandle*>(instream);
-    return handle->readCallback(reinterpret_cast<uint8_t*>(buffer), size, nitems, handle->readUserPointer);
+    return static_cast<size_t>(handle->readCallback(reinterpret_cast<uint8_t*>(buffer), size, nitems, handle->readUserPointer));
 }
 
 static size_t header_callback(char* buffer, size_t size, size_t nitems, void* instream)
 {
     CallbackHandle* handle = static_cast<CallbackHandle*>(instream);
-    return handle->headerCallback(reinterpret_cast<uint8_t*>(buffer), size, nitems, handle->headerUserPointer);
+    return static_cast<size_t>(handle->headerCallback(reinterpret_cast<uint8_t*>(buffer), size, nitems, handle->headerUserPointer));
 }
 
 extern "C" void RegisterReadWriteCallback(CURL* curl, ReadWriteFunction functionType, ReadWriteCallback callback, void* userPointer, CallbackHandle** callbackHandle)

--- a/src/Native/System.Security.Cryptography.Native/pal_err.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_err.cpp
@@ -25,10 +25,10 @@ extern "C" uint64_t ErrGetErrorAlloc(int32_t* isAllocFailure)
 
 extern "C" const char* ErrReasonErrorString(uint64_t error)
 {
-    return ERR_reason_error_string(error);
+    return ERR_reason_error_string(static_cast<unsigned long>(error));
 }
 
 extern "C" void ErrErrorStringN(uint64_t e, char* buf, int32_t len)
 {
-    ERR_error_string_n(e, buf, UnsignedCast(len));
+    ERR_error_string_n(static_cast<unsigned long>(e), buf, UnsignedCast(len));
 }


### PR DESCRIPTION
CoreFX made some assumptions in the native code wrappers about the size of the types used by other libraries. This enables the use of the large file support POSIX functions on ARM, and otherwise casts to the expected type, this should always be casting returns to a larger type so could only be problematic if we assume that we can pass an argument that is larger than a 32 bit integer.