### PR TITLE
Remove sync APIs from SslStream and NegotiateStream

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNITcpHandle.cs
@@ -173,7 +173,7 @@ namespace System.Data.SqlClient.SNI
 
             try
             {
-                _sslStream.AuthenticateAsClient(_targetServer);
+                _sslStream.AuthenticateAsClientAsync(_targetServer).GetAwaiter().GetResult();
                 _sslOverTdsStream.FinishHandshake();
             }
             catch (AuthenticationException aue)

--- a/src/System.Net.Security/ref/System.Net.Security.cs
+++ b/src/System.Net.Security/ref/System.Net.Security.cs
@@ -45,20 +45,11 @@ namespace System.Net.Security
         public override int ReadTimeout { get { return default(int); } set { } }
         public virtual System.Security.Principal.IIdentity RemoteIdentity { get { return default(System.Security.Principal.IIdentity); } }
         public override int WriteTimeout { get { return default(int); } set { } }
-        public virtual void AuthenticateAsClient() { }
-        public virtual void AuthenticateAsClient(NetworkCredential credential, string targetName) { }
-        public virtual void AuthenticateAsClient(NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ChannelBinding binding, string targetName) { }
-        public virtual void AuthenticateAsClient(NetworkCredential credential, string targetName, ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel allowedImpersonationLevel) { }
-        public virtual void AuthenticateAsClient(NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ChannelBinding binding, string targetName, ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel allowedImpersonationLevel) { }
         public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync() { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(NetworkCredential credential, string targetName) { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ChannelBinding binding, string targetName) { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(NetworkCredential credential, string targetName, ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel allowedImpersonationLevel) { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ChannelBinding binding, string targetName, ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel allowedImpersonationLevel) { return default(System.Threading.Tasks.Task); }
-        public virtual void AuthenticateAsServer() { }
-        public virtual void AuthenticateAsServer(System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy policy) { }
-        public virtual void AuthenticateAsServer(NetworkCredential credential, ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel requiredImpersonationLevel) { }
-        public virtual void AuthenticateAsServer(NetworkCredential credential, System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy policy, ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel requiredImpersonationLevel) { }
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync() { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(System.Security.Authentication.ExtendedProtection.ExtendedProtectionPolicy policy) { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(NetworkCredential credential, ProtectionLevel requiredProtectionLevel, System.Security.Principal.TokenImpersonationLevel requiredImpersonationLevel) { return default(System.Threading.Tasks.Task); }
@@ -107,12 +98,8 @@ namespace System.Net.Security
         public virtual System.Security.Authentication.SslProtocols SslProtocol { get { return default(System.Security.Authentication.SslProtocols); } }
         public System.Net.TransportContext TransportContext { get { return default(System.Net.TransportContext); } }
         public override int WriteTimeout { get { return default(int); } set { } }
-        public virtual void AuthenticateAsClient(string targetHost) { }
-        public virtual void AuthenticateAsClient(string targetHost, System.Security.Cryptography.X509Certificates.X509CertificateCollection clientCertificates, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation) { }
         public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(string targetHost) { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task AuthenticateAsClientAsync(string targetHost, System.Security.Cryptography.X509Certificates.X509CertificateCollection clientCertificates, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation) { return default(System.Threading.Tasks.Task); }
-        public virtual void AuthenticateAsServer(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate) { }
-        public virtual void AuthenticateAsServer(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate, bool clientCertificateRequired, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation) { }
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate) { return default(System.Threading.Tasks.Task); }
         public virtual System.Threading.Tasks.Task AuthenticateAsServerAsync(System.Security.Cryptography.X509Certificates.X509Certificate serverCertificate, bool clientCertificateRequired, System.Security.Authentication.SslProtocols enabledSslProtocols, bool checkCertificateRevocation) { return default(System.Threading.Tasks.Task); }
         public override void Flush() { }

--- a/src/System.Net.Security/src/Shims/NegotiateStream.cs
+++ b/src/System.Net.Security/src/Shims/NegotiateStream.cs
@@ -80,31 +80,6 @@ namespace System.Net.Security
             }
         }
 
-        public virtual void AuthenticateAsClient()
-        {
-            throw new PlatformNotSupportedException();
-        }
-
-        public virtual void AuthenticateAsClient(NetworkCredential credential, string targetName)
-        {
-            throw new PlatformNotSupportedException();
-        }
-
-        public virtual void AuthenticateAsClient(NetworkCredential credential, ChannelBinding binding, string targetName)
-        {
-            throw new PlatformNotSupportedException();
-        }
-
-        public virtual void AuthenticateAsClient(NetworkCredential credential, string targetName, ProtectionLevel requiredProtectionLevel, TokenImpersonationLevel allowedImpersonationLevel)
-        {
-            throw new PlatformNotSupportedException();
-        }
-
-        public virtual void AuthenticateAsClient(NetworkCredential credential, ChannelBinding binding, string targetName, ProtectionLevel requiredProtectionLevel, TokenImpersonationLevel allowedImpersonationLevel)
-        {
-            throw new PlatformNotSupportedException();
-        }
-
         public virtual Task AuthenticateAsClientAsync()
         {
             throw new PlatformNotSupportedException();
@@ -126,26 +101,6 @@ namespace System.Net.Security
         }
 
         public virtual Task AuthenticateAsClientAsync(NetworkCredential credential, ChannelBinding binding, string targetName, ProtectionLevel requiredProtectionLevel, TokenImpersonationLevel allowedImpersonationLevel)
-        {
-            throw new PlatformNotSupportedException();
-        }
-
-        public virtual void AuthenticateAsServer()
-        {
-            throw new PlatformNotSupportedException();
-        }
-
-        public virtual void AuthenticateAsServer(ExtendedProtectionPolicy policy)
-        {
-            throw new PlatformNotSupportedException();
-        }
-
-        public virtual void AuthenticateAsServer(NetworkCredential credential, ProtectionLevel requiredProtectionLevel, TokenImpersonationLevel requiredImpersonationLevel)
-        {
-            throw new PlatformNotSupportedException();
-        }
-
-        public virtual void AuthenticateAsServer(NetworkCredential credential, ExtendedProtectionPolicy policy, ProtectionLevel requiredProtectionLevel, TokenImpersonationLevel requiredImpersonationLevel)
         {
             throw new PlatformNotSupportedException();
         }

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslStream.cs
@@ -101,19 +101,6 @@ namespace System.Net.Security
         //
         // Client side auth.
         //
-        public virtual void AuthenticateAsClient(string targetHost)
-        {
-            AuthenticateAsClient(targetHost, new X509CertificateCollection(), SecurityProtocol.DefaultSecurityProtocols, false);
-        }
-
-        public virtual void AuthenticateAsClient(string targetHost, X509CertificateCollection clientCertificates, SslProtocols enabledSslProtocols, bool checkCertificateRevocation)
-        {
-            SecurityProtocol.ThrowOnNotAllowed(enabledSslProtocols);
-
-            _sslState.ValidateCreateContext(false, targetHost, enabledSslProtocols, null, clientCertificates, true, checkCertificateRevocation);
-            _sslState.ProcessAuthentication(null);
-        }
-
         internal virtual IAsyncResult BeginAuthenticateAsClient(string targetHost, AsyncCallback asyncCallback, object asyncState)
         {
             return BeginAuthenticateAsClient(targetHost, new X509CertificateCollection(), SecurityProtocol.DefaultSecurityProtocols, false,
@@ -139,20 +126,6 @@ namespace System.Net.Security
         //
         // Server side auth.
         //
-        public virtual void AuthenticateAsServer(X509Certificate serverCertificate)
-        {
-            AuthenticateAsServer(serverCertificate, false, SecurityProtocol.DefaultSecurityProtocols, false);
-        }
-
-        public virtual void AuthenticateAsServer(X509Certificate serverCertificate, bool clientCertificateRequired,
-                                               SslProtocols enabledSslProtocols, bool checkCertificateRevocation)
-        {
-            SecurityProtocol.ThrowOnNotAllowed(enabledSslProtocols);
-
-            _sslState.ValidateCreateContext(true, string.Empty, enabledSslProtocols, serverCertificate, null, clientCertificateRequired, checkCertificateRevocation);
-            _sslState.ProcessAuthentication(null);
-        }
-
         internal virtual IAsyncResult BeginAuthenticateAsServer(X509Certificate serverCertificate, AsyncCallback asyncCallback, object asyncState)
 
         {

--- a/src/System.Net.Security/tests/FunctionalTests/ClientDefaultEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientDefaultEncryptionTest.cs
@@ -43,7 +43,7 @@ namespace System.Net.Security.Tests
 
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null))
                 {
-                    sslStream.AuthenticateAsClient("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
+                    await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
                     _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
                         client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
                         sslStream.CipherAlgorithm, sslStream.CipherStrength);
@@ -64,7 +64,7 @@ namespace System.Net.Security.Tests
 
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null))
                 {
-                    sslStream.AuthenticateAsClient("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
+                    await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
                     _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
                         client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
                         sslStream.CipherAlgorithm, sslStream.CipherStrength);
@@ -85,13 +85,10 @@ namespace System.Net.Security.Tests
 
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null))
                 {
-                    Assert.Throws<IOException>(() =>
-                    {
-                        sslStream.AuthenticateAsClient("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
-                    });
+                    await Assert.ThrowsAsync<IOException>(() =>
+                        sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false));
                 }
             }
         }
     }
 }
