### PR TITLE
Fix WinHttpHandler response handling for manual cookie parsing

### DIFF
--- a/src/Common/src/Interop/Windows/winhttp/Interop.winhttp.cs
+++ b/src/Common/src/Interop/Windows/winhttp/Interop.winhttp.cs
@@ -134,6 +134,16 @@ internal partial class Interop
             SafeWinHttpHandle requestHandle,
             uint infoLevel,
             string name,
+            [Out] StringBuilder buffer,
+            ref uint bufferLength,
+            ref uint index);
+
+        [DllImport(Interop.Libraries.WinHttp, CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool WinHttpQueryHeaders(
+            SafeWinHttpHandle requestHandle,
+            uint infoLevel,
+            string name,
             ref uint number,
             ref uint bufferLength,
             IntPtr index);

--- a/src/Common/src/Interop/Windows/winhttp/Interop.winhttp_types.cs
+++ b/src/Common/src/Interop/Windows/winhttp/Interop.winhttp_types.cs
@@ -70,6 +70,7 @@ internal partial class Interop
         public const uint WINHTTP_QUERY_RAW_HEADERS = 21;
         public const uint WINHTTP_QUERY_RAW_HEADERS_CRLF = 22;
         public const uint WINHTTP_QUERY_CONTENT_ENCODING = 29;
+        public const uint WINHTTP_QUERY_SET_COOKIE = 43;
         public const uint WINHTTP_QUERY_CUSTOM = 65535;
         public const string WINHTTP_HEADER_NAME_BY_INDEX = null;
         public const byte[] WINHTTP_NO_OUTPUT_BUFFER = null;

--- a/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
+++ b/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
@@ -23,6 +23,7 @@
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpAuthHelper.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpCertificateHelper.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpChannelBinding.cs" />
+    <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpCookieContainerAdapter.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpHandler.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpRequestCallback.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpRequestState.cs" />

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCookieContainerAdapter.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpCookieContainerAdapter.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+using SafeWinHttpHandle = Interop.WinHttp.SafeWinHttpHandle;
+
+namespace System.Net.Http
+{
+    internal static class WinHttpCookieContainerAdapter
+    {
+        private const string CookieHeaderNameWithColon = "Cookie" + ":";
+
+        public static void AddResponseCookiesToContainer(WinHttpRequestState state)
+        {
+            HttpRequestMessage request = state.RequestMessage;
+            SafeWinHttpHandle requestHandle = state.RequestHandle;
+            CookieContainer cookieContainer = state.Handler.CookieContainer;
+            
+            Debug.Assert(state.Handler.CookieUsePolicy == CookieUsePolicy.UseSpecifiedCookieContainer);
+            Debug.Assert(cookieContainer != null);
+
+            // Get 'Set-Cookie' headers from response.
+            List<string> cookieHeaders =
+                WinHttpResponseParser.GetResponseHeaders(requestHandle, Interop.WinHttp.WINHTTP_QUERY_SET_COOKIE);
+            WinHttpTraceHelper.Trace("WINHTTP_QUERY_SET_COOKIE");
+            
+            foreach (string cookieHeader in cookieHeaders)
+            {
+                WinHttpTraceHelper.Trace(cookieHeader);
+                try
+                {
+                    cookieContainer.SetCookies(request.RequestUri, cookieHeader);
+                    WinHttpTraceHelper.Trace(cookieHeader);
+                }
+                catch (CookieException)
+                {
+                    // We ignore malformed cookies in the response.
+                    WinHttpTraceHelper.Trace("Ignoring invalid cookie: {0}", cookieHeader);
+                }
+            }            
+        }
+        
+        public static void ResetCookieRequestHeaders(WinHttpRequestState state, Uri redirectUri)
+        {
+            SafeWinHttpHandle requestHandle = state.RequestHandle;
+            
+            Debug.Assert(state.Handler.CookieUsePolicy == CookieUsePolicy.UseSpecifiedCookieContainer);
+            
+            // Clear cookies.
+            if (!Interop.WinHttp.WinHttpAddRequestHeaders(
+                requestHandle,
+                CookieHeaderNameWithColon,
+                (uint)CookieHeaderNameWithColon.Length,
+                Interop.WinHttp.WINHTTP_ADDREQ_FLAG_REPLACE))
+            {
+                int lastError = Marshal.GetLastWin32Error();
+                if (lastError != Interop.WinHttp.ERROR_WINHTTP_HEADER_NOT_FOUND)
+                {
+                    throw WinHttpException.CreateExceptionUsingError(lastError);
+                }
+            }
+
+            // Re-add cookies. The GetCookieHeader() method will return the correct set of
+            // cookies based on the redirectUri.
+            string cookieHeader = GetCookieHeader(redirectUri, state.Handler.CookieContainer);
+            if (!string.IsNullOrEmpty(cookieHeader))
+            {
+                if (!Interop.WinHttp.WinHttpAddRequestHeaders(
+                    requestHandle,
+                    cookieHeader,
+                    (uint)cookieHeader.Length,
+                    Interop.WinHttp.WINHTTP_ADDREQ_FLAG_ADD))
+                {
+                    WinHttpException.ThrowExceptionUsingLastError();
+                }
+            }
+        }
+        
+        public static string GetCookieHeader(Uri uri, CookieContainer cookies)
+        {
+            string cookieHeader = null;
+
+            Debug.Assert(cookies != null);
+
+            string cookieValues = cookies.GetCookieHeader(uri);
+            if (!string.IsNullOrEmpty(cookieValues))
+            {
+                cookieHeader = CookieHeaderNameWithColon + " " + cookieValues;                
+            }
+
+            return cookieHeader;
+        }        
+    }
+}

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
@@ -43,6 +43,16 @@ namespace System.Net.Http
             Debug.WriteLine(message);
         }
 
+        public static void Trace(string format, object arg0)
+        {
+            if (!IsTraceEnabled())
+            {
+                return;
+            }
+            
+            Debug.WriteLine(format, arg0);
+        }
+
         public static void Trace(string format, object arg0, object arg1, object arg2)
         {
             if (!IsTraceEnabled())

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeInterop.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/FakeInterop.cs
@@ -259,10 +259,16 @@ internal static partial class Interop
             uint infoLevel, string name,
             StringBuilder buffer,
             ref uint bufferLength,
-            IntPtr index)
+            ref uint index)
         {
             string httpVersion = "HTTP/1.1";
             string statusText = "OK";
+
+            if (infoLevel == Interop.WinHttp.WINHTTP_QUERY_SET_COOKIE)
+            {
+                TestControl.LastWin32Error = (int)Interop.WinHttp.ERROR_WINHTTP_HEADER_NOT_FOUND;
+                return false;
+            }
 
             if (infoLevel == Interop.WinHttp.WINHTTP_QUERY_VERSION)
             {

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
@@ -65,6 +65,9 @@
     <Compile Include="..\..\src\System\Net\Http\WinHttpChannelBinding.cs">
       <Link>ProductionCode\WinHttpChannelBinding.cs</Link>
     </Compile>
+    <Compile Include="..\..\src\System\Net\Http\WinHttpCookieContainerAdapter.cs">
+      <Link>ProductionCode\WinHttpCookieContainerAdapter.cs</Link>
+    </Compile>
     <Compile Include="..\..\src\System\Net\Http\WinHttpHandler.cs">
       <Link>ProductionCode\WinHttpHandler.cs</Link>
     </Compile>

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -34,8 +34,14 @@ namespace System.Net.Http.Functional.Tests
         public readonly static object[][] HeaderValueAndUris = {
             new object[] { "X-CustomHeader", "x-value", HttpTestServers.RemoteEchoServer },
             new object[] { "X-Cust-Header-NoValue", "" , HttpTestServers.RemoteEchoServer },
-            new object[] { "X-CustomHeader", "x-value", HttpTestServers.RedirectUriForDestinationUri(false, HttpTestServers.RemoteEchoServer, -1) },
-            new object[] { "X-Cust-Header-NoValue", "" , HttpTestServers.RedirectUriForDestinationUri(false, HttpTestServers.RemoteEchoServer, -1) },
+            new object[] { "X-CustomHeader", "x-value", HttpTestServers.RedirectUriForDestinationUri(
+                secure:false,
+                destinationUri:HttpTestServers.RemoteEchoServer,
+                hops:1) },
+            new object[] { "X-Cust-Header-NoValue", "" , HttpTestServers.RedirectUriForDestinationUri(
+                secure:false,
+                destinationUri:HttpTestServers.RemoteEchoServer,
+                hops:1) },
         };
         public readonly static object[][] Http2Servers = HttpTestServers.Http2Servers;
 
@@ -202,7 +208,7 @@ namespace System.Net.Http.Functional.Tests
             handler.Credentials = _credential;
             using (var client = new HttpClient(handler))
             {
-                Uri uri = HttpTestServers.BasicAuthUriForCreds(false, Username, Password);
+                Uri uri = HttpTestServers.BasicAuthUriForCreds(secure:false, userName:Username, password:Password);
                 using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
                     Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -215,7 +221,7 @@ namespace System.Net.Http.Functional.Tests
         {
             using (var client = new HttpClient())
             {
-                Uri uri = HttpTestServers.BasicAuthUriForCreds(false, Username, Password);
+                Uri uri = HttpTestServers.BasicAuthUriForCreds(secure:false, userName:Username, password:Password);
                 using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
                     Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
@@ -230,7 +236,10 @@ namespace System.Net.Http.Functional.Tests
             handler.AllowAutoRedirect = false;
             using (var client = new HttpClient(handler))
             {
-                Uri uri = HttpTestServers.RedirectUriForDestinationUri(false, HttpTestServers.RemoteEchoServer, 1);
+                Uri uri = HttpTestServers.RedirectUriForDestinationUri(
+                    secure:false,
+                    destinationUri:HttpTestServers.RemoteEchoServer,
+                    hops:1);
                 _output.WriteLine("Uri: {0}", uri);
                 using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
@@ -246,7 +255,10 @@ namespace System.Net.Http.Functional.Tests
             handler.AllowAutoRedirect = true;
             using (var client = new HttpClient(handler))
             {
-                Uri uri = HttpTestServers.RedirectUriForDestinationUri(false, HttpTestServers.RemoteEchoServer, 1);
+                Uri uri = HttpTestServers.RedirectUriForDestinationUri(
+                    secure:false,
+                    destinationUri:HttpTestServers.RemoteEchoServer,
+                    hops:1);
                 _output.WriteLine("Uri: {0}", uri);
                 using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
@@ -262,7 +274,10 @@ namespace System.Net.Http.Functional.Tests
             handler.AllowAutoRedirect = true;
             using (var client = new HttpClient(handler))
             {
-                Uri uri = HttpTestServers.RedirectUriForDestinationUri(false, HttpTestServers.SecureRemoteEchoServer, 1);
+                Uri uri = HttpTestServers.RedirectUriForDestinationUri(
+                    secure:false,
+                    destinationUri:HttpTestServers.SecureRemoteEchoServer,
+                    hops:1);
                 _output.WriteLine("Uri: {0}", uri);
                 using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
@@ -278,7 +293,10 @@ namespace System.Net.Http.Functional.Tests
             handler.AllowAutoRedirect = true;
             using (var client = new HttpClient(handler))
             {
-                Uri uri = HttpTestServers.RedirectUriForDestinationUri(true, HttpTestServers.RemoteEchoServer, 1);
+                Uri uri = HttpTestServers.RedirectUriForDestinationUri(
+                    secure:true,
+                    destinationUri:HttpTestServers.RemoteEchoServer,
+                    hops:1);
                 _output.WriteLine("Uri: {0}", uri);
                 using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
@@ -292,10 +310,10 @@ namespace System.Net.Http.Functional.Tests
         {
             var handler = new HttpClientHandler();
             handler.AllowAutoRedirect = true;
-            Uri targetUri = HttpTestServers.BasicAuthUriForCreds(false, Username, Password);
+            Uri targetUri = HttpTestServers.BasicAuthUriForCreds(secure:false, userName:Username, password:Password);
             using (var client = new HttpClient(handler))
             {
-                Uri uri = HttpTestServers.RedirectUriForDestinationUri(false, targetUri, 1);
+                Uri uri = HttpTestServers.RedirectUriForDestinationUri(secure:false, destinationUri:targetUri, hops:1);
                 _output.WriteLine("Uri: {0}", uri);
                 using (HttpResponseMessage response = await client.GetAsync(uri))
                 {
@@ -314,9 +332,9 @@ namespace System.Net.Http.Functional.Tests
             {
                 await Assert.ThrowsAsync<HttpRequestException>(() => 
                     client.GetAsync(HttpTestServers.RedirectUriForDestinationUri(
-                        false,
-                        HttpTestServers.RemoteEchoServer,
-                        hops + 1)));
+                        secure:false,
+                        destinationUri:HttpTestServers.RemoteEchoServer,
+                        hops:(hops + 1))));
             }
         }
 
@@ -327,7 +345,7 @@ namespace System.Net.Http.Functional.Tests
             handler.Credentials = _credential;
             using (var client = new HttpClient(handler))
             {
-                Uri redirectUri = HttpTestServers.RedirectUriForCreds(false, Username, Password);
+                Uri redirectUri = HttpTestServers.RedirectUriForCreds(secure:false, userName:Username, password:Password);
                 using (HttpResponseMessage unAuthResponse = await client.GetAsync(redirectUri))
                 {
                     Assert.Equal(HttpStatusCode.Unauthorized, unAuthResponse.StatusCode);
@@ -338,8 +356,8 @@ namespace System.Net.Http.Functional.Tests
         [Fact]
         public async Task GetAsync_CredentialIsCredentialCacheUriRedirect_StatusCodeOK()
         {
-            Uri uri = HttpTestServers.BasicAuthUriForCreds(false, Username, Password);
-            Uri redirectUri = HttpTestServers.RedirectUriForCreds(false, Username, Password);
+            Uri uri = HttpTestServers.BasicAuthUriForCreds(secure:false, userName:Username, password:Password);
+            Uri redirectUri = HttpTestServers.RedirectUriForCreds(secure:false, userName:Username, password:Password);
             _output.WriteLine(uri.AbsoluteUri);
             _output.WriteLine(redirectUri.AbsoluteUri);
             var credentialCache = new CredentialCache();
@@ -371,12 +389,12 @@ namespace System.Net.Http.Functional.Tests
         }
 
         [Theory]
-        [InlineData("cookiename", "cookievalue")]
-        public async Task GetAsync_SetCookieContainer_CookieSent(string name, string value)
+        [InlineData("cookieName1", "cookieValue1")]
+        public async Task GetAsync_SetCookieContainer_CookieSent(string cookieName, string cookieValue)
         {
             var handler = new HttpClientHandler();
             var cookieContainer = new CookieContainer();
-            cookieContainer.Add(HttpTestServers.RemoteEchoServer, new Cookie(name, value));
+            cookieContainer.Add(HttpTestServers.RemoteEchoServer, new Cookie(cookieName, cookieValue));
             handler.CookieContainer = cookieContainer;
             using (var client = new HttpClient(handler))
             {
@@ -385,9 +403,32 @@ namespace System.Net.Http.Functional.Tests
                     Assert.Equal(HttpStatusCode.OK, httpResponse.StatusCode);
                     string responseText = await httpResponse.Content.ReadAsStringAsync();
                     _output.WriteLine(responseText);
-                    Assert.True(TestHelper.JsonMessageContainsKeyValue(responseText, "Cookie", name + "=" + value));
+                    Assert.True(TestHelper.JsonMessageContainsKeyValue(responseText, cookieName, cookieValue));
                 }
             }
+        }
+
+        [ActiveIssue(4960, PlatformID.AnyUnix)]
+        [Theory]
+        [InlineData("cookieName1", "cookieValue1")]
+        public async Task GetAsync_RedirectResponseHasCookie_CookieSentToFinalUri(string cookieName, string cookieValue)
+        {
+            Uri uri = HttpTestServers.RedirectUriForDestinationUri(
+                secure:false,
+                destinationUri:HttpTestServers.RemoteEchoServer,
+                hops:1);
+            using (HttpClient client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.Add(
+                    "X-SetCookie",
+                    string.Format("{0}={1};Path=/", cookieName, cookieValue));
+                using (HttpResponseMessage httpResponse = await client.GetAsync(uri))
+                {
+                    string responseText = await httpResponse.Content.ReadAsStringAsync();
+                    _output.WriteLine(responseText);
+                    Assert.True(TestHelper.JsonMessageContainsKeyValue(responseText, cookieName, cookieValue));
+                }
+            }            
         }
 
         [Theory, MemberData("HeaderValueAndUris")]


### PR DESCRIPTION
WinHttpHandler was losing 'Set-Cookie' response headers during auto redirection handling when the handler was in 'manual cookie' mode. I.e. `CookieUsePolicy.UseSpecifiedCookieContainer`. This is the only mode that HttpClientHandler uses.

The 'Set-Cookie' headers were currently only parsed out when a final HTTP response happened. This meant that 'Set-Cookie' headers present in interim 3xx redirection responses as well as interim 401, 407 auth responses would not be stored into the CookieContainer. Hence, those same cookies could not be sent back to the server when needed.

The fix is to make sure we parse out the 'Set-Cookie' headers whenever we get an HTTP response back from WinHTTP. As part of this fix, I re-factored out the cookie handling code into a separate class. I also added specific WinHttpHandler tests for the two different cookie modes as well as a HttpClientHandler test to validate cross-platform (i.e. CurlHandler).

Fixes #4960