### PR TITLE
CurlHandler fix for cookie handling

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -43,6 +43,7 @@ namespace System.Net.Http
             internal MultiAgent _associatedMultiAgent;
             internal SendTransferState _sendTransferState;
             internal bool _isRedirect = false;
+            internal Uri _targetUri;
 
             private SafeCallbackHandle _callbackHandle;
 
@@ -59,6 +60,7 @@ namespace System.Net.Http
                 }
 
                 _responseMessage = new CurlResponseMessage(this);
+                _targetUri = requestMessage.RequestUri;
             }
 
             /// <summary>
@@ -566,6 +568,12 @@ namespace System.Net.Http
                     _offset = offset;
                     _count = count;
                 }
+            }
+
+            internal void  SetRedirectUri(Uri redirectUri)
+            {
+                _targetUri = _requestMessage.RequestUri;
+                _requestMessage.RequestUri = redirectUri;
             }
 
             [Conditional(VerboseDebuggingConditional)]

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -523,9 +523,6 @@ namespace System.Net.Http
                         }
                         // Ignore errors: no need to fail for the sake of putting the credentials into the cache
                     }
-
-                    completedOperation._handler.AddResponseCookies(
-                        completedOperation._requestMessage.RequestUri, completedOperation._responseMessage);
                 }
 
                 // Complete or fail the request
@@ -580,6 +577,10 @@ namespace System.Net.Http
                                 else if (easy._isRedirect && string.Equals(headerName, HttpKnownHeaderNames.Location, StringComparison.OrdinalIgnoreCase))
                                 {
                                     HandleRedirectLocationHeader(easy, headerValue);
+                                }
+                                else if (string.Equals(headerName, HttpKnownHeaderNames.SetCookie, StringComparison.OrdinalIgnoreCase))
+                                {
+                                    easy._handler.AddResponseCookies(easy, headerValue);
                                 }
                             }
                         }

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -398,31 +398,25 @@ namespace System.Net.Http
             }
         }
 
-        private void AddResponseCookies(Uri serverUri, HttpResponseMessage response)
+        private void AddResponseCookies(EasyRequest state, string cookieHeader)
         {
             if (!_useCookie)
             {
                 return;
             }
 
-            if (response.Headers.Contains(HttpKnownHeaderNames.SetCookie))
+            try
             {
-                IEnumerable<string> cookieHeaders = response.Headers.GetValues(HttpKnownHeaderNames.SetCookie);
-                foreach (var cookieHeader in cookieHeaders)
-                {
-                    try
-                    {
-                        _cookieContainer.SetCookies(serverUri, cookieHeader);
-                    }
-                    catch (CookieException e)
-                    {
-                        string msg = string.Format("Malformed cookie: SetCookies Failed with {0}, server: {1}, cookie:{2}",
-                                                   e.Message,
-                                                   serverUri.OriginalString,
-                                                   cookieHeader);
-                        VerboseTrace(msg);
-                    }
-                }
+                _cookieContainer.SetCookies(state._targetUri, cookieHeader);
+                state.SetCookieOption(state._requestMessage.RequestUri);
+            }
+            catch (CookieException e)
+            {
+                string msg = string.Format("Malformed cookie: SetCookies Failed with {0}, server: {1}, cookie:{2}",
+                                           e.Message,
+                                           state._requestMessage.RequestUri,
+                                           cookieHeader);
+                VerboseTrace(msg);
             }
         }
 
@@ -608,7 +602,8 @@ namespace System.Net.Http
                     // set cookies again
                     state.SetCookieOption(forwardUri);
                 }
-                state._requestMessage.RequestUri = forwardUri;
+
+                state.SetRedirectUri(forwardUri);
             }
 
             // set the headers again. This is a workaround for libcurl's limitation in handling headers with empty values

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -408,7 +408,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue(4960, PlatformID.AnyUnix)]
         [Theory]
         [InlineData("cookieName1", "cookieValue1")]
         public async Task GetAsync_RedirectResponseHasCookie_CookieSentToFinalUri(string cookieName, string cookieValue)


### PR DESCRIPTION
CurlHandler has been handling cookies only from the final HTTP response.
The cookies sent during the intermediate http responses (during 3XX redirection as well as interim 401, 407 responses) were getting ignored.

This fix ensures that the cookies from all the responses are handled.