### PR TITLE
Port .NET Native version of System.Collections

### DIFF
--- a/src/Common/src/System/Collections/Generic/LowLevelComparer.cs
+++ b/src/Common/src/System/Collections/Generic/LowLevelComparer.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+// LowLevelComparer<T> emulates the desktop type System.Collections.Generic.Comparer<T>
+//
+
+using System;
+using System.Collections;
+
+namespace System.Collections.Generic
+{
+    internal sealed class LowLevelComparer<T> : IComparer<T>
+    {
+        internal static IComparer<T> Default
+        {
+            get
+            {
+                if (_default == null)
+                    _default = CreateComparer();
+                return _default;
+            }
+        }
+
+        private LowLevelComparer()
+        {
+        }
+
+        public int Compare(T x, T y)
+        {
+            return DefaultCompareImpl(x, y);
+        }
+
+        //
+        // Implements both Comparer<T>.Default.Compare(x,y) and LowLevelComparer<T>.Default.Compare(x,y)
+        //
+        // FxOverRh port notes:
+        //
+        // - Compat note:
+        //
+        //   If T does not implement IComparable<> but the specific instance (x or y) does, we behave differently
+        //   from the desktop:
+        //
+        //      - We do the comparison using IComparable<>.
+        //      - The desktop does the comparison using IComparable, or throws if at least one of x and y does not implement IComparable.
+        //
+        //   This is a consequence of the fact that the desktop only exploits IComparable<> if T implements IComparable<>.
+        //   We have no way to perform this check using Win8P's reduced Type surface area. Thus, we check the instance object for IComparable<> instead.
+        //
+        //
+        // - Nullables
+        //
+        //   Currently, Comparer<Nullable<T>> is broken due to the fact that the special rules for boxing Nullables are implemented yet.
+        //   Once that's fixed, this code should work correctly,
+        //
+        internal static int DefaultCompareImpl(T x, T y)
+        {
+            // Desktop compat note: If either x or y are null, this api must not invoke either IComparable.Compare or IComparable<T>.Compare on either
+            // x or y.
+            if (x == null)
+            {
+                if (y == null)
+                    return 0;
+                else
+                    return -1;
+            }
+            if (y == null)
+                return 1;
+
+            IComparable<T> igcx = x as IComparable<T>;
+            if (igcx != null)
+                return igcx.CompareTo(y);
+            IComparable<T> igcy = y as IComparable<T>;
+            if (igcy != null)
+                return -igcy.CompareTo(x);
+
+            return LowLevelComparer.Default.Compare(x, y);
+        }
+
+        private static IComparer<T> CreateComparer()
+        {
+            // NUTC compiler optimization see comments in EqualityComparer.cs
+            if (typeof(T) == typeof(Int32))
+                return (IComparer<T>)(Object)(new LowLevelInt32Comparer());
+
+            return new LowLevelComparer<T>();
+        }
+
+        private static IComparer<T> _default;
+    }
+
+    internal class LowLevelInt32Comparer : IComparer<Int32>
+    {
+        public int Compare(Int32 x, Int32 y)
+        {
+            if (x < y)
+                return -1;
+            else if (x > y)
+                return 1;
+            else
+                return 0;
+        }
+    }
+}

--- a/src/Common/src/System/Collections/LowLevelComparer.cs
+++ b/src/Common/src/System/Collections/LowLevelComparer.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+//
+// LowLevelComparer emulates the desktop type System.Collections.Comparer.
+//
+// This type is not part of the Win8P surface area but it is used by some code inside System.Private.CoreLib as well as the
+// the implementation of Comparer<T> in System.Collections.
+//
+//
+
+using System;
+using System.Globalization;
+using System.Diagnostics;
+
+namespace System.Collections
+{
+    internal sealed class LowLevelComparer : IComparer
+    {
+        internal static readonly LowLevelComparer Default = new LowLevelComparer();
+
+        private LowLevelComparer()
+        {
+        }
+
+        public int Compare(Object a, Object b)
+        {
+            if (a == b) return 0;
+            if (a == null) return -1;
+            if (b == null) return 1;
+
+            IComparable ia = a as IComparable;
+            if (ia != null)
+                return ia.CompareTo(b);
+
+            IComparable ib = b as IComparable;
+            if (ib != null)
+                return -ib.CompareTo(a);
+
+            throw new ArgumentException(SR.Argument_ImplementIComparable);
+        }
+    }
+}

