### PR TITLE
Fix race condition in SslStream authentication

### DIFF
--- a/src/System.Net.Security/src/Resources/Strings.resx
+++ b/src/System.Net.Security/src/Resources/Strings.resx
@@ -141,9 +141,6 @@
   <data name="net_io_invalidnestedcall" xml:space="preserve">
     <value> The {0} method cannot be called when another {1} operation is pending.</value>
   </data>
-  <data name="net_io_invalidendcall" xml:space="preserve">
-    <value>{0} can only be called once for each asynchronous operation.</value>
-  </data>
   <data name="net_io_must_be_rw_stream" xml:space="preserve">
     <value>The stream has to be read/write.</value>
   </data>

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslState.cs
@@ -705,10 +705,7 @@ namespace System.Net.Security
                 throw new ArgumentException(SR.Format(SR.net_io_async_result, result.GetType().FullName), "asyncResult");
             }
 
-            if (Interlocked.Exchange(ref _nestedAuth, 0) == 0)
-            {
-                throw new InvalidOperationException(SR.Format(SR.net_io_invalidendcall, "EndAuthenticate"));
-            }
+            _nestedAuth = 0;
 
             InternalEndProcessAuthentication(lazyResult);
 


### PR DESCRIPTION
This fixes the race condition we were seeing in test case execution .For which the issue is #4317 .
the basic cause for it was -  _nestedAuth  was getting set at 2 places still at the later stage it was checking if its not already checked , but there can be cases where (due to the delay in the execution of another threads) at both the places it sets  _nestedAuth   to 0 and hence results into the unwanted exception. 
Refer issue #4317 for more details.