### PR TITLE
Exclude two tests due to a JIT integration bug.

### DIFF
--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Generated.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Generated.cs
@@ -113,6 +113,7 @@ namespace Tests.Expressions
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/coreclr/issues/2315", PlatformID.AnyUnix)]
         public static void CompileInterpretCrossCheck_Call()
         {
             var exprs = default(IEnumerable<Expression>);
@@ -402,6 +403,7 @@ namespace Tests.Expressions
         }
 
         [Fact]
+        [ActiveIssue("https://github.com/dotnet/coreclr/issues/2315", PlatformID.AnyUnix)] 
         public static void CompileInterpretCrossCheck_MemberAccess()
         {
             var exprs = default(IEnumerable<Expression>);


### PR DESCRIPTION
This is a temporary exclusion which should be fixed soon. See https://github.com/dotnet/coreclr/issues/2315.