### PR TITLE
Add facade projects for all supported platforms

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -117,6 +117,7 @@
     <DnuRestoreDir Include="$(ToolsDir)" />
     <!-- workaround to address issue where DNX won't recurse directories under a project.json
          https://github.com/aspnet/dnx/commit/0dda8bf86863364cc20421f1af7494f1b2a3256f -->
+    <DnuRestoreDir Include="$(MSBuildProjectDirectory)\src\*\src\**\project.json" />
     <DnuRestoreDir Include="$(MSBuildProjectDirectory)\src\*\ref\*\project.json" />
     <DnuRestoreDir Include="$(MSBuildProjectDirectory)\src\*\tests\*\project.json" />
     <DnuRestoreDir Include="$(MSBuildProjectDirectory)\src\*\*\netcore50aot\project.json" />

--- a/src/Microsoft.Win32.Primitives/src/Microsoft.Win32.Primitives.builds
+++ b/src/Microsoft.Win32.Primitives/src/Microsoft.Win32.Primitives.builds
@@ -5,6 +5,9 @@
     <Project Include="Microsoft.Win32.Primitives.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\Microsoft.Win32.Primitives.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/Microsoft.Win32.Primitives/src/facade/Microsoft.Win32.Primitives.csproj
+++ b/src/Microsoft.Win32.Primitives/src/facade/Microsoft.Win32.Primitives.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>Microsoft.Win32.Primitives</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Microsoft.Win32.Primitives/src/facade/project.json
+++ b/src/Microsoft.Win32.Primitives/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.builds
+++ b/src/Microsoft.Win32.Registry/src/Microsoft.Win32.Registry.builds
@@ -5,6 +5,9 @@
     <Project Include="Microsoft.Win32.Registry.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\Microsoft.Win32.Registry.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/Microsoft.Win32.Registry/src/facade/Microsoft.Win32.Registry.csproj
+++ b/src/Microsoft.Win32.Registry/src/facade/Microsoft.Win32.Registry.csproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>Microsoft.Win32.Registry</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Microsoft.Win32.Registry/src/facade/project.json
+++ b/src/Microsoft.Win32.Registry/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.AppContext/src/System.AppContext.builds
+++ b/src/System.AppContext/src/System.AppContext.builds
@@ -1,14 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  <ItemGroup Condition="'$(TargetsWindows)' == 'true'">
+  <ItemGroup>
     <Project Include="System.AppContext.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
-    <Project Include="System.AppContext.csproj">
+    <Project Include="System.AppContext.csproj" Condition="'$(TargetsWindows)' == 'true'">
       <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties>
     </Project>
-    <Project Include="System.AppContext.csproj">
+    <Project Include="System.AppContext.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.AppContext.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.AppContext.csproj" Condition="'$(TargetsWindows)' == 'true'">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
     </Project>
   </ItemGroup>

--- a/src/System.AppContext/src/facade/System.AppContext.csproj
+++ b/src/System.AppContext/src/facade/System.AppContext.csproj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.AppContext</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.AppContext/src/facade/project.json
+++ b/src/System.AppContext/src/facade/project.json
@@ -1,0 +1,14 @@
+{
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Collections.Concurrent/src/System.Collections.Concurrent.builds
+++ b/src/System.Collections.Concurrent/src/System.Collections.Concurrent.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Collections.Concurrent.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Collections.Concurrent.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Collections.Concurrent/src/facade/System.Collections.Concurrent.csproj
+++ b/src/System.Collections.Concurrent/src/facade/System.Collections.Concurrent.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Collections.Concurrent</AssemblyName>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Collections.Concurrent/src/facade/project.json
+++ b/src/System.Collections.Concurrent/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Collections.NonGeneric/src/System.Collections.NonGeneric.builds
+++ b/src/System.Collections.NonGeneric/src/System.Collections.NonGeneric.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Collections.NonGeneric.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Collections.NonGeneric.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Collections.NonGeneric/src/facade/System.Collections.NonGeneric.csproj
+++ b/src/System.Collections.NonGeneric/src/facade/System.Collections.NonGeneric.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Collections.NonGeneric</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Collections.NonGeneric/src/facade/project.json
+++ b/src/System.Collections.NonGeneric/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Collections.Specialized/src/System.Collections.Specialized.builds
+++ b/src/System.Collections.Specialized/src/System.Collections.Specialized.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Collections.Specialized.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Collections.Specialized.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Collections.Specialized/src/facade/System.Collections.Specialized.csproj
+++ b/src/System.Collections.Specialized/src/facade/System.Collections.Specialized.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Collections.Specialized</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Collections.Specialized/src/facade/project.json
+++ b/src/System.Collections.Specialized/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Collections/src/System.Collections.builds
+++ b/src/System.Collections/src/System.Collections.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Collections.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Collections.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Collections/src/facade/System.Collections.csproj
+++ b/src/System.Collections/src/facade/System.Collections.csproj
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Collections</AssemblyName>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Core" Condition="'$(TargetGroup)' == 'net46'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Collections/src/facade/project.json
+++ b/src/System.Collections/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.ComponentModel.EventBasedAsync/src/System.ComponentModel.EventBasedAsync.builds
+++ b/src/System.ComponentModel.EventBasedAsync/src/System.ComponentModel.EventBasedAsync.builds
@@ -5,6 +5,9 @@
     <Project Include="System.ComponentModel.EventBasedAsync.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.ComponentModel.EventBasedAsync.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.ComponentModel.EventBasedAsync/src/facade/System.ComponentModel.EventBasedAsync.csproj
+++ b/src/System.ComponentModel.EventBasedAsync/src/facade/System.ComponentModel.EventBasedAsync.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.ComponentModel.EventBasedAsync</AssemblyName>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.ComponentModel.EventBasedAsync/src/facade/project.json
+++ b/src/System.ComponentModel.EventBasedAsync/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.ComponentModel/src/System.ComponentModel.builds
+++ b/src/System.ComponentModel/src/System.ComponentModel.builds
@@ -5,6 +5,9 @@
     <Project Include="System.ComponentModel.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.ComponentModel.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.ComponentModel/src/facade/System.ComponentModel.csproj
+++ b/src/System.ComponentModel/src/facade/System.ComponentModel.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.ComponentModel</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.ComponentModel/src/facade/project.json
+++ b/src/System.ComponentModel/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Console/src/System.Console.builds
+++ b/src/System.Console/src/System.Console.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Console.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Console.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Console/src/facade/System.Console.csproj
+++ b/src/System.Console/src/facade/System.Console.csproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Console</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Console/src/facade/project.json
+++ b/src/System.Console/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Data.Common/src/System.Data.Common.builds
+++ b/src/System.Data.Common/src/System.Data.Common.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Data.Common.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Data.Common.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Data.Common/src/facade/System.Data.Common.csproj
+++ b/src/System.Data.Common/src/facade/System.Data.Common.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Data.Common</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Data" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Data.Common/src/facade/project.json
+++ b/src/System.Data.Common/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.builds
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Data.SqlClient.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Data.SqlClient.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Data.SqlClient/src/facade/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/facade/System.Data.SqlClient.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Data.SqlClient</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Data" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Data.SqlClient/src/facade/project.json
+++ b/src/System.Data.SqlClient/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Diagnostics.Contracts/src/System.Diagnostics.Contracts.builds
+++ b/src/System.Diagnostics.Contracts/src/System.Diagnostics.Contracts.builds
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Diagnostics.Contracts.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Diagnostics.Contracts.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50aot</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Diagnostics.Contracts.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Diagnostics.Contracts.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Diagnostics.Contracts/src/facade/System.Diagnostics.Contracts.csproj
+++ b/src/System.Diagnostics.Contracts/src/facade/System.Diagnostics.Contracts.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Diagnostics.Contracts</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
+    <ProjectJson>netcore50aot\project.json</ProjectJson>
+    <ProjectLockJson>netcore50aot\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Private.CoreLib" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.Contracts/src/facade/netcore50aot/project.json
+++ b/src/System.Diagnostics.Contracts/src/facade/netcore50aot/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        }
+    }
+}

