### PR TITLE
Fix CallSite type problem

### DIFF
--- a/src/System.Dynamic.Runtime/src/System/Linq/Expressions/Compiler/TypeInfoExtensions.cs
+++ b/src/System.Dynamic.Runtime/src/System/Linq/Expressions/Compiler/TypeInfoExtensions.cs
@@ -24,11 +24,7 @@ namespace System.Linq.Expressions.Compiler
             // nope, go ahead and create it and spend the
             // cost of creating the array.
             Type[] paramTypes = new Type[args.Count + 2];
-#if FEATURE_COMPILE        
             paramTypes[0] = typeof(CallSite);
-#else
-            paramTypes[0] = typeof(object);
-#endif 
             paramTypes[paramTypes.Length - 1] = retType;
             for (int i = 0; i < args.Count; i++)
             {


### PR DESCRIPTION
For GitHub issue #3556

This should probably be amended to use the correct `#DEFINE`, as I don't know what it should be.

Thanks for the investigation @DinoV. This unblocks our internal problem that is the same bug as the above issue. We need an updated `System.Dynamic.Runtime` package as soon as we can get it. Hand-overwriting the DLL with my manually compiled one is not fun for our team :smiling_imp: 