### PR TITLE
System.Net EventSource Logging

### DIFF
--- a/src/Common/src/Interop/Windows/Winsock/SafeNativeOverlapped.cs
+++ b/src/Common/src/Interop/Windows/Winsock/SafeNativeOverlapped.cs
@@ -20,7 +20,7 @@ namespace System.Net.Sockets
         protected SafeNativeOverlapped()
             : this(IntPtr.Zero)
         {
-            GlobalLog.Print("SafeNativeOverlapped#" + Logging.HashString(this) + "::ctor(null)");
+            GlobalLog.Print("SafeNativeOverlapped#" + LoggingHash.HashString(this) + "::ctor(null)");
         }
 
         protected SafeNativeOverlapped(IntPtr handle)
@@ -34,7 +34,7 @@ namespace System.Net.Sockets
         {
             _safeCloseSocket = socketHandle;
 
-            GlobalLog.Print("SafeNativeOverlapped#" + Logging.HashString(this) + "::ctor(socket#" + Logging.HashString(socketHandle) + ")");
+            GlobalLog.Print("SafeNativeOverlapped#" + LoggingHash.HashString(this) + "::ctor(socket#" + LoggingHash.HashString(socketHandle) + ")");
 #if DEBUG
             _safeCloseSocket.AddRef();
 #endif
@@ -45,7 +45,7 @@ namespace System.Net.Sockets
             if (disposing)
             {
                 // It is important that the boundHandle is released immediately to allow new overlapped operations.
-                GlobalLog.Print("SafeNativeOverlapped#" + Logging.HashString(this) + "::Dispose(true)");
+                GlobalLog.Print("SafeNativeOverlapped#" + LoggingHash.HashString(this) + "::Dispose(true)");
                 FreeNativeOverlapped();
             }
         }
@@ -57,7 +57,7 @@ namespace System.Net.Sockets
 
         protected override bool ReleaseHandle()
         {
-            GlobalLog.Print("SafeNativeOverlapped#" + Logging.HashString(this) + "::ReleaseHandle()");
+            GlobalLog.Print("SafeNativeOverlapped#" + LoggingHash.HashString(this) + "::ReleaseHandle()");
 
             FreeNativeOverlapped();
             return true;

--- a/src/Common/src/Interop/Windows/secur32/NegotiationInfoClass.cs
+++ b/src/Common/src/Interop/Windows/secur32/NegotiationInfoClass.cs
@@ -36,7 +36,7 @@ namespace System.Net
                     name = Marshal.PtrToStringUni(unmanagedString);
                 }
 
-                GlobalLog.Print("NegotiationInfoClass::.ctor() packageInfo:" + packageInfo.ToString("x8") + " negotiationState:" + negotiationState.ToString("x8") + " name:" + Logging.ObjectToString(name));
+                GlobalLog.Print("NegotiationInfoClass::.ctor() packageInfo:" + packageInfo.ToString("x8") + " negotiationState:" + negotiationState.ToString("x8") + " name:" + LoggingHash.ObjectToString(name));
 
                 // An optimization for future string comparisons.
                 if (string.Compare(name, Kerberos, StringComparison.OrdinalIgnoreCase) == 0)

--- a/src/Common/src/Interop/Windows/secur32/SSPIWrapper.cs
+++ b/src/Common/src/Interop/Windows/secur32/SSPIWrapper.cs
@@ -31,18 +31,14 @@ namespace System.Net
                             }
 
                             SecurityPackageInfoClass[] securityPackages = new SecurityPackageInfoClass[moduleCount];
-                            if (Logging.On)
-                            {
-                                Logging.PrintInfo(Logging.Web, SR.net_log_sspi_enumerating_security_packages);
-                            }
 
                             int i;
                             for (i = 0; i < moduleCount; i++)
                             {
                                 securityPackages[i] = new SecurityPackageInfoClass(arrayBaseHandle, i);
-                                if (Logging.On)
+                                if (SecurityEventSource.Log.IsEnabled())
                                 {
-                                    Logging.PrintInfo(Logging.Web, "    " + securityPackages[i].Name);
+                                    SecurityEventSource.Log.EnumerateSecurityPackages(securityPackages[i].Name);
                                 }
                             }
 
@@ -82,9 +78,9 @@ namespace System.Net
                 }
             }
 
-            if (Logging.On)
+            if (SecurityEventSource.Log.IsEnabled())
             {
-                Logging.PrintInfo(Logging.Web, SR.Format(SR.net_log_sspi_security_package_not_found, packageName));
+                SecurityEventSource.Log.SspiPackageNotFound(packageName);
             }
 
             if (throwIfMissing)
@@ -98,13 +94,9 @@ namespace System.Net
         public static SafeFreeCredentials AcquireDefaultCredential(SSPIInterface secModule, string package, Interop.Secur32.CredentialUse intent)
         {
             GlobalLog.Print("SSPIWrapper::AcquireDefaultCredential(): using " + package);
-            if (Logging.On)
+            if (SecurityEventSource.Log.IsEnabled())
             {
-                Logging.PrintInfo(
-                    Logging.Web,
-                    "AcquireDefaultCredential(" +
-                    "package = " + package + ", " +
-                    "intent  = " + intent + ")");
+                SecurityEventSource.Log.AcquireDefaultCredential(package, intent);
             }
 
             SafeFreeCredentials outCredential = null;
@@ -116,9 +108,9 @@ namespace System.Net
                 GlobalLog.Print("SSPIWrapper::AcquireDefaultCredential(): error " + Interop.MapSecurityStatus((uint)errorCode));
 #endif
 
-                if (Logging.On)
+                if (NetEventSource.Log.IsEnabled())
                 {
-                    Logging.PrintError(Logging.Web, SR.Format(SR.net_log_operation_failed_with_error, "AcquireDefaultCredential()", String.Format(CultureInfo.CurrentCulture, "0X{0:X}", errorCode)));
+                    NetEventSource.PrintError(NetEventSource.ComponentType.Security, SR.Format(SR.net_log_operation_failed_with_error, "AcquireDefaultCredential()", String.Format(CultureInfo.CurrentCulture, "0X{0:X}", errorCode)));
                 }
 
                 throw new Win32Exception(errorCode);
@@ -130,13 +122,9 @@ namespace System.Net
         {
             GlobalLog.Print("SSPIWrapper::AcquireCredentialsHandle#2(): using " + package);
 
-            if (Logging.On)
+            if (SecurityEventSource.Log.IsEnabled())
             {
-                Logging.PrintInfo(Logging.Web,
-                    "AcquireCredentialsHandle(" +
-                    "package  = " + package + ", " +
-                    "intent   = " + intent + ", " +
-                    "authdata = " + authdata + ")");
+                SecurityEventSource.AcquireCredentialsHandle(package, intent, authdata);
             }
 
             SafeFreeCredentials credentialsHandle = null;
@@ -150,9 +138,9 @@ namespace System.Net
 #if TRACE_VERBOSE
                 GlobalLog.Print("SSPIWrapper::AcquireCredentialsHandle#2(): error " + Interop.MapSecurityStatus((uint)errorCode));
 #endif
-                if (Logging.On)
+                if (NetEventSource.Log.IsEnabled())
                 {
-                    Logging.PrintError(Logging.Web, SR.Format(SR.net_log_operation_failed_with_error, "AcquireCredentialsHandle()", String.Format(CultureInfo.CurrentCulture, "0X{0:X}", errorCode)));
+                    NetEventSource.PrintError(NetEventSource.ComponentType.Security, SR.Format(SR.net_log_operation_failed_with_error, "AcquireCredentialsHandle()", String.Format(CultureInfo.CurrentCulture, "0X{0:X}", errorCode)));
                 }
 
                 throw new Win32Exception(errorCode);
@@ -162,13 +150,9 @@ namespace System.Net
 
         public static SafeFreeCredentials AcquireCredentialsHandle(SSPIInterface secModule, string package, Interop.Secur32.CredentialUse intent, ref SafeSspiAuthDataHandle authdata)
         {
-            if (Logging.On)
+            if (SecurityEventSource.Log.IsEnabled())
             {
-                Logging.PrintInfo(Logging.Web,
-                    "AcquireCredentialsHandle(" +
-                    "package  = " + package + ", " +
-                    "intent   = " + intent + ", " +
-                    "authdata = " + authdata + ")");
+                SecurityEventSource.AcquireCredentialsHandle(package, intent, authdata);
             }
 
             SafeFreeCredentials credentialsHandle = null;
@@ -176,9 +160,9 @@ namespace System.Net
 
             if (errorCode != 0)
             {
-                if (Logging.On)
+                if (NetEventSource.Log.IsEnabled())
                 {
-                    Logging.PrintError(Logging.Web, SR.Format(SR.net_log_operation_failed_with_error, "AcquireCredentialsHandle()", String.Format(CultureInfo.CurrentCulture, "0X{0:X}", errorCode)));
+                    NetEventSource.PrintError(NetEventSource.ComponentType.Security, SR.Format(SR.net_log_operation_failed_with_error, "AcquireCredentialsHandle()", String.Format(CultureInfo.CurrentCulture, "0X{0:X}", errorCode)));
                 }
 
                 throw new Win32Exception(errorCode);
@@ -191,13 +175,9 @@ namespace System.Net
         {
             GlobalLog.Print("SSPIWrapper::AcquireCredentialsHandle#3(): using " + package);
 
-            if (Logging.On)
+            if (SecurityEventSource.Log.IsEnabled())
             {
-                Logging.PrintInfo(Logging.Web,
-                    "AcquireCredentialsHandle(" +
-                    "package = " + package + ", " +
-                    "intent  = " + intent + ", " +
-                    "scc     = " + scc + ")");
+                SecurityEventSource.AcquireCredentialsHandle(package, intent, scc);
             }
 
             SafeFreeCredentials outCredential = null;
@@ -213,9 +193,9 @@ namespace System.Net
                 GlobalLog.Print("SSPIWrapper::AcquireCredentialsHandle#3(): error " + Interop.MapSecurityStatus((uint)errorCode));
 #endif
 
-                if (Logging.On)
+                if (NetEventSource.Log.IsEnabled())
                 {
-                    Logging.PrintError(Logging.Web, SR.Format(SR.net_log_operation_failed_with_error, "AcquireCredentialsHandle()", String.Format(CultureInfo.CurrentCulture, "0X{0:X}", errorCode)));
+                    NetEventSource.PrintError(NetEventSource.ComponentType.Security, SR.Format(SR.net_log_operation_failed_with_error, "AcquireCredentialsHandle()", String.Format(CultureInfo.CurrentCulture, "0X{0:X}", errorCode)));
                 }
 
                 throw new Win32Exception(errorCode);
@@ -229,21 +209,19 @@ namespace System.Net
 
         internal static int InitializeSecurityContext(SSPIInterface secModule, ref SafeFreeCredentials credential, ref SafeDeleteContext context, string targetName, Interop.Secur32.ContextFlags inFlags, Interop.Secur32.Endianness datarep, SecurityBuffer inputBuffer, SecurityBuffer outputBuffer, ref Interop.Secur32.ContextFlags outFlags)
         {
-            if (Logging.On)
+            if (SecurityEventSource.Log.IsEnabled())
             {
-                Logging.PrintInfo(Logging.Web,
-                    "InitializeSecurityContext(" +
-                    "credential = " + credential.ToString() + ", " +
-                    "context = " + Logging.ObjectToString(context) + ", " +
-                    "targetName = " + targetName + ", " +
-                    "inFlags = " + inFlags + ")");
+                SecurityEventSource.Log.InitializeSecurityContext(credential.ToString(),
+                    LoggingHash.ObjectToString(context),
+                    targetName,
+                    inFlags);
             }
 
             int errorCode = secModule.InitializeSecurityContext(ref credential, ref context, targetName, inFlags, datarep, inputBuffer, outputBuffer, ref outFlags);
 
-            if (Logging.On)
+            if (SecurityEventSource.Log.IsEnabled())
             {
-                Logging.PrintInfo(Logging.Web, SR.Format(SR.net_log_sspi_security_context_input_buffer, "InitializeSecurityContext", (inputBuffer == null ? 0 : inputBuffer.size), outputBuffer.size, (Interop.SecurityStatus)errorCode));
+                SecurityEventSource.Log.SecurityContextInputBuffer("InitializeSecurityContext", (inputBuffer == null ? 0 : inputBuffer.size), outputBuffer.size, (Interop.SecurityStatus)errorCode);
             }
 
             return errorCode;
@@ -251,21 +229,19 @@ namespace System.Net
 
         internal static int InitializeSecurityContext(SSPIInterface secModule, SafeFreeCredentials credential, ref SafeDeleteContext context, string targetName, Interop.Secur32.ContextFlags inFlags, Interop.Secur32.Endianness datarep, SecurityBuffer[] inputBuffers, SecurityBuffer outputBuffer, ref Interop.Secur32.ContextFlags outFlags)
         {
-            if (Logging.On)
+            if (SecurityEventSource.Log.IsEnabled())
             {
-                Logging.PrintInfo(Logging.Web,
-                    "InitializeSecurityContext(" +
-                    "credential = " + credential.ToString() + ", " +
-                    "context = " + Logging.ObjectToString(context) + ", " +
-                    "targetName = " + targetName + ", " +
-                    "inFlags = " + inFlags + ")");
+                SecurityEventSource.Log.InitializeSecurityContext(credential.ToString(),
+                    LoggingHash.ObjectToString(context),
+                    targetName,
+                    inFlags);
             }
 
             int errorCode = secModule.InitializeSecurityContext(credential, ref context, targetName, inFlags, datarep, inputBuffers, outputBuffer, ref outFlags);
 
-            if (Logging.On)
+            if (SecurityEventSource.Log.IsEnabled())
             {
-                Logging.PrintInfo(Logging.Web, SR.Format(SR.net_log_sspi_security_context_input_buffers, "InitializeSecurityContext", (inputBuffers == null ? 0 : inputBuffers.Length), outputBuffer.size, (Interop.SecurityStatus)errorCode));
+                SecurityEventSource.Log.SecurityContextInputBuffers("InitializeSecurityContext", (inputBuffers == null ? 0 : inputBuffers.Length), outputBuffer.size, (Interop.SecurityStatus)errorCode);
             }
 
             return errorCode;
@@ -273,20 +249,16 @@ namespace System.Net
 
         internal static int AcceptSecurityContext(SSPIInterface secModule, ref SafeFreeCredentials credential, ref SafeDeleteContext context, Interop.Secur32.ContextFlags inFlags, Interop.Secur32.Endianness datarep, SecurityBuffer inputBuffer, SecurityBuffer outputBuffer, ref Interop.Secur32.ContextFlags outFlags)
         {
-            if (Logging.On)
+            if (SecurityEventSource.Log.IsEnabled())
             {
-                Logging.PrintInfo(Logging.Web,
-                    "AcceptSecurityContext(" +
-                    "credential = " + credential.ToString() + ", " +
-                    "context = " + Logging.ObjectToString(context) + ", " +
-                    "inFlags = " + inFlags + ")");
+                SecurityEventSource.Log.AcceptSecurityContext(credential.ToString(), LoggingHash.ObjectToString(context), inFlags);
             }
 
             int errorCode = secModule.AcceptSecurityContext(ref credential, ref context, inputBuffer, inFlags, datarep, outputBuffer, ref outFlags);
 
-            if (Logging.On)
+            if (SecurityEventSource.Log.IsEnabled())
             {
-                Logging.PrintInfo(Logging.Web, SR.Format(SR.net_log_sspi_security_context_input_buffer, "AcceptSecurityContext", (inputBuffer == null ? 0 : inputBuffer.size), outputBuffer.size, (Interop.SecurityStatus)errorCode));
+                SecurityEventSource.Log.SecurityContextInputBuffer("AcceptSecurityContext", (inputBuffer == null ? 0 : inputBuffer.size), outputBuffer.size, (Interop.SecurityStatus)errorCode);
             }
 
             return errorCode;
@@ -294,20 +266,16 @@ namespace System.Net
 
         internal static int AcceptSecurityContext(SSPIInterface secModule, SafeFreeCredentials credential, ref SafeDeleteContext context, Interop.Secur32.ContextFlags inFlags, Interop.Secur32.Endianness datarep, SecurityBuffer[] inputBuffers, SecurityBuffer outputBuffer, ref Interop.Secur32.ContextFlags outFlags)
         {
-            if (Logging.On)
+            if (SecurityEventSource.Log.IsEnabled())
             {
-                Logging.PrintInfo(Logging.Web,
-                    "AcceptSecurityContext(" +
-                    "credential = " + credential.ToString() + ", " +
-                    "context = " + Logging.ObjectToString(context) + ", " +
-                    "inFlags = " + inFlags + ")");
+                SecurityEventSource.Log.AcceptSecurityContext(credential.ToString(), LoggingHash.ObjectToString(context), inFlags);
             }
 
             int errorCode = secModule.AcceptSecurityContext(credential, ref context, inputBuffers, inFlags, datarep, outputBuffer, ref outFlags);
 
-            if (Logging.On)
+            if (SecurityEventSource.Log.IsEnabled())
             {
-                Logging.PrintInfo(Logging.Web, SR.Format(SR.net_log_sspi_security_context_input_buffers, "AcceptSecurityContext", (inputBuffers == null ? 0 : inputBuffers.Length), outputBuffer.size, (Interop.SecurityStatus)errorCode));
+                SecurityEventSource.Log.SecurityContextInputBuffers("AcceptSecurityContext", (inputBuffers == null ? 0 : inputBuffers.Length), outputBuffer.size, (Interop.SecurityStatus)errorCode);
             }
 
             return errorCode;
@@ -317,9 +285,9 @@ namespace System.Net
         {
             int errorCode = secModule.CompleteAuthToken(ref context, inputBuffers);
 
-            if (Logging.On)
+            if (SecurityEventSource.Log.IsEnabled())
             {
-                Logging.PrintInfo(Logging.Web, SR.Format(SR.net_log_operation_returned_something, "CompleteAuthToken()", (Interop.SecurityStatus)errorCode));
+                SecurityEventSource.Log.OperationReturnedSomething("CompleteAuthToken()", (Interop.SecurityStatus)errorCode);
             }
 
             return errorCode;
@@ -462,15 +430,15 @@ namespace System.Net
                         GlobalLog.Assert(iBuffer.size >= 0 && iBuffer.size <= (iBuffer.token == null ? 0 : iBuffer.token.Length - iBuffer.offset), "SSPIWrapper::EncryptDecryptHelper|'size' out of range.  [{0}]", iBuffer.size);
                     }
 
-                    if (errorCode != 0 && Logging.On)
+                    if (errorCode != 0 && NetEventSource.Log.IsEnabled())
                     {                         
                         if (errorCode == Interop.Secur32.SEC_I_RENEGOTIATE)
                         {
-                            Logging.PrintError(Logging.Web, SR.Format(SR.net_log_operation_returned_something, op, "SEC_I_RENEGOTIATE"));
+                            NetEventSource.PrintError(NetEventSource.ComponentType.Security, SR.Format(SR.event_OperationReturnedSomething, op, "SEC_I_RENEGOTIATE"));
                         }
                         else
                         {
-                            Logging.PrintError(Logging.Web, SR.Format(SR.net_log_operation_failed_with_error, op, String.Format(CultureInfo.CurrentCulture, "0X{0:X}", errorCode)));
+                            NetEventSource.PrintError(NetEventSource.ComponentType.Security, SR.Format(SR.net_log_operation_failed_with_error, op, String.Format(CultureInfo.CurrentCulture, "0X{0:X}", errorCode)));
                         }
                     }
 
@@ -501,7 +469,7 @@ namespace System.Net
                 return null;
             }
 
-            GlobalLog.Leave("QueryContextChannelBinding", Logging.HashString(result));
+            GlobalLog.Leave("QueryContextChannelBinding", LoggingHash.HashString(result));
             return result;
         }
 
@@ -637,7 +605,7 @@ namespace System.Net
                     sspiHandle.Dispose();
                 }
             }
-            GlobalLog.Leave("QueryContextAttributes", Logging.ObjectToString(attribute));
+            GlobalLog.Leave("QueryContextAttributes", LoggingHash.ObjectToString(attribute));
             return attribute;
         }
 

--- a/src/Common/src/Interop/Windows/secur32/SecuritySafeHandles.cs
+++ b/src/Common/src/Interop/Windows/secur32/SecuritySafeHandles.cs
@@ -507,7 +507,7 @@ namespace System.Net.Security
 #if TRACE_VERBOSE
             GlobalLog.Enter("SafeDeleteContext::InitializeSecurityContext");
             GlobalLog.Print("    credential       = " + inCredentials.ToString());
-            GlobalLog.Print("    refContext       = " + Logging.ObjectToString(refContext));
+            GlobalLog.Print("    refContext       = " + LoggingHash.ObjectToString(refContext));
             GlobalLog.Print("    targetName       = " + targetName);
             GlobalLog.Print("    inFlags          = " + inFlags);
             GlobalLog.Print("    reservedI        = 0x0");
@@ -686,7 +686,7 @@ namespace System.Net.Security
                 }
             }
 
-            GlobalLog.Leave("SafeDeleteContext::InitializeSecurityContext() unmanaged InitializeSecurityContext()", "errorCode:0x" + errorCode.ToString("x8") + " refContext:" + Logging.ObjectToString(refContext));
+            GlobalLog.Leave("SafeDeleteContext::InitializeSecurityContext() unmanaged InitializeSecurityContext()", "errorCode:0x" + errorCode.ToString("x8") + " refContext:" + LoggingHash.ObjectToString(refContext));
 
             return errorCode;
         }
@@ -792,7 +792,7 @@ namespace System.Net.Security
 #if TRACE_VERBOSE
             GlobalLog.Enter("SafeDeleteContext::AcceptSecurityContex");
             GlobalLog.Print("    credential       = " + inCredentials.ToString());
-            GlobalLog.Print("    refContext       = " + Logging.ObjectToString(refContext));
+            GlobalLog.Print("    refContext       = " + LoggingHash.ObjectToString(refContext));
 
             GlobalLog.Print("    inFlags          = " + inFlags);
 
@@ -963,7 +963,7 @@ namespace System.Net.Security
                 }
             }
 
-            GlobalLog.Leave("SafeDeleteContext::AcceptSecurityContex() unmanaged AcceptSecurityContex()", "errorCode:0x" + errorCode.ToString("x8") + " refContext:" + Logging.ObjectToString(refContext));
+            GlobalLog.Leave("SafeDeleteContext::AcceptSecurityContex() unmanaged AcceptSecurityContex()", "errorCode:0x" + errorCode.ToString("x8") + " refContext:" + LoggingHash.ObjectToString(refContext));
 
             return errorCode;
         }
@@ -1057,7 +1057,7 @@ namespace System.Net.Security
             SecurityBuffer[] inSecBuffers)
         {
             GlobalLog.Enter("SafeDeleteContext::CompleteAuthToken");
-            GlobalLog.Print("    refContext       = " + Logging.ObjectToString(refContext));
+            GlobalLog.Print("    refContext       = " + LoggingHash.ObjectToString(refContext));
 #if TRACE_VERBOSE
             GlobalLog.Print("    inSecBuffers[]   = length:" + inSecBuffers.Length);
 #endif
@@ -1142,7 +1142,7 @@ namespace System.Net.Security
                 }
             }
 
-            GlobalLog.Leave("SafeDeleteContext::CompleteAuthToken() unmanaged CompleteAuthToken()", "errorCode:0x" + errorCode.ToString("x8") + " refContext:" + Logging.ObjectToString(refContext));
+            GlobalLog.Leave("SafeDeleteContext::CompleteAuthToken() unmanaged CompleteAuthToken()", "errorCode:0x" + errorCode.ToString("x8") + " refContext:" + LoggingHash.ObjectToString(refContext));
 
             return errorCode;
         }

