### PR TITLE
Update S.R.InteropServices.WindowsRuntime targets

### DIFF
--- a/src/System.Runtime.InteropServices.WindowsRuntime/src/System.Runtime.InteropServices.WindowsRuntime.builds
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/src/System.Runtime.InteropServices.WindowsRuntime.builds
@@ -3,10 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Runtime.InteropServices.WindowsRuntime.csproj" Condition="'$(TargetsWindows)' == 'true'">
-      <AdditionalProperties>TargetGroup=netcore50aot</AdditionalProperties>
+      <AdditionalProperties>TargetGroup=</AdditionalProperties>
     </Project>
     <Project Include="System.Runtime.InteropServices.WindowsRuntime.csproj" Condition="'$(TargetsWindows)' == 'true'">
-      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties>
+      <AdditionalProperties>TargetGroup=netcore50aot</AdditionalProperties>
     </Project>
     <Project Include="System.Runtime.InteropServices.WindowsRuntime.csproj" Condition="'$(TargetsWindows)' == 'true'">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>

--- a/src/System.Runtime.InteropServices.WindowsRuntime/src/System.Runtime.InteropServices.WindowsRuntime.csproj
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/src/System.Runtime.InteropServices.WindowsRuntime.csproj
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <!-- Setting default TargetGroup before importing dir.prop -->
-    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50aot</TargetGroup>
+    <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
@@ -11,25 +10,24 @@
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">dotnet5.4</PackageTargetFramework>
+    <PackageTargetRuntime>win8</PackageTargetRuntime>
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50aot_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
 
-  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
-    <ProjectJson>netcore50aot\project.json</ProjectJson>
-    <ProjectLockJson>netcore50aot\project.lock.json</ProjectLockJson>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
-    <TargetingPackReference Include="System.Private.CoreLib" Condition="'$(TargetGroup)' == 'netcore50aot'" />
-    <TargetingPackReference Include="System.Private.Interop" Condition="'$(TargetGroup)' == 'netcore50aot'" />
+  <ItemGroup Condition="'$(TargetGroup)' != 'netcore50aot'">
+    <TargetingPackReference Include="mscorlib" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
+    <TargetingPackReference Include="System.Private.CoreLib" />
+    <TargetingPackReference Include="System.Private.Interop" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Runtime.InteropServices.WindowsRuntime/src/netcore50aot/project.json
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/src/netcore50aot/project.json
@@ -1,9 +1,0 @@
-{
-    "frameworks": {
-        "netcore50": {
-            "dependencies": {
-                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
-            }
-        }
-    }
-}

--- a/src/System.Runtime.InteropServices.WindowsRuntime/src/project.json
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/src/project.json
@@ -1,13 +1,18 @@
 {
   "frameworks": {
+    "dotnet5.4": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23607"
+      }
+    },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
       }
     },
     "net46": {
       "dependencies": {
-        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0"
       }
     }
   }


### PR DESCRIPTION
Update it so that it targets dotnet5.4 for Win8 when on CoreCLR.

cc @pallavit @ericstj 

This is blocking my other build work so I'm going ahead and fixing it in master. 