### PR TITLE
Separate ConsolePal.GetCharset into a reusable Common helper

### DIFF
--- a/src/Common/src/System/Text/EncodingHelper.Unix.cs
+++ b/src/Common/src/System/Text/EncodingHelper.Unix.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Text
+{
+    internal static partial class EncodingHelper
+    {
+        /// <summary>Creates an encoding from the current environment.</summary>
+        /// <returns>The encoding, or null if it could not be determined.</returns>
+        internal static Encoding GetEncodingFromCharset()
+        {
+            string charset = GetCharset();
+            if (charset != null)
+            {
+                try { return Encoding.GetEncoding(charset); }
+                catch { }
+            }
+            return null;
+        }
+
+        /// <summary>Environment variables that should be checked, in order, for locale.</summary>
+        /// <remarks>
+        /// One of these environment variables should contain a string of a form consistent with
+        /// the X/Open Portability Guide syntax:
+        ///     language[territory][.charset][@modifier]
+        /// We're interested in the charset, as it specifies the encoding used
+        /// for the console.
+        /// </remarks>
+        private static readonly string[] s_localeEnvVars = { "LC_ALL", "LC_MESSAGES", "LANG" }; // this ordering codifies the lookup rules prescribed by POSIX
+
+        /// <summary>Gets the current charset name from the environment.</summary>
+        /// <returns>The charset name if found; otherwise, null.</returns>
+        private static string GetCharset()
+        {
+            // Find the first of the locale environment variables that's set.
+            string locale = null;
+            foreach (string envVar in s_localeEnvVars)
+            {
+                locale = Environment.GetEnvironmentVariable(envVar);
+                if (!string.IsNullOrWhiteSpace(locale)) break;
+            }
+
+            // If we found one, try to parse it.
+            // The locale string is expected to be of a form that matches the
+            // X/Open Portability Guide syntax: language[_territory][.charset][@modifier]
+            if (locale != null)
+            {
+                // Does it contain the optional charset?
+                int dotPos = locale.IndexOf('.');
+                if (dotPos >= 0)
+                {
+                    dotPos++;
+                    int atPos = locale.IndexOf('@', dotPos + 1);
+
+                    // return the charset from the locale, stripping off everything else
+                    string charset = atPos < dotPos ?
+                        locale.Substring(dotPos) :                // no modifier
+                        locale.Substring(dotPos, atPos - dotPos); // has modifier
+                    return charset.ToLowerInvariant();
+                }
+            }
+
+            // no charset found; the default will be used
+            return null;
+        }
+    }
+}

--- a/src/Common/src/System/Text/EncodingHelper.cs
+++ b/src/Common/src/System/Text/EncodingHelper.cs
@@ -7,9 +7,8 @@ using System.Text;
 namespace System.Text
 {
     // If we find issues with this or if more libraries need this behavior we will revist the solution.
-    internal class EncodingHelper
+    internal static partial class EncodingHelper
     {
-
         // Since only a minimum set of encodings are available by default,
         // Console encoding might not be available and require provider registering.
         // To avoid encoding exception in Console APIs we default to UTF8 in such scenarios.

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -131,6 +131,9 @@
     <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
       <Link>Common\System\IO\StringBuilderCache.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Text\EncodingHelper.Unix.cs">
+      <Link>Common\System\Text\EncodingHelper.Unix.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Text\StringOrCharArray.cs">
       <Link>Common\System\Text\StringOrCharArray.cs</Link>
     </Compile>

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -400,60 +400,10 @@ namespace System
         /// <returns>The encoding.</returns>
         private static Encoding GetConsoleEncoding()
         {
-            string charset = GetCharset();
-            if (charset != null)
-            {
-                // Try to use an encoding that matches the current charset
-                try { return new ConsoleEncoding(Encoding.GetEncoding(charset)); }
-                catch { } // unknown charset, or arbitrary exceptions thrown from providers
-            }
-            return new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
-        }
-
-        /// <summary>Environment variables that should be checked, in order, for locale.</summary>
-        /// <remarks>
-        /// One of these environment variables should contain a string of a form consistent with
-        /// the X/Open Portability Guide syntax:
-        ///     language[territory][.charset][@modifier]
-        /// We're interested in the charset, as it specifies the encoding used
-        /// for the console.
-        /// </remarks>
-        private static readonly string[] LocaleEnvVars = { "LC_ALL", "LC_MESSAGES", "LANG" }; // this ordering codifies the lookup rules prescribed by POSIX
-
-        /// <summary>Gets the current charset name from the environment.</summary>
-        /// <returns>The charset name if found; otherwise, null.</returns>
-        private static string GetCharset()
-        {
-            // Find the first of the locale environment variables that's set.
-            string locale = null;
-            foreach (string envVar in LocaleEnvVars)
-            {
-                locale = Environment.GetEnvironmentVariable(envVar);
-                if (!string.IsNullOrWhiteSpace(locale)) break;
-            }
-
-            // If we found one, try to parse it.
-            // The locale string is expected to be of a form that matches the
-            // X/Open Portability Guide syntax: language[_territory][.charset][@modifier]
-            if (locale != null)
-            {
-                // Does it contain the optional charset?
-                int dotPos = locale.IndexOf('.');
-                if (dotPos >= 0)
-                {
-                    dotPos++;
-                    int atPos = locale.IndexOf('@', dotPos + 1);
-
-                    // return the charset from the locale, stripping off everything else
-                    string charset = atPos < dotPos ?
-                        locale.Substring(dotPos) :                // no modifier
-                        locale.Substring(dotPos, atPos - dotPos); // has modifier
-                    return charset.ToLowerInvariant();
-                }
-            }
-
-            // no charset found; the default will be used
-            return null;
+            Encoding enc = EncodingHelper.GetEncodingFromCharset();
+            return enc != null ? (Encoding)
+                new ConsoleEncoding(enc) :
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
         }
 
         /// <summary>


### PR DESCRIPTION
To allow it to be used from other components.

Fixes #4909
cc: @kkurni, @ellismg