--- a/src/Common/src/System/Net/ContextAwareResult.cs
+++ b/src/Common/src/System/Net/ContextAwareResult.cs
@@ -140,7 +140,7 @@ namespace System.Net
         {
             get
             {
-                GlobalLog.Assert(!InternalPeekCompleted || (_flags & StateFlags.ThreadSafeContextCopy) != 0, "ContextAwareResult#{0}::ContextCopy|Called on completed result.", Logging.HashString(this));
+                GlobalLog.Assert(!InternalPeekCompleted || (_flags & StateFlags.ThreadSafeContextCopy) != 0, "ContextAwareResult#{0}::ContextCopy|Called on completed result.", LoggingHash.HashString(this));
                 if (InternalPeekCompleted)
                 {
                     throw new InvalidOperationException(SR.net_completed_result);
@@ -153,17 +153,17 @@ namespace System.Net
                 }
 
                 // Make sure the context was requested.
-                GlobalLog.Assert(AsyncCallback != null || (_flags & StateFlags.CaptureContext) != 0, "ContextAwareResult#{0}::ContextCopy|No context captured - specify a callback or forceCaptureContext.", Logging.HashString(this));
+                GlobalLog.Assert(AsyncCallback != null || (_flags & StateFlags.CaptureContext) != 0, "ContextAwareResult#{0}::ContextCopy|No context captured - specify a callback or forceCaptureContext.", LoggingHash.HashString(this));
 
                 // Just use the lock to block.  We might be on the thread that owns the lock which is great, it means we
                 // don't need a context anyway.
                 if ((_flags & StateFlags.PostBlockFinished) == 0)
                 {
-                    GlobalLog.Assert(_lock != null, "ContextAwareResult#{0}::ContextCopy|Must lock (StartPostingAsyncOp()) { ... FinishPostingAsyncOp(); } when calling ContextCopy (unless it's only called after FinishPostingAsyncOp).", Logging.HashString(this));
+                    GlobalLog.Assert(_lock != null, "ContextAwareResult#{0}::ContextCopy|Must lock (StartPostingAsyncOp()) { ... FinishPostingAsyncOp(); } when calling ContextCopy (unless it's only called after FinishPostingAsyncOp).", LoggingHash.HashString(this));
                     lock (_lock) { }
                 }
 
-                GlobalLog.Assert(!InternalPeekCompleted || (_flags & StateFlags.ThreadSafeContextCopy) != 0, "ContextAwareResult#{0}::ContextCopy|Result became completed during call.", Logging.HashString(this));
+                GlobalLog.Assert(!InternalPeekCompleted || (_flags & StateFlags.ThreadSafeContextCopy) != 0, "ContextAwareResult#{0}::ContextCopy|Result became completed during call.", LoggingHash.HashString(this));
                 if (InternalPeekCompleted)
                 {
                     throw new InvalidOperationException(SR.net_completed_result);
@@ -180,7 +180,7 @@ namespace System.Net
         {
             get
             {
-                GlobalLog.Assert(!InternalPeekCompleted || (_flags & StateFlags.ThreadSafeContextCopy) != 0, "ContextAwareResult#{0}::Identity|Called on completed result.", Logging.HashString(this));
+                GlobalLog.Assert(!InternalPeekCompleted || (_flags & StateFlags.ThreadSafeContextCopy) != 0, "ContextAwareResult#{0}::Identity|Called on completed result.", LoggingHash.HashString(this));
                 if (InternalPeekCompleted)
                 {
                     throw new InvalidOperationException(SR.net_completed_result);
@@ -192,17 +192,17 @@ namespace System.Net
                 }
 
                 // Make sure the identity was requested.
-                GlobalLog.Assert((_flags & StateFlags.CaptureIdentity) != 0, "ContextAwareResult#{0}::Identity|No identity captured - specify captureIdentity.", Logging.HashString(this));
+                GlobalLog.Assert((_flags & StateFlags.CaptureIdentity) != 0, "ContextAwareResult#{0}::Identity|No identity captured - specify captureIdentity.", LoggingHash.HashString(this));
 
                 // Just use the lock to block.  We might be on the thread that owns the lock which is great, it means we
                 // don't need an identity anyway.
                 if ((_flags & StateFlags.PostBlockFinished) == 0)
                 {
-                    GlobalLog.Assert(_lock != null, "ContextAwareResult#{0}::Identity|Must lock (StartPostingAsyncOp()) { ... FinishPostingAsyncOp(); } when calling Identity (unless it's only called after FinishPostingAsyncOp).", Logging.HashString(this));
+                    GlobalLog.Assert(_lock != null, "ContextAwareResult#{0}::Identity|Must lock (StartPostingAsyncOp()) { ... FinishPostingAsyncOp(); } when calling Identity (unless it's only called after FinishPostingAsyncOp).", LoggingHash.HashString(this));
                     lock (_lock) { }
                 }
 
-                GlobalLog.Assert(!InternalPeekCompleted || (_flags & StateFlags.ThreadSafeContextCopy) != 0, "ContextAwareResult#{0}::Identity|Result became completed during call.", Logging.HashString(this));
+                GlobalLog.Assert(!InternalPeekCompleted || (_flags & StateFlags.ThreadSafeContextCopy) != 0, "ContextAwareResult#{0}::Identity|Result became completed during call.", LoggingHash.HashString(this));
                 if (InternalPeekCompleted)
                 {
                     throw new InvalidOperationException(SR.net_completed_result);
@@ -235,7 +235,7 @@ namespace System.Net
         // object from being created.
         internal object StartPostingAsyncOp(bool lockCapture)
         {
-            GlobalLog.Assert(!InternalPeekCompleted, "ContextAwareResult#{0}::StartPostingAsyncOp|Called on completed result.", Logging.HashString(this));
+            GlobalLog.Assert(!InternalPeekCompleted, "ContextAwareResult#{0}::StartPostingAsyncOp|Called on completed result.", LoggingHash.HashString(this));
 
             DebugProtectState(true);
 
@@ -310,7 +310,7 @@ namespace System.Net
         {
             base.Cleanup();
 
-            GlobalLog.Print("ContextAwareResult#" + Logging.HashString(this) + "::Cleanup()");
+            GlobalLog.Print("ContextAwareResult#" + LoggingHash.HashString(this) + "::Cleanup()");
 #if !NetNative
             if (_windowsIdentity != null)
             {
@@ -328,7 +328,7 @@ namespace System.Net
         // Returns whether the operation completed sync or not.
         private bool CaptureOrComplete(ref ExecutionContext cachedContext, bool returnContext)
         {
-            GlobalLog.Assert((_flags & StateFlags.PostBlockStarted) != 0, "ContextAwareResult#{0}::CaptureOrComplete|Called without calling StartPostingAsyncOp.", Logging.HashString(this));
+            GlobalLog.Assert((_flags & StateFlags.PostBlockStarted) != 0, "ContextAwareResult#{0}::CaptureOrComplete|Called without calling StartPostingAsyncOp.", LoggingHash.HashString(this));
 
             // See if we're going to need to capture the context.
             bool capturingContext = AsyncCallback != null || (_flags & StateFlags.CaptureContext) != 0;
@@ -338,7 +338,7 @@ namespace System.Net
             // capturing the context won't be sufficient.
             if ((_flags & StateFlags.CaptureIdentity) != 0 && !InternalPeekCompleted && (!capturingContext))
             {
-                GlobalLog.Print("ContextAwareResult#" + Logging.HashString(this) + "::CaptureOrComplete() starting identity capture");
+                GlobalLog.Print("ContextAwareResult#" + LoggingHash.HashString(this) + "::CaptureOrComplete() starting identity capture");
                 SafeCaptureIdentity();
             }
 
@@ -346,7 +346,7 @@ namespace System.Net
             // Note that Capture() can return null, for example if SuppressFlow() is in effect.
             if (capturingContext && !InternalPeekCompleted)
             {
-                GlobalLog.Print("ContextAwareResult#" + Logging.HashString(this) + "::CaptureOrComplete() starting capture");
+                GlobalLog.Print("ContextAwareResult#" + LoggingHash.HashString(this) + "::CaptureOrComplete() starting capture");
                 if (cachedContext == null)
                 {
                     cachedContext = ExecutionContext.Capture();
@@ -364,14 +364,14 @@ namespace System.Net
                         _context = cachedContext.CreateCopy();
                     }
                 }
-                GlobalLog.Print("ContextAwareResult#" + Logging.HashString(this) + "::CaptureOrComplete() _Context:" + Logging.HashString(_context));
+                GlobalLog.Print("ContextAwareResult#" + LoggingHash.HashString(this) + "::CaptureOrComplete() _Context:" + LoggingHash.HashString(_context));
             }
             else
             {
                 // Otherwise we have to have completed synchronously, or not needed the context.
-                GlobalLog.Print("ContextAwareResult#" + Logging.HashString(this) + "::CaptureOrComplete() skipping capture");
+                GlobalLog.Print("ContextAwareResult#" + LoggingHash.HashString(this) + "::CaptureOrComplete() skipping capture");
                 cachedContext = null;
-                GlobalLog.Assert(AsyncCallback == null || CompletedSynchronously, "ContextAwareResult#{0}::CaptureOrComplete|Didn't capture context, but didn't complete synchronously!", Logging.HashString(this));
+                GlobalLog.Assert(AsyncCallback == null || CompletedSynchronously, "ContextAwareResult#{0}::CaptureOrComplete|Didn't capture context, but didn't complete synchronously!", LoggingHash.HashString(this));
             }
 
             // Now we want to see for sure what to do.  We might have just captured the context for no reason.
@@ -381,7 +381,7 @@ namespace System.Net
             DebugProtectState(false);
             if (CompletedSynchronously)
             {
-                GlobalLog.Print("ContextAwareResult#" + Logging.HashString(this) + "::CaptureOrComplete() completing synchronously");
+                GlobalLog.Print("ContextAwareResult#" + LoggingHash.HashString(this) + "::CaptureOrComplete() completing synchronously");
                 base.Complete(IntPtr.Zero);
                 return true;
             }
@@ -392,7 +392,7 @@ namespace System.Net
         // This method is guaranteed to be called only once.  If called with a non-zero userToken, the context is not flowed.
         protected override void Complete(IntPtr userToken)
         {
-            GlobalLog.Print("ContextAwareResult#" + Logging.HashString(this) + "::Complete() _Context(set):" + (_context != null).ToString() + " userToken:" + userToken.ToString());
+            GlobalLog.Print("ContextAwareResult#" + LoggingHash.HashString(this) + "::Complete() _Context(set):" + (_context != null).ToString() + " userToken:" + userToken.ToString());
 
             // If no flowing, just complete regularly.
             if ((_flags & StateFlags.PostBlockStarted) == 0)
@@ -425,7 +425,7 @@ namespace System.Net
 
         private void CompleteCallback(object state)
         {
-            GlobalLog.Print("ContextAwareResult#" + Logging.HashString(this) + "::CompleteCallback() Context set, calling callback.");
+            GlobalLog.Print("ContextAwareResult#" + LoggingHash.HashString(this) + "::CompleteCallback() Context set, calling callback.");
             base.Complete(IntPtr.Zero);
         }
     }

--- a/src/Common/src/System/Net/LazyAsyncResult.cs
+++ b/src/Common/src/System/Net/LazyAsyncResult.cs
@@ -63,14 +63,14 @@ namespace System.Net
             _asyncState = myState;
             _asyncCallback = myCallBack;
             _result = DBNull.Value;
-            GlobalLog.Print("LazyAsyncResult#" + Logging.HashString(this) + "::.ctor()");
+            GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::.ctor()");
         }
 
         // Allows creating a pre-completed result with less interlockeds.  Beware!  Constructor calls the callback.
         // If a derived class ever uses this and overloads Cleanup, this may need to change.
         internal LazyAsyncResult(object myObject, object myState, AsyncCallback myCallBack, object result)
         {
-            GlobalLog.Assert(result != DBNull.Value, "LazyAsyncResult#{0}::.ctor()|Result can't be set to DBNull - it's a special internal value.", Logging.HashString(this));
+            GlobalLog.Assert(result != DBNull.Value, "LazyAsyncResult#{0}::.ctor()|Result can't be set to DBNull - it's a special internal value.", LoggingHash.HashString(this));
             _asyncObject = myObject;
             _asyncState = myState;
             _asyncCallback = myCallBack;
@@ -79,15 +79,15 @@ namespace System.Net
 
             if (_asyncCallback != null)
             {
-                GlobalLog.Print("LazyAsyncResult#" + Logging.HashString(this) + "::Complete() invoking callback");
+                GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::Complete() invoking callback");
                 _asyncCallback(this);
             }
             else
             {
-                GlobalLog.Print("LazyAsyncResult#" + Logging.HashString(this) + "::Complete() no callback to invoke");
+                GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::Complete() no callback to invoke");
             }
 
-            GlobalLog.Print("LazyAsyncResult#" + Logging.HashString(this) + "::.ctor() (pre-completed)");
+            GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::.ctor() (pre-completed)");
         }
 
         // Interface method to return the original async object.
@@ -131,7 +131,7 @@ namespace System.Net
         {
             get
             {
-                GlobalLog.Print("LazyAsyncResult#" + Logging.HashString(this) + "::get_AsyncWaitHandle()");
+                GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::get_AsyncWaitHandle()");
 
 #if DEBUG
                 // Can't be called when state is protected.
@@ -162,7 +162,7 @@ namespace System.Net
                     LazilyCreateEvent(out asyncEvent);
                 }
 
-                GlobalLog.Print("LazyAsyncResult#" + Logging.HashString(this) + "::get_AsyncWaitHandle() _event:" + Logging.HashString(_event));
+                GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::get_AsyncWaitHandle() _event:" + LoggingHash.HashString(_event));
                 return asyncEvent;
             }
         }
@@ -221,7 +221,7 @@ namespace System.Net
         {
             get
             {
-                GlobalLog.Print("LazyAsyncResult#" + Logging.HashString(this) + "::get_CompletedSynchronously()");
+                GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::get_CompletedSynchronously()");
 
 #if DEBUG
                 // Can't be called when state is protected.
@@ -238,7 +238,7 @@ namespace System.Net
                     result = Interlocked.CompareExchange(ref _intCompleted, HighBit, 0);
                 }
 
-                GlobalLog.Print("LazyAsyncResult#" + Logging.HashString(this) + "::get_CompletedSynchronously() returns: " + ((result > 0) ? "true" : "false"));
+                GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::get_CompletedSynchronously() returns: " + ((result > 0) ? "true" : "false"));
                 return result > 0;
             }
         }
@@ -248,7 +248,7 @@ namespace System.Net
         {
             get
             {
-                GlobalLog.Print("LazyAsyncResult#" + Logging.HashString(this) + "::get_IsCompleted()");
+                GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::get_IsCompleted()");
 
 #if DEBUG
                 // Can't be called when state is protected.
@@ -295,8 +295,8 @@ namespace System.Net
                 // then the "result" parameter passed to InvokeCallback() will be ignored.
 
                 // It's an error to call after the result has been completed or with DBNull.
-                GlobalLog.Assert(value != DBNull.Value, "LazyAsyncResult#{0}::set_Result()|Result can't be set to DBNull - it's a special internal value.", Logging.HashString(this));
-                GlobalLog.Assert(!InternalPeekCompleted, "LazyAsyncResult#{0}::set_Result()|Called on completed result.", Logging.HashString(this));
+                GlobalLog.Assert(value != DBNull.Value, "LazyAsyncResult#{0}::set_Result()|Result can't be set to DBNull - it's a special internal value.", LoggingHash.HashString(this));
+                GlobalLog.Assert(!InternalPeekCompleted, "LazyAsyncResult#{0}::set_Result()|Called on completed result.", LoggingHash.HashString(this));
                 _result = value;
             }
         }
@@ -332,7 +332,7 @@ namespace System.Net
         // the equivalent of InvokeCallback().
         protected void ProtectedInvokeCallback(object result, IntPtr userToken)
         {
-            GlobalLog.Print("LazyAsyncResult#" + Logging.HashString(this) + "::ProtectedInvokeCallback() result = " +
+            GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::ProtectedInvokeCallback() result = " +
                             (result is Exception ? ((Exception)result).Message : result == null ? "<null>" : result.ToString()) +
                             ", userToken:" + userToken.ToString());
 
@@ -399,7 +399,7 @@ namespace System.Net
                 ++threadContext._nestedIOCount;
                 if (_asyncCallback != null)
                 {
-                    GlobalLog.Print("LazyAsyncResult#" + Logging.HashString(this) + "::Complete() invoking callback");
+                    GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::Complete() invoking callback");
 
                     if (threadContext._nestedIOCount >= ForceAsyncCount)
                     {
@@ -420,7 +420,7 @@ namespace System.Net
                 }
                 else
                 {
-                    GlobalLog.Print("LazyAsyncResult#" + Logging.HashString(this) + "::Complete() no callback to invoke");
+                    GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::Complete() no callback to invoke");
                 }
             }
             finally
@@ -483,7 +483,7 @@ namespace System.Net
             {
                 try
                 {
-                    GlobalLog.Print("LazyAsyncResult#" + Logging.HashString(this) + "::InternalWaitForCompletion() Waiting for completion _event#" + Logging.HashString(waitHandle));
+                    GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::InternalWaitForCompletion() Waiting for completion _event#" + LoggingHash.HashString(waitHandle));
                     waitHandle.WaitOne(Timeout.Infinite);
                 }
                 catch (ObjectDisposedException)
@@ -518,7 +518,7 @@ namespace System.Net
                 sw.SpinOnce();
             }
 
-            GlobalLog.Print("LazyAsyncResult#" + Logging.HashString(this) + "::InternalWaitForCompletion() done: " +
+            GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::InternalWaitForCompletion() done: " +
                             (_result is Exception ? ((Exception)_result).Message : _result == null ? "<null>" : _result.ToString()));
 
             return _result;

--- a/src/Common/src/System/Net/Logging/HttpEventSource.cs
+++ b/src/Common/src/System/Net/Logging/HttpEventSource.cs
@@ -1,0 +1,163 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Tracing;
+using System.Net.Http;
+using System.Globalization;
+
+namespace System.Net
+{
+    //TODO: If localization resources are not found, logging does not work. Issue #5126.
+    [EventSource(Name = "Microsoft-System-Net-Http",
+        Guid = "bdd9a83e-1929-5482-0d73-2fe5e1c0e16d",
+        LocalizationResources = "FxResources.System.Net.Http.SR")]
+    internal sealed class HttpEventSource : EventSource
+    {
+        private const int ASSOCIATE_ID = 1;
+        private const int URI_BASE_ADDRESS_ID = 2;
+        private const int CONTENT_NULL_ID = 3;
+        private const int CLIENT_SEND_COMPLETED = 4;
+        private const int HEADERS_INVALID_VALUE_ID = 5;
+
+        private readonly static HttpEventSource s_log = new HttpEventSource();
+        private HttpEventSource() { }
+        public static HttpEventSource Log
+        {
+            get
+            {
+                return s_log;
+            }
+        }
+
+        [NonEvent]
+        internal static void Associate(object objA, object objB)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            s_log.Associate(LoggingHash.GetObjectName(objA),
+                            LoggingHash.HashInt(objA),
+                            LoggingHash.GetObjectName(objB),
+                            LoggingHash.HashInt(objB));
+        }
+
+        [Event(ASSOCIATE_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational, Message = "[{0}#{1}]<-->[{2}#{3}]")]
+        internal unsafe void Associate(string objectA, int objectAHash, string objectB, int objectBHash)
+        {
+            const int SIZEDATA = 4;
+            fixed (char* arg1Ptr = objectA, arg2Ptr = objectB)
+            {
+                EventData* dataDesc = stackalloc EventSource.EventData[SIZEDATA];
+
+                dataDesc[0].DataPointer = (IntPtr)(arg1Ptr);
+                dataDesc[0].Size = (objectA.Length + 1) * sizeof(char); // Size in bytes, including a null terminator. 
+                dataDesc[1].DataPointer = (IntPtr)(&objectAHash);
+                dataDesc[1].Size = sizeof(int);
+                dataDesc[2].DataPointer = (IntPtr)(arg2Ptr);
+                dataDesc[2].Size = (objectB.Length + 1) * sizeof(char);
+                dataDesc[3].DataPointer = (IntPtr)(&objectBHash);
+                dataDesc[3].Size = sizeof(int);
+
+                WriteEventCore(ASSOCIATE_ID, SIZEDATA, dataDesc);
+            }
+        }
+
+        [NonEvent]
+        internal static void UriBaseAddress(object obj, string baseAddress)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            s_log.UriBaseAddress(baseAddress, LoggingHash.GetObjectName(obj), LoggingHash.HashInt(obj));
+        }
+
+        [Event(URI_BASE_ADDRESS_ID, Keywords = Keywords.Debug,
+            Level = EventLevel.Informational)]
+        internal unsafe void UriBaseAddress(string uriBaseAddress, string objName, int objHash)
+        {
+            const int SIZEDATA = 3;
+            fixed (char* arg1Ptr = uriBaseAddress, arg2Ptr = objName)
+            {
+                EventData* dataDesc = stackalloc EventSource.EventData[SIZEDATA];
+
+                dataDesc[0].DataPointer = (IntPtr)(arg1Ptr);
+                dataDesc[0].Size = (uriBaseAddress.Length + 1) * sizeof(char); // Size in bytes, including a null terminator. 
+                dataDesc[1].DataPointer = (IntPtr)(arg2Ptr);
+                dataDesc[1].Size = (objName.Length + 1) * sizeof(char);
+                dataDesc[2].DataPointer = (IntPtr)(&objHash);
+                dataDesc[2].Size = sizeof(int);
+
+                WriteEventCore(URI_BASE_ADDRESS_ID, SIZEDATA, dataDesc);
+            }
+        }
+
+        [NonEvent]
+        internal static void ContentNull(object obj)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            s_log.ContentNull(LoggingHash.GetObjectName(obj), LoggingHash.HashInt(obj));
+        }
+
+        [Event(CONTENT_NULL_ID, Keywords = Keywords.Debug,
+            Level = EventLevel.Informational)]
+        internal void ContentNull(string objName, int objHash)
+        {
+            WriteEvent(CONTENT_NULL_ID, objName, objHash);
+        }
+
+        [NonEvent]
+        internal static void ClientSendCompleted(HttpClient httpClient, HttpResponseMessage response, HttpRequestMessage request)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            string responseString = "";
+            if (response != null)
+            {
+                responseString = response.ToString();
+            }
+            s_log.ClientSendCompleted(LoggingHash.HashInt(request), LoggingHash.HashInt(response), responseString, LoggingHash.HashInt(httpClient));
+        }
+
+        [Event(CLIENT_SEND_COMPLETED, Keywords = Keywords.Debug,
+            Level = EventLevel.Verbose)]
+        internal unsafe void ClientSendCompleted(int httpRequestMessageHash, int httpResponseMessageHash, string responseString, int httpClientHash)
+        {
+            const int SIZEDATA = 4;
+            fixed (char* arg1Ptr = responseString)
+            {
+                EventData* dataDesc = stackalloc EventSource.EventData[SIZEDATA];
+                dataDesc[0].DataPointer = (IntPtr)(&httpRequestMessageHash);
+                dataDesc[0].Size = sizeof(int);
+                dataDesc[1].DataPointer = (IntPtr)(&httpResponseMessageHash);
+                dataDesc[1].Size = sizeof(int);
+                dataDesc[2].DataPointer = (IntPtr)(arg1Ptr);
+                dataDesc[2].Size = (responseString.Length + 1) * sizeof(char);
+                dataDesc[3].DataPointer = (IntPtr)(&httpClientHash);
+                dataDesc[3].Size = sizeof(int);
+
+                WriteEventCore(CLIENT_SEND_COMPLETED, SIZEDATA, dataDesc);
+            }
+        }
+
+        [Event(HEADERS_INVALID_VALUE_ID, Keywords = Keywords.Debug,
+            Level = EventLevel.Verbose)]
+        internal void HeadersInvalidValue(string name, string rawValue)
+        {
+            WriteEvent(HEADERS_INVALID_VALUE_ID, name, rawValue);
+        }
+
+        public class Keywords
+        {
+            public const EventKeywords Default = (EventKeywords)0x0001;
+            public const EventKeywords Debug = (EventKeywords)0x0002;
+        }
+    }
+}

--- a/src/Common/src/System/Net/Logging/LoggingHash.cs
+++ b/src/Common/src/System/Net/Logging/LoggingHash.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Tracing;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Threading;
+
+namespace System.Net
+{
+    internal static class LoggingHash
+    {
+        // Converts an object to a normalized string that can be printed
+        // takes System.Net.ObjectNamedFoo and coverts to ObjectNamedFoo, 
+        // except IPAddress, IPEndPoint, and Uri, which return ToString().
+        internal static string GetObjectName(object obj)
+        {
+            if (obj == null)
+            {
+                return "null";
+            }
+            if (obj is Uri || obj is System.Net.IPAddress || obj is System.Net.IPEndPoint || obj is string)
+            {
+                return obj.ToString();
+            }
+            else
+            {
+                return obj.GetType().ToString();
+            }
+        }
+        internal static int HashInt(object objectValue)
+        {
+            if (objectValue == null)
+            {
+                return 0;
+            }
+            else
+            {
+                return objectValue.GetHashCode();
+            }
+        }
+
+        internal static string ObjectToString(object objectValue)
+        {
+            if (objectValue == null)
+            {
+                return "(null)";
+            }
+            else if (objectValue is string && ((string)objectValue).Length == 0)
+            {
+                return "(string.empty)";
+            }
+            else if (objectValue is Exception)
+            {
+                return ExceptionMessage(objectValue as Exception);
+            }
+            else if (objectValue is IntPtr)
+            {
+                return "0x" + ((IntPtr)objectValue).ToString("x");
+            }
+            else
+            {
+                return objectValue.ToString();
+            }
+        }
+
+        private static string ExceptionMessage(Exception exception)
+        {
+            if (exception == null)
+            {
+                return string.Empty;
+            }
+
+            if (exception.InnerException == null)
+            {
+                return exception.Message;
+            }
+
+            return exception.Message + " (" + ExceptionMessage(exception.InnerException) + ")";
+        }
+
+        internal static string HashString(object objectValue)
+        {
+            if (objectValue == null)
+            {
+                return "(null)";
+            }
+            else if (objectValue is string && ((string)objectValue).Length == 0)
+            {
+                return "(string.empty)";
+            }
+            else
+            {
+                return objectValue.GetHashCode().ToString(NumberFormatInfo.InvariantInfo);
+            }
+        }
+
+        internal static object[] GetObjectLogHash(object obj)
+        {
+            object[] hashObject = new object[2];
+            hashObject[0] = GetObjectName(obj);
+            hashObject[1] = HashInt(obj);
+            return hashObject;
+        }
+    }
+}

--- a/src/Common/src/System/Net/Logging/NetEventSource.cs
+++ b/src/Common/src/System/Net/Logging/NetEventSource.cs
@@ -1,0 +1,266 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Tracing;
+using System.Globalization;
+
+namespace System.Net
+{
+    [EventSource(Name = "Microsoft-System-Net",
+        Guid = "501a994a-eb63-5415-9af1-1b031260f16c")]
+    internal sealed class NetEventSource : EventSource
+    {
+        private const int FUNCTIONSTART_ID = 1;
+        private const int FUNCTIONSTOP_ID = 2;
+        private const int CRITICALEXCEPTION_ID = 3;
+        private const int CRITICALERROR_ID = 4;
+
+        private readonly static NetEventSource s_log = new NetEventSource();
+        private NetEventSource() { }
+        public static NetEventSource Log
+        {
+            get
+            {
+                return s_log;
+            }
+        }
+
+        [NonEvent]
+        internal static void Enter(ComponentType componentType, object obj, string method, object paramObject)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            string callerName;
+            int callerHash;
+            string parametersName = "";
+            int parametersHash = 0;
+            if (obj is string)
+            {
+                callerName = obj as string;
+                callerHash = 0;
+            }
+            else
+            {
+                callerName = LoggingHash.GetObjectName(obj);
+                callerHash = LoggingHash.HashInt(obj);
+            }
+
+            if (paramObject is string)
+            {
+                parametersName = paramObject as string;
+                parametersHash = 0;
+            }
+
+            else if (paramObject != null)
+            {
+                parametersName = LoggingHash.GetObjectName(paramObject);
+                parametersHash = LoggingHash.HashInt(paramObject);
+            }
+            s_log.FunctionStart(callerName,
+                                callerHash,
+                                LoggingHash.GetObjectName(method),
+                                parametersName,
+                                parametersHash,
+                                componentType);
+        }
+
+        [Event(FUNCTIONSTART_ID, Keywords = Keywords.FunctionEntryExit,
+    Level = EventLevel.Verbose, Message = "[{5}] {0}#{1}::{2}({3}#{4})")]
+        internal unsafe void FunctionStart(string callerName,
+                                            int callerHash,
+                                            string method,
+                                            string parametersName,
+                                            int parametersHash,
+                                            ComponentType componentType)
+        {
+            const int SIZEDATA = 6;
+            fixed (char* arg1Ptr = callerName, arg2Ptr = method, arg3Ptr = parametersName)
+            {
+                EventData* dataDesc = stackalloc EventSource.EventData[SIZEDATA];
+
+                dataDesc[0].DataPointer = (IntPtr)arg1Ptr;
+                dataDesc[0].Size = (callerName.Length + 1) * sizeof(char); // Size in bytes, including a null terminator. 
+                dataDesc[1].DataPointer = (IntPtr)(&callerHash);
+                dataDesc[1].Size = sizeof(int);
+                dataDesc[2].DataPointer = (IntPtr)(arg2Ptr);
+                dataDesc[2].Size = (method.Length + 1) * sizeof(char);
+                dataDesc[3].DataPointer = (IntPtr)(arg3Ptr);
+                dataDesc[3].Size = (parametersName.Length + 1) * sizeof(char);
+                dataDesc[4].DataPointer = (IntPtr)(&parametersHash);
+                dataDesc[4].Size = sizeof(int);
+                dataDesc[5].DataPointer = (IntPtr)(&componentType);
+                dataDesc[5].Size = sizeof(int);
+
+                WriteEventCore(FUNCTIONSTART_ID, SIZEDATA, dataDesc);
+            }
+        }
+
+        [NonEvent]
+        internal static void Exit(ComponentType componentType, object obj, string method, object retObject)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            string callerName;
+            int callerHash;
+            string parametersName = "";
+            int parametersHash = 0;
+            if (obj is string)
+            {
+                callerName = obj as string;
+                callerHash = 0;
+            }
+            else
+            {
+                callerName = LoggingHash.GetObjectName(obj);
+                callerHash = LoggingHash.HashInt(obj);
+            }
+
+            if (retObject is string)
+            {
+                parametersName = retObject as string;
+                parametersHash = 0;
+            }
+
+            else if (retObject != null)
+            {
+                parametersName = LoggingHash.GetObjectName(retObject);
+                parametersHash = LoggingHash.HashInt(retObject);
+            }
+            s_log.FunctionStop(callerName,
+                    callerHash,
+                    LoggingHash.GetObjectName(method),
+                    parametersName,
+                    parametersHash,
+                    componentType);
+        }
+
+        [Event(FUNCTIONSTOP_ID, Keywords = Keywords.FunctionEntryExit,
+    Level = EventLevel.Verbose, Message = "[{5}] {0}#{1}::{2}({3}#{4})")]
+        internal unsafe void FunctionStop(string callerName,
+                                            int callerHash,
+                                            string method,
+                                            string parametersName,
+                                            int parametersHash,
+                                            ComponentType componentType)
+        {
+            const int SIZEDATA = 6;
+            fixed (char* arg1Ptr = callerName, arg2Ptr = method, arg3Ptr = parametersName)
+            {
+                EventData* dataDesc = stackalloc EventSource.EventData[SIZEDATA];
+
+                dataDesc[0].DataPointer = (IntPtr)arg1Ptr;
+                dataDesc[0].Size = (callerName.Length + 1) * sizeof(char); // Size in bytes, including a null terminator. 
+                dataDesc[1].DataPointer = (IntPtr)(&callerHash);
+                dataDesc[1].Size = sizeof(int);
+                dataDesc[2].DataPointer = (IntPtr)(arg2Ptr);
+                dataDesc[2].Size = (method.Length + 1) * sizeof(char);
+                dataDesc[3].DataPointer = (IntPtr)(arg3Ptr);
+                dataDesc[3].Size = (parametersName.Length + 1) * sizeof(char);
+                dataDesc[4].DataPointer = (IntPtr)(&parametersHash);
+                dataDesc[4].Size = sizeof(int);
+                dataDesc[5].DataPointer = (IntPtr)(&componentType);
+                dataDesc[5].Size = sizeof(int);
+
+                WriteEventCore(FUNCTIONSTOP_ID, SIZEDATA, dataDesc);
+            }
+        }
+
+        [NonEvent]
+        internal static void Exception(ComponentType componentType, object obj, string method, Exception e)
+        {
+            s_log.CriticalException(LoggingHash.GetObjectName(obj),
+                                                    LoggingHash.GetObjectName(method),
+                                                    LoggingHash.GetObjectName(e.Message),
+                                                    LoggingHash.HashInt(obj),
+                                                    LoggingHash.GetObjectName(e.StackTrace),
+                                                    componentType);
+        }
+
+        [Event(CRITICALEXCEPTION_ID, Keywords = Keywords.Default,
+    Level = EventLevel.Critical)]
+        internal unsafe void CriticalException(string objName, string method, string message, int objHash, string stackTrace, ComponentType componentType)
+        {
+            const int SIZEDATA = 6;
+            fixed (char* arg1Ptr = objName, arg2Ptr = method, arg3Ptr = message, arg4Ptr = stackTrace)
+            {
+                EventData* dataDesc = stackalloc EventSource.EventData[SIZEDATA];
+
+                dataDesc[0].DataPointer = (IntPtr)arg1Ptr;
+                dataDesc[0].Size = (objName.Length + 1) * sizeof(char); // Size in bytes, including a null terminator. 
+                dataDesc[1].DataPointer = (IntPtr)(arg2Ptr);
+                dataDesc[1].Size = (method.Length + 1) * sizeof(char);
+                dataDesc[2].DataPointer = (IntPtr)(arg3Ptr);
+                dataDesc[2].Size = (message.Length + 1) * sizeof(char);
+                dataDesc[3].DataPointer = (IntPtr)(&objHash);
+                dataDesc[3].Size = sizeof(int);
+                dataDesc[4].DataPointer = (IntPtr)(arg4Ptr);
+                dataDesc[4].Size = (stackTrace.Length + 1) * sizeof(char);
+                dataDesc[5].DataPointer = (IntPtr)(&componentType);
+                dataDesc[5].Size = sizeof(int);
+                WriteEventCore(CRITICALEXCEPTION_ID, SIZEDATA, dataDesc);
+            }
+        }
+
+        [NonEvent]
+        internal static void PrintError(ComponentType componentType, string msg)
+        {
+            if (msg == null)
+            {
+                return;
+            }
+            s_log.CriticalError(LoggingHash.GetObjectName(msg), "", "", 0, componentType);
+        }
+
+        [NonEvent]
+        internal static void PrintError(ComponentType componentType, object obj, string method, string msg)
+        {
+            s_log.CriticalError(LoggingHash.GetObjectName(msg),
+                                LoggingHash.GetObjectName(method),
+                                LoggingHash.GetObjectName(obj),
+                                LoggingHash.HashInt(obj),
+                                componentType);
+        }
+
+        [Event(CRITICALERROR_ID, Keywords = Keywords.Default,
+Level = EventLevel.Critical)]
+        internal unsafe void CriticalError(string message, string method, string objName, int objHash, ComponentType componentType)
+        {
+            const int SIZEDATA = 5;
+            fixed (char* arg1Ptr = message, arg2Ptr = method, arg3Ptr = objName)
+            {
+                EventData* dataDesc = stackalloc EventSource.EventData[SIZEDATA];
+
+                dataDesc[0].DataPointer = (IntPtr)arg1Ptr;
+                dataDesc[0].Size = (message.Length + 1) * sizeof(char); // Size in bytes, including a null terminator. 
+                dataDesc[1].DataPointer = (IntPtr)(arg2Ptr);
+                dataDesc[1].Size = (method.Length + 1) * sizeof(char);
+                dataDesc[2].DataPointer = (IntPtr)(arg3Ptr);
+                dataDesc[2].Size = (objName.Length + 1) * sizeof(char);
+                dataDesc[3].DataPointer = (IntPtr)(&objHash);
+                dataDesc[3].Size = sizeof(int);
+                dataDesc[4].DataPointer = (IntPtr)(&componentType);
+                dataDesc[4].Size = sizeof(int);
+                WriteEventCore(CRITICALERROR_ID, SIZEDATA, dataDesc);
+            }
+        }
+
+        public class Keywords
+        {
+            public const EventKeywords Default = (EventKeywords)0x0001;
+            public const EventKeywords Debug = (EventKeywords)0x0002;
+            public const EventKeywords FunctionEntryExit = (EventKeywords)0x0004;
+        }
+
+        public enum ComponentType
+        {
+            Socket,
+            Http,
+            WebSocket,
+            Security
+        }
+    }
+}

--- a/src/Common/src/System/Net/Logging/SecurityEventSource.Windows.cs
+++ b/src/Common/src/System/Net/Logging/SecurityEventSource.Windows.cs
@@ -1,0 +1,173 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Tracing;
+
+namespace System.Net
+{
+    internal sealed partial class SecurityEventSource : EventSource
+    {
+        [Event(ACQUIRE_DEFAULT_CREDENTIAL_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal void AcquireDefaultCredential(string packageName, Interop.Secur32.CredentialUse intent)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            string arg1Str = "";
+            if (packageName != null)
+            {
+                arg1Str = packageName;
+            }
+            s_log.WriteEvent(ACQUIRE_DEFAULT_CREDENTIAL_ID, arg1Str, intent);
+        }
+
+        [NonEvent]
+        internal static void AcquireCredentialsHandle(string packageName, Interop.Secur32.CredentialUse intent, object authdata)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            string arg1Str = "";
+            if (packageName != null)
+            {
+                arg1Str = packageName;
+            }
+            s_log.AcquireCredentialsHandle(arg1Str, intent, LoggingHash.GetObjectName(authdata));
+        }
+
+        [Event(ACQUIRE_CREDENTIALS_HANDLE_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal unsafe void AcquireCredentialsHandle(string packageName, Interop.Secur32.CredentialUse intent, string authdata)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            const int SIZEDATA = 3;
+            fixed (char* arg1Ptr = packageName, arg2Ptr = authdata)
+            {
+                EventData* dataDesc = stackalloc EventSource.EventData[SIZEDATA];
+                dataDesc[0].DataPointer = (IntPtr)(arg1Ptr);
+                dataDesc[0].Size = (packageName.Length + 1) * sizeof(char);
+                dataDesc[1].DataPointer = (IntPtr)(&intent);
+                dataDesc[1].Size = sizeof(int);
+                dataDesc[2].DataPointer = (IntPtr)(arg2Ptr);
+                dataDesc[2].Size = (authdata.Length + 1) * sizeof(char);
+
+                WriteEventCore(ACQUIRE_CREDENTIALS_HANDLE_ID, SIZEDATA, dataDesc);
+            }
+        }
+
+        [Event(INITIALIZE_SECURITY_CONTEXT_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal unsafe void InitializeSecurityContext(string credential, string context, string targetName, Interop.Secur32.ContextFlags inFlags)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            fixed (char* arg1Ptr = credential, arg2Ptr = context, arg3Ptr = targetName)
+            {
+                const int SIZEDATA = 4;
+                EventData* dataDesc = stackalloc EventSource.EventData[SIZEDATA];
+                dataDesc[0].DataPointer = (IntPtr)(arg1Ptr);
+                dataDesc[0].Size = (credential.Length + 1) * sizeof(char);
+                dataDesc[1].DataPointer = (IntPtr)(arg2Ptr);
+                dataDesc[1].Size = (context.Length + 1) * sizeof(char);
+                dataDesc[2].DataPointer = (IntPtr)(arg2Ptr);
+                dataDesc[2].Size = (targetName.Length + 1) * sizeof(char);
+                dataDesc[3].DataPointer = (IntPtr)(&inFlags);
+                dataDesc[3].Size = sizeof(int);
+
+                WriteEventCore(INITIALIZE_SECURITY_CONTEXT_ID, SIZEDATA, dataDesc);
+            }
+        }
+
+        [Event(ACCEPT_SECURITY_CONTEXT_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal unsafe void AcceptSecurityContext(string credential, string context, Interop.Secur32.ContextFlags inFlags)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            fixed (char* arg1Ptr = credential, arg2Ptr = context)
+            {
+                const int SIZEDATA = 3;
+                EventData* dataDesc = stackalloc EventSource.EventData[SIZEDATA];
+                dataDesc[0].DataPointer = (IntPtr)(arg1Ptr);
+                dataDesc[0].Size = (credential.Length + 1) * sizeof(char);
+                dataDesc[1].DataPointer = (IntPtr)(arg2Ptr);
+                dataDesc[1].Size = (context.Length + 1) * sizeof(char);
+                dataDesc[2].DataPointer = (IntPtr)(&inFlags);
+                dataDesc[2].Size = sizeof(int);
+
+                WriteEventCore(ACCEPT_SECURITY_CONTEXT_ID, SIZEDATA, dataDesc);
+            }
+        }
+
+        [Event(OPERATION_RETURNED_SOMETHING_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal void OperationReturnedSomething(string operation, Interop.SecurityStatus errorCode)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            WriteEvent(OPERATION_RETURNED_SOMETHING_ID, operation, errorCode);
+        }
+
+        [Event(SECURITY_CONTEXT_INPUT_BUFFER_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal unsafe void SecurityContextInputBuffer(string context, int inputBufferSize, int outputBufferSize, Interop.SecurityStatus errorCode)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            fixed (char* arg1Ptr = context)
+            {
+                const int SIZEDATA = 4;
+                EventData* dataDesc = stackalloc EventSource.EventData[SIZEDATA];
+                dataDesc[0].DataPointer = (IntPtr)(arg1Ptr);
+                dataDesc[0].Size = (context.Length + 1) * sizeof(char);
+                dataDesc[1].DataPointer = (IntPtr)(&inputBufferSize);
+                dataDesc[1].Size = sizeof(int);
+                dataDesc[2].DataPointer = (IntPtr)(&outputBufferSize);
+                dataDesc[2].Size = sizeof(int);
+                dataDesc[3].DataPointer = (IntPtr)(&errorCode);
+                dataDesc[3].Size = sizeof(int);
+
+                WriteEventCore(SECURITY_CONTEXT_INPUT_BUFFER_ID, SIZEDATA, dataDesc);
+            }
+        }
+
+        [Event(SECURITY_CONTEXT_INPUT_BUFFERS_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal unsafe void SecurityContextInputBuffers(string context, int inputBuffersSize, int outputBufferSize, Interop.SecurityStatus errorCode)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            fixed (char* arg1Ptr = context)
+            {
+                const int SIZEDATA = 4;
+                EventData* dataDesc = stackalloc EventSource.EventData[SIZEDATA];
+                dataDesc[0].DataPointer = (IntPtr)(arg1Ptr);
+                dataDesc[0].Size = (context.Length + 1) * sizeof(char);
+                dataDesc[1].DataPointer = (IntPtr)(&inputBuffersSize);
+                dataDesc[1].Size = sizeof(int);
+                dataDesc[2].DataPointer = (IntPtr)(&outputBufferSize);
+                dataDesc[2].Size = sizeof(int);
+                dataDesc[3].DataPointer = (IntPtr)(&errorCode);
+                dataDesc[3].Size = sizeof(int);
+
+                WriteEventCore(SECURITY_CONTEXT_INPUT_BUFFERS_ID, SIZEDATA, dataDesc);
+            }
+        }
+    }
+}

--- a/src/Common/src/System/Net/Logging/SecurityEventSource.cs
+++ b/src/Common/src/System/Net/Logging/SecurityEventSource.cs
@@ -1,0 +1,395 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Tracing;
+using System.Globalization;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+
+namespace System.Net
+{
+    //TODO: If localization resources are not found, logging does not work. Issue #5126.
+    [EventSource(Name = "Microsoft-System-Net-Security",
+        Guid = "066c0e27-a02d-5a98-9a4d-078cc3b1a896",
+        LocalizationResources = "FxResources.System.Net.Security.SR")]
+    internal sealed partial class SecurityEventSource : EventSource
+    {
+        private const int ENUMERATE_SECURITY_PACKAGES_ID = 1;
+        private const int SSPI_PACKAGE_NOT_FOUND_ID = 2;
+        private const int ACQUIRE_DEFAULT_CREDENTIAL_ID = 3;
+        private const int ACQUIRE_CREDENTIALS_HANDLE_ID = 4;
+        private const int SECURE_CHANNEL_CTOR_ID = 5;
+        private const int LOCATING_PRIVATE_KEY_ID = 6;
+        private const int CERT_IS_TYPE_2_ID = 7;
+        private const int FOUND_CERT_IN_STORE_ID = 8;
+        private const int NOT_FOUND_CERT_IN_STORE_ID = 9;
+        private const int INITIALIZE_SECURITY_CONTEXT_ID = 10;
+        private const int SECURITY_CONTEXT_INPUT_BUFFER_ID = 11;
+        private const int SECURITY_CONTEXT_INPUT_BUFFERS_ID = 12;
+        private const int ACCEPT_SECURITY_CONTEXT_ID = 13;
+        private const int OPERATION_RETURNED_SOMETHING_ID = 14;
+        private const int REMOTE_CERTIFICATE_ID = 15;
+        private const int CERTIFICATE_FROM_DELEGATE_ID = 16;
+        private const int NO_DELEGATE_NO_CLIENT_CERT_ID = 17;
+        private const int NO_DELEGATE_BUT_CLIENT_CERT_ID = 18;
+        private const int ATTEMPTING_RESTART_USING_CERT_ID = 19;
+        private const int NO_ISSUERS_TRY_ALL_CERTS_ID = 20;
+        private const int LOOK_FOR_MATCHING_CERTS_ID = 21;
+        private const int SELECTED_CERT_ID = 22;
+        private const int CERTS_AFTER_FILTERING_ID = 23;
+        private const int FINDING_MATCHING_CERTS_ID = 24;
+        private const int USING_CACHED_CREDENTIAL_ID = 25;
+        private const int SSPI_SELECTED_CIPHER_SUITE_ID = 26;
+        private const int REMOTE_CERTIFICATE_ERROR_ID = 27;
+        private const int REMOTE_CERTIFICATE_VALID_ID = 28;
+        private const int REMOTE_CERTIFICATE_SUCCESS_ID = 29;
+        private const int REMOTE_CERTIFICATE_INVALID_ID = 30;
+
+
+        private readonly static SecurityEventSource s_log = new SecurityEventSource();
+        private SecurityEventSource() { }
+        public static SecurityEventSource Log
+        {
+            get
+            {
+                return s_log;
+            }
+        }
+
+        [Event(ENUMERATE_SECURITY_PACKAGES_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal void EnumerateSecurityPackages(string securityPackage)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            string arg1Str = "";
+            if (securityPackage != null)
+            {
+                arg1Str = securityPackage;
+            }
+            s_log.WriteEvent(ENUMERATE_SECURITY_PACKAGES_ID, arg1Str);
+        }
+
+        [Event(SSPI_PACKAGE_NOT_FOUND_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal void SspiPackageNotFound(string packageName)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            string arg1Str = "";
+            if (packageName != null)
+            {
+                arg1Str = packageName;
+            }
+            s_log.WriteEvent(SSPI_PACKAGE_NOT_FOUND_ID, arg1Str);
+        }
+
+        [NonEvent]
+        internal static void SecureChannelCtor(object secureChannel,
+                                                string hostname,
+                                                X509CertificateCollection clientCertificates,
+                                                 EncryptionPolicy encryptionPolicy)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            int clientCertificatesCount = 0;
+            string arg1Str = "";
+            if (clientCertificates != null)
+            {
+                clientCertificatesCount = clientCertificates.Count;
+            }
+            if (hostname != null)
+            {
+                arg1Str = hostname;
+            }
+            s_log.SecureChannelCtor(arg1Str, LoggingHash.HashInt(secureChannel), clientCertificatesCount, encryptionPolicy);
+        }
+
+        [Event(SECURE_CHANNEL_CTOR_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal unsafe void SecureChannelCtor(string hostname, int secureChannelHash, int clientCertificatesCount, EncryptionPolicy encryptionPolicy)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            fixed (char* arg1Ptr = hostname)
+            {
+                const int SIZEDATA = 4;
+                EventData* dataDesc = stackalloc EventSource.EventData[SIZEDATA];
+                dataDesc[0].DataPointer = (IntPtr)(arg1Ptr);
+                dataDesc[0].Size = (hostname.Length + 1) * sizeof(char);
+                dataDesc[1].DataPointer = (IntPtr)(&secureChannelHash);
+                dataDesc[1].Size = sizeof(int);
+                dataDesc[2].DataPointer = (IntPtr)(&clientCertificatesCount);
+                dataDesc[2].Size = sizeof(int);
+                dataDesc[3].DataPointer = (IntPtr)(&encryptionPolicy);
+                dataDesc[3].Size = sizeof(int);
+
+                WriteEventCore(SECURE_CHANNEL_CTOR_ID, SIZEDATA, dataDesc);
+            }
+        }
+
+        [Event(LOCATING_PRIVATE_KEY_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal void LocatingPrivateKey(string x509Certificate, int secureChannelHash)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            WriteEvent(LOCATING_PRIVATE_KEY_ID, x509Certificate, secureChannelHash);
+        }
+
+        [Event(CERT_IS_TYPE_2_ID, Keywords = Keywords.Default,
+    Level = EventLevel.Informational)]
+        internal void CertIsType2(int secureChannelHash)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            WriteEvent(CERT_IS_TYPE_2_ID, secureChannelHash);
+        }
+
+        [Event(FOUND_CERT_IN_STORE_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal void FoundCertInStore(string store, int secureChannelHash)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            WriteEvent(FOUND_CERT_IN_STORE_ID, store, secureChannelHash);
+        }
+
+        [Event(NOT_FOUND_CERT_IN_STORE_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal void NotFoundCertInStore(int secureChannelHash)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            WriteEvent(NOT_FOUND_CERT_IN_STORE_ID, secureChannelHash);
+        }
+
+        [Event(REMOTE_CERTIFICATE_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal void RemoteCertificate(string remoteCertificate)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            WriteEvent(REMOTE_CERTIFICATE_ID, remoteCertificate);
+        }
+
+
+        [Event(CERTIFICATE_FROM_DELEGATE_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal void CertificateFromDelegate(int secureChannelHash)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            WriteEvent(CERTIFICATE_FROM_DELEGATE_ID, secureChannelHash);
+        }
+
+        [Event(NO_DELEGATE_NO_CLIENT_CERT_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal void NoDelegateNoClientCert(int secureChannelHash)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            WriteEvent(NO_DELEGATE_NO_CLIENT_CERT_ID, secureChannelHash);
+        }
+
+        [Event(NO_DELEGATE_BUT_CLIENT_CERT_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal void NoDelegateButClientCert(int secureChannelHash)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            WriteEvent(NO_DELEGATE_BUT_CLIENT_CERT_ID, secureChannelHash);
+        }
+
+        [Event(ATTEMPTING_RESTART_USING_CERT_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal void AttemptingRestartUsingCert(string clientCertificate, int secureChannelHash)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            WriteEvent(ATTEMPTING_RESTART_USING_CERT_ID, clientCertificate, secureChannelHash);
+        }
+
+        [Event(NO_ISSUERS_TRY_ALL_CERTS_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal void NoIssuersTryAllCerts(int secureChannelHash)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            WriteEvent(NO_ISSUERS_TRY_ALL_CERTS_ID, secureChannelHash);
+        }
+
+        [Event(LOOK_FOR_MATCHING_CERTS_ID, Keywords = Keywords.Default,
+Level = EventLevel.Informational)]
+        internal void LookForMatchingCerts(int issuersCount, int secureChannelHash)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            WriteEvent(LOOK_FOR_MATCHING_CERTS_ID, issuersCount, secureChannelHash);
+        }
+
+        [Event(SELECTED_CERT_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal void SelectedCert(string clientCertificate, int secureChannelHash)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            WriteEvent(SELECTED_CERT_ID, clientCertificate, secureChannelHash);
+        }
+
+        [Event(CERTS_AFTER_FILTERING_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal void CertsAfterFiltering(int filteredCertsCount, int secureChannelHash)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            WriteEvent(CERTS_AFTER_FILTERING_ID, filteredCertsCount, secureChannelHash);
+        }
+
+        [Event(FINDING_MATCHING_CERTS_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal void FindingMatchingCerts(int secureChannelHash)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            WriteEvent(FINDING_MATCHING_CERTS_ID, secureChannelHash);
+        }
+
+        [Event(USING_CACHED_CREDENTIAL_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal void UsingCachedCredential(int secureChannelHash)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            WriteEvent(USING_CACHED_CREDENTIAL_ID, secureChannelHash);
+        }
+
+        [Event(SSPI_SELECTED_CIPHER_SUITE_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal unsafe void SspiSelectedCipherSuite(string process,
+                                                        SslProtocols sslProtocol,
+                                                        CipherAlgorithmType cipherAlgorithm,
+                                                        int cipherStrength,
+                                                        HashAlgorithmType hashAlgorithm,
+                                                        int hashStrength,
+                                                        ExchangeAlgorithmType keyExchangeAlgorithm,
+                                                        int keyExchangeStrength)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            fixed (char* arg1Ptr = process)
+            {
+                const int SIZEDATA = 8;
+                EventData* dataDesc = stackalloc EventSource.EventData[SIZEDATA];
+                dataDesc[0].DataPointer = (IntPtr)(arg1Ptr);
+                dataDesc[0].Size = (process.Length + 1) * sizeof(char);
+                dataDesc[1].DataPointer = (IntPtr)(&sslProtocol);
+                dataDesc[1].Size = sizeof(int);
+                dataDesc[2].DataPointer = (IntPtr)(&cipherAlgorithm);
+                dataDesc[2].Size = sizeof(int);
+                dataDesc[3].DataPointer = (IntPtr)(&cipherStrength);
+                dataDesc[3].Size = sizeof(int);
+                dataDesc[4].DataPointer = (IntPtr)(&hashAlgorithm);
+                dataDesc[4].Size = sizeof(int);
+                dataDesc[2].DataPointer = (IntPtr)(&hashStrength);
+                dataDesc[2].Size = sizeof(int);
+                dataDesc[3].DataPointer = (IntPtr)(&keyExchangeAlgorithm);
+                dataDesc[3].Size = sizeof(int);
+                dataDesc[4].DataPointer = (IntPtr)(&keyExchangeStrength);
+                dataDesc[4].Size = sizeof(int);
+                WriteEventCore(SSPI_SELECTED_CIPHER_SUITE_ID, SIZEDATA, dataDesc);
+            }
+        }
+
+        [Event(REMOTE_CERTIFICATE_ERROR_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Verbose)]
+        internal void RemoteCertificateError(int secureChannelHash, string message)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            WriteEvent(REMOTE_CERTIFICATE_ERROR_ID, secureChannelHash, message);
+        }
+
+        [Event(REMOTE_CERTIFICATE_VALID_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Verbose)]
+        internal void RemoteCertDeclaredValid(int secureChannelHash)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            WriteEvent(REMOTE_CERTIFICATE_VALID_ID, secureChannelHash);
+        }
+
+        [Event(REMOTE_CERTIFICATE_SUCCESS_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Verbose)]
+        internal void RemoteCertHasNoErrors(int secureChannelHash)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            WriteEvent(REMOTE_CERTIFICATE_SUCCESS_ID, secureChannelHash);
+        }
+
+        [Event(REMOTE_CERTIFICATE_INVALID_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Verbose)]
+        internal void RemoteCertUserDeclaredInvalid(int secureChannelHash)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            WriteEvent(REMOTE_CERTIFICATE_INVALID_ID, secureChannelHash);
+        }
+
+        public class Keywords
+        {
+            public const EventKeywords Default = (EventKeywords)0x0001;
+            public const EventKeywords Debug = (EventKeywords)0x0002;
+        }
+    }
+}

--- a/src/Common/src/System/Net/Logging/SocketsEventSource.cs
+++ b/src/Common/src/System/Net/Logging/SocketsEventSource.cs
@@ -1,0 +1,265 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Tracing;
+using System.Globalization;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+
+namespace System.Net
+{
+    //TODO: If localization resources are not found, logging does not work. Issue #5126.
+    [EventSource(Name = "Microsoft-System-Net-Sockets",
+        Guid = "e03c0352-f9c9-56ff-0ea7-b94ba8cabc6b",
+        LocalizationResources = "FxResources.System.Net.Sockets.SR")]
+    internal sealed class SocketsEventSource : EventSource
+    {
+        private const int ACCEPTED_ID = 1;
+        private const int CONNECTED_ID = 2;
+        private const int CONNECTED_ASYNC_DNS_ID = 3;
+        private const int NOT_LOGGED_FILE_ID = 4;
+        private const int DUMP_ARRAY_ID = 5;
+        private const int DUMP_ARRAY_ASYNC_ID = 6;
+
+        private const int DefaultMaxDumpSize = 1024;
+
+        private readonly static SocketsEventSource s_log = new SocketsEventSource();
+        private SocketsEventSource() { }
+        public static SocketsEventSource Log
+        {
+            get
+            {
+                return s_log;
+            }
+        }
+
+        [NonEvent]
+        internal static void Accepted(Socket socket, object remoteEp, object localEp)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            s_log.Accepted(LoggingHash.GetObjectName(remoteEp), LoggingHash.GetObjectName(localEp), LoggingHash.HashInt(socket));
+        }
+
+        [Event(ACCEPTED_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal unsafe void Accepted(string remoteEp, string localEp, int socketHash)
+        {
+            fixed (char* arg1Ptr = remoteEp, arg2Ptr = localEp)
+            {
+                const int SIZEDATA = 3;
+                EventData* dataDesc = stackalloc EventSource.EventData[SIZEDATA];
+                dataDesc[0].DataPointer = (IntPtr)(arg1Ptr);
+                dataDesc[0].Size = (remoteEp.Length + 1) * sizeof(char);
+                dataDesc[1].DataPointer = (IntPtr)(arg2Ptr);
+                dataDesc[1].Size = (localEp.Length + 1) * sizeof(char);
+                dataDesc[2].DataPointer = (IntPtr)(&socketHash);
+                dataDesc[2].Size = sizeof(int);
+
+                WriteEventCore(ACCEPTED_ID, SIZEDATA, dataDesc);
+            }
+        }
+
+        [NonEvent]
+        internal static void Connected(Socket socket, object localEp, object remoteEp)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            s_log.Connected(LoggingHash.GetObjectName(localEp), LoggingHash.GetObjectName(remoteEp), LoggingHash.HashInt(socket));
+        }
+
+        [Event(CONNECTED_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal unsafe void Connected(string localEp, string remoteEp, int socketHash)
+        {
+            fixed (char* arg1Ptr = localEp, arg2Ptr = remoteEp)
+            {
+                const int SIZEDATA = 3;
+                EventData* dataDesc = stackalloc EventSource.EventData[SIZEDATA];
+                dataDesc[0].DataPointer = (IntPtr)(arg1Ptr);
+                dataDesc[0].Size = (localEp.Length + 1) * sizeof(char);
+                dataDesc[1].DataPointer = (IntPtr)(arg2Ptr);
+                dataDesc[1].Size = (remoteEp.Length + 1) * sizeof(char);
+                dataDesc[2].DataPointer = (IntPtr)(&socketHash);
+                dataDesc[2].Size = sizeof(int);
+
+                WriteEventCore(CONNECTED_ID, SIZEDATA, dataDesc);
+            }
+        }
+
+        [Event(CONNECTED_ASYNC_DNS_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal void ConnectedAsyncDns(int socketHash)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            WriteEvent(CONNECTED_ASYNC_DNS_ID, socketHash);
+        }
+
+        [Event(NOT_LOGGED_FILE_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal unsafe void NotLoggedFile(string filePath, int socketHash, SocketAsyncOperation completedOperation)
+        {
+            fixed (char* arg1Ptr = filePath)
+            {
+                const int SIZEDATA = 3;
+                EventData* dataDesc = stackalloc EventSource.EventData[SIZEDATA];
+                dataDesc[0].DataPointer = (IntPtr)(arg1Ptr);
+                dataDesc[0].Size = (filePath.Length + 1) * sizeof(char);
+                dataDesc[1].DataPointer = (IntPtr)(&completedOperation);
+                dataDesc[1].Size = sizeof(int);
+                dataDesc[2].DataPointer = (IntPtr)(&socketHash);
+                dataDesc[2].Size = sizeof(int);
+
+                WriteEventCore(NOT_LOGGED_FILE_ID, SIZEDATA, dataDesc);
+            }
+        }
+
+        [NonEvent]
+        internal static void Dump(object method, IntPtr bufferPtr, int length)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            if (length > DefaultMaxDumpSize)
+            {
+                length = DefaultMaxDumpSize;
+            }
+            byte[] buffer = new byte[length];
+            Marshal.Copy(bufferPtr, buffer, 0, length);
+
+            if (method is MethodType)
+            {
+                s_log.DebugDumpArray((MethodType)method, buffer);
+            }
+            else if (method is SocketAsyncOperation)
+            {
+                s_log.DumpArrayAsync((SocketAsyncOperation)method, buffer);
+            }
+        }
+
+        [NonEvent]
+        internal static void Dump(object method, byte[] buffer, int offset, int length)
+        {
+            if (!s_log.IsEnabled() || offset > buffer.Length)
+            {
+                return;
+            }
+
+            if (length > DefaultMaxDumpSize)
+            {
+                length = DefaultMaxDumpSize;
+            }
+
+            if ((length < 0) || (length > buffer.Length - offset))
+            {
+                length = buffer.Length - offset;
+            }
+
+            byte[] partialBuffer = new byte[length];
+            Buffer.BlockCopy(buffer, offset, partialBuffer, 0, length);
+
+            if (method is MethodType)
+            {
+                s_log.DebugDumpArray((MethodType)method, partialBuffer);
+            }
+            else if (method is SocketAsyncOperation)
+            {
+                s_log.DumpArrayAsync((SocketAsyncOperation)method, partialBuffer);
+            }
+        }
+
+        [Event(DUMP_ARRAY_ID, Keywords = Keywords.Default,
+            Level = EventLevel.Informational)]
+        internal unsafe void DebugDumpArray(MethodType method, byte[] buffer)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            const int SIZEDATA = 3;
+            EventSource.EventData* descrs = stackalloc EventSource.EventData[SIZEDATA];
+            descrs[0].DataPointer = (IntPtr)(&method);
+            descrs[0].Size = sizeof(int);
+            if (buffer == null || buffer.Length == 0)
+            {
+                int blobSize = 0;
+                descrs[1].DataPointer = (IntPtr)(&blobSize);
+                descrs[1].Size = 4;
+                descrs[2].DataPointer = (IntPtr)(&blobSize); // Valid address instead of empty contents.
+                descrs[2].Size = 0;
+                WriteEventCore(DUMP_ARRAY_ID, SIZEDATA, descrs);
+            }
+            else
+            {
+                int blobSize = buffer.Length;
+                fixed (byte* blob = &buffer[0])
+                {
+                    descrs[1].DataPointer = (IntPtr)(&blobSize);
+                    descrs[1].Size = 4;
+                    descrs[2].DataPointer = (IntPtr)blob;
+                    descrs[2].Size = blobSize;
+                    WriteEventCore(DUMP_ARRAY_ID, SIZEDATA, descrs);
+                }
+            }
+        }
+
+        [Event(DUMP_ARRAY_ASYNC_ID, Keywords = Keywords.Default,
+    Level = EventLevel.Informational)]
+        internal unsafe void DumpArrayAsync(SocketAsyncOperation completedOperation, byte[] buffer)
+        {
+            if (!s_log.IsEnabled())
+            {
+                return;
+            }
+            const int SIZEDATA = 3;
+            EventSource.EventData* descrs = stackalloc EventSource.EventData[SIZEDATA];
+            descrs[0].DataPointer = (IntPtr)(&completedOperation);
+            descrs[0].Size = sizeof(int);
+            if (buffer == null || buffer.Length == 0)
+            {
+                int blobSize = 0;
+                descrs[1].DataPointer = (IntPtr)(&blobSize);
+                descrs[1].Size = 4;
+                descrs[2].DataPointer = (IntPtr)(&blobSize); // Valid address instead of empty contents.
+                descrs[2].Size = 0;
+                WriteEventCore(DUMP_ARRAY_ASYNC_ID, SIZEDATA, descrs);
+            }
+            else
+            {
+                int blobSize = buffer.Length;
+                fixed (byte* blob = &buffer[0])
+                {
+                    descrs[1].DataPointer = (IntPtr)(&blobSize);
+                    descrs[1].Size = 4;
+                    descrs[2].DataPointer = (IntPtr)blob;
+                    descrs[2].Size = blobSize;
+                    WriteEventCore(DUMP_ARRAY_ASYNC_ID, SIZEDATA, descrs);
+                }
+            }
+        }
+
+        public class Keywords
+        {
+            public const EventKeywords Default = (EventKeywords)0x0001;
+            public const EventKeywords Debug = (EventKeywords)0x0002;
+        }
+
+        public enum MethodType
+        {
+            Send,
+            SendTo,
+            Receive,
+            ReceiveFrom,
+            FinishOperation,
+            PostCompletion
+        }
+    }
+}

--- a/src/Common/src/System/Net/SafeCloseSocket.Windows.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Windows.cs
@@ -46,7 +46,7 @@ namespace System.Net.Sockets
                     if (_iocpBoundHandle == null)
                     {
                         // Bind the socket native _handle to the ThreadPool.
-                        GlobalLog.Print("SafeCloseSocket#" + Logging.HashString(this) + "::BindToCompletionPort() calling ThreadPool.BindHandle()");
+                        GlobalLog.Print("SafeCloseSocket#" + LoggingHash.HashString(this) + "::BindToCompletionPort() calling ThreadPool.BindHandle()");
 
                         try
                         {

--- a/src/Common/src/System/Net/SafeCloseSocket.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.cs
@@ -96,7 +96,7 @@ namespace System.Net.Sockets
             SafeCloseSocket ret = new SafeCloseSocket();
             CreateSocket(socket, ret);
 
-            GlobalLog.Print("SafeCloseSocket#" + Logging.HashString(ret) + "::CreateSocket()");
+            GlobalLog.Print("SafeCloseSocket#" + LoggingHash.HashString(ret) + "::CreateSocket()");
 
             return ret;
         }
@@ -139,8 +139,8 @@ namespace System.Net.Sockets
         protected override bool ReleaseHandle()
         {
             GlobalLog.Print(
-                "SafeCloseSocket#" + Logging.HashString(this) + "::ReleaseHandle() m_InnerSocket=" +
-                _innerSocket == null ? "null" : Logging.HashString(_innerSocket));
+                "SafeCloseSocket#" + LoggingHash.HashString(this) + "::ReleaseHandle() m_InnerSocket=" +
+                _innerSocket == null ? "null" : LoggingHash.HashString(_innerSocket));
 
             _released = true;
             InnerSafeCloseSocket innerSocket = _innerSocket == null ? null : Interlocked.Exchange<InnerSafeCloseSocket>(ref _innerSocket, null);
@@ -163,8 +163,8 @@ namespace System.Net.Sockets
         internal void CloseAsIs()
         {
             GlobalLog.Print(
-                "SafeCloseSocket#" + Logging.HashString(this) + "::CloseAsIs() m_InnerSocket=" +
-                _innerSocket == null ? "null" : Logging.HashString(_innerSocket));
+                "SafeCloseSocket#" + LoggingHash.HashString(this) + "::CloseAsIs() m_InnerSocket=" +
+                _innerSocket == null ? "null" : LoggingHash.HashString(_innerSocket));
 
 #if DEBUG
             // If this throws it could be very bad.

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -204,7 +204,7 @@
   <data name="net_http_client_send_canceled" xml:space="preserve">
     <value>Request for {0} was canceled.</value>
   </data>
-  <data name="net_http_client_send_completed" xml:space="preserve">
+  <data name="event_ClientSendCompleted" xml:space="preserve">
     <value>Request for {0} completed successfully. Returning response {1}: {2}</value>
   </data>
   <data name="net_http_parser_invalid_base64_string" xml:space="preserve">
@@ -222,7 +222,7 @@
   <data name="net_http_content_field_too_long" xml:space="preserve">
     <value>The field cannot be longer than {0} characters.</value>
   </data>
-  <data name="net_http_log_headers_invalid_value" xml:space="preserve">
+  <data name="event_HeadersInvalidValue" xml:space="preserve">
     <value>Value for header '{0}' has invalid format. Value: '{1}'.</value>
   </data>
   <data name="net_http_log_headers_no_newlines" xml:space="preserve">
@@ -237,7 +237,7 @@
   <data name="net_http_log_content_no_task_returned_copytoasync" xml:space="preserve">
     <value>Type '{0}.CopyToAsync()' did not return a System.Threading.Tasks.Task object.</value>
   </data>
-  <data name="net_http_log_content_null" xml:space="preserve">
+  <data name="event_ContentNull" xml:space="preserve">
     <value>Content set to '&lt;null&gt;'.</value>
   </data>
   <data name="net_http_handler_not_assigned" xml:space="preserve">

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -103,9 +103,16 @@
     <Compile Include="$(CommonPath)\System\Net\HttpKnownHeaderNames.cs">
       <Link>Common\System\Net\HttpKnownHeaderNames.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging.cs">
-      <Link>Common\System\Net\Logging.cs</Link>
+    <Compile Include="$(CommonPath)\System\Net\Logging\LoggingHash.cs">
+      <Link>Common\System\Net\Logging\LoggingHash.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Logging\HttpEventSource.cs">
+      <Link>Common\System\Net\Logging\HttpEventSource.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.cs">
+      <Link>Common\System\Net\Logging\NetEventSource.cs</Link>
+    </Compile>
+
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
     <Compile Include="System\Net\Http\HttpClientHandler.Windows.cs" />

--- a/src/System.Net.Http/src/System/Net/Http/DelegatingHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/DelegatingHandler.cs
@@ -30,7 +30,7 @@ namespace System.Net.Http
                 }
                 CheckDisposedOrStarted();
 
-                if (Logging.On) Logging.Associate(Logging.Http, this, value);
+                if (HttpEventSource.Log.IsEnabled()) HttpEventSource.Associate(this, value);
                 _innerHandler = value;
             }
         }

--- a/src/System.Net.Http/src/System/Net/Http/Headers/ByteArrayHeaderParser.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/ByteArrayHeaderParser.cs
@@ -49,7 +49,7 @@ namespace System.Net.Http.Headers
             }
             catch (FormatException e)
             {
-                if (Logging.On) Logging.PrintError(Logging.Http, string.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_parser_invalid_base64_string, base64String, e.Message));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.PrintError(NetEventSource.ComponentType.Http, string.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_parser_invalid_base64_string, base64String, e.Message));
             }
 
             return false;

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HeaderUtilities.cs
@@ -78,7 +78,7 @@ namespace System.Net.Http.Headers
                     return qualityValue;
                 }
                 // If the stored value is an invalid quality value, just return null and log a warning. 
-                if (Logging.On) Logging.PrintError(Logging.Http, string.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_log_headers_invalid_quality, qualityParameter.Value));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.PrintError(NetEventSource.ComponentType.Http, string.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_log_headers_invalid_quality, qualityParameter.Value));
             }
             return null;
         }
@@ -306,7 +306,7 @@ namespace System.Net.Http.Headers
             }
             catch (FormatException e)
             {
-                if (Logging.On) Logging.PrintError(Logging.Http, string.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_log_headers_wrong_email_format, value, e.Message));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.PrintError(NetEventSource.ComponentType.Http, string.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_log_headers_wrong_email_format, value, e.Message));
             }
             return false;
         }

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpHeaders.cs
@@ -813,7 +813,7 @@ namespace System.Net.Http.Headers
                 {
                     if (!TryParseAndAddRawHeaderValue(name, info, rawValue, true))
                     {
-                        if (Logging.On) Logging.PrintWarning(Logging.Http, string.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_log_headers_invalid_value, name, rawValue));
+                        if (HttpEventSource.Log.IsEnabled()) HttpEventSource.Log.HeadersInvalidValue(name, rawValue);
                     }
                 }
             }
@@ -835,7 +835,7 @@ namespace System.Net.Http.Headers
             {
                 if (!TryParseAndAddRawHeaderValue(name, info, rawValue, true))
                 {
-                    if (Logging.On) Logging.PrintWarning(Logging.Http, string.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_log_headers_invalid_value, name, rawValue));
+                    if (HttpEventSource.Log.IsEnabled()) HttpEventSource.Log.HeadersInvalidValue(name, rawValue);
                 }
             }
         }
@@ -1169,7 +1169,7 @@ namespace System.Net.Http.Headers
         {
             if (HttpRuleParser.ContainsInvalidNewLine(value))
             {
-                if (Logging.On) Logging.PrintError(Logging.Http, string.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_log_headers_no_newlines, name, value));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.PrintError(NetEventSource.ComponentType.Http, string.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_log_headers_no_newlines, name, value));
                 return true;
             }
             return false;

--- a/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClient.cs
@@ -53,7 +53,7 @@ namespace System.Net.Http
                 CheckBaseAddress(value, "value");
                 CheckDisposedOrStarted();
 
-                if (Logging.On) Logging.PrintInfo(Logging.Http, this, "BaseAddress: '" + _baseAddress + "'");
+                if (HttpEventSource.Log.IsEnabled()) HttpEventSource.UriBaseAddress(this, _baseAddress.ToString());
 
                 _baseAddress = value;
             }