--- a/src/System.Collections/System.Collections.sln
+++ b/src/System.Collections/System.Collections.sln
@@ -1,32 +1,73 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Collections.Tests", "tests\System.Collections.Tests.csproj", "{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Collections", "src\System.Collections.csproj", "{D5FF747F-7A0B-9003-885A-FE9A63E755E5}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{23EC0B36-E211-4825-8636-8BB5A52BAC5A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{1562AFFA-2EB8-4650-AF30-655C038FC045}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{9F7AB953-32ED-44FC-98FD-2DE78A567EB9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Collections", "ref\System.Collections.csproj", "{62E1C77D-E8C7-46F5-9499-8AC302F533A6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Collections.Tests", "tests\System.Collections.Tests.csproj", "{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		net46_Debug|Any CPU = net46_Debug|Any CPU
+		net46_Release|Any CPU = net46_Release|Any CPU
+		netcore50_Debug|Any CPU = netcore50_Debug|Any CPU
+		netcore50_Release|Any CPU = netcore50_Release|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BE8ED8C1-C314-4C4E-A929-64C9C8B3552A}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.net46_Debug|Any CPU.ActiveCfg = net46_Debug|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.net46_Debug|Any CPU.Build.0 = net46_Debug|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.net46_Release|Any CPU.ActiveCfg = net46_Release|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.net46_Release|Any CPU.Build.0 = net46_Release|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.netcore50_Debug|Any CPU.ActiveCfg = netcore50_Debug|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.netcore50_Debug|Any CPU.Build.0 = netcore50_Debug|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.netcore50_Release|Any CPU.ActiveCfg = netcore50_Release|Any CPU
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.netcore50_Release|Any CPU.Build.0 = netcore50_Release|Any CPU
 		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D5FF747F-7A0B-9003-885A-FE9A63E755E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.net46_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.net46_Release|Any CPU.Build.0 = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.netcore50_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.netcore50_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.netcore50_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.netcore50_Release|Any CPU.Build.0 = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.net46_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.net46_Release|Any CPU.Build.0 = Release|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.netcore50_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.netcore50_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.netcore50_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.netcore50_Release|Any CPU.Build.0 = Release|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{D5FF747F-7A0B-9003-885A-FE9A63E755E5} = {23EC0B36-E211-4825-8636-8BB5A52BAC5A}
+		{62E1C77D-E8C7-46F5-9499-8AC302F533A6} = {1562AFFA-2EB8-4650-AF30-655C038FC045}
+		{9574CEEC-5554-411B-B44C-6CA9EC1CEB08} = {9F7AB953-32ED-44FC-98FD-2DE78A567EB9}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Collections/src/System.Collections.builds
+++ b/src/System.Collections/src/System.Collections.builds
@@ -8,6 +8,9 @@
     <Project Include="System.Collections.csproj" Condition="'$(TargetsWindows)' == 'true'">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
     </Project>
+    <Project Include="System.Collections.csproj" Condition="'$(TargetsWindows)' == 'true'">
+      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Collections/src/System.Collections.csproj
+++ b/src/System.Collections/src/System.Collections.csproj
@@ -16,7 +16,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
-  <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+  <ItemGroup Condition="'$(TargetGroup)' == ''">
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj">
       <Name>System.Runtime</Name>
     </ProjectReference>
@@ -24,11 +26,6 @@
       <Project>{E7E8DE8A-9EC1-46A8-A6EE-727DB32DBEB8}</Project>
       <Name>System.Diagnostics.Debug</Name>
     </ProjectReference>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
-    <TargetingPackReference Include="mscorlib" />
-    <TargetingPackReference Include="System" />
-    <TargetingPackReference Include="System.Core" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
     <Compile Include="System\Collections\Generic\BitHelper.cs" />
@@ -44,13 +41,32 @@
     <Compile Include="System\Collections\Generic\Stack.cs" />
     <Compile Include="System\Collections\Generic\StackDebugView.cs" />
     <Compile Include="System\Collections\StructuralComparisons.cs" />
-    <!-- Common -->
+    <!-- Shared Common -->
     <Compile Include="$(CommonPath)\System\Collections\HashHelpers.cs">
       <Link>Common\System\Collections\HashHelpers.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Collections\Generic\EnumerableHelpers.cs">
       <Link>Common\System\Collections\Generic\EnumerableHelpers.cs</Link>
     </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcore50'">
+    <Compile Include="System\Collections\BitArray.cs" />
+    <Compile Include="System\Collections\Generic\Comparer.cs" />
+    <Compile Include="System\Collections\Generic\Dictionary.cs" />
+    <Compile Include="System\Collections\Generic\EqualityComparer.cs" />
+    <Compile Include="System\Collections\Generic\List.cs" />
+    <!-- .NET Native Common -->
+    <Compile Include="$(CommonPath)\System\Collections\LowLevelComparer.cs">
+      <Link>Common\System\Collections\LowLevelComparer.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Collections\Generic\LowLevelComparer.cs">
+      <Link>Common\System\Collections\Generic\LowLevelComparer.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
+    <TargetingPackReference Include="mscorlib" />
+    <TargetingPackReference Include="System" />
+    <TargetingPackReference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Collections/src/System/Collections/BitArray.cs
+++ b/src/System.Collections/src/System/Collections/BitArray.cs
@@ -1,0 +1,546 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.Contracts;
+
+namespace System.Collections
+{
+    // A vector of bits.  Use this to store bits efficiently, without having to do bit 
+    // shifting yourself.
+    [System.Runtime.InteropServices.ComVisible(true)]
+    public sealed class BitArray : ICollection
+    {
+        private BitArray()
+        {
+        }
+
+        /*=========================================================================
+        ** Allocates space to hold length bit values. All of the values in the bit
+        ** array are set to false.
+        **
+        ** Exceptions: ArgumentException if length < 0.
+        =========================================================================*/
+        public BitArray(int length)
+            : this(length, false)
+        {
+        }
+
+        /*=========================================================================
+        ** Allocates space to hold length bit values. All of the values in the bit
+        ** array are set to defaultValue.
+        **
+        ** Exceptions: ArgumentOutOfRangeException if length < 0.
+        =========================================================================*/
+        public BitArray(int length, bool defaultValue)
+        {
+            if (length < 0)
+            {
+                throw new ArgumentOutOfRangeException("length", SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+            Contract.EndContractBlock();
+
+            m_array = new int[GetArrayLength(length, BitsPerInt32)];
+            m_length = length;
+
+            int fillValue = defaultValue ? unchecked(((int)0xffffffff)) : 0;
+            for (int i = 0; i < m_array.Length; i++)
+            {
+                m_array[i] = fillValue;
+            }
+
+            _version = 0;
+        }
+
+        /*=========================================================================
+        ** Allocates space to hold the bit values in bytes. bytes[0] represents
+        ** bits 0 - 7, bytes[1] represents bits 8 - 15, etc. The LSB of each byte
+        ** represents the lowest index value; bytes[0] & 1 represents bit 0,
+        ** bytes[0] & 2 represents bit 1, bytes[0] & 4 represents bit 2, etc.
+        **
+        ** Exceptions: ArgumentException if bytes == null.
+        =========================================================================*/
+        public BitArray(byte[] bytes)
+        {
+            if (bytes == null)
+            {
+                throw new ArgumentNullException("bytes");
+            }
+            Contract.EndContractBlock();
+            // this value is chosen to prevent overflow when computing m_length.
+            // m_length is of type int32 and is exposed as a property, so 
+            // type of m_length can't be changed to accommodate.
+            if (bytes.Length > Int32.MaxValue / BitsPerByte)
+            {
+                throw new ArgumentException(SR.Format(SR.Argument_ArrayTooLarge, BitsPerByte), "bytes");
+            }
+
+            m_array = new int[GetArrayLength(bytes.Length, BytesPerInt32)];
+            m_length = bytes.Length * BitsPerByte;
+
+            int i = 0;
+            int j = 0;
+            while (bytes.Length - j >= 4)
+            {
+                m_array[i++] = (bytes[j] & 0xff) |
+                              ((bytes[j + 1] & 0xff) << 8) |
+                              ((bytes[j + 2] & 0xff) << 16) |
+                              ((bytes[j + 3] & 0xff) << 24);
+                j += 4;
+            }
+
+            Contract.Assert(bytes.Length - j >= 0, "BitArray byteLength problem");
+            Contract.Assert(bytes.Length - j < 4, "BitArray byteLength problem #2");
+
+            switch (bytes.Length - j)
+            {
+                case 3:
+                    m_array[i] = ((bytes[j + 2] & 0xff) << 16);
+                    goto case 2;
+                // fall through
+                case 2:
+                    m_array[i] |= ((bytes[j + 1] & 0xff) << 8);
+                    goto case 1;
+                // fall through
+                case 1:
+                    m_array[i] |= (bytes[j] & 0xff);
+                    break;
+            }
+
+            _version = 0;
+        }
+
+        public BitArray(bool[] values)
+        {
+            if (values == null)
+            {
+                throw new ArgumentNullException("values");
+            }
+            Contract.EndContractBlock();
+
+            m_array = new int[GetArrayLength(values.Length, BitsPerInt32)];
+            m_length = values.Length;
+
+            for (int i = 0; i < values.Length; i++)
+            {
+                if (values[i])
+                    m_array[i / 32] |= (1 << (i % 32));
+            }
+
+            _version = 0;
+        }
+
+        /*=========================================================================
+        ** Allocates space to hold the bit values in values. values[0] represents
+        ** bits 0 - 31, values[1] represents bits 32 - 63, etc. The LSB of each
+        ** integer represents the lowest index value; values[0] & 1 represents bit
+        ** 0, values[0] & 2 represents bit 1, values[0] & 4 represents bit 2, etc.
+        **
+        ** Exceptions: ArgumentException if values == null.
+        =========================================================================*/
+        public BitArray(int[] values)
+        {
+            if (values == null)
+            {
+                throw new ArgumentNullException("values");
+            }
+            Contract.EndContractBlock();
+            // this value is chosen to prevent overflow when computing m_length
+            if (values.Length > Int32.MaxValue / BitsPerInt32)
+            {
+                throw new ArgumentException(SR.Format(SR.Argument_ArrayTooLarge, BitsPerInt32), "values");
+            }
+
+            m_array = new int[values.Length];
+            Array.Copy(values, 0, m_array, 0, values.Length);
+            m_length = values.Length * BitsPerInt32;
+
+            _version = 0;
+        }
+
+        /*=========================================================================
+        ** Allocates a new BitArray with the same length and bit values as bits.
+        **
+        ** Exceptions: ArgumentException if bits == null.
+        =========================================================================*/
+        public BitArray(BitArray bits)
+        {
+            if (bits == null)
+            {
+                throw new ArgumentNullException("bits");
+            }
+            Contract.EndContractBlock();
+
+            int arrayLength = GetArrayLength(bits.m_length, BitsPerInt32);
+
+            m_array = new int[arrayLength];
+            Array.Copy(bits.m_array, 0, m_array, 0, arrayLength);
+            m_length = bits.m_length;
+
+            _version = bits._version;
+        }
+
+        public bool this[int index]
+        {
+            get
+            {
+                return Get(index);
+            }
+            set
+            {
+                Set(index, value);
+            }
+        }
+
+        /*=========================================================================
+        ** Returns the bit value at position index.
+        **
+        ** Exceptions: ArgumentOutOfRangeException if index < 0 or
+        **             index >= GetLength().
+        =========================================================================*/
+        public bool Get(int index)
+        {
+            if (index < 0 || index >= Length)
+            {
+                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+            }
+            Contract.EndContractBlock();
+
+            return (m_array[index / 32] & (1 << (index % 32))) != 0;
+        }
+
+        /*=========================================================================
+        ** Sets the bit value at position index to value.
+        **
+        ** Exceptions: ArgumentOutOfRangeException if index < 0 or
+        **             index >= GetLength().
+        =========================================================================*/
+        public void Set(int index, bool value)
+        {
+            if (index < 0 || index >= Length)
+            {
+                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+            }
+            Contract.EndContractBlock();
+
+            if (value)
+            {
+                m_array[index / 32] |= (1 << (index % 32));
+            }
+            else
+            {
+                m_array[index / 32] &= ~(1 << (index % 32));
+            }
+
+            _version++;
+        }
+
+        /*=========================================================================
+        ** Sets all the bit values to value.
+        =========================================================================*/
+        public void SetAll(bool value)
+        {
+            int fillValue = value ? unchecked(((int)0xffffffff)) : 0;
+            int ints = GetArrayLength(m_length, BitsPerInt32);
+            for (int i = 0; i < ints; i++)
+            {
+                m_array[i] = fillValue;
+            }
+
+            _version++;
+        }
+
+        /*=========================================================================
+        ** Returns a reference to the current instance ANDed with value.
+        **
+        ** Exceptions: ArgumentException if value == null or
+        **             value.Length != this.Length.
+        =========================================================================*/
+        public BitArray And(BitArray value)
+        {
+            if (value == null)
+                throw new ArgumentNullException("value");
+            if (Length != value.Length)
+                throw new ArgumentException(SR.Arg_ArrayLengthsDiffer);
+            Contract.EndContractBlock();
+
+            int ints = GetArrayLength(m_length, BitsPerInt32);
+            for (int i = 0; i < ints; i++)
+            {
+                m_array[i] &= value.m_array[i];
+            }
+
+            _version++;
+            return this;
+        }
+
+        /*=========================================================================
+        ** Returns a reference to the current instance ORed with value.
+        **
+        ** Exceptions: ArgumentException if value == null or
+        **             value.Length != this.Length.
+        =========================================================================*/
+        public BitArray Or(BitArray value)
+        {
+            if (value == null)
+                throw new ArgumentNullException("value");
+            if (Length != value.Length)
+                throw new ArgumentException(SR.Arg_ArrayLengthsDiffer);
+            Contract.EndContractBlock();
+
+            int ints = GetArrayLength(m_length, BitsPerInt32);
+            for (int i = 0; i < ints; i++)
+            {
+                m_array[i] |= value.m_array[i];
+            }
+
+            _version++;
+            return this;
+        }
+
+        /*=========================================================================
+        ** Returns a reference to the current instance XORed with value.
+        **
+        ** Exceptions: ArgumentException if value == null or
+        **             value.Length != this.Length.
+        =========================================================================*/
+        public BitArray Xor(BitArray value)
+        {
+            if (value == null)
+                throw new ArgumentNullException("value");
+            if (Length != value.Length)
+                throw new ArgumentException(SR.Arg_ArrayLengthsDiffer);
+            Contract.EndContractBlock();
+
+            int ints = GetArrayLength(m_length, BitsPerInt32);
+            for (int i = 0; i < ints; i++)
+            {
+                m_array[i] ^= value.m_array[i];
+            }
+
+            _version++;
+            return this;
+        }
+
+        /*=========================================================================
+        ** Inverts all the bit values. On/true bit values are converted to
+        ** off/false. Off/false bit values are turned on/true. The current instance
+        ** is updated and returned.
+        =========================================================================*/
+        public BitArray Not()
+        {
+            int ints = GetArrayLength(m_length, BitsPerInt32);
+            for (int i = 0; i < ints; i++)
+            {
+                m_array[i] = ~m_array[i];
+            }
+
+            _version++;
+            return this;
+        }
+
+        public int Length
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() >= 0);
+                return m_length;
+            }
+            set
+            {
+                if (value < 0)
+                {
+                    throw new ArgumentOutOfRangeException("value", SR.ArgumentOutOfRange_NeedNonNegNum);
+                }
+                Contract.EndContractBlock();
+
+                int newints = GetArrayLength(value, BitsPerInt32);
+                if (newints > m_array.Length || newints + _ShrinkThreshold < m_array.Length)
+                {
+                    // grow or shrink (if wasting more than _ShrinkThreshold ints)
+                    Array.Resize(ref m_array, newints);
+                }
+
+                if (value > m_length)
+                {
+                    // clear high bit values in the last int
+                    int last = GetArrayLength(m_length, BitsPerInt32) - 1;
+                    int bits = m_length % 32;
+                    if (bits > 0)
+                    {
+                        m_array[last] &= (1 << bits) - 1;
+                    }
+
+                    // clear remaining int values
+                    Array.Clear(m_array, last + 1, newints - last - 1);
+                }
+
+                m_length = value;
+                _version++;
+            }
+        }
+
+        // ICollection implementation
+        void ICollection.CopyTo(Array array, int index)
+        {
+            if (array == null)
+                throw new ArgumentNullException("array");
+
+            if (index < 0)
+                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_NeedNonNegNum);
+
+            if (array.Rank != 1)
+                throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
+
+            Contract.EndContractBlock();
+
+            if (array is int[])
+            {
+                Array.Copy(m_array, 0, array, index, GetArrayLength(m_length, BitsPerInt32));
+            }
+            else if (array is byte[])
+            {
+                int arrayLength = GetArrayLength(m_length, BitsPerByte);
+                if ((array.Length - index) < arrayLength)
+                    throw new ArgumentException(SR.Argument_InvalidOffLen);
+
+                byte[] b = (byte[])array;
+                for (int i = 0; i < arrayLength; i++)
+                    b[index + i] = (byte)((m_array[i / 4] >> ((i % 4) * 8)) & 0x000000FF); // Shift to bring the required byte to LSB, then mask
+            }
+            else if (array is bool[])
+            {
+                if (array.Length - index < m_length)
+                    throw new ArgumentException(SR.Argument_InvalidOffLen);
+
+                bool[] b = (bool[])array;
+                for (int i = 0; i < m_length; i++)
+                    b[index + i] = ((m_array[i / 32] >> (i % 32)) & 0x00000001) != 0;
+            }
+            else
+                throw new ArgumentException(SR.Arg_BitArrayTypeUnsupported);
+        }
+
+        int ICollection.Count
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() >= 0);
+
+                return m_length;
+            }
+        }
+
+        Object ICollection.SyncRoot
+        {
+            get
+            {
+                if (_syncRoot == null)
+                {
+                    System.Threading.Interlocked.CompareExchange<Object>(ref _syncRoot, new Object(), null);
+                }
+                return _syncRoot;
+            }
+        }
+
+        bool ICollection.IsSynchronized
+        {
+            get
+            {
+                return false;
+            }
+        }
+
+        public IEnumerator GetEnumerator()
+        {
+            return new BitArrayEnumeratorSimple(this);
+        }
+
+        // XPerY=n means that n Xs can be stored in 1 Y. 
+        private const int BitsPerInt32 = 32;
+        private const int BytesPerInt32 = 4;
+        private const int BitsPerByte = 8;
+
+        /// <summary>
+        /// Used for conversion between different representations of bit array. 
+        /// Returns (n+(div-1))/div, rearranged to avoid arithmetic overflow. 
+        /// For example, in the bit to int case, the straightforward calc would 
+        /// be (n+31)/32, but that would cause overflow. So instead it's 
+        /// rearranged to ((n-1)/32) + 1, with special casing for 0.
+        /// 
+        /// Usage:
+        /// GetArrayLength(77, BitsPerInt32): returns how many ints must be 
+        /// allocated to store 77 bits.
+        /// </summary>
+        /// <param name="n"></param>
+        /// <param name="div">use a conversion constant, e.g. BytesPerInt32 to get
+        /// how many ints are required to store n bytes</param>
+        /// <returns></returns>
+        private static int GetArrayLength(int n, int div)
+        {
+            Contract.Assert(div > 0, "GetArrayLength: div arg must be greater than 0");
+            return n > 0 ? (((n - 1) / div) + 1) : 0;
+        }
+
+        private class BitArrayEnumeratorSimple : IEnumerator
+        {
+            private BitArray bitarray;
+            private int index;
+            private int version;
+            private bool currentElement;
+
+            internal BitArrayEnumeratorSimple(BitArray bitarray)
+            {
+                this.bitarray = bitarray;
+                this.index = -1;
+                version = bitarray._version;
+            }
+
+            public Object Clone()
+            {
+                return MemberwiseClone();
+            }
+
+            public virtual bool MoveNext()
+            {
+                ICollection bitarrayAsICollection = bitarray;
+                if (version != bitarray._version) throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
+                if (index < (bitarrayAsICollection.Count - 1))
+                {
+                    index++;
+                    currentElement = bitarray.Get(index);
+                    return true;
+                }
+                else
+                    index = bitarrayAsICollection.Count;
+
+                return false;
+            }
+
+            public virtual Object Current
+            {
+                get
+                {
+                    if (index == -1)
+                        throw new InvalidOperationException(SR.InvalidOperation_EnumNotStarted);
+                    if (index >= ((ICollection)bitarray).Count)
+                        throw new InvalidOperationException(SR.InvalidOperation_EnumEnded);
+                    return currentElement;
+                }
+            }
+
+            public void Reset()
+            {
+                if (version != bitarray._version) throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
+                index = -1;
+            }
+        }
+
+        private int[] m_array;
+        private int m_length;
+        private int _version;
+        private Object _syncRoot;
+
+        private const int _ShrinkThreshold = 256;
+    }
+}

