### PR TITLE
Port List.Reverse changes from CoreCLR

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/List.cs
+++ b/src/System.Collections/src/System/Collections/Generic/List.cs
@@ -1033,9 +1033,6 @@ namespace System.Collections.Generic
         // which was previously located at index i will now be located at
         // index index + (index + count - i - 1).
         // 
-        // This method uses the Array.Reverse method to reverse the
-        // elements.
-        // 
         public void Reverse(int index, int count)
         {
             if (index < 0)
@@ -1051,13 +1048,19 @@ namespace System.Collections.Generic
             if (_size - index < count)
                 throw new ArgumentException(SR.Argument_InvalidOffLen);
             Contract.EndContractBlock();
+
+            // The non-generic Array.Reverse is not used because it does not perform
+            // well for non-primitive value types.
+            // If/when a generic Array.Reverse<T> becomes available, the below code
+            // can be deleted and replaced with a call to Array.Reverse<T>.
             int i = index;
             int j = index + count - 1;
+            T[] array = _items;
             while (i < j)
             {
-                T temp = _items[i];
-                _items[i] = _items[j];
-                _items[j] = temp;
+                T temp = array[i];
+                array[i] = array[j];
+                array[j] = temp;
                 i++;
                 j--;
             }


### PR DESCRIPTION
Port dotnet/coreclr#1231 to CoreRT/.NET Native clone of List.

---

The CoreRT/.NET Native clone already had its own implementation of `Reverse` similar to the changes made in CoreCLR, the only differences are some comments and the CoreRT/.NET Native clone was operating on the `_items` field directly instead of using a local variable. This PR aligns the two implementations.