### PR TITLE
Adding the initial implementation of the System.Buffers namespace.

### DIFF
--- a/src/System.Buffers/System.Buffers.sln
+++ b/src/System.Buffers/System.Buffers.sln
@@ -1,0 +1,27 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.22609.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Buffers", "src\System.Buffers.csproj", "{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Buffers.Tests", "tests\System.Buffers.Tests.csproj", "{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/System.Buffers/src/Resources/Strings.resx
+++ b/src/System.Buffers/src/Resources/Strings.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/System.Buffers/src/System.Buffers.builds
+++ b/src/System.Buffers/src/System.Buffers.builds
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Buffers.csproj">
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Buffers/src/System.Buffers.csproj
+++ b/src/System.Buffers/src/System.Buffers.csproj
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <ProjectGuid>{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}</ProjectGuid>
+    <PackageTargetFramework>dotnet5.0</PackageTargetFramework>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the options -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="System\Buffers\ArrayPool.cs" />
+    <Compile Include="System\Buffers\ArrayPoolBucket.cs" />
+    <Compile Include="System\Buffers\DefaultArrayPool.cs" />
+    <Compile Include="System\Buffers\Utilities.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Buffers/src/System/Buffers/ArrayPool.cs
+++ b/src/System.Buffers/src/System/Buffers/ArrayPool.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace System.Buffers
+{
+    /// <summary>
+    /// This class provides resource pooling for arrays of any type. This is can increase performance
+    /// of certain applications where lots of arrays are created and destroyed in rapid succession.
+    /// This class is thread-safe.
+    /// </summary>
+    public abstract class ArrayPool<T>
+    {
+        /// <summary>The default number of arrays that are available for rent.</summary>
+        private const int DefaultNumberOfArraysPerBucket = 50;
+        /// <summary>The default length of each Rent'able array; equal to 1MB in bytes</summary>
+        private const int DefaultArrayLength = 1048576;
+
+        private static ArrayPool<T> s_sharedInstance = null;
+
+        /// <summary>
+        /// Retrieves a shared instance pool that is thread-safe and can be used by 
+        /// multiple components of the same system. When using the default Shared pool,
+        /// buffers will be allocated when all of the pooled buffers have been exhausted.
+        /// </summary>
+        public static ArrayPool<T> Shared
+        {
+            get
+            {
+                ArrayPool<T> instance = Volatile.Read(ref s_sharedInstance);
+                if (instance == null)
+                {
+                    Interlocked.CompareExchange(ref s_sharedInstance, new DefaultArrayPool<T>(DefaultArrayLength, DefaultNumberOfArraysPerBucket), null);
+                    instance = s_sharedInstance;
+                }
+
+                return instance;
+            }
+        }
+
+        /// <summary>
+        /// Creates a new ArrayPool instance of the given type using the default configuration options.
+        /// </summary>
+        /// <returns>Returns a new ArrayPool<T> instance with the specified configuration options</return>
+        public static ArrayPool<T> Create()
+        {
+            return Create(DefaultArrayLength, DefaultNumberOfArraysPerBucket);
+        }
+
+        /// <summary>
+        /// Creates a new ArrayPool instance of the given type.
+        /// </summary>
+        /// <param name="maxArrayLength">The maximum length of any Rent request.</param>
+        /// <param name-"numberOfArrays">The maximum number of arrays that will be rented.</param>
+        /// <returns>Returns a new ArrayPool<T> instance with the specified configuration options</return>
+        public static ArrayPool<T> Create(int maxArrayLength, int numberOfArrays)
+        {
+            return new DefaultArrayPool<T>(maxArrayLength, numberOfArrays);
+        }
+
+        /// <summary>
+        /// Retrieves a buffer from the pool that is at least the requested length. This buffer is loaned
+        /// to the caller and the caller must call Return when finished with the buffer.
+        /// </summary>
+        /// <param name="length">The number of elements in the desired buffer</param>
+        /// <returns>Returns an array of type T that is at least 'length' in size</returns>
+        public abstract T[] Rent(int minimumLength);
+
+        /// <summary>
+        /// Returns a buffer to the pool that has been Rented or Enlarged. Once a buffer has been
+        /// Returned, the caller gives up all ownership of the buffer and cannot use the reference
+        /// again. A buffer must only be Returned once.
+        /// </summary>
+        /// <param name="buffer">The buffer that will be Returned to the pool for general use.</param>
+        /// <param name="clearArray">
+        /// If true, the buffer will be cleared of any data; otherwise, the buffer will be returned with any
+        /// data intact.
+        /// </param>
+        public abstract void Return(T[] buffer, bool clearArray = false);
+    }
+}

--- a/src/System.Buffers/src/System/Buffers/ArrayPoolBucket.cs
+++ b/src/System.Buffers/src/System/Buffers/ArrayPoolBucket.cs
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace System.Buffers
+{
+    /// <summary>
+    /// Provides a thread-safe bucket containing buffers that can be Rented and Returned as part 
+    /// of a buffer pool; it should not be used independent of the pool.
+    /// </summary>
+    internal sealed class ArrayPoolBucket<T>
+    {
+        private int _index;
+        private readonly T[][] _data;
+        private readonly int _bufferLength;
+        private SpinLock _lock;
+
+        /// <summary>
+        /// Creates the pool with numberOfBuffers arrays where each buffer is of bufferLength length.
+        /// </summary>
+        internal ArrayPoolBucket(int bufferLength, int numberOfBuffers)
+        {
+            _lock = new SpinLock();
+            _data = new T[numberOfBuffers][];
+            _bufferLength = bufferLength;
+        }
+
+        /// <summary>
+        /// Returns an array from the Bucket sized according to the Bucket size.
+        /// If the Bucket is empty, null is returned.
+        /// </summary>
+        /// <returns>Returns a valid buffer when the bucket has free buffers; otherwise, returns null</returns>
+        internal T[] Rent()
+        {
+            T[] buffer = null;
+
+            // Use a SpinLock since it is super lightweight
+            // and our lock is very short lived. Wrap in try-finally
+            // to protect against thread-aborts
+            bool taken = false;
+            try
+            {
+                _lock.Enter(ref taken);
+
+                // Check if all of our buffers have been rented
+                if (_index < _data.Length)
+                {
+                    buffer = _data[_index] ?? new T[_bufferLength];
+                    _data[_index++] = null;
+                }
+            }
+            finally
+            {
+                if (taken) _lock.Exit(false);
+            }
+
+            return buffer;
+        }
+
+        /// <summary>
+        /// Attempts to return a Buffer to the bucket. This can fail
+        /// if the buffer being returned was allocated and we don't have
+        /// room for it in the bucket.
+        /// </summary>
+        internal void Return(T[] buffer)
+        {
+            // Use a SpinLock since it is super lightweight
+            // and our lock is very short lived. Wrap in try-finally
+            // to protect against thread-aborts
+            bool taken = false;
+            try
+            {
+                _lock.Enter(ref taken);
+
+                // If we have space to put the buffer back, do it. If we don't
+                // then there was a buffer alloc'd that was returned instead so
+                // we can just drop this buffer
+                if (_index != 0)
+                {
+                    _data[--_index] = buffer;
+                }
+            }
+            finally
+            {
+                if (taken) _lock.Exit(false);
+            }
+        }
+    }
+}

--- a/src/System.Buffers/src/System/Buffers/DefaultArrayPool.cs
+++ b/src/System.Buffers/src/System/Buffers/DefaultArrayPool.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace System.Buffers
+{
+    internal sealed class DefaultArrayPool<T> : ArrayPool<T>
+    {
+        private const int MinimiumArraySize = 16;
+        private ArrayPoolBucket<T>[] _buckets;
+
+        internal DefaultArrayPool(int maxLength, int arraysPerBucket)
+        {
+            if (maxLength <= 0)
+                throw new ArgumentOutOfRangeException("maxLength");
+            if (arraysPerBucket <= 0)
+                throw new ArgumentOutOfRangeException("arraysPerBucket");
+
+            // Our bucketing algorithm has a minimum length of 16
+            if (maxLength < MinimiumArraySize)
+                maxLength = MinimiumArraySize;
+            
+            int maxBuckets = Utilities.SelectBucketIndex(maxLength);
+            _buckets = new ArrayPoolBucket<T>[maxBuckets + 1];
+            for (int i = 0; i < _buckets.Length; i++)
+                _buckets[i] = new ArrayPoolBucket<T>(Utilities.GetMaxSizeForBucket(i), arraysPerBucket);
+        }
+
+        public override T[] Rent(int minimumLength)
+        {
+            if (minimumLength <= 0)
+                throw new ArgumentOutOfRangeException("minimumLength");
+
+            int index = Utilities.SelectBucketIndex(minimumLength);
+            if (index < _buckets.Length)
+            {
+                T[] buffer = null;
+
+                // Search for an array starting at the 'index' bucket. If the bucket
+                // is empty, bump up to the next higher bucket and try that one
+                for (int i = index; i < _buckets.Length; i++)
+                {
+                    buffer = _buckets[i].Rent();
+
+                    // If the bucket has an array left and returned it, give it to the caller
+                    if (buffer != null)
+                    {
+                        return buffer;
+                    }
+                }
+            }
+
+            // Gettings here means we have too big of a request OR all the buckets from 
+            // index through _buckets.Length are taken so we need to allocate a buffer on-demand.
+            return new T[Utilities.GetMaxSizeForBucket(index)];
+        }
+
+        public override void Return(T[] buffer, bool clearArray = false)
+        {
+            if (buffer == null)
+                throw new ArgumentNullException("buffer");
+
+            // If we can tell that the buffer was allocated, drop it. Otherwise, check if we have space in the pool
+            int bucket = Utilities.SelectBucketIndex(buffer.Length);
+            if (bucket < _buckets.Length)
+            {
+                // Clear the array if the user requests
+                if (clearArray) Array.Clear(buffer, 0, buffer.Length);
+
+                _buckets[bucket].Return(buffer);
+            }
+        }
+    }
+}

--- a/src/System.Buffers/src/System/Buffers/Utilities.cs
+++ b/src/System.Buffers/src/System/Buffers/Utilities.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace System.Buffers
+{
+    internal static class Utilities
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int SelectBucketIndex(int bufferSize)
+        {
+            uint bitsRemaining = ((uint)bufferSize - 1) >> 4;
+            int poolIndex = 0;
+
+            while (bitsRemaining > 0)
+            {
+                bitsRemaining >>= 1;
+                poolIndex++;
+            }
+
+            return poolIndex;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static int GetMaxSizeForBucket(int binIndex)
+        {
+            checked
+            {
+                int result = 2;
+                int shifts = binIndex + 3;
+                result <<= shifts;
+                return result;
+            }
+        }
+    }
+}

--- a/src/System.Buffers/src/project.json
+++ b/src/System.Buffers/src/project.json
@@ -1,0 +1,11 @@
+{
+  "dependencies": {
+    "System.Diagnostics.Debug": "4.0.11-rc2-23610",
+    "System.Resources.ResourceManager": "4.0.1-rc2-23610",
+    "System.Runtime": "4.0.21-rc2-23610",
+    "System.Threading": "4.0.11-rc2-23610"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Buffers/tests/ArrayPool/UnitTests.cs
+++ b/src/System.Buffers/tests/ArrayPool/UnitTests.cs
@@ -1,0 +1,215 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Buffers;
+using Xunit;
+
+namespace System.Buffers.ArrayPool.Tests
+{
+    public partial class ArrayPoolUnitTests
+    {
+        private struct TestStruct
+        {
+            internal string InternalRef;
+        }
+            
+        /*
+            NOTE - due to test parallelism and sharing, use an instance pool for testing unless necessary
+        */ 
+        [Fact]
+        public static void SharedInstanceCreatesAnInstanceOnFirstCall()
+        {
+            Assert.NotNull(ArrayPool<byte>.Shared);
+        }
+
+        [Fact]
+        public static void SharedInstanceOnlyCreatesOneInstanceOfOneTypep()
+        {
+            ArrayPool<byte> instance = ArrayPool<byte>.Shared;
+            Assert.Same(instance, ArrayPool<byte>.Shared);
+        }
+
+        [Fact]
+        public static void CreateWillCreateMultipleInstancesOfTheSameType()
+        {
+            Assert.NotSame(ArrayPool<byte>.Create(), ArrayPool<byte>.Create());
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public static void CreatingAPoolWithInvalidArrayCountThrows(int length)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("arraysPerBucket", () => ArrayPool<byte>.Create(numberOfArrays: length, maxArrayLength: 16));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public static void CreatingAPoolWithInvalidMaximumArraySizeThrows(int length)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>("maxLength", () => ArrayPool<byte>.Create(maxArrayLength: length, numberOfArrays: 1));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public static void RentingWithInvalidLengthThrows(int length)
+        {
+            ArrayPool<byte> pool = ArrayPool<byte>.Create();
+            Assert.Throws<ArgumentOutOfRangeException>("minimumLength", () => pool.Rent(length));
+        }
+
+        [Fact]
+        public static void RentingAValidSizeArraySucceeds()
+        {
+            Assert.NotNull(ArrayPool<byte>.Create().Rent(100));
+        }
+
+        [Fact]
+        public static void RentingMultipleArraysGivesBackDifferentInstances()
+        {
+            ArrayPool<byte> instance = ArrayPool<byte>.Create(numberOfArrays: 2, maxArrayLength: 16);
+            Assert.NotSame(instance.Rent(100), instance.Rent(100));
+        }
+
+        [Fact]
+        public static void RentingMoreArraysThanSpecifiedInCreateWillStillSucceed()
+        {
+            ArrayPool<byte> instance = ArrayPool<byte>.Create(numberOfArrays: 1, maxArrayLength: 16);
+            Assert.NotNull(instance.Rent(100));
+            Assert.NotNull(instance.Rent(100));
+        }
+
+        [Fact]
+        public static void RentCanReturnBiggerArraySizeThanRequested()
+        {
+            ArrayPool<byte> pool = ArrayPool<byte>.Create(numberOfArrays: 1, maxArrayLength: 32);
+            byte[] rented = pool.Rent(27);
+            Assert.NotNull(rented);
+            Assert.Equal(rented.Length, 32);
+        }
+
+        [Fact]
+        public static void RentingAnArrayWithLengthGreaterThanSpecifiedInCreateSillSucceeds()
+        {
+            Assert.NotNull(ArrayPool<byte>.Create(maxArrayLength: 100, numberOfArrays: 1).Rent(200));
+        }
+
+        [Fact]
+        public static void CallingReturnBufferWithNullBufferThrows()
+        {
+            ArrayPool<byte> pool = ArrayPool<byte>.Create();
+            Assert.Throws<ArgumentNullException>("buffer", () => pool.Return(null));
+        }
+
+        private static void FillArray(byte[] buffer)
+        {
+            for (byte i = 0; i < buffer.Length; i++)
+                buffer[i] = i;
+        }
+
+        private static void CheckFilledArray(byte[] buffer, Action<byte, byte> assert)
+        {
+            for (byte i = 0; i < buffer.Length; i++)
+            {
+                assert(buffer[i], i);
+            }
+        }
+
+        [Fact]
+        public static void CallingReturnWithoutClearingDoesNotClearTheBuffer()
+        {
+            ArrayPool<byte> pool = ArrayPool<byte>.Create();
+            byte[] buffer = pool.Rent(4);
+            FillArray(buffer);
+            pool.Return(buffer, clearArray: false);
+            CheckFilledArray(buffer, (byte b1, byte b2) => Assert.Equal(b1, b2));
+        }
+
+        [Fact]
+        public static void CallingReturnWithClearingDoesClearTheBuffer()
+        {
+            ArrayPool<byte> pool = ArrayPool<byte>.Create();
+            byte[] buffer = pool.Rent(4);
+            FillArray(buffer);
+
+            // Note - yes this is bad to hold on to the old instance but we need to validate the contract
+            pool.Return(buffer, clearArray: true);
+            CheckFilledArray(buffer, (byte b1, byte b2) => Assert.Equal(b1, default(byte)));
+        }
+
+        [Fact]
+        public static void CallingReturnOnReferenceTypeArrayDoesNotClearTheArray()
+        {
+            ArrayPool<string> pool = ArrayPool<string>.Create();
+            string[] array = pool.Rent(2);
+            array[0] = "foo";
+            array[1] = "bar";
+            pool.Return(array, clearArray: false);
+            Assert.NotNull(array[0]);
+            Assert.NotNull(array[1]);
+        }
+
+        [Fact]
+        public static void CallingReturnOnReferenceTypeArrayAndClearingSetsTypesToNull()
+        {
+            ArrayPool<string> pool = ArrayPool<string>.Create();
+            string[] array = pool.Rent(2);
+            array[0] = "foo";
+            array[1] = "bar";
+            pool.Return(array, clearArray: true);
+            Assert.Null(array[0]);
+            Assert.Null(array[1]);
+        }
+
+        [Fact]
+        public static void CallingReturnOnValueTypeWithInternalReferenceTypesAndClearingSetsValueTypeToDefault()
+        {
+            ArrayPool<TestStruct> pool = ArrayPool<TestStruct>.Create();
+            TestStruct[] array = pool.Rent(2);
+            array[0].InternalRef = "foo";
+            array[1].InternalRef = "bar";
+            pool.Return(array, clearArray: true);
+            Assert.Equal(array[0], default(TestStruct));
+            Assert.Equal(array[1], default(TestStruct));
+        }
+
+        [Fact]
+        public static void TakingAllBuffersFromABucketPlusAnAllocatedOneShouldAllowReturningAllBuffers()
+        {
+            ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, numberOfArrays: 1);
+            byte[] rented = pool.Rent(16);
+            byte[] allocated = pool.Rent(16);
+            pool.Return(rented);
+            pool.Return(allocated);
+        }
+
+        [Fact]
+        public static void NewDefaultArrayPoolWithSmallBufferSizeRoundsToOurSmallestSupportedSize()
+        {
+            ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 8, numberOfArrays: 1);
+            byte[] rented = pool.Rent(8);
+            Assert.True(rented.Length == 16);
+        }
+
+        [Fact]
+        public static void ReturningABufferGreaterThanMaxSizeDoesNotThrow()
+        {
+            ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, numberOfArrays: 1);
+            byte[] rented = pool.Rent(32);
+            pool.Return(rented);
+        }
+
+        [Fact]
+        public static void RentingAllBuffersAndCallingRentAgainWillAllocateBufferAndReturnIt()
+        {
+            ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, numberOfArrays: 1);
+            byte[] rented1 = pool.Rent(16);
+            byte[] rented2 = pool.Rent(16);
+            Assert.NotNull(rented1);
+            Assert.NotNull(rented2);
+        }
+    }
+}

--- a/src/System.Buffers/tests/System.Buffers.Tests.csproj
+++ b/src/System.Buffers/tests/System.Buffers.Tests.csproj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{62E2AD5F-C8D0-45FB-B6A5-AED2C77F198C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AssemblyName>System.Buffers.Tests</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="ArrayPool\UnitTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Buffers.csproj">
+      <Name>System.Buffers</Name>
+      <Project>{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Buffers/tests/project.json
+++ b/src/System.Buffers/tests/project.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": {
+    "System.Runtime": "4.0.21-rc2-23610",
+    "System.Runtime.Extensions": "4.0.11-rc2-23610",
+    "System.Resources.ResourceManager": "4.0.1-rc2-23610",
+    "System.Threading": "4.0.11-rc2-23610",
+    "xunit": "2.1.0",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}


### PR DESCRIPTION
Adding the initial implementation of the System.Buffers namespace.
This includes the initial ArrayPool for buffered Arrays as well
as Unit Tests for verifying the pool's usage. This is the initial
fix for issue #4547. Note that this is not the final implementation
but rather the initial implementation that will be iterated on in
the coming weeks.

/cc @KrzysztofCwalina @stephentoub @rynowak @benaadams

NOTE: there are some unresolved issues that are still being worked through - mainly around configuration of the shared pool. These issues will be worked out in the coming days and weeks; however, to unblock other people, this PR is being put out now. This code is by no means set-in-stone for release, there will be changes and tweaks going forward :)