### PR TITLE
Modify System.IO.Compression.DeflateStream.Flush to actually flush.

### DIFF
--- a/src/System.IO.Compression/src/System/IO/Compression/Deflater.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/Deflater.cs
@@ -169,6 +169,21 @@ namespace System.IO.Compression
             return errC == ZErrorCode.StreamEnd;
         }
 
+        internal int Flush(byte[] outputBuffer)
+        {
+            Debug.Assert(null != outputBuffer, "Can't pass in a null output buffer!");
+            Debug.Assert(NeedsInput(), "We have something left in previous input!");
+            Debug.Assert(!_inputBufferHandle.IsAllocated);
+
+            // Note: we require that NeedsInput() == true, i.e. that 0 == _zlibStream.AvailIn.
+            // If there is still input left we should never be getting here; instead we
+            // should be calling GetDeflateOutput.
+
+            int bytesRead;
+            ReadDeflateOutput(outputBuffer, ZFlushCode.SyncFlush, out bytesRead);
+            return bytesRead;
+        }
+
         #endregion
 
 

--- a/src/System.IO.Compression/src/System/IO/Compression/Deflater.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/Deflater.cs
@@ -158,6 +158,7 @@ namespace System.IO.Compression
         internal bool Finish(byte[] outputBuffer, out int bytesRead)
         {
             Debug.Assert(null != outputBuffer, "Can't pass in a null output buffer!");
+            Debug.Assert(outputBuffer.Length > 0, "Can't pass in an empty output buffer!");
             Debug.Assert(NeedsInput(), "We have something left in previous input!");
             Debug.Assert(!_inputBufferHandle.IsAllocated);
 
@@ -169,9 +170,13 @@ namespace System.IO.Compression
             return errC == ZErrorCode.StreamEnd;
         }
 
-        internal int Flush(byte[] outputBuffer)
+        /// <summary>
+        /// Returns true if there was something to flush. Otherwise False.
+        /// </summary>
+        internal bool Flush(byte[] outputBuffer, out int bytesRead)
         {
             Debug.Assert(null != outputBuffer, "Can't pass in a null output buffer!");
+            Debug.Assert(outputBuffer.Length > 0 , "Can't pass in an empty output buffer!");
             Debug.Assert(NeedsInput(), "We have something left in previous input!");
             Debug.Assert(!_inputBufferHandle.IsAllocated);
 
@@ -179,9 +184,7 @@ namespace System.IO.Compression
             // If there is still input left we should never be getting here; instead we
             // should be calling GetDeflateOutput.
 
-            int bytesRead;
-            ReadDeflateOutput(outputBuffer, ZFlushCode.SyncFlush, out bytesRead);
-            return bytesRead;
+            return ReadDeflateOutput(outputBuffer, ZFlushCode.SyncFlush, out bytesRead) == ZErrorCode.Ok;
         }
 
         #endregion

--- a/src/System.IO.Compression/src/System/IO/Compression/ZLibNative.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZLibNative.cs
@@ -25,6 +25,7 @@ namespace System.IO.Compression
         public enum FlushCode : int
         {
             NoFlush = 0,
+            SyncFlush = 2,
             Finish = 4,
         }
 


### PR DESCRIPTION
The existing implementation of Flush and FlushAsync for System.IO.Compression.DeflateStream doesn't actually flush - it only checks that the stream isn't disposed. This commit modifies Flush to Flush and also adds unit tests around the new functionality.

Some more detailed discussion is available at #3669

@stephentoub @redknightlois @ericstj 