### PR TITLE
Improve memory use of HashSet constructed from HashSet.

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -115,13 +115,19 @@ namespace System.Collections.Generic
             var otherAsHashSet = collection as HashSet<T>;
             if (otherAsHashSet != null && AreEqualityComparersEqual(this, otherAsHashSet))
             {
+                if (otherAsHashSet._buckets == null)
+                {
+                    // Source hasn't initialized buckets yet, so neither need this.
+                    Debug.Assert(otherAsHashSet._slots == null);
+                    return;
+                }
+
                 _buckets = (int[])otherAsHashSet._buckets.Clone();
                 _slots = (Slot[])otherAsHashSet._slots.Clone();
 
                 _count = otherAsHashSet._count;
                 _lastIndex = otherAsHashSet._lastIndex;
                 _freeList = otherAsHashSet._freeList;
-                _version = otherAsHashSet._version;
 
                 // _comparer is already the same
             }

--- a/src/System.Collections/tests/Generic/HashSet/HashSet_ConstructorTests.cs
+++ b/src/System.Collections/tests/Generic/HashSet/HashSet_ConstructorTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 using Tests.HashSet_HashSetTestSupport;
 
@@ -11,6 +12,30 @@ namespace Tests
 {
     public class HashSet_Constructor
     {
+        // Use parity only as a hashcode so as to have many collisions.
+        private class BadIntEqualityComparer : IEqualityComparer<int>
+        {
+            public bool Equals(int x, int y)
+            {
+                return x == y;
+            }
+
+            public int GetHashCode(int obj)
+            {
+                return obj % 2;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is BadIntEqualityComparer; // Equal to all other instances of this type, not to anything else.
+            }
+
+            public override int GetHashCode()
+            {
+                return unchecked((int)0xC001CAFE); // Doesn't matter as long as its constant.
+            }
+        }
+
         private static int s_nextInt;
         private static Func<int> s_intGenerator = () =>
         {
@@ -118,6 +143,7 @@ namespace Tests
             HashSetTestSupport<int> driver = new HashSetTestSupport<int>(hashSet, s_intGenerator, items);
             driver.VerifyHashSetTests();
         }
+
         [Fact]
         public static void Ctor_IEnumerable_Single_Neg()
         {
@@ -155,6 +181,17 @@ namespace Tests
             HashSetTestSupport<int> driver = new HashSetTestSupport<int>(hashSet, s_intGenerator, expected);
             driver.VerifyHashSetTests();
         }
+
+        [Fact]
+        public static void Ctor_IEnumerable_ManyDuplicates()
+        {
+            int[] items = new int[] { 4, -23, -23, -2, 4, 6, 0, 4, 123, -4, 123 };
+            HashSet<int> hashSet = new HashSet<int>(Enumerable.Range(0, 40).SelectMany(i => items).ToArray());
+            int[] expected = new int[] { -23, -2, 4, 6, 0, 123, -4 };
+            HashSetTestSupport<int> driver = new HashSetTestSupport<int>(hashSet, s_intGenerator, expected);
+            driver.VerifyHashSetTests();
+        }
+
         [Fact]
         public static void Ctor_IEnumerable_Duplicate_Neg()
         {
@@ -338,6 +375,55 @@ namespace Tests
             driver.VerifyHashSetTests();
         }
 
+        private static IEnumerable<int> NonSquares(int limit)
+        {
+            for (int i = 0; i != limit; ++i)
+            {
+                int root = (int)Math.Sqrt(i);
+                if (i != root * root)
+                    yield return i;
+            }
+        }
+
+        [Fact]
+        public static void Ctor_IEnumerable_HashSet_Sparse()
+        {
+            HashSet<int> source = new HashSet<int>();
+            for (int i = 0; i != 1000; ++i)
+            {
+                source.Add(i);
+            }
+
+            foreach (int i in NonSquares(1000)) // Unevenly spaced survivors increases chance of catching any spacing-related bugs.
+            {
+                source.Remove(i);
+            }
+
+            HashSet<int> hashSet = new HashSet<int>(source);
+
+            HashSetTestSupport<int> driver = new HashSetTestSupport<int>(hashSet, s_intGenerator, new List<int>(source).ToArray());
+            driver.VerifyHashSetTests();
+        }
+
+        [Fact]
+        public static void Ctor_IEnumerable_HashSet_SparseManyCollisions()
+        {
+            HashSet<int> source = new HashSet<int>(new BadIntEqualityComparer());
+            for (int i = 0; i != 1000; ++i)
+            {
+                source.Add(i);
+            }
+
+            foreach (int i in NonSquares(1000)) // Unevenly spaced survivors increases chance of catching any spacing-related bugs.
+            {
+                source.Remove(i);
+            }
+
+            HashSet<int> hashSet = new HashSet<int>(source, new BadIntEqualityComparer());
+
+            HashSetTestSupport<int> driver = new HashSetTestSupport<int>(hashSet, s_intGenerator, new List<int>(source).ToArray(), new BadIntEqualityComparer());
+            driver.VerifyHashSetTests();
+        }
         #endregion
     }
 }

--- a/src/System.Collections/tests/Generic/HashSet/HashSet_ConstructorTests.cs
+++ b/src/System.Collections/tests/Generic/HashSet/HashSet_ConstructorTests.cs
@@ -328,6 +328,16 @@ namespace Tests
             driver.VerifyHashSet_NegativeTests();
         }
 
+        [Fact]
+        public static void Ctor_IEnumerable_HashSet_Fresh_HashSet()
+        {
+            HashSet<int> source = new HashSet<int>();
+            HashSet<int> hashSet = new HashSet<int>(source);
+
+            HashSetTestSupport<int> driver = new HashSetTestSupport<int>(hashSet, s_intGenerator, new int[0]);
+            driver.VerifyHashSetTests();
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
If a `HashSet` is constructed from an existing `HashSet` then use the current approach if the count is above a particular ratio to the capacity, but if it is below that ratio (small enough that if created just from those items and then added to the next resize would still not reach that capacity) use an optimised version of `AddIfNotPresent` to add each item.

Fixes #5141 

@justinvp this combines your suggestion about an optimised version of `AddIfNotPresent` with mine of using the current approach above a certain threshold of count/capacity. I took that threshold as being `ExpandPrime(count + 1)` though there's no perfect value (the best value would depend on what additions where later done, and how long the produced set would be kept in memory, so it can't be perfectly deduced).

Done on top of the two commits for #5131 rather than repeat things that need to be included in this.

I pretty much ignored the idea of optimising `UnionWith`. That certainly could be done along the same lines, but the `AddValue` I have here couldn't be quite as tightly optimised, with the skip on tests for the item being present and the skips on incrementing the count and version having to be undone.

At the very least this needs more tests before I take off the WIP tag.

Contains the commits that were previously in #5131, so Fixes #5130.