### PR TITLE
Make SslStream::RemoteCertificate return an X509Certificate2 object.

### DIFF
--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslStream.cs
@@ -262,7 +262,7 @@ namespace System.Net.Security
                 object chkCertificateOrBytes = _remoteCertificateOrBytes;
                 if (chkCertificateOrBytes != null && chkCertificateOrBytes.GetType() == typeof(byte[]))
                 {
-                    return (X509Certificate)(_remoteCertificateOrBytes = new X509Certificate((byte[])chkCertificateOrBytes));
+                    return (X509Certificate)(_remoteCertificateOrBytes = new X509Certificate2((byte[])chkCertificateOrBytes));
                 }
                 else
                 {


### PR DESCRIPTION
This is the only place in all of corefx (outside of the X509Certificates tests) that instantiates an X509Certificate object (instead of an X509Certificate2).

Since the property still return an X509Certificate(1), the callers would have to cast it to use the X509Certificate2-only properties, but now an `as` will suffice, whereas before it required an up-converting operation.

This should alleviate the user concern from #4510.
cc: @CIPop @davidsh