### PR TITLE
Implement TripleDES on Windows using CNG and on Unix using OpenSsl.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.Cipher.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.Cipher.cs
@@ -60,5 +60,11 @@ internal static partial class Interop
 
         [DllImport(Libraries.CryptoNative)]
         internal static extern IntPtr EvpAes256Cbc();
+
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern IntPtr EvpDes3Ecb();
+
+        [DllImport(Libraries.CryptoNative)]
+        internal static extern IntPtr EvpDes3Cbc();
     }
 }

--- a/src/Common/src/Interop/Windows/BCrypt/Cng.cs
+++ b/src/Common/src/Interop/Windows/BCrypt/Cng.cs
@@ -68,7 +68,11 @@ namespace Internal.NativeCrypto
             BCRYPT_ALG_HANDLE_HMAC_FLAG = 0x00000008,
         }
 
-        public const String BCRYPT_AES_ALGORITHM = "AES";
+        public const string BCRYPT_3DES_ALGORITHM = "3DES";
+        public const string BCRYPT_AES_ALGORITHM = "AES";
+
+        public const string BCRYPT_CHAIN_MODE_CBC = "ChainingModeCBC";
+        public const string BCRYPT_CHAIN_MODE_ECB = "ChainingModeECB";
 
         public static SafeAlgorithmHandle BCryptOpenAlgorithmProvider(String pszAlgId, String pszImplementation, OpenAlgorithmProviderFlags dwFlags)
         {

--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/TripleDES/TripleDESReusabilityTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/TripleDES/TripleDESReusabilityTests.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.Encryption.TripleDes.Tests
+{
+    public static class TripleDESReusabilityTests
+    {
+        [Fact]
+        public static void TripleDESReuseEncryptorDecryptor()
+        {
+            byte[] key = "6b42da08f93e819fbd26fce0785b0eec3d0cb6bfa053c505".HexToByteArray();
+            byte[] iv = "8fc67ce5e7f28cde".HexToByteArray();
+
+            using (TripleDES alg = TripleDESFactory.Create())
+            {
+                alg.Key = key;
+                alg.IV = iv;
+                alg.Padding = PaddingMode.PKCS7;
+                alg.Mode = CipherMode.CBC;
+
+                using (ICryptoTransform encryptor = alg.CreateEncryptor())
+                using (ICryptoTransform decryptor = alg.CreateDecryptor())
+                {
+                    for (int i = 0; i < 2; i++)
+                    {
+                        byte[] plainText1 = "e867f915e275eab27d6951165d26dec6dd0acafcfc".HexToByteArray();
+                        byte[] cipher1 = encryptor.Transform(plainText1);
+                        byte[] expectedCipher1 = "446f57875e107702afde16b57eaf250b87b8110bef29af89".HexToByteArray();
+                        Assert.Equal<byte>(expectedCipher1, cipher1);
+
+                        byte[] decrypted1 = decryptor.Transform(cipher1);
+                        byte[] expectedDecrypted1 = "e867f915e275eab27d6951165d26dec6dd0acafcfc".HexToByteArray();
+                        Assert.Equal<byte>(expectedDecrypted1, decrypted1);
+
+
+                        byte[] plainText2 = "54686973206973206120736563726574206d657373616765".HexToByteArray();
+                        byte[] cipher2 = encryptor.Transform(plainText2);
+                        byte[] expectedCipher2 = "da6af8adc5d934c24943176db82eef34aa027c93e9dbe52dc5f1fa64fef4061c".HexToByteArray();
+                        Assert.Equal<byte>(expectedCipher2, cipher2);
+
+                        byte[] decrypted2 = decryptor.Transform(cipher2);
+                        byte[] expectedDecrypted2 = "54686973206973206120736563726574206d657373616765".HexToByteArray();
+                        Assert.Equal<byte>(expectedDecrypted2, decrypted2);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Native/System.Security.Cryptography.Native/pal_evp_cipher.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp_cipher.cpp
@@ -110,3 +110,13 @@ extern "C" const EVP_CIPHER* EvpAes256Cbc()
 {
     return EVP_aes_256_cbc();
 }
+
+extern "C" const EVP_CIPHER* EvpDes3Ecb()
+{
+    return EVP_des_ede3();
+}
+
+extern "C" const EVP_CIPHER* EvpDes3Cbc()
+{
+    return EVP_des_ede3_cbc();
+}

--- a/src/Native/System.Security.Cryptography.Native/pal_evp_cipher.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp_cipher.h
@@ -108,3 +108,19 @@ EvpAes256Cbc
 Direct shim to EVP_aes_256_cbc.
 */
 extern "C" const EVP_CIPHER* EvpAes256Cbc();
+
+/*
+Function:
+EvpDes3Ecb
+
+Direct shim to EVP_des_ede3.
+*/
+extern "C" const EVP_CIPHER* EvpDes3Ecb();
+
+/*
+Function:
+EvpDes3Cbc
+
+Direct shim to EVP_des_ede3_cbc.
+*/
+extern "C" const EVP_CIPHER* EvpDes3Cbc();

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesCngCryptoTransform.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesCngCryptoTransform.cs
@@ -104,7 +104,7 @@ namespace Internal.Cryptography
         private byte[] _iv;         // _iv holds a copy of the original IV for Reset(), until it is cleared by Dispose().
         private byte[] _currentIv;  // CNG mutates this with the updated IV for the next stage on each Encrypt/Decrypt call.
 
-        private static readonly SafeAlgorithmHandle s_hAlgCbc = OpenAesAlgorithm("ChainingModeCBC");
-        private static readonly SafeAlgorithmHandle s_hAlgEcb = OpenAesAlgorithm("ChainingModeECB");
+        private static readonly SafeAlgorithmHandle s_hAlgCbc = OpenAesAlgorithm(Cng.BCRYPT_CHAIN_MODE_CBC);
+        private static readonly SafeAlgorithmHandle s_hAlgEcb = OpenAesAlgorithm(Cng.BCRYPT_CHAIN_MODE_ECB);
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesNativeCryptoTransform.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/AesNativeCryptoTransform.cs
@@ -204,17 +204,7 @@ namespace Internal.Cryptography
 
         protected byte[] GetCipherIv(byte[] iv)
         {
-            if (CipherMode.UsesIv())
-            {
-                if (iv == null)
-                {
-                    throw new CryptographicException(SR.Cryptography_MissingIV);
-                }
-
-                return iv;
-            }
-
-            return null;
+            return CipherMode.GetCipherIv(iv);
         }
     }
 }

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/Helpers.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/Helpers.cs
@@ -11,6 +11,11 @@ namespace Internal.Cryptography
     {
         public static byte[] CloneByteArray(this byte[] src)
         {
+            if (src == null)
+            {
+                return null;
+            }
+
             return (byte[])(src.Clone());
         }
 
@@ -22,6 +27,21 @@ namespace Internal.Cryptography
         public static bool UsesIv(this CipherMode cipherMode)
         {
             return cipherMode != CipherMode.ECB;
+        }
+
+        public static byte[] GetCipherIv(this CipherMode cipherMode, byte[] iv)
+        {
+            if (cipherMode.UsesIv())
+            {
+                if (iv == null)
+                {
+                    throw new CryptographicException(SR.Cryptography_MissingIV);
+                }
+
+                return iv;
+            }
+
+            return null;
         }
 
         public static bool IsLegalSize(this int size, KeySizes[] legalSizes)

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesCngCipher.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesCngCipher.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Security.Cryptography;
+using Internal.NativeCrypto;
+
+namespace Internal.Cryptography
+{
+    internal sealed class TripleDesCngCipher : BasicSymmetricCipher
+    {
+        private static readonly SafeAlgorithmHandle s_hAlgCbc = Open3DesAlgorithm(Cng.BCRYPT_CHAIN_MODE_CBC);
+        private static readonly SafeAlgorithmHandle s_hAlgEcb = Open3DesAlgorithm(Cng.BCRYPT_CHAIN_MODE_ECB);
+
+        private readonly bool _encrypting;
+        private SafeKeyHandle _hKey;
+        private byte[] _currentIv;  // CNG mutates this with the updated IV for the next stage on each Encrypt/Decrypt call.
+                                    // The base IV holds a copy of the original IV for Reset(), until it is cleared by Dispose().
+
+        public TripleDesCngCipher(CipherMode cipherMode, int blockSizeInBytes, byte[] key, byte[] iv, bool encrypting)
+            : base(cipherMode.GetCipherIv(iv), blockSizeInBytes)
+        {
+            _encrypting = encrypting;
+
+            if (IV != null)
+            {
+                _currentIv = new byte[IV.Length];
+            }
+
+            SafeAlgorithmHandle hAlg = GetCipherAlgorithm(cipherMode);
+            _hKey = hAlg.BCryptImportKey(key);
+            Reset();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                SafeKeyHandle hKey = _hKey;
+                _hKey = null;
+                if (hKey != null)
+                {
+                    hKey.Dispose();
+                }
+
+                byte[] currentIv = _currentIv;
+                _currentIv = null;
+                if (currentIv != null)
+                {
+                    Array.Clear(currentIv, 0, currentIv.Length);
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override int Transform(byte[] input, int inputOffset, int count, byte[] output, int outputOffset)
+        {
+            Debug.Assert(input != null);
+            Debug.Assert(inputOffset >= 0);
+            Debug.Assert(count > 0);
+            Debug.Assert((count % BlockSizeInBytes) == 0);
+            Debug.Assert(input.Length - inputOffset >= count);
+            Debug.Assert(output != null);
+            Debug.Assert(outputOffset >= 0);
+            Debug.Assert(output.Length - outputOffset >= count);
+
+            int numBytesWritten;
+            if (_encrypting)
+            {
+                numBytesWritten = _hKey.BCryptEncrypt(input, inputOffset, count, _currentIv, output, outputOffset, output.Length - outputOffset);
+            }
+            else
+            {
+                numBytesWritten = _hKey.BCryptDecrypt(input, inputOffset, count, _currentIv, output, outputOffset, output.Length - outputOffset);
+            }
+
+            if (numBytesWritten != count)
+            {
+                // CNG gives us no way to tell BCryptDecrypt() that we're decrypting the final block, nor is it performing any
+                // padding /depadding for us. So there's no excuse for a provider to hold back output for "future calls." Though
+                // this isn't technically our problem to detect, we might as well detect it now for easier diagnosis.
+                throw new CryptographicException(SR.Cryptography_UnexpectedTransformTruncation);
+            }
+
+            return numBytesWritten;
+        }
+
+        public override byte[] TransformFinal(byte[] input, int inputOffset, int count)
+        {
+            Debug.Assert(input != null);
+            Debug.Assert(inputOffset >= 0);
+            Debug.Assert(count >= 0);
+            Debug.Assert((count % BlockSizeInBytes) == 0);
+            Debug.Assert(input.Length - inputOffset >= count);
+
+            byte[] output = new byte[count];
+            if (count != 0)
+            {
+                int numBytesWritten = Transform(input, inputOffset, count, output, 0);
+                Debug.Assert(numBytesWritten == count);  // Our implementation of Transform() guarantees this. See comment above.
+            }
+
+            Reset();
+            return output;
+        }
+
+        private void Reset()
+        {
+            if (IV != null)
+            {
+                Buffer.BlockCopy(IV, 0, _currentIv, 0, IV.Length);
+            }
+        }
+
+        private static SafeAlgorithmHandle GetCipherAlgorithm(CipherMode cipherMode)
+        {
+            // Windows 8 added support to set the CipherMode value on a key,
+            // but Windows 7 requires that it be set on the algorithm before key creation.
+            switch (cipherMode)
+            {
+                case CipherMode.CBC:
+                    return s_hAlgCbc;
+                case CipherMode.ECB:
+                    return s_hAlgEcb;
+                default:
+                    // This is what AesCngCryptoTransform::GetCipherAlgorithm throws when it doesn't understand the value.
+                    throw new NotSupportedException();
+            }
+        }
+
+        private static SafeAlgorithmHandle Open3DesAlgorithm(string cipherMode)
+        {
+            SafeAlgorithmHandle hAlg = Cng.BCryptOpenAlgorithmProvider(Cng.BCRYPT_3DES_ALGORITHM, null, Cng.OpenAlgorithmProviderFlags.NONE);
+            hAlg.SetCipherMode(cipherMode);
+
+            return hAlg;
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.Unix.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.Unix.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Cryptography;
+
+namespace Internal.Cryptography
+{
+    partial class TripleDesImplementation
+    {
+        private ICryptoTransform CreateTransformCore(
+            CipherMode cipherMode,
+            PaddingMode paddingMode,
+            byte[] key,
+            byte[] iv,
+            int blockSize,
+            bool encrypting)
+        {
+            BasicSymmetricCipher cipher = new TripleDesOpenSslCipher(cipherMode, blockSize, key, iv, encrypting);
+            return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
+        }
+
+        // -----------------------------
+        // ---- PAL layer ends here ----
+        // -----------------------------    
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.Windows.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.Windows.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Security.Cryptography;
+
+namespace Internal.Cryptography
+{
+    partial class TripleDesImplementation
+    {
+        private ICryptoTransform CreateTransformCore(
+            CipherMode cipherMode,
+            PaddingMode paddingMode,
+            byte[] key,
+            byte[] iv,
+            int blockSize,
+            bool encrypting)
+        {
+            BasicSymmetricCipher cipher = new TripleDesCngCipher(cipherMode, blockSize, key, iv, encrypting);
+            return UniversalCryptoTransform.Create(paddingMode, cipher, encrypting);
+        }
+
+        // -----------------------------
+        // ---- PAL layer ends here ----
+        // -----------------------------    
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesImplementation.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Security.Cryptography;
+
+namespace Internal.Cryptography
+{
+    internal sealed partial class TripleDesImplementation : TripleDES
+    {
+        private const int BitsPerByte = 8;
+        private static readonly RandomNumberGenerator s_rng = RandomNumberGenerator.Create();
+
+        public override KeySizes[] LegalKeySizes
+        {
+            get
+            {
+                // CNG does not support 128-bit keys.
+                // Only support 192-bit keys on all platforms for simplicity.
+                return new KeySizes[] { new KeySizes(minSize: 3 * 64, maxSize: 3 * 64, skipSize: 0) };
+            }
+        }
+
+        public override ICryptoTransform CreateDecryptor()
+        {
+            return CreateTransform(this.Key, this.IV, encrypting: false);
+        }
+
+        public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV)
+        {
+            return CreateTransform(rgbKey, rgbIV.CloneByteArray(), encrypting: false);
+        }
+
+        public override ICryptoTransform CreateEncryptor()
+        {
+            return CreateTransform(this.Key, this.IV, encrypting: true);
+        }
+
+        public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV)
+        {
+            return CreateTransform(rgbKey, rgbIV.CloneByteArray(), encrypting: true);
+        }
+
+        public override void GenerateIV()
+        {
+            byte[] iv = new byte[BlockSize / BitsPerByte];
+            s_rng.GetBytes(iv);
+            IV = iv;
+        }
+
+        public sealed override void GenerateKey()
+        {
+            byte[] key = new byte[KeySize / BitsPerByte];
+            s_rng.GetBytes(key);
+            Key = key;
+        }
+
+        private ICryptoTransform CreateTransform(byte[] rgbKey, byte[] rgbIV, bool encrypting)
+        {
+            // note: rgbIV is guaranteed to be cloned before this method, so no need to clone it again
+
+            if (rgbKey == null)
+                throw new ArgumentNullException("rgbKey");
+
+            long keySize = rgbKey.Length * (long)BitsPerByte;
+            if (keySize > int.MaxValue || !((int)keySize).IsLegalSize(this.LegalKeySizes))
+                throw new ArgumentException(SR.Cryptography_InvalidKeySize, "rgbKey");
+
+            if (rgbIV != null)
+            {
+                long ivSize = rgbIV.Length * (long)BitsPerByte;
+                if (ivSize != BlockSize)
+                    throw new ArgumentException(SR.Cryptography_InvalidIVSize, "rgbIV");
+            }
+
+            return CreateTransformCore(Mode, Padding, rgbKey, rgbIV, BlockSize / BitsPerByte, encrypting);
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesOpenSslCipher.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/Internal/Cryptography/TripleDesOpenSslCipher.cs
@@ -1,0 +1,165 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Security.Cryptography;
+using Microsoft.Win32.SafeHandles;
+
+namespace Internal.Cryptography
+{
+    internal class TripleDesOpenSslCipher : BasicSymmetricCipher
+    {
+        private readonly bool _encrypting;
+        private SafeEvpCipherCtxHandle _ctx;
+
+        public TripleDesOpenSslCipher(CipherMode cipherMode, int blockSizeInBytes, byte[] key, byte[] iv, bool encrypting)
+            : base(cipherMode.GetCipherIv(iv), blockSizeInBytes)
+        {
+            _encrypting = encrypting;
+
+            OpenKey(cipherMode, key);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (_ctx != null)
+                {
+                    _ctx.Dispose();
+                    _ctx = null;
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override unsafe int Transform(byte[] input, int inputOffset, int count, byte[] output, int outputOffset)
+        {
+            Debug.Assert(input != null);
+            Debug.Assert(inputOffset >= 0);
+            Debug.Assert(count > 0);
+            Debug.Assert((count % BlockSizeInBytes) == 0);
+            Debug.Assert(input.Length - inputOffset >= count);
+            Debug.Assert(output != null);
+            Debug.Assert(outputOffset >= 0);
+            Debug.Assert(output.Length - outputOffset >= count);
+
+            return CipherUpdate(input, inputOffset, count, output, outputOffset);
+        }
+
+        public override byte[] TransformFinal(byte[] input, int inputOffset, int count)
+        {
+            Debug.Assert(input != null);
+            Debug.Assert(inputOffset >= 0);
+            Debug.Assert(count >= 0);
+            Debug.Assert((count % BlockSizeInBytes) == 0);
+            Debug.Assert(input.Length - inputOffset >= count);
+
+            byte[] output = ProcessFinalBlock(input, inputOffset, count);
+            Reset();
+            return output;
+        }
+
+        private unsafe byte[] ProcessFinalBlock(byte[] input, int inputOffset, int count)
+        {
+            byte[] output = new byte[count];
+            int outputBytes = CipherUpdate(input, inputOffset, count, output, 0);
+
+            fixed (byte* outputStart = output)
+            {
+                byte* outputCurrent = outputStart + outputBytes;
+
+                int bytesWritten;
+                CheckBoolReturn(Interop.Crypto.EvpCipherFinalEx(_ctx, outputCurrent, out bytesWritten));
+                outputBytes += bytesWritten;
+            }
+
+            if (outputBytes == output.Length)
+            {
+                return output;
+            }
+
+            if (outputBytes == 0)
+            {
+                return Array.Empty<byte>();
+            }
+
+            byte[] userData = new byte[outputBytes];
+            Buffer.BlockCopy(output, 0, userData, 0, outputBytes);
+            return userData;
+        }
+
+        private unsafe int CipherUpdate(byte[] input, int inputOffset, int count, byte[] output, int outputOffset)
+        {
+            bool status;
+            int bytesWritten;
+
+            fixed (byte* inputStart = input)
+            fixed (byte* outputStart = output)
+            {
+                byte* inputCurrent = inputStart + inputOffset;
+                byte* outputCurrent = outputStart + outputOffset;
+
+                status = Interop.Crypto.EvpCipherUpdate(
+                    _ctx,
+                    outputCurrent,
+                    out bytesWritten,
+                    inputCurrent,
+                    count);
+            }
+
+            CheckBoolReturn(status);
+            return bytesWritten;
+        }
+
+        private void OpenKey(CipherMode cipherMode, byte[] key)
+        {
+            // The algorithm pointer is a static pointer, so not having any cleanup code is correct.
+            IntPtr algorithm;
+            switch (cipherMode)
+            {
+                case CipherMode.CBC:
+                    algorithm = Interop.Crypto.EvpDes3Cbc();
+                    break;
+                case CipherMode.ECB:
+                    algorithm = Interop.Crypto.EvpDes3Ecb();
+                    break;
+                default:
+                    // This is what AesCngCryptoTransform::GetCipherAlgorithm throws when it doesn't understand the value.
+                    throw new NotSupportedException();
+            }
+
+            _ctx = Interop.Crypto.EvpCipherCreate(
+                algorithm,
+                key,
+                IV,
+                _encrypting ? 1 : 0);
+
+            if (_ctx == null)
+            {
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
+            }
+
+            // OpenSSL will happily do PKCS#7 padding for us, but since we support padding modes
+            // that it doesn't (PaddingMode.Zeros) we'll just always pad the blocks ourselves.
+            CheckBoolReturn(Interop.Crypto.EvpCipherCtxSetPadding(_ctx, 0));
+        }
+
+        private void Reset()
+        {
+            bool status = Interop.Crypto.EvpCipherReset(_ctx);
+
+            CheckBoolReturn(status);
+        }
+
+        private static void CheckBoolReturn(bool returnValue)
+        {
+            if (!returnValue)
+            {
+                throw Interop.Crypto.CreateOpenSslCryptographicException();
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
@@ -180,4 +180,7 @@
   <data name="WorkInProgress" xml:space="preserve">
     <value>Implementation in progress.</value>
   </data>
+  <data name="Cryptography_UnexpectedTransformTruncation" xml:space="preserve">
+    <value>CNG provider unexpectedly terminated encryption or decryption prematurely.</value>
+  </data>
 </root>

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -23,6 +23,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU' " />
   <ItemGroup>
+    <Compile Include="Internal\Cryptography\TripleDesImplementation.cs" />
     <Compile Include="System\Security\Cryptography\Aes.cs" />
     <Compile Include="System\Security\Cryptography\DeriveBytes.cs" />
     <Compile Include="System\Security\Cryptography\DSAParameters.cs" />
@@ -52,8 +53,20 @@
     <Compile Include="Internal\Cryptography\Helpers.cs" />
     <Compile Include="Internal\Cryptography\HMACCommon.cs" />
     <Compile Include="Internal\Cryptography\HashAlgorithmNames.cs" />
+    <Compile Include="$(CommonPath)\Internal\Cryptography\BasicSymmetricCipher.cs">
+      <Link>Internal\Cryptography\BasicSymmetricCipher.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Internal\Cryptography\HashProvider.cs">
       <Link>Internal\Cryptography\HashProvider.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Internal\Cryptography\UniversalCryptoTransform.cs">
+      <Link>Internal\Cryptography\UniversalCryptoTransform.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Internal\Cryptography\UniversalCryptoEncryptor.cs">
+      <Link>Internal\Cryptography\UniversalCryptoEncryptor.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Internal\Cryptography\UniversalCryptoDecryptor.cs">
+      <Link>Internal\Cryptography\UniversalCryptoDecryptor.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
@@ -62,7 +75,9 @@
     <Compile Include="Internal\Cryptography\AesCngCryptoEncryptor.cs" />
     <Compile Include="Internal\Cryptography\AesCngCryptoTransform.cs" />
     <Compile Include="Internal\Cryptography\AesImplementation.Windows.cs" />
+    <Compile Include="Internal\Cryptography\TripleDesCngCipher.cs" />
     <Compile Include="Internal\Cryptography\HashProviderDispenser.Windows.cs" />
+    <Compile Include="Internal\Cryptography\TripleDesImplementation.Windows.cs" />
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
     </Compile>
@@ -129,6 +144,8 @@
     <Compile Include="Internal\Cryptography\AesImplementation.Unix.cs" />
     <Compile Include="Internal\Cryptography\AesOpenSslCryptoTransform.cs" />
     <Compile Include="Internal\Cryptography\HashProviderDispenser.Unix.cs" />
+    <Compile Include="Internal\Cryptography\TripleDesImplementation.Unix.cs" />
+    <Compile Include="Internal\Cryptography\TripleDesOpenSslCipher.cs" />
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/TripleDES.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/TripleDES.cs
@@ -17,7 +17,7 @@ namespace System.Security.Cryptography
 
         public static TripleDES Create()
         {
-            throw new NotImplementedException(SR.WorkInProgress);
+            return new TripleDesImplementation();
         }
 
         public override KeySizes[] LegalKeySizes

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -37,6 +37,12 @@
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\AES\AesFactory.cs">
       <Link>CommonTest\AlgorithmImplementations\AES\AesFactory.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESCipherTests.cs">
+      <Link>CommonTest\AlgorithmImplementations\TripleDES\TripleDESCipherTests.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESFactory.cs">
+      <Link>CommonTest\AlgorithmImplementations\TripleDES\TripleDESFactory.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs">
       <Link>CommonTest\System\RandomDataGenerator.cs</Link>
     </Compile>
@@ -60,6 +66,7 @@
     <Compile Include="Sha256Tests.cs" />
     <Compile Include="Sha384Tests.cs" />
     <Compile Include="Sha512Tests.cs" />
+    <Compile Include="TripleDesProvider.cs" />
     <Compile Include="TripleDesTests.cs" />
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>

--- a/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
+++ b/src/System.Security.Cryptography.Algorithms/tests/System.Security.Cryptography.Algorithms.Tests.csproj
@@ -43,6 +43,9 @@
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESFactory.cs">
       <Link>CommonTest\AlgorithmImplementations\TripleDES\TripleDESFactory.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESReusabilityTests.cs">
+      <Link>CommonTest\AlgorithmImplementations\TripleDES\TripleDESReusabilityTests.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\RandomDataGenerator.cs">
       <Link>CommonTest\System\RandomDataGenerator.cs</Link>
     </Compile>

--- a/src/System.Security.Cryptography.Algorithms/tests/TripleDesProvider.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/TripleDesProvider.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Security.Cryptography.Encryption.TripleDes.Tests
+{
+    internal class TripleDesProvider : ITripleDESProvider
+    {
+        public TripleDES Create()
+        {
+            return TripleDES.Create();
+        }
+    }
+
+    public partial class TripleDESFactory
+    {
+        private static readonly ITripleDESProvider s_provider = new TripleDesProvider();
+    }
+}

--- a/src/System.Security.Cryptography.Algorithms/tests/TripleDesTests.cs
+++ b/src/System.Security.Cryptography.Algorithms/tests/TripleDesTests.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Linq;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Security.Cryptography;
+using System.Text;
 using Test.Cryptography;
 using Xunit;
 
@@ -44,6 +46,35 @@ namespace System.Security.Cryptography.Encryption.TripleDes.Tests
                     Assert.Throws<CryptographicException>(() => d.Key = key);
                 }
             }
+        }
+
+        [Fact]
+        public static void TripleDesCreate()
+        {
+            byte[] inputBytes = Encoding.ASCII.GetBytes("This is a secret message and is a sentence that is longer than a block, it ensures that multi-block functions work.");
+            TripleDES tripleDes = TripleDES.Create();
+
+            byte[] encryptedBytes;
+            using (MemoryStream input = new MemoryStream(inputBytes))
+            using (CryptoStream cryptoStream = new CryptoStream(input, tripleDes.CreateEncryptor(), CryptoStreamMode.Read))
+            using (MemoryStream output = new MemoryStream())
+            {
+                cryptoStream.CopyTo(output);
+                encryptedBytes = output.ToArray();
+            }
+
+            Assert.NotEqual(inputBytes, encryptedBytes);
+
+            byte[] decryptedBytes;
+            using (MemoryStream input = new MemoryStream(encryptedBytes))
+            using (CryptoStream cryptoStream = new CryptoStream(input, tripleDes.CreateDecryptor(), CryptoStreamMode.Read))
+            using (MemoryStream output = new MemoryStream())
+            {
+                cryptoStream.CopyTo(output);
+                decryptedBytes = output.ToArray();
+            }
+
+            Assert.Equal(inputBytes, decryptedBytes);
         }
 
         private static IEnumerable<byte[]> BadKeys()

--- a/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
+++ b/src/System.Security.Cryptography.Cng/tests/System.Security.Cryptography.Cng.Tests.csproj
@@ -65,6 +65,9 @@
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESFactory.cs">
       <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESFactory.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESReusabilityTests.cs">
+      <Link>CommonTest\System\Security\Cryptography\AlgorithmImplementations\TripleDES\TripleDESReusabilityTests.cs</Link>
+    </Compile>
 
     <Compile Include="RSACngProvider.cs" />
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\AlgorithmImplementations\RSA\EncryptDecrypt.cs">


### PR DESCRIPTION
TripleDES.Create throws a NotImplementedException on both Windows and Unix.

This implements the TripleDES algorithm on Windows and Unix.

Fix #4845 

@bartonjs @stephentoub 