### PR TITLE
Enable/Disable Handles inheritance while creating a process on windows

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.Windows.cs
@@ -597,16 +597,16 @@ namespace System.Diagnostics
                         finally
                         {
                             retVal = Interop.mincore.CreateProcess(
-                                    null,                // we don't need this since all the info is in commandLine
-                                    commandLine,         // pointer to the command line string
-                                    ref unused_SecAttrs, // address to process security attributes, we don't need to inheriat the handle
-                                    ref unused_SecAttrs, // address to thread security attributes.
-                                    true,                // handle inheritance flag
-                                    creationFlags,       // creation flags
-                                    environmentPtr,      // pointer to new environment block
-                                    workingDirectory,    // pointer to current directory name
-                                    startupInfo,         // pointer to STARTUPINFO
-                                    processInfo      // pointer to PROCESS_INFORMATION
+                                    null,                     // we don't need this since all the info is in commandLine
+                                    commandLine,              // pointer to the command line string
+                                    ref unused_SecAttrs,      // address to process security attributes, we don't need to inheriat the handle
+                                    ref unused_SecAttrs,      // address to thread security attributes.
+                                    startInfo.InheritHandles, // handle inheritance flag
+                                    creationFlags,            // creation flags
+                                    environmentPtr,           // pointer to new environment block
+                                    workingDirectory,         // pointer to current directory name
+                                    startupInfo,              // pointer to STARTUPINFO
+                                    processInfo               // pointer to PROCESS_INFORMATION
                                 );
                             if (!retVal)
                                 errorCode = Marshal.GetLastWin32Error();

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessStartInfo.cs
@@ -23,6 +23,7 @@ namespace System.Diagnostics
         private bool _redirectStandardError = false;
         private Encoding _standardOutputEncoding;
         private Encoding _standardErrorEncoding;
+        private bool _inheritHandles = true;
 
         private bool _createNoWindow = false;
         internal Dictionary<string, string> _environmentVariables;
@@ -134,6 +135,13 @@ namespace System.Diagnostics
             get { return _standardErrorEncoding; }
             set { _standardErrorEncoding = value; }
         }
+
+        public bool InheritHandles
+        {
+            get { return _inheritHandles; }
+            set { _inheritHandles = value; }
+        }
+
 
         public Encoding StandardOutputEncoding
         {


### PR DESCRIPTION
Hi,

I was wondering why we dont have a way to manipulate Handle Inheritance while creating a process.
For some reasons, I need this kind of behavior. The processes I create have not need of Father Handles.
By default the ProcessStartInfo has InheritHandles = true.
Api consumer can is able to tune the CreateProcess behavior.
