### PR TITLE
Remove openSUSE 13.2 from PR testing

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -275,7 +275,7 @@ def innerLoopNonWindowsOSs = ['Ubuntu', 'Debian8.2', 'OSX', 'FreeBSD', 'CentOS7.
             if (isPR) {
                 // Set PR trigger.
                 // Set of OS's that work currently. 
-                if (os in ['Ubuntu', 'OpenSUSE13.2', 'CentOS7.1']) {
+                if (os in ['Ubuntu', 'CentOS7.1']) {
                     Utilities.addGithubPRTrigger(newFlowJob, "Innerloop ${os} ${configuration} Build and Test")
                 }
             }


### PR DESCRIPTION
The openSUSE 13.2 Debug build has been a fair bit recently and the
failures look related to some recent changes in CLR (likely due to the
recent JIT changes that have gone in).

While we investigate the failure (see #5082) I am removing the per PR jobs
from CI.