### PR TITLE
Make Windows-Specific cert properties throw PNSE on Unix.

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509CertificateReader.cs
@@ -165,13 +165,21 @@ namespace Internal.Cryptography.Pal
         public bool Archived
         {
             get { return false; }
-            set { throw new NotImplementedException(); }
+            set
+            {
+                throw new PlatformNotSupportedException(
+                    SR.Format(SR.Cryptography_Unix_X509_PropertyNotSettable, "Archived"));
+            }
         }
 
         public string FriendlyName
         {
             get { return ""; }
-            set { throw new NotImplementedException(); }
+            set
+            {
+                throw new PlatformNotSupportedException(
+                  SR.Format(SR.Cryptography_Unix_X509_PropertyNotSettable, "FriendlyName"));
+            }
         }
 
         public X500DistinguishedName SubjectName

--- a/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -174,6 +174,9 @@
   <data name="Cryptography_Unix_X509_MachineStoresRootOnly" xml:space="preserve">
     <value>Unix LocalMachine X509Store is limited to the Root and CertificateAuthority stores.</value>
   </data>
+  <data name="Cryptography_Unix_X509_PropertyNotSettable" xml:space="preserve">
+      <value>The {0} value cannot be set on Unix.</value>
+  </data>
   <data name="Cryptography_Unix_X509_SerializedExport" xml:space="preserve">
     <value>X509ContentType.SerializedCert and X509ContentType.SerializedStore are not supported on Unix.</value>
   </data>


### PR DESCRIPTION
The Archived and FriendlyName properties are implementation details of the Windows Certificate Store, and have no equivalent on Unix.  These properties were initially filled in with NotImplementedException, and that's now being replaced with PlatformNotSupportedException since there is no plan to make these properties have a semantic interpretation for 1.0.0-rtm (or, at this point, beyond).

Partial fix for #1993.