--- a/src/System.Collections/src/System/Collections/Generic/Comparer.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Comparer.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Diagnostics.Contracts;
+
+namespace System.Collections.Generic
+{
+    public abstract class Comparer<T> : IComparer, IComparer<T>
+    {
+        protected Comparer()
+        {
+        }
+
+        public static Comparer<T> Default
+        {
+            get
+            {
+                if (_default == null)
+                    _default = CreateComparer();
+                return _default;
+            }
+        }
+
+        public abstract int Compare(T x, T y);
+
+        public static Comparer<T> Create(Comparison<T> comparison)
+        {
+            Contract.Ensures(Contract.Result<Comparer<T>>() != null);
+
+            if (comparison == null)
+                throw new ArgumentNullException("comparison");
+
+            return new ComparisonComparer<T>(comparison);
+        }
+
+        int System.Collections.IComparer.Compare(Object x, Object y)
+        {
+            if (x == null) return y == null ? 0 : -1;
+            if (y == null) return 1;
+            if (x is T && y is T) return Compare((T)x, (T)y);
+            throw new ArgumentException(SR.Argument_InvalidArgumentForComparison);
+        }
+
+        private static Comparer<T> CreateComparer()
+        {
+            // NUTC compiler optimization see comments in EqualityComparer.cs
+            if (typeof(T) == typeof(Int32))
+                return (Comparer<T>)(Object)(new Int32Comparer());
+
+            return new DefaultComparer<T>();
+        }
+
+        private static Comparer<T> _default;
+    }
+
+
+    internal class DefaultComparer<T> : Comparer<T>
+    {
+        public override int Compare(T x, T y)
+        {
+            return LowLevelComparer<T>.DefaultCompareImpl(x, y);
+        }
+    }
+
+    internal class ComparisonComparer<T> : Comparer<T>
+    {
+        private readonly Comparison<T> _comparison;
+
+        public ComparisonComparer(Comparison<T> comparison)
+        {
+            _comparison = comparison;
+        }
+
+        public override int Compare(T x, T y)
+        {
+            return _comparison(x, y);
+        }
+    }
+
+    internal class Int32Comparer : Comparer<Int32>
+    {
+        public override int Compare(Int32 x, Int32 y)
+        {
+            if (x < y)
+                return -1;
+            else if (x > y)
+                return 1;
+            else
+                return 0;
+        }
+    }
+}

