### PR TITLE
Filter package builds to OSEnviroment when building from the root

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -15,6 +15,8 @@
     <Project Include="src\packages.builds">
       <!-- When we do a traversal build we build all libraries prior to building packages -->
       <AdditionalProperties>BuildPackageLibraryReferences=false</AdditionalProperties>
+      <!-- For the root traversal default filter the OSGroup to the OSEnvironment which is the OS we are running on -->
+      <FilterToOSGroup Condition="'$(BuildAllOSGroups)' != 'true'">$(OSEnvironment)</FilterToOSGroup>
     </Project>
     <Project Include="src\post.msbuild" />
   </ItemGroup>


### PR DESCRIPTION
We are already filtering the library builds to OSEnviroment so we
need to similarly filiter the package builds.

Fixes #5168 

cc @ericstj @stephentoub 