### PR TITLE
Update Http and WebSocket test servers

### DIFF
--- a/src/Common/tests/System/Net/HttpTestServers.cs
+++ b/src/Common/tests/System/Net/HttpTestServers.cs
@@ -7,7 +7,7 @@ namespace System.Net.Tests
 {
     internal class HttpTestServers
     {
-        public const string Host = "corefx-networking.azurewebsites.net";
+        public const string Host = "corefx-net.azurewebsites.net";
         public const string Http2Host = "http2.akamai.com";
 
         private const string HttpScheme = "http";

--- a/src/Common/tests/System/Net/WebSocketTestServers.cs
+++ b/src/Common/tests/System/Net/WebSocketTestServers.cs
@@ -5,7 +5,7 @@ namespace System.Net.Tests
 {
     internal class WebSocketTestServers
     {
-        public const string Host = "corefx-networking.azurewebsites.net";
+        public const string Host = "corefx-net.azurewebsites.net";
 
         private const string EchoHandler = "WebSocket/EchoWebSocket.ashx";
         private const string EchoHeadersHandler = "WebSocket/EchoWebSocketHeaders.ashx";


### PR DESCRIPTION
Switch to a different (more scalable) Azure-based test server for Http
and WebSocket.tests.