### PR TITLE
Add ProcessStartInfo.UseShellExecute support on Unix

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Unix.cs
@@ -198,11 +198,27 @@ namespace System.Diagnostics
         /// <param name="startInfo">The start info with which to start the process.</param>
         private bool StartCore(ProcessStartInfo startInfo)
         {
-            // Resolve the path to the specified file name
-            string filename = ResolvePath(startInfo.FileName);
+            string filename;
+            string[] argv;
 
-            // Parse argv, envp, and cwd out of the ProcessStartInfo
-            string[] argv = CreateArgv(startInfo);
+            if (startInfo.UseShellExecute)
+            {
+                if (startInfo.RedirectStandardInput || startInfo.RedirectStandardOutput || startInfo.RedirectStandardError)
+                {
+                    throw new InvalidOperationException(SR.CantRedirectStreams);
+                }
+
+                const string ShellPath = "/bin/sh";
+
+                filename = ShellPath;
+                argv = new string[3] { ShellPath, "-c", startInfo.FileName + " " + startInfo.Arguments};
+            }
+            else
+            {
+                filename = ResolvePath(startInfo.FileName);
+                argv = ParseArgv(startInfo);
+            }
+
             string[] envp = CreateEnvp(startInfo);
             string cwd = !string.IsNullOrWhiteSpace(startInfo.WorkingDirectory) ? startInfo.WorkingDirectory : null;
 
@@ -262,7 +278,7 @@ namespace System.Diagnostics
         /// <summary>Converts the filename and arguments information from a ProcessStartInfo into an argv array.</summary>
         /// <param name="psi">The ProcessStartInfo.</param>
         /// <returns>The argv array.</returns>
-        private static string[] CreateArgv(ProcessStartInfo psi)
+        private static string[] ParseArgv(ProcessStartInfo psi)
         {
             string argv0 = psi.FileName; // pass filename (instead of resolved path) as argv[0], to match what caller supplied
             if (string.IsNullOrEmpty(psi.Arguments))

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Unix.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Unix.cs
@@ -33,5 +33,7 @@ namespace System.Diagnostics
             get { throw new PlatformNotSupportedException(); }
             set { throw new PlatformNotSupportedException(); }
         }
+
+        public bool UseShellExecute { get; set; }
     }
 }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.Windows.cs
@@ -37,5 +37,19 @@ namespace System.Diagnostics
             get { return _loadUserProfile; }
             set { _loadUserProfile = value; }
         }
+
+        // CoreCLR can't correctly support UseShellExecute=true for the following reasons
+        // 1. ShellExecuteEx is not supported on onecore.
+        // 2. ShellExecuteEx needs to run as STA but managed code runs as MTA by default and Thread.SetApartmentState() is not supported on all platforms.
+        //
+        // Irrespective of the limited functionality of the property we still expose it in the contract as it can be implemented
+        // on other platforms.  Further, the default value of UseShellExecute is true on desktop and scenarios like redirection mandates 
+        // the value to be false. So in order to provide maximum code portability we expose UseShellExecute in the contract 
+        // and throw PlatformNotSupportedException in portable library in case it is set to true.
+        public bool UseShellExecute
+        {
+            get { return false; }
+            set { if (value == true) throw new PlatformNotSupportedException(SR.UseShellExecute); }
+        }
     }
 }

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
@@ -141,20 +141,6 @@ namespace System.Diagnostics
             set { _standardOutputEncoding = value; }
         }
 
-        // CoreCLR can't correctly support UseShellExecute=true for the following reasons
-        // 1. ShellExecuteEx is not supported on onecore.
-        // 2. ShellExecuteEx needs to run as STA but managed code runs as MTA by default and Thread.SetApartmentState() is not supported on all platforms.
-        //
-        // Irrespective of the limited functionality of the property we still support it in the contract for the below reason.
-        // The default value of UseShellExecute is true on desktop and scenarios like redirection mandates the value to be false.
-        // So in order to provide maximum code portability we expose UseShellExecute in the contract 
-        // and throw PlatformNotSupportedException in portable library in case it is set to true.
-        public bool UseShellExecute
-        {
-            get { return false; }
-            set { if (value == true) throw new PlatformNotSupportedException(SR.UseShellExecute); }
-        }
-
         /// <devdoc>
         ///    <para>
         ///       Returns or sets the application, document, or URL that is to be launched.

--- a/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessStartInfoTests.cs
@@ -230,17 +230,53 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [PlatformSpecific(PlatformID.Windows)] // UseShellExecute currently not supported on Windows
         [Fact]
-        public void TestUseShellExecuteProperty()
+        public void TestUseShellExecuteProperty_SetAndGet_Windows()
         {
             ProcessStartInfo psi = new ProcessStartInfo();
+            Assert.False(psi.UseShellExecute);
 
             // Calling the setter
-            psi.UseShellExecute = false;
             Assert.Throws<PlatformNotSupportedException>(() => { psi.UseShellExecute = true; });
+            psi.UseShellExecute = false;
 
             // Calling the getter
             Assert.False(psi.UseShellExecute, "UseShellExecute=true is not supported on onecore.");
+        }
+
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        [Fact]
+        public void TestUseShellExecuteProperty_SetAndGet_Unix()
+        {
+            ProcessStartInfo psi = new ProcessStartInfo();
+            Assert.False(psi.UseShellExecute);
+
+            psi.UseShellExecute = true;
+            Assert.True(psi.UseShellExecute);
+
+            psi.UseShellExecute = false;
+            Assert.False(psi.UseShellExecute);
+        }
+
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public void TestUseShellExecuteProperty_Redirects_NotSupported(int std)
+        {
+            Process p = CreateProcessLong();
+            p.StartInfo.UseShellExecute = true;
+
+            switch (std)
+            {
+                case 0: p.StartInfo.RedirectStandardInput = true; break;
+                case 1: p.StartInfo.RedirectStandardOutput = true; break;
+                case 2: p.StartInfo.RedirectStandardError = true; break;
+            }
+
+            Assert.Throws<InvalidOperationException>(() => p.Start());
         }
 
         [Fact]

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -121,6 +121,17 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        [Fact]
+        public void TestUseShellExecute_Unix_Succeeds()
+        {
+            using (var p = Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = "exit", Arguments = "42" }))
+            {
+                Assert.True(p.WaitForExit(WaitInMS));
+                Assert.Equal(42, p.ExitCode);
+            }
+        }
+
         [Fact]
         public void TestExitTime()
         {


### PR DESCRIPTION
Implemented via the existing fork/execve mechanism, but using /bin/sh as the target filename.

cc: @pallavit, @Priya91 