-

--- a/src/System.Net.Security/tests/FunctionalTests/ServerAllowNoEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerAllowNoEncryptionTest.cs
@@ -42,7 +42,7 @@ namespace System.Net.Security.Tests
 
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.RequireEncryption))
                 {
-                    sslStream.AuthenticateAsClient("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
+                    await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
                     _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
                         client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
                         sslStream.CipherAlgorithm, sslStream.CipherStrength);
@@ -63,7 +63,7 @@ namespace System.Net.Security.Tests
 
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.AllowNoEncryption))
                 {
-                    sslStream.AuthenticateAsClient("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
+                    await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
                     _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
                         client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
                         sslStream.CipherAlgorithm, sslStream.CipherStrength);
@@ -84,7 +84,7 @@ namespace System.Net.Security.Tests
 
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.NoEncryption))
                 {
-                    sslStream.AuthenticateAsClient("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
+                    await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
                     _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
                         client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
                         sslStream.CipherAlgorithm, sslStream.CipherStrength);
@@ -97,4 +97,3 @@ namespace System.Net.Security.Tests
         }
     }
 }
-

--- a/src/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
@@ -42,10 +42,8 @@ namespace System.Net.Security.Tests
 
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.RequireEncryption))
                 {
-                    Assert.Throws<IOException>(() =>
-                    {
-                        sslStream.AuthenticateAsClient("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
-                    });
+                    await Assert.ThrowsAsync<IOException>(() =>
+                        sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false));
                 }
             }
         }
