### PR TITLE
Fix solution files for renamed projects

### DIFF
--- a/src/System.Diagnostics.Tools/System.Diagnostics.Tools.sln
+++ b/src/System.Diagnostics.Tools/System.Diagnostics.Tools.sln
@@ -1,28 +1,59 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.Tools.CoreCLR", "src\System.Diagnostics.Tools.CoreCLR.csproj", "{0B68298B-4672-4CA0-AD25-2F9ABEA1FF95}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.Tools", "src\System.Diagnostics.Tools.csproj", "{0B68298B-4672-4CA0-AD25-2F9ABEA1FF95}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{74DB0932-BB18-480B-8E83-FC32621BA1CA}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{BB4B2F40-98F9-4014-B749-74811673191D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{CC045EA3-4BAA-4D03-9FA7-25349DF444B9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.Tools", "ref\System.Diagnostics.Tools.csproj", "{E54D3E59-911A-415D-BDBA-6C1DC0F37DC4}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Diagnostics.Tools.Tests", "tests\System.Diagnostics.Tools.Tests.csproj", "{41BF89E4-8C67-45A6-8044-13009E363220}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		net46_Debug|Any CPU = net46_Debug|Any CPU
+		net46_Release|Any CPU = net46_Release|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{0B68298B-4672-4CA0-AD25-2F9ABEA1FF95}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0B68298B-4672-4CA0-AD25-2F9ABEA1FF95}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0B68298B-4672-4CA0-AD25-2F9ABEA1FF95}.net46_Debug|Any CPU.ActiveCfg = net46_Debug|Any CPU
+		{0B68298B-4672-4CA0-AD25-2F9ABEA1FF95}.net46_Debug|Any CPU.Build.0 = net46_Debug|Any CPU
+		{0B68298B-4672-4CA0-AD25-2F9ABEA1FF95}.net46_Release|Any CPU.ActiveCfg = net46_Release|Any CPU
+		{0B68298B-4672-4CA0-AD25-2F9ABEA1FF95}.net46_Release|Any CPU.Build.0 = net46_Release|Any CPU
 		{0B68298B-4672-4CA0-AD25-2F9ABEA1FF95}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0B68298B-4672-4CA0-AD25-2F9ABEA1FF95}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E54D3E59-911A-415D-BDBA-6C1DC0F37DC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E54D3E59-911A-415D-BDBA-6C1DC0F37DC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E54D3E59-911A-415D-BDBA-6C1DC0F37DC4}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E54D3E59-911A-415D-BDBA-6C1DC0F37DC4}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E54D3E59-911A-415D-BDBA-6C1DC0F37DC4}.net46_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{E54D3E59-911A-415D-BDBA-6C1DC0F37DC4}.net46_Release|Any CPU.Build.0 = Debug|Any CPU
+		{E54D3E59-911A-415D-BDBA-6C1DC0F37DC4}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{E54D3E59-911A-415D-BDBA-6C1DC0F37DC4}.Release|Any CPU.Build.0 = Debug|Any CPU
 		{41BF89E4-8C67-45A6-8044-13009E363220}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{41BF89E4-8C67-45A6-8044-13009E363220}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{41BF89E4-8C67-45A6-8044-13009E363220}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{41BF89E4-8C67-45A6-8044-13009E363220}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{41BF89E4-8C67-45A6-8044-13009E363220}.net46_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{41BF89E4-8C67-45A6-8044-13009E363220}.net46_Release|Any CPU.Build.0 = Release|Any CPU
 		{41BF89E4-8C67-45A6-8044-13009E363220}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{41BF89E4-8C67-45A6-8044-13009E363220}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{0B68298B-4672-4CA0-AD25-2F9ABEA1FF95} = {74DB0932-BB18-480B-8E83-FC32621BA1CA}
+		{E54D3E59-911A-415D-BDBA-6C1DC0F37DC4} = {BB4B2F40-98F9-4014-B749-74811673191D}
+		{41BF89E4-8C67-45A6-8044-13009E363220} = {CC045EA3-4BAA-4D03-9FA7-25349DF444B9}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Diagnostics.Tools/src/project.json
+++ b/src/System.Diagnostics.Tools/src/project.json
@@ -7,7 +7,7 @@
     },
     "net46":{
       "dependencies": {
-        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0-rc2-23530",
+        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0",
       }
     }
   }

