### PR TITLE
Add "error:" prefix to error messages from run-test.sh

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -94,7 +94,7 @@ create_test_overlay()
   # Copy the CoreCLR native binaries
   if [ ! -d $CoreClrBins ]
   then
-	echo "Coreclr $OS binaries not found at $CoreClrBins"
+	echo "error: Coreclr $OS binaries not found at $CoreClrBins"
 	exit 1
   fi
   cp -r $CoreClrBins/* $OverlayDir
@@ -103,7 +103,7 @@ create_test_overlay()
   # TODO When the mscorlib flavors get properly changed then 
   if [ ! -f $mscorlibLocation ]
   then
-	echo "Mscorlib not found at $mscorlibLocation"
+	echo "error: Mscorlib not found at $mscorlibLocation"
 	exit 1
   fi
   cp -r $mscorlibLocation $OverlayDir
@@ -111,7 +111,7 @@ create_test_overlay()
   # Then the native CoreFX binaries
   if [ ! -d $CoreFxNativeBins ]
   then
-	echo "Corefx native binaries should be built (use build.sh native in root)"
+	echo "error: Corefx native binaries should be built (use build.sh native in root)"
 	exit 1
   fi
   cp $CoreFxNativeBins/* $OverlayDir
@@ -158,7 +158,7 @@ runtest()
 
   if [ ! -d "$dirName" ] || [ ! -f "$dirName/$testDllName" ]
   then
-    echo "Did not find corresponding test dll for $testProject at $dirName/$testDllName"
+    echo "error: Did not find corresponding test dll for $testProject at $dirName/$testDllName"
     exit 1
   fi
 
@@ -186,7 +186,7 @@ runtest()
 
   if [ $exitCode -ne 0 ]
   then
-      echo "One or more tests failed while running tests from '$fileNameWithoutExtension'.  Exit code $exitCode."
+      echo "error: One or more tests failed while running tests from '$fileNameWithoutExtension'.  Exit code $exitCode."
   fi
 
   popd > /dev/null
@@ -197,13 +197,13 @@ coreclr_code_coverage()
 {
   if [ ! "$OS" == "FreeBSD" ] && [ ! "$OS" == "Linux" ] && [ ! "$OS" == "OSX" ]
   then
-      echo "Code Coverage not supported on $OS"
+      echo "error: Code Coverage not supported on $OS"
       exit 1
   fi
 
   if [ "$CoreClrSrc" == "" ]
     then
-      echo "Coreclr source files are required to generate code coverage reports"
+      echo "error: Coreclr source files are required to generate code coverage reports"
       echo "Coreclr source files root path can be passed using '--coreclr-src' argument"
       exit 1
   fi
@@ -315,13 +315,13 @@ fi
 
 if [ ! "$Configuration" == "Debug" ] && [ ! "$Configuration" == "Release" ]
 then
-    echo "Configuration should be Debug or Release"
+    echo "error: Configuration should be Debug or Release"
     exit 1
 fi
 
 if [ ! "$OS" == "FreeBSD" ] && [ ! "$OS" == "Linux" ] && [ ! "$OS" == "OSX" ]
 then
-    echo "OS should be FreeBSD, Linux or OSX"
+    echo "error: OS should be FreeBSD, Linux or OSX"
     exit 1
 fi
 


### PR DESCRIPTION
Without these, it can be difficult to spot the cause of an error in an output log.

cc: @ellismg 