### PR TITLE
Remove RestorePackages=true from S.Diagnostics.Tracing.Tests project

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/System.Diagnostics.Tracing.Tests.csproj
+++ b/src/System.Diagnostics.Tracing/tests/System.Diagnostics.Tracing.Tests.csproj
@@ -9,7 +9,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Diagnostics.Tracing.Tests</RootNamespace>
     <AssemblyName>System.Diagnostics.Tracing.Tests</AssemblyName>
-    <RestorePackages>true</RestorePackages>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
This should fix the issue we have been seeing in the CI after the removal of the checked in lock files.

Example:
http://dotnet-ci.cloudapp.net/job/dotnet_corefx/job/centos7.1_debug_bld_prtest/156/console
http://dotnet-ci.cloudapp.net/job/dotnet_corefx/job/windows_nt_debug_prtest/169/console
