### PR TITLE
Remove dead code from System.Data.SqlClient

### DIFF
--- a/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SmiMetaData.cs
+++ b/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SmiMetaData.cs
@@ -10,7 +10,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Data;
 using System.Data.SqlTypes;
-using System.Globalization;
 
 namespace Microsoft.SqlServer.Server
 {
@@ -456,48 +455,6 @@ namespace Microsoft.SqlServer.Server
                 DefaultTime,                   // SqlDbType.Time
                 DefaultDateTime2,              // SqlDbType.DateTime2
                 DefaultDateTimeOffset,         // SqlDbType.DateTimeOffset
-            };
-
-        // static array of type names ordered by corresponding SqlDbType.
-        // NOTE: INDEXED BY SqlDbType ENUM!  MUST UPDATE THIS ARRAY WHEN UPDATING SqlDbType!
-        //   ONLY ACCESS THIS GLOBAL FROM get_TypeName!
-        private static string[] s_typeNameByDatabaseType =
-            {
-                "bigint",               // SqlDbType.BigInt
-                "binary",               // SqlDbType.Binary
-                "bit",                  // SqlDbType.Bit
-                "char",                 // SqlDbType.Char
-                "datetime",             // SqlDbType.DateTime
-                "decimal",              // SqlDbType.Decimal
-                "float",                // SqlDbType.Float
-                "image",                // SqlDbType.Image
-                "int",                  // SqlDbType.Int
-                "money",                // SqlDbType.Money
-                "nchar",                // SqlDbType.NChar
-                "ntext",                // SqlDbType.NText
-                "nvarchar",             // SqlDbType.NVarChar
-                "real",                 // SqlDbType.Real
-                "uniqueidentifier",     // SqlDbType.UniqueIdentifier
-                "smalldatetime",        // SqlDbType.SmallDateTime
-                "smallint",             // SqlDbType.SmallInt
-                "smallmoney",           // SqlDbType.SmallMoney
-                "text",                 // SqlDbType.Text
-                "timestamp",            // SqlDbType.Timestamp
-                "tinyint",              // SqlDbType.TinyInt
-                "varbinary",            // SqlDbType.VarBinary
-                "varchar",              // SqlDbType.VarChar
-                "sql_variant",          // SqlDbType.Variant
-                null,                   // placeholder for 24
-                "xml",                  // SqlDbType.Xml
-                null,                   // placeholder for 26
-                null,                   // placeholder for 27
-                null,                   // placeholder for 28
-                String.Empty,           // SqlDbType.Udt  -- get type name from Type.FullName instead.
-                String.Empty,           // Structured types have user-defined type names.
-                "date",                 // SqlDbType.Date
-                "time",                 // SqlDbType.Time
-                "datetime2",            // SqlDbType.DateTime2
-                "datetimeoffset",       // SqlDbType.DateTimeOffset
             };
 
         // Internal setter to be used by constructors only!  Modifies state!

--- a/src/System.Data.SqlClient/src/System/Data/Common/DbConnectionOptions.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/DbConnectionOptions.cs
@@ -66,14 +66,12 @@ namespace System.Data.Common
             internal const string Integrated_Security = "integrated security";
             internal const string Password = "password";
             internal const string Persist_Security_Info = "persist security info";
-            internal const string User_ID = "user id";
         };
 
         // known connection string common synonyms
         private static class SYNONYM
         {
             internal const string Pwd = "pwd";
-            internal const string UID = "uid";
         };
 
         private readonly string _usersConnectionString;

--- a/src/System.Data.SqlClient/src/System/Data/Sql/SqlMetaData.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Sql/SqlMetaData.cs
@@ -1565,44 +1565,6 @@ namespace Microsoft.SqlServer.Server
             return MaxTimeScale;
         }
 
