### PR TITLE
Bump minor version on immutable collections

### DIFF
--- a/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -15,7 +15,7 @@
     <FileAlignment>512</FileAlignment>
     <DocumentationFile>$(OutputPath)System.Collections.Immutable.xml</DocumentationFile>
     <GenerateAppxPackageOnBuild>False</GenerateAppxPackageOnBuild>
-    <AssemblyVersion>1.1.38</AssemblyVersion>
+    <AssemblyVersion>1.2.0</AssemblyVersion>
     <PackageTargetFramework>dotnet5.1</PackageTargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
API was added to this assembly in commit 54140899. So bumping the minor version is appropriate per the policy set by @ericstj in commit 40723b79.