### PR TITLE
Fix Localization Issues on Linux Due to Unsupported Windows DLLs

### DIFF
--- a/src/System.Data.SqlClient/src/Interop/LocaleInterop.cs
+++ b/src/System.Data.SqlClient/src/Interop/LocaleInterop.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Concurrent;
 using System.Data.Common;
+using System.Data.SqlClient;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
@@ -14,15 +15,16 @@ namespace System.Data
     {
         // Maps between LCIDs and LocaleName+AnsiCodePages+Encodings
         private static readonly ConcurrentDictionary<int, Tuple<string, int, Encoding>> s_cachedEncodings = new ConcurrentDictionary<int, Tuple<string, int, Encoding>>();
-
+#if !MANAGED_SNI
         private const string ApiWinCoreLocalization = "api-ms-win-core-localization-l1-2-0.dll";
         private const string ApiWinCoreLocalizationObsolete = "api-ms-win-core-localization-obsolete-l1-2-0.dll";
-
+#endif
         private const int LOCALE_NAME_MAX_LENGTH = 85;
         private const int ERROR_INVALID_PARAMETER = 0x57;
         private const uint LOCALE_IDEFAULTANSICODEPAGE = 0x00001004;
         private const uint LOCALE_RETURN_NUMBER = 0x20000000;
 
+#if !MANAGED_SNI
         [DllImport(ApiWinCoreLocalization, SetLastError = true, CharSet = CharSet.Unicode)]
         private static extern int GetLocaleInfoEx(string lpLocaleName, uint LCType, [Out] out uint lpLCData, int cchData);
 
@@ -87,26 +89,58 @@ namespace System.Data
             }
             return s_cachedEncodings.GetOrAdd(lcid, GetDetailsInternal);
         }
+#endif
 
         internal static Encoding GetEncodingForLcid(int lcid)
         {
+#if MANAGED_SNI
+            if (lcid != TdsEnums.DEFAULT_ENGLISH_LOCALE_ID)
+            {
+                throw new NotSupportedException("Only the English-US locale is currently supported on non-Windows systems. Invalid Locale ID: " + lcid);
+            }
+            return Encoding.UTF8;
+#else
             return GetDetailsForLcid(lcid).Item3;
+#endif
         }
 
         internal static int GetCodePageForLcid(int lcid)
         {
+#if MANAGED_SNI
+            if (lcid != TdsEnums.DEFAULT_ENGLISH_LOCALE_ID)
+            {
+                throw new NotSupportedException("Only the English-US locale is currently supported on non-Windows systems. Invalid Locale ID: " + lcid);
+            }
+            return TdsEnums.DEFAULT_ENGLISH_CODE_PAGE_VALUE;
+#else
             return GetDetailsForLcid(lcid).Item2;
+#endif
         }
 
         internal static string GetLocaleNameForLcid(int lcid)
         {
+#if MANAGED_SNI
+            if (lcid != TdsEnums.DEFAULT_ENGLISH_LOCALE_ID)
+            {
+                throw new NotSupportedException("Only the English-US locale is currently supported on non-Windows systems. Invalid Locale ID: " + lcid);
+            }
+            return TdsEnums.DEFAULT_ENGLISH_LOCALE_NAME;
+#else
             return GetDetailsForLcid(lcid).Item1;
+#endif
         }
 
         internal static int GetLcidForLocaleName(string localeName)
         {
             Debug.Assert(localeName != null, "Locale name should never be null");
 
+#if MANAGED_SNI
+            if(!localeName.Equals(TdsEnums.DEFAULT_ENGLISH_LOCALE_NAME))
+            {
+                throw new NotSupportedException("Only the English-US locale is currently supported on non-Windows systems. Invalid Locale Name: " + localeName);
+            }
+            return TdsEnums.DEFAULT_ENGLISH_LOCALE_ID;
+#else
             uint lcid = LocaleNameToLCID(localeName, 0);
             if (lcid != 0)
             {
@@ -120,11 +154,16 @@ namespace System.Data
 
                 throw new CultureNotFoundException("localeName", localeName, message: null);
             }
+#endif
         }
 
         internal static int GetCurrentCultureLcid()
         {
+#if MANAGED_SNI
+            return TdsEnums.DEFAULT_ENGLISH_LOCALE_ID;
+#else
             return GetLcidForLocaleName(CultureInfo.CurrentCulture.ToString());
+#endif
         }
     }
 }

