### PR TITLE
Support HttpRequestMessage.Version in WinHttpHandler

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -791,12 +791,24 @@ namespace System.Net.Http
                     secureConnection = false;
                 }
 
+                // Try to use the requested version if a known/supported version was explicitly requested.
+                // Otherwise, we simply use winhttp's default.
+                string httpVersion = null;
+                if (state.RequestMessage.Version == HttpVersion.Version10)
+                {
+                    httpVersion = "HTTP/1.0";
+                }
+                else if (state.RequestMessage.Version == HttpVersion.Version11)
+                {
+                    httpVersion = "HTTP/1.1";
+                }
+
                 // Create an HTTP request handle.
                 state.RequestHandle = Interop.WinHttp.WinHttpOpenRequest(
                     connectHandle,
                     state.RequestMessage.Method.Method,
                     state.RequestMessage.RequestUri.PathAndQuery,
-                    null,
+                    httpVersion,
                     Interop.WinHttp.WINHTTP_NO_REFERER,
                     Interop.WinHttp.WINHTTP_DEFAULT_ACCEPT_TYPES,
                     secureConnection ? Interop.WinHttp.WINHTTP_FLAG_SECURE : 0);

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -752,6 +752,12 @@ namespace System.Net.Http.Functional.Tests
             {
                 request.Version = requestVersion;
             }
+            else
+            {
+                // The default value for HttpRequestMessage.Version is Version(1,1).
+                // So, we need to set something different to test the "unknown" version.
+                request.Version = new Version(0,0);
+            }
 
             using (var client = new HttpClient())
             using (HttpResponseMessage response = await client.SendAsync(request))

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -706,23 +706,28 @@ namespace System.Net.Http.Functional.Tests
         #endregion
 
         #region Version tests
-        [ActiveIssue(4754, PlatformID.Windows)]
+        // The HTTP RFC 7230 states that servers are NOT required to respond back with the same
+        // minor version if they support a higher minor version. In fact, the RFC states that
+        // servers SHOULD send back the highest minor version they support. So, testing the
+        // response version to see if the client sent a particular request version only works
+        // for some servers. In particular the 'Http2Servers' used in these tests always seem
+        // to echo the minor version of the request.
         [Theory, MemberData("Http2Servers")]
-        public async Task SendAsync_RequestVersion10_ResponseVersion10(Uri server)
+        public async Task SendAsync_RequestVersion10_ServerReceivesVersion10Request(Uri server)
         {
             Version responseVersion = await SendRequestAndGetResponseVersionAsync(new Version(1, 0), server);
             Assert.Equal(new Version(1, 0), responseVersion);
         }
 
         [Theory, MemberData("Http2Servers")]
-        public async Task SendAsync_RequestVersion11_ResponseVersion11(Uri server)
+        public async Task SendAsync_RequestVersion11_ServerReceivesVersion11Request(Uri server)
         {
             Version responseVersion = await SendRequestAndGetResponseVersionAsync(new Version(1, 1), server);
             Assert.Equal(new Version(1, 1), responseVersion);
         }
 
         [Theory, MemberData("Http2Servers")]
-        public async Task SendAsync_RequestVersionNotSpecified_ResponseVersion11(Uri server)
+        public async Task SendAsync_RequestVersionNotSpecified_ServerReceivesVersion11Request(Uri server)
         {
             Version responseVersion = await SendRequestAndGetResponseVersionAsync(null, server);
             Assert.Equal(new Version(1, 1), responseVersion);


### PR DESCRIPTION
WinHttpHandler was currently ignoring the `HttpRequestMessage.Version`
property and was always sending out requests using 'HTTP/1.1' which is the
default for winhttp.

This fix now will look at the request message `Version` property and
send out the request using either 1.0 or 1.1.  If neither of these
versions are specified, then the request is sent out using the default
winhttp version (which is currently 1.1 as of Windows 10).

Note: The .NET Framework (Desktop) will throw an exception if neither
1.0 nor 1.1 version is specified.  Currently CoreFx including NETNative,
WinHttpHandler and CurlHandler will simply use a default instead of
throwing. While this is different behavior than Desktop, it is more
desirable in the long run.

There is a separate issue #4870 to add HTTP/2.0 support to WinHttpHandler.

Fixes #4754