### PR TITLE
Move the IO check for EINTR down into the native shims.

### DIFF
--- a/src/Common/src/Interop/Unix/Interop.IOErrors.cs
+++ b/src/Common/src/Interop/Unix/Interop.IOErrors.cs
@@ -5,61 +5,100 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {
-    private static bool CheckIo(ErrorInfo errorInfo, string path, bool isDirectory, Func<ErrorInfo, ErrorInfo> errorRewriter)
+    private static void ThrowExceptionForIoErrno(ErrorInfo errorInfo, string path, bool isDirectory, Func<ErrorInfo, ErrorInfo> errorRewriter)
     {
         Debug.Assert(errorInfo.Error != Error.SUCCESS);
+        Debug.Assert(errorInfo.Error != Error.EINTR, "EINTR errors should be handled by the native shim and never bubble up to managed code");
 
         if (errorRewriter != null)
         {
             errorInfo = errorRewriter(errorInfo);
         }
 
-        if (errorInfo.Error != Error.EINTR)
-        {
-            throw Interop.GetExceptionForIoErrno(errorInfo, path, isDirectory);
-        }
-
-        return true;
+        throw Interop.GetExceptionForIoErrno(errorInfo, path, isDirectory);
     }
 
-    internal static bool CheckIo(Error error, string path = null, bool isDirectory = false, Func<ErrorInfo, ErrorInfo> errorRewriter = null)
+    internal static void CheckIo(Error error, string path = null, bool isDirectory = false, Func<ErrorInfo, ErrorInfo> errorRewriter = null)
     {
-        return error != Interop.Error.SUCCESS && CheckIo(error.Info(), path, isDirectory, errorRewriter);
+        if (error != Interop.Error.SUCCESS)
+        {
+            ThrowExceptionForIoErrno(error.Info(), path, isDirectory, errorRewriter);
+        }
     }
 
     /// <summary>
     /// Validates the result of system call that returns greater than or equal to 0 on success
     /// and less than 0 on failure, with errno set to the error code.
-    /// If the system call failed due to interruption (EINTR), true is returned and 
-    /// the caller should (usually) retry. If the system call failed for any other reason, 
-    /// an exception is thrown. Otherwise, the system call succeeded, and false is returned.
+    /// If the system call failed for any reason, an exception is thrown. Otherwise, the system call succeeded.
     /// </summary>
     /// <param name="result">The result of the system call.</param>
     /// <param name="path">The path with which this error is associated.  This may be null.</param>
     /// <param name="isDirectory">true if the <paramref name="path"/> is known to be a directory; otherwise, false.</param>
     /// <param name="errorRewriter">Optional function to change an error code prior to processing it.</param>
     /// <returns>
-    /// true if the system call should be retried due to it being interrupted; otherwise, false.
-    /// An exception will be thrown if the system call failed for any reason other than interruption.
+    /// On success, returns the non-negative result long that was validated.
     /// </returns>
-    internal static bool CheckIo(long result, string path = null, bool isDirectory = false, Func<ErrorInfo, ErrorInfo> errorRewriter = null)
+    internal static long CheckIo(long result, string path = null, bool isDirectory = false, Func<ErrorInfo, ErrorInfo> errorRewriter = null)
     {
-        return result < 0 && CheckIo(Sys.GetLastErrorInfo(), path, isDirectory, errorRewriter);
+        if (result < 0)
+        {
+            ThrowExceptionForIoErrno(Sys.GetLastErrorInfo(), path, isDirectory, errorRewriter);
+        }
+
+        return result;
     }
 
     /// <summary>
     /// Validates the result of system call that returns greater than or equal to 0 on success
     /// and less than 0 on failure, with errno set to the error code.
-    /// If the system call failed due to interruption (EINTR), true is returned and 
-    /// the caller should (usually) retry. If the system call failed for any other reason, 
-    /// an exception is thrown. Otherwise, the system call succeeded, and false is returned.
+    /// If the system call failed for any reason, an exception is thrown. Otherwise, the system call succeeded.
     /// </summary>
-    internal static bool CheckIo(IntPtr ptr, string path = null, bool isDirectory = false, Func<ErrorInfo, ErrorInfo> errorRewriter = null)
+    /// <returns>
+    /// On success, returns the non-negative result int that was validated.
+    /// </returns>
+    internal static int CheckIo(int result, string path = null, bool isDirectory = false, Func<ErrorInfo, ErrorInfo> errorRewriter = null)
     {
-        return CheckIo((long)ptr, path, isDirectory, errorRewriter);
+        CheckIo((long)result, path, isDirectory, errorRewriter);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Validates the result of system call that returns greater than or equal to 0 on success
+    /// and less than 0 on failure, with errno set to the error code.
+    /// If the system call failed for any reason, an exception is thrown. Otherwise, the system call succeeded.
+    /// </summary>
+    /// <returns>
+    /// On success, returns the non-negative result IntPtr that was validated.
+    /// </returns>
+    internal static IntPtr CheckIo(IntPtr result, string path = null, bool isDirectory = false, Func<ErrorInfo, ErrorInfo> errorRewriter = null)
+    {
+        CheckIo((long)result, path, isDirectory, errorRewriter);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Validates the result of system call that returns greater than or equal to 0 on success
+    /// and less than 0 on failure, with errno set to the error code.
+    /// If the system call failed for any reason, an exception is thrown. Otherwise, the system call succeeded.
+    /// </summary>
+    /// <returns>
+    /// On success, returns the valid SafeFileHandle that was validated.
+    /// </returns>
+    internal static TSafeHandle CheckIo<TSafeHandle>(TSafeHandle handle, string path = null, bool isDirectory = false, Func<ErrorInfo, ErrorInfo> errorRewriter = null)
+        where TSafeHandle : SafeHandle
+    {
+        if (handle.IsInvalid)
+        {
+            ThrowExceptionForIoErrno(Sys.GetLastErrorInfo(), path, isDirectory, errorRewriter);
+        }
+
+        return handle;
     }
 
     /// <summary>

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Open.Pipe.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Open.Pipe.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 
@@ -9,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static extern SafeFileHandle Dup(SafeFileHandle oldfd);
+        [DllImport(Libraries.SystemNative, EntryPoint = "Open", SetLastError = true)]
+        internal static extern SafePipeHandle OpenPipe(string filename, OpenFlags flags, int mode);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Open.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Open.cs
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
 
 internal static partial class Interop
 {
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, SetLastError = true)]
-        internal static extern IntPtr Open(string filename, OpenFlags flags, int mode);
+        internal static extern SafeFileHandle Open(string filename, OpenFlags flags, int mode);
     }
 }

