### PR TITLE
Add packages for remaining native shims

### DIFF
--- a/dir.traversal.targets
+++ b/dir.traversal.targets
@@ -17,6 +17,9 @@
         <AdditionalProperties Condition="'%(Project.OSGroup)'!=''">OSGroup=%(Project.OSGroup);%(Project.AdditionalProperties)</AdditionalProperties>
       </Project>
       <Project>
+        <AdditionalProperties Condition="'%(Project.Platform)'!=''">Platform=%(Project.Platform);%(Project.AdditionalProperties)</AdditionalProperties>
+      </Project>
+      <Project>
         <AdditionalProperties Condition="'%(Project.FilterToOSGroup)'!=''">FilterToOSGroup=%(Project.FilterToOSGroup);%(Project.AdditionalProperties)</AdditionalProperties>
       </Project>
       <Project>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/centos/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/centos/runtime.native.System.IO.Compression.pkgproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>1.0.1</Version>
+    <PackageTargetRuntime>centos.7.1-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <File Include="$(CentOSNativePath)\System.IO.Compression.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/osx/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/osx/runtime.native.System.IO.Compression.pkgproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <Version>1.0.1</Version>
+    <PackageTargetRuntime>osx.10.10-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <File Include="$(OSXNativePath)\System.IO.Compression.Native.dylib">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
@@ -3,10 +3,34 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="runtime.native.System.IO.Compression.pkgproj"/>
-    <Project Condition="'$(TargetsCentOS)' == 'true'" Include="centos\runtime.native.System.IO.Compression.pkgproj"/>
-    <Project Condition="'$(TargetsLinux)' == 'true'" Include="ubuntu\runtime.native.System.IO.Compression.pkgproj"/>
-    <Project Condition="'$(TargetsOSX)' == 'true'" Include="osx\runtime.native.System.IO.Compression.pkgproj"/>
-    <Project Condition="'$(TargetsWindows)' == 'true'" Include="win\runtime.native.System.IO.Compression.pkgproj"/>
+    <Project Include="centos\runtime.native.System.IO.Compression.pkgproj">
+      <!-- currently we build both "centos" and "ubuntu" packages on Linux,
+           but will only publish one of the packages based on what OS we
+           were actually building on.  
+           Remove this when fixing https://github.com/dotnet/corefx/issues/5190 -->
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="ubuntu\runtime.native.System.IO.Compression.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="osx\runtime.native.System.IO.Compression.pkgproj">
+      <OSGroup>OSX</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="win\runtime.native.System.IO.Compression.pkgproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <Platform>x86</Platform>
+    </Project>
+    <Project Include="win\runtime.native.System.IO.Compression.pkgproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="win\runtime.native.System.IO.Compression.pkgproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <Platform>arm</Platform>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.builds
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="runtime.native.System.IO.Compression.pkgproj"/>
+    <Project Condition="'$(TargetsCentOS)' == 'true'" Include="centos\runtime.native.System.IO.Compression.pkgproj"/>
+    <Project Condition="'$(TargetsLinux)' == 'true'" Include="ubuntu\runtime.native.System.IO.Compression.pkgproj"/>
+    <Project Condition="'$(TargetsOSX)' == 'true'" Include="osx\runtime.native.System.IO.Compression.pkgproj"/>
+    <Project Condition="'$(TargetsWindows)' == 'true'" Include="win\runtime.native.System.IO.Compression.pkgproj"/>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/runtime.native.System.IO.Compression.pkgproj
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>4.1.0</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <SkipValidatePackage>true</SkipValidatePackage>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="centos\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="osx\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="win\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="win\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>arm</Platform>
+    </ProjectReference>
+    <ProjectReference Include="win\runtime.native.System.IO.Compression.pkgproj">
+      <Platform>x86</Platform>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/ubuntu/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/ubuntu/runtime.native.System.IO.Compression.pkgproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>1.0.1</Version>
+    <PackageTargetRuntime>ubuntu.14.04-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <File Include="$(UbuntuNativePath)\System.IO.Compression.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.IO.Compression/win/runtime.native.System.IO.Compression.pkgproj
+++ b/src/Native/pkg/runtime.native.System.IO.Compression/win/runtime.native.System.IO.Compression.pkgproj
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>4.0.1</Version>
+    <PackageTargetRuntime>win7-$(PackagePlatform)</PackageTargetRuntime>
+  </PropertyGroup>
+
+  <!-- These paths are not built in CoreFx, enable when fixing https://github.com/dotnet/corefx/issues/826 -->
+  <ItemGroup Condition="Exists('$(OutputRootPath)ProjectK')">
+    <File Include="$(OutputRootPath)ProjectK\Runtime\clrcompression.dll">
+      <TargetPath>runtimes/win7-$(PackagePlatform)/native</TargetPath>
+    </File>
+    <!-- use Win10 temporarily as the distinguishing factor, in reality the distinction is app-container vs not. -->
+    <File Include="$(OutputRootPath)NetCoreForCoreCLR\native\clrcompression.dll">
+      <TargetPath>runtimes/win10-$(PackagePlatform)/native</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Net.Http/centos/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/centos/runtime.native.System.Net.Http.pkgproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>1.0.1</Version>
+    <PackageTargetRuntime>centos.7.1-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <File Include="$(CentOSNativePath)\System.Net.Http.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Net.Http/osx/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/osx/runtime.native.System.Net.Http.pkgproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <Version>1.0.1</Version>
+    <PackageTargetRuntime>osx.10.10-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <File Include="$(OSXNativePath)\System.Net.Http.Native.dylib">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.builds
+++ b/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.builds
@@ -3,9 +3,22 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="runtime.native.System.Net.Http.pkgproj"/>
-    <Project Condition="'$(TargetsCentOS)' == 'true'" Include="centos\runtime.native.System.Net.Http.pkgproj"/>
-    <Project Condition="'$(TargetsLinux)' == 'true'" Include="ubuntu\runtime.native.System.Net.Http.pkgproj"/>
-    <Project Condition="'$(TargetsOSX)' == 'true'" Include="osx\runtime.native.System.Net.Http.pkgproj"/>
+    <Project Include="centos\runtime.native.System.Net.Http.pkgproj">
+      <!-- currently we build both "centos" and "ubuntu" packages on Linux,
+           but will only publish one of the packages based on what OS we
+           were actually building on.  
+           Remove this when fixing https://github.com/dotnet/corefx/issues/5190 -->
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="ubuntu\runtime.native.System.Net.Http.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="osx\runtime.native.System.Net.Http.pkgproj">
+      <OSGroup>OSX</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.builds
+++ b/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.builds
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="runtime.native.System.Net.Http.pkgproj"/>
+    <Project Condition="'$(TargetsCentOS)' == 'true'" Include="centos\runtime.native.System.Net.Http.pkgproj"/>
+    <Project Condition="'$(TargetsLinux)' == 'true'" Include="ubuntu\runtime.native.System.Net.Http.pkgproj"/>
+    <Project Condition="'$(TargetsOSX)' == 'true'" Include="osx\runtime.native.System.Net.Http.pkgproj"/>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/runtime.native.System.Net.Http.pkgproj
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>4.0.1</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <SkipValidatePackage>true</SkipValidatePackage>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="centos\runtime.native.System.Net.Http.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="osx\runtime.native.System.Net.Http.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\runtime.native.System.Net.Http.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Net.Http/ubuntu/runtime.native.System.Net.Http.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Net.Http/ubuntu/runtime.native.System.Net.Http.pkgproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>1.0.1</Version>
+    <PackageTargetRuntime>ubuntu.14.04-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <File Include="$(UbuntuNativePath)\System.Net.Http.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/centos/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/centos/runtime.native.System.Security.Cryptography.pkgproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>1.0.1</Version>
+    <PackageTargetRuntime>centos.7.1-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <File Include="$(CentOSNativePath)\System.Security.Cryptography.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/osx/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/osx/runtime.native.System.Security.Cryptography.pkgproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <Version>1.0.1</Version>
+    <PackageTargetRuntime>osx.10.10-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <File Include="$(OSXNativePath)\System.Security.Cryptography.Native.dylib">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.builds
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.builds
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="runtime.native.System.Security.Cryptography.pkgproj"/>
+    <Project Condition="'$(TargetsCentOS)' == 'true'" Include="centos\runtime.native.System.Security.Cryptography.pkgproj"/>
+    <Project Condition="'$(TargetsLinux)' == 'true'" Include="ubuntu\runtime.native.System.Security.Cryptography.pkgproj"/>
+    <Project Condition="'$(TargetsOSX)' == 'true'" Include="osx\runtime.native.System.Security.Cryptography.pkgproj"/>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.builds
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.builds
@@ -3,9 +3,22 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="runtime.native.System.Security.Cryptography.pkgproj"/>
-    <Project Condition="'$(TargetsCentOS)' == 'true'" Include="centos\runtime.native.System.Security.Cryptography.pkgproj"/>
-    <Project Condition="'$(TargetsLinux)' == 'true'" Include="ubuntu\runtime.native.System.Security.Cryptography.pkgproj"/>
-    <Project Condition="'$(TargetsOSX)' == 'true'" Include="osx\runtime.native.System.Security.Cryptography.pkgproj"/>
+    <Project Include="centos\runtime.native.System.Security.Cryptography.pkgproj">
+      <!-- currently we build both "centos" and "ubuntu" packages on Linux,
+           but will only publish one of the packages based on what OS we
+           were actually building on.  
+           Remove this when fixing https://github.com/dotnet/corefx/issues/5190 -->
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="ubuntu\runtime.native.System.Security.Cryptography.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="osx\runtime.native.System.Security.Cryptography.pkgproj">
+      <OSGroup>OSX</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/runtime.native.System.Security.Cryptography.pkgproj
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>4.0.0</Version>
+    <SkipPackageFileCheck>true</SkipPackageFileCheck>
+    <SkipValidatePackage>true</SkipValidatePackage>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="centos\runtime.native.System.Security.Cryptography.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="osx\runtime.native.System.Security.Cryptography.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+    <ProjectReference Include="ubuntu\runtime.native.System.Security.Cryptography.pkgproj">
+      <Platform>amd64</Platform>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/runtime.native.System.Security.Cryptography.pkgproj
+++ b/src/Native/pkg/runtime.native.System.Security.Cryptography/ubuntu/runtime.native.System.Security.Cryptography.pkgproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <PropertyGroup>
+    <Version>1.0.1</Version>
+    <PackageTargetRuntime>ubuntu.14.04-$(PackagePlatform)</PackageTargetRuntime>
+    <!-- only build for x64 -->
+    <PackagePlatforms>x64;</PackagePlatforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <File Include="$(UbuntuNativePath)\System.Security.Cryptography.Native.so">
+      <TargetPath>runtimes/$(PackageTargetRuntime)/native</TargetPath>
+    </File>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Native/pkg/runtime.native.System/runtime.native.System.builds
+++ b/src/Native/pkg/runtime.native.System/runtime.native.System.builds
@@ -3,9 +3,22 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="runtime.native.System.pkgproj"/>
-    <Project Condition="'$(TargetsCentOS)' == 'true'" Include="centos\runtime.native.System.pkgproj"/>
-    <Project Condition="'$(TargetsLinux)' == 'true'" Include="ubuntu\runtime.native.System.pkgproj"/>
-    <Project Condition="'$(TargetsOSX)' == 'true'" Include="osx\runtime.native.System.pkgproj"/>
+    <Project Include="centos\runtime.native.System.pkgproj">
+      <!-- currently we build both "centos" and "ubuntu" packages on Linux,
+           but will only publish one of the packages based on what OS we
+           were actually building on.  
+           Remove this when fixing https://github.com/dotnet/corefx/issues/5190 -->
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="ubuntu\runtime.native.System.pkgproj">
+      <OSGroup>Linux</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
+    <Project Include="osx\runtime.native.System.pkgproj">
+      <OSGroup>OSX</OSGroup>
+      <Platform>amd64</Platform>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/packages.builds
+++ b/src/packages.builds
@@ -2,7 +2,11 @@
 <Project ToolsVersion="12.0" DefaultTargets="BuildAndTest" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="*\pkg\**\*.builds" />
+    <Project Include="Native\pkg\**\*.builds">
+      <AdditionalProperties>SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
+    </Project>
+    <Project Include="*\pkg\*.builds" />
   </ItemGroup>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>


### PR DESCRIPTION
This change moves the remaining native shim projects
into corefx from TFS.  rt.native.System.IO.Compression
still  refers to internal paths (conditioned on existence)
until clrcompression is moved to the open.

/cc @weshaggard @chcosta 