### PR TITLE
Fix CngProvider constructors for AesCng and TripleDESCng

### DIFF
--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/AesCng.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/AesCng.cs
@@ -31,7 +31,7 @@ namespace System.Security.Cryptography
         }
 
         public AesCng(string keyName, CngProvider provider)
-            : this(keyName, CngProvider.MicrosoftSoftwareKeyStorageProvider, CngKeyOpenOptions.None)
+            : this(keyName, provider, CngKeyOpenOptions.None)
         {
         }
 

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/TripleDESCng.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/TripleDESCng.cs
@@ -31,7 +31,7 @@ namespace System.Security.Cryptography
         }
 
         public TripleDESCng(string keyName, CngProvider provider)
-            : this(keyName, CngProvider.MicrosoftSoftwareKeyStorageProvider, CngKeyOpenOptions.None)
+            : this(keyName, provider, CngKeyOpenOptions.None)
         {
         }
 


### PR DESCRIPTION
The AesCng and TripleDESCng constructors don't use the CngProvider parameter and instead hard-code the SoftwareKey storage provider.

I updated the constructors to use the passed in provider.

@bartonjs @AtsushiKan 