--- a/src/System.Diagnostics.Contracts/src/facade/netcoreaot/project.json
+++ b/src/System.Diagnostics.Contracts/src/facade/netcoreaot/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        }
+    }
+}

--- a/src/System.Diagnostics.Contracts/src/facade/project.json
+++ b/src/System.Diagnostics.Contracts/src/facade/project.json
@@ -1,0 +1,19 @@
+{
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.builds
+++ b/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.builds
@@ -5,6 +5,12 @@
     <Project Include="System.Diagnostics.Debug.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Diagnostics.Debug.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50aot</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Diagnostics.Debug.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Diagnostics.Debug/src/facade/System.Diagnostics.Debug.csproj
+++ b/src/System.Diagnostics.Debug/src/facade/System.Diagnostics.Debug.csproj
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Diagnostics.Debug</AssemblyName>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+    <TargetingPackReference Include="System.Private.CoreLib" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.Debug/src/facade/project.json
+++ b/src/System.Diagnostics.Debug/src/facade/project.json
@@ -1,0 +1,14 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Diagnostics.FileVersionInfo/src/System.Diagnostics.FileVersionInfo.builds
+++ b/src/System.Diagnostics.FileVersionInfo/src/System.Diagnostics.FileVersionInfo.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Diagnostics.FileVersionInfo.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Diagnostics.FileVersionInfo.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Diagnostics.FileVersionInfo/src/facade/System.Diagnostics.FileVersionInfo.csproj
+++ b/src/System.Diagnostics.FileVersionInfo/src/facade/System.Diagnostics.FileVersionInfo.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Diagnostics.FileVersionInfo</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.FileVersionInfo/src/facade/project.json
+++ b/src/System.Diagnostics.FileVersionInfo/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Diagnostics.Process/src/System.Diagnostics.Process.builds
+++ b/src/System.Diagnostics.Process/src/System.Diagnostics.Process.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Diagnostics.Process.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Diagnostics.Process.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Diagnostics.Process/src/facade/System.Diagnostics.Process.csproj
+++ b/src/System.Diagnostics.Process/src/facade/System.Diagnostics.Process.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Diagnostics.Process</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.Process/src/facade/project.json
+++ b/src/System.Diagnostics.Process/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Diagnostics.TextWriterTraceListener/src/System.Diagnostics.TextWriterTraceListener.builds
+++ b/src/System.Diagnostics.TextWriterTraceListener/src/System.Diagnostics.TextWriterTraceListener.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Diagnostics.TextWriterTraceListener.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Diagnostics.TextWriterTraceListener.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Diagnostics.TextWriterTraceListener/src/facade/System.Diagnostics.TextWriterTraceListener.csproj
+++ b/src/System.Diagnostics.TextWriterTraceListener/src/facade/System.Diagnostics.TextWriterTraceListener.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Diagnostics.TextWriterTraceListener</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.TextWriterTraceListener/src/facade/project.json
+++ b/src/System.Diagnostics.TextWriterTraceListener/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Diagnostics.Tools/src/System.Diagnostics.Tools.builds
+++ b/src/System.Diagnostics.Tools/src/System.Diagnostics.Tools.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Diagnostics.Tools.CoreCLR.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Diagnostics.Tools.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Diagnostics.Tools/src/facade/System.Diagnostics.Tools.csproj
+++ b/src/System.Diagnostics.Tools/src/facade/System.Diagnostics.Tools.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Diagnostics.Tools</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.Tools/src/facade/project.json
+++ b/src/System.Diagnostics.Tools/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Diagnostics.TraceSource/src/System.Diagnostics.TraceSource.builds
+++ b/src/System.Diagnostics.TraceSource/src/System.Diagnostics.TraceSource.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Diagnostics.TraceSource.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Diagnostics.TraceSource.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Diagnostics.TraceSource/src/facade/System.Diagnostics.TraceSource.csproj
+++ b/src/System.Diagnostics.TraceSource/src/facade/System.Diagnostics.TraceSource.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Diagnostics.TraceSource</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.TraceSource/src/facade/project.json
+++ b/src/System.Diagnostics.TraceSource/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.builds
+++ b/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.builds
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Diagnostics.Tracing.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Diagnostics.Tracing/src/facade/System.Diagnostics.Tracing.csproj
+++ b/src/System.Diagnostics.Tracing/src/facade/System.Diagnostics.Tracing.csproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Diagnostics.Tracing</AssemblyName>
+    <AssemblyVersion>4.0.21.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.Tracing/src/facade/project.json
+++ b/src/System.Diagnostics.Tracing/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Dynamic.Runtime/src/System.Dynamic.Runtime.builds
+++ b/src/System.Dynamic.Runtime/src/System.Dynamic.Runtime.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Dynamic.Runtime.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Dynamic.Runtime.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Dynamic.Runtime/src/facade/System.Dynamic.Runtime.csproj
+++ b/src/System.Dynamic.Runtime/src/facade/System.Dynamic.Runtime.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Dynamic.Runtime</AssemblyName>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Core" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Dynamic.Runtime/src/facade/project.json
+++ b/src/System.Dynamic.Runtime/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Globalization.Calendars/src/System.Globalization.Calendars.builds
+++ b/src/System.Globalization.Calendars/src/System.Globalization.Calendars.builds
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Globalization.Calendars.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Globalization.Calendars.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50aot</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Globalization.Calendars.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Globalization.Calendars.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Globalization.Calendars/src/facade/System.Globalization.Calendars.csproj
+++ b/src/System.Globalization.Calendars/src/facade/System.Globalization.Calendars.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Globalization.Calendars</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
+    <ProjectJson>netcore50aot\project.json</ProjectJson>
+    <ProjectLockJson>netcore50aot\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Private.CoreLib" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Globalization.Calendars/src/facade/netcore50aot/project.json
+++ b/src/System.Globalization.Calendars/src/facade/netcore50aot/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        }
+    }
+}

--- a/src/System.Globalization.Calendars/src/facade/netcoreaot/project.json
+++ b/src/System.Globalization.Calendars/src/facade/netcoreaot/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        }
+    }
+}

--- a/src/System.Globalization.Calendars/src/facade/project.json
+++ b/src/System.Globalization.Calendars/src/facade/project.json
@@ -1,0 +1,19 @@
+{
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Globalization/src/System.Globalization.builds
+++ b/src/System.Globalization/src/System.Globalization.builds
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Globalization.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Globalization.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50aot</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Globalization.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Globalization.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Globalization/src/facade/System.Globalization.csproj
+++ b/src/System.Globalization/src/facade/System.Globalization.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Globalization</AssemblyName>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
+    <ProjectJson>netcore50aot\project.json</ProjectJson>
+    <ProjectLockJson>netcore50aot\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Private.CoreLib" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Globalization/src/facade/netcore50aot/project.json
+++ b/src/System.Globalization/src/facade/netcore50aot/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        }
+    }
+}