@@ -110,13 +110,13 @@ namespace System.Net.Http
         public HttpClient(HttpMessageHandler handler, bool disposeHandler)
             : base(handler, disposeHandler)
         {
-            if (Logging.On) Logging.Enter(Logging.Http, this, ".ctor", handler);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Http, this, ".ctor", handler);
 
             _timeout = s_defaultTimeout;
             _maxResponseContentBufferSize = HttpContent.MaxBufferSize;
             _pendingRequestsCts = new CancellationTokenSource();
 
-            if (Logging.On) Logging.Exit(Logging.Http, this, ".ctor", null);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Http, this, ".ctor", null);
         }
 
         #endregion Constructors
@@ -395,7 +395,7 @@ namespace System.Net.Http
                 catch (Exception e)
                 {
                     // Make sure we catch any exception, otherwise the task will catch it and throw in the finalizer.
-                    if (Logging.On) Logging.Exception(Logging.Http, this, "SendAsync", e);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Exception(NetEventSource.ComponentType.Http, this, "SendAsync", e);
                     tcs.TrySetException(e);
                 }
             });
@@ -406,7 +406,7 @@ namespace System.Net.Http
         {
             CheckDisposed();
 
-            if (Logging.On) Logging.Enter(Logging.Http, this, "CancelPendingRequests", "");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Http, this, "CancelPendingRequests", "");
 
             // With every request we link this cancellation token source.
             CancellationTokenSource currentCts = Interlocked.Exchange(ref _pendingRequestsCts,
@@ -415,7 +415,7 @@ namespace System.Net.Http
             currentCts.Cancel();
             currentCts.Dispose();
 
-            if (Logging.On) Logging.Exit(Logging.Http, this, "CancelPendingRequests", "");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Http, this, "CancelPendingRequests", "");
         }
 
         #endregion Advanced Send Overloads
