### PR TITLE
Remove dead code from RSA

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSA.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/RSA.cs
@@ -19,24 +19,6 @@ namespace System.Security.Cryptography
         protected abstract byte[] HashData(byte[] data, int offset, int count, HashAlgorithmName hashAlgorithm);
         protected abstract byte[] HashData(Stream data, HashAlgorithmName hashAlgorithm);
 
-        //Implementing this in the derived class. This was implemented in AsymmetricAlgorithm
-        // earlier. Now it is expected that class deriving from AsymmetricAlgorithm will implement this
-        protected KeySizes[] _legalKeySizesValue;
-        public override KeySizes[] LegalKeySizes
-        {
-            get
-            {
-                if (null != _legalKeySizesValue)
-                {
-                    return _legalKeySizesValue.CloneKeySizesArray();
-                }
-                else
-                {
-                    return null;
-                }
-            }
-        }
-
         public byte[] SignData(byte[] data, HashAlgorithmName hashAlgorithm, RSASignaturePadding padding)
         {
             if (data == null)


### PR DESCRIPTION
_legalKeySizesValue isn't in the contract, and no implementations of RSA exist within the Algorithms library, so no one is capable of setting it.

The net result is that the derived types are already re-overriding it, and not calling base, so this is a wasted field and wasted property.