### PR TITLE
ObservableCollection<T>: Reuse immutable EventArgs objects

### DIFF
--- a/src/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs
+++ b/src/System.ObjectModel/src/System/Collections/ObjectModel/ObservableCollection.cs
@@ -131,8 +131,8 @@ namespace System.Collections.ObjectModel
         {
             CheckReentrancy();
             base.ClearItems();
-            OnPropertyChanged(CountString);
-            OnPropertyChanged(IndexerName);
+            OnCountPropertyChanged();
+            OnIndexerPropertyChanged();
             OnCollectionReset();
         }
 
@@ -147,8 +147,8 @@ namespace System.Collections.ObjectModel
 
             base.RemoveItem(index);
 
-            OnPropertyChanged(CountString);
-            OnPropertyChanged(IndexerName);
+            OnCountPropertyChanged();
+            OnIndexerPropertyChanged();
             OnCollectionChanged(NotifyCollectionChangedAction.Remove, removedItem, index);
         }
 
@@ -161,8 +161,8 @@ namespace System.Collections.ObjectModel
             CheckReentrancy();
             base.InsertItem(index, item);
 
-            OnPropertyChanged(CountString);
-            OnPropertyChanged(IndexerName);
+            OnCountPropertyChanged();
+            OnIndexerPropertyChanged();
             OnCollectionChanged(NotifyCollectionChangedAction.Add, item, index);
         }
 
@@ -176,7 +176,7 @@ namespace System.Collections.ObjectModel
             T originalItem = this[index];
             base.SetItem(index, item);
 
-            OnPropertyChanged(IndexerName);
+            OnIndexerPropertyChanged();
             OnCollectionChanged(NotifyCollectionChangedAction.Replace, originalItem, item, index);
         }
 
@@ -193,7 +193,7 @@ namespace System.Collections.ObjectModel
             base.RemoveItem(oldIndex);
             base.InsertItem(newIndex, removedItem);
 
-            OnPropertyChanged(IndexerName);
+            OnIndexerPropertyChanged();
             OnCollectionChanged(NotifyCollectionChangedAction.Move, removedItem, newIndex, oldIndex);
         }
 
@@ -280,11 +280,19 @@ namespace System.Collections.ObjectModel
 
         #region Private Methods
         /// <summary>
-        /// Helper to raise a PropertyChanged event  />).
+        /// Helper to raise a PropertyChanged event for the Count property
         /// </summary>
-        private void OnPropertyChanged(string propertyName)
+        private void OnCountPropertyChanged()
         {
-            OnPropertyChanged(new PropertyChangedEventArgs(propertyName));
+            OnPropertyChanged(EventArgsCache.CountPropertyChanged);
+        }
+
+        /// <summary>
+        /// Helper to raise a PropertyChanged event for the Indexer property
+        /// </summary>
+        private void OnIndexerPropertyChanged()
+        {
+            OnPropertyChanged(EventArgsCache.IndexerPropertyChanged);
         }
 
         /// <summary>
@@ -316,7 +324,7 @@ namespace System.Collections.ObjectModel
         /// </summary>
         private void OnCollectionReset()
         {
-            OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+            OnCollectionChanged(EventArgsCache.ResetCollectionChanged);
         }
         #endregion Private Methods
 
@@ -356,13 +364,14 @@ namespace System.Collections.ObjectModel
 
         #region Private Fields
 
-        private const string CountString = "Count";
-
-        // This must agree with Binding.IndexerName.  It is declared separately
-        // here so as to avoid a dependency on PresentationFramework.dll.
-        private const string IndexerName = "Item[]";
-
-        private SimpleMonitor _monitor = new SimpleMonitor();
+        private readonly SimpleMonitor _monitor = new SimpleMonitor();
         #endregion Private Fields
+    }
+
+    internal static class EventArgsCache
+    {
+        internal static readonly PropertyChangedEventArgs CountPropertyChanged = new PropertyChangedEventArgs("Count");
+        internal static readonly PropertyChangedEventArgs IndexerPropertyChanged = new PropertyChangedEventArgs("Item[]");
+        internal static readonly NotifyCollectionChangedEventArgs ResetCollectionChanged = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset);
     }
 }


### PR DESCRIPTION
Instead of always allocating new instances of `PropertyChangedEventArgs` for the `Count` and `Indexer` properties, and `NotifyCollectionChangedEventArgs` for `NotifyCollectionChangedAction.Reset`, reuse cached instances.