@@ -503,7 +503,7 @@ namespace System.Net.Http
                     // Make sure we catch any exception, otherwise the task will catch it and throw in the finalizer.
                     response.Dispose();
                     tcs.TrySetException(e);
-                    if (Logging.On) Logging.Exception(Logging.Http, this, "SendAsync", e);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Exception(NetEventSource.ComponentType.Http, this, "SendAsync", e);
                 }
             });
         }
@@ -621,7 +621,7 @@ namespace System.Net.Http
         private void SetTaskCompleted(HttpRequestMessage request, CancellationTokenSource cancellationTokenSource,
             TaskCompletionSource<HttpResponseMessage> tcs, HttpResponseMessage response)
         {
-            if (Logging.On) Logging.PrintInfo(Logging.Http, this, string.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_client_send_completed, Logging.GetObjectLogHash(request), Logging.GetObjectLogHash(response), response));
+            if (HttpEventSource.Log.IsEnabled()) HttpEventSource.ClientSendCompleted(this, response, request);
             tcs.TrySetResult(response);
             cancellationTokenSource.Dispose();
         }
@@ -643,12 +643,12 @@ namespace System.Net.Http
 
             if (cancellationTokenSource.IsCancellationRequested)
             {
-                if (Logging.On) Logging.PrintError(Logging.Http, this, method, string.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_client_send_canceled, Logging.GetObjectLogHash(request)));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.PrintError(NetEventSource.ComponentType.Http, this, method, string.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_client_send_canceled, LoggingHash.GetObjectLogHash(request)));
             }
             else
             {
                 Debug.Assert(e != null);
-                if (Logging.On) Logging.PrintError(Logging.Http, this, method, string.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_client_send_error, Logging.GetObjectLogHash(request), e));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.PrintError(NetEventSource.ComponentType.Http, this, method, string.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_client_send_error, LoggingHash.GetObjectLogHash(request), e));
             }
         }
 

--- a/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpContent.cs
@@ -154,12 +154,12 @@ namespace System.Net.Http
         protected HttpContent()
         {
             // Log to get an ID for the current content. This ID is used when the content gets associated to a message.
-            if (Logging.On) Logging.Enter(Logging.Http, this, ".ctor", null);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Http, this, ".ctor", null);
 
             // We start with the assumption that we can calculate the content length.
             _canCalculateLength = true;
 
-            if (Logging.On) Logging.Exit(Logging.Http, this, ".ctor", null);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Http, this, ".ctor", null);
         }
 
         public Task<string> ReadAsStringAsync()
@@ -429,7 +429,7 @@ namespace System.Net.Http
                         {
                             // Make sure we catch any exception, otherwise the task will catch it and throw in the finalizer.
                             tcs.TrySetException(e);
-                            if (Logging.On) Logging.Exception(Logging.Http, this, "LoadIntoBufferAsync", e);
+                            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exception(NetEventSource.ComponentType.Http, this, "LoadIntoBufferAsync", e);
                         }
                     });
                 }
@@ -573,7 +573,7 @@ namespace System.Net.Http
         {
             if (task == null)
             {
-                if (Logging.On) Logging.PrintError(Logging.Http, string.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_log_content_no_task_returned_copytoasync, this.GetType().ToString()));
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.PrintError(NetEventSource.ComponentType.Http, string.Format(System.Globalization.CultureInfo.InvariantCulture, SR.net_http_log_content_no_task_returned_copytoasync, this.GetType().ToString()));
                 throw new InvalidOperationException(SR.net_http_content_no_task_returned);
             }
         }

--- a/src/System.Net.Http/src/System/Net/Http/HttpMessageHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpMessageHandler.cs
@@ -13,8 +13,8 @@ namespace System.Net.Http
     {
         protected HttpMessageHandler()
         {
-            if (Logging.On) Logging.Enter(Logging.Http, this, ".ctor", null);
-            if (Logging.On) Logging.Exit(Logging.Http, this, ".ctor", null);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Http, this, ".ctor", null);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Http, this, ".ctor", null);
         }
 
         protected internal abstract Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken);

--- a/src/System.Net.Http/src/System/Net/Http/HttpMessageInvoker.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpMessageInvoker.cs
@@ -22,19 +22,19 @@ namespace System.Net.Http
 
         public HttpMessageInvoker(HttpMessageHandler handler, bool disposeHandler)
         {
-            if (Logging.On) Logging.Enter(Logging.Http, this, ".ctor", handler);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Http, this, ".ctor", handler);
 
             if (handler == null)
             {
                 throw new ArgumentNullException("handler");
             }
 
-            if (Logging.On) Logging.Associate(Logging.Http, this, handler);
+            if (HttpEventSource.Log.IsEnabled()) HttpEventSource.Associate(this, handler);
 
             _handler = handler;
             _disposeHandler = disposeHandler;
 
-            if (Logging.On) Logging.Exit(Logging.Http, this, ".ctor", null);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Http, this, ".ctor", null);
         }
 
         public virtual Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
@@ -46,13 +46,13 @@ namespace System.Net.Http
             }
             CheckDisposed();
 
-            if (Logging.On)
-                Logging.Enter(Logging.Http, this, "SendAsync",
-    Logging.GetObjectLogHash(request) + ": " + request);
+            if (NetEventSource.Log.IsEnabled())
+                NetEventSource.Enter(NetEventSource.ComponentType.Http, this, "SendAsync",
+    LoggingHash.GetObjectLogHash(request) + ": " + request);
 
             Task<HttpResponseMessage> task = _handler.SendAsync(request, cancellationToken);
 
-            if (Logging.On) Logging.Exit(Logging.Http, this, "SendAsync", task);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Http, this, "SendAsync", task);
 
             return task;
         }

--- a/src/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpRequestMessage.cs
@@ -48,15 +48,15 @@ namespace System.Net.Http
             {
                 CheckDisposed();
 
-                if (Logging.On)
+                if (HttpEventSource.Log.IsEnabled())
                 {
                     if (value == null)
                     {
-                        Logging.PrintInfo(Logging.Http, this, SR.net_http_log_content_null);
+                        HttpEventSource.ContentNull(this);
                     }
                     else
                     {
-                        Logging.Associate(Logging.Http, this, value);
+                        HttpEventSource.Associate(this, value);
                     }
                 }
 
@@ -128,16 +128,16 @@ namespace System.Net.Http
 
         public HttpRequestMessage(HttpMethod method, Uri requestUri)
         {
-            if (Logging.On) Logging.Enter(Logging.Http, this, ".ctor", "Method: " + method + ", Uri: '" + requestUri + "'");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Http, this, ".ctor", "Method: " + method + ", Uri: '" + requestUri + "'");
             InitializeValues(method, requestUri);
-            if (Logging.On) Logging.Exit(Logging.Http, this, ".ctor", null);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Http, this, ".ctor", null);
         }
 
         [SuppressMessage("Microsoft.Design", "CA1057:StringUriOverloadsCallSystemUriOverloads",
             Justification = "It is OK to provide 'null' values. A Uri instance is created from 'requestUri' if it is != null.")]
         public HttpRequestMessage(HttpMethod method, string requestUri)
         {
-            if (Logging.On) Logging.Enter(Logging.Http, this, ".ctor", "Method: " + method + ", Uri: '" + requestUri + "'");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Http, this, ".ctor", "Method: " + method + ", Uri: '" + requestUri + "'");
 
             // It's OK to have a 'null' request Uri. If HttpClient is used, the 'BaseAddress' will be added.
             // If there is no 'BaseAddress', sending this request message will throw.
@@ -151,7 +151,7 @@ namespace System.Net.Http
                 InitializeValues(method, new Uri(requestUri, UriKind.RelativeOrAbsolute));
             }
 
-            if (Logging.On) Logging.Exit(Logging.Http, this, ".ctor", null);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Http, this, ".ctor", null);
         }
 
         public override string ToString()

--- a/src/System.Net.Http/src/System/Net/Http/HttpResponseMessage.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpResponseMessage.cs
@@ -42,15 +42,15 @@ namespace System.Net.Http
             {
                 CheckDisposed();
 
-                if (Logging.On)
+                if (HttpEventSource.Log.IsEnabled())
                 {
                     if (value == null)
                     {
-                        Logging.PrintInfo(Logging.Http, this, SR.net_http_log_content_null);
+                        HttpEventSource.ContentNull(this);
                     }
                     else
                     {
-                        Logging.Associate(Logging.Http, this, value);
+                        HttpEventSource.Associate(this, value);
                     }
                 }
 
@@ -114,7 +114,7 @@ namespace System.Net.Http
             set
             {
                 CheckDisposed();
-                if (Logging.On && (value != null)) Logging.Associate(Logging.Http, this, value);
+                if (HttpEventSource.Log.IsEnabled() && (value != null)) HttpEventSource.Associate(this, value);
                 _requestMessage = value;
             }
         }
@@ -131,7 +131,7 @@ namespace System.Net.Http
 
         public HttpResponseMessage(HttpStatusCode statusCode)
         {
-            if (Logging.On) Logging.Enter(Logging.Http, this, ".ctor", "StatusCode: " + (int)statusCode + ", ReasonPhrase: '" + _reasonPhrase + "'");
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Http, this, ".ctor", "StatusCode: " + (int)statusCode + ", ReasonPhrase: '" + _reasonPhrase + "'");
 
             if (((int)statusCode < 0) || ((int)statusCode > 999))
             {
@@ -141,7 +141,7 @@ namespace System.Net.Http
             _statusCode = statusCode;
             _version = HttpUtilities.DefaultResponseVersion;
 
-            if (Logging.On) Logging.Exit(Logging.Http, this, ".ctor", null);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Http, this, ".ctor", null);
         }
 
         public HttpResponseMessage EnsureSuccessStatusCode()

--- a/src/System.Net.Http/src/System/Net/Http/MultipartContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/MultipartContent.cs
@@ -302,7 +302,7 @@ namespace System.Net.Http
 
         private void HandleAsyncException(string method, Exception ex)
         {
-            if (Logging.On) Logging.Exception(Logging.Http, this, method, ex);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exception(NetEventSource.ComponentType.Http, this, method, ex);
             TaskCompletionSource<object> lastTcs = CleanupAsync();
             lastTcs.TrySetException(ex);
         }

--- a/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StreamContent.cs
@@ -40,7 +40,7 @@ namespace System.Net.Http
             {
                 _start = content.Position;
             }
-            if (Logging.On) Logging.Associate(Logging.Http, this, content);
+            if (HttpEventSource.Log.IsEnabled()) HttpEventSource.Associate(this, content);
         }
 
         protected override Task SerializeToStreamAsync(Stream stream, TransportContext context)

--- a/src/System.Net.Http/src/System/Net/Http/StreamToStreamCopy.cs
+++ b/src/System.Net.Http/src/System/Net/Http/StreamToStreamCopy.cs
@@ -53,7 +53,7 @@ namespace System.Net.Http
             catch (Exception e)
             {
                 // Dispose() should never throw, but since we're on an async codepath, make sure to catch the exception.
-                if (Logging.On) Logging.Exception(Logging.Http, null, "CopyAsync", e);
+                if (NetEventSource.Log.IsEnabled()) NetEventSource.Exception(NetEventSource.ComponentType.Http, null, "CopyAsync", e);
             }
         }
     }

--- a/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
+++ b/src/System.Net.Http/tests/UnitTests/System.Net.Http.Unit.Tests.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>System.Net.Http.Unit.Tests</RootNamespace>
     <AssemblyName>System.Net.Http.Unit.Tests</AssemblyName>
     <StringResourcesPath>..\..\src\Resources\Strings.resx</StringResourcesPath>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   
   <!-- Help VS understand available configurations -->
@@ -326,8 +327,14 @@
     <Compile Include="$(CommonPath)\System\Net\HttpVersion.cs">
       <Link>Common\System\Net\HttpVersion.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging.cs">
-      <Link>ProductionCode\Logging.cs</Link>
+    <Compile Include="$(CommonPath)\System\Net\Logging\LoggingHash.cs">
+      <Link>Common\System\Net\Logging\LoggingHash.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Logging\HttpEventSource.cs">
+      <Link>Common\System\Net\Logging\HttpEventSource.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.cs">
+      <Link>Common\System\Net\Logging\NetEventSource.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Net.NameResolution/src/System.Net.NameResolution.csproj
+++ b/src/System.Net.NameResolution/src/System.Net.NameResolution.csproj
@@ -39,14 +39,17 @@
     <Compile Include="$(CommonPath)\System\Net\Shims\TraceSource.cs">
       <Link>Common\System\Net\Shims\TraceSource.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\Logging.cs">
-      <Link>Common\System\Net\Logging\Logging.cs</Link>
+    <Compile Include="$(CommonPath)\System\Net\Logging\LoggingHash.cs">
+      <Link>Common\System\Net\Logging\LoggingHash.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Net\Logging\GlobalLog.cs">
       <Link>Common\System\Net\Logging\GlobalLog.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Net\Logging\EventSourceLogging.cs">
       <Link>Common\System\Net\Logging\EventSourceLogging.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.cs">
+      <Link>Common\System\Net\Logging\NetEventSource.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
       <Link>Common\System\Net\InternalException.cs</Link>

--- a/src/System.Net.NameResolution/src/System/Net/DNS.cs
+++ b/src/System.Net.NameResolution/src/System/Net/DNS.cs
@@ -22,7 +22,7 @@ namespace System.Net
 
         internal static IPHostEntry InternalGetHostByName(string hostName, bool includeIPv6)
         {
-            if (Logging.On) Logging.Enter(Logging.Sockets, "DNS", "GetHostByName", hostName);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Socket, "DNS", "GetHostByName", hostName);
             IPHostEntry ipHostEntry = null;
 
             GlobalLog.Print("Dns.GetHostByName: " + hostName);
@@ -68,7 +68,7 @@ namespace System.Net
                 ipHostEntry = NameResolutionPal.GetHostByName(hostName);
             }
 
-            if (Logging.On) Logging.Exit(Logging.Sockets, "DNS", "GetHostByName", ipHostEntry);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Socket, "DNS", "GetHostByName", ipHostEntry);
             return ipHostEntry;
         } // GetHostByName
 
@@ -101,9 +101,9 @@ namespace System.Net
                     if (errorCode == SocketError.Success)
                         return hostEntry;
 
-                    if (Logging.On)
+                    if (NetEventSource.Log.IsEnabled())
                     {
-                        Logging.Exception(Logging.Sockets, "DNS",
+                        NetEventSource.Exception(NetEventSource.ComponentType.Socket, "DNS",
                         "InternalGetHostByAddress", new InternalSocketException(errorCode, nativeErrorCode));
                     }
 
@@ -333,46 +333,46 @@ namespace System.Net
 
         private static IAsyncResult BeginGetHostEntry(string hostNameOrAddress, AsyncCallback requestCallback, object stateObject)
         {
-            if (Logging.On) Logging.Enter(Logging.Sockets, "DNS", "BeginGetHostEntry", hostNameOrAddress);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Socket, "DNS", "BeginGetHostEntry", hostNameOrAddress);
             IAsyncResult asyncResult = HostResolutionBeginHelper(hostNameOrAddress, false, requestCallback, stateObject);
 
-            if (Logging.On) Logging.Exit(Logging.Sockets, "DNS", "BeginGetHostEntry", asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Socket, "DNS", "BeginGetHostEntry", asyncResult);
             return asyncResult;
         } // BeginResolve
 
         private static IAsyncResult BeginGetHostEntry(IPAddress address, AsyncCallback requestCallback, object stateObject)
         {
-            if (Logging.On) Logging.Enter(Logging.Sockets, "DNS", "BeginGetHostEntry", address);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Socket, "DNS", "BeginGetHostEntry", address);
             IAsyncResult asyncResult = HostResolutionBeginHelper(address, true, true, requestCallback, stateObject);
 