--- a/src/System.Runtime.Extensions/System.Runtime.Extensions.sln
+++ b/src/System.Runtime.Extensions/System.Runtime.Extensions.sln
@@ -1,44 +1,38 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.Extensions", "src\System.Runtime.Extensions.csproj", "{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{1962877E-782F-499B-8468-F0F2A0692E96}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{4253F45C-FA2F-4743-9FC8-20666C416A68}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{8C66E70A-65C3-443E-A23A-18A1C12972B0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.Extensions", "ref\System.Runtime.Extensions.csproj", "{E73B023E-609E-4281-866A-3AECB1AB5D48}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.Extensions.Tests", "tests\System.Runtime.Extensions.Tests.csproj", "{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}"
-EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{1CA59CB2-FE88-4510-92AC-3561026C3B13}"
-	ProjectSection(SolutionItems) = preProject
-		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
-	EndProjectSection
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.Extensions.CoreCLR", "src\System.Runtime.Extensions.CoreCLR.csproj", "{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
 		FreeBSD_Debug|Any CPU = FreeBSD_Debug|Any CPU
 		FreeBSD_Release|Any CPU = FreeBSD_Release|Any CPU
 		Linux_Debug|Any CPU = Linux_Debug|Any CPU
 		Linux_Release|Any CPU = Linux_Release|Any CPU
+		net46_Debug|Any CPU = net46_Debug|Any CPU
+		net46_Release|Any CPU = net46_Release|Any CPU
 		OSX_Debug|Any CPU = OSX_Debug|Any CPU
 		OSX_Release|Any CPU = OSX_Release|Any CPU
+		Release|Any CPU = Release|Any CPU
 		Windows_Debug|Any CPU = Windows_Debug|Any CPU
 		Windows_Release|Any CPU = Windows_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.FreeBSD_Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.FreeBSD_Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.FreeBSD_Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.FreeBSD_Release|Any CPU.Build.0 = Release|Any CPU
-		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Linux_Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Linux_Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Linux_Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Linux_Release|Any CPU.Build.0 = Release|Any CPU
-		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.OSX_Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.OSX_Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.OSX_Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.OSX_Release|Any CPU.Build.0 = Release|Any CPU
-		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Windows_Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Windows_Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Windows_Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Windows_Release|Any CPU.Build.0 = Release|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.Debug|Any CPU.ActiveCfg = net46_Debug|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.Debug|Any CPU.Build.0 = net46_Debug|Any CPU
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.FreeBSD_Debug|Any CPU.ActiveCfg = FreeBSD_Debug|Any CPU
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.FreeBSD_Debug|Any CPU.Build.0 = FreeBSD_Debug|Any CPU
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.FreeBSD_Release|Any CPU.ActiveCfg = FreeBSD_Release|Any CPU
@@ -47,16 +41,75 @@ Global
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.Linux_Debug|Any CPU.Build.0 = Linux_Debug|Any CPU
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.Linux_Release|Any CPU.ActiveCfg = Linux_Release|Any CPU
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.Linux_Release|Any CPU.Build.0 = Linux_Release|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.net46_Debug|Any CPU.ActiveCfg = net46_Debug|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.net46_Debug|Any CPU.Build.0 = net46_Debug|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.net46_Release|Any CPU.ActiveCfg = net46_Release|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.net46_Release|Any CPU.Build.0 = net46_Release|Any CPU
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.OSX_Debug|Any CPU.ActiveCfg = OSX_Debug|Any CPU
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.OSX_Debug|Any CPU.Build.0 = OSX_Debug|Any CPU
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.OSX_Release|Any CPU.ActiveCfg = OSX_Release|Any CPU
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.OSX_Release|Any CPU.Build.0 = OSX_Release|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.Release|Any CPU.ActiveCfg = net46_Release|Any CPU
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.Release|Any CPU.Build.0 = net46_Release|Any CPU
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
 		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.FreeBSD_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.FreeBSD_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.FreeBSD_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.FreeBSD_Release|Any CPU.Build.0 = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.Linux_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.Linux_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.Linux_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.Linux_Release|Any CPU.Build.0 = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.net46_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.net46_Release|Any CPU.Build.0 = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.OSX_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.OSX_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.OSX_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.OSX_Release|Any CPU.Build.0 = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.Windows_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.Windows_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.Windows_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{E73B023E-609E-4281-866A-3AECB1AB5D48}.Windows_Release|Any CPU.Build.0 = Debug|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.FreeBSD_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.FreeBSD_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.FreeBSD_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.FreeBSD_Release|Any CPU.Build.0 = Release|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Linux_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Linux_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Linux_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Linux_Release|Any CPU.Build.0 = Release|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.net46_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.net46_Release|Any CPU.Build.0 = Release|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.OSX_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.OSX_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.OSX_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.OSX_Release|Any CPU.Build.0 = Release|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Windows_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Windows_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Windows_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9}.Windows_Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A} = {1962877E-782F-499B-8468-F0F2A0692E96}
+		{E73B023E-609E-4281-866A-3AECB1AB5D48} = {8C66E70A-65C3-443E-A23A-18A1C12972B0}
+		{6C314C9B-3D28-4B05-9B4C-B57A00A9B3B9} = {4253F45C-FA2F-4743-9FC8-20666C416A68}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Runtime.Extensions/src/project.json
+++ b/src/System.Runtime.Extensions/src/project.json
@@ -7,7 +7,7 @@
     },
     "net46":{
       "dependencies": {
-            "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0-rc2-23530"
+            "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0"
       }
     }
   }