-        private static DbType[] s_sxm_rgSqlDbTypeToDbType = {
-            DbType.Int64,           // SqlDbType.BigInt
-            DbType.Binary,          // SqlDbType.Binary
-            DbType.Boolean,         // SqlDbType.Bit
-            DbType.AnsiString,      // SqlDbType.Char
-            DbType.DateTime,        // SqlDbType.DateTime
-            DbType.Decimal,         // SqlDbType.Decimal
-            DbType.Double,          // SqlDbType.Float
-            DbType.Binary,          // SqlDbType.Image
-            DbType.Int32,           // SqlDbType.Int
-            DbType.Currency,        // SqlDbType.Money
-            DbType.String,          // SqlDbType.NChar
-            DbType.String,          // SqlDbType.NText
-            DbType.String,          // SqlDbType.NVarChar
-            DbType.Single,          // SqlDbType.Real
-            DbType.Guid,            // SqlDbType.UniqueIdentifier
-            DbType.DateTime,        // SqlDbType.SmallDateTime
-            DbType.Int16,           // SqlDbType.SmallInt
-            DbType.Currency,        // SqlDbType.SmallMoney
-            DbType.AnsiString,      // SqlDbType.Text
-            DbType.Binary,          // SqlDbType.Timestamp
-            DbType.Byte,            // SqlDbType.TinyInt
-            DbType.Binary,          // SqlDbType.VarBinary
-            DbType.AnsiString,      // SqlDbType.VarChar
-            DbType.Object,          // SqlDbType.Variant
-            DbType.Object,          // SqlDbType.Row
-            DbType.Xml,             // SqlDbType.Xml
-            DbType.String,          // SqlDbType.NVarChar, place holder
-            DbType.String,          // SqlDbType.NVarChar, place holder
-            DbType.String,          // SqlDbType.NVarChar, place holder
-            DbType.Object,          // SqlDbType.Udt
-            DbType.Object,          // SqlDbType.Structured
-            DbType.Date,            // SqlDbType.Date
-            DbType.Time,            // SqlDbType.Time
-            DbType.DateTime2,       // SqlDbType.DateTime2
-            DbType.DateTimeOffset   // SqlDbType.DateTimeOffset
-        };
-
         private void SetDefaultsForType(SqlDbType dbType)
         {
             if (SqlDbType.BigInt <= dbType && SqlDbType.DateTimeOffset >= dbType)

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/LocalDBAPI.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/LocalDBAPI.cs
@@ -87,11 +87,6 @@ namespace System.Data
             }
         }
 
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate int LocalDBCreateInstanceDelegate([MarshalAs(UnmanagedType.LPWStr)] string version, [MarshalAs(UnmanagedType.LPWStr)] string instance, UInt32 flags);
-
-
-
         [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Unicode)]
         private delegate int LocalDBFormatMessageDelegate(int hrLocalDB, UInt32 dwFlags, UInt32 dwLanguageId, StringBuilder buffer, ref UInt32 buflen);
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopy.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlBulkCopy.cs
@@ -158,14 +158,6 @@ namespace System.Data.SqlClient
 
     public sealed class SqlBulkCopy : IDisposable
     {
-        private enum TableNameComponents
-        {
-            Server = 0,
-            Catalog,
-            Owner,
-            TableName,
-        }
-
         // Enum for specifying SqlDataReader.Get method used 
         private enum ValueMethod : byte
         {
@@ -198,16 +190,9 @@ namespace System.Data.SqlClient
         // MetaData has n columns but no rows
         // Collation has 4 columns and n rows
 
-        private const int TranCountResultId = 0;
-        private const int TranCountRowId = 0;
-        private const int TranCountValueId = 0;
-
         private const int MetaDataResultId = 1;
 
         private const int CollationResultId = 2;
-        private const int ColIdId = 0;
-        private const int NameId = 1;
-        private const int Tds_CollationId = 2;
         private const int CollationId = 3;
 
         private const int MAX_LENGTH = 0x7FFFFFFF;
@@ -1881,24 +1866,6 @@ namespace System.Data.SqlClient
             {
                 return null;
             }
-        }
-
-        private TaskCompletionSource<object> ContinueTaskPend(Task task, TaskCompletionSource<object> source, Func<TaskCompletionSource<object>> action)
-        {
-            if (task == null)
-            {
-                return action();
-            }
-            else
-            {
-                Debug.Assert(source != null, "source should already be initialized if task is not null");
-                AsyncHelper.ContinueTask(task, source, () =>
-                {
-                    TaskCompletionSource<object> newSource = action();
-                    Debug.Assert(newSource == null, "Shouldn't create a new source when one already exists");
-                });
-            }
-            return null;
         }
 
         // Copies all the rows in a batch

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -286,17 +286,6 @@ namespace System.Data.SqlClient
             }
         }
 
-
-        private SqlInternalConnectionTds InternalTdsConnection
-        {
-            get
-            {
-                return (SqlInternalConnectionTds)_activeConnection.InnerConnection;
-            }
-        }
-
-
-
         internal SqlStatistics Statistics
         {
             get
@@ -1734,72 +1723,6 @@ namespace System.Data.SqlClient
 
             return returnedTask;
         }