-            if (Logging.On) Logging.Exit(Logging.Sockets, "DNS", "BeginGetHostEntry", asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Socket, "DNS", "BeginGetHostEntry", asyncResult);
             return asyncResult;
         } // BeginResolve
 
         private static IPHostEntry EndGetHostEntry(IAsyncResult asyncResult)
         {
-            if (Logging.On) Logging.Enter(Logging.Sockets, "DNS", "EndGetHostEntry", asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Socket, "DNS", "EndGetHostEntry", asyncResult);
             IPHostEntry ipHostEntry = HostResolutionEndHelper(asyncResult);
 
-            if (Logging.On) Logging.Exit(Logging.Sockets, "DNS", "EndGetHostEntry", ipHostEntry);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Socket, "DNS", "EndGetHostEntry", ipHostEntry);
             return ipHostEntry;
         } // EndResolve()
 
         private static IAsyncResult BeginGetHostAddresses(string hostNameOrAddress, AsyncCallback requestCallback, object state)
         {
-            if (Logging.On) Logging.Enter(Logging.Sockets, "DNS", "BeginGetHostAddresses", hostNameOrAddress);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Socket, "DNS", "BeginGetHostAddresses", hostNameOrAddress);
             IAsyncResult asyncResult = HostResolutionBeginHelper(hostNameOrAddress, true, requestCallback, state);
 
-            if (Logging.On) Logging.Exit(Logging.Sockets, "DNS", "BeginGetHostAddresses", asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Socket, "DNS", "BeginGetHostAddresses", asyncResult);
             return asyncResult;
         } // BeginResolve
 
         private static IPAddress[] EndGetHostAddresses(IAsyncResult asyncResult)
         {
-            if (Logging.On) Logging.Enter(Logging.Sockets, "DNS", "EndGetHostAddresses", asyncResult);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Socket, "DNS", "EndGetHostAddresses", asyncResult);
             IPHostEntry ipHostEntry = HostResolutionEndHelper(asyncResult);
 
-            if (Logging.On) Logging.Exit(Logging.Sockets, "DNS", "EndGetHostAddresses", ipHostEntry);
+            if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Socket, "DNS", "EndGetHostAddresses", ipHostEntry);
             return ipHostEntry.AddressList;
         } // EndResolveToAddresses
 

--- a/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -157,7 +157,7 @@ namespace System.Net
                 if (IPAddress.TryParse(hostName, out address))
                 {
                     IPHostEntry ipHostEntry = NameResolutionUtilities.GetUnresolvedAnswer(address);
-                    if (Logging.On) Logging.Exit(Logging.Sockets, "DNS", "GetHostByName", ipHostEntry);
+                    if (NetEventSource.Log.IsEnabled()) NetEventSource.Exit(NetEventSource.ComponentType.Socket, "DNS", "GetHostByName", ipHostEntry);
                     return ipHostEntry;
                 }
 

--- a/src/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.csproj
+++ b/src/System.Net.NameResolution/tests/PalTests/System.Net.NameResolution.Pal.Tests.csproj
@@ -24,6 +24,13 @@
     <Compile Include="NameResolutionPalTests.cs" />
     <Compile Include="Fakes\GlobalLog.cs" />
     <Compile Include="Fakes\Logging.cs" />
+    
+    <Compile Include="$(CommonPath)\System\Net\Logging\LoggingHash.cs">
+      <Link>Common\System\Net\Logging\LoggingHash.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.cs">
+      <Link>Common\System\Net\Logging\NetEventSource.cs</Link>
+    </Compile>
 
     <Compile Include="..\..\src\System\Net\IPHostEntry.cs" >
       <Link>ProductionCode\System\Net\IPHostEntry.cs</Link>

--- a/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -84,6 +84,9 @@
     <Compile Include="$(CommonPath)\System\Net\Logging\Logging.cs">
       <Link>Common\System\Net\Logging\Logging.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Logging\LoggingHash.cs">
+      <Link>Common\System\Net\Logging\LoggingHash.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\Logging\GlobalLog.cs">
       <Link>Common\System\Net\Logging\GlobalLog.cs</Link>
     </Compile>

--- a/src/System.Net.Security/src/Resources/Strings.resx
+++ b/src/System.Net.Security/src/Resources/Strings.resx
@@ -219,76 +219,76 @@
   <data name="net_log_exception" xml:space="preserve">
     <value>Exception in {0}::{1} - {2}.</value>
   </data>
-  <data name="net_log_sspi_enumerating_security_packages" xml:space="preserve">
+  <data name="event_EnumerateSecurityPackages" xml:space="preserve">
     <value>Enumerating security packages:</value>
   </data>
-  <data name="net_log_sspi_security_package_not_found" xml:space="preserve">
+  <data name="event_SspiPackageNotFound" xml:space="preserve">
     <value>Security package '{0}' was not found.</value>
   </data>
-  <data name="net_log_sspi_security_context_input_buffer" xml:space="preserve">
+  <data name="event_SecurityContextInputBuffer" xml:space="preserve">
     <value>{0}(In-Buffer length={1}, Out-Buffer length={2}, returned code={3}).</value>
   </data>
-  <data name="net_log_sspi_security_context_input_buffers" xml:space="preserve">
+  <data name="event_SecurityContextInputBuffers" xml:space="preserve">
     <value>{0}(In-Buffers count={1}, Out-Buffer length={2}, returned code={3}).</value>
   </data>
-  <data name="net_log_sspi_selected_cipher_suite" xml:space="preserve">
+  <data name="event_SspiSelectedCipherSuite" xml:space="preserve">
     <value>{0}(Protocol={1}, Cipher={2} {3} bit strength, Hash={4} {5} bit strength, Key Exchange={6} {7} bit strength).</value>
   </data>
-  <data name="net_log_remote_certificate" xml:space="preserve">
+  <data name="event_RemoteCertificate" xml:space="preserve">
     <value>Remote certificate: {0}.</value>
   </data>
-  <data name="net_log_locating_private_key_for_certificate" xml:space="preserve">
+  <data name="event_LocatingPrivateKey" xml:space="preserve">
     <value>Locating the private key for the certificate: {0}.</value>
   </data>
-  <data name="net_log_cert_is_of_type_2" xml:space="preserve">
+  <data name="event_CertIsType2" xml:space="preserve">
     <value>Certificate is of type X509Certificate2 and contains the private key.</value>
   </data>
-  <data name="net_log_found_cert_in_store" xml:space="preserve">
+  <data name="event_FoundCertInStore" xml:space="preserve">
     <value>Found the certificate in the {0} store.</value>
   </data>
-  <data name="net_log_did_not_find_cert_in_store" xml:space="preserve">
+  <data name="event_NotFoundCertInStore" xml:space="preserve">
     <value>Cannot find the certificate in either the LocalMachine store or the CurrentUser store.</value>
   </data>
   <data name="net_log_open_store_failed" xml:space="preserve">
     <value>Opening Certificate store {0} failed, exception: {1}.</value>
   </data>
-  <data name="net_log_got_certificate_from_delegate" xml:space="preserve">
+  <data name="event_CertificateFromDelegate" xml:space="preserve">
     <value>Got a certificate from the client delegate.</value>
   </data>
-  <data name="net_log_no_delegate_and_have_no_client_cert" xml:space="preserve">
+  <data name="event_NoDelegateNoClientCert" xml:space="preserve">
     <value>Client delegate did not provide a certificate; and there are not other user-provided certificates. Need to attempt a session restart.</value>
   </data>
-  <data name="net_log_no_delegate_but_have_client_cert" xml:space="preserve">
+  <data name="event_NoDelegateButClientCert" xml:space="preserve">
     <value>Client delegate did not provide a certificate; but there are other user-provided certificates.</value>
   </data>
-  <data name="net_log_attempting_restart_using_cert" xml:space="preserve">
+  <data name="event_AttemptingRestartUsingCert" xml:space="preserve">
     <value>Attempting to restart the session using the user-provided certificate: {0}.</value>
   </data>
-  <data name="net_log_no_issuers_try_all_certs" xml:space="preserve">
+  <data name="event_NoIssuersTryAllCerts" xml:space="preserve">
     <value>We have user-provided certificates. The server has not specified any issuers, so try all the certificates.</value>
   </data>
-  <data name="net_log_server_issuers_look_for_matching_certs" xml:space="preserve">
+  <data name="event_LookForMatchingCerts" xml:space="preserve">
     <value>We have user-provided certificates. The server has specified {0} issuer(s). Looking for certificates that match any of the issuers.</value>
   </data>
-  <data name="net_log_selected_cert" xml:space="preserve">
+  <data name="event_SelectedCert" xml:space="preserve">
     <value>Selected certificate: {0}.</value>
   </data>
-  <data name="net_log_n_certs_after_filtering" xml:space="preserve">
+  <data name="event_CertsAfterFiltering" xml:space="preserve">
     <value>Left with {0} client certificates to choose from.</value>
   </data>
-  <data name="net_log_finding_matching_certs" xml:space="preserve">
+  <data name="event_FindingMatchingCerts" xml:space="preserve">
     <value>Trying to find a matching certificate in the certificate store.</value>
   </data>
-  <data name="net_log_using_cached_credential" xml:space="preserve">
+  <data name="event_UsingCachedCredential" xml:space="preserve">
     <value>Using the cached credential handle.</value>
   </data>
-  <data name="net_log_remote_cert_user_declared_valid" xml:space="preserve">
+  <data name="event_RemoteCertDeclaredValid" xml:space="preserve">
     <value>Remote certificate was verified as valid by the user.</value>
   </data>
-  <data name="net_log_remote_cert_user_declared_invalid" xml:space="preserve">
+  <data name="event_RemoteCertUserDeclaredInvalid" xml:space="preserve">
     <value>Remote certificate was verified as invalid by the user.</value>
   </data>
-  <data name="net_log_remote_cert_has_no_errors" xml:space="preserve">
+  <data name="event_RemoteCertHasNoErrors" xml:space="preserve">
     <value>Remote certificate has no errors.</value>
   </data>
   <data name="net_log_remote_cert_has_errors" xml:space="preserve">
@@ -300,7 +300,7 @@
   <data name="net_log_remote_cert_name_mismatch" xml:space="preserve">
     <value>Certificate name mismatch.</value>
   </data>
-  <data name="net_log_operation_returned_something" xml:space="preserve">
+  <data name="event_OperationReturnedSomething" xml:space="preserve">
     <value>{0} returned {1}.</value>
   </data>
   <data name="net_log_operation_failed_with_error" xml:space="preserve">

--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -57,14 +57,20 @@
     <Compile Include="$(CommonPath)\System\Net\Shims\TraceSource.cs">
       <Link>Common\System\Net\Shims\TraceSource.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\Logging.cs">
-      <Link>Common\System\Net\Logging\Logging.cs</Link>
+    <Compile Include="$(CommonPath)\System\Net\Logging\LoggingHash.cs">
+      <Link>Common\System\Net\Logging\LogginHash.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Net\Logging\GlobalLog.cs">
       <Link>Common\System\Net\Logging\GlobalLog.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Net\Logging\EventSourceLogging.cs">
       <Link>Common\System\Net\Logging\EventSourceLogging.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.cs">
+      <Link>Common\System\Net\Logging\NetEventSource.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Logging\SecurityEventSource.cs">
+      <Link>Common\System\Net\Logging\SecurityEventSource.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
       <Link>Common\System\Net\InternalException.cs</Link>
@@ -181,6 +187,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\secur32\SecSizes.cs">
       <Link>Common\Interop\Windows\secur32\SecSizes.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Logging\SecurityEventSource.Windows.cs">
+      <Link>Common\System\Net\Logging\SecurityEventSource.Windows.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Windows\secur32\SecurityPackageInfo.cs">
       <Link>Common\Interop\Windows\secur32\SecurityPackageInfo.cs</Link>

--- a/src/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
@@ -92,7 +92,7 @@ namespace System.Net
                 return null;
             }
 
-            GlobalLog.Enter("CertificateValidationPal.Unix SecureChannel#" + Logging.HashString(securityContext) + "::GetRemoteCertificate()");
+            GlobalLog.Enter("CertificateValidationPal.Unix SecureChannel#" + LoggingHash.HashString(securityContext) + "::GetRemoteCertificate()");
             X509Certificate2 result = null;
             SafeFreeCertContext remoteContext = null;
             try
@@ -141,12 +141,12 @@ namespace System.Net
                 }
             }
 
-            if (Logging.On)
+            if (SecurityEventSource.Log.IsEnabled())
             {
-                Logging.PrintInfo(Logging.Web, SR.Format(SR.net_log_remote_certificate, (result == null ? "null" : result.ToString(true))));
+                SecurityEventSource.Log.RemoteCertificate(result == null ? "null" : result.ToString(true));
             }
 
-            GlobalLog.Leave("CertificateValidationPal.Unix SecureChannel#" + Logging.HashString(securityContext) + "::GetRemoteCertificate()", (result == null ? "null" : result.Subject));
+            GlobalLog.Leave("CertificateValidationPal.Unix SecureChannel#" + LoggingHash.HashString(securityContext) + "::GetRemoteCertificate()", (result == null ? "null" : result.Subject));
 
             return result;
         }      

--- a/src/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
@@ -93,7 +93,7 @@ namespace System.Net
                 return null;
             }
 
-            GlobalLog.Enter("CertificateValidationPal.Windows SecureChannel#" + Logging.HashString(securityContext) + "::GetRemoteCertificate()");
+            GlobalLog.Enter("CertificateValidationPal.Windows SecureChannel#" + LoggingHash.HashString(securityContext) + "::GetRemoteCertificate()");
             X509Certificate2 result = null;
             SafeFreeCertContext remoteContext = null;
             try
@@ -114,12 +114,12 @@ namespace System.Net
                 }
             }
 
-            if (Logging.On)
+            if (SecurityEventSource.Log.IsEnabled())
             {
-                Logging.PrintInfo(Logging.Web, SR.Format(SR.net_log_remote_certificate, (result == null ? "null" : result.ToString(true))));
+                SecurityEventSource.Log.RemoteCertificate(result == null ? "null" : result.ToString(true));
             }
 
-            GlobalLog.Leave("CertificateValidationPal.Windows SecureChannel#" + Logging.HashString(securityContext) + "::GetRemoteCertificate()", (result == null ? "null" : result.Subject));
+            GlobalLog.Leave("CertificateValidationPal.Windows SecureChannel#" + LoggingHash.HashString(securityContext) + "::GetRemoteCertificate()", (result == null ? "null" : result.Subject));
 
             return result;
         }
@@ -162,7 +162,7 @@ namespace System.Net
 
                                 X500DistinguishedName x500DistinguishedName = new X500DistinguishedName(x);
                                 issuers[i] = x500DistinguishedName.Name;
-                                GlobalLog.Print("SecureChannel#" + Logging.HashString(securityContext) + "::GetIssuers() IssuerListEx[" + i + "]:" + issuers[i]);
+                                GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(securityContext) + "::GetIssuers() IssuerListEx[" + i + "]:" + issuers[i]);
                             }
                         }
                     }
@@ -231,9 +231,9 @@ namespace System.Net
                                 return null;
                             }
 
-                            if (Logging.On)
+                            if (NetEventSource.Log.IsEnabled())
                             {
-                                Logging.PrintError(Logging.Web, SR.Format(SR.net_log_open_store_failed, storeLocation, exception));
+                                NetEventSource.PrintError(NetEventSource.ComponentType.Security, SR.Format(SR.net_log_open_store_failed, storeLocation, exception));
                             }
 
                             throw;

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslState.cs
@@ -586,17 +586,16 @@ namespace System.Net.Security
                 ForceAuthentication(Context.IsServer, null, asyncRequest);
 
                 // Not aync so the connection is completed at this point.
-                if (lazyResult == null && Logging.On)
+                if (lazyResult == null && SecurityEventSource.Log.IsEnabled())
                 {
-                    Logging.PrintInfo(Logging.Web, SR.Format(SR.net_log_sspi_selected_cipher_suite,
-                        "ProcessAuthentication",
+                    SecurityEventSource.Log.SspiSelectedCipherSuite("ProcessAuthentication",
                         SslProtocol,
                         CipherAlgorithm,
                         CipherStrength,
                         HashAlgorithm,
                         HashStrength,
                         KeyExchangeAlgorithm,
-                        KeyExchangeStrength));
+                        KeyExchangeStrength);
                 }
             }
             finally
@@ -713,17 +712,16 @@ namespace System.Net.Security
             InternalEndProcessAuthentication(lazyResult);
 
             // Connection is completed at this point.
-            if (Logging.On)
+            if (SecurityEventSource.Log.IsEnabled())
             {
-                Logging.PrintInfo(Logging.Web, SR.Format(SR.net_log_sspi_selected_cipher_suite,
-                    "EndProcessAuthentication",
+                SecurityEventSource.Log.SspiSelectedCipherSuite("EndProcessAuthentication",
                     SslProtocol,
                     CipherAlgorithm,
                     CipherStrength,
                     HashAlgorithm,
                     HashStrength,
                     KeyExchangeAlgorithm,
-                    KeyExchangeStrength));
+                    KeyExchangeStrength);
             }
         }
         //

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslStreamInternal.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslStreamInternal.cs
@@ -488,7 +488,7 @@ namespace System.Net.Security
             // ERROR - examine what kind
             ProtocolToken message = new ProtocolToken(null, errorCode);
 
-            GlobalLog.Print("SecureChannel#" + Logging.HashString(this) + "::***Processing an error Status = " + message.Status.ToString());
+            GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::***Processing an error Status = " + message.Status.ToString());
 
             if (message.Renegotiate)
             {

--- a/src/System.Net.Security/src/System/Net/SslStreamPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/SslStreamPal.Windows.cs
@@ -137,7 +137,7 @@ namespace System.Net
 
             if (errorCode != 0)
             {
-                GlobalLog.Print("SslStreamPal.Windows: SecureChannel#" + Logging.HashString(securityContext) + "::Encrypt ERROR" + errorCode.ToString("x"));
+                GlobalLog.Print("SslStreamPal.Windows: SecureChannel#" + LoggingHash.HashString(securityContext) + "::Encrypt ERROR" + errorCode.ToString("x"));
                 resultSize = 0;
             }
             else

--- a/src/System.Net.Sockets/src/Resources/Strings.resx
+++ b/src/System.Net.Sockets/src/Resources/Strings.resx
@@ -261,13 +261,13 @@
   <data name="net_log_socket_connected" xml:space="preserve">
     <value>Created connection from {0} to {1}.</value>
   </data>
-  <data name="net_log_socket_accepted" xml:space="preserve">
+  <data name="event_Accepted" xml:space="preserve">
     <value>Accepted connection from {0} to {1}.</value>
   </data>
-  <data name="net_log_socket_not_logged_file" xml:space="preserve">
+  <data name="event_NotLoggedFile" xml:space="preserve">
     <value>Not logging data from file: {0}.</value>
   </data>
-  <data name="net_log_socket_connect_dnsendpoint" xml:space="preserve">
+  <data name="event_ConnectedAsyncDns" xml:space="preserve">
     <value>Connecting to a DnsEndPoint.</value>
   </data>
   <data name="ArgumentOutOfRange_Bounds_Lower_Upper" xml:space="preserve">

--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -69,17 +69,20 @@
     <Compile Include="System\Net\Sockets\ReceiveMessageOverlappedAsyncResult.cs" />
         
     <!-- Logging -->
-    <Compile Include="$(CommonPath)\System\Net\Shims\TraceSource.cs">
-      <Link>Common\System\Net\Shims\TraceSource.cs</Link>
-    </Compile>
-    <Compile Include="$(CommonPath)\System\Net\Logging\Logging.cs">
-      <Link>Common\System\Net\Logging\Logging.cs</Link>
-    </Compile>
     <Compile Include="$(CommonPath)\System\Net\Logging\GlobalLog.cs">
       <Link>Common\System\Net\Logging\GlobalLog.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Net\Logging\EventSourceLogging.cs">
       <Link>Common\System\Net\Logging\EventSourceLogging.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Logging\LoggingHash.cs">
+      <Link>Common\System\Net\Logging\LoggingHash.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Logging\SocketsEventSource.cs">
+      <Link>Common\System\Net\Logging\SocketsEventSource.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Logging\NetEventSource.cs">
+      <Link>Common\System\Net\Logging\NetEventSource.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Net\InternalException.cs">
       <Link>Common\System\Net\InternalException.cs</Link>

--- a/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Windows.cs
@@ -25,7 +25,7 @@ namespace System.Net.Sockets
             if (errorCode == SocketError.Success)
             {
                 _localBytesTransferred = numBytes;
-                if (Logging.On)
+                if (SocketsEventSource.Log.IsEnabled())
                 {
                     LogBuffer((long)numBytes);
                 }
@@ -65,7 +65,7 @@ namespace System.Net.Sockets
                     {
                         errorCode = (SocketError)Marshal.GetLastWin32Error();
                     }
-                    GlobalLog.Print("AcceptOverlappedAsyncResult#" + Logging.HashString(this) + "::PostCallback() setsockopt handle:" + handle.ToString() + " AcceptSocket:" + Logging.HashString(_acceptSocket) + " itsHandle:" + _acceptSocket.SafeHandle.DangerousGetHandle().ToString() + " returns:" + errorCode.ToString());
+                    GlobalLog.Print("AcceptOverlappedAsyncResult#" + LoggingHash.HashString(this) + "::PostCallback() setsockopt handle:" + handle.ToString() + " AcceptSocket:" + LoggingHash.HashString(_acceptSocket) + " itsHandle:" + _acceptSocket.SafeHandle.DangerousGetHandle().ToString() + " returns:" + errorCode.ToString());
                 }
                 catch (ObjectDisposedException)
                 {
@@ -101,17 +101,17 @@ namespace System.Net.Sockets
 
         private void LogBuffer(long size)
         {
-            GlobalLog.Assert(Logging.On, "AcceptOverlappedAsyncResult#{0}::LogBuffer()|Logging is off!", Logging.HashString(this));
+            GlobalLog.Assert(SocketsEventSource.Log.IsEnabled(), "AcceptOverlappedAsyncResult#{0}::LogBuffer()|Logging is off!", LoggingHash.HashString(this));
             IntPtr pinnedBuffer = Marshal.UnsafeAddrOfPinnedArrayElement(_buffer, 0);
             if (pinnedBuffer != IntPtr.Zero)
             {
                 if (size > -1)
                 {
-                    Logging.Dump(Logging.Sockets, _listenSocket, "PostCompletion", pinnedBuffer, (int)Math.Min(size, (long)_buffer.Length));
+                    SocketsEventSource.Dump(SocketsEventSource.MethodType.PostCompletion, pinnedBuffer, (int)Math.Min(size, (long)_buffer.Length));
                 }
                 else
                 {
-                    Logging.Dump(Logging.Sockets, _listenSocket, "PostCompletion", pinnedBuffer, (int)_buffer.Length);
+                    SocketsEventSource.Dump(SocketsEventSource.MethodType.PostCompletion, pinnedBuffer, (int)_buffer.Length);
                 }
             }
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Unix.cs
@@ -20,8 +20,8 @@ namespace System.Net.Sockets
             : base(socket, asyncState, asyncCallback)
         {
             GlobalLog.Print(
-                "BaseOverlappedAsyncResult#" + Logging.HashString(this) +
-                "(Socket#" + Logging.HashString(socket) + ")");
+                "BaseOverlappedAsyncResult#" + LoggingHash.HashString(this) +
+                "(Socket#" + LoggingHash.HashString(socket) + ")");
         }
 
         public void CompletionCallback(int numBytes, SocketError errorCode)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
@@ -27,8 +27,8 @@ namespace System.Net.Sockets
         {
             _cleanupCount = 1;
             GlobalLog.Print(
-                "BaseOverlappedAsyncResult#" + Logging.HashString(this) +
-                "(Socket#" + Logging.HashString(socket) + ")");
+                "BaseOverlappedAsyncResult#" + LoggingHash.HashString(this) +
+                "(Socket#" + LoggingHash.HashString(socket) + ")");
         }
 
         internal SafeNativeOverlapped NativeOverlapped
@@ -67,8 +67,8 @@ namespace System.Net.Sockets
                 NativeOverlapped* overlapped = boundHandle.AllocateNativeOverlapped(s_ioCallback, this, objectsToPin);
                 _nativeOverlapped = new SafeNativeOverlapped(s.SafeHandle, overlapped);
                 GlobalLog.Print(
-                    "BaseOverlappedAsyncResult#" + Logging.HashString(this) +
-                    "::boundHandle#" + Logging.HashString(boundHandle) +
+                    "BaseOverlappedAsyncResult#" + LoggingHash.HashString(this) +
+                    "::boundHandle#" + LoggingHash.HashString(boundHandle) +
                     "::AllocateNativeOverlapped. Return=" +
                     _nativeOverlapped.DangerousGetHandle().ToString("x"));
             }
@@ -85,10 +85,10 @@ namespace System.Net.Sockets
 
                 object returnObject = null;
 
-                GlobalLog.Assert(!asyncResult.InternalPeekCompleted, "BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|asyncResult.IsCompleted", Logging.HashString(asyncResult));
+                GlobalLog.Assert(!asyncResult.InternalPeekCompleted, "BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|asyncResult.IsCompleted", LoggingHash.HashString(asyncResult));
 
                 GlobalLog.Print(
-                    "BaseOverlappedAsyncResult#" + Logging.HashString(asyncResult) + "::CompletionPortCallback" +
+                    "BaseOverlappedAsyncResult#" + LoggingHash.HashString(asyncResult) + "::CompletionPortCallback" +
                     " errorCode:" + errorCode.ToString() +
                     " numBytes:" + numBytes.ToString() +
                     " pOverlapped:" + ((int)nativeOverlapped).ToString());
@@ -129,10 +129,10 @@ namespace System.Net.Sockets
                             if (!success)
                             {
                                 socketError = (SocketError)Marshal.GetLastWin32Error();
-                                GlobalLog.Assert(socketError != 0, "BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|socketError:0 numBytes:{1}", Logging.HashString(asyncResult), numBytes);
+                                GlobalLog.Assert(socketError != 0, "BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|socketError:0 numBytes:{1}", LoggingHash.HashString(asyncResult), numBytes);
                             }
 