--- a/src/System.Collections/src/System/Collections/Generic/Dictionary.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Dictionary.cs
@@ -1,0 +1,1266 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
+
+namespace System.Collections.Generic
+{
+    [DebuggerTypeProxy(typeof(IDictionaryDebugView<,>))]
+    [DebuggerDisplay("Count = {Count}")]
+    [System.Runtime.InteropServices.ComVisible(false)]
+    public class Dictionary<TKey, TValue> : IDictionary<TKey, TValue>, IDictionary, IReadOnlyDictionary<TKey, TValue>
+    {
+        private struct Entry
+        {
+            public int hashCode;    // Lower 31 bits of hash code, -1 if unused
+            public int next;        // Index of next entry, -1 if last
+            public TKey key;           // Key of entry
+            public TValue value;         // Value of entry
+        }
+
+        private int[] buckets;
+        private Entry[] entries;
+        private int count;
+        private int version;
+
+        private int freeList;
+        private int freeCount;
+        private IEqualityComparer<TKey> comparer;
+        private KeyCollection keys;
+        private ValueCollection values;
+        private Object _syncRoot;
+
+        // constants for serialization
+        private const String VersionName = "Version";
+        private const String HashSizeName = "HashSize";  // Must save buckets.Length
+        private const String KeyValuePairsName = "KeyValuePairs";
+        private const String ComparerName = "Comparer";
+
+        public Dictionary() : this(0, null) { }
+
+        public Dictionary(int capacity) : this(capacity, null) { }
+
+        public Dictionary(IEqualityComparer<TKey> comparer) : this(0, comparer) { }
+
+        public Dictionary(int capacity, IEqualityComparer<TKey> comparer)
+        {
+            if (capacity < 0) throw new ArgumentOutOfRangeException("capacity");
+            if (capacity > 0) Initialize(capacity);
+            this.comparer = comparer ?? EqualityComparer<TKey>.Default;
+        }
+
+        public Dictionary(IDictionary<TKey, TValue> dictionary) : this(dictionary, null) { }
+
+        public Dictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey> comparer) :
+            this(dictionary != null ? dictionary.Count : 0, comparer)
+        {
+            if (dictionary == null)
+            {
+                throw new ArgumentNullException("dictionary");
+            }
+
+            foreach (KeyValuePair<TKey, TValue> pair in dictionary)
+            {
+                Add(pair.Key, pair.Value);
+            }
+        }
+
+        public IEqualityComparer<TKey> Comparer
+        {
+            get
+            {
+                return comparer;
+            }
+        }
+
+        public int Count
+        {
+            get { return count - freeCount; }
+        }
+
+        public KeyCollection Keys
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<KeyCollection>() != null);
+                if (keys == null) keys = new KeyCollection(this);
+                return keys;
+            }
+        }
+
+        ICollection<TKey> IDictionary<TKey, TValue>.Keys
+        {
+            get
+            {
+                if (keys == null) keys = new KeyCollection(this);
+                return keys;
+            }
+        }
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys
+        {
+            get
+            {
+                if (keys == null) keys = new KeyCollection(this);
+                return keys;
+            }
+        }
+
+        public ValueCollection Values
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<ValueCollection>() != null);
+                if (values == null) values = new ValueCollection(this);
+                return values;
+            }
+        }
+
+        ICollection<TValue> IDictionary<TKey, TValue>.Values
+        {
+            get
+            {
+                if (values == null) values = new ValueCollection(this);
+                return values;
+            }
+        }
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values
+        {
+            get
+            {
+                if (values == null) values = new ValueCollection(this);
+                return values;
+            }
+        }
+
+        public TValue this[TKey key]
+        {
+            get
+            {
+                int i = FindEntry(key);
+                if (i >= 0) return entries[i].value;
+                throw new KeyNotFoundException();
+            }
+            set
+            {
+                Insert(key, value, false);
+            }
+        }
+
+        public void Add(TKey key, TValue value)
+        {
+            Insert(key, value, true);
+        }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> keyValuePair)
+        {
+            Add(keyValuePair.Key, keyValuePair.Value);
+        }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> keyValuePair)
+        {
+            int i = FindEntry(keyValuePair.Key);
+            if (i >= 0 && EqualityComparer<TValue>.Default.Equals(entries[i].value, keyValuePair.Value))
+            {
+                return true;
+            }
+            return false;
+        }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> keyValuePair)
+        {
+            int i = FindEntry(keyValuePair.Key);
+            if (i >= 0 && EqualityComparer<TValue>.Default.Equals(entries[i].value, keyValuePair.Value))
+            {
+                Remove(keyValuePair.Key);
+                return true;
+            }
+            return false;
+        }
+
+        public void Clear()
+        {
+            if (count > 0)
+            {
+                for (int i = 0; i < buckets.Length; i++) buckets[i] = -1;
+                Array.Clear(entries, 0, count);
+                freeList = -1;
+                count = 0;
+                freeCount = 0;
+                version++;
+            }
+        }
+
+        public bool ContainsKey(TKey key)
+        {
+            return FindEntry(key) >= 0;
+        }
+
+        public bool ContainsValue(TValue value)
+        {
+            if (value == null)
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    if (entries[i].hashCode >= 0 && entries[i].value == null) return true;
+                }
+            }
+            else
+            {
+                EqualityComparer<TValue> c = EqualityComparer<TValue>.Default;
+                for (int i = 0; i < count; i++)
+                {
+                    if (entries[i].hashCode >= 0 && c.Equals(entries[i].value, value)) return true;
+                }
+            }
+            return false;
+        }
+
+        private void CopyTo(KeyValuePair<TKey, TValue>[] array, int index)
+        {
+            if (array == null)
+            {
+                throw new ArgumentNullException("array");
+            }
+
+            if (index < 0 || index > array.Length)
+            {
+                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            if (array.Length - index < Count)
+            {
+                throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
+            }
+
+            int count = this.count;
+            Entry[] entries = this.entries;
+            for (int i = 0; i < count; i++)
+            {
+                if (entries[i].hashCode >= 0)
+                {
+                    array[index++] = new KeyValuePair<TKey, TValue>(entries[i].key, entries[i].value);
+                }
+            }
+        }
+
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(this, Enumerator.KeyValuePair);
+        }
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
+        {
+            return new Enumerator(this, Enumerator.KeyValuePair);
+        }
+
+        private int FindEntry(TKey key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException("key");
+            }
+
+            if (buckets != null)
+            {
+                int hashCode = comparer.GetHashCode(key) & 0x7FFFFFFF;
+                for (int i = buckets[hashCode % buckets.Length]; i >= 0; i = entries[i].next)
+                {
+                    if (entries[i].hashCode == hashCode && comparer.Equals(entries[i].key, key)) return i;
+                }
+            }
+            return -1;
+        }
+
+        private void Initialize(int capacity)
+        {
+            int size = HashHelpers.GetPrime(capacity);
+            buckets = new int[size];
+            for (int i = 0; i < buckets.Length; i++) buckets[i] = -1;
+            entries = new Entry[size];
+            freeList = -1;
+        }
+
+        private void Insert(TKey key, TValue value, bool add)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException("key");
+            }
+
+            if (buckets == null) Initialize(0);
+            int hashCode = comparer.GetHashCode(key) & 0x7FFFFFFF;
+            int targetBucket = hashCode % buckets.Length;
+
+#if FEATURE_RANDOMIZED_STRING_HASHING
+            int collisionCount = 0;
+#endif
+
+            for (int i = buckets[targetBucket]; i >= 0; i = entries[i].next)
+            {
+                if (entries[i].hashCode == hashCode && comparer.Equals(entries[i].key, key))
+                {
+                    if (add)
+                    {
+                        throw new ArgumentException(SR.Argument_AddingDuplicate);
+                    }
+                    entries[i].value = value;
+                    version++;
+                    return;
+                }
+#if FEATURE_RANDOMIZED_STRING_HASHING
+                collisionCount++;
+#endif
+            }
+
+            int index;
+
+            if (freeCount > 0)
+            {
+                index = freeList;
+                freeList = entries[index].next;
+                freeCount--;
+            }
+            else
+            {
+                if (count == entries.Length)
+                {
+                    Resize();
+                    targetBucket = hashCode % buckets.Length;
+                }
+                index = count;
+                count++;
+            }
+
+            entries[index].hashCode = hashCode;
+            entries[index].next = buckets[targetBucket];
+            entries[index].key = key;
+            entries[index].value = value;
+            buckets[targetBucket] = index;
+            version++;
+#if FEATURE_RANDOMIZED_STRING_HASHING
+            if (collisionCount > HashHelpers.HashCollisionThreshold && HashHelpers.IsWellKnownEqualityComparer(comparer))
+            {
+                comparer = (IEqualityComparer<TKey>)HashHelpers.GetRandomizedEqualityComparer(comparer);
+                Resize(entries.Length, true);
+            }
+#endif
+
+        }
+
+        private void Resize()
+        {
+            Resize(HashHelpers.ExpandPrime(count), false);
+        }
+
+        private void Resize(int newSize, bool forceNewHashCodes)
+        {
+            Contract.Assert(newSize >= entries.Length);
+            int[] newBuckets = new int[newSize];
+            for (int i = 0; i < newBuckets.Length; i++) newBuckets[i] = -1;
+
+            Entry[] newEntries = new Entry[newSize];
+            Array.Copy(entries, 0, newEntries, 0, count);
+
+            if (forceNewHashCodes)
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    if (newEntries[i].hashCode != -1)
+                    {
+                        newEntries[i].hashCode = (comparer.GetHashCode(newEntries[i].key) & 0x7FFFFFFF);
+                    }
+                }
+            }
+
+            for (int i = 0; i < count; i++)
+            {
+                if (newEntries[i].hashCode >= 0)
+                {
+                    int bucket = newEntries[i].hashCode % newSize;
+                    newEntries[i].next = newBuckets[bucket];
+                    newBuckets[bucket] = i;
+                }
+            }
+
+            buckets = newBuckets;
+            entries = newEntries;
+        }
+
+        public bool Remove(TKey key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException("key");
+            }
+
+            if (buckets != null)
+            {
+                int hashCode = comparer.GetHashCode(key) & 0x7FFFFFFF;
+                int bucket = hashCode % buckets.Length;
+                int last = -1;
+                for (int i = buckets[bucket]; i >= 0; last = i, i = entries[i].next)
+                {
+                    if (entries[i].hashCode == hashCode && comparer.Equals(entries[i].key, key))
+                    {
+                        if (last < 0)
+                        {
+                            buckets[bucket] = entries[i].next;
+                        }
+                        else
+                        {
+                            entries[last].next = entries[i].next;
+                        }
+                        entries[i].hashCode = -1;
+                        entries[i].next = freeList;
+                        entries[i].key = default(TKey);
+                        entries[i].value = default(TValue);
+                        freeList = i;
+                        freeCount++;
+                        version++;
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            int i = FindEntry(key);
+            if (i >= 0)
+            {
+                value = entries[i].value;
+                return true;
+            }
+            value = default(TValue);
+            return false;
+        }
+
+        // This is a convenience method for the internal callers that were converted from using Hashtable.
+        // Many were combining key doesn't exist and key exists but null value (for non-value types) checks.
+        // This allows them to continue getting that behavior with minimal code delta. This is basically
+        // TryGetValue without the out param
+        internal TValue GetValueOrDefault(TKey key)
+        {
+            int i = FindEntry(key);
+            if (i >= 0)
+            {
+                return entries[i].value;
+            }
+            return default(TValue);
+        }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly
+        {
+            get { return false; }
+        }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int index)
+        {
+            CopyTo(array, index);
+        }
+
+        void ICollection.CopyTo(Array array, int index)
+        {
+            if (array == null)
+            {
+                throw new ArgumentNullException("array");
+            }
+
+            if (array.Rank != 1)
+            {
+                throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
+            }
+
+            if (array.GetLowerBound(0) != 0)
+            {
+                throw new ArgumentException(SR.Arg_NonZeroLowerBound);
+            }
+
+            if (index < 0 || index > array.Length)
+            {
+                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            if (array.Length - index < Count)
+            {
+                throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
+            }
+
+            KeyValuePair<TKey, TValue>[] pairs = array as KeyValuePair<TKey, TValue>[];
+            if (pairs != null)
+            {
+                CopyTo(pairs, index);
+            }
+            else if (array is DictionaryEntry[])
+            {
+                DictionaryEntry[] dictEntryArray = array as DictionaryEntry[];
+                Entry[] entries = this.entries;
+
+                for (int i = 0; i < count; i++)
+                {
+                    if (entries[i].hashCode >= 0)
+                    {
+                        dictEntryArray[index++] = new DictionaryEntry(entries[i].key, entries[i].value);
+                    }
+                }
+            }
+            else
+            {
+                object[] objects = array as object[];
+                if (objects == null)
+                {
+                    throw new ArgumentException(SR.Argument_InvalidArrayType);
+                }
+
+                try
+                {
+                    int count = this.count;
+                    Entry[] entries = this.entries;
+                    for (int i = 0; i < count; i++)
+                    {
+                        if (entries[i].hashCode >= 0)
+                        {
+                            objects[index++] = new KeyValuePair<TKey, TValue>(entries[i].key, entries[i].value);
+                        }
+                    }
+                }
+                catch (ArrayTypeMismatchException)
+                {
+                    throw new ArgumentException(SR.Argument_InvalidArrayType);
+                }
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return new Enumerator(this, Enumerator.KeyValuePair);
+        }
+
+        bool ICollection.IsSynchronized
+        {
+            get { return false; }
+        }
+
+        object ICollection.SyncRoot
+        {
+            get
+            {
+                if (_syncRoot == null)
+                {
+                    System.Threading.Interlocked.CompareExchange<Object>(ref _syncRoot, new Object(), null);
+                }
+                return _syncRoot;
+            }
+        }
+
+        bool IDictionary.IsFixedSize
+        {
+            get { return false; }
+        }
+
+        bool IDictionary.IsReadOnly
+        {
+            get { return false; }
+        }
+
+        ICollection IDictionary.Keys
+        {
+            get { return (ICollection)Keys; }
+        }
+
+        ICollection IDictionary.Values
+        {
+            get { return (ICollection)Values; }
+        }
+
+        object IDictionary.this[object key]
+        {
+            get
+            {
+                if (IsCompatibleKey(key))
+                {
+                    int i = FindEntry((TKey)key);
+                    if (i >= 0)
+                    {
+                        return entries[i].value;
+                    }
+                }
+                return null;
+            }
+            set
+            {
+                if (key == null)
+                {
+                    throw new ArgumentNullException("key");
+                }
+                if (value == null && !(default(TValue) == null))
+                    throw new ArgumentNullException("value");
+
+                try
+                {
+                    TKey tempKey = (TKey)key;
+                    try
+                    {
+                        this[tempKey] = (TValue)value;
+                    }
+                    catch (InvalidCastException)
+                    {
+                        throw new ArgumentException(SR.Format(SR.Arg_WrongType, value, typeof(TValue)), "value");
+                    }
+                }
+                catch (InvalidCastException)
+                {
+                    throw new ArgumentException(SR.Format(SR.Arg_WrongType, key, typeof(TKey)), "key");
+                }
+            }
+        }
+
+        private static bool IsCompatibleKey(object key)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException("key");
+            }
+            return (key is TKey);
+        }
+
+        void IDictionary.Add(object key, object value)
+        {
+            if (key == null)
+            {
+                throw new ArgumentNullException("key");
+            }
+
+            if (value == null && !(default(TValue) == null))
+                throw new ArgumentNullException("value");
+
+            try
+            {
+                TKey tempKey = (TKey)key;
+
+                try
+                {
+                    Add(tempKey, (TValue)value);
+                }
+                catch (InvalidCastException)
+                {
+                    throw new ArgumentException(SR.Format(SR.Arg_WrongType, value, typeof(TValue)), "value");
+                }
+            }
+            catch (InvalidCastException)
+            {
+                throw new ArgumentException(SR.Format(SR.Arg_WrongType, key, typeof(TKey)), "key");
+            }
+        }
+
+        bool IDictionary.Contains(object key)
+        {
+            if (IsCompatibleKey(key))
+            {
+                return ContainsKey((TKey)key);
+            }
+
+            return false;
+        }
+
+        IDictionaryEnumerator IDictionary.GetEnumerator()
+        {
+            return new Enumerator(this, Enumerator.DictEntry);
+        }
+
+        void IDictionary.Remove(object key)
+        {
+            if (IsCompatibleKey(key))
+            {
+                Remove((TKey)key);
+            }
+        }
+
+        public struct Enumerator : IEnumerator<KeyValuePair<TKey, TValue>>,
+            IDictionaryEnumerator
+        {
+            private Dictionary<TKey, TValue> dictionary;
+            private int version;
+            private int index;
+            private KeyValuePair<TKey, TValue> current;
+            private int getEnumeratorRetType;  // What should Enumerator.Current return?
+
+            internal const int DictEntry = 1;
+            internal const int KeyValuePair = 2;
+
+            internal Enumerator(Dictionary<TKey, TValue> dictionary, int getEnumeratorRetType)
+            {
+                this.dictionary = dictionary;
+                version = dictionary.version;
+                index = 0;
+                this.getEnumeratorRetType = getEnumeratorRetType;
+                current = new KeyValuePair<TKey, TValue>();
+            }
+
+            public bool MoveNext()
+            {
+                if (version != dictionary.version)
+                {
+                    throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
+                }
+
+                // Use unsigned comparison since we set index to dictionary.count+1 when the enumeration ends.
+                // dictionary.count+1 could be negative if dictionary.count is Int32.MaxValue
+                while ((uint)index < (uint)dictionary.count)
+                {
+                    if (dictionary.entries[index].hashCode >= 0)
+                    {
+                        current = new KeyValuePair<TKey, TValue>(dictionary.entries[index].key, dictionary.entries[index].value);
+                        index++;
+                        return true;
+                    }
+                    index++;
+                }
+
+                index = dictionary.count + 1;
+                current = new KeyValuePair<TKey, TValue>();
+                return false;
+            }
+
+            public KeyValuePair<TKey, TValue> Current
+            {
+                get { return current; }
+            }
+
+            public void Dispose()
+            {
+            }
+
+            object IEnumerator.Current
+            {
+                get
+                {
+                    if (index == 0 || (index == dictionary.count + 1))
+                    {
+                        throw new InvalidOperationException(SR.InvalidOperation_EnumOpCantHappen);
+                    }
+
+                    if (getEnumeratorRetType == DictEntry)
+                    {
+                        return new System.Collections.DictionaryEntry(current.Key, current.Value);
+                    }
+                    else
+                    {
+                        return new KeyValuePair<TKey, TValue>(current.Key, current.Value);
+                    }
+                }
+            }
+
+            void IEnumerator.Reset()
+            {
+                if (version != dictionary.version)
+                {
+                    throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
+                }
+
+                index = 0;
+                current = new KeyValuePair<TKey, TValue>();
+            }
+
+            DictionaryEntry IDictionaryEnumerator.Entry
+            {
+                get
+                {
+                    if (index == 0 || (index == dictionary.count + 1))
+                    {
+                        throw new InvalidOperationException(SR.InvalidOperation_EnumOpCantHappen);
+                    }
+
+                    return new DictionaryEntry(current.Key, current.Value);
+                }
+            }
+
+            object IDictionaryEnumerator.Key
+            {
+                get
+                {
+                    if (index == 0 || (index == dictionary.count + 1))
+                    {
+                        throw new InvalidOperationException(SR.InvalidOperation_EnumOpCantHappen);
+                    }
+
+                    return current.Key;
+                }
+            }
+
+            object IDictionaryEnumerator.Value
+            {
+                get
+                {
+                    if (index == 0 || (index == dictionary.count + 1))
+                    {
+                        throw new InvalidOperationException(SR.InvalidOperation_EnumOpCantHappen);
+                    }
+
+                    return current.Value;
+                }
+            }
+        }
+
+        [DebuggerTypeProxy(typeof(DictionaryKeyCollectionDebugView<,>))]
+        [DebuggerDisplay("Count = {Count}")]
+        public sealed class KeyCollection : ICollection<TKey>, ICollection, IReadOnlyCollection<TKey>
+        {
+            private Dictionary<TKey, TValue> dictionary;
+
+            public KeyCollection(Dictionary<TKey, TValue> dictionary)
+            {
+                if (dictionary == null)
+                {
+                    throw new ArgumentNullException("dictionary");
+                }
+                this.dictionary = dictionary;
+            }
+
+            public Enumerator GetEnumerator()
+            {
+                return new Enumerator(dictionary);
+            }
+
+            public void CopyTo(TKey[] array, int index)
+            {
+                if (array == null)
+                {
+                    throw new ArgumentNullException("array");
+                }
+
+                if (index < 0 || index > array.Length)
+                {
+                    throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_NeedNonNegNum);
+                }
+
+                if (array.Length - index < dictionary.Count)
+                {
+                    throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
+                }
+
+                int count = dictionary.count;
+                Entry[] entries = dictionary.entries;
+
+                for (int i = 0; i < count; i++)
+                {
+                    if (entries[i].hashCode >= 0) array[index++] = entries[i].key;
+                }
+            }
+
+            public int Count
+            {
+                get { return dictionary.Count; }
+            }
+
+            bool ICollection<TKey>.IsReadOnly
+            {
+                get { return true; }
+            }
+
+            void ICollection<TKey>.Add(TKey item)
+            {
+                throw new NotSupportedException(SR.NotSupported_KeyCollectionSet);
+            }
+
+            void ICollection<TKey>.Clear()
+            {
+                throw new NotSupportedException(SR.NotSupported_KeyCollectionSet);
+            }
+
+            bool ICollection<TKey>.Contains(TKey item)
+            {
+                return dictionary.ContainsKey(item);
+            }
+
+            bool ICollection<TKey>.Remove(TKey item)
+            {
+                throw new NotSupportedException(SR.NotSupported_KeyCollectionSet);
+            }
+
+            IEnumerator<TKey> IEnumerable<TKey>.GetEnumerator()
+            {
+                return new Enumerator(dictionary);
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return new Enumerator(dictionary);
+            }
+
+            void ICollection.CopyTo(Array array, int index)
+            {
+                if (array == null)
+                {
+                    throw new ArgumentNullException("array");
+                }
+
+                if (array.Rank != 1)
+                {
+                    throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
+                }
+
+                if (array.GetLowerBound(0) != 0)
+                {
+                    throw new ArgumentException(SR.Arg_NonZeroLowerBound);
+                }
+
+                if (index < 0 || index > array.Length)
+                {
+                    throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_NeedNonNegNum);
+                }
+
+                if (array.Length - index < dictionary.Count)
+                {
+                    throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
+                }
+
+                TKey[] keys = array as TKey[];
+                if (keys != null)
+                {
+                    CopyTo(keys, index);
+                }
+                else
+                {
+                    object[] objects = array as object[];
+                    if (objects == null)
+                    {
+                        throw new ArgumentException(SR.Argument_InvalidArrayType);
+                    }
+
+                    int count = dictionary.count;
+                    Entry[] entries = dictionary.entries;
+
+                    try
+                    {
+                        for (int i = 0; i < count; i++)
+                        {
+                            if (entries[i].hashCode >= 0) objects[index++] = entries[i].key;
+                        }
+                    }
+                    catch (ArrayTypeMismatchException)
+                    {
+                        throw new ArgumentException(SR.Argument_InvalidArrayType);
+                    }
+                }
+            }
+
+            bool ICollection.IsSynchronized
+            {
+                get { return false; }
+            }
+
+            Object ICollection.SyncRoot
+            {
+                get { return ((ICollection)dictionary).SyncRoot; }
+            }
+
+            public struct Enumerator : IEnumerator<TKey>, System.Collections.IEnumerator
+            {
+                private Dictionary<TKey, TValue> dictionary;
+                private int index;
+                private int version;
+                private TKey currentKey;
+
+                internal Enumerator(Dictionary<TKey, TValue> dictionary)
+                {
+                    this.dictionary = dictionary;
+                    version = dictionary.version;
+                    index = 0;
+                    currentKey = default(TKey);
+                }
+
+                public void Dispose()
+                {
+                }
+
+                public bool MoveNext()
+                {
+                    if (version != dictionary.version)
+                    {
+                        throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
+                    }
+
+                    while ((uint)index < (uint)dictionary.count)
+                    {
+                        if (dictionary.entries[index].hashCode >= 0)
+                        {
+                            currentKey = dictionary.entries[index].key;
+                            index++;
+                            return true;
+                        }
+                        index++;
+                    }
+
+                    index = dictionary.count + 1;
+                    currentKey = default(TKey);
+                    return false;
+                }
+
+                public TKey Current
+                {
+                    get
+                    {
+                        return currentKey;
+                    }
+                }
+
+                Object System.Collections.IEnumerator.Current
+                {
+                    get
+                    {
+                        if (index == 0 || (index == dictionary.count + 1))
+                        {
+                            throw new InvalidOperationException(SR.InvalidOperation_EnumOpCantHappen);
+                        }
+
+                        return currentKey;
+                    }
+                }
+
+                void System.Collections.IEnumerator.Reset()
+                {
+                    if (version != dictionary.version)
+                    {
+                        throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
+                    }
+
+                    index = 0;
+                    currentKey = default(TKey);
+                }
+            }
+        }
+
+        [DebuggerTypeProxy(typeof(DictionaryValueCollectionDebugView<,>))]
+        [DebuggerDisplay("Count = {Count}")]
+        public sealed class ValueCollection : ICollection<TValue>, ICollection, IReadOnlyCollection<TValue>
+        {
+            private Dictionary<TKey, TValue> dictionary;
+
+            public ValueCollection(Dictionary<TKey, TValue> dictionary)
+            {
+                if (dictionary == null)
+                {
+                    throw new ArgumentNullException("dictionary");
+                }
+                this.dictionary = dictionary;
+            }
+
+            public Enumerator GetEnumerator()
+            {
+                return new Enumerator(dictionary);
+            }
+
+            public void CopyTo(TValue[] array, int index)
+            {
+                if (array == null)
+                {
+                    throw new ArgumentNullException("array");
+                }
+
+                if (index < 0 || index > array.Length)
+                {
+                    throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_NeedNonNegNum);
+                }
+
+                if (array.Length - index < dictionary.Count)
+                {
+                    throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
+                }
+
+                int count = dictionary.count;
+                Entry[] entries = dictionary.entries;
+
+                for (int i = 0; i < count; i++)
+                {
+                    if (entries[i].hashCode >= 0) array[index++] = entries[i].value;
+                }
+            }
+
+            public int Count
+            {
+                get { return dictionary.Count; }
+            }
+
+            bool ICollection<TValue>.IsReadOnly
+            {
+                get { return true; }
+            }
+
+            void ICollection<TValue>.Add(TValue item)
+            {
+                throw new NotSupportedException(SR.NotSupported_ValueCollectionSet);
+            }
+
+            bool ICollection<TValue>.Remove(TValue item)
+            {
+                throw new NotSupportedException(SR.NotSupported_ValueCollectionSet);
+            }
+
+            void ICollection<TValue>.Clear()
+            {
+                throw new NotSupportedException(SR.NotSupported_ValueCollectionSet);
+            }
+
+            bool ICollection<TValue>.Contains(TValue item)
+            {
+                return dictionary.ContainsValue(item);
+            }
+
+            IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator()
+            {
+                return new Enumerator(dictionary);
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return new Enumerator(dictionary);
+            }
+
+            void ICollection.CopyTo(Array array, int index)
+            {
+                if (array == null)
+                {
+                    throw new ArgumentNullException("array");
+                }
+
+                if (array.Rank != 1)
+                {
+                    throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
+                }
+
+                if (array.GetLowerBound(0) != 0)
+                {
+                    throw new ArgumentException(SR.Arg_NonZeroLowerBound);
+                }
+
+                if (index < 0 || index > array.Length)
+                {
+                    throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_NeedNonNegNum);
+                }
+
+                if (array.Length - index < dictionary.Count)
+                    throw new ArgumentException(SR.Arg_ArrayPlusOffTooSmall);
+
+                TValue[] values = array as TValue[];
+                if (values != null)
+                {
+                    CopyTo(values, index);
+                }
+                else
+                {
+                    object[] objects = array as object[];
+                    if (objects == null)
+                    {
+                        throw new ArgumentException(SR.Argument_InvalidArrayType);
+                    }
+
+                    int count = dictionary.count;
+                    Entry[] entries = dictionary.entries;
+
+                    try
+                    {
+                        for (int i = 0; i < count; i++)
+                        {
+                            if (entries[i].hashCode >= 0) objects[index++] = entries[i].value;
+                        }
+                    }
+                    catch (ArrayTypeMismatchException)
+                    {
+                        throw new ArgumentException(SR.Argument_InvalidArrayType);
+                    }
+                }
+            }
+
+            bool ICollection.IsSynchronized
+            {
+                get { return false; }
+            }
+
+            Object ICollection.SyncRoot
+            {
+                get { return ((ICollection)dictionary).SyncRoot; }
+            }
+
+            public struct Enumerator : IEnumerator<TValue>, System.Collections.IEnumerator
+            {
+                private Dictionary<TKey, TValue> dictionary;
+                private int index;
+                private int version;
+                private TValue currentValue;
+
+                internal Enumerator(Dictionary<TKey, TValue> dictionary)
+                {
+                    this.dictionary = dictionary;
+                    version = dictionary.version;
+                    index = 0;
+                    currentValue = default(TValue);
+                }
+
+                public void Dispose()
+                {
+                }
+
+                public bool MoveNext()
+                {
+                    if (version != dictionary.version)
+                    {
+                        throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
+                    }
+
+                    while ((uint)index < (uint)dictionary.count)
+                    {
+                        if (dictionary.entries[index].hashCode >= 0)
+                        {
+                            currentValue = dictionary.entries[index].value;
+                            index++;
+                            return true;
+                        }
+                        index++;
+                    }
+                    index = dictionary.count + 1;
+                    currentValue = default(TValue);
+                    return false;
+                }
+
+                public TValue Current
+                {
+                    get
+                    {
+                        return currentValue;
+                    }
+                }
+
+                Object System.Collections.IEnumerator.Current
+                {
+                    get
+                    {
+                        if (index == 0 || (index == dictionary.count + 1))
+                        {
+                            throw new InvalidOperationException(SR.InvalidOperation_EnumOpCantHappen);
+                        }
+
+                        return currentValue;
+                    }
+                }
+
+                void System.Collections.IEnumerator.Reset()
+                {
+                    if (version != dictionary.version)
+                    {
+                        throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
+                    }
+                    index = 0;
+                    currentValue = default(TValue);
+                }
+            }
+        }
+    }
+}