--- a/src/System.Data.SqlClient/src/Interop/SNINativeMethodWrapper.cs
+++ b/src/System.Data.SqlClient/src/Interop/SNINativeMethodWrapper.cs
@@ -405,8 +405,10 @@ namespace System.Data
 {
     internal static class SafeNativeMethods
     {
+#if !MANAGED_SNI
         [DllImport("api-ms-win-core-libraryloader-l1-1-0.dll", CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true, SetLastError = true)]
         internal static extern IntPtr GetProcAddress(IntPtr HModule, [MarshalAs(UnmanagedType.LPStr), In] string funcName);
+#endif
     }
 }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/LocalDBAPI.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/LocalDBAPI.cs
@@ -101,6 +101,7 @@ namespace System.Data
         {
             get
             {
+#if !MANAGED_SNI
                 if (s_localDBFormatMessage == null)
                 {
                     bool lockTaken = false;
@@ -110,7 +111,6 @@ namespace System.Data
                         if (s_localDBFormatMessage == null)
                         {
                             IntPtr functionAddr = SafeNativeMethods.GetProcAddress(UserInstanceDLLHandle, "LocalDBFormatMessage");
-
                             if (functionAddr == IntPtr.Zero)
                             {
                                 int hResult = Marshal.GetLastWin32Error();
@@ -125,6 +125,7 @@ namespace System.Data
                             Monitor.Exit(s_dllLock);
                     }
                 }
+#endif
                 return s_localDBFormatMessage;
             }
         }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -2259,7 +2259,14 @@ namespace System.Data.SqlClient
 
                         if (null != ds)
                         {
-                            ds.Close();
+                            try
+                            {
+                                ds.Close();
+                            }
+                            catch (Exception exClose)
+                            {
+                                Debug.WriteLine("Received Exception from SqlDataReader.Close() while in another Catch block: " + exClose);
+                            }
                         }
                     }
                     throw;
@@ -2297,7 +2304,14 @@ namespace System.Data.SqlClient
                             _execType = EXECTYPE.PREPAREPENDING; // reset execution type to pending
                         }
 
-                        ds.Close();
+                        try
+                        {
+                            ds.Close();
+                        }
+                        catch(Exception exClose)
+                        {
+                            Debug.WriteLine("Received Exception from SqlDataReader.Close() while in another Catch block: " + exClose);
+                        }
                     }
 
                     throw;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsEnums.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsEnums.cs
@@ -531,6 +531,8 @@ namespace System.Data.SqlClient
 
         public const string DEFAULT_ENGLISH_CODE_PAGE_STRING = "iso_1";
         public const short DEFAULT_ENGLISH_CODE_PAGE_VALUE = 1252;
+        public const short DEFAULT_ENGLISH_LOCALE_ID = 1033;
+        public const string DEFAULT_ENGLISH_LOCALE_NAME = "en-US";
         public const short CHARSET_CODE_PAGE_OFFSET = 2;
         internal const int MAX_SERVERNAME = 255;
 


### PR DESCRIPTION
Bypasses Windows localization references on Linux/OSX by using hardcoded English-US locale constants. Using the Windows localization DLLs on Linux/OSX causes DLL load failure issues.

Once actual localization support is added for Linux/OSX, these workarounds can be removed.

Same DLL load issue as in:
https://github.com/dotnet/corefx/issues/4579

This DLL load issue also caused the problems seen in:
https://github.com/dotnet/corefx/issues/4676
^ The Close() error in the issue 4676 is due to packet data processing issues in a graceful close that was caused by a caught load-DLL exception. Basically, the localization DLL load throws an Exception, and when we catch this exception we try to do some cleanup & close on a DataReader. This throws another exception due to invalid packet data caused by the original DLL exception. Thus the true cause was being masked by this new "connection error" exception in SqlDataReader.Close(). 