--- a/src/System.Globalization/src/facade/netcoreaot/project.json
+++ b/src/System.Globalization/src/facade/netcoreaot/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        }
+    }
+}

--- a/src/System.Globalization/src/facade/project.json
+++ b/src/System.Globalization/src/facade/project.json
@@ -1,0 +1,19 @@
+{
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.IO.Compression.ZipFile/src/System.IO.Compression.ZipFile.builds
+++ b/src/System.IO.Compression.ZipFile/src/System.IO.Compression.ZipFile.builds
@@ -5,6 +5,9 @@
     <Project Include="System.IO.Compression.ZipFile.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.IO.Compression.ZipFile.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.IO.Compression.ZipFile/src/facade/System.IO.Compression.ZipFile.csproj
+++ b/src/System.IO.Compression.ZipFile/src/facade/System.IO.Compression.ZipFile.csproj
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <UseECMAKey Condition="'$(UseECMAKey)' == ''">true</UseECMAKey>
+    <AssemblyName>System.IO.Compression.ZipFile</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.IO.Compression.FileSystem" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.IO.Compression.ZipFile/src/facade/project.json
+++ b/src/System.IO.Compression.ZipFile/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.IO.FileSystem.DriveInfo/src/System.IO.FileSystem.DriveInfo.builds
+++ b/src/System.IO.FileSystem.DriveInfo/src/System.IO.FileSystem.DriveInfo.builds
@@ -5,6 +5,9 @@
     <Project Include="System.IO.FileSystem.DriveInfo.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.IO.FileSystem.DriveInfo.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.IO.FileSystem.DriveInfo/src/facade/System.IO.FileSystem.DriveInfo.csproj
+++ b/src/System.IO.FileSystem.DriveInfo/src/facade/System.IO.FileSystem.DriveInfo.csproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.IO.FileSystem.DriveInfo</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.IO.FileSystem.DriveInfo/src/facade/project.json
+++ b/src/System.IO.FileSystem.DriveInfo/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.IO.FileSystem.Primitives/src/System.IO.FileSystem.Primitives.builds
+++ b/src/System.IO.FileSystem.Primitives/src/System.IO.FileSystem.Primitives.builds
@@ -5,6 +5,9 @@
     <Project Include="System.IO.FileSystem.Primitives.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.IO.FileSystem.Primitives.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.IO.FileSystem.Primitives/src/facade/System.IO.FileSystem.Primitives.csproj
+++ b/src/System.IO.FileSystem.Primitives/src/facade/System.IO.FileSystem.Primitives.csproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.IO.FileSystem.Primitives</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.IO.FileSystem.Primitives/src/facade/project.json
+++ b/src/System.IO.FileSystem.Primitives/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.builds
+++ b/src/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.builds
@@ -5,6 +5,9 @@
     <Project Include="System.IO.FileSystem.Watcher.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.IO.FileSystem.Watcher.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.IO.FileSystem.Watcher/src/facade/System.IO.FileSystem.Watcher.csproj
+++ b/src/System.IO.FileSystem.Watcher/src/facade/System.IO.FileSystem.Watcher.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.IO.FileSystem.Watcher</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.IO.FileSystem.Watcher/src/facade/project.json
+++ b/src/System.IO.FileSystem.Watcher/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.builds
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.builds
@@ -3,10 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.IO.FileSystem.csproj">
-      <AdditionalProperties>TargetGroup=</AdditionalProperties> 
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
-    <Project Include="System.IO.FileSystem.csproj" Condition="'$(TargetsWindows)' == 'true'">
-      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties>
+    <Project Include="facade\System.IO.FileSystem.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.IO.FileSystem/src/facade/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/facade/System.IO.FileSystem.csproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.IO.FileSystem</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.IO.FileSystem/src/facade/project.json
+++ b/src/System.IO.FileSystem/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.builds
+++ b/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.builds
@@ -5,6 +5,9 @@
     <Project Include="System.IO.MemoryMappedFiles.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.IO.MemoryMappedFiles.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.IO.MemoryMappedFiles/src/facade/System.IO.MemoryMappedFiles.csproj
+++ b/src/System.IO.MemoryMappedFiles/src/facade/System.IO.MemoryMappedFiles.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.IO.MemoryMappedFiles</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Core" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.IO.MemoryMappedFiles/src/facade/project.json
+++ b/src/System.IO.MemoryMappedFiles/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.IO.Pipes/src/System.IO.Pipes.builds
+++ b/src/System.IO.Pipes/src/System.IO.Pipes.builds
@@ -5,6 +5,9 @@
     <Project Include="System.IO.Pipes.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.IO.Pipes.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.IO.Pipes/src/facade/System.IO.Pipes.csproj
+++ b/src/System.IO.Pipes/src/facade/System.IO.Pipes.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.IO.Pipes</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Core" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.IO.Pipes/src/facade/project.json
+++ b/src/System.IO.Pipes/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.IO.UnmanagedMemoryStream/src/System.IO.UnmanagedMemoryStream.builds
+++ b/src/System.IO.UnmanagedMemoryStream/src/System.IO.UnmanagedMemoryStream.builds
@@ -5,6 +5,9 @@
     <Project Include="System.IO.UnmanagedMemoryStream.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.IO.UnmanagedMemoryStream.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.IO.UnmanagedMemoryStream/src/facade/System.IO.UnmanagedMemoryStream.csproj
+++ b/src/System.IO.UnmanagedMemoryStream/src/facade/System.IO.UnmanagedMemoryStream.csproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.IO.UnmanagedMemoryStream</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.IO.UnmanagedMemoryStream/src/facade/project.json
+++ b/src/System.IO.UnmanagedMemoryStream/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.IO/src/System.IO.builds
+++ b/src/System.IO/src/System.IO.builds
@@ -5,6 +5,9 @@
     <Project Include="System.IO.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.IO.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.IO/src/facade/System.IO.csproj
+++ b/src/System.IO/src/facade/System.IO.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.IO</AssemblyName>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.IO/src/facade/project.json
+++ b/src/System.IO/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Linq.Expressions/src/Facade/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/Facade/System.Linq.Expressions.csproj
@@ -1,26 +1,28 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- Setting default TargetGroup before importing dir.prop -->
     <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
   </PropertyGroup>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Linq.Expressions</AssemblyName>
-    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <AssemblyVersion>4.0.11.0</AssemblyVersion>
-    <ProjectJson>..\project.json</ProjectJson>
-    <ProjectLockJson>..\project.lock.json</ProjectLockJson>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
   </PropertyGroup>
 
-  <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU' " />
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU' " />
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
 
   <ItemGroup>
-    <TargetingPackReference Include="mscorlib" />
-    <TargetingPackReference Include="System.Core" />
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Core" Condition="'$(TargetGroup)' == 'net46'" />
   </ItemGroup>
-  
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Linq.Expressions/src/Facade/project.json
+++ b/src/System.Linq.Expressions/src/Facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.builds
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.builds
@@ -3,15 +3,15 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Linq.Expressions.csproj">
-      <AdditionalProperties>TargetGroup=</AdditionalProperties> 
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
-    <Project Include="System.Linq.Expressions.csproj">
+    <Project Include="System.Linq.Expressions.csproj" Condition="'$(TargetsWindows)' == 'true'">
       <AdditionalProperties>TargetGroup=netcore50aot</AdditionalProperties>
     </Project>
-    <Project Include="System.Linq.Expressions.csproj">
-      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties> 
+    <Project Include="System.Linq.Expressions.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties>
     </Project>
-    <Project Include="Facade\System.Linq.Expressions.csproj">
+    <Project Include="Facade\System.Linq.Expressions.csproj" Condition="'$(TargetsWindows)' == 'true'">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
     </Project>
   </ItemGroup>

--- a/src/System.Linq.Parallel/src/System.Linq.Parallel.builds
+++ b/src/System.Linq.Parallel/src/System.Linq.Parallel.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Linq.Parallel.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Linq.Parallel.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Linq.Parallel/src/facade/System.Linq.Parallel.csproj
+++ b/src/System.Linq.Parallel/src/facade/System.Linq.Parallel.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Linq.Parallel</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Core" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Linq.Parallel/src/facade/project.json
+++ b/src/System.Linq.Parallel/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Linq.Queryable/src/System.Linq.Queryable.builds
+++ b/src/System.Linq.Queryable/src/System.Linq.Queryable.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Linq.Queryable.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Linq.Queryable.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Linq.Queryable/src/facade/System.Linq.Queryable.csproj
+++ b/src/System.Linq.Queryable/src/facade/System.Linq.Queryable.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Linq.Queryable</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Core" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Linq.Queryable/src/facade/project.json
+++ b/src/System.Linq.Queryable/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Linq/src/System.Linq.builds
+++ b/src/System.Linq/src/System.Linq.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Linq.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Linq.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Linq/src/facade/System.Linq.csproj
+++ b/src/System.Linq/src/facade/System.Linq.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Linq</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Core" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Linq/src/facade/project.json
+++ b/src/System.Linq/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Net.NameResolution/src/System.Net.NameResolution.builds
+++ b/src/System.Net.NameResolution/src/System.Net.NameResolution.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Net.NameResolution.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Net.NameResolution.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Net.NameResolution/src/facade/System.Net.NameResolution.csproj
+++ b/src/System.Net.NameResolution/src/facade/System.Net.NameResolution.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Net.NameResolution</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Net.NameResolution/src/facade/project.json
+++ b/src/System.Net.NameResolution/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Net.Primitives/src/System.Net.Primitives.builds
+++ b/src/System.Net.Primitives/src/System.Net.Primitives.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Net.Primitives.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Net.Primitives.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Net.Primitives/src/facade/System.Net.Primitives.csproj
+++ b/src/System.Net.Primitives/src/facade/System.Net.Primitives.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Net.Primitives</AssemblyName>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Net.Primitives/src/facade/project.json
+++ b/src/System.Net.Primitives/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Net.Requests/src/System.Net.Requests.builds
+++ b/src/System.Net.Requests/src/System.Net.Requests.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Net.Requests.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Net.Requests.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Net.Requests/src/facade/System.Net.Requests.csproj
+++ b/src/System.Net.Requests/src/facade/System.Net.Requests.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Net.Requests</AssemblyName>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Net.Requests/src/facade/project.json
+++ b/src/System.Net.Requests/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Net.Security/src/System.Net.Security.builds
+++ b/src/System.Net.Security/src/System.Net.Security.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Net.Security.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Net.Security.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Net.Security/src/facade/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/facade/System.Net.Security.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Net.Security</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Net.Security/src/facade/project.json
+++ b/src/System.Net.Security/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Net.Utilities/src/System.Net.Utilities.builds
+++ b/src/System.Net.Utilities/src/System.Net.Utilities.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Net.Utilities.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Net.Utilities.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Net.Utilities/src/facade/System.Net.Utilities.csproj
+++ b/src/System.Net.Utilities/src/facade/System.Net.Utilities.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Net.Utilities</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Net.Utilities/src/facade/project.json
+++ b/src/System.Net.Utilities/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Net.WebHeaderCollection/src/System.Net.WebHeaderCollection.builds
+++ b/src/System.Net.WebHeaderCollection/src/System.Net.WebHeaderCollection.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Net.WebHeaderCollection.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Net.WebHeaderCollection.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Net.WebHeaderCollection/src/facade/System.Net.WebHeaderCollection.csproj
+++ b/src/System.Net.WebHeaderCollection/src/facade/System.Net.WebHeaderCollection.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Net.WebHeaderCollection</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Net.WebHeaderCollection/src/facade/project.json
+++ b/src/System.Net.WebHeaderCollection/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.builds
+++ b/src/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Net.WebSockets.Client.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Net.WebSockets.Client.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Net.WebSockets.Client/src/facade/System.Net.WebSockets.Client.csproj
+++ b/src/System.Net.WebSockets.Client/src/facade/System.Net.WebSockets.Client.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Net.WebSockets.Client</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Net.WebSockets.Client/src/facade/project.json
+++ b/src/System.Net.WebSockets.Client/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Net.WebSockets/src/System.Net.WebSockets.builds
+++ b/src/System.Net.WebSockets/src/System.Net.WebSockets.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Net.WebSockets.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Net.WebSockets.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Net.WebSockets/src/facade/System.Net.WebSockets.csproj
+++ b/src/System.Net.WebSockets/src/facade/System.Net.WebSockets.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Net.WebSockets</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Net.WebSockets/src/facade/project.json
+++ b/src/System.Net.WebSockets/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.ObjectModel/src/System.ObjectModel.builds
+++ b/src/System.ObjectModel/src/System.ObjectModel.builds
@@ -5,6 +5,9 @@
     <Project Include="System.ObjectModel.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.ObjectModel.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.ObjectModel/src/facade/System.ObjectModel.csproj
+++ b/src/System.ObjectModel/src/facade/System.ObjectModel.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.ObjectModel</AssemblyName>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.ObjectModel/src/facade/project.json
+++ b/src/System.ObjectModel/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.builds
+++ b/src/System.Reflection.DispatchProxy/src/System.Reflection.DispatchProxy.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Reflection.DispatchProxy.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Reflection.DispatchProxy.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50aot</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Reflection.DispatchProxy/src/facade/System.Reflection.DispatchProxy.csproj
+++ b/src/System.Reflection.DispatchProxy/src/facade/System.Reflection.DispatchProxy.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Reflection.DispatchProxy</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="System.Private.CoreLib" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+    <TargetingPackReference Include="System.Private.Interop" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection.DispatchProxy/src/facade/project.json
+++ b/src/System.Reflection.DispatchProxy/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        }
+    }
+}