--- a/src/System.Collections/src/System/Collections/Generic/EqualityComparer.cs
+++ b/src/System.Collections/src/System/Collections/Generic/EqualityComparer.cs
@@ -1,0 +1,336 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+/*============================================================
+**
+** Class: EqualityComparer<T> 
+**
+===========================================================*/
+
+using System;
+using System.Collections;
+
+namespace System.Collections.Generic
+{
+    public abstract class EqualityComparer<T> : IEqualityComparer, IEqualityComparer<T>
+    {
+        protected EqualityComparer()
+        {
+        }
+
+        public static EqualityComparer<T> Default
+        {
+            get
+            {
+                if (_default == null)
+                {
+                    object comparer;
+
+                    // NUTC compiler is able to static evalulate the conditions and only put the necessary branches in finally binary code, 
+                    // even casting to EqualityComparer<T> can be removed.
+
+                    // For example: for Byte, the code generated is
+                    //     if (_default == null) _default = new EqualityComparerForByte(); return _default;
+
+                    // For classes, due to generic sharing, the code generated is:
+                    //     if (_default == null) { if (handle == typeof(string).RuntimeTypeHandle) comparer = new EqualityComparerForString(); else comparer = new LastResortEqalityComparer<T>; ...
+
+                    if (typeof(T) == typeof(SByte))
+                        comparer = new EqualityComparerForSByte();
+                    else if (typeof(T) == typeof(Byte))
+                        comparer = new EqualityComparerForByte();
+                    else if (typeof(T) == typeof(Int16))
+                        comparer = new EqualityComparerForInt16();
+                    else if (typeof(T) == typeof(UInt16))
+                        comparer = new EqualityComparerForUInt16();
+                    else if (typeof(T) == typeof(Int32))
+                        comparer = new EqualityComparerForInt32();
+                    else if (typeof(T) == typeof(UInt32))
+                        comparer = new EqualityComparerForUInt32();
+                    else if (typeof(T) == typeof(Int64))
+                        comparer = new EqualityComparerForInt64();
+                    else if (typeof(T) == typeof(UInt64))
+                        comparer = new EqualityComparerForUInt64();
+                    else if (typeof(T) == typeof(IntPtr))
+                        comparer = new EqualityComparerForIntPtr();
+                    else if (typeof(T) == typeof(UIntPtr))
+                        comparer = new EqualityComparerForUIntPtr();
+                    else if (typeof(T) == typeof(Single))
+                        comparer = new EqualityComparerForSingle();
+                    else if (typeof(T) == typeof(Double))
+                        comparer = new EqualityComparerForDouble();
+                    else if (typeof(T) == typeof(Decimal))
+                        comparer = new EqualityComparerForDecimal();
+                    else if (typeof(T) == typeof(String))
+                        comparer = new EqualityComparerForString();
+                    else
+                        comparer = new LastResortEqualityComparer<T>();
+
+                    _default = (EqualityComparer<T>)comparer;
+                }
+
+                return _default;
+            }
+        }
+
+        private static volatile EqualityComparer<T> _default;
+
+        public abstract bool Equals(T x, T y);
+
+        public abstract int GetHashCode(T obj);
+
+        int IEqualityComparer.GetHashCode(object obj)
+        {
+            if (obj == null)
+                return 0;
+            if (obj is T)
+                return GetHashCode((T)obj);
+            throw new ArgumentException(SR.Argument_InvalidArgumentForComparison);
+        }
+
+        bool IEqualityComparer.Equals(object x, object y)
+        {
+            if (x == y)
+                return true;
+            if (x == null || y == null)
+                return false;
+            if ((x is T) && (y is T))
+                return Equals((T)x, (T)y);
+            throw new ArgumentException(SR.Argument_InvalidArgumentForComparison);
+        }
+    }
+
+    //
+    // ProjectN compatiblity notes:
+    //
+    //    Unlike the full desktop, we make no attempt to use the IEquatable<T> interface on T. Because we can't generate
+    //    code at runtime, we derive no performance benefit from using the type-specific Equals(). We can't even
+    //    perform the check for IEquatable<> at the time the type-specific constructor is created (due to the removable of Type.IsAssignableFrom).
+    //    We would thus be incurring an interface cast check on each call to Equals() for no performance gain.
+    //
+    //    This should not cause a compat problem unless some type implements an IEquatable.Equals() that is semantically
+    //    incompatible with Object.Equals(). That goes specifically against the documented guidelines (and would in any case,
+    //    break any hashcode-dependent collection.) 
+    //
+    internal sealed class LastResortEqualityComparer<T> : EqualityComparer<T>
+    {
+        public LastResortEqualityComparer()
+        {
+        }
+
+        public sealed override bool Equals(T x, T y)
+        {
+            if (x == null)
+                return y == null;
+            if (y == null)
+                return false;
+
+            return x.Equals(y);
+        }
+
+        public sealed override int GetHashCode(T obj)
+        {
+            if (obj == null)
+                return 0;
+            return obj.GetHashCode();
+        }
+    }
+
+
+    internal sealed class EqualityComparerForSByte : EqualityComparer<SByte>
+    {
+        public override bool Equals(SByte x, SByte y)
+        {
+            return x == y;
+        }
+
+        public override int GetHashCode(SByte x)
+        {
+            return x.GetHashCode();
+        }
+    }
+
+
+    internal sealed class EqualityComparerForByte : EqualityComparer<Byte>
+    {
+        public override bool Equals(Byte x, Byte y)
+        {
+            return x == y;
+        }
+
+        public override int GetHashCode(Byte x)
+        {
+            return x.GetHashCode();
+        }
+    }
+
+
+    internal sealed class EqualityComparerForInt16 : EqualityComparer<Int16>
+    {
+        public override bool Equals(Int16 x, Int16 y)
+        {
+            return x == y;
+        }
+
+        public override int GetHashCode(Int16 x)
+        {
+            return x.GetHashCode();
+        }
+    }
+
+
+    internal sealed class EqualityComparerForUInt16 : EqualityComparer<UInt16>
+    {
+        public override bool Equals(UInt16 x, UInt16 y)
+        {
+            return x == y;
+        }
+
+        public override int GetHashCode(UInt16 x)
+        {
+            return x.GetHashCode();
+        }
+    }
+
+
+    internal sealed class EqualityComparerForInt32 : EqualityComparer<Int32>
+    {
+        public override bool Equals(Int32 x, Int32 y)
+        {
+            return x == y;
+        }
+
+        public override int GetHashCode(Int32 x)
+        {
+            return x.GetHashCode();
+        }
+    }
+
+
+    internal sealed class EqualityComparerForUInt32 : EqualityComparer<UInt32>
+    {
+        public override bool Equals(UInt32 x, UInt32 y)
+        {
+            return x == y;
+        }
+
+        public override int GetHashCode(UInt32 x)
+        {
+            return x.GetHashCode();
+        }
+    }
+
+
+    internal sealed class EqualityComparerForInt64 : EqualityComparer<Int64>
+    {
+        public override bool Equals(Int64 x, Int64 y)
+        {
+            return x == y;
+        }
+
+        public override int GetHashCode(Int64 x)
+        {
+            return x.GetHashCode();
+        }
+    }
+
+
+    internal sealed class EqualityComparerForUInt64 : EqualityComparer<UInt64>
+    {
+        public override bool Equals(UInt64 x, UInt64 y)
+        {
+            return x == y;
+        }
+
+        public override int GetHashCode(UInt64 x)
+        {
+            return x.GetHashCode();
+        }
+    }
+
+
+    internal sealed class EqualityComparerForIntPtr : EqualityComparer<IntPtr>
+    {
+        public override bool Equals(IntPtr x, IntPtr y)
+        {
+            return x == y;
+        }
+
+        public override int GetHashCode(IntPtr x)
+        {
+            return x.GetHashCode();
+        }
+    }
+
+
+    internal sealed class EqualityComparerForUIntPtr : EqualityComparer<UIntPtr>
+    {
+        public override bool Equals(UIntPtr x, UIntPtr y)
+        {
+            return x == y;
+        }
+
+        public override int GetHashCode(UIntPtr x)
+        {
+            return x.GetHashCode();
+        }
+    }
+
+
+    internal sealed class EqualityComparerForSingle : EqualityComparer<Single>
+    {
+        public override bool Equals(Single x, Single y)
+        {
+            return x == y;
+        }
+
+        public override int GetHashCode(Single x)
+        {
+            return x.GetHashCode();
+        }
+    }
+
+
+    internal sealed class EqualityComparerForDouble : EqualityComparer<Double>
+    {
+        public override bool Equals(Double x, Double y)
+        {
+            return x == y;
+        }
+
+        public override int GetHashCode(Double x)
+        {
+            return x.GetHashCode();
+        }
+    }
+
+
+    internal sealed class EqualityComparerForDecimal : EqualityComparer<Decimal>
+    {
+        public override bool Equals(Decimal x, Decimal y)
+        {
+            return x == y;
+        }
+
+        public override int GetHashCode(Decimal x)
+        {
+            return x.GetHashCode();
+        }
+    }
+
+    internal sealed class EqualityComparerForString : EqualityComparer<String>
+    {
+        public override bool Equals(String x, String y)
+        {
+            return x == y;
+        }
+
+        public override int GetHashCode(String x)
+        {
+            if (x == null)
+                return 0;
+            return x.GetHashCode();
+        }
+    }
+}
+