--- a/src/Common/src/System/Diagnostics/Debug.Unix.cs
+++ b/src/Common/src/System/Diagnostics/Debug.Unix.cs
@@ -93,11 +93,6 @@ namespace System.Diagnostics
                                 int bytesWritten = Interop.Sys.Write(fileHandle, buf + totalBytesWritten, bufCount);
                                 if (bytesWritten < 0)
                                 {
-                                    if (Interop.Sys.GetLastErrorInfo().Error == Interop.Error.EINTR)
-                                    {
-                                        continue;
-                                    }
-
                                     // On error, simply stop writing the debug output.  This could commonly happen if stderr
                                     // was piped to a program that ended before this program did, resulting in EPIPE errors.
                                     return;

--- a/src/Native/Common/pal_utilities.h
+++ b/src/Native/Common/pal_utilities.h
@@ -7,6 +7,7 @@
 #include "pal_config.h"
 
 #include <assert.h>
+#include <errno.h>
 #include <limits>
 #include <stddef.h>
 #include <stdio.h>
@@ -137,4 +138,14 @@ inline static int ToFileDescriptor(intptr_t fd)
 inline static int ToFileDescriptorUnchecked(intptr_t fd)
 {
     return static_cast<int>(fd);
+}
+
+/**
+* Checks if the IO operation was interupted and needs to be retried.
+* Returns true if the operation was interupted; otherwise, false.
+*/
+template <typename TInt>
+static inline bool CheckInterrupted(TInt result)
+{
+    return result < 0 && errno == EINTR;
 }

--- a/src/Native/System.Native/pal_console.cpp
+++ b/src/Native/System.Native/pal_console.cpp
@@ -93,7 +93,8 @@ extern "C" int32_t ReadStdinUnbuffered(void* buffer, int32_t bufferSize)
         return -1;
     }
 