--- a/src/System.Runtime.InteropServices/System.Runtime.InteropServices.sln
+++ b/src/System.Runtime.InteropServices/System.Runtime.InteropServices.sln
@@ -1,9 +1,17 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.InteropServices.CoreCLR", "src\System.Runtime.InteropServices.CoreCLR.csproj", "{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.InteropServices", "src\System.Runtime.InteropServices.csproj", "{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{BF085DA4-C0E8-463E-B0FC-4C01822E6162}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{B754B947-C1E1-4FFE-B03B-CEAC451913DC}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{E8CF0B11-55CA-408D-A489-5727F3ED6A17}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.InteropServices", "ref\System.Runtime.InteropServices.csproj", "{B17014F1-D902-417F-89B0-271204695831}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.InteropServices.Tests", "tests\System.Runtime.InteropServices.Tests.csproj", "{A824F4CD-935B-4496-A1B2-C3664936DA7B}"
 EndProject
@@ -12,6 +20,10 @@ Global
 		Debug|Any CPU = Debug|Any CPU
 		Linux_Debug|Any CPU = Linux_Debug|Any CPU
 		Linux_Release|Any CPU = Linux_Release|Any CPU
+		net46_Debug|Any CPU = net46_Debug|Any CPU
+		net46_Release|Any CPU = net46_Release|Any CPU
+		netcore50aot_Debug|Any CPU = netcore50aot_Debug|Any CPU
+		netcore50aot_Release|Any CPU = netcore50aot_Release|Any CPU
 		OSX_Debug|Any CPU = OSX_Debug|Any CPU
 		OSX_Release|Any CPU = OSX_Release|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -19,28 +31,68 @@ Global
 		Windows_Release|Any CPU = Windows_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
-		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.Debug|Any CPU.ActiveCfg = net46_Debug|Any CPU
+		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.Debug|Any CPU.Build.0 = net46_Debug|Any CPU
 		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.Linux_Debug|Any CPU.ActiveCfg = Linux_Debug|Any CPU
 		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.Linux_Debug|Any CPU.Build.0 = Linux_Debug|Any CPU
 		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.Linux_Release|Any CPU.ActiveCfg = Linux_Release|Any CPU
 		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.Linux_Release|Any CPU.Build.0 = Linux_Release|Any CPU
+		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.net46_Debug|Any CPU.ActiveCfg = net46_Debug|Any CPU
+		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.net46_Debug|Any CPU.Build.0 = net46_Debug|Any CPU
+		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.net46_Release|Any CPU.ActiveCfg = net46_Release|Any CPU
+		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.net46_Release|Any CPU.Build.0 = net46_Release|Any CPU
+		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.netcore50aot_Debug|Any CPU.ActiveCfg = netcore50aot_Debug|Any CPU
+		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.netcore50aot_Debug|Any CPU.Build.0 = netcore50aot_Debug|Any CPU
+		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.netcore50aot_Release|Any CPU.ActiveCfg = netcore50aot_Release|Any CPU
+		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.netcore50aot_Release|Any CPU.Build.0 = netcore50aot_Release|Any CPU
 		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.OSX_Debug|Any CPU.ActiveCfg = OSX_Debug|Any CPU
 		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.OSX_Debug|Any CPU.Build.0 = OSX_Debug|Any CPU
 		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.OSX_Release|Any CPU.ActiveCfg = OSX_Release|Any CPU
 		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.OSX_Release|Any CPU.Build.0 = OSX_Release|Any CPU
-		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
-		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.Release|Any CPU.ActiveCfg = net46_Release|Any CPU
+		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.Release|Any CPU.Build.0 = net46_Release|Any CPU
 		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
 		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
 		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
 		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.Linux_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.Linux_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.Linux_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.Linux_Release|Any CPU.Build.0 = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.net46_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.net46_Release|Any CPU.Build.0 = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.netcore50aot_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.netcore50aot_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.netcore50aot_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.netcore50aot_Release|Any CPU.Build.0 = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.OSX_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.OSX_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.OSX_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.OSX_Release|Any CPU.Build.0 = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.Windows_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.Windows_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.Windows_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{B17014F1-D902-417F-89B0-271204695831}.Windows_Release|Any CPU.Build.0 = Debug|Any CPU
 		{A824F4CD-935B-4496-A1B2-C3664936DA7B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A824F4CD-935B-4496-A1B2-C3664936DA7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A824F4CD-935B-4496-A1B2-C3664936DA7B}.Linux_Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A824F4CD-935B-4496-A1B2-C3664936DA7B}.Linux_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A824F4CD-935B-4496-A1B2-C3664936DA7B}.Linux_Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A824F4CD-935B-4496-A1B2-C3664936DA7B}.Linux_Release|Any CPU.Build.0 = Release|Any CPU