@@ -61,7 +59,7 @@ namespace System.Net.Security.Tests
 
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.AllowNoEncryption))
                 {
-                    sslStream.AuthenticateAsClient("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
+                    await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
 
                     _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
                         client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
@@ -85,7 +83,7 @@ namespace System.Net.Security.Tests
 
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.NoEncryption))
                 {
-                    sslStream.AuthenticateAsClient("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
+                    await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
                     _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
                         client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
                         sslStream.CipherAlgorithm, sslStream.CipherStrength);
@@ -98,4 +96,3 @@ namespace System.Net.Security.Tests
         }
     }
 }
-

--- a/src/System.Net.Security/tests/FunctionalTests/ServerRequireEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerRequireEncryptionTest.cs
@@ -42,7 +42,7 @@ namespace System.Net.Security.Tests
 
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.RequireEncryption))
                 {
-                    sslStream.AuthenticateAsClient("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
+                    await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
                     _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
                         client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
                         sslStream.CipherAlgorithm, sslStream.CipherStrength);
@@ -63,7 +63,7 @@ namespace System.Net.Security.Tests
 
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.AllowNoEncryption))
                 {
-                    sslStream.AuthenticateAsClient("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
+                    await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
                     _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
                         client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
                         sslStream.CipherAlgorithm, sslStream.CipherStrength);
@@ -83,10 +83,8 @@ namespace System.Net.Security.Tests
                 await client.ConnectAsync(serverRequireEncryption.RemoteEndPoint.Address, serverRequireEncryption.RemoteEndPoint.Port);
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.NoEncryption))
                 {
-                    Assert.Throws<IOException>(() =>
-                    {
-                        sslStream.AuthenticateAsClient("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
-                    });
+                    await Assert.ThrowsAsync<IOException>(() =>
+                        sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false));
                 }
             }
         }

--- a/src/System.Net.Security/tests/FunctionalTests/TransportContextTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/TransportContextTest.cs
@@ -34,7 +34,7 @@ namespace System.Net.Security.Tests
 
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.RequireEncryption))
                 {
-                    sslStream.AuthenticateAsClient("localhost", null, SslProtocols.Tls, false);
+                    await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocols.Tls, false);
 
                     TransportContext context = sslStream.TransportContext;
                     CheckTransportContext(context);


### PR DESCRIPTION
As per the System.Net.* API review dotnet/apireviews#21 removing
the sync versions of the AuthenticateAsClient, AuthenticateAsServer
methods from the SslStream and NegotiateStream classes.

Part of #4732