-
-        // If the user part is quoted, remove first and last brackets and then unquote any right square
-        // brackets in the procedure.  This is a very simple parser that performs no validation.  As
-        // with the function below, ideally we should have support from the server for this.
-        private static string UnquoteProcedurePart(string part)
-        {
-            if ((null != part) && (2 <= part.Length))
-            {
-                if ('[' == part[0] && ']' == part[part.Length - 1])
-                {
-                    part = part.Substring(1, part.Length - 2); // strip outer '[' & ']'
-                    part = part.Replace("]]", "]"); // undo quoted "]" from "]]" to "]"
-                }
-            }
-            return part;
-        }
-
-        // User value in this format: [server].[database].[schema].[sp_foo];1
-        // This function should only be passed "[sp_foo];1".
-        // This function uses a pretty simple parser that doesn't do any validation.
-        // Ideally, we would have support from the server rather than us having to do this.
-        private static string UnquoteProcedureName(string name, out object groupNumber)
-        {
-            groupNumber = null; // Out param - initialize value to no value.
-            string sproc = name;
-
-            if (null != sproc)
-            {
-                if (Char.IsDigit(sproc[sproc.Length - 1]))
-                { // If last char is a digit, parse.
-                    int semicolon = sproc.LastIndexOf(';');
-                    if (semicolon != -1)
-                    { // If we found a semicolon, obtain the integer.
-                        string part = sproc.Substring(semicolon + 1);
-                        int number = 0;
-                        if (Int32.TryParse(part, out number))
-                        { // No checking, just fail if this doesn't work.
-                            groupNumber = number;
-                            sproc = sproc.Substring(0, semicolon);
-                        }
-                    }
-                }
-                sproc = UnquoteProcedurePart(sproc);
-            }
-            return sproc;
-        }
-
-        //index into indirection arrays for columns of interest to DeriveParameters
-        private enum ProcParamsColIndex
-        {
-            ParameterName = 0,
-            ParameterType,
-            DataType,                  // obsolete in katmai, use ManagedDataType instead
-            ManagedDataType,          // new in katmai
-            CharacterMaximumLength,
-            NumericPrecision,
-            NumericScale,
-            TypeCatalogName,
-            TypeSchemaName,
-            TypeName,
-            XmlSchemaCollectionCatalogName,
-            XmlSchemaCollectionSchemaName,
-            XmlSchemaCollectionName,
-            UdtTypeName,                // obsolete in Katmai.  Holds the actual typename if UDT, since TypeName didn't back then.
-            DateTimeScale               // new in Katmai
-        };
 
         // Yukon- column ordinals (this array indexed by ProcParamsColIndex
         static readonly internal string[] PreKatmaiProcParamsNames = new string[] {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnection.cs
@@ -45,14 +45,6 @@ namespace System.Data.SqlClient
             CacheConnectionStringProperties();
         }
 
-        private SqlConnection(SqlConnection connection)
-        { // Clone
-            GC.SuppressFinalize(this);
-            CopyFrom(connection);
-            _connectionString = connection._connectionString;
-            CacheConnectionStringProperties();
-        }
-
         // This method will be called once connection string is set or changed. 
         private void CacheConnectionStringProperties()
         {
@@ -135,25 +127,6 @@ namespace System.Data.SqlClient
                 _AsyncCommandInProgress = value;
             }
         }
