### PR TITLE
Fix SqlParameter Scale and Precision inheritance

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlParameter.cs
@@ -479,7 +479,7 @@ namespace System.Data.SqlClient
             }
         }
 
-        public new Byte Precision
+        public override Byte Precision
         {
             get
             {
@@ -523,7 +523,7 @@ namespace System.Data.SqlClient
             return (0 != _precision);
         }
 
-        public new Byte Scale
+        public override Byte Scale
         {
             get
             {
@@ -534,6 +534,7 @@ namespace System.Data.SqlClient
                 ScaleInternal = value;
             }
         }
+
         internal byte ScaleInternal
         {
             get


### PR DESCRIPTION
The .Net implementation relied on the interfaces to access the
properties on the child class. With the interfaces removed, the SqlParameter
was not updated to override the DbParameter member, so getting or setting Scale or
Precision was broken if the object was cast to DbParameter. As noted by
@mgravell in issue dotnet/corefx#1612

This should correct the behavior, although I'm curious why the parent member
are not abstract, instead of stubs.