### PR TITLE
Removing coreclr active issue 2315.

### DIFF
--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Generated.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Generated.cs
@@ -113,7 +113,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/coreclr/issues/2315", PlatformID.AnyUnix)]
         [ActiveIssue(5067, PlatformID.Windows)]
         public static void CompileInterpretCrossCheck_Call()
         {
@@ -404,7 +403,6 @@ namespace Tests.Expressions
         }
 
         [Fact]
-        [ActiveIssue("https://github.com/dotnet/coreclr/issues/2315", PlatformID.AnyUnix)]
         [ActiveIssue(5067, PlatformID.Windows)]
         public static void CompileInterpretCrossCheck_MemberAccess()
         {


### PR DESCRIPTION
Only removes issue 2315 from the two linq tests that were disabled.

See https://github.com/dotnet/corefx/pull/4952 for more history.