### PR TITLE
Use ordinal when checking for hex prefix

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BaseNumberConverter.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/BaseNumberConverter.cs
@@ -87,10 +87,8 @@ namespace System.ComponentModel
                     {
                         return this.FromString(text.Substring(1), 16);
                     }
-                    else if (this.AllowHex && text.StartsWith("0x")
-                             || text.StartsWith("0X")
-                             || text.StartsWith("&h")
-                             || text.StartsWith("&H"))
+                    else if (this.AllowHex && text.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
+                             || text.StartsWith("&h", StringComparison.OrdinalIgnoreCase))
                     {
                         return this.FromString(text.Substring(2), 16);
                     }


### PR DESCRIPTION
In general lingustic comparsion is slower than ordinal comparision.
When using ICU for globalization, the lingustic StartsWith code path
actually ends up doing a lot of work inside ICU itself. While we'll try
to make things better (see dotnet/corefx#3672) for common cases like
ASCII only, if code doesn't need ligustic comparision the best practice
is to not request it.

BaseNumberConverter was using a lingustic StartsWith to detect a hex
prefix when trying to parse a number but it is better served by just
always using ordinal comparisons.

This results in a ~35% QPS improvement in some very barebones ASP.NET
scenarios (like the one outlined in richardkiene/CoreCLRWebAPISample) on
my local machine.