-    ssize_t count = read(STDIN_FILENO, buffer, UnsignedCast(bufferSize));
+    ssize_t count;
+    while (CheckInterrupted(count = read(STDIN_FILENO, buffer, UnsignedCast(bufferSize))));
     return static_cast<int32_t>(count);
 }
 

--- a/src/Native/System.Native/pal_process.cpp
+++ b/src/Native/System.Native/pal_process.cpp
@@ -311,7 +311,9 @@ extern "C" int32_t WaitPid(int32_t pid, int32_t* status, WaitPidOptions options)
 {
     assert(status != nullptr);
 
-    return waitpid(pid, status, static_cast<int>(options));
+    int32_t result;
+    while (CheckInterrupted(result = waitpid(pid, status, static_cast<int>(options))));
+    return result;
 }
 
 extern "C" int32_t WExitStatus(int32_t status)

--- a/src/Native/System.Native/pal_time.cpp
+++ b/src/Native/System.Native/pal_time.cpp
@@ -3,6 +3,7 @@
 
 #include "pal_config.h"
 #include "pal_time.h"
+#include "pal_utilities.h"
 
 #include <assert.h>
 #include <utime.h>
@@ -30,7 +31,10 @@ extern "C" int32_t UTime(const char* path, UTimBuf* times)
 
     utimbuf temp;
     ConvertUTimBuf(*times, temp);
-    return utime(path, &temp);
+
+    int32_t result;
+    while (CheckInterrupted(result = utime(path, &temp)));
+    return result;
 }
 
 extern "C" int32_t GetTimestampResolution(uint64_t* resolution)

