### PR TITLE
Change Configuration to ConfigurationGroup in our build and test scripts

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -84,13 +84,13 @@ def targetNugetRuntimeMap = ['OSX' : 'osx.10.10-x64',
 def osShortName = ['Windows 10': 'win10', 'Windows 7' : 'win7', 'Windows_NT' : 'windows_nt']
 [true, false].each { isPR ->
     ['Windows 10', 'Windows 7', 'Windows_NT'].each { os ->
-        ['Debug', 'Release'].each { configuration ->
+        ['Debug', 'Release'].each { configurationGroup ->
 
-            def newJobName = "outerloop_${osShortName[os]}_${configuration.toLowerCase()}"
+            def newJobName = "outerloop_${osShortName[os]}_${configurationGroup.toLowerCase()}"
 
             def newJob = job(Utilities.getFullJobName(project, newJobName, isPR)) {
                 steps {
-                    batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && Build.cmd /p:Configuration=${configuration} /p:WithCategories=\"InnerLoop;OuterLoop\" /p:TestWithLocalLibraries=true")
+                    batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && Build.cmd /p:ConfigurationGroup=${configurationGroup} /p:WithCategories=\"InnerLoop;OuterLoop\" /p:TestWithLocalLibraries=true")
                 }
             }
 
@@ -105,7 +105,7 @@ def osShortName = ['Windows 10': 'win10', 'Windows 7' : 'win7', 'Windows_NT' : '
             if (isPR) {
                 // Set PR trigger.
                 // TODO: More elaborate regex trigger?
-                Utilities.addGithubPRTrigger(newJob, "OuterLoop ${os} ${configuration}", "(?i).*test\\W+outerloop.*")
+                Utilities.addGithubPRTrigger(newJob, "OuterLoop ${os} ${configurationGroup}", "(?i).*test\\W+outerloop.*")
             }
             else {
                 // Set a periodic trigger
@@ -122,7 +122,7 @@ def osShortName = ['Windows 10': 'win10', 'Windows 7' : 'win7', 'Windows_NT' : '
 
 def innerLoopNonWindowsOSs = ['Ubuntu', 'Debian8.2', 'OSX', 'FreeBSD', 'CentOS7.1', 'OpenSUSE13.2']
 [true, false].each { isPR ->
-    ['Debug', 'Release'].each { configuration ->
+    ['Debug', 'Release'].each { configurationGroup ->
         innerLoopNonWindowsOSs.each { os ->
             def osGroup = osGroupMap[os]
             
@@ -130,11 +130,11 @@ def innerLoopNonWindowsOSs = ['Ubuntu', 'Debian8.2', 'OSX', 'FreeBSD', 'CentOS7.
             // First define the nativecomp build
             //
             
-            def newNativeCompBuildJobName = "nativecomp_${os.toLowerCase()}_${configuration.toLowerCase()}"
+            def newNativeCompBuildJobName = "nativecomp_${os.toLowerCase()}_${configurationGroup.toLowerCase()}"
             
             def newNativeCompJob = job(Utilities.getFullJobName(project, newNativeCompBuildJobName, isPR)) {
                 steps {
-                    shell("./build.sh native x64 ${configuration.toLowerCase()}")
+                    shell("./build.sh native x64 ${configurationGroup.toLowerCase()}")
                 }
             }
             
@@ -149,11 +149,11 @@ def innerLoopNonWindowsOSs = ['Ubuntu', 'Debian8.2', 'OSX', 'FreeBSD', 'CentOS7.
             // First we set up a build job that builds the corefx repo on Windows
             //
             
-            def newBuildJobName = "${os.toLowerCase()}_${configuration.toLowerCase()}_bld"
+            def newBuildJobName = "${os.toLowerCase()}_${configurationGroup.toLowerCase()}_bld"
 
             def newBuildJob = job(Utilities.getFullJobName(project, newBuildJobName, isPR)) {
                 steps {
-                    batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && build.cmd /p:Configuration=${configuration} /p:OSGroup=${osGroup} /p:SkipTests=true /p:TestNugetRuntimeId=${targetNugetRuntimeMap[os]}")
+                    batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && build.cmd /p:ConfigurationGroup=${configurationGroup} /p:OSGroup=${osGroup} /p:SkipTests=true /p:TestNugetRuntimeId=${targetNugetRuntimeMap[os]}")
                     // Package up the results.
                     batchFile("C:\\Packer\\Packer.exe .\\bin\\build.pack .\\bin")
                 }
@@ -164,7 +164,7 @@ def innerLoopNonWindowsOSs = ['Ubuntu', 'Debian8.2', 'OSX', 'FreeBSD', 'CentOS7.
             // Set up standard options.
             Utilities.standardJobSetup(newBuildJob, project, isPR)
             // Archive the results
-            Utilities.addArchival(newBuildJob, "bin/build.pack,bin/osGroup.AnyCPU.${configuration}/**,bin/ref/**,bin/packages/**,msbuild.log")
+            Utilities.addArchival(newBuildJob, "bin/build.pack,bin/osGroup.AnyCPU.${configurationGroup}/**,bin/ref/**,bin/packages/**,msbuild.log")
             
             //
             // Then we set up a job that runs the test on the target OS
@@ -173,7 +173,7 @@ def innerLoopNonWindowsOSs = ['Ubuntu', 'Debian8.2', 'OSX', 'FreeBSD', 'CentOS7.
             def fullNativeCompBuildJobName = Utilities.getFolderName(project) + '/' + newNativeCompJob.name
             def fullCoreFXBuildJobName = Utilities.getFolderName(project) + '/' + newBuildJob.name
             
-            def newTestJobName = "${os.toLowerCase()}_${configuration.toLowerCase()}_tst"
+            def newTestJobName = "${os.toLowerCase()}_${configurationGroup.toLowerCase()}_tst"
             
             def newTestJob = job(Utilities.getFullJobName(project, newTestJobName, isPR)) {
                 steps {
@@ -218,9 +218,9 @@ def innerLoopNonWindowsOSs = ['Ubuntu', 'Debian8.2', 'OSX', 'FreeBSD', 'CentOS7.
                     // Export the LTTNG environment variable and then run the tests
                     shell("""export LTTNG_HOME=/home/dotnet-bot
                     ./run-test.sh \\
-                        --configuration ${configuration} \\
+                        --configurationGroup ${configurationGroup} \\
                         --os ${osGroup} \\
-                        --corefx-tests \${WORKSPACE}/bin/tests/${osGroup}.AnyCPU.${configuration} \\
+                        --corefx-tests \${WORKSPACE}/bin/tests/${osGroup}.AnyCPU.${configurationGroup} \\
                         --coreclr-bins \${WORKSPACE}/bin/Product/${osGroup}.x64.Release/ \\
                         --mscorlib-bins \${WORKSPACE}/bin/Product/${osGroup}.x64.Release/
                     """)
@@ -246,7 +246,7 @@ def innerLoopNonWindowsOSs = ['Ubuntu', 'Debian8.2', 'OSX', 'FreeBSD', 'CentOS7.
             //
             
             def fullCoreFXTestJobName = Utilities.getFolderName(project) + '/' + newTestJob.name
-            def flowJobName = "${os.toLowerCase()}_${configuration.toLowerCase()}"
+            def flowJobName = "${os.toLowerCase()}_${configurationGroup.toLowerCase()}"
             def newFlowJob = buildFlowJob(Utilities.getFullJobName(project, flowJobName, isPR)) {
                 buildFlow("""
                     parallel (
@@ -276,7 +276,7 @@ def innerLoopNonWindowsOSs = ['Ubuntu', 'Debian8.2', 'OSX', 'FreeBSD', 'CentOS7.
                 // Set PR trigger.
                 // Set of OS's that work currently. 
                 if (os in ['Ubuntu', 'CentOS7.1']) {
-                    Utilities.addGithubPRTrigger(newFlowJob, "Innerloop ${os} ${configuration} Build and Test")
+                    Utilities.addGithubPRTrigger(newFlowJob, "Innerloop ${os} ${configurationGroup} Build and Test")
                 }
             }
             else {
@@ -292,13 +292,13 @@ def innerLoopNonWindowsOSs = ['Ubuntu', 'Debian8.2', 'OSX', 'FreeBSD', 'CentOS7.
 def supportedFullCyclePlatforms = ['Windows_NT']
 
 [true, false].each { isPR ->
-    ['Debug', 'Release'].each { configuration ->
+    ['Debug', 'Release'].each { configurationGroup ->
         supportedFullCyclePlatforms.each { osGroup ->
-            def newJobName = "${osGroup.toLowerCase()}_${configuration.toLowerCase()}"
+            def newJobName = "${osGroup.toLowerCase()}_${configurationGroup.toLowerCase()}"
 
             def newJob = job(Utilities.getFullJobName(project, newJobName, isPR)) {
                 steps {
-                    batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && build.cmd /p:Configuration=${configuration} /p:OSGroup=${osGroup}")
+                    batchFile("call \"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\vcvarsall.bat\" x86 && build.cmd /p:ConfigurationGroup=${configurationGroup} /p:OSGroup=${osGroup}")
                     batchFile("C:\\Packer\\Packer.exe .\\bin\\build.pack .\\bin")
                 }
             }
@@ -314,7 +314,7 @@ def supportedFullCyclePlatforms = ['Windows_NT']
             // Set up triggers
             if (isPR) {
                 // Set PR trigger.
-                Utilities.addGithubPRTrigger(newJob, "Innerloop ${osGroup} ${configuration} Build and Test")
+                Utilities.addGithubPRTrigger(newJob, "Innerloop ${osGroup} ${configurationGroup} Build and Test")
             }
             else {
                 // Set a push trigger

--- a/run-test.sh
+++ b/run-test.sh
@@ -21,18 +21,18 @@ usage()
     echo "Input sources:"
     echo "    --coreclr-bins <location>         Location of root of the binaries directory"
     echo "                                      containing the FreeBSD, Linux or OSX coreclr build"
-    echo "                                      default: <repo_root>/bin/Product/<OS>.x64.<Configuration>"
+    echo "                                      default: <repo_root>/bin/Product/<OS>.x64.<ConfigurationGroup>"
     echo "    --mscorlib-bins <location>        Location of the root binaries directory containing"
     echo "                                      the FreeBSD, Linux or OSX mscorlib.dll"
-    echo "                                      default: <repo_root>/bin/Product/<OS>.x64.<Configuration>"
+    echo "                                      default: <repo_root>/bin/Product/<OS>.x64.<ConfigurationGroup>"
     echo "    --corefx-tests <location>         Location of the root binaries location containing"
     echo "                                      the tests to run"
-    echo "                                      default: <repo_root>/bin/tests/<OS>.AnyCPU.<Configuration>"
+    echo "                                      default: <repo_root>/bin/tests/<OS>.AnyCPU.<ConfigurationGroup>"
     echo "    --corefx-native-bins <location>   Location of the FreeBSD, Linux or OSX native corefx binaries"
-    echo "                                      default: <repo_root>/bin/<OS>.x64.<Configuration>"
+    echo "                                      default: <repo_root>/bin/<OS>.x64.<ConfigurationGroup>"
     echo
     echo "Flavor/OS options:"
-    echo "    --configuration <config>          Configuration to run (Debug/Release)"
+    echo "    --configurationGroup <config>     ConfigurationGroup to run (Debug/Release)"
     echo "                                      default: Debug"
     echo "    --os <os>                         OS to run (FreeBSD, Linux or OSX)"
     echo "                                      default: detect current OS"
@@ -45,7 +45,7 @@ usage()
     echo "    --coreclr-coverage                Optional argument to get coreclr code coverage reports"
     echo "    --coreclr-objs <location>         Location of root of the object directory"
     echo "                                      containing the FreeBSD, Linux or OSX coreclr build"
-    echo "                                      default: <repo_root>/bin/obj/<OS>.x64.<Configuration>"
+    echo "                                      default: <repo_root>/bin/obj/<OS>.x64.<ConfigurationGroup"
     echo "    --coreclr-src <location>          Location of root of the directory"
     echo "                                      containing the coreclr source files"
     echo
@@ -54,8 +54,8 @@ usage()
 
 ProjectRoot="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 # Location parameters
-# OS/Configuration defaults
-Configuration="Debug"
+# OS/ConfigurationGroup defaults
+ConfigurationGroup="Debug"
 OSName=$(uname -s)
 case $OSName in
     Darwin)
@@ -78,7 +78,7 @@ esac
 # Misc defaults
 TestSelection=".*"
 TestsFailed=0
-OverlayDir="$ProjectRoot/bin/tests/$OS.AnyCPU.$Configuration/TestOverlay/"
+OverlayDir="$ProjectRoot/bin/tests/$OS.AnyCPU.$ConfigurationGroup/TestOverlay/"
 
 create_test_overlay()
 {
@@ -89,7 +89,7 @@ create_test_overlay()
   rm -rf $OverlayDir
   mkdir -p $OverlayDir
   
-  local LowerConfiguration="$(echo $Configuration | awk '{print tolower($0)}')"
+  local LowerConfigurationGroup="$(echo $ConfigurationGroup | awk '{print tolower($0)}')"
  
   # Copy the CoreCLR native binaries
   if [ ! -d $CoreClrBins ]
@@ -268,8 +268,8 @@ do
         --restrict-proj)
         TestSelection=$2
         ;;
-        --configuration)
-        Configuration=$2
+        --configurationGroup)
+        ConfigurationGroup=$2
         ;;
         --os)
         OS=$2
@@ -293,29 +293,29 @@ done
 
 if [ "$CoreClrBins" == "" ]
 then
-    CoreClrBins="$ProjectRoot/bin/Product/$OS.x64.$Configuration"
+    CoreClrBins="$ProjectRoot/bin/Product/$OS.x64.$ConfigurationGroup"
 fi
 
 if [ "$MscorlibBins" == "" ]
 then
-    MscorlibBins="$ProjectRoot/bin/Product/$OS.x64.$Configuration"
+    MscorlibBins="$ProjectRoot/bin/Product/$OS.x64.$ConfigurationGroup"
 fi
 
 if [ "$CoreFxTests" == "" ]
 then
-    CoreFxTests="$ProjectRoot/bin/tests/$OS.AnyCPU.$Configuration"
+    CoreFxTests="$ProjectRoot/bin/tests/$OS.AnyCPU.$ConfigurationGroup"
 fi
 
 if [ "$CoreFxNativeBins" == "" ]
 then
-    CoreFxNativeBins="$ProjectRoot/bin/$OS.x64.$Configuration/Native"
+    CoreFxNativeBins="$ProjectRoot/bin/$OS.x64.$ConfigurationGroup/Native"
 fi
 
 # Check parameters up front for valid values:
 
-if [ ! "$Configuration" == "Debug" ] && [ ! "$Configuration" == "Release" ]
+if [ ! "$ConfigurationGroup" == "Debug" ] && [ ! "$ConfigurationGroup" == "Release" ]
 then
-    echo "error: Configuration should be Debug or Release"
+    echo "error: ConfigurationGroup should be Debug or Release"
     exit 1
 fi
 
@@ -327,13 +327,13 @@ fi
 
 if [ "$CoreClrObjs" == "" ]
 then
-    CoreClrObjs="$ProjectRoot/bin/obj/$OS.x64.$Configuration"
+    CoreClrObjs="$ProjectRoot/bin/obj/$OS.x64.$ConfigurationGroup"
 fi
 
 
 create_test_overlay
 
-# Walk the directory tree rooted at src bin/tests/$OS.AnyCPU.$Configuration/
+# Walk the directory tree rooted at src bin/tests/$OS.AnyCPU.$ConfigurationGroup/
 
 TestsFailed=0
 numberOfProcesses=0


### PR DESCRIPTION
Switch build and test scripts to pass ConfigurationGroup instead of Configuration for Debug/Release. This is necessary to avoid msbuild from force setting Configuration when passed at the command line, see https://github.com/weshaggard/corefx/commit/d41b1bf66901e8fd21d21ec7ea485a959e9182aa for how I've currently hacked around it. 

@mmitche PTAL. Can you tell me how I can test these groovy scripts updates before merging? 