--- a/src/System.Reflection.Emit.ILGeneration/src/System.Reflection.Emit.ILGeneration.builds
+++ b/src/System.Reflection.Emit.ILGeneration/src/System.Reflection.Emit.ILGeneration.builds
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Reflection.Emit.ILGeneration.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Reflection.Emit.ILGeneration.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Reflection.Emit.ILGeneration.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Reflection.Emit.ILGeneration/src/facade/System.Reflection.Emit.ILGeneration.csproj
+++ b/src/System.Reflection.Emit.ILGeneration/src/facade/System.Reflection.Emit.ILGeneration.csproj
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Reflection.Emit.ILGeneration</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection.Emit.ILGeneration/src/facade/project.json
+++ b/src/System.Reflection.Emit.ILGeneration/src/facade/project.json
@@ -1,0 +1,19 @@
+{
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Reflection.Emit.Lightweight/src/System.Reflection.Emit.Lightweight.builds
+++ b/src/System.Reflection.Emit.Lightweight/src/System.Reflection.Emit.Lightweight.builds
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Reflection.Emit.Lightweight.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Reflection.Emit.Lightweight.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Reflection.Emit.Lightweight.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Reflection.Emit.Lightweight/src/facade/System.Reflection.Emit.Lightweight.csproj
+++ b/src/System.Reflection.Emit.Lightweight/src/facade/System.Reflection.Emit.Lightweight.csproj
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Reflection.Emit.Lightweight</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection.Emit.Lightweight/src/facade/project.json
+++ b/src/System.Reflection.Emit.Lightweight/src/facade/project.json
@@ -1,0 +1,19 @@
+{
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Reflection.Emit/src/System.Reflection.Emit.builds
+++ b/src/System.Reflection.Emit/src/System.Reflection.Emit.builds
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Reflection.Emit.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Reflection.Emit.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Reflection.Emit.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Reflection.Emit/src/facade/System.Reflection.Emit.csproj
+++ b/src/System.Reflection.Emit/src/facade/System.Reflection.Emit.csproj
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Reflection.Emit</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection.Emit/src/facade/project.json
+++ b/src/System.Reflection.Emit/src/facade/project.json
@@ -1,0 +1,19 @@
+{
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Reflection.Extensions/src/System.Reflection.Extensions.builds
+++ b/src/System.Reflection.Extensions/src/System.Reflection.Extensions.builds
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Reflection.Extensions.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Reflection.Extensions.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Reflection.Extensions.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Reflection.Extensions/src/facade/System.Reflection.Extensions.csproj
+++ b/src/System.Reflection.Extensions/src/facade/System.Reflection.Extensions.csproj
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Reflection.Extensions</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection.Extensions/src/facade/project.json
+++ b/src/System.Reflection.Extensions/src/facade/project.json
@@ -1,0 +1,19 @@
+{
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Reflection.Primitives/src/System.Reflection.Primitives.builds
+++ b/src/System.Reflection.Primitives/src/System.Reflection.Primitives.builds
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Reflection.Primitives.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Reflection.Primitives.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Reflection.Primitives.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Reflection.Primitives/src/facade/System.Reflection.Primitives.csproj
+++ b/src/System.Reflection.Primitives/src/facade/System.Reflection.Primitives.csproj
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Reflection.Primitives</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection.Primitives/src/facade/project.json
+++ b/src/System.Reflection.Primitives/src/facade/project.json
@@ -1,0 +1,19 @@
+{
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Reflection/src/System.Reflection.builds
+++ b/src/System.Reflection/src/System.Reflection.builds
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Reflection.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Reflection.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50aot</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Reflection.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Reflection.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Reflection/src/facade/System.Reflection.csproj
+++ b/src/System.Reflection/src/facade/System.Reflection.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Reflection</AssemblyName>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
+    <ProjectJson>netcore50aot\project.json</ProjectJson>
+    <ProjectLockJson>netcore50aot\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Private.CoreLib" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+    <TargetingPackReference Include="System.Private.Reflection" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection/src/facade/netcore50aot/project.json
+++ b/src/System.Reflection/src/facade/netcore50aot/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        }
+    }
+}

--- a/src/System.Reflection/src/facade/netcoreaot/project.json
+++ b/src/System.Reflection/src/facade/netcoreaot/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        }
+    }
+}