+		{A824F4CD-935B-4496-A1B2-C3664936DA7B}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A824F4CD-935B-4496-A1B2-C3664936DA7B}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A824F4CD-935B-4496-A1B2-C3664936DA7B}.net46_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A824F4CD-935B-4496-A1B2-C3664936DA7B}.net46_Release|Any CPU.Build.0 = Release|Any CPU
+		{A824F4CD-935B-4496-A1B2-C3664936DA7B}.netcore50aot_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A824F4CD-935B-4496-A1B2-C3664936DA7B}.netcore50aot_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A824F4CD-935B-4496-A1B2-C3664936DA7B}.netcore50aot_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A824F4CD-935B-4496-A1B2-C3664936DA7B}.netcore50aot_Release|Any CPU.Build.0 = Release|Any CPU
 		{A824F4CD-935B-4496-A1B2-C3664936DA7B}.OSX_Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A824F4CD-935B-4496-A1B2-C3664936DA7B}.OSX_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A824F4CD-935B-4496-A1B2-C3664936DA7B}.OSX_Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -54,5 +106,10 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE} = {BF085DA4-C0E8-463E-B0FC-4C01822E6162}
+		{B17014F1-D902-417F-89B0-271204695831} = {E8CF0B11-55CA-408D-A489-5727F3ED6A17}
+		{A824F4CD-935B-4496-A1B2-C3664936DA7B} = {B754B947-C1E1-4FFE-B03B-CEAC451913DC}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Runtime.InteropServices/src/project.json
+++ b/src/System.Runtime.InteropServices/src/project.json
@@ -12,7 +12,7 @@
     },
     "net46":{
       "dependencies": {
-            "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0-rc2-23530"
+            "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0"
       }
     }
   }

