### PR TITLE
Remove unused WorkInProgress resource string.

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Algorithms/src/Resources/Strings.resx
@@ -177,9 +177,6 @@
   <data name="Cryptography_UnknownPaddingMode" xml:space="preserve">
     <value>Unknown padding mode used.</value>
   </data>
-  <data name="WorkInProgress" xml:space="preserve">
-    <value>Implementation in progress.</value>
-  </data>
   <data name="Cryptography_UnexpectedTransformTruncation" xml:space="preserve">
     <value>CNG provider unexpectedly terminated encryption or decryption prematurely.</value>
   </data>

--- a/src/System.Security.Cryptography.Cng/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Cng/src/Resources/Strings.resx
@@ -234,9 +234,6 @@
   <data name="Cryptography_WeakKey" xml:space="preserve">
     <value>Specified key is a known weak key for this algorithm and cannot be used.</value>
   </data>
-  <data name="WorkInProgress" xml:space="preserve">
-    <value>WorkInProgress.</value>
-  </data>
   <data name="WorkInProgress_UnsupportedHash" xml:space="preserve">
     <value>Unsupported hash algorithm. RSACng currently supports only MD5, SHA1, SHA256, SHA384 and SHA512.</value>
   </data>

--- a/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -243,9 +243,6 @@
   <data name="Unknown_Error" xml:space="preserve">
     <value>Unknown error.</value>
   </data>
-  <data name="WorkInProgress" xml:space="preserve">
-    <value>WorkInProgress.</value>
-  </data>
   <data name="Cryptography_FileStatusError" xml:space="preserve">
     <value>Unable to get file status.</value>
   </data>


### PR DESCRIPTION
I missed these unused strings when I implemented TripleDES last year.

@bartonjs @stephentoub 