--- a/src/Native/System.Native/pal_uid.cpp
+++ b/src/Native/System.Native/pal_uid.cpp
@@ -23,7 +23,8 @@ extern "C" int32_t GetPwUidR(uint32_t uid, Passwd* pwd, char* buf, int32_t bufle
 
     struct passwd nativePwd;
     struct passwd* result;
-    int error = getpwuid_r(uid, &nativePwd, buf, UnsignedCast(buflen), &result);
+    int error;
+    while ((error = getpwuid_r(uid, &nativePwd, buf, UnsignedCast(buflen), &result) == EINTR));
 
     // positive error number returned -> failure other than entry-not-found
     if (error != 0)

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -857,8 +857,7 @@ namespace System
         {
             fixed (byte* bufPtr = buffer)
             {
-                int result;
-                while (Interop.CheckIo(result = Interop.Sys.Read(fd, (byte*)bufPtr + offset, count))) ;
+                int result = Interop.CheckIo(Interop.Sys.Read(fd, (byte*)bufPtr + offset, count));
                 Debug.Assert(result <= count);
                 return result;
             }
@@ -885,12 +884,7 @@ namespace System
                 if (bytesWritten < 0)
                 {
                     Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();
-                    if (errorInfo.Error == Interop.Error.EINTR)
-                    {
-                        // Interrupted... try again.
-                        continue;
-                    }
-                    else if (errorInfo.Error == Interop.Error.EPIPE)
+                    if (errorInfo.Error == Interop.Error.EPIPE)
                     {
                         // Broken pipe... likely due to being redirected to a program
                         // that ended, so simply pretend we were successful.

--- a/src/System.Console/src/System/IO/StdInStreamReader.cs
+++ b/src/System.Console/src/System/IO/StdInStreamReader.cs
@@ -74,8 +74,7 @@ namespace System.IO
 
         internal unsafe int ReadStdinUnbuffered(byte* buffer, int bufferSize)
         {
-            int result;
-            Interop.CheckIo(result = Interop.Sys.ReadStdinUnbuffered(buffer, bufferSize));
+            int result = Interop.CheckIo(Interop.Sys.ReadStdinUnbuffered(buffer, bufferSize));
             Debug.Assert(result > 0 && result <= bufferSize);
             return result;
         }

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -123,7 +123,7 @@ namespace System.IO
                 // lock on the file and all other modes use a shared lock.  While this is not as granular as Windows, not mandatory, 
                 // and not atomic with file opening, it's better than nothing.
                 Interop.Sys.LockOperations lockOperation = (share == FileShare.None) ? Interop.Sys.LockOperations.LOCK_EX : Interop.Sys.LockOperations.LOCK_SH;
-                SysCall<Interop.Sys.LockOperations, int>((fd, op, _) => Interop.Sys.FLock(fd, op), lockOperation | Interop.Sys.LockOperations.LOCK_NB);
+                CheckFileCall(Interop.Sys.FLock(_fileHandle, lockOperation | Interop.Sys.LockOperations.LOCK_NB));
 
                 // These provide hints around how the file will be accessed.  Specifying both RandomAccess
                 // and Sequential together doesn't make sense as they are two competing options on the same spectrum,
@@ -134,9 +134,7 @@ namespace System.IO
                     0;
                 if (fadv != 0)
                 {
-                    SysCall<Interop.Sys.FileAdvice, int>(
-                        (fd, advice, _) => Interop.Sys.PosixFAdvise(fd, 0, 0, advice),
-                        fadv,
+                    CheckFileCall(Interop.Sys.PosixFAdvise(_fileHandle, 0, 0, fadv), 
                         ignoreNotSupported: true); // just a hint.
                 }
 
@@ -294,7 +292,7 @@ namespace System.IO
                 if (!_canSeek.HasValue)
                 {
                     // Lazily-initialize whether we're able to seek, tested by seeking to our current location.
-                    _canSeek = SysCall<int, int>((fd, _, __) => Interop.Sys.LSeek(fd, 0, Interop.Sys.SeekWhence.SEEK_CUR), throwOnError: false) >= 0;
+                    _canSeek = Interop.Sys.LSeek(_fileHandle, 0, Interop.Sys.SeekWhence.SEEK_CUR) >= 0;
                 }
                 return _canSeek.Value;
             }
@@ -321,12 +319,9 @@ namespace System.IO
                 }
 
                 // Get the length of the file as reported by the OS
-                long length = SysCall<int, int>((fd, _, __) =>
-                {
-                    Interop.Sys.FileStatus status;
-                    int result = Interop.Sys.FStat(fd, out status);
-                    return result >= 0 ? status.Size : result;
-                });
+                Interop.Sys.FileStatus status;
+                CheckFileCall(Interop.Sys.FStat(_fileHandle, out status));
+                long length = status.Size;
 
                 // But we may have buffered some data to be written that puts our length
                 // beyond what the OS is aware of.  Update accordingly.
@@ -499,7 +494,7 @@ namespace System.IO
         /// <summary>Flushes the OS buffer.  This does not flush the internal read/write buffer.</summary>
         private void FlushOSBuffer()
         {
-            SysCall<int, int>((fd, _, __) => Interop.Sys.FSync(fd));
+            CheckFileCall(Interop.Sys.FSync(_fileHandle));
         }
 
         /// <summary>
@@ -622,7 +617,7 @@ namespace System.IO
                 SeekCore(value, SeekOrigin.Begin);
             }
 
-            SysCall<long, int>((fd, length, _) => Interop.Sys.FTruncate(fd, length), value);
+            CheckFileCall(Interop.Sys.FTruncate(_fileHandle, value));
 
             // Return file pointer to where it was before setting length
             if (origPos != value)
@@ -760,12 +755,8 @@ namespace System.IO
             int bytesRead;
             fixed (byte* bufPtr = array)
             {
-                bytesRead = (int)SysCall((fd, ptr, len) =>
-                {
-                    int result = Interop.Sys.Read(fd, (byte*)ptr, len);
-                    Debug.Assert(result <= len);
-                    return result;
-                }, (IntPtr)(bufPtr + offset), count);
+                bytesRead = CheckFileCall(Interop.Sys.Read(_fileHandle, bufPtr + offset, count));
+                Debug.Assert(bytesRead <= count);
             }
             _filePosition += bytesRead;
             return bytesRead;
@@ -1001,12 +992,9 @@ namespace System.IO
             {
                 while (count > 0)
                 {
-                    int bytesWritten = (int)SysCall((fd, ptr, len) =>
-                    {
-                        int result = Interop.Sys.Write(fd, (byte*)ptr, len);
-                        Debug.Assert(result <= len);
-                        return result;
-                    }, (IntPtr)(bufPtr + offset), count);
+                    int bytesWritten = CheckFileCall(Interop.Sys.Write(_fileHandle, bufPtr + offset, count));
+                    Debug.Assert(bytesWritten <= count);
+
                     _filePosition += bytesWritten;
                     count -= bytesWritten;
                     offset += bytesWritten;
@@ -1121,7 +1109,7 @@ namespace System.IO
         private void WriteByteCore(byte value)
         {
             PrepareForWriting();
-            
+
             // Flush the write buffer if it's full
             if (_writePos == _bufferLength)
             {
@@ -1250,58 +1238,30 @@ namespace System.IO
             Debug.Assert(!_fileHandle.IsClosed && CanSeek);
             Debug.Assert(origin >= SeekOrigin.Begin && origin <= SeekOrigin.End);
 
-            long pos = SysCall((fd, off, or) => Interop.Sys.LSeek(fd, off, or), offset, (Interop.Sys.SeekWhence)(int)origin); // SeekOrigin values are the same as Interop.libc.SeekWhence values
+            long pos = CheckFileCall(Interop.Sys.LSeek(_fileHandle, offset, (Interop.Sys.SeekWhence)(int)origin)); // SeekOrigin values are the same as Interop.libc.SeekWhence values
             _filePosition = pos;
             return pos;
         }
 
-        /// <summary>
-        /// Helper for making system calls that involve the stream's file descriptor.
-        /// System calls are expected to return greather than or equal to zero on success,
-        /// and less than zero on failure.  In the case of failure, errno is expected to
-        /// be set to the relevant error code.
-        /// </summary>
-        /// <typeparam name="TArg1">Specifies the type of an argument to the system call.</typeparam>
-        /// <typeparam name="TArg2">Specifies the type of another argument to the system call.</typeparam>
-        /// <param name="sysCall">A delegate that invokes the system call.</param>
-        /// <param name="arg1">The first argument to be passed to the system call, after the file descriptor.</param>
-        /// <param name="arg2">The second argument to be passed to the system call.</param>
-        /// <param name="throwOnError">true to throw an exception if a non-interuption error occurs; otherwise, false.</param>
-        /// <returns>The return value of the system call.</returns>
-        /// <remarks>
-        /// Arguments are expected to be passed via <paramref name="arg1"/> and <paramref name="arg2"/>
-        /// so as to avoid delegate and closure allocations at the call sites.
-        /// </remarks>
-        private long SysCall<TArg1, TArg2>(
-            Func<SafeFileHandle, TArg1, TArg2, long> sysCall,
-            TArg1 arg1 = default(TArg1), TArg2 arg2 = default(TArg2),
-            bool throwOnError = true,
-            bool ignoreNotSupported = false)
+        private long CheckFileCall(long result, bool ignoreNotSupported = false)
         {
-            SafeFileHandle handle = _fileHandle;
-
-            Debug.Assert(sysCall != null);
-            Debug.Assert(handle != null);
-            Debug.Assert(!handle.IsInvalid);
-
-            // System calls may fail due to EINTR (signal interruption).  We need to retry in those cases.
-            while (true)
+            if (result < 0)
             {
-                long result = sysCall(handle, arg1, arg2);
-                if (result < 0)
+                Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();
+                if (!(ignoreNotSupported && errorInfo.Error == Interop.Error.ENOTSUP))
                 {
-                    Interop.ErrorInfo errorInfo = Interop.Sys.GetLastErrorInfo();
-                    if (errorInfo.Error == Interop.Error.EINTR)
-                    {
-                        continue;
-                    }
-                    else if (throwOnError && !(ignoreNotSupported && errorInfo.Error == Interop.Error.ENOTSUP))
-                    {
-                        throw Interop.GetExceptionForIoErrno(errorInfo, _path, isDirectory: false);
-                    }
+                    throw Interop.GetExceptionForIoErrno(errorInfo, _path, isDirectory: false);
                 }
-                return result;
             }
+
+            return result;
+        }
+
+        private int CheckFileCall(int result, bool ignoreNotSupported = false)
+        {
+            CheckFileCall((long)result, ignoreNotSupported);
+
+            return result;
         }
 
         /// <summary>State used when the stream is in async mode.</summary>

--- a/src/System.IO.Pipes/src/Microsoft/Win32/SafeHandles/SafePipeHandle.Unix.cs
+++ b/src/System.IO.Pipes/src/Microsoft/Win32/SafeHandles/SafePipeHandle.Unix.cs
@@ -20,13 +20,8 @@ namespace Microsoft.Win32.SafeHandles
         internal static SafePipeHandle Open(string path, Interop.Sys.OpenFlags flags, int mode)
         {
             // Ideally this would be a constrained execution region, but we don't have access to PrepareConstrainedRegions.
-            // The SafePipeHandle is allocated first to avoid the allocation after getting the file descriptor but before storing it.
-            SafePipeHandle handle = new SafePipeHandle();
+            SafePipeHandle handle = Interop.CheckIo(Interop.Sys.OpenPipe(path, flags, mode));
 
-            IntPtr fd;
-            while (Interop.CheckIo(fd = Interop.Sys.Open(path, flags, mode))) ;
-
-            handle.SetHandle(fd);
             Debug.Assert(!handle.IsInvalid);
 
             return handle;

--- a/src/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -176,6 +176,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Open.cs">
       <Link>Common\Interop\Unix\Interop.Open.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Open.Pipe.cs">
+      <Link>Common\Interop\Unix\Interop.Open.Pipe.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.OpenFlags.cs">
       <Link>Common\Interop\Unix\Interop.OpenFlags.cs</Link>
     </Compile>

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -93,7 +93,7 @@ namespace System.Net.Http
                     unsafe
                     {
                         int* fds = stackalloc int[2];
-                        while (Interop.CheckIo(Interop.Sys.Pipe(fds))) ;
+                        Interop.CheckIo(Interop.Sys.Pipe(fds));
                         _wakeupRequestedPipeFd = new SafeFileHandle((IntPtr)fds[Interop.Sys.ReadEndOfPipe], true);
                         _requestWakeupPipeFd = new SafeFileHandle((IntPtr)fds[Interop.Sys.WriteEndOfPipe], true);
                     }
@@ -164,7 +164,7 @@ namespace System.Net.Http
                 {
                     VerboseTrace("Writing to wakeup pipe");
                     byte b = 1;
-                    while ((Interop.CheckIo(Interop.Sys.Write(_requestWakeupPipeFd, &b, 1)))) ;
+                    Interop.CheckIo(Interop.Sys.Write(_requestWakeupPipeFd, &b, 1));
                 }
             }
 
@@ -182,8 +182,7 @@ namespace System.Net.Http
                 // subsequently clearing out more of the pipe.
                 const int ClearBufferSize = 64; // sufficiently large to clear the pipe in any normal case
                 byte* clearBuf = stackalloc byte[ClearBufferSize];
-                int bytesRead;
-                while (Interop.CheckIo(bytesRead = Interop.Sys.Read(_wakeupRequestedPipeFd, clearBuf, ClearBufferSize))) ;
+                int bytesRead = Interop.CheckIo(Interop.Sys.Read(_wakeupRequestedPipeFd, clearBuf, ClearBufferSize));
                 VerboseTraceIf(bytesRead > 1, "Read more than one byte from wakeup pipe: " + bytesRead);
             }
 

--- a/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.Unix.cs
@@ -188,8 +188,7 @@ namespace System.IO
             byte[] name = Encoding.UTF8.GetBytes(template);
 
             // Create, open, and close the temp file.
-            IntPtr fd;
-            Interop.CheckIo(fd = Interop.Sys.MksTemps(name, SuffixByteLength));
+            IntPtr fd = Interop.CheckIo(Interop.Sys.MksTemps(name, SuffixByteLength));
             Interop.Sys.Close(fd); // ignore any errors from close; nothing to do if cleanup isn't possible
 
             // 'name' is now the name of the file


### PR DESCRIPTION
This allows for the managed code to be cleaner, and it can easily return SafeHandle objects from P/Invoke methods.
Also, it fixes the problem where some code wasn't looping on Interop.CheckIo, which is a problem when EINTR is returned.

Fix #3168 

@stephentoub @nguerrera @sokket 