--- a/src/System.Threading/System.Threading.sln
+++ b/src/System.Threading/System.Threading.sln
@@ -1,28 +1,73 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Threading.CoreCLR", "src\System.Threading.CoreCLR.csproj", "{604027F5-1DFC-42F4-B4FE-61F8789BA647}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Threading", "src\System.Threading.csproj", "{604027F5-1DFC-42F4-B4FE-61F8789BA647}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{CABF1020-B981-4D9C-AB79-409123D746CC}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{91A9BE2D-F9A5-4C5C-8F12-C34F34967BA8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{49386B8A-1FEC-4FFD-8565-E7372925961C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Threading", "ref\System.Threading.csproj", "{E74C2D00-5541-4FF8-B44E-5C605AFDB07E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Threading.Tests", "tests\System.Threading.Tests.csproj", "{33F5A50E-B823-4FDD-8571-365C909ACEAE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		net46_Debug|Any CPU = net46_Debug|Any CPU
+		net46_Release|Any CPU = net46_Release|Any CPU
+		netcore50aot_Debug|Any CPU = netcore50aot_Debug|Any CPU
+		netcore50aot_Release|Any CPU = netcore50aot_Release|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{604027F5-1DFC-42F4-B4FE-61F8789BA647}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
-		{604027F5-1DFC-42F4-B4FE-61F8789BA647}.Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
-		{604027F5-1DFC-42F4-B4FE-61F8789BA647}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
-		{604027F5-1DFC-42F4-B4FE-61F8789BA647}.Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{604027F5-1DFC-42F4-B4FE-61F8789BA647}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{604027F5-1DFC-42F4-B4FE-61F8789BA647}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{604027F5-1DFC-42F4-B4FE-61F8789BA647}.net46_Debug|Any CPU.ActiveCfg = net46_Debug|Any CPU
+		{604027F5-1DFC-42F4-B4FE-61F8789BA647}.net46_Debug|Any CPU.Build.0 = net46_Debug|Any CPU
+		{604027F5-1DFC-42F4-B4FE-61F8789BA647}.net46_Release|Any CPU.ActiveCfg = net46_Release|Any CPU
+		{604027F5-1DFC-42F4-B4FE-61F8789BA647}.net46_Release|Any CPU.Build.0 = net46_Release|Any CPU
+		{604027F5-1DFC-42F4-B4FE-61F8789BA647}.netcore50aot_Debug|Any CPU.ActiveCfg = netcore50aot_Debug|Any CPU
+		{604027F5-1DFC-42F4-B4FE-61F8789BA647}.netcore50aot_Debug|Any CPU.Build.0 = netcore50aot_Debug|Any CPU
+		{604027F5-1DFC-42F4-B4FE-61F8789BA647}.netcore50aot_Release|Any CPU.ActiveCfg = netcore50aot_Release|Any CPU
+		{604027F5-1DFC-42F4-B4FE-61F8789BA647}.netcore50aot_Release|Any CPU.Build.0 = netcore50aot_Release|Any CPU
+		{604027F5-1DFC-42F4-B4FE-61F8789BA647}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{604027F5-1DFC-42F4-B4FE-61F8789BA647}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E74C2D00-5541-4FF8-B44E-5C605AFDB07E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E74C2D00-5541-4FF8-B44E-5C605AFDB07E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E74C2D00-5541-4FF8-B44E-5C605AFDB07E}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E74C2D00-5541-4FF8-B44E-5C605AFDB07E}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E74C2D00-5541-4FF8-B44E-5C605AFDB07E}.net46_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{E74C2D00-5541-4FF8-B44E-5C605AFDB07E}.net46_Release|Any CPU.Build.0 = Debug|Any CPU
+		{E74C2D00-5541-4FF8-B44E-5C605AFDB07E}.netcore50aot_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E74C2D00-5541-4FF8-B44E-5C605AFDB07E}.netcore50aot_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E74C2D00-5541-4FF8-B44E-5C605AFDB07E}.netcore50aot_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{E74C2D00-5541-4FF8-B44E-5C605AFDB07E}.netcore50aot_Release|Any CPU.Build.0 = Debug|Any CPU
+		{E74C2D00-5541-4FF8-B44E-5C605AFDB07E}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{E74C2D00-5541-4FF8-B44E-5C605AFDB07E}.Release|Any CPU.Build.0 = Debug|Any CPU
 		{33F5A50E-B823-4FDD-8571-365C909ACEAE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{33F5A50E-B823-4FDD-8571-365C909ACEAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33F5A50E-B823-4FDD-8571-365C909ACEAE}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33F5A50E-B823-4FDD-8571-365C909ACEAE}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33F5A50E-B823-4FDD-8571-365C909ACEAE}.net46_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33F5A50E-B823-4FDD-8571-365C909ACEAE}.net46_Release|Any CPU.Build.0 = Release|Any CPU
+		{33F5A50E-B823-4FDD-8571-365C909ACEAE}.netcore50aot_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{33F5A50E-B823-4FDD-8571-365C909ACEAE}.netcore50aot_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{33F5A50E-B823-4FDD-8571-365C909ACEAE}.netcore50aot_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{33F5A50E-B823-4FDD-8571-365C909ACEAE}.netcore50aot_Release|Any CPU.Build.0 = Release|Any CPU
 		{33F5A50E-B823-4FDD-8571-365C909ACEAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{33F5A50E-B823-4FDD-8571-365C909ACEAE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{604027F5-1DFC-42F4-B4FE-61F8789BA647} = {91A9BE2D-F9A5-4C5C-8F12-C34F34967BA8}
+		{E74C2D00-5541-4FF8-B44E-5C605AFDB07E} = {CABF1020-B981-4D9C-AB79-409123D746CC}
+		{33F5A50E-B823-4FDD-8571-365C909ACEAE} = {49386B8A-1FEC-4FFD-8565-E7372925961C}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Threading/src/project.json
+++ b/src/System.Threading/src/project.json
@@ -12,7 +12,7 @@
     },
     "net46":{
       "dependencies": {
-            "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0-rc2-23530"
+            "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0"
       }
     }
   }


### PR DESCRIPTION
I've just re-generated these solution files completely, so they also include the new configuration groups which were added along with the renames. As I was changing this, I also moved some projects to the stable version of the .NET 4.6 targeting pack NuGet package.