### PR TITLE
Optimize error handling around chain.Build in WinHttpHandler

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCertificateHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCertificateHelper.cs
@@ -27,8 +27,7 @@ namespace System.Net.Http
             chain.ChainPolicy.RevocationMode =
                 checkCertificateRevocationList ? X509RevocationMode.Online : X509RevocationMode.NoCheck;
             chain.ChainPolicy.RevocationFlag = X509RevocationFlag.ExcludeRoot;
-            chain.Build(certificate);
-            if (chain.ChainStatus != null && chain.ChainStatus.Length != 0)
+            if (!chain.Build(certificate))
             {
                 sslPolicyErrors |= SslPolicyErrors.RemoteCertificateChainErrors;
             }


### PR DESCRIPTION
This was a TODO item from #2165 suggested by @bartonjs.

The X509CertificateChain.Build() method returns a boolean indicating if
there were errors building the chain. It's more performant to check that
instead of inspecting the individual fields in the chain.