### PR TITLE
Update System.Security.Principal.Windows to use Win32Exception

### DIFF
--- a/src/System.Security.Principal.Windows/src/System.Security.Principal.Windows.csproj
+++ b/src/System.Security.Principal.Windows/src/System.Security.Principal.Windows.csproj
@@ -52,9 +52,6 @@
     <Compile Include="$(CommonPath)\Interop\Windows\secur32\Interop.UNICODE_STRING.cs">
       <Link>Common\Interop\Interop.UNICODE_STRING.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.FormatMessage.cs">
-      <Link>Common\Interop\Interop.FormatMessage.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.GetCurrentProcess_IntPtr.cs">
       <Link>Common\Interop\Interop.GetCurrentProcess.cs</Link>
     </Compile>

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/NTAccount.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/NTAccount.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Win32;
 using Microsoft.Win32.SafeHandles;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Globalization;
@@ -333,7 +334,7 @@ namespace System.Security.Principal
                         Debug.Assert(false, string.Format(CultureInfo.InvariantCulture, "Interop.LsaLookupNames(2) returned unrecognized error {0}", win32ErrorCode));
                     }
 
-                    throw new Exception(Interop.mincore.GetMessage(win32ErrorCode));
+                    throw new Win32Exception(win32ErrorCode);
                 }
 
                 //

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Win32;
 using Microsoft.Win32.SafeHandles;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Globalization;
@@ -408,7 +408,7 @@ namespace System.Security.Principal
             else if (Error != Interop.mincore.Errors.ERROR_SUCCESS)
             {
                 Debug.Assert(false, string.Format(CultureInfo.InvariantCulture, "Win32.CreateSidFromString returned unrecognized error {0}", Error));
-                throw new Exception(Interop.mincore.GetMessage(Error));
+                throw new Win32Exception(Error);
             }
 
             CreateFromBinaryForm(resultSid, 0);
@@ -504,7 +504,7 @@ namespace System.Security.Principal
                 else if (ErrorCode != Interop.mincore.Errors.ERROR_SUCCESS)
                 {
                     Debug.Assert(false, string.Format(CultureInfo.InvariantCulture, "Win32.GetWindowsAccountDomainSid returned unrecognized error {0}", ErrorCode));
-                    throw new Exception(Interop.mincore.GetMessage(ErrorCode));
+                    throw new Win32Exception(ErrorCode);
                 }
 
                 //
@@ -527,7 +527,7 @@ namespace System.Security.Principal
             else if (Error != Interop.mincore.Errors.ERROR_SUCCESS)
             {
                 Debug.Assert(false, string.Format(CultureInfo.InvariantCulture, "Win32.CreateWellKnownSid returned unrecognized error {0}", Error));
-                throw new Exception(Interop.mincore.GetMessage(Error));
+                throw new Win32Exception(Error);
             }
 
             CreateFromBinaryForm(resultSid, 0);
@@ -745,7 +745,7 @@ namespace System.Security.Principal
             else if (Error != Interop.mincore.Errors.ERROR_SUCCESS)
             {
                 Debug.Assert(false, string.Format(CultureInfo.InvariantCulture, "Win32.GetWindowsAccountDomainSid returned unrecognized error {0}", Error));
-                throw new Exception(Interop.mincore.GetMessage(Error));
+                throw new Win32Exception(Error);
             }
             return ResultSid;
         }
@@ -986,7 +986,7 @@ namespace System.Security.Principal
                     int win32ErrorCode = Interop.mincore.RtlNtStatusToDosError(unchecked((int)ReturnCode));
 
                     Debug.Assert(false, string.Format(CultureInfo.InvariantCulture, "Interop.LsaLookupSids returned {0}", win32ErrorCode));
-                    throw new Exception(Interop.mincore.GetMessage(win32ErrorCode));
+                    throw new Win32Exception(win32ErrorCode);
                 }
 
 

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
@@ -522,7 +522,7 @@ namespace System.Security.Principal
 
             if (Error == Interop.mincore.Errors.ERROR_INVALID_PARAMETER)
             {
-                throw new ArgumentException(Interop.mincore.GetMessage(Error), "sidType/domainSid");
+                throw new ArgumentException(new Win32Exception(Error).Message, "sidType/domainSid");
             }
             else if (Error != Interop.mincore.Errors.ERROR_SUCCESS)
             {

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/Win32.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/Win32.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using Microsoft.Win32;
 using Microsoft.Win32.SafeHandles;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 
@@ -68,7 +68,7 @@ namespace System.Security.Principal
             {
                 int win32ErrorCode = Interop.mincore.RtlNtStatusToDosError(unchecked((int)ReturnCode));
 
-                throw new Exception(Interop.mincore.GetMessage(win32ErrorCode));
+                throw new Win32Exception(win32ErrorCode);
             }
         }
 

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsPrincipal.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsPrincipal.cs
@@ -3,8 +3,8 @@
 
 using Microsoft.Win32.SafeHandles;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics.Contracts;
-using System.Runtime.InteropServices;
 using System.Security.Claims;
 
 namespace System.Security.Principal
