### PR TITLE
Always build desktop facades for packaged libraries

### DIFF
--- a/src/Microsoft.CSharp/src/Microsoft.CSharp.builds
+++ b/src/Microsoft.CSharp/src/Microsoft.CSharp.builds
@@ -2,8 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <!-- dotnet/corefx#3128 tracks removing this exclusion -->
-    <Project Include="Microsoft.CSharp.csproj" Condition="'$(TargetsWindows)' == 'true'">
+    <Project Include="Microsoft.CSharp.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
   </ItemGroup>

--- a/src/Microsoft.CSharp/src/Microsoft.CSharp.csproj
+++ b/src/Microsoft.CSharp/src/Microsoft.CSharp.csproj
@@ -10,6 +10,9 @@
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <RootNamespace>Microsoft.CSharp</RootNamespace>
     <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
+    
+    <!-- dotnet/corefx#3128 tracks removing this exclusion -->
+    <ExcludeLocalizationImport Condition="'$(TargetsWindows)' != 'true'">true</ExcludeLocalizationImport>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.builds
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.builds
@@ -5,7 +5,7 @@
     <Project Include="System.IO.FileSystem.csproj">
       <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
-    <Project Include="facade\System.IO.FileSystem.csproj" Condition="'$(TargetsWindows)' == 'true'">
+    <Project Include="facade\System.IO.FileSystem.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
     </Project>
   </ItemGroup>


### PR DESCRIPTION
The desktop facade must go in the reference package,
so we need to build it whenever we build OS-neutral
projects.

/cc @weshaggard @LLITCHEV @ellismg 