-
-
-        // Does this connection uses Integrated Security?
-        private bool UsesIntegratedSecurity(SqlConnectionString opt)
-        {
-            return opt != null ? opt.IntegratedSecurity : false;
-        }
-
-        // Does this connection uses old style of clear userID or Password in connection string?
-        private bool UsesClearUserIdOrPassword(SqlConnectionString opt)
-        {
-            bool result = false;
-            if (null != opt)
-            {
-                result = (!ADP.IsEmpty(opt.UserID) || !ADP.IsEmpty(opt.Password));
-            }
-            return result;
-        }
-
 
         internal SqlConnectionString.TypeSystem TypeSystem
         {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionFactory.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionFactory.cs
@@ -17,7 +17,6 @@ namespace System.Data.SqlClient
         private SqlConnectionFactory() : base() { }
 
         public static readonly SqlConnectionFactory SingletonInstance = new SqlConnectionFactory();
-        private const string _metaDataXml = "MetaDataXml";
 
         override public DbProviderFactory ProviderFactory
         {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionHelper.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionHelper.cs
@@ -29,22 +29,6 @@ namespace System.Data.SqlClient
             _innerConnection = DbConnectionClosedNeverOpened.SingletonInstance;
         }
 
-        private void CopyFrom(SqlConnection connection)
-        {
-            ADP.CheckArgumentNull(connection, "connection");
-            _userConnectionOptions = connection.UserConnectionOptions;
-            _poolGroup = connection.PoolGroup;
-
-            if (DbConnectionClosedNeverOpened.SingletonInstance == connection._innerConnection)
-            {
-                _innerConnection = DbConnectionClosedNeverOpened.SingletonInstance;
-            }
-            else
-            {
-                _innerConnection = DbConnectionClosedPreviouslyOpened.SingletonInstance;
-            }
-        }
-
         internal int CloseCount
         {
             get
@@ -75,13 +59,6 @@ namespace System.Data.SqlClient
             bool hidePassword = InnerConnection.ShouldHidePassword;
             DbConnectionOptions connectionOptions = UserConnectionOptions;
             return ((null != connectionOptions) ? connectionOptions.UsersConnectionString(hidePassword) : "");
-        }
-
-        private void ConnectionString_Set(string value)
-        {
-            DbConnectionPoolKey key = new DbConnectionPoolKey(value);
-
-            ConnectionString_Set(key);
         }
 
         private void ConnectionString_Set(DbConnectionPoolKey key)

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionString.cs
@@ -431,30 +431,6 @@ namespace System.Data.SqlClient
 
         internal TypeSystem TypeSystemVersion { get { return _typeSystemVersion; } }
 
-        private static bool CompareHostName(ref string host, string name, bool fixup)
-        {
-            // same computer name or same computer name + "\named instance"
-            bool equal = false;
-
-            if (host.Equals(name, StringComparison.OrdinalIgnoreCase))
-            {
-                if (fixup)
-                {
-                    host = ".";
-                }
-                equal = true;
-            }
-            else if (host.StartsWith(name + @"\", StringComparison.OrdinalIgnoreCase))
-            {
-                if (fixup)
-                {
-                    host = "." + host.Substring(name.Length);
-                }
-                equal = true;
-            }
-            return equal;
-        }
-
         // this hashtable is meant to be read-only translation of parsed string
         // keywords/synonyms to a known keyword string
         internal static Hashtable GetParseSynonyms()

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlSequentialTextReader.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlSequentialTextReader.cs
@@ -433,15 +433,6 @@ namespace System.Data.SqlClient
         }
 
         /// <summary>
-        /// True if there is data left to read
-        /// </summary>
-        /// <returns></returns>
-        private bool IsDataLeft
-        {
-            get { return ((_leftOverBytes != null) || (_reader.ColumnDataBytesRemaining() > 0)); }
-        }
-
-        /// <summary>
         /// True if there is a peeked character available
         /// </summary>
         private bool HasPeekedChar

--- a/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLBytes.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLBytes.cs
@@ -494,17 +494,6 @@ namespace System.Data.SqlTypes
             return _state == SqlBytesCharsState.Stream;
         }
 
-        private void SetBuffer(byte[] buffer)
-        {
-            m_rgbBuf = buffer;
-            _lCurLen = (m_rgbBuf == null) ? x_lNull : (long)m_rgbBuf.Length;
-            m_stream = null;
-            _state = (m_rgbBuf == null) ? SqlBytesCharsState.Null : SqlBytesCharsState.Buffer;
-
-            AssertValid();
-        }
-
-
         // --------------------------------------------------------------
         //	  Static fields, properties
         // --------------------------------------------------------------

--- a/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLChars.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLChars.cs
@@ -490,17 +490,6 @@ namespace System.Data.SqlTypes
             AssertValid();
         }
 
-        private void SetBuffer(char[] buffer)
-        {
-            m_rgchBuf = buffer;
-            _lCurLen = (m_rgchBuf == null) ? x_lNull : (long)m_rgchBuf.Length;
-            m_stream = null;
-            _state = (m_rgchBuf == null) ? SqlBytesCharsState.Null : SqlBytesCharsState.Buffer;
-
-            AssertValid();
-        }
-
-
         // --------------------------------------------------------------
         //	  Static fields, properties
         // --------------------------------------------------------------


### PR DESCRIPTION
Remove unused private fields, properties, constructors, methods, and nested types.