### PR TITLE
Get Unix file stats with LStat (instead of Stat)

### DIFF
--- a/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
+++ b/src/System.IO.FileSystem/src/System/IO/FileSystemInfo.Unix.cs
@@ -228,7 +228,9 @@ namespace System.IO
         {
             // This should not throw, instead we store the result so that we can throw it
             // when someone actually accesses a property.
-            int result = Interop.Sys.Stat(FullPath, out _fileStatus);
+            // Use LStat (rather than Stat) so that information about a symbolic link will be retrieved
+            // (rather than information about the target) if FullPath points to a symbolic link.
+            int result = Interop.Sys.LStat(FullPath, out _fileStatus);
             if (result >= 0)
             {
                 _fileStatusInitialized = 0;

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -43,6 +43,7 @@ namespace System.IO
             }
 
             // Now copy over relevant read/write/execute permissions from the source to the destination
+            // Use Stat (not LStat) since permissions for symbolic links are meaninless and defer to permissions on the target
             Interop.Sys.FileStatus status;
             Interop.CheckIo(Interop.Sys.Stat(sourceFullPath, out status), sourceFullPath);
             int newMode = status.Mode & (int)Interop.Sys.Permissions.Mask;

--- a/src/System.IO.FileSystem/tests/FileInfo/Exists.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Exists.cs
@@ -79,5 +79,36 @@ namespace System.IO.Tests
             FileInfo di = new FileInfo(fileName);
             Assert.False(di.Exists);
         }
+
+        // In some cases (such as when running without elevated privileges,
+        // the symbolic link may fail to create. Only run this test if it creates
+        // links successfully.
+        [ConditionalFact("CanCreateSymbolicLinks")]
+        public void SymLinksExistIndependentlyOfTarget()
+        {
+            var path = GetTestFilePath();
+            var linkPath = GetTestFilePath();
+            File.Create(path).Dispose();
+            Assert.True(MountHelper.CreateSymbolicLink(linkPath, path));
+            File.Delete(path);
+
+            var info = new FileInfo(path);
+            var linkInfo = new FileInfo(linkPath);
+            Assert.True(linkInfo.Exists);
+            Assert.False(info.Exists);
+        }
+
+        private static bool CanCreateSymbolicLinks
+        {
+            get
+            {
+                var path = Path.GetTempFileName();
+                var linkPath = path + ".link";
+                var ret = MountHelper.CreateSymbolicLink(linkPath, path);
+                try { File.Delete(path); } catch { }
+                try { File.Delete(linkPath); } catch { }
+                return ret;
+            }
+        }
     }
 }

--- a/src/System.IO.FileSystem/tests/PortedCommon/ReparsePointUtilities.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/ReparsePointUtilities.cs
@@ -28,6 +28,32 @@ public static class MountHelper
     [DllImport("api-ms-win-core-file-l1-1-0.dll", EntryPoint = "DeleteVolumeMountPointW", CharSet = CharSet.Unicode, BestFitMapping = false, SetLastError = true)]
     private static extern bool DeleteVolumeMountPoint(String mountPoint);
 
+    /// <summary>Creates a symbolic link using command line tools</summary>
+    /// <param name="linkPath">The existing file</param>
+    /// <param name="targetPath"></param>
+    public static bool CreateSymbolicLink(string linkPath, string targetPath)
+    {
+        Process symLinkProcess = null;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            symLinkProcess = Process.Start("cmd", string.Format("/c mklink \"{0}\" \"{1}\"", linkPath, targetPath));
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            symLinkProcess = Process.Start("ln", string.Format("-s \"{0}\" \"{1}\"", targetPath, linkPath));
+        }
+
+        if (symLinkProcess != null)
+        {
+            symLinkProcess.WaitForExit();
+            return (0 == symLinkProcess.ExitCode);
+        }
+        else
+        {
+            return false;
+        }
+    }
+
     public static void Mount(String volumeName, String mountPoint)
     {
 

--- a/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
+++ b/src/System.IO.FileSystem/tests/System.IO.FileSystem.Tests.csproj
@@ -164,6 +164,9 @@
     <Compile Include="$(CommonTestPath)\System\IO\FileCleanupTestBase.cs">
       <Link>Common\System\IO\FileCleanupTestBase.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\IO\TempFile.cs">
+      <Link>Common\System\IO\TempFile.cs</Link>
+    </Compile>
     <!-- Performance Tests -->
     <Compile Include="Performance\Perf.Directory.cs" />
     <Compile Include="Performance\Perf.File.cs" />

--- a/src/System.IO.FileSystem/tests/project.json
+++ b/src/System.IO.FileSystem/tests/project.json
@@ -4,6 +4,7 @@
     "System.Collections": "4.0.10",
     "System.Console": "4.0.0-rc2-23610",
     "System.Diagnostics.Debug": "4.0.10",
+    "System.Diagnostics.Process": "4.0.0",
     "System.Globalization": "4.0.10",
     "System.IO": "4.0.10",
     "System.IO.FileSystem.Primitives": "4.0.0",


### PR DESCRIPTION
Stat was ignoring symbolic links (and getting stats for the target
instead) which caused checks for whether or not a path was a sym link
to fail on Unix.

Fixes dotnet/corefx#5015