### PR TITLE
Remove dead code from System.Private.Uri

### DIFF
--- a/src/System.Private.Uri/src/Resources/Strings.resx
+++ b/src/System.Private.Uri/src/Resources/Strings.resx
@@ -153,9 +153,6 @@
   <data name="UnknownError_Num" xml:space="preserve">
     <value>Unknown error '{0}'.</value>
   </data>
-  <data name="net_uri_AlreadyRegistered" xml:space="preserve">
-    <value>A URI scheme name '{0}' already has a registered custom parser.</value>
-  </data>
   <data name="net_uri_BadAuthority" xml:space="preserve">
     <value>Invalid URI: The Authority/Host could not be parsed.</value>
   </data>
@@ -194,9 +191,6 @@
   </data>
   <data name="net_uri_MustRootedPath" xml:space="preserve">
     <value>Invalid URI: A Dos path must be rooted, for example, 'c:\\'.</value>
-  </data>
-  <data name="net_uri_NeedFreshParser" xml:space="preserve">
-    <value>The URI parser instance passed into 'uriParser' parameter is already registered with the scheme name '{0}'.</value>
   </data>
   <data name="net_uri_NotAbsolute" xml:space="preserve">
     <value>This operation is not supported for a relative URI.</value>

--- a/src/System.Private.Uri/src/System/DomainNameHelper.cs
+++ b/src/System.Private.Uri/src/System/DomainNameHelper.cs
@@ -9,8 +9,6 @@ namespace System
     // The idea is to stay with static helper methods and strings
     internal class DomainNameHelper
     {
-        private const char c_DummyChar = (char)0xFFFF;     //An Invalid Unicode character used as a dummy char passed into the parameter
-
         private DomainNameHelper()
         {
         }

--- a/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
+++ b/src/System.Private.Uri/src/System/IPv6AddressHelper.cs
@@ -14,8 +14,6 @@ namespace System
         // fields
 
         private const int NumberOfLabels = 8;
-        // Upper case hex, zero padded to 4 characters
-        private const string LegacyFormat = "{0:X4}:{1:X4}:{2:X4}:{3:X4}:{4:X4}:{5:X4}:{6:X4}:{7:X4}";
         // Lower case hex, no leading zeros
         private const string CanonicalNumberFormat = "{0:x}";
         private const string EmbeddedIPv4Format = ":{0:d}.{1:d}.{2:d}.{3:d}";

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -5,8 +5,6 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Globalization;
 using System.Collections.Generic;
-using System.Security;
-using System.Threading;
 
 namespace System
 {
@@ -27,7 +25,6 @@ namespace System
         internal static readonly string SchemeDelimiter = "://";
 
 
-        private const int c_Max16BitUtf8SequenceLength = 3 + 3 + 3 + 3; //each unicode byte takes 3 escaped chars
         internal const int c_MaxUriBufferSize = 0xFFF0;
         private const int c_MaxUriSchemeName = 1024;
 
@@ -839,21 +836,6 @@ namespace System
         // Value from config Uri section
         // On by default in .NET 4.5+ and cannot be disabled by config.
         private static volatile bool s_IriParsing = true; // IRI Parsing is always enabled in .NET Native and CoreCLR
-
-        private static object s_initLock;
-
-        private static object InitializeLock
-        {
-            get
-            {
-                if (s_initLock == null)
-                {
-                    object o = new object();
-                    Interlocked.CompareExchange(ref s_initLock, o, null);
-                }
-                return s_initLock;
-            }
-        }
 
         private string GetLocalPath()
         {

--- a/src/System.Private.Uri/src/System/UriHelper.cs
+++ b/src/System.Private.Uri/src/System/UriHelper.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Globalization;
 using System.Text;
 using System.Diagnostics;
 
@@ -677,9 +676,7 @@ namespace System
             return false;
         }
 
-        private const string RFC2396ReservedMarks = @";/?:@&=+$,";
         private const string RFC3986ReservedMarks = @":/?#[]@!$&'()*+,;=";
-        private const string RFC2396UnreservedMarks = @"-_.!~*'()";
         private const string RFC3986UnreservedMarks = @"-._~";
 
         private static unsafe bool IsReservedUnreservedOrHash(char c)

--- a/src/System.Private.Uri/src/System/UriSyntax.cs
+++ b/src/System.Private.Uri/src/System/UriSyntax.cs
@@ -99,13 +99,6 @@ namespace System
         internal static UriParser VsMacrosUri;
 
 
-        private enum UriQuirksVersion
-        {
-            // V1 = 1, // RFC 1738 - Not supported
-            V2 = 2, // RFC 2396
-            V3 = 3, // RFC 3986, 3987
-        }
-
         static UriParser()
         {
             s_table = new LowLevelDictionary<string, UriParser>(c_InitialTableSize);
@@ -234,35 +227,6 @@ namespace System
         {
             _flags = flags;
             _scheme = string.Empty;
-        }
-
-        private static void FetchSyntax(UriParser syntax, string lwrCaseSchemeName, int defaultPort)
-        {
-            if (syntax.SchemeName.Length != 0)
-                throw new InvalidOperationException(SR.Format(SR.net_uri_NeedFreshParser, syntax.SchemeName));
-
-            lock (s_table)
-            {
-                syntax._flags &= ~UriSyntaxFlags.V1_UnknownUri;
-                UriParser oldSyntax = null;
-                s_table.TryGetValue(lwrCaseSchemeName, out oldSyntax);
-                if (oldSyntax != null)
-                    throw new InvalidOperationException(SR.Format(SR.net_uri_AlreadyRegistered, oldSyntax.SchemeName));
-
-                s_tempTable.TryGetValue(syntax.SchemeName, out oldSyntax);
-                if (oldSyntax != null)
-                {
-                    // optimization on schemeName, will try to keep the first reference
-                    lwrCaseSchemeName = oldSyntax._scheme;
-                    s_tempTable.Remove(lwrCaseSchemeName);
-                }
-
-                syntax.OnRegister(lwrCaseSchemeName, defaultPort);
-                syntax._scheme = lwrCaseSchemeName;
-                syntax._port = defaultPort;
-
-                s_table[syntax.SchemeName] = syntax;
-            }
         }
 
         private const int c_MaxCapacity = 512;


### PR DESCRIPTION
Remove unused private fields, methods, nested types and resource strings.