### PR TITLE
CurlHandler Fix for request uri during redirect

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -608,6 +608,7 @@ namespace System.Net.Http
                     // set cookies again
                     state.SetCookieOption(forwardUri);
                 }
+                state._requestMessage.RequestUri = forwardUri;
             }
 
             // set the headers again. This is a workaround for libcurl's limitation in handling headers with empty values

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -287,6 +287,23 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [Fact]
+        public async Task GetAsync_AllowAutoRedirectTrue_RedirectToUriWithParams_RequestMsgUriSet()
+        {
+            var handler = new HttpClientHandler();
+            handler.AllowAutoRedirect = true;
+            Uri targetUri = HttpTestServers.BasicAuthUriForCreds(false, Username, Password);
+            using (var client = new HttpClient(handler))
+            {
+                Uri uri = HttpTestServers.RedirectUriForDestinationUri(false, targetUri, 1);
+                _output.WriteLine("Uri: {0}", uri);
+                using (HttpResponseMessage response = await client.GetAsync(uri))
+                {
+                    Assert.Equal(targetUri, response.RequestMessage.RequestUri);
+                }
+            }
+        }
+
         [Theory]
         [InlineData(6)]
         public async Task GetAsync_MaxAutomaticRedirectionsNServerHopsNPlus1_Throw(int hops)


### PR DESCRIPTION
CurlHandler is fixed to set the Response.RequestMessage.RequestUri to
the redirected uri.

Fixes #4945 