-                            GlobalLog.Assert(!success, "BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|Unexpectedly succeeded. errorCode:{1} numBytes:{2}", Logging.HashString(asyncResult), errorCode, numBytes);
+                            GlobalLog.Assert(!success, "BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|Unexpectedly succeeded. errorCode:{1} numBytes:{2}", LoggingHash.HashString(asyncResult), errorCode, numBytes);
                         }
                         catch (ObjectDisposedException)
                         {
@@ -189,7 +189,7 @@ namespace System.Net.Sockets
         {
             // Free the unmanaged memory if allocated.
             GlobalLog.Print(
-                "BaseOverlappedAsyncResult#" + Logging.HashString(this) +
+                "BaseOverlappedAsyncResult#" + LoggingHash.HashString(this) +
                 "::ForceReleaseUnmanagedStructures");
 
             _nativeOverlapped.Dispose();

--- a/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.cs
@@ -30,7 +30,7 @@ namespace System.Net.Sockets
         internal unsafe SocketError CheckAsyncCallOverlappedResult(SocketError errorCode)
         {
             GlobalLog.Print(
-                "BaseOverlappedAsyncResult#" + Logging.HashString(this) +
+                "BaseOverlappedAsyncResult#" + LoggingHash.HashString(this) +
                 "::CheckAsyncCallOverlappedResult(" + errorCode.ToString() + ")");
 
             if (errorCode == SocketError.Success || errorCode == SocketError.IOPending)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
@@ -1018,8 +1018,8 @@ namespace System.Net.Sockets
         private int _currentWriteTimeout = -1;
         internal void SetSocketTimeoutOption(SocketShutdown mode, int timeout, bool silent)
         {
-            GlobalLog.Print("NetworkStream#" + Logging.HashString(this) + "::SetSocketTimeoutOption() mode:" + mode + " silent:" + silent + " timeout:" + timeout + " m_CurrentReadTimeout:" + _currentReadTimeout + " m_CurrentWriteTimeout:" + _currentWriteTimeout);
-            GlobalLog.ThreadContract(ThreadKinds.Unknown, "NetworkStream#" + Logging.HashString(this) + "::SetSocketTimeoutOption");
+            GlobalLog.Print("NetworkStream#" + LoggingHash.HashString(this) + "::SetSocketTimeoutOption() mode:" + mode + " silent:" + silent + " timeout:" + timeout + " m_CurrentReadTimeout:" + _currentReadTimeout + " m_CurrentWriteTimeout:" + _currentWriteTimeout);
+            GlobalLog.ThreadContract(ThreadKinds.Unknown, "NetworkStream#" + LoggingHash.HashString(this) + "::SetSocketTimeoutOption");
 
             if (timeout < 0)
             {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Windows.cs
@@ -102,7 +102,7 @@ namespace System.Net.Sockets
         // 3) failed.
         internal override object PostCompletion(int numBytes)
         {
-            if (ErrorCode == 0 && Logging.On)
+            if (ErrorCode == 0 && SocketsEventSource.Log.IsEnabled())
             {
                 LogBuffer(numBytes);
             }
@@ -112,14 +112,14 @@ namespace System.Net.Sockets
 
         private void LogBuffer(int size)
         {
-            GlobalLog.Assert(Logging.On, "OverlappedAsyncResult#{0}::LogBuffer()|Logging is off!", Logging.HashString(this));
+            GlobalLog.Assert(SocketsEventSource.Log.IsEnabled(), "OverlappedAsyncResult#{0}::LogBuffer()|Logging is off!", LoggingHash.HashString(this));
             if (size > -1)
             {
                 if (_wsaBuffers != null)
                 {
                     foreach (WSABuffer wsaBuffer in _wsaBuffers)
                     {
-                        Logging.Dump(Logging.Sockets, AsyncObject, "PostCompletion", wsaBuffer.Pointer, Math.Min(wsaBuffer.Length, size));
+                        SocketsEventSource.Dump(SocketsEventSource.MethodType.PostCompletion, wsaBuffer.Pointer, Math.Min(wsaBuffer.Length, size));
                         if ((size -= wsaBuffer.Length) <= 0)
                         {
                             break;
@@ -128,7 +128,7 @@ namespace System.Net.Sockets
                 }
                 else
                 {
-                    Logging.Dump(Logging.Sockets, AsyncObject, "PostCompletion", _singleBuffer.Pointer, Math.Min(_singleBuffer.Length, size));
+                    SocketsEventSource.Dump(SocketsEventSource.MethodType.PostCompletion, _singleBuffer.Pointer, Math.Min(_singleBuffer.Length, size));
                 }
             }
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/ReceiveMessageOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/ReceiveMessageOverlappedAsyncResult.Windows.cs
@@ -150,7 +150,7 @@ namespace System.Net.Sockets
         internal override object PostCompletion(int numBytes)
         {
             InitIPPacketInformation();
-            if (ErrorCode == 0 && Logging.On)
+            if (ErrorCode == 0 && SocketsEventSource.Log.IsEnabled())
             {
                 LogBuffer(numBytes);
             }
@@ -160,8 +160,8 @@ namespace System.Net.Sockets
 
         private void LogBuffer(int size)
         {
-            GlobalLog.Assert(Logging.On, "ReceiveMessageOverlappedAsyncResult#{0}::LogBuffer()|Logging is off!", Logging.HashString(this));
-            Logging.Dump(Logging.Sockets, AsyncObject, "PostCompletion", _wsaBuffer->Pointer, Math.Min(_wsaBuffer->Length, size));
+            GlobalLog.Assert(SocketsEventSource.Log.IsEnabled(), "ReceiveMessageOverlappedAsyncResult#{0}::LogBuffer()|Logging is off!", LoggingHash.HashString(this));
+            SocketsEventSource.Dump(SocketsEventSource.MethodType.PostCompletion, _wsaBuffer->Pointer, Math.Min(_wsaBuffer->Length, size));
         }
     }
 }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -86,10 +86,10 @@ namespace System.Net.Sockets
         // Initializes a new instance of the Sockets.Socket class.
         public Socket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType)
         {
-            s_loggingEnabled = Logging.On;
+            s_loggingEnabled = SocketsEventSource.Log.IsEnabled();
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "Socket", addressFamily);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Socket", addressFamily);
             }
 
             InitializeSockets();
@@ -114,17 +114,17 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "Socket", null);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Socket", null);
             }
         }
 
         // Called by the class to create a socket to accept an incoming request.
         private Socket(SafeCloseSocket fd)
         {
-            s_loggingEnabled = Logging.On;
+            s_loggingEnabled = NetEventSource.Log.IsEnabled();
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "Socket", null);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Socket", null);
             }
             InitializeSockets();
 
@@ -144,7 +144,7 @@ namespace System.Net.Sockets
             _protocolType = Sockets.ProtocolType.Unknown;
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "Socket", null);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Socket", null);
             }
         }
         #endregion
@@ -184,7 +184,7 @@ namespace System.Net.Sockets
                 // This may throw ObjectDisposedException.
                 SocketError errorCode = SocketPal.GetAvailable(_handle, out argp);
 
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Available_get() Interop.Winsock.ioctlsocket returns errorCode:" + errorCode);
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Available_get() Interop.Winsock.ioctlsocket returns errorCode:" + errorCode);
 
                 // Throw an appropriate SocketException if the native call fails.
                 if (errorCode != SocketError.Success)
@@ -194,7 +194,7 @@ namespace System.Net.Sockets
                     UpdateStatusAfterSocketError(socketException);
                     if (s_loggingEnabled)
                     {
-                        Logging.Exception(Logging.Sockets, this, "Available", socketException);
+                        NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "Available", socketException);
                     }
                     throw socketException;
                 }
@@ -241,7 +241,7 @@ namespace System.Net.Sockets
                     UpdateStatusAfterSocketError(socketException);
                     if (s_loggingEnabled)
                     {
-                        Logging.Exception(Logging.Sockets, this, "LocalEndPoint", socketException);
+                        NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "LocalEndPoint", socketException);
                     }
                     throw socketException;
                 }
@@ -290,7 +290,7 @@ namespace System.Net.Sockets
                         UpdateStatusAfterSocketError(socketException);
                         if (s_loggingEnabled)
                         {
-                            Logging.Exception(Logging.Sockets, this, "RemoteEndPoint", socketException);
+                            NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "RemoteEndPoint", socketException);
                         }
                         throw socketException;
                     }
@@ -331,7 +331,7 @@ namespace System.Net.Sockets
                     throw new ObjectDisposedException(this.GetType().FullName);
                 }
 
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::set_Blocking() value:" + value.ToString() + " willBlock:" + _willBlock.ToString() + " willBlockInternal:" + _willBlockInternal.ToString());
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::set_Blocking() value:" + value.ToString() + " willBlock:" + _willBlock.ToString() + " willBlockInternal:" + _willBlockInternal.ToString());
 
                 bool current;
 
@@ -344,7 +344,7 @@ namespace System.Net.Sockets
                     UpdateStatusAfterSocketError(socketException);
                     if (s_loggingEnabled)
                     {
-                        Logging.Exception(Logging.Sockets, this, "Blocking", socketException);
+                        NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "Blocking", socketException);
                     }
                     throw socketException;
                 }
@@ -362,7 +362,7 @@ namespace System.Net.Sockets
         {
             get
             {
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Connected() _isConnected:" + _isConnected);
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Connected() _isConnected:" + _isConnected);
 
                 if (_nonBlockingConnectInProgress && Poll(0, SelectMode.SelectWrite))
                 {
@@ -691,7 +691,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "Bind", localEP);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Bind", localEP);
             }
 
             if (CleanedUp)
@@ -705,7 +705,7 @@ namespace System.Net.Sockets
                 throw new ArgumentNullException("localEP");
             }
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Bind() localEP:" + localEP.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Bind() localEP:" + localEP.ToString());
 
             EndPoint endPointSnapshot = localEP;
             IPEndPoint ipSnapshot = localEP as IPEndPoint;
@@ -727,7 +727,7 @@ namespace System.Net.Sockets
             DoBind(endPointSnapshot, socketAddress);
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "Bind", "");
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Bind", "");
             }
         }
 
@@ -735,7 +735,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "InternalBind", localEP);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "InternalBind", localEP);
             }
 
             if (CleanedUp)
@@ -743,7 +743,7 @@ namespace System.Net.Sockets
                 throw new ObjectDisposedException(GetType().FullName);
             }
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::InternalBind() localEP:" + localEP.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::InternalBind() localEP:" + localEP.ToString());
             GlobalLog.Assert(!(localEP is DnsEndPoint), "Calling InternalBind with a DnsEndPoint, about to get NotImplementedException");
 
             // Ask the EndPoint to generate a SocketAddress that we can pass down to native code.
@@ -753,7 +753,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "InternalBind", "");
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "InternalBind", "");
             }
         }
 
@@ -767,7 +767,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "DoBind", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "DoBind", socketException);
                 }
                 throw socketException;
             }
@@ -781,7 +781,7 @@ namespace System.Net.Sockets
 #if TRACE_VERBOSE
             try
             {
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Bind() SRC:" + Logging.ObjectToString(LocalEndPoint) + " Interop.Winsock.bind returns errorCode:" + errorCode);
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Bind() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " Interop.Winsock.bind returns errorCode:" + errorCode);
             }
             catch (ObjectDisposedException) { }
 #endif
@@ -794,7 +794,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "DoBind", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "DoBind", socketException);
                 }
                 throw socketException;
             }
@@ -831,7 +831,7 @@ namespace System.Net.Sockets
             }
 
             ValidateBlockingMode();
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Connect() DST:" + Logging.ObjectToString(remoteEP));
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Connect() DST:" + LoggingHash.ObjectToString(remoteEP));
 
             DnsEndPoint dnsEP = remoteEP as DnsEndPoint;
             if (dnsEP != null)
@@ -862,7 +862,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "Connect", address);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Connect", address);
             }
 
             if (CleanedUp)
@@ -887,7 +887,7 @@ namespace System.Net.Sockets
             Connect(remoteEP);
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "Connect", null);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Connect", null);
             }
         }
 
@@ -895,7 +895,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "Connect", host);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Connect", host);
             }
 
             if (CleanedUp)
@@ -919,7 +919,7 @@ namespace System.Net.Sockets
             Connect(addresses, port);
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "Connect", null);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Connect", null);
             }
         }
 
@@ -927,7 +927,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "Connect", addresses);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Connect", addresses);
             }
 
             if (CleanedUp)
@@ -1047,7 +1047,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "Connect", null);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Connect", null);
             }
         }
 
@@ -1056,14 +1056,14 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "Listen", backlog);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Listen", backlog);
             }
             if (CleanedUp)
             {
                 throw new ObjectDisposedException(this.GetType().FullName);
             }
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Listen() backlog:" + backlog.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Listen() backlog:" + backlog.ToString());
 
             // No access permissions are necessary here because the verification is done for Bind.
 
@@ -1075,7 +1075,7 @@ namespace System.Net.Sockets
 #if TRACE_VERBOSE
             try
             {
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Listen() SRC:" + Logging.ObjectToString(LocalEndPoint) + " Interop.Winsock.listen returns errorCode:" + errorCode);
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Listen() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " Interop.Winsock.listen returns errorCode:" + errorCode);
             }
             catch (ObjectDisposedException) { }
 #endif
@@ -1088,14 +1088,14 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "Listen", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "Listen", socketException);
                 }
                 throw socketException;
             }
             _isListening = true;
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "Listen", "");
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Listen", "");
             }
         }
 
@@ -1104,7 +1104,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "Accept", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Accept", "");
             }
 
             // Validate input parameters.
@@ -1130,7 +1130,7 @@ namespace System.Net.Sockets
             }
 
             ValidateBlockingMode();
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Accept() SRC:" + Logging.ObjectToString(LocalEndPoint));
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Accept() SRC:" + LoggingHash.ObjectToString(LocalEndPoint));
 
             Internals.SocketAddress socketAddress = IPEndPointExtensions.Serialize(_rightEndPoint);
 
@@ -1152,7 +1152,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "Accept", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "Accept", socketException);
                 }
                 throw socketException;
             }
@@ -1162,8 +1162,8 @@ namespace System.Net.Sockets
             Socket socket = CreateAcceptSocket(acceptedSocketHandle, _rightEndPoint.Create(socketAddress));
             if (s_loggingEnabled)
             {
-                Logging.PrintInfo(Logging.Sockets, socket, SR.Format(SR.net_log_socket_accepted, socket.RemoteEndPoint, socket.LocalEndPoint));
-                Logging.Exit(Logging.Sockets, this, "Accept", socket);
+                SocketsEventSource.Accepted(socket, socket.RemoteEndPoint, socket.LocalEndPoint);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Accept", socket);
             }
             return socket;
         }
@@ -1204,7 +1204,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "Send", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Send", "");
             }
             if (CleanedUp)
             {
@@ -1221,7 +1221,7 @@ namespace System.Net.Sockets
             }
 
             ValidateBlockingMode();
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Send() SRC:" + Logging.ObjectToString(LocalEndPoint) + " DST:" + Logging.ObjectToString(RemoteEndPoint));
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Send() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint));
 
             int bytesTransferred;
             errorCode = SocketPal.Send(_handle, buffers, socketFlags, out bytesTransferred);
@@ -1229,7 +1229,7 @@ namespace System.Net.Sockets
 #if TRACE_VERBOSE
             try
             {
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Send() SRC:" + Logging.ObjectToString(LocalEndPoint) + " DST:" + Logging.ObjectToString(RemoteEndPoint) + " Interop.Winsock.send returns errorCode:" + errorCode + " bytesTransferred:" + bytesTransferred);
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Send() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " Interop.Winsock.send returns errorCode:" + errorCode + " bytesTransferred:" + bytesTransferred);
             }
             catch (ObjectDisposedException) { }
 #endif
@@ -1240,8 +1240,8 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(errorCode);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "Send", new SocketException((int)errorCode));
-                    Logging.Exit(Logging.Sockets, this, "Send", 0);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "Send", new SocketException((int)errorCode));
+                    NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Send", 0);
                 }
                 return 0;
             }
@@ -1259,7 +1259,7 @@ namespace System.Net.Sockets
             }
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "Send", bytesTransferred);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Send", bytesTransferred);
             }
             return bytesTransferred;
         }
@@ -1280,7 +1280,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "Send", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Send", "");
             }
 
             if (CleanedUp)
@@ -1304,7 +1304,7 @@ namespace System.Net.Sockets
 
             errorCode = SocketError.Success;
             ValidateBlockingMode();
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Send() SRC:" + Logging.ObjectToString(LocalEndPoint) + " DST:" + Logging.ObjectToString(RemoteEndPoint) + " size:" + size);
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Send() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " size:" + size);
 
             // This can throw ObjectDisposedException.
             int bytesTransferred;
@@ -1317,8 +1317,8 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(errorCode);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "Send", new SocketException((int)errorCode));
-                    Logging.Exit(Logging.Sockets, this, "Send", 0);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "Send", new SocketException((int)errorCode));
+                    NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Send", 0);
                 }
                 return 0;
             }
@@ -1335,15 +1335,15 @@ namespace System.Net.Sockets
                 }
             }
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Send() Interop.Winsock.send returns:" + bytesTransferred.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Send() Interop.Winsock.send returns:" + bytesTransferred.ToString());
             GlobalLog.Dump(buffer, offset, bytesTransferred);
             if (s_loggingEnabled)
             {
-                Logging.Dump(Logging.Sockets, this, "Send", buffer, offset, size);
+                SocketsEventSource.Dump(SocketsEventSource.MethodType.Send, buffer, offset, size);
             }
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "Send", bytesTransferred);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Send", bytesTransferred);
             }
             return bytesTransferred;
         }
@@ -1353,7 +1353,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "SendTo", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "SendTo", "");
             }
             if (CleanedUp)
             {
@@ -1378,7 +1378,7 @@ namespace System.Net.Sockets
             }
 
             ValidateBlockingMode();
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::SendTo() SRC:" + Logging.ObjectToString(LocalEndPoint) + " size:" + size + " remoteEP:" + Logging.ObjectToString(remoteEP));
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SendTo() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " size:" + size + " remoteEP:" + LoggingHash.ObjectToString(remoteEP));
 
             // CheckCacheRemote will check ConnectPermission for remoteEP.
             EndPoint endPointSnapshot = remoteEP;
@@ -1396,7 +1396,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "SendTo", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "SendTo", socketException);
                 }
                 throw socketException;
             }
@@ -1419,15 +1419,15 @@ namespace System.Net.Sockets
                 }
             }
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::SendTo() returning bytesTransferred:" + bytesTransferred.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SendTo() returning bytesTransferred:" + bytesTransferred.ToString());
             GlobalLog.Dump(buffer, offset, bytesTransferred);
             if (s_loggingEnabled)
             {
-                Logging.Dump(Logging.Sockets, this, "SendTo", buffer, offset, size);
+                SocketsEventSource.Dump(SocketsEventSource.MethodType.SendTo, buffer, offset, size);
             }
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "SendTo", bytesTransferred);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "SendTo", bytesTransferred);
             }
             return bytesTransferred;
         }
@@ -1480,7 +1480,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "Receive", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Receive", "");
             }
             if (CleanedUp)
             {
@@ -1502,7 +1502,7 @@ namespace System.Net.Sockets
             }
 
             ValidateBlockingMode();
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Receive() SRC:" + Logging.ObjectToString(LocalEndPoint) + " DST:" + Logging.ObjectToString(RemoteEndPoint) + " size:" + size);
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Receive() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " size:" + size);
 
             int bytesTransferred;
             errorCode = SocketPal.Receive(_handle, buffer, offset, size, socketFlags, out bytesTransferred);
@@ -1513,8 +1513,8 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(errorCode);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "Receive", new SocketException((int)errorCode));
-                    Logging.Exit(Logging.Sockets, this, "Receive", 0);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "Receive", new SocketException((int)errorCode));
+                    NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Receive", 0);
                 }
                 return 0;
             }
@@ -1536,7 +1536,7 @@ namespace System.Net.Sockets
 #if TRACE_VERBOSE
             try
             {
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Receive() SRC:" + Logging.ObjectToString(LocalEndPoint) + " DST:" + Logging.ObjectToString(RemoteEndPoint) + " bytesTransferred:" + bytesTransferred);
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Receive() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " bytesTransferred:" + bytesTransferred);
             }
             catch (ObjectDisposedException) { }
 #endif
@@ -1544,11 +1544,11 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Dump(Logging.Sockets, this, "Receive", buffer, offset, bytesTransferred);
+                SocketsEventSource.Dump(SocketsEventSource.MethodType.Receive, buffer, offset, bytesTransferred);
             }
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "Receive", bytesTransferred);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Receive", bytesTransferred);
             }
 
             return bytesTransferred;
@@ -1574,7 +1574,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "Receive", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Receive", "");
             }
             if (CleanedUp)
             {
@@ -1593,7 +1593,7 @@ namespace System.Net.Sockets
 
 
             ValidateBlockingMode();
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Receive() SRC:" + Logging.ObjectToString(LocalEndPoint) + " DST:" + Logging.ObjectToString(RemoteEndPoint));
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Receive() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint));
 
             int bytesTransferred;
             errorCode = SocketPal.Receive(_handle, buffers, ref socketFlags, out bytesTransferred);
@@ -1601,7 +1601,7 @@ namespace System.Net.Sockets
 #if TRACE_VERBOSE
             try
             {
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Receive() SRC:" + Logging.ObjectToString(LocalEndPoint) + " DST:" + Logging.ObjectToString(RemoteEndPoint) + " Interop.Winsock.send returns errorCode:" + errorCode + " bytesTransferred:" + bytesTransferred);
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Receive() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " Interop.Winsock.send returns errorCode:" + errorCode + " bytesTransferred:" + bytesTransferred);
             }
             catch (ObjectDisposedException) { }
 #endif
@@ -1612,8 +1612,8 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(errorCode);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "Receive", new SocketException((int)errorCode));
-                    Logging.Exit(Logging.Sockets, this, "Receive", 0);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "Receive", new SocketException((int)errorCode));
+                    NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Receive", 0);
                 }
                 return 0;
             }
@@ -1635,14 +1635,14 @@ namespace System.Net.Sockets
 #if TRACE_VERBOSE
             try
             {
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Receive() SRC:" + Logging.ObjectToString(LocalEndPoint) + " DST:" + Logging.ObjectToString(RemoteEndPoint) + " bytesTransferred:" + bytesTransferred);
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Receive() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " bytesTransferred:" + bytesTransferred);
             }
             catch (ObjectDisposedException) { }
 #endif
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "Receive", bytesTransferred);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Receive", bytesTransferred);
             }
 
             return bytesTransferred;
@@ -1654,7 +1654,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "ReceiveMessageFrom", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "ReceiveMessageFrom", "");
             }
 
             if (CleanedUp)
@@ -1711,7 +1711,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "ReceiveMessageFrom", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "ReceiveMessageFrom", socketException);
                 }
                 throw socketException;
             }
@@ -1734,7 +1734,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "ReceiveMessageFrom", errorCode);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "ReceiveMessageFrom", errorCode);
             }
             return bytesTransferred;
         }
@@ -1745,7 +1745,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "ReceiveFrom", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "ReceiveFrom", "");
             }
             if (CleanedUp)
             {
@@ -1780,7 +1780,7 @@ namespace System.Net.Sockets
             }
 
             ValidateBlockingMode();
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::ReceiveFrom() SRC:" + Logging.ObjectToString(LocalEndPoint) + " size:" + size + " remoteEP:" + remoteEP.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::ReceiveFrom() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " size:" + size + " remoteEP:" + remoteEP.ToString());
 
             // We don't do a CAS demand here because the contents of remoteEP aren't used by
             // WSARecvFrom; all that matters is that we generate a unique-to-this-call SocketAddress
@@ -1801,7 +1801,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "ReceiveFrom", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "ReceiveFrom", socketException);
                 }
 
                 if (socketException.SocketErrorCode != SocketError.MessageSize)
@@ -1847,11 +1847,11 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Dump(Logging.Sockets, this, "ReceiveFrom", buffer, offset, size);
+                SocketsEventSource.Dump(SocketsEventSource.MethodType.ReceiveFrom, buffer, offset, size);
             }
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "ReceiveFrom", bytesTransferred);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "ReceiveFrom", bytesTransferred);
             }
             return bytesTransferred;
         }
@@ -1884,7 +1884,7 @@ namespace System.Net.Sockets
             // This can throw ObjectDisposedException.
             SocketError errorCode = SocketPal.Ioctl(_handle, ioControlCode, optionInValue, optionOutValue, out realOptionLength);
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::IOControl() Interop.Winsock.WSAIoctl returns errorCode:" + errorCode);
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::IOControl() Interop.Winsock.WSAIoctl returns errorCode:" + errorCode);
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -1894,7 +1894,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "IOControl", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "IOControl", socketException);
                 }
                 throw socketException;
             }
@@ -1919,7 +1919,7 @@ namespace System.Net.Sockets
             // This can throw ObjectDisposedException.
             SocketError errorCode = SocketPal.IoctlInternal(_handle, ioControlCode, optionInValue, inValueSize, optionOutValue, outValueSize, out realOptionLength);
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::IOControl() Interop.Winsock.WSAIoctl returns errorCode:" + errorCode);
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::IOControl() Interop.Winsock.WSAIoctl returns errorCode:" + errorCode);
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -1929,7 +1929,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "IOControl", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "IOControl", socketException);
                 }
                 throw socketException;
             }
@@ -1945,7 +1945,7 @@ namespace System.Net.Sockets
                 throw new ObjectDisposedException(this.GetType().FullName);
             }
             CheckSetOptionPermissions(optionLevel, optionName);
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::SetSocketOption(): optionLevel:" + optionLevel.ToString() + " optionName:" + optionName.ToString() + " optionValue:" + optionValue.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetSocketOption(): optionLevel:" + optionLevel.ToString() + " optionName:" + optionName.ToString() + " optionValue:" + optionValue.ToString());
             SetSocketOption(optionLevel, optionName, optionValue, false);
         }
 
@@ -1958,12 +1958,12 @@ namespace System.Net.Sockets
 
             CheckSetOptionPermissions(optionLevel, optionName);
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::SetSocketOption(): optionLevel:" + optionLevel.ToString() + " optionName:" + optionName.ToString() + " optionValue:" + optionValue.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetSocketOption(): optionLevel:" + optionLevel.ToString() + " optionName:" + optionName.ToString() + " optionValue:" + optionValue.ToString());
 
             // This can throw ObjectDisposedException.
             SocketError errorCode = SocketPal.SetSockOpt(_handle, optionLevel, optionName, optionValue);
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::SetSocketOption() Interop.Winsock.setsockopt returns errorCode:" + errorCode);
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetSocketOption() Interop.Winsock.setsockopt returns errorCode:" + errorCode);
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -1973,7 +1973,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "SetSocketOption", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "SetSocketOption", socketException);
                 }
                 throw socketException;
             }
@@ -2001,7 +2001,7 @@ namespace System.Net.Sockets
 
             CheckSetOptionPermissions(optionLevel, optionName);
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::SetSocketOption(): optionLevel:" + optionLevel.ToString() + " optionName:" + optionName.ToString() + " optionValue:" + optionValue.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetSocketOption(): optionLevel:" + optionLevel.ToString() + " optionName:" + optionName.ToString() + " optionValue:" + optionValue.ToString());
 
             if (optionLevel == SocketOptionLevel.Socket && optionName == SocketOptionName.Linger)
             {
@@ -2071,7 +2071,7 @@ namespace System.Net.Sockets
                 optionName,
                 out optionValue);
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::GetSocketOption() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::GetSocketOption() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -2081,7 +2081,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "GetSocketOption", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "GetSocketOption", socketException);
                 }
                 throw socketException;
             }
@@ -2106,7 +2106,7 @@ namespace System.Net.Sockets
                 optionValue,
                 ref optionLength);
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::GetSocketOption() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::GetSocketOption() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -2116,7 +2116,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "GetSocketOption", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "GetSocketOption", socketException);
                 }
                 throw socketException;
             }
@@ -2140,7 +2140,7 @@ namespace System.Net.Sockets
                 optionValue,
                 ref realOptionLength);
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::GetSocketOption() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::GetSocketOption() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -2150,7 +2150,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "GetSocketOption", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "GetSocketOption", socketException);
                 }
                 throw socketException;
             }
@@ -2175,7 +2175,7 @@ namespace System.Net.Sockets
 
             bool status;
             SocketError errorCode = SocketPal.Poll(_handle, microSeconds, mode, out status);
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Poll() Interop.Winsock.select returns socketCount:" + (int)errorCode);
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Poll() Interop.Winsock.select returns socketCount:" + (int)errorCode);
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -2185,7 +2185,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "Poll", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "Poll", socketException);
                 }
                 throw socketException;
             }
@@ -2247,7 +2247,7 @@ namespace System.Net.Sockets
             // Validate input parameters.
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "BeginConnect", remoteEP);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginConnect", remoteEP);
             }
 
             if (CleanedUp)
@@ -2288,7 +2288,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "BeginConnect", host);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginConnect", host);
             }
 
             if (CleanedUp)
@@ -2332,7 +2332,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "BeginConnect", result);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginConnect", result);
             }
             return result;
         }
@@ -2341,7 +2341,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "BeginConnect", address);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginConnect", address);
             }
             if (CleanedUp)
             {
@@ -2364,7 +2364,7 @@ namespace System.Net.Sockets
             IAsyncResult result = BeginConnect(new IPEndPoint(address, port), requestCallback, state);
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "BeginConnect", result);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginConnect", result);
             }
             return result;
         }
@@ -2373,7 +2373,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "BeginConnect", addresses);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginConnect", addresses);
             }
             if (CleanedUp)
             {
@@ -2417,7 +2417,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "BeginConnect", result);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginConnect", result);
             }
             return result;
         }
@@ -2438,7 +2438,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "EndConnect", asyncResult);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "EndConnect", asyncResult);
             }
             if (CleanedUp)
             {
@@ -2484,13 +2484,13 @@ namespace System.Net.Sockets
             castedAsyncResult.InternalWaitForCompletion();
             castedAsyncResult.EndCalled = true;
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::EndConnect() asyncResult:" + Logging.HashString(asyncResult));
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::EndConnect() asyncResult:" + LoggingHash.HashString(asyncResult));
 
             if (castedAsyncResult.Result is Exception)
             {
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "EndConnect", (Exception)castedAsyncResult.Result);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "EndConnect", (Exception)castedAsyncResult.Result);
                 }
                 throw (Exception)castedAsyncResult.Result;
             }
@@ -2501,14 +2501,14 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "EndConnect", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "EndConnect", socketException);
                 }
                 throw socketException;
             }
             if (s_loggingEnabled)
             {
-                Logging.PrintInfo(Logging.Sockets, this, SR.Format(SR.net_log_socket_connected, LocalEndPoint, RemoteEndPoint));
-                Logging.Exit(Logging.Sockets, this, "EndConnect", "");
+                SocketsEventSource.Connected(this, LocalEndPoint, RemoteEndPoint);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "EndConnect", "");
             }
         }
 
