### PR TITLE
Switch common Debug visibility to use partial class instead of #ifdef

### DIFF
--- a/src/Common/src/System/Diagnostics/Debug.Unix.cs
+++ b/src/Common/src/System/Diagnostics/Debug.Unix.cs
@@ -5,11 +5,10 @@ using Microsoft.Win32.SafeHandles;
 
 namespace System.Diagnostics
 {
-#if PUBLIC_DEBUG
-    public static partial class Debug
-#else
-    internal static partial class Debug
-#endif
+    // Intentionally excluding visibility so it defaults to internal except for
+    // the one public version in System.Diagnostics.Debug which defines
+    // another version of this partial class with the public visibility 
+    static partial class Debug
     {
         // internal and not readonly so that the tests can swap this out.
         internal static IDebugLogger s_logger = new UnixDebugLogger();

--- a/src/Common/src/System/Diagnostics/Debug.Windows.cs
+++ b/src/Common/src/System/Diagnostics/Debug.Windows.cs
@@ -5,11 +5,10 @@ using System.Security;
 
 namespace System.Diagnostics
 {
-#if PUBLIC_DEBUG
-    public static partial class Debug
-#else
-    internal static partial class Debug
-#endif
+    // Intentionally excluding visibility so it defaults to internal except for
+    // the one public version in System.Diagnostics.Debug which defines
+    // another version of this partial class with the public visibility 
+    static partial class Debug
     {
         // internal and not read only so that the tests can swap this out.
         internal static IDebugLogger s_logger = new WindowsDebugLogger();

--- a/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
+++ b/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
@@ -11,7 +11,6 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Diagnostics.Debug</AssemblyName>
     <AssemblyVersion>4.0.11.0</AssemblyVersion>
-    <DefineConstants>$(DefineConstants);PUBLIC_DEBUG</DefineConstants>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <NoWarn>0436</NoWarn>
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' != ''">None</ResourcesSourceOutputDirectory>
@@ -37,6 +36,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
   <ItemGroup Condition="'$(TargetGroup)' == ''">
     <Compile Include="Properties\InternalsVisibleTo.cs" />
+    <Compile Include="System\Diagnostics\Debug.Public.cs" />
     <Compile Include="$(CommonPath)\System\Diagnostics\Debug.cs">
       <Link>System\Diagnostics\Debug.cs</Link>
     </Compile>

--- a/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.Public.cs
+++ b/src/System.Diagnostics.Debug/src/System/Diagnostics/Debug.Public.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Diagnostics
+{
+    // Intentionally empty class, which is only used to define the public visibility
+    public static partial class Debug
+    {
+        // Debug members are comming from the common Debug.cs files
+    }
+}


### PR DESCRIPTION
cc @stephentoub @ellismg @mellinoe 

As part of some recent work I've seen a couple copy-paste issues where defines ended being set which might cause issues patterns like this one. Plus I really have never licked #ifdef around visibility.  So to help ensure someone doesn't accidentally expose some of our common shared classes publicly I kind of like this pattern but I'm curious what others think. 