--- a/src/System.Reflection/src/facade/project.json
+++ b/src/System.Reflection/src/facade/project.json
@@ -1,0 +1,19 @@
+{
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Resources.ReaderWriter/src/System.Resources.ReaderWriter.builds
+++ b/src/System.Resources.ReaderWriter/src/System.Resources.ReaderWriter.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Resources.ReaderWriter.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Resources.ReaderWriter.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Resources.ReaderWriter/src/facade/System.Resources.ReaderWriter.csproj
+++ b/src/System.Resources.ReaderWriter/src/facade/System.Resources.ReaderWriter.csproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Resources.ReaderWriter</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Resources.ReaderWriter/src/facade/project.json
+++ b/src/System.Resources.ReaderWriter/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Resources.ResourceManager/src/System.Resources.ResourceManager.builds
+++ b/src/System.Resources.ResourceManager/src/System.Resources.ResourceManager.builds
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Resources.ResourceManager.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Resources.ResourceManager.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Resources.ResourceManager.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Resources.ResourceManager/src/facade/System.Resources.ResourceManager.csproj
+++ b/src/System.Resources.ResourceManager/src/facade/System.Resources.ResourceManager.csproj
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Resources.ResourceManager</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Resources.ResourceManager/src/facade/project.json
+++ b/src/System.Resources.ResourceManager/src/facade/project.json
@@ -1,0 +1,19 @@
+{
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Runtime.CompilerServices.VisualC/src/System.Runtime.CompilerServices.VisualC.builds
+++ b/src/System.Runtime.CompilerServices.VisualC/src/System.Runtime.CompilerServices.VisualC.builds
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Runtime.CompilerServices.VisualC.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Runtime.CompilerServices.VisualC.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Runtime.CompilerServices.VisualC/src/facade/System.Runtime.CompilerServices.VisualC.csproj
+++ b/src/System.Runtime.CompilerServices.VisualC/src/facade/System.Runtime.CompilerServices.VisualC.csproj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Runtime.CompilerServices.VisualC</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.CompilerServices.VisualC/src/facade/project.json
+++ b/src/System.Runtime.CompilerServices.VisualC/src/facade/project.json
@@ -1,0 +1,14 @@
+{
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.builds
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Runtime.Extensions.CoreCLR.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Runtime.Extensions.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Runtime.Extensions/src/facade/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/facade/System.Runtime.Extensions.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Runtime.Extensions</AssemblyName>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Extensions/src/facade/project.json
+++ b/src/System.Runtime.Extensions/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Handles/src/System.Runtime.Handles.builds
+++ b/src/System.Runtime.Handles/src/System.Runtime.Handles.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Runtime.Handles.CoreCLR.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Runtime.Handles.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Runtime.Handles/src/facade/System.Runtime.Handles.csproj
+++ b/src/System.Runtime.Handles/src/facade/System.Runtime.Handles.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Runtime.Handles</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Core" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Handles/src/facade/project.json
+++ b/src/System.Runtime.Handles/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices.WindowsRuntime/src/System.Runtime.InteropServices.WindowsRuntime.builds
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/src/System.Runtime.InteropServices.WindowsRuntime.builds
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Runtime.InteropServices.WindowsRuntime.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50aot</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Runtime.InteropServices.WindowsRuntime.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Runtime.InteropServices.WindowsRuntime.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Runtime.InteropServices.WindowsRuntime/src/facade/System.Runtime.InteropServices.WindowsRuntime.csproj
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/src/facade/System.Runtime.InteropServices.WindowsRuntime.csproj
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50aot</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Runtime.InteropServices.WindowsRuntime</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
+    <ProjectJson>netcore50aot\project.json</ProjectJson>
+    <ProjectLockJson>netcore50aot\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Private.CoreLib" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+    <TargetingPackReference Include="System.Private.Interop" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.InteropServices.WindowsRuntime/src/facade/netcore50aot/project.json
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/src/facade/netcore50aot/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices.WindowsRuntime/src/facade/netcoreaot/project.json
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/src/facade/netcoreaot/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices.WindowsRuntime/src/facade/project.json
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/src/facade/project.json
@@ -1,0 +1,14 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Runtime.InteropServices/src/System.Runtime.InteropServices.builds
+++ b/src/System.Runtime.InteropServices/src/System.Runtime.InteropServices.builds
@@ -5,6 +5,12 @@
     <Project Include="System.Runtime.InteropServices.CoreCLR.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Runtime.InteropServices.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50aot</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Runtime.InteropServices.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Runtime.InteropServices/src/facade/System.Runtime.InteropServices.csproj
+++ b/src/System.Runtime.InteropServices/src/facade/System.Runtime.InteropServices.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Runtime.InteropServices</AssemblyName>
+    <AssemblyVersion>4.0.21.0</AssemblyVersion>
+    <AssemblyVersion>4.0.21.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Core" Condition="'$(TargetGroup)' == 'net46'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+    <TargetingPackReference Include="System.Private.CoreLib" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+    <TargetingPackReference Include="System.Private.Interop" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.InteropServices/src/facade/project.json
+++ b/src/System.Runtime.InteropServices/src/facade/project.json
@@ -1,0 +1,14 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Loader/src/System.Runtime.Loader.builds
+++ b/src/System.Runtime.Loader/src/System.Runtime.Loader.builds
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Runtime.Loader.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Runtime.Loader/src/facade/System.Runtime.Loader.csproj
+++ b/src/System.Runtime.Loader/src/facade/System.Runtime.Loader.csproj
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Runtime.Loader</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Loader/src/facade/project.json
+++ b/src/System.Runtime.Loader/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Numerics/src/System.Runtime.Numerics.builds
+++ b/src/System.Runtime.Numerics/src/System.Runtime.Numerics.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Runtime.Numerics.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Runtime.Numerics.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Runtime.Numerics/src/facade/System.Runtime.Numerics.csproj
+++ b/src/System.Runtime.Numerics/src/facade/System.Runtime.Numerics.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Runtime.Numerics</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Numerics" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Numerics/src/facade/project.json
+++ b/src/System.Runtime.Numerics/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Serialization.Json/src/System.Runtime.Serialization.Json.builds
+++ b/src/System.Runtime.Serialization.Json/src/System.Runtime.Serialization.Json.builds
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Runtime.Serialization.Json.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Runtime.Serialization.Json.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50aot</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Runtime.Serialization.Json.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Runtime.Serialization.Json.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Runtime.Serialization.Json/src/facade/System.Runtime.Serialization.Json.csproj
+++ b/src/System.Runtime.Serialization.Json/src/facade/System.Runtime.Serialization.Json.csproj
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Runtime.Serialization.Json</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
+    <ProjectJson>netcore50aot\project.json</ProjectJson>
+    <ProjectLockJson>netcore50aot\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Runtime.Serialization" Condition="'$(TargetGroup)' == 'net46'" />
+    <TargetingPackReference Include="System.Private.CoreLib" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+    <TargetingPackReference Include="System.Private.DataContractSerialization" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetGroup)' != 'netcore50aot' And '$(TargetGroup)' != 'net46'">
+    <ProjectReference Include="$(SourceDir)System.Private.DataContractSerialization\src\System.Private.DataContractSerialization.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Serialization.Json/src/facade/netcore50aot/project.json
+++ b/src/System.Runtime.Serialization.Json/src/facade/netcore50aot/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Serialization.Json/src/facade/netcoreaot/project.json
+++ b/src/System.Runtime.Serialization.Json/src/facade/netcoreaot/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Serialization.Json/src/facade/project.json
+++ b/src/System.Runtime.Serialization.Json/src/facade/project.json
@@ -1,0 +1,19 @@
+{
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Serialization.Xml/src/System.Runtime.Serialization.Xml.builds
+++ b/src/System.Runtime.Serialization.Xml/src/System.Runtime.Serialization.Xml.builds
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Runtime.Serialization.Xml.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Runtime.Serialization.Xml.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50aot</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Runtime.Serialization.Xml.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Runtime.Serialization.Xml/src/facade/System.Runtime.Serialization.Xml.csproj
+++ b/src/System.Runtime.Serialization.Xml/src/facade/System.Runtime.Serialization.Xml.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Runtime.Serialization.Xml</AssemblyName>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
+    <ProjectJson>netcore50aot\project.json</ProjectJson>
+    <ProjectLockJson>netcore50aot\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Private.CoreLib" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+    <TargetingPackReference Include="System.Private.DataContractSerialization" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+    <ProjectReference Include="$(SourceDir)System.Private.DataContractSerialization\src\System.Private.DataContractSerialization.csproj" />
+    <ProjectReference Include="$(SourceDir)System.Runtime.Serialization.Primitives\src\System.Runtime.Serialization.Primitives.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Serialization.Xml/src/facade/netcore50aot/project.json
+++ b/src/System.Runtime.Serialization.Xml/src/facade/netcore50aot/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Serialization.Xml/src/facade/netcoreaot/project.json
+++ b/src/System.Runtime.Serialization.Xml/src/facade/netcoreaot/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Serialization.Xml/src/facade/project.json
+++ b/src/System.Runtime.Serialization.Xml/src/facade/project.json
@@ -1,0 +1,14 @@
+{
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        }
+    }
+}

--- a/src/System.Runtime/src/System.Runtime.builds
+++ b/src/System.Runtime/src/System.Runtime.builds
@@ -8,6 +8,9 @@
     <Project Include="System.Runtime.csproj" Condition="'$(TargetsWindows)' == 'true'">
       <AdditionalProperties>TargetGroup=netcore50aot</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Runtime.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Runtime/src/System.Runtime.csproj
+++ b/src/System.Runtime/src/System.Runtime.csproj
@@ -14,8 +14,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System\Action.cs" />
     <Compile Include="System\Function.cs" />

--- a/src/System.Runtime/src/facade/System.Runtime.csproj
+++ b/src/System.Runtime/src/facade/System.Runtime.csproj
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Runtime</AssemblyName>
+    <AssemblyVersion>4.0.21.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Core" Condition="'$(TargetGroup)' == 'net46'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+    <TargetingPackReference Include="System.ComponentModel.Composition" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime/src/facade/project.json
+++ b/src/System.Runtime/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Security.AccessControl/src/System.Security.AccessControl.builds
+++ b/src/System.Security.AccessControl/src/System.Security.AccessControl.builds
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Security.AccessControl.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Security.AccessControl/src/facade/System.Security.AccessControl.csproj
+++ b/src/System.Security.AccessControl/src/facade/System.Security.AccessControl.csproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Security.AccessControl</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.AccessControl/src/facade/project.json
+++ b/src/System.Security.AccessControl/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Security.Claims/src/System.Security.Claims.builds
+++ b/src/System.Security.Claims/src/System.Security.Claims.builds
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Security.Claims.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Security.Claims/src/facade/System.Security.Claims.csproj
+++ b/src/System.Security.Claims/src/facade/System.Security.Claims.csproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Security.Claims</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.Claims/src/facade/project.json
+++ b/src/System.Security.Claims/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.builds
+++ b/src/System.Security.Cryptography.Cng/src/System.Security.Cryptography.Cng.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Security.Cryptography.Cng.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Security.Cryptography.Cng.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Cng/src/facade/System.Security.Cryptography.Cng.csproj
+++ b/src/System.Security.Cryptography.Cng/src/facade/System.Security.Cryptography.Cng.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Security.Cryptography.Cng</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Core" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.Cryptography.Cng/src/facade/project.json
+++ b/src/System.Security.Cryptography.Cng/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.builds
+++ b/src/System.Security.Cryptography.Csp/src/System.Security.Cryptography.Csp.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Security.Cryptography.Csp.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Security.Cryptography.Csp.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Csp/src/facade/System.Security.Cryptography.Csp.csproj
+++ b/src/System.Security.Cryptography.Csp/src/facade/System.Security.Cryptography.Csp.csproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Security.Cryptography.Csp</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.Cryptography.Csp/src/facade/project.json
+++ b/src/System.Security.Cryptography.Csp/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.builds
+++ b/src/System.Security.Cryptography.Encoding/src/System.Security.Cryptography.Encoding.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Security.Cryptography.Encoding.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Security.Cryptography.Encoding.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Encoding/src/facade/System.Security.Cryptography.Encoding.csproj
+++ b/src/System.Security.Cryptography.Encoding/src/facade/System.Security.Cryptography.Encoding.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Security.Cryptography.Encoding</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.Cryptography.Encoding/src/facade/project.json
+++ b/src/System.Security.Cryptography.Encoding/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Primitives/src/System.Security.Cryptography.Primitives.builds
+++ b/src/System.Security.Cryptography.Primitives/src/System.Security.Cryptography.Primitives.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Security.Cryptography.Primitives.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Security.Cryptography.Primitives.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Primitives/src/facade/System.Security.Cryptography.Primitives.csproj
+++ b/src/System.Security.Cryptography.Primitives/src/facade/System.Security.Cryptography.Primitives.csproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Security.Cryptography.Primitives</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.Cryptography.Primitives/src/facade/project.json
+++ b/src/System.Security.Cryptography.Primitives/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Security.Principal.Windows/src/System.Security.Principal.Windows.builds
+++ b/src/System.Security.Principal.Windows/src/System.Security.Principal.Windows.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Security.Principal.Windows.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Security.Principal.Windows.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Security.Principal.Windows/src/facade/System.Security.Principal.Windows.csproj
+++ b/src/System.Security.Principal.Windows/src/facade/System.Security.Principal.Windows.csproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Security.Principal.Windows</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.Principal.Windows/src/facade/project.json
+++ b/src/System.Security.Principal.Windows/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Security.Principal/src/System.Security.Principal.builds
+++ b/src/System.Security.Principal/src/System.Security.Principal.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Security.Principal.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Security.Principal.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Security.Principal/src/facade/System.Security.Principal.csproj
+++ b/src/System.Security.Principal/src/facade/System.Security.Principal.csproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Security.Principal</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.Principal/src/facade/project.json
+++ b/src/System.Security.Principal/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.ServiceProcess.ServiceController/src/System.ServiceProcess.ServiceController.builds
+++ b/src/System.ServiceProcess.ServiceController/src/System.ServiceProcess.ServiceController.builds
@@ -5,6 +5,9 @@
     <Project Include="System.ServiceProcess.ServiceController.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.ServiceProcess.ServiceController.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.ServiceProcess.ServiceController/src/facade/System.ServiceProcess.ServiceController.csproj
+++ b/src/System.ServiceProcess.ServiceController/src/facade/System.ServiceProcess.ServiceController.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.ServiceProcess.ServiceController</AssemblyName>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.ServiceProcess" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.ServiceProcess.ServiceController/src/facade/project.json
+++ b/src/System.ServiceProcess.ServiceController/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Text.Encoding.Extensions/src/System.Text.Encoding.Extensions.builds
+++ b/src/System.Text.Encoding.Extensions/src/System.Text.Encoding.Extensions.builds
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Text.Encoding.Extensions.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Text.Encoding.Extensions.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50aot</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Text.Encoding.Extensions.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Text.Encoding.Extensions.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Text.Encoding.Extensions/src/facade/System.Text.Encoding.Extensions.csproj
+++ b/src/System.Text.Encoding.Extensions/src/facade/System.Text.Encoding.Extensions.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Text.Encoding.Extensions</AssemblyName>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
+    <ProjectJson>netcore50aot\project.json</ProjectJson>
+    <ProjectLockJson>netcore50aot\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Private.CoreLib" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Text.Encoding.Extensions/src/facade/netcore50aot/project.json
+++ b/src/System.Text.Encoding.Extensions/src/facade/netcore50aot/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        }
+    }
+}