@@ -2544,7 +2544,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "BeginSend", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginSend", "");
             }
 
             if (CleanedUp)
@@ -2586,7 +2586,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "BeginSend", asyncResult);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginSend", asyncResult);
             }
             return asyncResult;
         }
@@ -2595,7 +2595,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "UnsafeBeginSend", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "UnsafeBeginSend", "");
             }
 
             if (CleanedUp)
@@ -2614,14 +2614,14 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "UnsafeBeginSend", asyncResult);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "UnsafeBeginSend", asyncResult);
             }
             return asyncResult;
         }
 
         private SocketError DoBeginSend(byte[] buffer, int offset, int size, SocketFlags socketFlags, OverlappedAsyncResult asyncResult)
         {
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::BeginSend() SRC:" + Logging.ObjectToString(LocalEndPoint) + " DST:" + Logging.ObjectToString(RemoteEndPoint) + " size:" + size.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginSend() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " size:" + size.ToString());
 
             // Guarantee to call CheckAsyncCallOverlappedResult if we call SetUnamangedStructures with a cache in order to
             // avoid a Socket leak in case of error.
@@ -2629,11 +2629,11 @@ namespace System.Net.Sockets
             try
             {
                 // Get the Send going.
-                GlobalLog.Print("BeginSend: asyncResult:" + Logging.HashString(asyncResult) + " size:" + size.ToString());
+                GlobalLog.Print("BeginSend: asyncResult:" + LoggingHash.HashString(asyncResult) + " size:" + size.ToString());
 
                 errorCode = SocketPal.SendAsync(_handle, buffer, offset, size, socketFlags, asyncResult);
 
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::BeginSend() Interop.Winsock.WSASend returns:" + errorCode.ToString() + " size:" + size.ToString() + " returning AsyncResult:" + Logging.HashString(asyncResult));
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginSend() Interop.Winsock.WSASend returns:" + errorCode.ToString() + " size:" + size.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
             }
             finally
             {
@@ -2646,7 +2646,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(errorCode);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "BeginSend", new SocketException((int)errorCode));
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "BeginSend", new SocketException((int)errorCode));
                 }
             }
             return errorCode;
@@ -2667,7 +2667,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "BeginSend", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginSend", "");
             }
 
             if (CleanedUp)
@@ -2704,25 +2704,25 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "BeginSend", asyncResult);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginSend", asyncResult);
             }
             return asyncResult;
         }
 
         private SocketError DoBeginSend(IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, OverlappedAsyncResult asyncResult)
         {
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::BeginSend() SRC:" + Logging.ObjectToString(LocalEndPoint) + " DST:" + Logging.ObjectToString(RemoteEndPoint) + " buffers:" + buffers);
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginSend() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " buffers:" + buffers);
 
             // Guarantee to call CheckAsyncCallOverlappedResult if we call SetUnamangedStructures with a cache in order to
             // avoid a Socket leak in case of error.
             SocketError errorCode = SocketError.SocketError;
             try
             {
-                GlobalLog.Print("BeginSend: asyncResult:" + Logging.HashString(asyncResult));
+                GlobalLog.Print("BeginSend: asyncResult:" + LoggingHash.HashString(asyncResult));
 
                 errorCode = SocketPal.SendAsync(_handle, buffers, socketFlags, asyncResult);
 
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::BeginSend() Interop.Winsock.WSASend returns:" + errorCode.ToString() + " returning AsyncResult:" + Logging.HashString(asyncResult));
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginSend() Interop.Winsock.WSASend returns:" + errorCode.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
             }
             finally
             {
@@ -2735,7 +2735,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(errorCode);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "BeginSend", new SocketException((int)errorCode));
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "BeginSend", new SocketException((int)errorCode));
                 }
             }
             return errorCode;
@@ -2768,7 +2768,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "EndSend", asyncResult);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "EndSend", asyncResult);
             }
             if (CleanedUp)
             {
@@ -2806,7 +2806,7 @@ namespace System.Net.Sockets
                 }
             }
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::EndSend() bytesTransferred:" + bytesTransferred.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::EndSend() bytesTransferred:" + bytesTransferred.ToString());
 
             // Throw an appropriate SocketException if the native call failed asynchronously.
             errorCode = (SocketError)castedAsyncResult.ErrorCode;
@@ -2816,14 +2816,14 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(errorCode);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "EndSend", new SocketException((int)errorCode));
-                    Logging.Exit(Logging.Sockets, this, "EndSend", 0);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "EndSend", new SocketException((int)errorCode));
+                    NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "EndSend", 0);
                 }
                 return 0;
             }
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "EndSend", bytesTransferred);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "EndSend", bytesTransferred);
             }
             return bytesTransferred;
         }
@@ -2852,7 +2852,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "BeginSendTo", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginSendTo", "");
             }
 
             if (CleanedUp)
@@ -2894,14 +2894,14 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "BeginSendTo", asyncResult);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginSendTo", asyncResult);
             }
             return asyncResult;
         }
 
         private void DoBeginSendTo(byte[] buffer, int offset, int size, SocketFlags socketFlags, EndPoint endPointSnapshot, Internals.SocketAddress socketAddress, OverlappedAsyncResult asyncResult)
         {
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::DoBeginSendTo() size:" + size.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginSendTo() size:" + size.ToString());
             EndPoint oldEndPoint = _rightEndPoint;
 
             // Guarantee to call CheckAsyncCallOverlappedResult if we call SetUnamangedStructures with a cache in order to
@@ -2916,7 +2916,7 @@ namespace System.Net.Sockets
 
                 errorCode = SocketPal.SendToAsync(_handle, buffer, offset, size, socketFlags, socketAddress, asyncResult);
 
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::DoBeginSendTo() Interop.Winsock.WSASend returns:" + errorCode.ToString() + " size:" + size + " returning AsyncResult:" + Logging.HashString(asyncResult));
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginSendTo() Interop.Winsock.WSASend returns:" + errorCode.ToString() + " size:" + size + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
             }
             catch (ObjectDisposedException)
             {
@@ -2937,12 +2937,12 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "BeginSendTo", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "BeginSendTo", socketException);
                 }
                 throw socketException;
             }
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::DoBeginSendTo() size:" + size.ToString() + " returning AsyncResult:" + Logging.HashString(asyncResult));
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginSendTo() size:" + size.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
         }
 
         // Routine Description:
@@ -2961,7 +2961,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "EndSendTo", asyncResult);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "EndSendTo", asyncResult);
             }
             if (CleanedUp)
             {
@@ -2999,7 +2999,7 @@ namespace System.Net.Sockets
                 }
             }
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::EndSendTo() bytesTransferred:" + bytesTransferred.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::EndSendTo() bytesTransferred:" + bytesTransferred.ToString());
 
             // Throw an appropriate SocketException if the native call failed asynchronously.
             if ((SocketError)castedAsyncResult.ErrorCode != SocketError.Success)
@@ -3009,13 +3009,13 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "EndSendTo", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "EndSendTo", socketException);
                 }
                 throw socketException;
             }
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "EndSendTo", bytesTransferred);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "EndSendTo", bytesTransferred);
             }
             return bytesTransferred;
         }
@@ -3057,7 +3057,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "BeginReceive", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginReceive", "");
             }
 
             if (CleanedUp)
@@ -3099,7 +3099,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "BeginReceive", asyncResult);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginReceive", asyncResult);
             }
             return asyncResult;
         }
@@ -3108,7 +3108,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "UnsafeBeginReceive", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "UnsafeBeginReceive", "");
             }
 
             if (CleanedUp)
@@ -3122,14 +3122,14 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "UnsafeBeginReceive", asyncResult);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "UnsafeBeginReceive", asyncResult);
             }
             return asyncResult;
         }
 
         private SocketError DoBeginReceive(byte[] buffer, int offset, int size, SocketFlags socketFlags, OverlappedAsyncResult asyncResult)
         {
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::BeginReceive() size:" + size.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginReceive() size:" + size.ToString());
 
 #if DEBUG
             IntPtr lastHandle = _handle.DangerousGetHandle();
@@ -3141,7 +3141,7 @@ namespace System.Net.Sockets
             {
                 errorCode = SocketPal.ReceiveAsync(_handle, buffer, offset, size, socketFlags, asyncResult);
 
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::BeginReceive() Interop.Winsock.WSARecv returns:" + errorCode.ToString() + " returning AsyncResult:" + Logging.HashString(asyncResult));
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginReceive() Interop.Winsock.WSARecv returns:" + errorCode.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
             }
             finally
             {
@@ -3151,13 +3151,13 @@ namespace System.Net.Sockets
             // Throw an appropriate SocketException if the native call fails synchronously.
             if (errorCode != SocketError.Success)
             {
-                GlobalLog.Assert(errorCode != SocketError.Success, "Socket#{0}::DoBeginReceive()|GetLastWin32Error() returned zero.", Logging.HashString(this));
+                GlobalLog.Assert(errorCode != SocketError.Success, "Socket#{0}::DoBeginReceive()|GetLastWin32Error() returned zero.", LoggingHash.HashString(this));
 
                 // Update the internal state of this socket according to the error before throwing.
                 UpdateStatusAfterSocketError(errorCode);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "BeginReceive", new SocketException((int)errorCode));
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "BeginReceive", new SocketException((int)errorCode));
                 }
                 asyncResult.InvokeCallback(new SocketException((int)errorCode));
             }
@@ -3188,7 +3188,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "BeginReceive", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginReceive", "");
             }
 
             if (CleanedUp)
@@ -3227,7 +3227,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "BeginReceive", asyncResult);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginReceive", asyncResult);
             }
             return asyncResult;
         }
@@ -3244,7 +3244,7 @@ namespace System.Net.Sockets
             {
                 errorCode = SocketPal.ReceiveAsync(_handle, buffers, socketFlags, asyncResult);
 
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::DoBeginReceive() Interop.Winsock.WSARecv returns:" + errorCode.ToString() + " returning AsyncResult:" + Logging.HashString(asyncResult));
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginReceive() Interop.Winsock.WSARecv returns:" + errorCode.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
             }
             finally
             {
@@ -3258,7 +3258,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(errorCode);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "BeginReceive", new SocketException((int)errorCode));
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "BeginReceive", new SocketException((int)errorCode));
                 }
             }
 #if DEBUG
@@ -3307,7 +3307,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "EndReceive", asyncResult);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "EndReceive", asyncResult);
             }
             if (CleanedUp)
             {
@@ -3348,7 +3348,7 @@ namespace System.Net.Sockets
 #if TRACE_VERBOSE
             try
             {
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::EndReceive() SRC:" + Logging.ObjectToString(LocalEndPoint) + " DST:" + Logging.ObjectToString(RemoteEndPoint) + " bytesTransferred:" + bytesTransferred.ToString());
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::EndReceive() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " bytesTransferred:" + bytesTransferred.ToString());
             }
             catch (ObjectDisposedException) { }
 #endif
@@ -3361,14 +3361,14 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(errorCode);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "EndReceive", new SocketException((int)errorCode));
-                    Logging.Exit(Logging.Sockets, this, "EndReceive", 0);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "EndReceive", new SocketException((int)errorCode));
+                    NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "EndReceive", 0);
                 }
                 return 0;
             }
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "EndReceive", bytesTransferred);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "EndReceive", bytesTransferred);
             }
             return bytesTransferred;
         }
@@ -3377,9 +3377,9 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "BeginReceiveMessageFrom", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginReceiveMessageFrom", "");
             }
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::BeginReceiveMessageFrom() size:" + size.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginReceiveMessageFrom() size:" + size.ToString());
 
             if (CleanedUp)
             {
@@ -3448,12 +3448,12 @@ namespace System.Net.Sockets
                     // That same map is implemented here just in case.
                     if (errorCode == SocketError.MessageSize)
                     {
-                        GlobalLog.Assert("Socket#" + Logging.HashString(this) + "::BeginReceiveMessageFrom()|Returned WSAEMSGSIZE!");
+                        GlobalLog.Assert("Socket#" + LoggingHash.HashString(this) + "::BeginReceiveMessageFrom()|Returned WSAEMSGSIZE!");
                         errorCode = SocketError.IOPending;
                     }
                 }
 
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::BeginReceiveMessageFrom() Interop.Winsock.WSARecvMsg returns:" + errorCode.ToString() + " size:" + size.ToString() + " returning AsyncResult:" + Logging.HashString(asyncResult));
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginReceiveMessageFrom() Interop.Winsock.WSARecvMsg returns:" + errorCode.ToString() + " size:" + size.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
             }
             catch (ObjectDisposedException)
             {
@@ -3474,7 +3474,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "BeginReceiveMessageFrom", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "BeginReceiveMessageFrom", socketException);
                 }
                 throw socketException;
             }
@@ -3493,10 +3493,10 @@ namespace System.Net.Sockets
                 }
             }
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::BeginReceiveMessageFrom() size:" + size.ToString() + " returning AsyncResult:" + Logging.HashString(asyncResult));
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginReceiveMessageFrom() size:" + size.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "BeginReceiveMessageFrom", asyncResult);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginReceiveMessageFrom", asyncResult);
             }
             return asyncResult;
         }
@@ -3505,7 +3505,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "EndReceiveMessageFrom", asyncResult);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "EndReceiveMessageFrom", asyncResult);
             }
             if (CleanedUp)
             {
@@ -3565,7 +3565,7 @@ namespace System.Net.Sockets
                 }
             }
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::EndReceiveMessageFrom() bytesTransferred:" + bytesTransferred.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::EndReceiveMessageFrom() bytesTransferred:" + bytesTransferred.ToString());
 
             // Throw an appropriate SocketException if the native call failed asynchronously.
             if ((SocketError)castedAsyncResult.ErrorCode != SocketError.Success && (SocketError)castedAsyncResult.ErrorCode != SocketError.MessageSize)
@@ -3575,7 +3575,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "EndReceiveMessageFrom", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "EndReceiveMessageFrom", socketException);
                 }
                 throw socketException;
             }
@@ -3585,7 +3585,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "EndReceiveMessageFrom", bytesTransferred);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "EndReceiveMessageFrom", bytesTransferred);
             }
             return bytesTransferred;
         }
@@ -3618,7 +3618,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "BeginReceiveFrom", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginReceiveFrom", "");
             }
 
             if (CleanedUp)
@@ -3681,7 +3681,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "BeginReceiveFrom", asyncResult);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginReceiveFrom", asyncResult);
             }
             return asyncResult;
         }
@@ -3689,7 +3689,7 @@ namespace System.Net.Sockets
         private void DoBeginReceiveFrom(byte[] buffer, int offset, int size, SocketFlags socketFlags, EndPoint endPointSnapshot, Internals.SocketAddress socketAddress, OverlappedAsyncResult asyncResult)
         {
             EndPoint oldEndPoint = _rightEndPoint;
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::DoBeginReceiveFrom() size:" + size.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginReceiveFrom() size:" + size.ToString());
 
             // Guarantee to call CheckAsyncCallOverlappedResult if we call SetUnamangedStructures with a cache in order to
             // avoid a Socket leak in case of error.
@@ -3706,7 +3706,7 @@ namespace System.Net.Sockets
 
                 errorCode = SocketPal.ReceiveFromAsync(_handle, buffer, offset, size, socketFlags, socketAddress, asyncResult);
 
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::DoBeginReceiveFrom() Interop.Winsock.WSARecvFrom returns:" + errorCode.ToString() + " size:" + size.ToString() + " returning AsyncResult:" + Logging.HashString(asyncResult));
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginReceiveFrom() Interop.Winsock.WSARecvFrom returns:" + errorCode.ToString() + " size:" + size.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
             }
             catch (ObjectDisposedException)
             {
@@ -3727,12 +3727,12 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "BeginReceiveFrom", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "BeginReceiveFrom", socketException);
                 }
                 throw socketException;
             }
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::DoBeginReceiveFrom() size:" + size.ToString() + " returning AsyncResult:" + Logging.HashString(asyncResult));
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginReceiveFrom() size:" + size.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
         }
 
         // Routine Description:
@@ -3752,7 +3752,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "EndReceiveFrom", asyncResult);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "EndReceiveFrom", asyncResult);
             }
             if (CleanedUp)
             {
@@ -3814,7 +3814,7 @@ namespace System.Net.Sockets
                 }
             }
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::EndReceiveFrom() bytesTransferred:" + bytesTransferred.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::EndReceiveFrom() bytesTransferred:" + bytesTransferred.ToString());
 
             // Throw an appropriate SocketException if the native call failed asynchronously.
             if ((SocketError)castedAsyncResult.ErrorCode != SocketError.Success)
@@ -3824,13 +3824,13 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "EndReceiveFrom", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "EndReceiveFrom", socketException);
                 }
                 throw socketException;
             }
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "EndReceiveFrom", bytesTransferred);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "EndReceiveFrom", bytesTransferred);
             }
             return bytesTransferred;
         }
@@ -3862,7 +3862,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "BeginAccept", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginAccept", "");
             }
 
             Debug.Assert(CleanedUp);
@@ -3879,7 +3879,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "BeginAccept", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginAccept", "");
             }
             if (CleanedUp)
             {
@@ -3904,7 +3904,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "BeginAccept", asyncResult);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginAccept", asyncResult);
             }
             return asyncResult;
         }
@@ -3924,14 +3924,14 @@ namespace System.Net.Sockets
             SafeCloseSocket acceptHandle;
             asyncResult.AcceptSocket = GetOrCreateAcceptSocket(acceptSocket, false, "acceptSocket", out acceptHandle);
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::DoBeginAccept() AcceptSocket:" + Logging.HashString(acceptSocket));
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginAccept() AcceptSocket:" + LoggingHash.HashString(acceptSocket));
 
             int socketAddressSize = _rightEndPoint.Serialize().Size;
             SocketError errorCode = SocketPal.AcceptAsync(this, _handle, acceptHandle, receiveSize, socketAddressSize, asyncResult);
 
             errorCode = asyncResult.CheckAsyncCallOverlappedResult(errorCode);
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::DoBeginAccept() Interop.Winsock.AcceptEx returns:" + errorCode.ToString() + Logging.HashString(asyncResult));
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginAccept() Interop.Winsock.AcceptEx returns:" + errorCode.ToString() + LoggingHash.HashString(asyncResult));
 
             // Throw an appropriate SocketException if the native call fails synchronously.
             if (errorCode != SocketError.Success)
@@ -3940,7 +3940,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "BeginAccept", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "BeginAccept", socketException);
                 }
                 throw socketException;
             }
@@ -3981,7 +3981,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "EndAccept", asyncResult);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "EndAccept", asyncResult);
             }
             if (CleanedUp)
             {
@@ -4025,7 +4025,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "EndAccept", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "EndAccept", socketException);
                 }
                 throw socketException;
             }
@@ -4033,15 +4033,15 @@ namespace System.Net.Sockets
 #if TRACE_VERBOSE
             try
             {
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::EndAccept() SRC:" + Logging.ObjectToString(LocalEndPoint) + " acceptedSocket:" + Logging.HashString(socket) + " acceptedSocket.SRC:" + Logging.ObjectToString(socket.LocalEndPoint) + " acceptedSocket.DST:" + Logging.ObjectToString(socket.RemoteEndPoint) + " bytesTransferred:" + bytesTransferred.ToString());
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::EndAccept() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " acceptedSocket:" + LoggingHash.HashString(socket) + " acceptedSocket.SRC:" + LoggingHash.ObjectToString(socket.LocalEndPoint) + " acceptedSocket.DST:" + LoggingHash.ObjectToString(socket.RemoteEndPoint) + " bytesTransferred:" + bytesTransferred.ToString());
             }
             catch (ObjectDisposedException) { }
 #endif
 
             if (s_loggingEnabled)
             {
-                Logging.PrintInfo(Logging.Sockets, socket, SR.Format(SR.net_log_socket_accepted, socket.RemoteEndPoint, socket.LocalEndPoint));
-                Logging.Exit(Logging.Sockets, this, "EndAccept", socket);
+                SocketsEventSource.Accepted(socket, socket.RemoteEndPoint, socket.LocalEndPoint);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "EndAccept", socket);
             }
             return socket;
         }
@@ -4051,19 +4051,19 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "Shutdown", how);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Shutdown", how);
             }
             if (CleanedUp)
             {
                 throw new ObjectDisposedException(this.GetType().FullName);
             }
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Shutdown() how:" + how.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Shutdown() how:" + how.ToString());
 
             // This can throw ObjectDisposedException.
             SocketError errorCode = SocketPal.Shutdown(_handle, _isConnected, _isDisconnected, how);
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Shutdown() Interop.Winsock.shutdown returns errorCode:" + errorCode);
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Shutdown() Interop.Winsock.shutdown returns errorCode:" + errorCode);
 
             // Skip good cases: success, socket already closed.
             if (errorCode != SocketError.Success && errorCode != SocketError.NotSocket)
@@ -4073,7 +4073,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "Shutdown", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "Shutdown", socketException);
                 }
                 throw socketException;
             }
@@ -4082,7 +4082,7 @@ namespace System.Net.Sockets
             InternalSetBlocking(_willBlockInternal);
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "Shutdown", "");
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Shutdown", "");
             }
         }
 
@@ -4093,7 +4093,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "AcceptAsync", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "AcceptAsync", "");
             }
 
             if (CleanedUp)
@@ -4155,7 +4155,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "AcceptAsync", retval);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "AcceptAsync", retval);
             }
             return retval;
         }
@@ -4166,7 +4166,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "ConnectAsync", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "ConnectAsync", "");
             }
 
             if (CleanedUp)
@@ -4199,7 +4199,7 @@ namespace System.Net.Sockets
             {
                 if (s_loggingEnabled)
                 {
-                    Logging.PrintInfo(Logging.Sockets, "Socket#" + Logging.HashString(this) + "::ConnectAsync " + SR.net_log_socket_connect_dnsendpoint);
+                    SocketsEventSource.Log.ConnectedAsyncDns(LoggingHash.HashInt(this));
                 }
 
                 if (dnsEP.AddressFamily != AddressFamily.Unspecified && !CanTryAddressFamily(dnsEP.AddressFamily))
@@ -4278,7 +4278,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "ConnectAsync", retval);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "ConnectAsync", retval);
             }
             return retval;
         }
@@ -4289,7 +4289,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, null, "ConnectAsync", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, null, "ConnectAsync", "");
             }
 
             if (e == null)
@@ -4342,7 +4342,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, null, "ConnectAsync", retval);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, null, "ConnectAsync", retval);
             }
             return retval;
         }
@@ -4362,7 +4362,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "ReceiveAsync", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "ReceiveAsync", "");
             }
 
             if (CleanedUp)
@@ -4409,7 +4409,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "ReceiveAsync", retval);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "ReceiveAsync", retval);
             }
             return retval;
         }
@@ -4420,7 +4420,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "ReceiveFromAsync", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "ReceiveFromAsync", "");
             }
 
             if (CleanedUp)
@@ -4484,7 +4484,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "ReceiveFromAsync", retval);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "ReceiveFromAsync", retval);
             }
             return retval;
         }
@@ -4495,7 +4495,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "ReceiveMessageFromAsync", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "ReceiveMessageFromAsync", "");
             }
 
             if (CleanedUp)
@@ -4560,7 +4560,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "ReceiveMessageFromAsync", retval);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "ReceiveMessageFromAsync", retval);
             }
 
             return retval;
@@ -4572,7 +4572,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "SendAsync", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "SendAsync", "");
             }
 
             if (CleanedUp)
@@ -4618,7 +4618,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "SendAsync", retval);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "SendAsync", retval);
             }
 
             return retval;
@@ -4630,7 +4630,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "SendPacketsAsync", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "SendPacketsAsync", "");
             }
 
             // Throw if socket disposed
@@ -4694,7 +4694,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "SendPacketsAsync", retval);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "SendPacketsAsync", retval);
             }
 
             return retval;
@@ -4706,7 +4706,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "SendToAsync", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "SendToAsync", "");
             }
 
             if (CleanedUp)
@@ -4760,7 +4760,7 @@ namespace System.Net.Sockets
 
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "SendToAsync", retval);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "SendToAsync", retval);
             }
 
             return retval;
@@ -4954,7 +4954,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "Connect", endPointSnapshot);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Connect", endPointSnapshot);
             }
 
             // This can throw ObjectDisposedException.
@@ -4962,7 +4962,7 @@ namespace System.Net.Sockets
 #if TRACE_VERBOSE
             try
             {
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::InternalConnect() SRC:" + Logging.ObjectToString(LocalEndPoint) + " DST:" + Logging.ObjectToString(RemoteEndPoint) + " Interop.Winsock.WSAConnect returns errorCode:" + errorCode);
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::InternalConnect() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " Interop.Winsock.WSAConnect returns errorCode:" + errorCode);
             }
             catch (ObjectDisposedException) { }
 #endif
@@ -4975,7 +4975,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "Connect", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "Connect", socketException);
                 }
                 throw socketException;
             }
@@ -4986,14 +4986,14 @@ namespace System.Net.Sockets
                 _rightEndPoint = endPointSnapshot;
             }
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::DoConnect() connection to:" + endPointSnapshot.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoConnect() connection to:" + endPointSnapshot.ToString());
 
             // Update state and performance counters.
             SetToConnected();
             if (s_loggingEnabled)
             {
-                Logging.PrintInfo(Logging.Sockets, this, SR.Format(SR.net_log_socket_connected, LocalEndPoint, RemoteEndPoint));
-                Logging.Exit(Logging.Sockets, this, "Connect", "");
+                SocketsEventSource.Connected(this, LocalEndPoint, RemoteEndPoint);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Connect", "");
             }
         }
 
@@ -5006,10 +5006,10 @@ namespace System.Net.Sockets
 
             try
             {
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Dispose() disposing:true CleanedUp:" + CleanedUp.ToString());
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Dispose() disposing:true CleanedUp:" + CleanedUp.ToString());
                 if (s_loggingEnabled)
                 {
-                    Logging.Enter(Logging.Sockets, this, "Dispose", null);
+                    NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Dispose", null);
                 }
             }
             catch (Exception exception)
@@ -5034,7 +5034,7 @@ namespace System.Net.Sockets
                 {
                     if (s_loggingEnabled)
                     {
-                        Logging.Exit(Logging.Sockets, this, "Dispose", null);
+                        NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Dispose", null);
                     }
                 }
                 catch (Exception exception)
@@ -5057,7 +5057,7 @@ namespace System.Net.Sockets
                 if (timeout == 0)
                 {
                     // Abortive.
-                    GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Dispose() Calling _handle.Dispose()");
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Dispose() Calling _handle.Dispose()");
                     _handle.Dispose();
                 }
                 else
@@ -5075,7 +5075,7 @@ namespace System.Net.Sockets
                     if (timeout < 0)
                     {
                         // Close with existing user-specified linger option.
-                        GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Dispose() Calling _handle.CloseAsIs()");
+                        GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Dispose() Calling _handle.CloseAsIs()");
                         _handle.CloseAsIs();
                     }
                     else
@@ -5139,16 +5139,16 @@ namespace System.Net.Sockets
 
         public void Dispose()
         {
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::Dispose() timeout = " + _closeTimeout);
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Dispose() timeout = " + _closeTimeout);
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "Dispose", null);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Dispose", null);
             }
             Dispose(true);
             GC.SuppressFinalize(this);
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "Dispose", null);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Dispose", null);
             }
         }
 
@@ -5160,7 +5160,7 @@ namespace System.Net.Sockets
         // This version does not throw.
         internal void InternalShutdown(SocketShutdown how)
         {
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::InternalShutdown() how:" + how.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::InternalShutdown() how:" + how.ToString());
 
             if (CleanedUp || _handle.IsInvalid)
             {
@@ -5207,10 +5207,10 @@ namespace System.Net.Sockets
 
         internal unsafe void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, int optionValue, bool silent)
         {
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::SetSocketOption() optionLevel:" + optionLevel + " optionName:" + optionName + " optionValue:" + optionValue + " silent:" + silent);
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetSocketOption() optionLevel:" + optionLevel + " optionName:" + optionName + " optionValue:" + optionValue + " silent:" + silent);
             if (silent && (CleanedUp || _handle.IsInvalid))
             {
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::SetSocketOption() skipping the call");
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetSocketOption() skipping the call");
                 return;
             }
             SocketError errorCode = SocketError.Success;
@@ -5218,7 +5218,7 @@ namespace System.Net.Sockets
             {
                 errorCode = SocketPal.SetSockOpt(_handle, optionLevel, optionName, optionValue);
 
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::SetSocketOption() Interop.Winsock.setsockopt returns errorCode:" + errorCode);
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetSocketOption() Interop.Winsock.setsockopt returns errorCode:" + errorCode);
             }
             catch
             {
@@ -5249,7 +5249,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "SetSocketOption", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "SetSocketOption", socketException);
                 }
                 throw socketException;
             }
