### PR TITLE
Ensure all CheckIo calls are wrapped in whiles

### DIFF
--- a/src/System.Console/src/System/IO/StdInStreamReader.cs
+++ b/src/System.Console/src/System/IO/StdInStreamReader.cs
@@ -75,7 +75,7 @@ namespace System.IO
         internal unsafe int ReadStdinUnbuffered(byte* buffer, int bufferSize)
         {
             int result;
-            Interop.CheckIo(result = Interop.Sys.ReadStdinUnbuffered(buffer, bufferSize));
+            while (Interop.CheckIo(result = Interop.Sys.ReadStdinUnbuffered(buffer, bufferSize))) ;
             Debug.Assert(result > 0 && result <= bufferSize);
             return result;
         }

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.cs
@@ -184,13 +184,13 @@ namespace System.IO.MemoryMappedFiles
                 // Unlink the shared memory object immediatley so that it'll go away once all handles 
                 // to it are closed (as with opened then unlinked files, it'll remain usable via
                 // the open handles even though it's unlinked and can't be opened anew via its name).
-                Interop.CheckIo(Interop.Sys.ShmUnlink(mapName));
+                while (Interop.CheckIo(Interop.Sys.ShmUnlink(mapName)));
 
                 // Give it the right capacity.  We do this directly with ftruncate rather
                 // than via FileStream.SetLength after the FileStream is created because, on some systems,
                 // lseek fails on shared memory objects, causing the FileStream to think it's unseekable,
                 // causing it to preemptively throw from SetLength.
-                Interop.CheckIo(Interop.Sys.FTruncate(fd, capacity));
+                while (Interop.CheckIo(Interop.Sys.FTruncate(fd, capacity)));
 
                 // Wrap the file descriptor in a stream and return it.
                 return new FileStream(fd, TranslateProtectionsToFileAccess(protections));
@@ -221,7 +221,7 @@ namespace System.IO.MemoryMappedFiles
             var fs = new FileStream(path, FileMode.CreateNew, TranslateProtectionsToFileAccess(protections), FileShare.ReadWrite, DefaultBufferSize);
             try
             {
-                Interop.CheckIo(Interop.Sys.Unlink(path));
+                while (Interop.CheckIo(Interop.Sys.Unlink(path))) ;
                 fs.SetLength(capacity);
             }
             catch

--- a/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
@@ -189,7 +189,7 @@ namespace System.IO
 
             // Create, open, and close the temp file.
             IntPtr fd;
-            Interop.CheckIo(fd = Interop.Sys.MksTemps(name, SuffixByteLength));
+            while (Interop.CheckIo(fd = Interop.Sys.MksTemps(name, SuffixByteLength))) ;
             Interop.Sys.Close(fd); // ignore any errors from close; nothing to do if cleanup isn't possible
 
             // 'name' is now the name of the file


### PR DESCRIPTION
There were just a few remaining.  They should all be fixed now.

Fixes https://github.com/dotnet/corefx/issues/3168
cc: @eerhardt 