### PR TITLE
Make unit tests async to work with 1 thread

### DIFF
--- a/src/System.IO.FileSystem/tests/FileStream/SafeFileHandle.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/SafeFileHandle.cs
@@ -5,6 +5,7 @@ using Microsoft.Win32.SafeHandles;
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.IO.Tests
@@ -58,7 +59,7 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        public void ThrowWhenHandlePositionIsChanged()
+        public async Task ThrowWhenHandlePositionIsChanged()
         {
             string fileName = GetTestFilePath();
 
@@ -98,7 +99,7 @@ namespace System.IO.Tests
                     }
                     else
                     {
-                        Assert.ThrowsAsync<IOException>(() => fs.ReadAsync(new byte[1], 0, 1)).Wait();
+                        await Assert.ThrowsAsync<IOException>(() => fs.ReadAsync(new byte[1], 0, 1));
                     }
 
                     fs.WriteByte(0);

--- a/src/System.Net.Utilities/tests/FunctionalTests/UnixPingUtilityTests.cs
+++ b/src/System.Net.Utilities/tests/FunctionalTests/UnixPingUtilityTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Net.Sockets;
+using System.Threading.Tasks;
 
 using Xunit;
 
@@ -18,9 +19,9 @@ namespace System.Net.NetworkInformation.Tests
         [InlineData(50)]
         [InlineData(1000)]
         [PlatformSpecific(PlatformID.AnyUnix)]
-        public static void PacketSizeIsRespected(int payloadSize)
+        public static async Task PacketSizeIsRespected(int payloadSize)
         {
-            IPAddress localAddress = TestSettings.GetLocalIPAddress().Result;
+            IPAddress localAddress = await TestSettings.GetLocalIPAddress();
             bool ipv4 = localAddress.AddressFamily == AddressFamily.InterNetwork;
             string arguments = UnixCommandLinePing.ConstructCommandLine(payloadSize, localAddress.ToString(), ipv4);
             string utilityPath = (localAddress.AddressFamily == AddressFamily.InterNetwork)


### PR DESCRIPTION
Currently, the tests System.IO.Tests.FileStream_SafeFileHandle.
ThrowWhenHandlePositionIsChanged and System.Net.NetworkInformation.
Tests.UnixPingUtilityTests.PacketSizeIsRespected hang when running on a
Unix machine with 1 thread.  Making the tests async fixes this issue.

cc: @stephentoub @ericstj @mellinoe 