### PR TITLE
Make System.Runtime.Extensions.Tests copy its product assembly to OutDir

### DIFF
--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -93,6 +93,7 @@
       <!-- Don't reference implementation assembly, but do deploy it. -->
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
     </ProjectReference>
     <ProjectReference Include="..\..\System.Private.Uri\src\System.Private.Uri.CoreCLR.csproj">


### PR DESCRIPTION
Building System.Runtime.Extensions.Tests.csproj doesn't copy it product
assembly to OutDir (like the other test projects do) which breaks cloud
testing.  Add the necessary build metadata to facility the copy.