@@ -5259,7 +5259,7 @@ namespace System.Net.Sockets
         {
             SocketError errorCode = SocketPal.SetMulticastOption(_handle, optionName, MR);
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::setMulticastOption() Interop.Winsock.setsockopt returns errorCode:" + errorCode);
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::setMulticastOption() Interop.Winsock.setsockopt returns errorCode:" + errorCode);
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -5269,7 +5269,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "setMulticastOption", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "setMulticastOption", socketException);
                 }
                 throw socketException;
             }
@@ -5280,7 +5280,7 @@ namespace System.Net.Sockets
         {
             SocketError errorCode = SocketPal.SetIPv6MulticastOption(_handle, optionName, MR);
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::setIPv6MulticastOption() Interop.Winsock.setsockopt returns errorCode:" + errorCode);
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::setIPv6MulticastOption() Interop.Winsock.setsockopt returns errorCode:" + errorCode);
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -5290,7 +5290,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "setIPv6MulticastOption", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "setIPv6MulticastOption", socketException);
                 }
                 throw socketException;
             }
@@ -5300,7 +5300,7 @@ namespace System.Net.Sockets
         {
             SocketError errorCode = SocketPal.SetLingerOption(_handle, lref);
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::setLingerOption() Interop.Winsock.setsockopt returns errorCode:" + errorCode);
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::setLingerOption() Interop.Winsock.setsockopt returns errorCode:" + errorCode);
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -5310,7 +5310,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "setLingerOption", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "setLingerOption", socketException);
                 }
                 throw socketException;
             }
@@ -5321,7 +5321,7 @@ namespace System.Net.Sockets
             LingerOption lingerOption;
             SocketError errorCode = SocketPal.GetLingerOption(_handle, out lingerOption);
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::getLingerOpt() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::getLingerOpt() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -5331,7 +5331,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "getLingerOpt", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "getLingerOpt", socketException);
                 }
                 throw socketException;
             }
@@ -5345,7 +5345,7 @@ namespace System.Net.Sockets
             SocketError errorCode = SocketPal.GetMulticastOption(_handle, optionName, out multicastOption);
 
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::getMulticastOpt() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::getMulticastOpt() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -5355,7 +5355,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "getMulticastOpt", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "getMulticastOpt", socketException);
                 }
                 throw socketException;
             }
@@ -5369,7 +5369,7 @@ namespace System.Net.Sockets
             IPv6MulticastOption multicastOption;
             SocketError errorCode = SocketPal.GetIPv6MulticastOption(_handle, optionName, out multicastOption);
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::getIPv6MulticastOpt() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::getIPv6MulticastOpt() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -5379,7 +5379,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "getIPv6MulticastOpt", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "getIPv6MulticastOpt", socketException);
                 }
                 throw socketException;
             }
@@ -5391,11 +5391,11 @@ namespace System.Net.Sockets
         // error code, and will update internal state on success.
         private SocketError InternalSetBlocking(bool desired, out bool current)
         {
-            GlobalLog.Enter("Socket#" + Logging.HashString(this) + "::InternalSetBlocking", "desired:" + desired.ToString() + " willBlock:" + _willBlock.ToString() + " willBlockInternal:" + _willBlockInternal.ToString());
+            GlobalLog.Enter("Socket#" + LoggingHash.HashString(this) + "::InternalSetBlocking", "desired:" + desired.ToString() + " willBlock:" + _willBlock.ToString() + " willBlockInternal:" + _willBlockInternal.ToString());
 
             if (CleanedUp)
             {
-                GlobalLog.Leave("Socket#" + Logging.HashString(this) + "::InternalSetBlocking", "ObjectDisposed");
+                GlobalLog.Leave("Socket#" + LoggingHash.HashString(this) + "::InternalSetBlocking", "ObjectDisposed");
                 current = _willBlock;
                 return SocketError.Success;
             }
@@ -5412,7 +5412,7 @@ namespace System.Net.Sockets
                 errorCode = SocketError.NotSocket;
             }
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::InternalSetBlocking() Interop.Winsock.ioctlsocket returns errorCode:" + errorCode);
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::InternalSetBlocking() Interop.Winsock.ioctlsocket returns errorCode:" + errorCode);
 
             // We will update only internal state but only on successfull win32 call
             // so if the native call fails, the state will remain the same.
@@ -5421,7 +5421,7 @@ namespace System.Net.Sockets
                 _willBlockInternal = willBlock;
             }
 
-            GlobalLog.Leave("Socket#" + Logging.HashString(this) + "::InternalSetBlocking", "errorCode:" + errorCode.ToString() + " willBlock:" + _willBlock.ToString() + " willBlockInternal:" + _willBlockInternal.ToString());
+            GlobalLog.Leave("Socket#" + LoggingHash.HashString(this) + "::InternalSetBlocking", "errorCode:" + errorCode.ToString() + " willBlock:" + _willBlock.ToString() + " willBlockInternal:" + _willBlockInternal.ToString());
             current = _willBlockInternal;
             return errorCode;
         }
@@ -5439,7 +5439,7 @@ namespace System.Net.Sockets
         {
             if (s_loggingEnabled)
             {
-                Logging.Enter(Logging.Sockets, this, "BeginConnectEx", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginConnectEx", "");
             }
 
             // This will check the permissions for connect.
@@ -5451,7 +5451,7 @@ namespace System.Net.Sockets
             // called if _rightEndPoint is not null, of that the endpoint is an IPEndPoint.
             if (_rightEndPoint == null)
             {
-                GlobalLog.Assert(endPointSnapshot.GetType() == typeof(IPEndPoint), "Socket#{0}::BeginConnectEx()|Socket not bound and endpoint not IPEndPoint.", Logging.HashString(this));
+                GlobalLog.Assert(endPointSnapshot.GetType() == typeof(IPEndPoint), "Socket#{0}::BeginConnectEx()|Socket not bound and endpoint not IPEndPoint.", LoggingHash.HashString(this));
                 if (endPointSnapshot.AddressFamily == AddressFamily.InterNetwork)
                 {
                     InternalBind(new IPEndPoint(IPAddress.Any, 0));
@@ -5497,7 +5497,7 @@ namespace System.Net.Sockets
                 SetToConnected();
             }
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::BeginConnectEx() Interop.Winsock.connect returns:" + errorCode.ToString());
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginConnectEx() Interop.Winsock.connect returns:" + errorCode.ToString());
 
             errorCode = asyncResult.CheckAsyncCallOverlappedResult(errorCode);
 
@@ -5510,7 +5510,7 @@ namespace System.Net.Sockets
                 UpdateStatusAfterSocketError(socketException);
                 if (s_loggingEnabled)
                 {
-                    Logging.Exception(Logging.Sockets, this, "BeginConnectEx", socketException);
+                    NetEventSource.Exception(NetEventSource.ComponentType.Socket, this, "BeginConnectEx", socketException);
                 }
                 throw socketException;
             }
@@ -5519,10 +5519,10 @@ namespace System.Net.Sockets
             // This is a nop if the context isn't being flowed.
             asyncResult.FinishPostingAsyncOp(ref Caches.ConnectClosureCache);
 
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::BeginConnectEx() to:" + endPointSnapshot.ToString() + " returning AsyncResult:" + Logging.HashString(asyncResult));
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginConnectEx() to:" + endPointSnapshot.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
             if (s_loggingEnabled)
             {
-                Logging.Exit(Logging.Sockets, this, "BeginConnectEx", asyncResult);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginConnectEx", asyncResult);
             }
             return asyncResult;
         }
@@ -5796,7 +5796,7 @@ namespace System.Net.Sockets
             // some point in time update the perf counter as well.
             _isConnected = true;
             _isDisconnected = false;
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::SetToConnected() now connected.");
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetToConnected() now connected.");
             if (s_perfCountersEnabled)
             {
                 SocketPerfCounter.Instance.Increment(SocketPerfCounterName.SocketConnectionsEstablished);
@@ -5805,7 +5805,7 @@ namespace System.Net.Sockets
 
         internal void SetToDisconnected()
         {
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::SetToDisconnected()");
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetToDisconnected()");
             if (!_isConnected)
             {
                 // Socket was already disconnected.
@@ -5820,7 +5820,7 @@ namespace System.Net.Sockets
             if (!CleanedUp)
             {
                 // If socket is still alive cancel WSAEventSelect().
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::SetToDisconnected()");
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetToDisconnected()");
             }
         }
 
@@ -5836,10 +5836,10 @@ namespace System.Net.Sockets
         {
             // If we already know the socket is disconnected
             // we don't need to do anything else.
-            GlobalLog.Print("Socket#" + Logging.HashString(this) + "::UpdateStatusAfterSocketError(socketException)");
+            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::UpdateStatusAfterSocketError(socketException)");
             if (s_loggingEnabled)
             {
-                Logging.PrintError(Logging.Sockets, this, "UpdateStatusAfterSocketError", errorCode.ToString());
+                NetEventSource.PrintError(NetEventSource.ComponentType.Socket, this, "UpdateStatusAfterSocketError", errorCode.ToString());
             }
 
             if (_isConnected && (_handle.IsInvalid || (errorCode != SocketError.WouldBlock &&
@@ -5847,7 +5847,7 @@ namespace System.Net.Sockets
                     errorCode != SocketError.TimedOut)))
             {
                 // The socket is no longer a valid socket.
-                GlobalLog.Print("Socket#" + Logging.HashString(this) + "::UpdateStatusAfterSocketError(socketException) Invalidating socket.");
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::UpdateStatusAfterSocketError(socketException) Invalidating socket.");
                 SetToDisconnected();
             }
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -133,18 +133,18 @@ namespace System.Net.Sockets
             {
                 overlapped = boundHandle.AllocateNativeOverlapped(_preAllocatedOverlapped);
                 GlobalLog.Print(
-                    "SocketAsyncEventArgs#" + Logging.HashString(this) +
-                    "::boundHandle#" + Logging.HashString(boundHandle) +
+                    "SocketAsyncEventArgs#" + LoggingHash.HashString(this) +
+                    "::boundHandle#" + LoggingHash.HashString(boundHandle) +
                     "::AllocateNativeOverlapped(m_PreAllocatedOverlapped=" +
-                    Logging.HashString(_preAllocatedOverlapped) +
+                    LoggingHash.HashString(_preAllocatedOverlapped) +
                     "). Returned = " + ((IntPtr)overlapped).ToString("x"));
             }
             else
             {
                 overlapped = boundHandle.AllocateNativeOverlapped(CompletionPortCallback, this, null);
                 GlobalLog.Print(
-                    "SocketAsyncEventArgs#" + Logging.HashString(this) +
-                    "::boundHandle#" + Logging.HashString(boundHandle) +
+                    "SocketAsyncEventArgs#" + LoggingHash.HashString(this) +
+                    "::boundHandle#" + LoggingHash.HashString(boundHandle) +
                     "::AllocateNativeOverlapped(pinData=null)" +
                     "). Returned = " + ((IntPtr)overlapped).ToString("x"));
             }
@@ -866,9 +866,9 @@ namespace System.Net.Sockets
                 {
                     _preAllocatedOverlapped = new PreAllocatedOverlapped(CompletionPortCallback, this, _buffer);
                     GlobalLog.Print(
-                        "SocketAsyncEventArgs#" + Logging.HashString(this) +
+                        "SocketAsyncEventArgs#" + LoggingHash.HashString(this) +
                         "::SetupOverlappedSingle: new PreAllocatedOverlapped pinSingleBuffer=true, non-null buffer: " +
-                        Logging.HashString(_preAllocatedOverlapped));
+                        LoggingHash.HashString(_preAllocatedOverlapped));
 
                     _pinnedSingleBuffer = _buffer;
                     _pinnedSingleBufferOffset = _offset;
@@ -883,9 +883,9 @@ namespace System.Net.Sockets
                 {
                     _preAllocatedOverlapped = new PreAllocatedOverlapped(CompletionPortCallback, this, null);
                     GlobalLog.Print(
-                        "SocketAsyncEventArgs#" + Logging.HashString(this) +
+                        "SocketAsyncEventArgs#" + LoggingHash.HashString(this) +
                         "::SetupOverlappedSingle: new PreAllocatedOverlapped pinSingleBuffer=true, null buffer: " +
-                        Logging.HashString(_preAllocatedOverlapped));
+                        LoggingHash.HashString(_preAllocatedOverlapped));
 
                     _pinnedSingleBuffer = null;
                     _pinnedSingleBufferOffset = 0;
@@ -901,9 +901,9 @@ namespace System.Net.Sockets
             {
                 _preAllocatedOverlapped = new PreAllocatedOverlapped(CompletionPortCallback, this, _acceptBuffer);
                 GlobalLog.Print(
-                    "SocketAsyncEventArgs#" + Logging.HashString(this) +
+                    "SocketAsyncEventArgs#" + LoggingHash.HashString(this) +
                     "::SetupOverlappedSingle: new PreAllocatedOverlapped pinSingleBuffer=false: " +
-                    Logging.HashString(_preAllocatedOverlapped));
+                    LoggingHash.HashString(_preAllocatedOverlapped));
 
                 _pinnedAcceptBuffer = _acceptBuffer;
                 _ptrAcceptBuffer = Marshal.UnsafeAddrOfPinnedArrayElement(_acceptBuffer, 0);
@@ -939,8 +939,8 @@ namespace System.Net.Sockets
             // Pin buffers and fill in WSABuffer descriptor pointers and lengths.
             _preAllocatedOverlapped = new PreAllocatedOverlapped(CompletionPortCallback, this, _objectsToPin);
             GlobalLog.Print(
-                "SocketAsyncEventArgs#" + Logging.HashString(this) + "::SetupOverlappedMultiple: new PreAllocatedOverlapped." +
-                Logging.HashString(_preAllocatedOverlapped));
+                "SocketAsyncEventArgs#" + LoggingHash.HashString(this) + "::SetupOverlappedMultiple: new PreAllocatedOverlapped." +
+                LoggingHash.HashString(_preAllocatedOverlapped));
 
             for (int i = 0; i < tempList.Length; i++)
             {
@@ -983,8 +983,8 @@ namespace System.Net.Sockets
             // Pin buffers.
             _preAllocatedOverlapped = new PreAllocatedOverlapped(CompletionPortCallback, this, _objectsToPin);
             GlobalLog.Print(
-                "SocketAsyncEventArgs#" + Logging.HashString(this) + "::SetupOverlappedSendPackets: new PreAllocatedOverlapped: " +
-                Logging.HashString(_preAllocatedOverlapped));
+                "SocketAsyncEventArgs#" + LoggingHash.HashString(this) + "::SetupOverlappedSendPackets: new PreAllocatedOverlapped: " +
+                LoggingHash.HashString(_preAllocatedOverlapped));
 
             // Get pointer to native descriptor.
             _ptrSendPacketsDescriptor = Marshal.UnsafeAddrOfPinnedArrayElement(_sendPacketsDescriptor, 0);
@@ -1025,17 +1025,17 @@ namespace System.Net.Sockets
             switch (_pinState)
             {
                 case PinState.SingleAcceptBuffer:
-                    Logging.Dump(Logging.Sockets, _currentSocket, "FinishOperation(" + _completedOperation + "Async)", _acceptBuffer, 0, size);
+                    SocketsEventSource.Dump(_completedOperation, _acceptBuffer, 0, size);
                     break;
 
                 case PinState.SingleBuffer:
-                    Logging.Dump(Logging.Sockets, _currentSocket, "FinishOperation(" + _completedOperation + "Async)", _buffer, _offset, size);
+                    SocketsEventSource.Dump(_completedOperation, _buffer, _offset, size);
                     break;
 
                 case PinState.MultipleBuffer:
                     foreach (WSABuffer wsaBuffer in _wsaBufferArray)
                     {
-                        Logging.Dump(Logging.Sockets, _currentSocket, "FinishOperation(" + _completedOperation + "Async)", wsaBuffer.Pointer, Math.Min(wsaBuffer.Length, size));
+                        SocketsEventSource.Dump(_completedOperation, wsaBuffer.Pointer, Math.Min(wsaBuffer.Length, size));
                         if ((size -= wsaBuffer.Length) <= 0)
                         {
                             break;
@@ -1057,12 +1057,12 @@ namespace System.Net.Sockets
                     if (spe._buffer != null && spe._count > 0)
                     {
                         // This element is a buffer.
-                        Logging.Dump(Logging.Sockets, _currentSocket, "FinishOperation(" + _completedOperation + "Async)Buffer", spe._buffer, spe._offset, Math.Min(spe._count, size));
+                        SocketsEventSource.Dump(_completedOperation, spe._buffer, spe._offset, Math.Min(spe._count, size));
                     }
                     else if (spe._filePath != null)
                     {
                         // This element is a file.
-                        Logging.PrintInfo(Logging.Sockets, _currentSocket, "FinishOperation(" + _completedOperation + "Async)", SR.Format(SR.net_log_socket_not_logged_file, spe._filePath));
+                        SocketsEventSource.Log.NotLoggedFile(spe._filePath, LoggingHash.HashInt(_currentSocket), _completedOperation);
                     }
                 }
             }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -83,7 +83,7 @@ namespace System.Net.Sockets
 
         private MultipleConnectAsync _multipleConnect;
 
-        private static bool s_loggingEnabled = Logging.On;
+        private static bool s_loggingEnabled = SocketsEventSource.Log.IsEnabled();
 
         public SocketAsyncEventArgs()
         {
@@ -691,7 +691,7 @@ namespace System.Net.Sockets
                         _acceptSocket = _currentSocket.UpdateAcceptSocket(_acceptSocket, _currentSocket._rightEndPoint.Create(remoteSocketAddress));
 
                         if (s_loggingEnabled)
-                            Logging.PrintInfo(Logging.Sockets, _acceptSocket, SR.Format(SR.net_log_socket_accepted, _acceptSocket.RemoteEndPoint, _acceptSocket.LocalEndPoint));
+                            SocketsEventSource.Accepted(_acceptSocket, _acceptSocket.RemoteEndPoint, _acceptSocket.LocalEndPoint);
                     }
                     else
                     {
@@ -720,7 +720,7 @@ namespace System.Net.Sockets
                     if (socketError == SocketError.Success)
                     {
                         if (s_loggingEnabled)
-                            Logging.PrintInfo(Logging.Sockets, _currentSocket, SR.Format(SR.net_log_socket_connected, _currentSocket.LocalEndPoint, _currentSocket.RemoteEndPoint));
+                            SocketsEventSource.Connected(_currentSocket, _currentSocket.LocalEndPoint, _currentSocket.RemoteEndPoint);
 
                         _currentSocket.SetToConnected();
                         _connectSocket = _currentSocket;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
@@ -23,23 +23,23 @@ namespace System.Net.Sockets
         public TcpClient()
             : this(AddressFamily.InterNetwork)
         {
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Enter(Logging.Sockets, this, "TcpClient", null);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "TcpClient", null);
             }
 
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Exit(Logging.Sockets, this, "TcpClient", null);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "TcpClient", null);
             }
         }
 
         // Initializes a new instance of the System.Net.Sockets.TcpClient class.
         public TcpClient(AddressFamily family)
         {
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Enter(Logging.Sockets, this, "TcpClient", family);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "TcpClient", family);
             }
 
             // Validate parameter
@@ -51,25 +51,25 @@ namespace System.Net.Sockets
             _family = family;
 
             initialize();
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Exit(Logging.Sockets, this, "TcpClient", null);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "TcpClient", null);
             }
         }
 
         // Used by TcpListener.Accept().
         internal TcpClient(Socket acceptedSocket)
         {
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Enter(Logging.Sockets, this, "TcpClient", acceptedSocket);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "TcpClient", acceptedSocket);
             }
 
             Client = acceptedSocket;
             _active = true;
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Exit(Logging.Sockets, this, "TcpClient", null);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "TcpClient", null);
             }
         }
 
@@ -115,15 +115,15 @@ namespace System.Net.Sockets
 
         internal IAsyncResult BeginConnect(string host, int port, AsyncCallback requestCallback, object state)
         {
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Enter(Logging.Sockets, this, "BeginConnect", host);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginConnect", host);
             }
 
             IAsyncResult result = Client.BeginConnect(host, port, requestCallback, state);
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Exit(Logging.Sockets, this, "BeginConnect", null);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginConnect", null);
             }
 
             return result;
@@ -131,15 +131,15 @@ namespace System.Net.Sockets
 
         internal IAsyncResult BeginConnect(IPAddress address, int port, AsyncCallback requestCallback, object state)
         {
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Enter(Logging.Sockets, this, "BeginConnect", address);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginConnect", address);
             }
 
             IAsyncResult result = Client.BeginConnect(address, port, requestCallback, state);
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Exit(Logging.Sockets, this, "BeginConnect", null);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginConnect", null);
             }
 
             return result;
@@ -147,15 +147,15 @@ namespace System.Net.Sockets
 
         internal IAsyncResult BeginConnect(IPAddress[] addresses, int port, AsyncCallback requestCallback, object state)
         {
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Enter(Logging.Sockets, this, "BeginConnect", addresses);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginConnect", addresses);
             }
 
             IAsyncResult result = Client.BeginConnect(addresses, port, requestCallback, state);
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Exit(Logging.Sockets, this, "BeginConnect", null);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginConnect", null);
             }
 
             return result;
@@ -163,16 +163,16 @@ namespace System.Net.Sockets
 
         internal void EndConnect(IAsyncResult asyncResult)
         {
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Enter(Logging.Sockets, this, "EndConnect", asyncResult);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "EndConnect", asyncResult);
             }
 
             Client.EndConnect(asyncResult);
             _active = true;
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Exit(Logging.Sockets, this, "EndConnect", null);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "EndConnect", null);
             }
         }
 
@@ -209,9 +209,9 @@ namespace System.Net.Sockets
         // Returns the stream used to read and write data to the remote host.
         public NetworkStream GetStream()
         {
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Enter(Logging.Sockets, this, "GetStream", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "GetStream", "");
             }
 
             if (_cleanedUp)
@@ -228,9 +228,9 @@ namespace System.Net.Sockets
                 _dataStream = new NetworkStream(Client, true);
             }
 
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Exit(Logging.Sockets, this, "GetStream", _dataStream);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "GetStream", _dataStream);
             }
 
             return _dataStream;
@@ -241,16 +241,16 @@ namespace System.Net.Sockets
         // Disposes the Tcp connection.
         protected virtual void Dispose(bool disposing)
         {
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Enter(Logging.Sockets, this, "Dispose", "");
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Dispose", "");
             }
 
             if (_cleanedUp)
             {
-                if (Logging.On)
+                if (NetEventSource.Log.IsEnabled())
                 {
-                    Logging.Exit(Logging.Sockets, this, "Dispose", "");
+                    NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Dispose", "");
                 }
 
                 return;
@@ -288,9 +288,9 @@ namespace System.Net.Sockets
             }
 
             _cleanedUp = true;
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Exit(Logging.Sockets, this, "Dispose", "");
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Dispose", "");
             }
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
@@ -20,9 +20,9 @@ namespace System.Net.Sockets
         // Initializes a new instance of the TcpListener class with the specified local end point.
         public TcpListener(IPEndPoint localEP)
         {
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Enter(Logging.Sockets, this, "TcpListener", localEP);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "TcpListener", localEP);
             }
 
             if (localEP == null)
@@ -31,9 +31,9 @@ namespace System.Net.Sockets
             }
             _serverSocketEP = localEP;
             _serverSocket = new Socket(_serverSocketEP.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Exit(Logging.Sockets, this, "TcpListener", null);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "TcpListener", null);
             }
         }
 
@@ -41,9 +41,9 @@ namespace System.Net.Sockets
         // and port.
         public TcpListener(IPAddress localaddr, int port)
         {
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Enter(Logging.Sockets, this, "TcpListener", localaddr);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "TcpListener", localaddr);
             }
 
             if (localaddr == null)
@@ -57,9 +57,9 @@ namespace System.Net.Sockets
 
             _serverSocketEP = new IPEndPoint(localaddr, port);
             _serverSocket = new Socket(_serverSocketEP.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Exit(Logging.Sockets, this, "TcpListener", null);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "TcpListener", null);
             }
         }
 
@@ -122,9 +122,9 @@ namespace System.Net.Sockets
                 throw new ArgumentOutOfRangeException("backlog");
             }
 
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Enter(Logging.Sockets, this, "Start", null);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Start", null);
             }
 
             GlobalLog.Print("TCPListener::Start()");
@@ -137,9 +137,9 @@ namespace System.Net.Sockets
             // Already listening.
             if (_active)
             {
-                if (Logging.On)
+                if (NetEventSource.Log.IsEnabled())
                 {
-                    Logging.Exit(Logging.Sockets, this, "Start", null);
+                    NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Start", null);
                 }
 
                 return;
@@ -158,18 +158,18 @@ namespace System.Net.Sockets
             }
 
             _active = true;
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Exit(Logging.Sockets, this, "Start", null);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Start", null);
             }
         }
 
         // Closes the network connection.
         public void Stop()
         {
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Enter(Logging.Sockets, this, "Stop", null);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Stop", null);
             }
 
             GlobalLog.Print("TCPListener::Stop()");
@@ -188,9 +188,9 @@ namespace System.Net.Sockets
                 _serverSocket.ExclusiveAddressUse = true;
             }
 
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Exit(Logging.Sockets, this, "Stop", null);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Stop", null);
             }
         }
 
@@ -207,9 +207,9 @@ namespace System.Net.Sockets
 
         internal IAsyncResult BeginAcceptSocket(AsyncCallback callback, object state)
         {
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Enter(Logging.Sockets, this, "BeginAcceptSocket", null);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginAcceptSocket", null);
             }
 
             if (!_active)
@@ -218,9 +218,9 @@ namespace System.Net.Sockets
             }
 
             IAsyncResult result = _serverSocket.BeginAccept(callback, state);
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Exit(Logging.Sockets, this, "BeginAcceptSocket", null);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginAcceptSocket", null);
             }
 
             return result;
@@ -228,9 +228,9 @@ namespace System.Net.Sockets
 
         internal Socket EndAcceptSocket(IAsyncResult asyncResult)
         {
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Enter(Logging.Sockets, this, "EndAcceptSocket", null);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "EndAcceptSocket", null);
             }
 
             if (asyncResult == null)
@@ -248,9 +248,9 @@ namespace System.Net.Sockets
             // This will throw ObjectDisposedException if Stop() has been called.
             Socket socket = asyncSocket.EndAccept(asyncResult);
 
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Exit(Logging.Sockets, this, "EndAcceptSocket", socket);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "EndAcceptSocket", socket);
             }
 
             return socket;
@@ -258,9 +258,9 @@ namespace System.Net.Sockets
 
         internal IAsyncResult BeginAcceptTcpClient(AsyncCallback callback, object state)
         {
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Enter(Logging.Sockets, this, "BeginAcceptTcpClient", null);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginAcceptTcpClient", null);
             }
 
             if (!_active)
@@ -269,9 +269,9 @@ namespace System.Net.Sockets
             }
 
             IAsyncResult result = _serverSocket.BeginAccept(callback, state);
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Exit(Logging.Sockets, this, "BeginAcceptTcpClient", null);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginAcceptTcpClient", null);
             }
 
             return result;
@@ -279,9 +279,9 @@ namespace System.Net.Sockets
 
         internal TcpClient EndAcceptTcpClient(IAsyncResult asyncResult)
         {
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Enter(Logging.Sockets, this, "EndAcceptTcpClient", null);
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "EndAcceptTcpClient", null);
             }
 
             if (asyncResult == null)
@@ -299,9 +299,9 @@ namespace System.Net.Sockets
             // This will throw ObjectDisposedException if Stop() has been called.
             Socket socket = asyncSocket.EndAccept(asyncResult);
 
-            if (Logging.On)
+            if (NetEventSource.Log.IsEnabled())
             {
-                Logging.Exit(Logging.Sockets, this, "EndAcceptTcpClient", socket);
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "EndAcceptTcpClient", socket);
             }
 
             return new TcpClient(socket);


### PR DESCRIPTION
Adding EventSources to substitute the previous logging model using
TraceSources.

In this PR 4 event sources are added:

-NetEventSource
-SocketsEventSource
-HttpEventSource
-SecurityEventSource

Event methods for NetEventSource, SocketsEventSource and HttpEventSource
are fully added. SecurityEventSource has only a few of
the new event methods implemented.
Changes in production code are done to match this new implementation.
(Only changes for events in Sockets, Http are fully done in this iteration).