--- a/src/System.Text.Encoding.Extensions/src/facade/netcoreaot/project.json
+++ b/src/System.Text.Encoding.Extensions/src/facade/netcoreaot/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        }
+    }
+}

--- a/src/System.Text.Encoding.Extensions/src/facade/project.json
+++ b/src/System.Text.Encoding.Extensions/src/facade/project.json
@@ -1,0 +1,19 @@
+{
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Text.Encoding/src/System.Text.Encoding.builds
+++ b/src/System.Text.Encoding/src/System.Text.Encoding.builds
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Text.Encoding.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Text.Encoding.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50aot</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Text.Encoding.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Text.Encoding.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Text.Encoding/src/facade/System.Text.Encoding.csproj
+++ b/src/System.Text.Encoding/src/facade/System.Text.Encoding.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Text.Encoding</AssemblyName>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
+    <ProjectJson>netcore50aot\project.json</ProjectJson>
+    <ProjectLockJson>netcore50aot\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Private.CoreLib" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Text.Encoding/src/facade/netcore50aot/project.json
+++ b/src/System.Text.Encoding/src/facade/netcore50aot/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        }
+    }
+}

--- a/src/System.Text.Encoding/src/facade/netcoreaot/project.json
+++ b/src/System.Text.Encoding/src/facade/netcoreaot/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        }
+    }
+}