--- a/src/System.Collections/src/System/Collections/Generic/List.cs
+++ b/src/System.Collections/src/System/Collections/Generic/List.cs
@@ -1,0 +1,1383 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime;
+using System.Runtime.Versioning;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.Collections.ObjectModel;
+
+namespace System.Collections.Generic
+{
+    // Implements a variable-size List that uses an array of objects to store the
+    // elements. A List has a capacity, which is the allocated length
+    // of the internal array. As elements are added to a List, the capacity
+    // of the List is automatically increased as required by reallocating the
+    // internal array.
+    // 
+    [DebuggerTypeProxy(typeof(ICollectionDebugView<>))]
+    [DebuggerDisplay("Count = {Count}")]
+    public class List<T> : IList<T>, System.Collections.IList, IReadOnlyList<T>
+    {
+        private const int _defaultCapacity = 4;
+
+        private T[] _items;
+        [ContractPublicPropertyName("Count")]
+        private int _size;
+        private int _version;
+        private Object _syncRoot;
+
+        static readonly T[] _emptyArray = new T[0];
+
+        // Constructs a List. The list is initially empty and has a capacity
+        // of zero. Upon adding the first element to the list the capacity is
+        // increased to 16, and then increased in multiples of two as required.
+        public List()
+        {
+            _items = _emptyArray;
+        }
+
+        // Constructs a List with a given initial capacity. The list is
+        // initially empty, but will have room for the given number of elements
+        // before any reallocations are required.
+        // 
+        public List(int capacity)
+        {
+            if (capacity < 0) throw new ArgumentOutOfRangeException("capacity", SR.ArgumentOutOfRange_NeedNonNegNum);
+            Contract.EndContractBlock();
+
+            if (capacity == 0)
+                _items = _emptyArray;
+            else
+                _items = new T[capacity];
+        }
+
+        // Constructs a List, copying the contents of the given collection. The
+        // size and capacity of the new list will both be equal to the size of the
+        // given collection.
+        // 
+        public List(IEnumerable<T> collection)
+        {
+            if (collection == null)
+                throw new ArgumentNullException("collection");
+            Contract.EndContractBlock();
+
+            ICollection<T> c = collection as ICollection<T>;
+            if (c != null)
+            {
+                int count = c.Count;
+                if (count == 0)
+                {
+                    _items = _emptyArray;
+                }
+                else
+                {
+                    _items = new T[count];
+                    c.CopyTo(_items, 0);
+                    _size = count;
+                }
+            }
+            else
+            {
+                _size = 0;
+                _items = _emptyArray;
+                // This enumerable could be empty.  Let Add allocate a new array, if needed.
+                // Note it will also go to _defaultCapacity first, not 1, then 2, etc.
+
+                using (IEnumerator<T> en = collection.GetEnumerator())
+                {
+                    while (en.MoveNext())
+                    {
+                        Add(en.Current);
+                    }
+                }
+            }
+        }
+
+        // Gets and sets the capacity of this list.  The capacity is the size of
+        // the internal array used to hold items.  When set, the internal 
+        // array of the list is reallocated to the given capacity.
+        // 
+        public int Capacity
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() >= 0);
+                return _items.Length;
+            }
+            set
+            {
+                if (value < _size)
+                {
+                    throw new ArgumentOutOfRangeException("value", SR.ArgumentOutOfRange_SmallCapacity);
+                }
+                Contract.EndContractBlock();
+
+                if (value != _items.Length)
+                {
+                    if (value > 0)
+                    {
+                        var items = new T[value];
+                        Array.Copy(_items, 0, items, 0, _size);
+                        _items = items;
+                    }
+                    else
+                    {
+                        _items = _emptyArray;
+                    }
+                }
+            }
+        }
+
+        // Read-only property describing how many elements are in the List.
+        public int Count
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<int>() >= 0);
+                return _size;
+            }
+        }
+
+        bool System.Collections.IList.IsFixedSize
+        {
+            get { return false; }
+        }
+
+
+        // Is this List read-only?
+        bool ICollection<T>.IsReadOnly
+        {
+            get { return false; }
+        }
+
+        bool System.Collections.IList.IsReadOnly
+        {
+            get { return false; }
+        }
+
+        // Is this List synchronized (thread-safe)?
+        bool System.Collections.ICollection.IsSynchronized
+        {
+            get { return false; }
+        }
+
+        // Synchronization root for this object.
+        Object System.Collections.ICollection.SyncRoot
+        {
+            get
+            {
+                if (_syncRoot == null)
+                {
+                    System.Threading.Interlocked.CompareExchange<Object>(ref _syncRoot, new Object(), null);
+                }
+                return _syncRoot;
+            }
+        }
+        // Sets or Gets the element at the given index.
+        // 
+        public T this[int index]
+        {
+            get
+            {
+                // Following trick can reduce the range check by one
+                if ((uint)index >= (uint)_size)
+                {
+                    throw new ArgumentOutOfRangeException();
+                }
+                Contract.EndContractBlock();
+                return _items[index];
+            }
+
+            set
+            {
+                if ((uint)index >= (uint)_size)
+                {
+                    throw new ArgumentOutOfRangeException();
+                }
+                Contract.EndContractBlock();
+                _items[index] = value;
+                _version++;
+            }
+        }
+
+        private static bool IsCompatibleObject(object value)
+        {
+            // Non-null values are fine.  Only accept nulls if T is a class or Nullable<U>.
+            // Note that default(T) is not equal to null for value types except when T is Nullable<U>. 
+            return ((value is T) || (value == null && default(T) == null));
+        }
+
+        Object System.Collections.IList.this[int index]
+        {
+            get
+            {
+                return this[index];
+            }
+            set
+            {
+                if (value == null && !(default(T) == null))
+                    throw new ArgumentNullException("value");
+
+                try
+                {
+                    this[index] = (T)value;
+                }
+                catch (InvalidCastException)
+                {
+                    throw new ArgumentException(SR.Format(SR.Arg_WrongType, value, typeof(T)), "value");
+                }
+            }
+        }
+
+        // Adds the given object to the end of this list. The size of the list is
+        // increased by one. If required, the capacity of the list is doubled
+        // before adding the new element.
+        //
+        public void Add(T item)
+        {
+            if (_size == _items.Length) EnsureCapacity(_size + 1);
+            _items[_size++] = item;
+            _version++;
+        }
+
+        int System.Collections.IList.Add(Object item)
+        {
+            if (item == null && !(default(T) == null))
+                throw new ArgumentNullException("item");
+
+            try
+            {
+                Add((T)item);
+            }
+            catch (InvalidCastException)
+            {
+                throw new ArgumentException(SR.Format(SR.Arg_WrongType, item, typeof(T)), "item");
+            }
+
+            return Count - 1;
+        }
+
+
+        // Adds the elements of the given collection to the end of this list. If
+        // required, the capacity of the list is increased to twice the previous
+        // capacity or the new size, whichever is larger.
+        //
+        public void AddRange(IEnumerable<T> collection)
+        {
+            Contract.Ensures(Count >= Contract.OldValue(Count));
+
+            InsertRange(_size, collection);
+        }
+
+        public ReadOnlyCollection<T> AsReadOnly()
+        {
+            return new ReadOnlyCollection<T>(this);
+        }
+
+        // Searches a section of the list for a given element using a binary search
+        // algorithm. Elements of the list are compared to the search value using
+        // the given IComparer interface. If comparer is null, elements of
+        // the list are compared to the search value using the IComparable
+        // interface, which in that case must be implemented by all elements of the
+        // list and the given search value. This method assumes that the given
+        // section of the list is already sorted; if this is not the case, the
+        // result will be incorrect.
+        //
+        // The method returns the index of the given value in the list. If the
+        // list does not contain the given value, the method returns a negative
+        // integer. The bitwise complement operator (~) can be applied to a
+        // negative result to produce the index of the first element (if any) that
+        // is larger than the given search value. This is also the index at which
+        // the search value should be inserted into the list in order for the list
+        // to remain sorted.
+        // 
+        // The method uses the Array.BinarySearch method to perform the
+        // search.
+        // 
+        public int BinarySearch(int index, int count, T item, IComparer<T> comparer)
+        {
+            if (index < 0)
+                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (count < 0)
+                throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (_size - index < count)
+                throw new ArgumentException(SR.Argument_InvalidOffLen);
+            Contract.Ensures(Contract.Result<int>() <= index + count);
+            Contract.EndContractBlock();
+
+            return Array.BinarySearch<T>(_items, index, count, item, comparer);
+        }
+
+        public int BinarySearch(T item)
+        {
+            Contract.Ensures(Contract.Result<int>() <= Count);
+            return BinarySearch(0, Count, item, null);
+        }
+
+        public int BinarySearch(T item, IComparer<T> comparer)
+        {
+            Contract.Ensures(Contract.Result<int>() <= Count);
+            return BinarySearch(0, Count, item, comparer);
+        }
+
+
+        // Clears the contents of List.
+        public void Clear()
+        {
+            if (_size > 0)
+            {
+                Array.Clear(_items, 0, _size); // Don't need to doc this but we clear the elements so that the gc can reclaim the references.
+                _size = 0;
+            }
+            _version++;
+        }
+
+        // Contains returns true if the specified element is in the List.
+        // It does a linear, O(n) search.  Equality is determined by calling
+        // item.Equals().
+        //
+        public bool Contains(T item)
+        {
+            if ((Object)item == null)
+            {
+                for (int i = 0; i < _size; i++)
+                    if ((Object)_items[i] == null)
+                        return true;
+                return false;
+            }
+            else
+            {
+                EqualityComparer<T> c = EqualityComparer<T>.Default;
+                for (int i = 0; i < _size; i++)
+                {
+                    if (c.Equals(_items[i], item)) return true;
+                }
+                return false;
+            }
+        }
+
+        bool System.Collections.IList.Contains(Object item)
+        {
+            if (IsCompatibleObject(item))
+            {
+                return Contains((T)item);
+            }
+            return false;
+        }
+
+        // Copies this List into array, which must be of a 
+        // compatible array type.  
+        //
+        public void CopyTo(T[] array)
+        {
+            CopyTo(array, 0);
+        }
+
+        // Copies this List into array, which must be of a 
+        // compatible array type.  
+        //
+        void System.Collections.ICollection.CopyTo(Array array, int arrayIndex)
+        {
+            if ((array != null) && (array.Rank != 1))
+            {
+                throw new ArgumentException(SR.Arg_RankMultiDimNotSupported);
+            }
+            Contract.EndContractBlock();
+
+            try
+            {
+                // Array.Copy will check for NULL.
+                Array.Copy(_items, 0, array, arrayIndex, _size);
+            }
+            catch (ArrayTypeMismatchException)
+            {
+                throw new ArgumentException(SR.Argument_InvalidArrayType);
+            }
+        }
+
+        // Copies a section of this list to the given array at the given index.
+        // 
+        // The method uses the Array.Copy method to copy the elements.
+        // 
+        public void CopyTo(int index, T[] array, int arrayIndex, int count)
+        {
+            if (_size - index < count)
+            {
+                throw new ArgumentException(SR.Argument_InvalidOffLen);
+            }
+            Contract.EndContractBlock();
+
+            // Delegate rest of error checking to Array.Copy.
+            Array.Copy(_items, index, array, arrayIndex, count);
+        }
+
+        public void CopyTo(T[] array, int arrayIndex)
+        {
+            // Delegate rest of error checking to Array.Copy.
+            Array.Copy(_items, 0, array, arrayIndex, _size);
+        }
+
+        // Ensures that the capacity of this list is at least the given minimum
+        // value. If the currect capacity of the list is less than min, the
+        // capacity is increased to twice the current capacity or to min,
+        // whichever is larger.
+        private void EnsureCapacity(int min)
+        {
+            if (_items.Length < min)
+            {
+                int newCapacity = _items.Length == 0 ? _defaultCapacity : _items.Length * 2;
+                // Allow the list to grow to maximum possible capacity (~2G elements) before encountering overflow.
+                // Note that this check works even when _items.Length overflowed thanks to the (uint) cast
+                //if ((uint)newCapacity > Array.MaxArrayLength) newCapacity = Array.MaxArrayLength;
+                if (newCapacity < min) newCapacity = min;
+                Capacity = newCapacity;
+            }
+        }
+
+        public bool Exists(Predicate<T> match)
+        {
+            return FindIndex(match) != -1;
+        }
+
+        public T Find(Predicate<T> match)
+        {
+            if (match == null)
+            {
+                throw new ArgumentNullException("match");
+            }
+            Contract.EndContractBlock();
+
+            for (int i = 0; i < _size; i++)
+            {
+                if (match(_items[i]))
+                {
+                    return _items[i];
+                }
+            }
+            return default(T);
+        }
+
+        public List<T> FindAll(Predicate<T> match)
+        {
+            if (match == null)
+            {
+                throw new ArgumentNullException("match");
+            }
+            Contract.EndContractBlock();
+
+            List<T> list = new List<T>();
+            for (int i = 0; i < _size; i++)
+            {
+                if (match(_items[i]))
+                {
+                    list.Add(_items[i]);
+                }
+            }
+            return list;
+        }
+
+        public int FindIndex(Predicate<T> match)
+        {
+            Contract.Ensures(Contract.Result<int>() >= -1);
+            Contract.Ensures(Contract.Result<int>() < Count);
+            return FindIndex(0, _size, match);
+        }
+
+        public int FindIndex(int startIndex, Predicate<T> match)
+        {
+            Contract.Ensures(Contract.Result<int>() >= -1);
+            Contract.Ensures(Contract.Result<int>() < startIndex + Count);
+            return FindIndex(startIndex, _size - startIndex, match);
+        }
+
+        public int FindIndex(int startIndex, int count, Predicate<T> match)
+        {
+            if ((uint)startIndex > (uint)_size)
+            {
+                throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
+            }
+
+            if (count < 0 || startIndex > _size - count)
+            {
+                throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_Count);
+            }
+
+            if (match == null)
+            {
+                throw new ArgumentNullException("match");
+            }
+            Contract.Ensures(Contract.Result<int>() >= -1);
+            Contract.Ensures(Contract.Result<int>() < startIndex + count);
+            Contract.EndContractBlock();
+
+            int endIndex = startIndex + count;
+            for (int i = startIndex; i < endIndex; i++)
+            {
+                if (match(_items[i])) return i;
+            }
+            return -1;
+        }
+
+        public T FindLast(Predicate<T> match)
+        {
+            if (match == null)
+            {
+                throw new ArgumentNullException("match");
+            }
+            Contract.EndContractBlock();
+
+            for (int i = _size - 1; i >= 0; i--)
+            {
+                if (match(_items[i]))
+                {
+                    return _items[i];
+                }
+            }
+            return default(T);
+        }
+
+        public int FindLastIndex(Predicate<T> match)
+        {
+            Contract.Ensures(Contract.Result<int>() >= -1);
+            Contract.Ensures(Contract.Result<int>() < Count);
+            return FindLastIndex(_size - 1, _size, match);
+        }
+
+        public int FindLastIndex(int startIndex, Predicate<T> match)
+        {
+            Contract.Ensures(Contract.Result<int>() >= -1);
+            Contract.Ensures(Contract.Result<int>() <= startIndex);
+            return FindLastIndex(startIndex, startIndex + 1, match);
+        }
+
+        public int FindLastIndex(int startIndex, int count, Predicate<T> match)
+        {
+            if (match == null)
+            {
+                throw new ArgumentNullException("match");
+            }
+            Contract.Ensures(Contract.Result<int>() >= -1);
+            Contract.Ensures(Contract.Result<int>() <= startIndex);
+            Contract.EndContractBlock();
+
+            if (_size == 0)
+            {
+                // Special case for 0 length List
+                if (startIndex != -1)
+                {
+                    throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
+                }
+            }
+            else
+            {
+                // Make sure we're not out of range            
+                if ((uint)startIndex >= (uint)_size)
+                {
+                    throw new ArgumentOutOfRangeException("startIndex", SR.ArgumentOutOfRange_Index);
+                }
+            }
+
+            // 2nd have of this also catches when startIndex == MAXINT, so MAXINT - 0 + 1 == -1, which is < 0.
+            if (count < 0 || startIndex - count + 1 < 0)
+            {
+                throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_Count);
+            }
+
+            int endIndex = startIndex - count;
+            for (int i = startIndex; i > endIndex; i--)
+            {
+                if (match(_items[i]))
+                {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        public void ForEach(Action<T> action)
+        {
+            if (action == null)
+            {
+                throw new ArgumentNullException("match");
+            }
+
+            int version = _version;
+
+            for (int i = 0; i < _size; i++)
+            {
+                if (version != _version)
+                {
+                    break;
+                }
+                action(_items[i]);
+            }
+
+            if (version != _version)
+                throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
+        }
+
+        // Returns an enumerator for this list with the given
+        // permission for removal of elements. If modifications made to the list 
+        // while an enumeration is in progress, the MoveNext and 
+        // GetObject methods of the enumerator will throw an exception.
+        //
+        public Enumerator GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        /// <internalonly/>
+        IEnumerator<T> IEnumerable<T>.GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return new Enumerator(this);
+        }
+
+        public List<T> GetRange(int index, int count)
+        {
+            if (index < 0)
+            {
+                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            if (_size - index < count)
+            {
+                throw new ArgumentException(SR.Argument_InvalidOffLen);
+            }
+            Contract.Ensures(Contract.Result<List<T>>() != null);
+            Contract.EndContractBlock();
+
+            List<T> list = new List<T>(count);
+            Array.Copy(_items, index, list._items, 0, count);
+            list._size = count;
+            return list;
+        }
+
+
+        // Returns the index of the first occurrence of a given value in a range of
+        // this list. The list is searched forwards from beginning to end.
+        // The elements of the list are compared to the given value using the
+        // Object.Equals method.
+        // 
+        // This method uses the Array.IndexOf method to perform the
+        // search.
+        // 
+        public int IndexOf(T item)
+        {
+            Contract.Ensures(Contract.Result<int>() >= -1);
+            Contract.Ensures(Contract.Result<int>() < Count);
+            return Array.IndexOf(_items, item, 0, _size);
+        }
+
+        int System.Collections.IList.IndexOf(Object item)
+        {
+            if (IsCompatibleObject(item))
+            {
+                return IndexOf((T)item);
+            }
+            return -1;
+        }
+
+        // Returns the index of the first occurrence of a given value in a range of
+        // this list. The list is searched forwards, starting at index
+        // index and ending at count number of elements. The
+        // elements of the list are compared to the given value using the
+        // Object.Equals method.
+        // 
+        // This method uses the Array.IndexOf method to perform the
+        // search.
+        // 
+        public int IndexOf(T item, int index)
+        {
+            if (index > _size)
+                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+            Contract.Ensures(Contract.Result<int>() >= -1);
+            Contract.Ensures(Contract.Result<int>() < Count);
+            Contract.EndContractBlock();
+            return Array.IndexOf(_items, item, index, _size - index);
+        }
+
+        // Returns the index of the first occurrence of a given value in a range of
+        // this list. The list is searched forwards, starting at index
+        // index and upto count number of elements. The
+        // elements of the list are compared to the given value using the
+        // Object.Equals method.
+        // 
+        // This method uses the Array.IndexOf method to perform the
+        // search.
+        // 
+        public int IndexOf(T item, int index, int count)
+        {
+            if (index > _size)
+                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+
+            if (count < 0 || index > _size - count)
+                throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_Count);
+            Contract.Ensures(Contract.Result<int>() >= -1);
+            Contract.Ensures(Contract.Result<int>() < Count);
+            Contract.EndContractBlock();
+
+            return Array.IndexOf(_items, item, index, count);
+        }
+
+        // Inserts an element into this list at a given index. The size of the list
+        // is increased by one. If required, the capacity of the list is doubled
+        // before inserting the new element.
+        // 
+        public void Insert(int index, T item)
+        {
+            // Note that insertions at the end are legal.
+            if ((uint)index > (uint)_size)
+            {
+                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_ListInsert);
+            }
+            Contract.EndContractBlock();
+            if (_size == _items.Length) EnsureCapacity(_size + 1);
+            if (index < _size)
+            {
+                Array.Copy(_items, index, _items, index + 1, _size - index);
+            }
+            _items[index] = item;
+            _size++;
+            _version++;
+        }
+
+        void System.Collections.IList.Insert(int index, Object item)
+        {
+            if (item == null && !(default(T) == null))
+                throw new ArgumentNullException("item");
+
+            try
+            {
+                Insert(index, (T)item);
+            }
+            catch (InvalidCastException)
+            {
+                throw new ArgumentException(SR.Format(SR.Arg_WrongType, item, typeof(T)), "item");
+            }
+        }
+
+        // Inserts the elements of the given collection at a given index. If
+        // required, the capacity of the list is increased to twice the previous
+        // capacity or the new size, whichever is larger.  Ranges may be added
+        // to the end of the list by setting index to the List's size.
+        //
+        public void InsertRange(int index, IEnumerable<T> collection)
+        {
+            if (collection == null)
+            {
+                throw new ArgumentNullException("collection");
+            }
+
+            if ((uint)index > (uint)_size)
+            {
+                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+            }
+            Contract.EndContractBlock();
+
+            ICollection<T> c = collection as ICollection<T>;
+            if (c != null)
+            {    // if collection is ICollection<T>
+                int count = c.Count;
+                if (count > 0)
+                {
+                    EnsureCapacity(_size + count);
+                    if (index < _size)
+                    {
+                        Array.Copy(_items, index, _items, index + count, _size - index);
+                    }
+
+                    // If we're inserting a List into itself, we want to be able to deal with that.
+                    if (this == c)
+                    {
+                        // Copy first part of _items to insert location
+                        Array.Copy(_items, 0, _items, index, index);
+                        // Copy last part of _items back to inserted location
+                        Array.Copy(_items, index + count, _items, index * 2, _size - index);
+                    }
+                    else
+                    {
+                        T[] itemsToInsert = new T[count];
+                        c.CopyTo(itemsToInsert, 0);
+                        Array.Copy(itemsToInsert, 0, _items, index, count);
+                    }
+                    _size += count;
+                }
+            }
+            else
+            {
+                using (IEnumerator<T> en = collection.GetEnumerator())
+                {
+                    while (en.MoveNext())
+                    {
+                        Insert(index++, en.Current);
+                    }
+                }
+            }
+            _version++;
+        }
+
+        // Returns the index of the last occurrence of a given value in a range of
+        // this list. The list is searched backwards, starting at the end 
+        // and ending at the first element in the list. The elements of the list 
+        // are compared to the given value using the Object.Equals method.
+        // 
+        // This method uses the Array.LastIndexOf method to perform the
+        // search.
+        // 
+        public int LastIndexOf(T item)
+        {
+            Contract.Ensures(Contract.Result<int>() >= -1);
+            Contract.Ensures(Contract.Result<int>() < Count);
+            if (_size == 0)
+            {  // Special case for empty list
+                return -1;
+            }
+            else
+            {
+                return LastIndexOf(item, _size - 1, _size);
+            }
+        }
+
+        // Returns the index of the last occurrence of a given value in a range of
+        // this list. The list is searched backwards, starting at index
+        // index and ending at the first element in the list. The 
+        // elements of the list are compared to the given value using the 
+        // Object.Equals method.
+        // 
+        // This method uses the Array.LastIndexOf method to perform the
+        // search.
+        // 
+        public int LastIndexOf(T item, int index)
+        {
+            if (index >= _size)
+                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_Index);
+            Contract.Ensures(Contract.Result<int>() >= -1);
+            Contract.Ensures(((Count == 0) && (Contract.Result<int>() == -1)) || ((Count > 0) && (Contract.Result<int>() <= index)));
+            Contract.EndContractBlock();
+            return LastIndexOf(item, index, index + 1);
+        }
+
+        // Returns the index of the last occurrence of a given value in a range of
+        // this list. The list is searched backwards, starting at index
+        // index and upto count elements. The elements of
+        // the list are compared to the given value using the Object.Equals
+        // method.
+        // 
+        // This method uses the Array.LastIndexOf method to perform the
+        // search.
+        // 
+        public int LastIndexOf(T item, int index, int count)
+        {
+            if ((Count != 0) && (index < 0))
+            {
+                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            if ((Count != 0) && (count < 0))
+            {
+                throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+            Contract.Ensures(Contract.Result<int>() >= -1);
+            Contract.Ensures(((Count == 0) && (Contract.Result<int>() == -1)) || ((Count > 0) && (Contract.Result<int>() <= index)));
+            Contract.EndContractBlock();
+
+            if (_size == 0)
+            {  // Special case for empty list
+                return -1;
+            }
+
+            if (index >= _size)
+            {
+                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_BiggerThanCollection);
+            }
+
+            if (count > index + 1)
+            {
+                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_BiggerThanCollection);
+            }
+
+            return Array.LastIndexOf(_items, item, index, count);
+        }
+
+        // Removes the element at the given index. The size of the list is
+        // decreased by one.
+        // 
+        public bool Remove(T item)
+        {
+            int index = IndexOf(item);
+            if (index >= 0)
+            {
+                RemoveAt(index);
+                return true;
+            }
+
+            return false;
+        }
+
+        void System.Collections.IList.Remove(Object item)
+        {
+            if (IsCompatibleObject(item))
+            {
+                Remove((T)item);
+            }
+        }
+
+        // This method removes all items which matches the predicate.
+        // The complexity is O(n).   
+        public int RemoveAll(Predicate<T> match)
+        {
+            if (match == null)
+            {
+                throw new ArgumentNullException("match");
+            }
+            Contract.Ensures(Contract.Result<int>() >= 0);
+            Contract.Ensures(Contract.Result<int>() <= Contract.OldValue(Count));
+            Contract.EndContractBlock();
+
+            int freeIndex = 0;   // the first free slot in items array
+
+            // Find the first item which needs to be removed.
+            while (freeIndex < _size && !match(_items[freeIndex])) freeIndex++;
+            if (freeIndex >= _size) return 0;
+
+            int current = freeIndex + 1;
+            while (current < _size)
+            {
+                // Find the first item which needs to be kept.
+                while (current < _size && match(_items[current])) current++;
+
+                if (current < _size)
+                {
+                    // copy item to the free slot.
+                    _items[freeIndex++] = _items[current++];
+                }
+            }
+
+            Array.Clear(_items, freeIndex, _size - freeIndex);
+            int result = _size - freeIndex;
+            _size = freeIndex;
+            _version++;
+            return result;
+        }
+
+        // Removes the element at the given index. The size of the list is
+        // decreased by one.
+        // 
+        public void RemoveAt(int index)
+        {
+            if ((uint)index >= (uint)_size)
+            {
+                throw new ArgumentOutOfRangeException("index");
+            }
+            Contract.EndContractBlock();
+            _size--;
+            if (index < _size)
+            {
+                Array.Copy(_items, index + 1, _items, index, _size - index);
+            }
+            _items[_size] = default(T);
+            _version++;
+        }
+
+        // Removes a range of elements from this list.
+        // 
+        public void RemoveRange(int index, int count)
+        {
+            if (index < 0)
+            {
+                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            if (_size - index < count)
+                throw new ArgumentException(SR.Argument_InvalidOffLen);
+            Contract.EndContractBlock();
+
+            if (count > 0)
+            {
+                int i = _size;
+                _size -= count;
+                if (index < _size)
+                {
+                    Array.Copy(_items, index + count, _items, index, _size - index);
+                }
+                Array.Clear(_items, _size, count);
+                _version++;
+            }
+        }
+
+        // Reverses the elements in this list.
+        public void Reverse()
+        {
+            Reverse(0, Count);
+        }
+
+        // Reverses the elements in a range of this list. Following a call to this
+        // method, an element in the range given by index and count
+        // which was previously located at index i will now be located at
+        // index index + (index + count - i - 1).
+        // 
+        // This method uses the Array.Reverse method to reverse the
+        // elements.
+        // 
+        public void Reverse(int index, int count)
+        {
+            if (index < 0)
+            {
+                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            if (_size - index < count)
+                throw new ArgumentException(SR.Argument_InvalidOffLen);
+            Contract.EndContractBlock();
+            int i = index;
+            int j = index + count - 1;
+            while (i < j)
+            {
+                T temp = _items[i];
+                _items[i] = _items[j];
+                _items[j] = temp;
+                i++;
+                j--;
+            }
+            _version++;
+        }
+
+        // Sorts the elements in this list.  Uses the default comparer and 
+        // Array.Sort.
+        public void Sort()
+        {
+            Sort(0, Count, null);
+        }
+
+        // Sorts the elements in this list.  Uses Array.Sort with the
+        // provided comparer.
+        public void Sort(IComparer<T> comparer)
+        {
+            Sort(0, Count, comparer);
+        }
+
+        // Sorts the elements in a section of this list. The sort compares the
+        // elements to each other using the given IComparer interface. If
+        // comparer is null, the elements are compared to each other using
+        // the IComparable interface, which in that case must be implemented by all
+        // elements of the list.
+        // 
+        // This method uses the Array.Sort method to sort the elements.
+        // 
+        public void Sort(int index, int count, IComparer<T> comparer)
+        {
+            if (index < 0)
+            {
+                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_NeedNonNegNum);
+            }
+
+            if (_size - index < count)
+                throw new ArgumentException(SR.Argument_InvalidOffLen);
+            Contract.EndContractBlock();
+
+            Array.Sort<T>(_items, index, count, comparer);
+            _version++;
+        }
+
+        public void Sort(Comparison<T> comparison)
+        {
+            if (comparison == null)
+            {
+                throw new ArgumentNullException("comparison");
+            }
+            Contract.EndContractBlock();
+
+            if (_size > 0)
+            {
+                IComparer<T> comparer = Comparer<T>.Create(comparison);
+                Array.Sort(_items, 0, _size, comparer);
+            }
+        }
+
+        // ToArray returns a new Object array containing the contents of the List.
+        // This requires copying the List, which is an O(n) operation.
+        public T[] ToArray()
+        {
+            Contract.Ensures(Contract.Result<T[]>() != null);
+            Contract.Ensures(Contract.Result<T[]>().Length == Count);
+
+            T[] array = new T[_size];
+            Array.Copy(_items, 0, array, 0, _size);
+            return array;
+        }
+
+        // Sets the capacity of this list to the size of the list. This method can
+        // be used to minimize a list's memory overhead once it is known that no
+        // new elements will be added to the list. To completely clear a list and
+        // release all memory referenced by the list, execute the following
+        // statements:
+        // 
+        // list.Clear();
+        // list.TrimExcess();
+        // 
+        public void TrimExcess()
+        {
+            int threshold = (int)(((double)_items.Length) * 0.9);
+            if (_size < threshold)
+            {
+                Capacity = _size;
+            }
+        }
+
+        public bool TrueForAll(Predicate<T> match)
+        {
+            if (match == null)
+            {
+                throw new ArgumentNullException("match");
+            }
+            Contract.EndContractBlock();
+
+            for (int i = 0; i < _size; i++)
+            {
+                if (!match(_items[i]))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        internal static IList<T> Synchronized(List<T> list)
+        {
+            return new SynchronizedList(list);
+        }
+
+        internal class SynchronizedList : IList<T>
+        {
+            private List<T> _list;
+            private Object _root;
+
+            internal SynchronizedList(List<T> list)
+            {
+                _list = list;
+                _root = ((System.Collections.ICollection)list).SyncRoot;
+            }
+
+            public int Count
+            {
+                get
+                {
+                    lock (_root)
+                    {
+                        return _list.Count;
+                    }
+                }
+            }
+
+            public bool IsReadOnly
+            {
+                get
+                {
+                    return ((ICollection<T>)_list).IsReadOnly;
+                }
+            }
+
+            public void Add(T item)
+            {
+                lock (_root)
+                {
+                    _list.Add(item);
+                }
+            }
+
+            public void Clear()
+            {
+                lock (_root)
+                {
+                    _list.Clear();
+                }
+            }
+
+            public bool Contains(T item)
+            {
+                lock (_root)
+                {
+                    return _list.Contains(item);
+                }
+            }
+
+            public void CopyTo(T[] array, int arrayIndex)
+            {
+                lock (_root)
+                {
+                    _list.CopyTo(array, arrayIndex);
+                }
+            }
+
+            public bool Remove(T item)
+            {
+                lock (_root)
+                {
+                    return _list.Remove(item);
+                }
+            }
+
+            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+            {
+                lock (_root)
+                {
+                    return _list.GetEnumerator();
+                }
+            }
+
+            IEnumerator<T> IEnumerable<T>.GetEnumerator()
+            {
+                lock (_root)
+                {
+                    return ((IEnumerable<T>)_list).GetEnumerator();
+                }
+            }
+
+            public T this[int index]
+            {
+                get
+                {
+                    lock (_root)
+                    {
+                        return _list[index];
+                    }
+                }
+                set
+                {
+                    lock (_root)
+                    {
+                        _list[index] = value;
+                    }
+                }
+            }
+
+            public int IndexOf(T item)
+            {
+                lock (_root)
+                {
+                    return _list.IndexOf(item);
+                }
+            }
+
+            public void Insert(int index, T item)
+            {
+                lock (_root)
+                {
+                    _list.Insert(index, item);
+                }
+            }
+
+            public void RemoveAt(int index)
+            {
+                lock (_root)
+                {
+                    _list.RemoveAt(index);
+                }
+            }
+        }
+
+        public struct Enumerator : IEnumerator<T>, System.Collections.IEnumerator
+        {
+            private List<T> list;
+            private int index;
+            private int version;
+            private T current;
+
+            internal Enumerator(List<T> list)
+            {
+                this.list = list;
+                index = 0;
+                version = list._version;
+                current = default(T);
+            }
+
+            public void Dispose()
+            {
+            }
+
+            public bool MoveNext()
+            {
+                List<T> localList = list;
+
+                if (version == localList._version && ((uint)index < (uint)localList._size))
+                {
+                    current = localList._items[index];
+                    index++;
+                    return true;
+                }
+                return MoveNextRare();
+            }
+
+            private bool MoveNextRare()
+            {
+                if (version != list._version)
+                {
+                    throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
+                }
+
+                index = list._size + 1;
+                current = default(T);
+                return false;
+            }
+
+            public T Current
+            {
+                get
+                {
+                    return current;
+                }
+            }
+
+            Object System.Collections.IEnumerator.Current
+            {
+                get
+                {
+                    if (index == 0 || index == list._size + 1)
+                    {
+                        throw new InvalidOperationException(SR.InvalidOperation_EnumOpCantHappen);
+                    }
+                    return Current;
+                }
+            }
+
+            void System.Collections.IEnumerator.Reset()
+            {
+                if (version != list._version)
+                {
+                    throw new InvalidOperationException(SR.InvalidOperation_EnumFailedVersion);
+                }
+
+                index = 0;
+                current = default(T);
+            }
+        }
+    }
+}
+

--- a/src/System.Collections/src/project.json
+++ b/src/System.Collections/src/project.json
@@ -7,7 +7,18 @@
     },
     "net46": {
       "dependencies": {
-        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0"
+      }
+    },
+    "netcore50": {
+      "dependencies": {
+        "System.Diagnostics.Contracts": "4.0.1-rc2-23610",
+        "System.Diagnostics.Debug": "4.0.11-rc2-23610",
+        "System.Diagnostics.Tools": "4.0.1-rc2-23610",
+        "System.Threading": "4.0.11-rc2-23610",
+        "System.Resources.ResourceManager": "4.0.1-rc2-23610",
+        "System.Runtime": "4.0.21-rc2-23610",
+        "System.Runtime.Extensions": "4.0.11-rc2-23610"
       }
     }
   }


### PR DESCRIPTION
This is a direct port of the .NET Native version of System.Collections from our internal source tree. It contains a few more types, like Dictionary, List, etc. that in CoreCLR are implemented in mscorlib. I've regenerated the solution file so that the new configurations can be accessed from Visual Studio.

NOTE: I have not made any cleanup changes in this version. I started doing so but noticed that the existing code in System.Collections could use a lot of cleanup in the first place. I think we should do separate cleanup of the whole library.

@weshaggard 