### PR TITLE
SymmetricAlgorithms shouldn't clone the IV byte[] unnecessarily.

### DIFF
--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesContractTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesContractTests.cs
@@ -81,8 +81,8 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 {
                     return;
                 }
-                Assert.Throws<ArgumentException>("key", () => aes.CreateEncryptor(key, iv));
-                Assert.Throws<ArgumentException>("key", () => aes.CreateDecryptor(key, iv));
+                Assert.Throws<ArgumentException>("rgbKey", () => aes.CreateEncryptor(key, iv));
+                Assert.Throws<ArgumentException>("rgbKey", () => aes.CreateDecryptor(key, iv));
             }
         }
 
@@ -105,8 +105,8 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
                 {
                     return;
                 }
-                Assert.Throws<ArgumentException>("iv", () => aes.CreateEncryptor(key, iv));
-                Assert.Throws<ArgumentException>("iv", () => aes.CreateDecryptor(key, iv));
+                Assert.Throws<ArgumentException>("rgbIV", () => aes.CreateEncryptor(key, iv));
+                Assert.Throws<ArgumentException>("rgbIV", () => aes.CreateDecryptor(key, iv));
             }
         }
 

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesCngCryptoTransform.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesCngCryptoTransform.cs
@@ -17,7 +17,7 @@ namespace Internal.Cryptography
 
             if (cipherIv != null)
             {
-                _iv = cipherIv.CloneByteArray();
+                _iv = cipherIv;
                 _currentIv = new byte[cipherIv.Length];
             }
 

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesImplementation.cs
@@ -8,14 +8,24 @@ namespace Internal.Cryptography
 {
     internal sealed partial class AesImplementation : Aes
     {
+        public sealed override ICryptoTransform CreateDecryptor()
+        {
+            return CreateTransform(Key, IV, encrypting: false);
+        }
+
         public sealed override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV)
         {
-            return CreateTransform(rgbKey, rgbIV, encrypting: false);
+            return CreateTransform(rgbKey, rgbIV.CloneByteArray(), encrypting: false);
+        }
+
+        public sealed override ICryptoTransform CreateEncryptor()
+        {
+            return CreateTransform(Key, IV, encrypting: true);
         }
 
         public sealed override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV)
         {
-            return CreateTransform(rgbKey, rgbIV, encrypting: true);
+            return CreateTransform(rgbKey, rgbIV.CloneByteArray(), encrypting: true);
         }
 
         public sealed override void GenerateIV()
@@ -39,18 +49,20 @@ namespace Internal.Cryptography
 
         private ICryptoTransform CreateTransform(byte[] rgbKey, byte[] rgbIV, bool encrypting)
         {
+            // note: rbgIV is guaranteed to be cloned before this method, so no need to clone it again
+
             if (rgbKey == null)
-                throw new ArgumentNullException("key");
+                throw new ArgumentNullException("rgbKey");
 
             long keySize = rgbKey.Length * (long)BitsPerByte;
             if (keySize > int.MaxValue || !((int)keySize).IsLegalSize(this.LegalKeySizes))
-                throw new ArgumentException(SR.Cryptography_InvalidKeySize, "key");
+                throw new ArgumentException(SR.Cryptography_InvalidKeySize, "rgbKey");
 
             if (rgbIV != null)
             {
                 long ivSize = rgbIV.Length * (long)BitsPerByte;
                 if (ivSize != BlockSize)
-                    throw new ArgumentException(SR.Cryptography_InvalidIVSize, "iv");
+                    throw new ArgumentException(SR.Cryptography_InvalidIVSize, "rgbIV");
             }
 
             if (encrypting)

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/Helpers.cs
@@ -11,6 +11,11 @@ namespace Internal.Cryptography
     {
         public static byte[] CloneByteArray(this byte[] src)
         {
+            if (src == null)
+            {
+                return null;
+            }
+
             return (byte[])(src.Clone());
         }
 

--- a/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Cng/src/Internal/Cryptography/Helpers.cs
@@ -17,6 +17,11 @@ namespace Internal.Cryptography
     {
         public static byte[] CloneByteArray(this byte[] src)
         {
+            if (src == null)
+            {
+                return null;
+            }
+
             return (byte[])(src.Clone());
         }
 

--- a/src/System.Security.Cryptography.Csp/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Csp/src/Internal/Cryptography/Helpers.cs
@@ -11,6 +11,11 @@ namespace Internal.Cryptography
     {
         public static byte[] CloneByteArray(this byte[] src)
         {
+            if (src == null)
+            {
+                return null;
+            }
+
             return (byte[])(src.Clone());
         }
     }

--- a/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Encoding/src/Internal/Cryptography/Helpers.cs
@@ -11,6 +11,11 @@ namespace Internal.Cryptography
     {
         public static byte[] CloneByteArray(this byte[] src)
         {
+            if (src == null)
+            {
+                return null;
+            }
+
             return (byte[])(src.Clone());
         }
     }

--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/Helpers.cs
@@ -11,6 +11,11 @@ namespace System.Security.Cryptography
     {
         public static byte[] CloneByteArray(this byte[] src)
         {
+            if (src == null)
+            {
+                return null;
+            }
+
             return (byte[])(src.Clone());
         }
 

--- a/src/System.Security.Cryptography.Primitives/tests/KeyedHashAlgorithmTests.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/KeyedHashAlgorithmTests.cs
@@ -55,13 +55,10 @@ namespace System.Security.Cryptography.Hashing.Tests
             using (var keyedHash = new TestKeyedHashAlgorithm())
             {
                 keyedHash.Key = key;
-
                 Assert.NotNull(keyedHash.Key);
 
                 keyedHash.Dispose();
-
-                byte[] ignored;
-                Assert.Throws<NullReferenceException>(() => ignored = keyedHash.Key);
+                Assert.Null(keyedHash.Key);
             }
         }
 
@@ -70,7 +67,11 @@ namespace System.Security.Cryptography.Hashing.Tests
         {
             using (var keyedHash = new TestKeyedHashAlgorithm())
             {
-                Assert.Throws<NullReferenceException>(() => keyedHash.Key = null);
+                keyedHash.Key = new byte[1];
+                Assert.NotNull(keyedHash.Key);
+
+                keyedHash.Key = null;
+                Assert.Null(keyedHash.Key);
             }
         }
 
@@ -82,7 +83,7 @@ namespace System.Security.Cryptography.Hashing.Tests
 
             protected override byte[] HashFinal()
             {
-                return Array.Empty<byte>(); ;
+                return Array.Empty<byte>();
             }
 
             public override void Initialize()

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Helpers.cs
@@ -11,6 +11,11 @@ namespace Internal.Cryptography
     {
         public static byte[] CloneByteArray(this byte[] src)
         {
+            if (src == null)
+            {
+                return null;
+            }
+
             return (byte[])(src.Clone());
         }
 


### PR DESCRIPTION
Since BasicSymmetricCipher clears out its IV byte[] upon Dispose(), it needs to have a cloned copy of the IV byte[].  However, we clone it unnecessarily in certain cases.

Also, fixing a small issue with the ArgumentExceptions thrown from calling CreateEncryptor and CreateDecryptor on AesCng and TripleDESCng.  The name of the parameters are rgbKey and rgbIV, so the strings passed in to the ArgumentException should match.

@bartonjs @stephentoub 