--- a/src/System.Text.Encoding/src/facade/project.json
+++ b/src/System.Text.Encoding/src/facade/project.json
@@ -1,0 +1,19 @@
+{
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.builds
+++ b/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Text.RegularExpressions.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Text.RegularExpressions.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Text.RegularExpressions/src/facade/System.Text.RegularExpressions.csproj
+++ b/src/System.Text.RegularExpressions/src/facade/System.Text.RegularExpressions.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Text.RegularExpressions</AssemblyName>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Text.RegularExpressions/src/facade/project.json
+++ b/src/System.Text.RegularExpressions/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Threading.Tasks.Parallel/src/System.Threading.Tasks.Parallel.builds
+++ b/src/System.Threading.Tasks.Parallel/src/System.Threading.Tasks.Parallel.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Threading.Tasks.Parallel.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Threading.Tasks.Parallel.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Threading.Tasks.Parallel/src/facade/System.Threading.Tasks.Parallel.csproj
+++ b/src/System.Threading.Tasks.Parallel/src/facade/System.Threading.Tasks.Parallel.csproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Threading.Tasks.Parallel</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Threading.Tasks.Parallel/src/facade/project.json
+++ b/src/System.Threading.Tasks.Parallel/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Threading.Tasks/src/System.Threading.Tasks.builds
+++ b/src/System.Threading.Tasks/src/System.Threading.Tasks.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Threading.Tasks.CoreCLR.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Threading.Tasks.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Threading.Tasks/src/facade/System.Threading.Tasks.csproj
+++ b/src/System.Threading.Tasks/src/facade/System.Threading.Tasks.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Threading.Tasks</AssemblyName>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Core" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Threading.Tasks/src/facade/project.json
+++ b/src/System.Threading.Tasks/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Threading.Thread/src/System.Threading.Thread.builds
+++ b/src/System.Threading.Thread/src/System.Threading.Thread.builds
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Threading.Thread.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Threading.Thread.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Threading.Thread/src/facade/System.Threading.Thread.csproj
+++ b/src/System.Threading.Thread/src/facade/System.Threading.Thread.csproj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Threading.Thread</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Threading.Thread/src/facade/project.json
+++ b/src/System.Threading.Thread/src/facade/project.json
@@ -1,0 +1,14 @@
+{
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Threading.ThreadPool/src/System.Threading.ThreadPool.builds
+++ b/src/System.Threading.ThreadPool/src/System.Threading.ThreadPool.builds
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Threading.ThreadPool.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Threading.ThreadPool.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Threading.ThreadPool/src/facade/System.Threading.ThreadPool.csproj
+++ b/src/System.Threading.ThreadPool/src/facade/System.Threading.ThreadPool.csproj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Threading.ThreadPool</AssemblyName>
+    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Threading.ThreadPool/src/facade/project.json
+++ b/src/System.Threading.ThreadPool/src/facade/project.json
@@ -1,0 +1,14 @@
+{
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Threading.Timer/src/System.Threading.Timer.builds
+++ b/src/System.Threading.Timer/src/System.Threading.Timer.builds
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="facade\System.Threading.Timer.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Threading.Timer.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50aot</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Threading.Timer.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Threading.Timer.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Threading.Timer/src/facade/System.Threading.Timer.csproj
+++ b/src/System.Threading.Timer/src/facade/System.Threading.Timer.csproj
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Threading.Timer</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
+    <ProjectJson>netcore50aot\project.json</ProjectJson>
+    <ProjectLockJson>netcore50aot\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Private.CoreLib" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+    <TargetingPackReference Include="System.Private.Threading" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Threading.Timer/src/facade/netcore50aot/project.json
+++ b/src/System.Threading.Timer/src/facade/netcore50aot/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        }
+    }
+}

