### PR TITLE
Remove dead method PfxToCollection.

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
@@ -185,20 +185,6 @@ namespace Internal.Cryptography.Pal
             return new OpenSslX509StoreProvider(coll);
         }
 
-        private static IStorePal PfxToCollection(OpenSslPkcs12Reader pfx, string password)
-        {
-            pfx.Decrypt(password);
-
-            X509Certificate2Collection coll = new X509Certificate2Collection();
-
-            foreach (OpenSslX509CertificateReader certPal in pfx.ReadCertificates())
-            {
-                coll.Add(new X509Certificate2(certPal));
-            }
-
-            return new OpenSslX509StoreProvider(coll);
-        }
-
         private static IStorePal CloneStore(X509Certificate2Collection seed)
         {
             X509Certificate2Collection coll = new X509Certificate2Collection();


### PR DESCRIPTION
This method was added in commit a8f70ba3814aaf6f324af278306a4ad4222bc376, and then in a2cef285f05061860ad2863aad45ef3a1edf2d93 (less than a month later) a more generalized form of this method was made, and the only call removed.