### PR TITLE
Make backing field of Vector.Count readonly

### DIFF
--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector.cs
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector.cs
@@ -56,7 +56,7 @@ namespace System.Numerics
                 return s_count;
             }
         }
-        private static int s_count = InitializeCount();
+        private static readonly int s_count = InitializeCount();
 
         /// <summary>
         /// Returns a vector containing all zeroes.

--- a/src/System.Numerics.Vectors/src/System/Numerics/Vector.tt
+++ b/src/System.Numerics.Vectors/src/System/Numerics/Vector.tt
@@ -61,7 +61,7 @@ namespace System.Numerics
                 return s_count;
             }
         }
-        private static int s_count = InitializeCount();
+        private static readonly int s_count = InitializeCount();
 
         /// <summary>
         /// Returns a vector containing all zeroes.


### PR DESCRIPTION
Addresses #5152 

Even just considering our style guide, we should make this field readonly. It is effectively a constant value for each primitive type, so it is never assigned outside of its initializer.

@CarolEidt , @benaadams