@@ -168,7 +168,7 @@ namespace System.Security.Principal
                                                   (uint)TokenImpersonationLevel.Identification,
                                                   (uint)TokenType.TokenImpersonation,
                                                   ref token))
-                    throw new SecurityException(Interop.mincore.GetMessage(Marshal.GetLastWin32Error()));
+                    throw new SecurityException(new Win32Exception().Message);
             }
 
             bool isMember = false;
@@ -176,7 +176,7 @@ namespace System.Security.Principal
             if (!Interop.mincore.CheckTokenMembership((_identity.ImpersonationLevel != TokenImpersonationLevel.None ? _identity.AccessToken : token),
                                                   sid.BinaryForm,
                                                   ref isMember))
-                throw new SecurityException(Interop.mincore.GetMessage(Marshal.GetLastWin32Error()));
+                throw new SecurityException(new Win32Exception().Message);
 
             token.Dispose();
             return isMember;

--- a/src/System.Security.Principal.Windows/src/project.json
+++ b/src/System.Security.Principal.Windows/src/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "Microsoft.Win32.Primitives": "4.0.0",
     "System.Collections": "4.0.0",
     "System.Diagnostics.Contracts": "4.0.0",
     "System.Globalization": "4.0.0",

--- a/src/System.Security.Principal.Windows/src/project.lock.json
+++ b/src/System.Security.Principal.Windows/src/project.lock.json
@@ -3,6 +3,19 @@
   "version": 2,
   "targets": {
     "DNXCore,Version=v5.0": {
+      "Microsoft.Win32.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
       "System.Collections/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -217,6 +230,19 @@
       }
     },
     "DNXCore,Version=v5.0/win7-x86": {
+      "Microsoft.Win32.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
       "System.Collections/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -431,6 +457,19 @@
       }
     },
     "DNXCore,Version=v5.0/win7-x64": {
+      "Microsoft.Win32.Primitives/4.0.0": {
+        "type": "package",
+        "dependencies": {
+          "System.Runtime": "4.0.20",
+          "System.Runtime.InteropServices": "4.0.20"
+        },
+        "compile": {
+          "ref/dotnet/Microsoft.Win32.Primitives.dll": {}
+        },
+        "runtime": {
+          "lib/dotnet/Microsoft.Win32.Primitives.dll": {}
+        }
+      },
       "System.Collections/4.0.0": {
         "type": "package",
         "dependencies": {
@@ -646,6 +685,38 @@
     }
   },
   "libraries": {
+    "Microsoft.Win32.Primitives/4.0.0": {
+      "type": "package",
+      "serviceable": true,
+      "sha512": "CypEz9/lLOup8CEhiAmvr7aLs1zKPYyEU1sxQeEr6G0Ci8/F0Y6pYR1zzkROjM8j8Mq0typmbu676oYyvErQvg==",
+      "files": [
+        "lib/dotnet/Microsoft.Win32.Primitives.dll",
+        "lib/MonoAndroid10/_._",
+        "lib/MonoTouch10/_._",
+        "lib/net46/Microsoft.Win32.Primitives.dll",
+        "lib/xamarinios10/_._",
+        "lib/xamarinmac20/_._",
+        "Microsoft.Win32.Primitives.4.0.0.nupkg",
+        "Microsoft.Win32.Primitives.4.0.0.nupkg.sha512",
+        "Microsoft.Win32.Primitives.nuspec",
+        "ref/dotnet/de/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/es/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/fr/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/it/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/ja/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/ko/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/Microsoft.Win32.Primitives.dll",
+        "ref/dotnet/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/ru/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/zh-hans/Microsoft.Win32.Primitives.xml",
+        "ref/dotnet/zh-hant/Microsoft.Win32.Primitives.xml",
+        "ref/MonoAndroid10/_._",
+        "ref/MonoTouch10/_._",
+        "ref/net46/Microsoft.Win32.Primitives.dll",
+        "ref/xamarinios10/_._",
+        "ref/xamarinmac20/_._"
+      ]
+    },
     "System.Collections/4.0.0": {
       "type": "package",
       "sha512": "i2vsGDIEbWdHcUSNDPKZP/ZWod6o740el7mGTCy0dqbCxQh74W4QoC+klUwPEtGEFuvzJ7bJgvwJqscosVNyZQ==",
@@ -1320,6 +1391,7 @@
   },
   "projectFileDependencyGroups": {
     "": [
+      "Microsoft.Win32.Primitives >= 4.0.0",
       "System.Collections >= 4.0.0",
       "System.Diagnostics.Contracts >= 4.0.0",
       "System.Globalization >= 4.0.0",


### PR DESCRIPTION
Two changes to System.Security.Principal.Windows:
- Throw Win32Exception instead of Exception in places where in the full framework SystemException is thrown.  In the full framework Win32Exception is a SystemException, so it's a close approximation, plus it allows avoiding needing to explicitly P/Invoke to FormatMessage.
- As long as we're using Win32Exception in some places, use it everywhere we were P/Invoking to FormatMessage, such that we can get rid of that P/Invoke code from this assembly entirely.

Fixes #4807 
cc: @bartonjs, @mjrousos 

(@ericstj, is there anything else I need to do around the project.json update to include Microsoft.Win32.Primitives?)