--- a/src/System.Threading.Timer/src/facade/netcoreaot/project.json
+++ b/src/System.Threading.Timer/src/facade/netcoreaot/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        }
+    }
+}

--- a/src/System.Threading.Timer/src/facade/project.json
+++ b/src/System.Threading.Timer/src/facade/project.json
@@ -1,0 +1,19 @@
+{
+    "frameworks": {
+        "dnxcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Threading/src/System.Threading.builds
+++ b/src/System.Threading/src/System.Threading.builds
@@ -5,6 +5,12 @@
     <Project Include="System.Threading.CoreCLR.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Threading.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50aot</AdditionalProperties>
+    </Project>
+    <Project Include="facade\System.Threading.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Threading/src/facade/System.Threading.csproj
+++ b/src/System.Threading/src/facade/System.Threading.csproj
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Threading</AssemblyName>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System" Condition="'$(TargetGroup)' == 'net46'" />
+    <TargetingPackReference Include="System.Core" Condition="'$(TargetGroup)' == 'net46'" />
+    <TargetingPackReference Include="System.Private.CoreLib" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+    <TargetingPackReference Include="System.Private.Threading" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Threading/src/facade/project.json
+++ b/src/System.Threading/src/facade/project.json
@@ -1,0 +1,14 @@
+{
+    "frameworks": {
+        "netcore50": {
+            "dependencies": {
+                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+            }
+        },
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Xml.ReaderWriter/src/System.Xml.ReaderWriter.builds
+++ b/src/System.Xml.ReaderWriter/src/System.Xml.ReaderWriter.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Xml.ReaderWriter.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Xml.ReaderWriter.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Xml.ReaderWriter/src/facade/System.Xml.ReaderWriter.csproj
+++ b/src/System.Xml.ReaderWriter/src/facade/System.Xml.ReaderWriter.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Xml.ReaderWriter</AssemblyName>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Xml" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Xml.ReaderWriter/src/facade/project.json
+++ b/src/System.Xml.ReaderWriter/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Xml.XDocument/src/System.Xml.XDocument.builds
+++ b/src/System.Xml.XDocument/src/System.Xml.XDocument.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Xml.XDocument.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Xml.XDocument.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Xml.XDocument/src/facade/System.Xml.XDocument.csproj
+++ b/src/System.Xml.XDocument/src/facade/System.Xml.XDocument.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Xml.XDocument</AssemblyName>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Xml.Linq" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Xml.XDocument/src/facade/project.json
+++ b/src/System.Xml.XDocument/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Xml.XPath/src/System.Xml.XPath.builds
+++ b/src/System.Xml.XPath/src/System.Xml.XPath.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Xml.XPath.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Xml.XPath.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Xml.XPath/src/facade/System.Xml.XPath.csproj
+++ b/src/System.Xml.XPath/src/facade/System.Xml.XPath.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Xml.XPath</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Xml" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Xml.XPath/src/facade/project.json
+++ b/src/System.Xml.XPath/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Xml.XmlDocument/src/System.Xml.XmlDocument.builds
+++ b/src/System.Xml.XmlDocument/src/System.Xml.XmlDocument.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Xml.XmlDocument.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Xml.XmlDocument.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Xml.XmlDocument/src/facade/System.Xml.XmlDocument.csproj
+++ b/src/System.Xml.XmlDocument/src/facade/System.Xml.XmlDocument.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Xml.XmlDocument</AssemblyName>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Xml" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Xml.XmlDocument/src/facade/project.json
+++ b/src/System.Xml.XmlDocument/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}

--- a/src/System.Xml.XmlSerializer/src/System.Xml.XmlSerializer.builds
+++ b/src/System.Xml.XmlSerializer/src/System.Xml.XmlSerializer.builds
@@ -5,6 +5,9 @@
     <Project Include="System.Xml.XmlSerializer.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
+    <Project Include="facade\System.Xml.XmlSerializer.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Xml.XmlSerializer/src/facade/System.Xml.XmlSerializer.csproj
+++ b/src/System.Xml.XmlSerializer/src/facade/System.Xml.XmlSerializer.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- Setting default TargetGroup before importing dir.prop -->
+    <TargetGroup Condition="'$(TargetGroup)' == ''">net46</TargetGroup>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>System.Xml.XmlSerializer</AssemblyName>
+    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+  </PropertyGroup>
+
+  <!-- Help VS understand available configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+
+  <ItemGroup>
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
+    <TargetingPackReference Include="System.Xml" Condition="'$(TargetGroup)' == 'net46'" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Xml.XmlSerializer/src/facade/project.json
+++ b/src/System.Xml.XmlSerializer/src/facade/project.json
@@ -1,0 +1,9 @@
+{
+    "frameworks": {
+        "net46": {
+            "dependencies": {
+                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+            }
+        }
+    }
+}


### PR DESCRIPTION
These facade project files were generated using a porting tool I wrote, which examined some information from our internal build and created appropriate project files. The tool is here: [FacadePorter](https://github.com/mellinoe/FacadePorter). I have also re-generated all of the .builds files so that they import the facade projects in the correct manner (there is a tool for this in the above repo as well).

We will build facades for the following frameworks:
* "CoreCLR", the default configuration
* .NET Native (netcore50 or netcore50aot)
* "NetCoreForCoreCLR": Provides the debugging experience for Universal apps.
* .NET Framework: the desktop facades, currently targeting the "net46" framework.

The diff here doesn't show very much because of the number of files changed.

I know there's a few things that still need to be fixed up:
* Double-check that the re-generated .builds files are correct. It looks like we have some manual workarounds in some of them, like Microsoft.CSharp.builds for example, has the following, which the regeneration deleted:

````
    <!-- dotnet/corefx#3128 tracks removing this exclusion -->
    <Project Include="Microsoft.CSharp.csproj" Condition="'$(OsEnvironment)' == 'Unix'">
````

* Lock all of the project.lock.json files
* Any other feedback

NOTE: None of these projects will be used by anything until we switch our internal build to use them.