### PR TITLE
Correctly decode an empty value RDN on Unix.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.Print.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.Print.cs
@@ -60,6 +60,11 @@ internal static partial class Interop
                     throw CreateOpenSslCryptographicException();
                 }
 
+                if (len == 0)
+                {
+                    return "";
+                }
+
                 int bioSize = GetMemoryBioSize(bio);
                 utf8Bytes = new byte[bioSize + 1];
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/X500NameEncoder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/X500NameEncoder.cs
@@ -155,7 +155,7 @@ namespace Internal.Cryptography.Pal
         {
             if (string.IsNullOrEmpty(rdnValue))
             {
-                return false;
+                return true;
             }
 
             if (IsQuotableWhitespace(rdnValue[0]) ||

--- a/src/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameTests.cs
@@ -276,6 +276,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         public static readonly object[][] QuotedContentsCases =
         {
+            // Empty value
+            new object[]
+            {
+                "CN=\"\"",
+                "300B3109300706035504031300"
+            },
+
             // Comma (RDN separator)
             new object[]
             {


### PR DESCRIPTION
When Asn1StringPrintEx returns 0 the answer is the empty string, rather than to continue trying to do work.

And Windows considers the empty RDN value quotable.

Added the empty string to the quoted contents decoding suite.

Fixes #5102.