### PR TITLE
Add netcore50 configuration to System.Diagnostics.Tools

### DIFF
--- a/src/System.Diagnostics.Tools/src/System.Diagnostics.Tools.builds
+++ b/src/System.Diagnostics.Tools/src/System.Diagnostics.Tools.builds
@@ -6,6 +6,9 @@
     <Project Include="System.Diagnostics.Tools.csproj">
       <TargetGroup>net46</TargetGroup>
     </Project>
+    <Project Include="System.Diagnostics.Tools.csproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Diagnostics.Tools/src/System.Diagnostics.Tools.csproj
+++ b/src/System.Diagnostics.Tools/src/System.Diagnostics.Tools.csproj
@@ -12,9 +12,16 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
-  <ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+  <ItemGroup Condition="'$(TargetGroup)' == '' Or '$(TargetGroup)' == 'net46'">
     <TargetingPackReference Include="mscorlib" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
     <TargetingPackReference Include="System" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
+    <TargetingPackReference Include="System.Private.CoreLib" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
     <Compile Include="System\CodeDom\Compiler\GeneratedCodeAttribute.cs" />

--- a/src/System.Diagnostics.Tools/src/project.json
+++ b/src/System.Diagnostics.Tools/src/project.json
@@ -7,7 +7,12 @@
     },
     "net46":{
       "dependencies": {
-        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0",
+        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0"
+      }
+    },
+    "netcore50": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23530"
       }
     }
   }


### PR DESCRIPTION
This adds the netcore50 configuration for System.Diagnostics.Tools. It's the same as the CoreCLR version except it references System.Private.CoreLib instead of mscorlib. I re-organized the TargetingPackReference items because technically System.dll was being "included" for CoreCLR, when no such targeting pack assembly exists there.

I cross-checked the .NET Native DLL built by this with the version we are building internally and they seem to be identical.

@weshaggard 