### PR TITLE
Add extra exception catching in FinishExecuteReader

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlCommand.cs
@@ -2259,7 +2259,14 @@ namespace System.Data.SqlClient
 
                         if (null != ds)
                         {
-                            ds.Close();
+                            try
+                            {
+                                ds.Close();
+                            }
+                            catch(Exception exClose)
+                            {
+                                Debug.WriteLine("Received this exception from SqlDataReader.Close() while in another catch block: " + exClose.ToString());
+                            }
                         }
                     }
                     throw;
@@ -2297,7 +2304,14 @@ namespace System.Data.SqlClient
                             _execType = EXECTYPE.PREPAREPENDING; // reset execution type to pending
                         }
 
-                        ds.Close();
+                        try
+                        {
+                            ds.Close();
+                        }
+                        catch (Exception exClose)
+                        {
+                            Debug.WriteLine("Received this exception from SqlDataReader.Close() while in another catch block: " + exClose.ToString());
+                        }
                     }
 
                     throw;


### PR DESCRIPTION
Adds extra exception catching in FinishExecuteReader, so that additional exceptions in catch blocks don't hide the original exceptions.

This fix is necessary because an exception from SqlDataReader.Close() in a catch block masked a unable-to-load-DLL exception which actually caused the Close() exception in the first place.

Original SqlDataReader.Close() issue: https://github.com/dotnet/corefx/issues/4676

Overarching localization DLL issue: https://github.com/dotnet/corefx/issues/4579