### PR TITLE
Add support for encoding X500DistinguishedName values on Unix.

### DIFF
--- a/src/Common/src/System/Security/Cryptography/DerSequenceReader.cs
+++ b/src/Common/src/System/Security/Cryptography/DerSequenceReader.cs
@@ -270,6 +270,7 @@ namespace System.Security.Cryptography
             OctetString = 0x04,
             Null = 0x05,
             ObjectIdentifier = 0x06,
+            UTF8String = 0x0C,
             Sequence = 0x10,
             Set = 0x11,
             PrintableString = 0x13,

--- a/src/Common/tests/System/Security/Cryptography/ByteUtils.cs
+++ b/src/Common/tests/System/Security/Cryptography/ByteUtils.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Globalization;
+using System.Text;
 
 namespace Test.Cryptography
 {
@@ -30,6 +31,18 @@ namespace Test.Cryptography
             }
 
             return bytes;
+        }
+
+        internal static string ByteArrayToHex(this byte[] bytes)
+        {
+            StringBuilder builder = new StringBuilder(bytes.Length * 2);
+
+            foreach (byte b in bytes)
+            {
+                builder.Append(b.ToString("X2"));
+            }
+
+            return builder.ToString();
         }
 
         internal static byte[] RepeatByte(byte b, int count)

--- a/src/System.Security.Cryptography.Encoding/tests/DerEncoderTests.cs
+++ b/src/System.Security.Cryptography.Encoding/tests/DerEncoderTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Text;
 using Test.Cryptography;
 using Xunit;
 
@@ -153,6 +154,206 @@ namespace System.Security.Cryptography.Encoding.Tests
                 DerEncoder.SegmentedEncodeUnsignedInteger(new byte[] { 0x01, 0x00 }));
 
             Assert.Equal(expected, encoded);
+        }
+
+        [Theory]
+        [InlineData("", true)]
+        [InlineData("This is a PrintableString.", true)]
+        [InlineData("This is not @ PrintableString.", false)]
+        [InlineData("\u65E5\u672C\u8A9E is not a PrintableString", false)]
+        public static void CheckPrintableString(string candidate, bool expected)
+        {
+            Assert.Equal(expected, DerEncoder.IsValidPrintableString(candidate.ToCharArray()));
+        }
+
+        // No bounds check tests are done here, because the method is currently assert-based,
+        // not exception-based.
+        [Theory]
+        [InlineData("", 0, 0, true)]
+        [InlineData("This is a PrintableString.", 0, 26, true)]
+        [InlineData("This is not @ PrintableString.", 0, 30, false)]
+        [InlineData("This is not @ PrintableString.", 0, 12, true)]
+        [InlineData("This is not @ PrintableString.", 12, 0, true)]
+        [InlineData("This is not @ PrintableString.", 12, 1, false)]
+        [InlineData("This is not @ PrintableString.", 13, 17, true)]
+        [InlineData("\u65E5\u672C\u8A9E is not a PrintableString", 0, 27, false)]
+        [InlineData("\u65E5\u672C\u8A9E is not a PrintableString", 0, 0, true)]
+        [InlineData("\u65E5\u672C\u8A9E is not a PrintableString", 3, 24, true)]
+        public static void CheckPrintableSubstring(string candidate, int offset, int length, bool expected)
+        {
+            Assert.Equal(expected, DerEncoder.IsValidPrintableString(candidate.ToCharArray(), offset, length));
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("Hello", "48656C6C6F")]
+        [InlineData("banana", "62616E616E61")]
+        public static void CheckIA5StringEncoding(string input, string expectedHex)
+        {
+            byte[][] encodedString = DerEncoder.SegmentedEncodeIA5String(input.ToCharArray());
+
+            Assert.NotNull(encodedString);
+            Assert.Equal(3, encodedString.Length);
+
+            // Check the tag
+            Assert.NotNull(encodedString[0]);
+            Assert.Equal(1, encodedString[0].Length);
+            Assert.Equal(0x16, encodedString[0][0]);
+
+            // Check the length. Since the input cases are all less than 0x7F bytes
+            // the length is only one byte.
+            Assert.NotNull(encodedString[1]);
+            Assert.Equal(1, encodedString[1].Length);
+            Assert.Equal(expectedHex.Length / 2, encodedString[1][0]);
+
+            // Check the value
+            Assert.Equal(expectedHex.HexToByteArray(), encodedString[2]);
+
+            // And, full roundtrip
+            Assert.Equal(input, Text.Encoding.ASCII.GetString(encodedString[2]));
+        }
+
+        [Theory]
+        [InlineData("Hello", 3, 2, "6C6F")]
+        [InlineData("banana", 1, 4, "616E616E")]
+        public static void CheckIA5SubstringEncoding(string input, int offset, int length, string expectedHex)
+        {
+            byte[][] encodedString = DerEncoder.SegmentedEncodeIA5String(input.ToCharArray(), offset, length);
+
+            Assert.NotNull(encodedString);
+            Assert.Equal(3, encodedString.Length);
+
+            // Check the tag
+            Assert.NotNull(encodedString[0]);
+            Assert.Equal(1, encodedString[0].Length);
+            Assert.Equal(0x16, encodedString[0][0]);
+
+            // Check the length. Since the input cases are all less than 0x7F bytes
+            // the length is only one byte.
+            Assert.NotNull(encodedString[1]);
+            Assert.Equal(1, encodedString[1].Length);
+            Assert.Equal(expectedHex.Length / 2, encodedString[1][0]);
+
+            // Check the value
+            Assert.Equal(expectedHex.HexToByteArray(), encodedString[2]);
+
+            // And, full roundtrip
+            Assert.Equal(input.Substring(offset, length), Text.Encoding.ASCII.GetString(encodedString[2]));
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("Hello", "48656C6C6F")]
+        [InlineData("banana", "62616E616E61")]
+        public static void CheckPrintableStringEncoding(string input, string expectedHex)
+        {
+            byte[][] encodedString = DerEncoder.SegmentedEncodePrintableString(input.ToCharArray());
+
+            Assert.NotNull(encodedString);
+            Assert.Equal(3, encodedString.Length);
+
+            // Check the tag
+            Assert.NotNull(encodedString[0]);
+            Assert.Equal(1, encodedString[0].Length);
+            Assert.Equal(0x13, encodedString[0][0]);
+
+            // Check the length. Since the input cases are all less than 0x7F bytes
+            // the length is only one byte.
+            Assert.NotNull(encodedString[1]);
+            Assert.Equal(1, encodedString[1].Length);
+            Assert.Equal(expectedHex.Length / 2, encodedString[1][0]);
+
+            // Check the value
+            Assert.Equal(expectedHex.HexToByteArray(), encodedString[2]);
+
+            // And, full roundtrip
+            Assert.Equal(input, Text.Encoding.ASCII.GetString(encodedString[2]));
+        }
+
+        [Theory]
+        [InlineData("Hello", 3, 2, "6C6F")]
+        [InlineData("banana", 1, 4, "616E616E")]
+        public static void CheckPrintableSubstringEncoding(string input, int offset, int length, string expectedHex)
+        {
+            byte[][] encodedString = DerEncoder.SegmentedEncodePrintableString(input.ToCharArray(), offset, length);
+
+            Assert.NotNull(encodedString);
+            Assert.Equal(3, encodedString.Length);
+
+            // Check the tag
+            Assert.NotNull(encodedString[0]);
+            Assert.Equal(1, encodedString[0].Length);
+            Assert.Equal(0x13, encodedString[0][0]);
+
+            // Check the length. Since the input cases are all less than 0x7F bytes
+            // the length is only one byte.
+            Assert.NotNull(encodedString[1]);
+            Assert.Equal(1, encodedString[1].Length);
+            Assert.Equal(expectedHex.Length / 2, encodedString[1][0]);
+
+            // Check the value
+            Assert.Equal(expectedHex.HexToByteArray(), encodedString[2]);
+
+            // And, full roundtrip
+            Assert.Equal(input.Substring(offset, length), Text.Encoding.ASCII.GetString(encodedString[2]));
+        }
+
+        [Theory]
+        [InlineData("", "")]
+        [InlineData("Hello", "48656C6C6F")]
+        [InlineData("banana", "62616E616E61")]
+        [InlineData("\u65E5\u672C\u8A9E", "E697A5E69CACE8AA9E")]
+        public static void CheckUTF8StringEncoding(string input, string expectedHex)
+        {
+            byte[][] encodedString = DerEncoder.SegmentedEncodeUtf8String(input.ToCharArray());
+
+            Assert.NotNull(encodedString);
+            Assert.Equal(3, encodedString.Length);
+
+            // Check the tag
+            Assert.NotNull(encodedString[0]);
+            Assert.Equal(1, encodedString[0].Length);
+            Assert.Equal(0x0C, encodedString[0][0]);
+
+            // Check the length. Since the input cases are all less than 0x7F bytes
+            // the length is only one byte.
+            Assert.NotNull(encodedString[1]);
+            Assert.Equal(1, encodedString[1].Length);
+            Assert.Equal(expectedHex.Length / 2, encodedString[1][0]);
+
+            // Check the value
+            Assert.Equal(expectedHex.HexToByteArray(), encodedString[2]);
+
+            // And, full roundtrip
+            Assert.Equal(input, Text.Encoding.UTF8.GetString(encodedString[2]));
+        }
+
+        [Theory]
+        [InlineData("Hello", 3, 2, "6C6F")]
+        [InlineData("banana", 1, 4, "616E616E")]
+        [InlineData("\u65E5\u672C\u8A9E", 1, 1, "E69CAC")]
+        public static void CheckUTF8SubstringEncoding(string input, int offset, int length, string expectedHex)
+        {
+            byte[][] encodedString = DerEncoder.SegmentedEncodeUtf8String(input.ToCharArray(), offset, length);
+            Assert.NotNull(encodedString);
+            Assert.Equal(3, encodedString.Length);
+
+            // Check the tag
+            Assert.NotNull(encodedString[0]);
+            Assert.Equal(1, encodedString[0].Length);
+            Assert.Equal(0x0C, encodedString[0][0]);
+
+            // Check the length. Since the input cases are all less than 0x7F bytes
+            // the length is only one byte.
+            Assert.NotNull(encodedString[1]);
+            Assert.Equal(1, encodedString[1].Length);
+            Assert.Equal(expectedHex.Length / 2, encodedString[1][0]);
+
+            // Check the value
+            Assert.Equal(expectedHex.HexToByteArray(), encodedString[2]);
+
+            // And, full roundtrip
+            Assert.Equal(input.Substring(offset, length), Text.Encoding.UTF8.GetString(encodedString[2]));
         }
     }
 }

--- a/src/System.Security.Cryptography.Encoding/tests/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.Encoding/tests/Resources/Strings.resx
@@ -120,4 +120,7 @@
   <data name="Argument_InvalidOidValue" xml:space="preserve">
     <value>The OID value was invalid.</value>
   </data>
+  <data name="Cryptography_Invalid_IA5String" xml:space="preserve">
+    <value>The string contains a character not in the 7 bit ASCII character set.</value>
+  </data>
 </root>

--- a/src/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
+++ b/src/System.Security.Cryptography.Encoding/tests/System.Security.Cryptography.Encoding.Tests.csproj
@@ -11,6 +11,7 @@
     <OutputType>Library</OutputType>
     <AssemblyName>System.Security.Cryptography.Encoding.Tests</AssemblyName>
     <RootNamespace>System.Security.Cryptography.Encoding.Tests</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Security.Cryptography.Encoding.csproj">

--- a/src/System.Security.Cryptography.OpenSsl/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.OpenSsl/src/Resources/Strings.resx
@@ -144,4 +144,7 @@
   <data name="Cryptography_UnsupportedEcKeyAlgorithm" xml:space="preserve">
     <value>Cannot use imported EC_KEY. '{0}' is not a supported algorithm.</value>
   </data>
+  <data name="Cryptography_Invalid_IA5String" xml:space="preserve">
+    <value>The string contains a character not in the 7 bit ASCII character set.</value>
+  </data>
 </root>

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Oids.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Oids.cs
@@ -27,6 +27,7 @@ namespace Internal.Cryptography
         public const string InhibitAnyPolicyExtension   = "2.5.29.54";
         public const string Ecc                         = "1.2.840.10045.2.1";
         public const string RsaRsa                      = "1.2.840.113549.1.1.1";
+        public const string EmailAddress                = "1.2.840.113549.1.9.1";
         public const string EnrollCertTypeExtension     = "1.3.6.1.4.1.311.20.2";
         public const string CertificateTemplate         = "1.3.6.1.4.1.311.21.7";
         public const string ApplicationCertPolicies     = "1.3.6.1.4.1.311.21.10";

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509Encoder.cs
@@ -33,7 +33,7 @@ namespace Internal.Cryptography.Pal
 
         public byte[] X500DistinguishedNameEncode(string distinguishedName, X500DistinguishedNameFlags flag)
         {
-            throw new NotImplementedException();
+            return X500NameEncoder.X500DistinguishedNameEncode(distinguishedName, flag);
         }
 
         public string X500DistinguishedNameFormat(byte[] encodedDistinguishedName, bool multiLine)

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/X500NameEncoder.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/X500NameEncoder.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -12,6 +14,8 @@ namespace Internal.Cryptography.Pal
 {
     internal static class X500NameEncoder
     {
+        private const string OidTagPrefix = "OID.";
+
         private static readonly char[] s_quoteNeedingChars =
         {
             ',',
@@ -25,6 +29,11 @@ namespace Internal.Cryptography.Pal
             '#',
             ';',
         };
+
+        private static readonly List<char> s_useSemicolonSeparators = new List<char>(1) { ';' };
+        private static readonly List<char> s_useCommaSeparators = new List<char>(1) { ',' };
+        private static readonly List<char> s_useNewlineSeparators = new List<char>(2) { '\r', '\n' };
+        private static readonly List<char> s_defaultSeparators = new List<char>(2) { ',', ';' };
 
         internal static string X500DistinguishedNameDecode(
             byte[] encodedName,
@@ -150,7 +159,50 @@ namespace Internal.Cryptography.Pal
                 return decodedName.ToString();
             }
         }
-        
+
+        internal static byte[] X500DistinguishedNameEncode(
+            string stringForm,
+            X500DistinguishedNameFlags flags)
+        {
+            bool reverse = (flags & X500DistinguishedNameFlags.Reversed) == X500DistinguishedNameFlags.Reversed;
+            bool noQuotes = (flags & X500DistinguishedNameFlags.DoNotUseQuotes) == X500DistinguishedNameFlags.DoNotUseQuotes;
+
+            List<char> dnSeparators;
+
+            // This rank ordering is based off of testing against the Windows implementation.
+            if ((flags & X500DistinguishedNameFlags.UseSemicolons) == X500DistinguishedNameFlags.UseSemicolons)
+            {
+                // Just semicolon.
+                dnSeparators = s_useSemicolonSeparators;
+            }
+            else if ((flags & X500DistinguishedNameFlags.UseCommas) == X500DistinguishedNameFlags.UseCommas)
+            {
+                // Just comma
+                dnSeparators = s_useCommaSeparators;
+            }
+            else if ((flags & X500DistinguishedNameFlags.UseNewLines) == X500DistinguishedNameFlags.UseNewLines)
+            {
+                // CR or LF.  Not "and".  Whichever is first was the separator, the later one is trimmed as whitespace.
+                dnSeparators = s_useNewlineSeparators;
+            }
+            else
+            {
+                // Comma or semicolon, but not CR or LF.
+                dnSeparators = s_defaultSeparators;
+            }
+
+            Debug.Assert(dnSeparators.Count != 0);
+
+            List<byte[][]> encodedSets = ParseDistinguishedName(stringForm, dnSeparators, noQuotes);
+
+            if (reverse)
+            {
+                encodedSets.Reverse();
+            }
+
+            return DerEncoder.ConstructSequence(encodedSets);
+        }
+
         private static bool NeedsQuoting(string rdnValue)
         {
             if (string.IsNullOrEmpty(rdnValue))
@@ -190,7 +242,7 @@ namespace Internal.Cryptography.Pal
             if (StringComparer.Ordinal.Equals(oid.FriendlyName, oidValue) ||
                 string.IsNullOrEmpty(oid.FriendlyName))
             {
-                decodedName.Append("OID.");
+                decodedName.Append(OidTagPrefix);
                 decodedName.Append(oid.Value);
             }
             else
@@ -199,6 +251,446 @@ namespace Internal.Cryptography.Pal
             }
 
             decodedName.Append('=');
+        }
+
+        private enum ParseState
+        {
+            Invalid,
+            SeekTag,
+            SeekTagEnd,
+            SeekEquals,
+            SeekValueStart,
+            SeekValueEnd,
+            SeekEndQuote,
+            MaybeEndQuote,
+            SeekComma,
+        }
+
+        private static List<byte[][]> ParseDistinguishedName(
+            string stringForm,
+            List<char> dnSeparators,
+            bool noQuotes)
+        {
+            // 16 is way more RDNs than we should ever need. A fairly standard set of values is
+            // { E, CN, O, OU, L, S, C } = 7;
+            // The EV values add in
+            // {
+            //   STREET, PostalCode, SERIALNUMBER, 2.5.4.15,
+            //   1.3.6.1.4.1.311.60.2.1.2, 1.3.6.1.4.1.311.60.2.1.3
+            // } = 6
+            //
+            // 7 + 6 = 13, round up to the nearest power-of-two.
+            const int InitalRdnSize = 16;
+            List<byte[][]> encodedSets = new List<byte[][]>(InitalRdnSize);
+            char[] chars = stringForm.ToCharArray();
+
+            int pos;
+            int end = chars.Length;
+
+            int tagStart = -1;
+            int tagEnd = -1;
+            Oid tagOid = null;
+            int valueStart = -1;
+            int valueEnd = -1;
+            bool hadEscapedQuote = false;
+
+            const char KeyValueSeparator = '=';
+            const char QuotedValueChar = '"';
+
+            ParseState state = ParseState.SeekTag;
+
+            for (pos = 0; pos < end; pos++)
+            {
+                char c = chars[pos];
+
+                switch (state)
+                {
+                    case ParseState.SeekTag:
+                        if (char.IsWhiteSpace(c))
+                        {
+                            continue;
+                        }
+
+                        if (char.IsControl(c))
+                        {
+                            state = ParseState.Invalid;
+                            break;
+                        }
+
+                        // The first character in the tag start.
+                        // We know that there's at least one valid
+                        // character, so make end be start+1.
+                        //
+                        // Single letter values with no whitespace padding them
+                        // (e.g. E=) would otherwise be ambiguous with length.
+                        // (SeekEquals can't set the tagEnd value because it
+                        // doesn't know if it was preceded by whitespace)
+
+                        // Note that we make no check here for the dnSeparator(s).
+                        // Two separators in a row is invalid (except for UseNewlines,
+                        // and they are only allowed because they are whitespace).
+                        //
+                        // But the throw for an invalid value will come from when the
+                        // OID fails to encode.
+                        tagStart = pos;
+                        tagEnd = pos + 1;
+                        state = ParseState.SeekTagEnd;
+                        break;
+
+                    case ParseState.SeekTagEnd:
+                        if (c == KeyValueSeparator)
+                        {
+                            goto case ParseState.SeekEquals;
+                        }
+
+                        if (char.IsWhiteSpace(c))
+                        {
+                            // Tag values aren't permitted whitespace, but there
+                            // can be whitespace between the tag and the separator.
+                            state = ParseState.SeekEquals;
+                            break;
+                        }
+
+                        if (char.IsControl(c))
+                        {
+                            state = ParseState.Invalid;
+                            break;
+                        }
+
+                        // We found another character in the tag, so move the
+                        // end (non-inclusive) to the next character.
+                        tagEnd = pos + 1;
+                        break;
+
+                    case ParseState.SeekEquals:
+                        if (c == KeyValueSeparator)
+                        {
+                            Debug.Assert(tagStart >= 0);
+                            tagOid = ParseOid(stringForm, tagStart, tagEnd);
+                            tagStart = -1;
+
+                            state = ParseState.SeekValueStart;
+                            break;
+                        }
+
+                        if (!char.IsWhiteSpace(c))
+                        {
+                            state = ParseState.Invalid;
+                            break;
+                        }
+
+                        break;
+
+                    case ParseState.SeekValueStart:
+                        if (char.IsWhiteSpace(c))
+                        {
+                            continue;
+                        }
+
+                        // If the first non-whitespace character is a quote,
+                        // this is a quoted string.  Unless the flags say to
+                        // not interpret quoted strings.
+                        if (c == QuotedValueChar && !noQuotes)
+                        {
+                            state = ParseState.SeekEndQuote;
+                            valueStart = pos + 1;
+                            break;
+                        }
+
+                        // It's possible to just write "CN=,O=". So we might
+                        // run into the RDN separator here.
+                        if (dnSeparators.Contains(c))
+                        {
+                            valueStart = pos;
+                            valueEnd = pos;
+                            goto case ParseState.SeekComma;
+                        }
+
+                        state = ParseState.SeekValueEnd;
+                        valueStart = pos;
+                        valueEnd = pos + 1;
+                        break;
+
+                    case ParseState.SeekEndQuote:
+                        // The only escape sequence in DN parsing is that a quoted
+                        // value can embed quotes via "", the same as a C# verbatim
+                        // string.  So, if we see a quote while looking for a close
+                        // quote we need to remember that this might have been the
+                        // end, but be open to the possibility that there's another
+                        // quote coming.
+                        if (c == QuotedValueChar)
+                        {
+                            state = ParseState.MaybeEndQuote;
+                            valueEnd = pos;
+                            break;
+                        }
+
+                        // Everything else is okay.
+                        break;
+
+                    case ParseState.MaybeEndQuote:
+                        if (c == QuotedValueChar)
+                        {
+                            state = ParseState.SeekEndQuote;
+                            hadEscapedQuote = true;
+                            valueEnd = -1;
+                            break;
+                        }
+
+                        // If the character wasn't another quote:
+                        //   dnSeparator: process value, state transition to SeekTag
+                        //   whitespace: state transition to SeekComma
+                        //   anything else: invalid.
+                        // since that's the same table as SeekComma, just change state
+                        // and go there.
+                        state = ParseState.SeekComma;
+                        goto case ParseState.SeekComma;
+
+                    case ParseState.SeekValueEnd:
+                        // Every time we see a non-whitespace character we need to mark it
+                        if (dnSeparators.Contains(c))
+                        {
+                            goto case ParseState.SeekComma;
+                        }
+
+                        if (char.IsWhiteSpace(c))
+                        {
+                            continue;
+                        }
+
+                        // Including control characters.
+                        valueEnd = pos + 1;
+
+                        break;
+
+                    case ParseState.SeekComma:
+                        if (dnSeparators.Contains(c))
+                        {
+                            Debug.Assert(tagOid != null);
+                            Debug.Assert(valueEnd != -1);
+                            Debug.Assert(valueStart != -1);
+
+                            encodedSets.Add(ParseRdn(tagOid, chars, valueStart, valueEnd, hadEscapedQuote));
+                            tagOid = null;
+                            valueStart = -1;
+                            valueEnd = -1;
+                            state = ParseState.SeekTag;
+                            break;
+                        }
+
+                        if (!char.IsWhiteSpace(c))
+                        {
+                            state = ParseState.Invalid;
+                            break;
+                        }
+
+                        break;
+
+                    default:
+                        Debug.Fail(
+                            string.Format(
+                                "Invalid parser state. Position {0}, State {1}, Character {2}, String \"{3}\"",
+                                pos,
+                                state,
+                                c,
+                                stringForm));
+
+                        throw new CryptographicException(SR.Cryptography_Invalid_X500Name);
+                }
+
+                if (state == ParseState.Invalid)
+                {
+                    break;
+                }
+            }
+
+            // Okay, so we've run out of input.  There are a couple of valid states we can be in.
+            // * 'CN='
+            //   state: SeekValueStart.  Neither valueStart nor valueEnd has a value yet.
+            // * 'CN=a'
+            //   state: SeekValueEnd.  valueEnd was set to pos(a) + 1, close it off.
+            // * 'CN=a '
+            //   state: SeekValueEnd.  valueEnd is marking at the start of the whitespace.
+            // * 'CN="a"'
+            //   state: MaybeEndQuote.  valueEnd is marking at the end-quote.
+            // * 'CN="a" '
+            //   state: SeekComma.  This is the same as MaybeEndQuote.
+            // * 'CN=a,'
+            //   state: SeekTag.  There's nothing to do here.
+            // * ''
+            //   state: SeekTag.  There's nothing to do here.
+            //
+            // And, of course, invalid ones.
+            // * 'CN="'
+            //   state: SeekEndQuote.  Throw.
+            // * 'CN':
+            //   state: SeekEndTag.  Throw.
+            switch (state)
+            {
+                // The last semantic character parsed was =.
+                case ParseState.SeekValueStart:
+                    valueStart = chars.Length;
+                    valueEnd = valueStart;
+                    goto case ParseState.SeekComma;
+
+                // If we were in an unquoted value and just ran out of text
+                case ParseState.SeekValueEnd:
+                    Debug.Assert(!hadEscapedQuote);
+                    goto case ParseState.SeekComma;
+
+                // If the last character was a close quote, or it was a close quote
+                // then some whitespace.
+                case ParseState.MaybeEndQuote:
+                case ParseState.SeekComma:
+                    Debug.Assert(tagOid != null);
+                    Debug.Assert(valueStart != -1);
+                    Debug.Assert(valueEnd != -1);
+
+                    encodedSets.Add(ParseRdn(tagOid, chars, valueStart, valueEnd, hadEscapedQuote));
+                    break;
+
+                // If the entire string was empty, or ended in a dnSeparator.
+                case ParseState.SeekTag:
+                    break;
+
+                default:
+                    // While this is an error, it should be due to bad input, so no Debug.Fail.
+                    throw new CryptographicException(SR.Cryptography_Invalid_X500Name);
+            }
+
+            return encodedSets;
+        }
+
+        private static Oid ParseOid(string stringForm, int tagStart, int tagEnd)
+        {
+            int length = tagEnd - tagStart;
+
+            if (length > OidTagPrefix.Length)
+            {
+                // Since we only care if the match starts exactly at tagStart, tell IndexOf
+                // that we're only examining OidTagPrefix.Length characters.  So it won't do
+                // more than one linear equality check.
+                int prefixIndex = stringForm.IndexOf(
+                    OidTagPrefix,
+                    tagStart,
+                    OidTagPrefix.Length,
+                    StringComparison.OrdinalIgnoreCase);
+
+                if (prefixIndex == tagStart)
+                {
+                    return new Oid(stringForm.Substring(tagStart + OidTagPrefix.Length, length - OidTagPrefix.Length));
+                }
+            }
+
+            return new Oid(stringForm.Substring(tagStart, length));
+        }
+
+        private static byte[][] ParseRdn(Oid tagOid, char[] chars, int valueStart, int valueEnd, bool hadEscapedQuote)
+        {
+            bool ia5String = (tagOid.Value == Oids.EmailAddress);
+            byte[][] encodedOid;
+
+            try
+            {
+                encodedOid = DerEncoder.SegmentedEncodeOid(tagOid);
+            }
+            catch (CryptographicException e)
+            {
+                throw new CryptographicException(SR.Cryptography_Invalid_X500Name, e);
+            }
+
+            if (hadEscapedQuote)
+            {
+                char[] value = ExtractValue(chars, valueStart, valueEnd);
+
+                return ParseRdn(encodedOid, value, ia5String);
+            }
+
+            return ParseRdn(encodedOid, chars, valueStart, valueEnd, ia5String);
+        }
+
+        private static byte[][] ParseRdn(
+            byte[][] encodedOid,
+            char[] chars,
+            int valueStart,
+            int valueEnd,
+            bool ia5String)
+        {
+            byte[][] encodedValue;
+
+            int length = valueEnd - valueStart;
+
+            if (ia5String)
+            {
+                // An email address with an invalid value will throw.
+                encodedValue = DerEncoder.SegmentedEncodeIA5String(chars, valueStart, length);
+            }
+            else if (DerEncoder.IsValidPrintableString(chars, valueStart, length))
+            {
+                encodedValue = DerEncoder.SegmentedEncodePrintableString(chars, valueStart, length);
+            }
+            else
+            {
+                encodedValue = DerEncoder.SegmentedEncodeUtf8String(chars, valueStart, length);
+            }
+
+            return DerEncoder.ConstructSegmentedSet(
+                DerEncoder.ConstructSegmentedSequence(
+                    encodedOid,
+                    encodedValue));
+        }
+
+        private static byte[][] ParseRdn(byte[][] encodedOid, char[] value, bool ia5String)
+        {
+            byte[][] encodedValue;
+
+            if (ia5String)
+            {
+                // An email address with an invalid value will throw.
+                encodedValue = DerEncoder.SegmentedEncodeIA5String(value);
+            }
+            else if (DerEncoder.IsValidPrintableString(value))
+            {
+                encodedValue = DerEncoder.SegmentedEncodePrintableString(value);
+            }
+            else
+            {
+                encodedValue = DerEncoder.SegmentedEncodeUtf8String(value);
+            }
+
+            return DerEncoder.ConstructSegmentedSet(
+                DerEncoder.ConstructSegmentedSequence(
+                    encodedOid,
+                    encodedValue));
+        }
+
+        private static char[] ExtractValue(char[] chars, int valueStart, int valueEnd)
+        {
+            // The string is guaranteed to be between ((valueEnd - valueStart) / 2) (all quotes) and
+            // (valueEnd - valueStart - 1) (one escaped quote)
+            List<char> builder = new List<char>(valueEnd - valueStart - 1);
+
+            bool skippedQuote = false;
+
+            for (int i = valueStart; i < valueEnd; i++)
+            {
+                char c = chars[i];
+
+                if (c == '"' && !skippedQuote)
+                {
+                    skippedQuote = true;
+                    continue;
+                }
+
+                // If we just skipped a quote, this will be one.
+                // If this is a quote, we should have just skipped one.
+                Debug.Assert(skippedQuote == (c == '"'));
+
+                skippedQuote = false;
+                builder.Add(c);
+            }
+
+            return builder.ToArray();
         }
     }
 }

--- a/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
+++ b/src/System.Security.Cryptography.X509Certificates/src/Resources/Strings.resx
@@ -258,4 +258,10 @@
   <data name="Cryptography_TooBroadFilePermissions" xml:space="preserve">
     <value>Invalid file permissions. The file '{0}' must not be readable or writable by anyone other than the owner.</value>
   </data>
+  <data name="Cryptography_Invalid_X500Name" xml:space="preserve">
+    <value>The string contains an invalid X500 name attribute key, oid, value or delimiter.</value>
+  </data>
+  <data name="Cryptography_Invalid_IA5String" xml:space="preserve">
+    <value>The string contains a character not in the 7 bit ASCII character set.</value>
+  </data>
 </root>

--- a/src/System.Security.Cryptography.X509Certificates/tests/NameTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/NameTests.cs
@@ -9,7 +9,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class NameTests
     {
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void TestEncode()
         {
             byte[] expectedEncoding = "300e310c300a06035504031303466f6f".HexToByteArray();

--- a/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/tests/System.Security.Cryptography.X509Certificates.Tests.csproj
@@ -42,6 +42,7 @@
     <Compile Include="PropsTests.cs" />
     <Compile Include="PublicKeyTests.cs" />
     <Compile Include="TestData.cs" />
+    <Compile Include="X500DistinguishedNameEncodingTests.cs" />
     <Compile Include="X500DistinguishedNameTests.cs" />
     <Compile Include="X509StoreTests.cs" />
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">

--- a/src/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameEncodingTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X500DistinguishedNameEncodingTests.cs
@@ -1,0 +1,795 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using Test.Cryptography;
+using Xunit;
+
+namespace System.Security.Cryptography.X509Certificates.Tests
+{
+    public static class X500DistinguishedNameEncodingTests
+    {
+        private const string InvalidX500NameFragment = "invalid X500 name";
+        private const string InvalidIA5StringFragment = "7 bit ASCII";
+
+        [Fact]
+        public static void EncodeEmptyValue()
+        {
+            X500DistinguishedName dn = new X500DistinguishedName("");
+
+            ProcessTestCase(
+                new SimpleEncoderTestCase(
+                    "",
+                    null,
+                    "3000",
+                    null),
+                dn);
+        }
+
+        [Theory]
+        [MemberData("SingleRdnTestCases")]
+        public static void EncodeSingleRdn(SimpleEncoderTestCase testCase)
+        {
+            X500DistinguishedName dn = new X500DistinguishedName(testCase.Input, X500DistinguishedNameFlags.None);
+
+            ProcessTestCase(testCase, dn);
+        }
+
+        [Theory]
+        [MemberData("GetFlagBasedDnCases")]
+        public static void EncodeWithFlags(FlagControlledEncoderTestCase testCase)
+        {
+            X500DistinguishedName dn = new X500DistinguishedName(testCase.Input, testCase.Flags);
+
+            ProcessTestCase(testCase, dn);
+        }
+
+        [Theory]
+        [MemberData("SeparatorFlagCombinations")]
+        private static void VerifySeparatorProcessing(X500DistinguishedNameFlags flags)
+        {
+            const string input = "CN=a, O=b; OU=c\r L=d\n S=e";
+
+            // No separator flags: , and ; => CN, O, OU
+            const string withNoFlags = "CN=a, O=b, OU=\"c\r L=d\n S=e\"";
+            // UseNewlines: \r and \n => CN, L, S
+            const string withNewlines = "CN=\"a, O=b; OU=c\", L=d, S=e";
+            // UseCommas: , => CN, O
+            const string withCommas = "CN=a, O=\"b; OU=c\r L=d\n S=e\"";
+            // UseSemicolons: ; => CN, OU
+            const string withSemicolons = "CN=\"a, O=b\", OU=\"c\r L=d\n S=e\"";
+
+            string expected;
+
+            // Semicolons, if specified, always wins.
+            // then commas, if specified, wins.
+            // then newlines, if specified is valid.
+            // Specifying nothing at all is (for some reason) both commas and semicolons.
+            if ((flags & X500DistinguishedNameFlags.UseSemicolons) != 0)
+            {
+                expected = withSemicolons;
+            }
+            else if ((flags & X500DistinguishedNameFlags.UseCommas) != 0)
+            {
+                expected = withCommas;
+            }
+            else if ((flags & X500DistinguishedNameFlags.UseNewLines) != 0)
+            {
+                expected = withNewlines;
+            }
+            else
+            {
+                expected = withNoFlags;
+            }
+
+            X500DistinguishedName dn = new X500DistinguishedName(input, flags);
+
+            Assert.Equal(expected, dn.Format(false));
+        }
+
+        [Theory]
+        // Separator character with no tag
+        [InlineData(",", InvalidX500NameFragment)]
+        // Control character preceding tag
+        [InlineData("\u0008CN=a", InvalidX500NameFragment)]
+        // Control character after tag
+        [InlineData("CN\u0008=a", InvalidX500NameFragment)]
+        // Control character within tag
+        [InlineData("C\u0008N=a", InvalidX500NameFragment)]
+        // Control character after whitespace after tag
+        [InlineData("CN \u0008=a", InvalidX500NameFragment)]
+        // Unresolvable OID
+        [InlineData("1.a.1.3=a", InvalidX500NameFragment)]
+        // Open quote with no close quote. (Don't you hate it when people do that?
+        [InlineData("CN=\"unterminated", InvalidX500NameFragment)]
+        // Non-ASCII values in an E field
+        [InlineData("E=\u65E5\u672C\u8A9E", InvalidIA5StringFragment)]
+        public static void InvalidInput(string input, string messageFragment)
+        {
+            CryptographicException exception =
+                Assert.ThrowsAny<CryptographicException>(() => new X500DistinguishedName(input));
+
+            if (CultureInfo.CurrentCulture.Name == "en-US")
+            {
+                Assert.Contains(messageFragment, exception.Message);
+            }
+        }
+
+        [Theory]
+        [MemberData("ParserBoundaryCases")]
+        public static void CheckParserBoundaryCases(SimpleEncoderTestCase testCase)
+        {
+            X500DistinguishedName dn = new X500DistinguishedName(testCase.Input, X500DistinguishedNameFlags.None);
+
+            ProcessTestCase(testCase, dn);
+        }
+
+        private static void ProcessTestCase(SimpleEncoderTestCase testCase, X500DistinguishedName dn)
+        {
+            // The simple encoding test is "does it output the expected text?", then
+            // we'll move on to the exact bytes.
+            Assert.Equal(testCase.GetNormalizedValue(), dn.Format(false));
+
+            string expectedHex;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                expectedHex = testCase.GetBmpEncoding() ?? testCase.GetPreferredEncoding();
+            }
+            else
+            {
+                expectedHex = testCase.GetPreferredEncoding();
+            }
+
+            string actualHex = dn.RawData.ByteArrayToHex();
+
+            Assert.Equal(expectedHex, actualHex);
+        }
+
+        public static readonly object[][] SingleRdnTestCases =
+        {
+            new object[]
+            {
+                // No accent characters means this fits within a PrintableString.
+                // There's only one correct encoding.
+                new SimpleEncoderTestCase(
+                    "CN=Common Name",
+                    null,
+                    "3016311430120603550403130B436F6D6D6F6E204E616D65",
+                    null),
+            },
+
+            new object[]
+            {
+                // Let's get a bit spicy and accent an o. Now that it doesn't fit in
+                // a PrintableString it should be a UTF8String (RFC 3280 - 2004 deadline,
+                // RFC 5280 unconditional (5280 was written in 2008)).
+                //
+                // Windows continues to use BMPString (UCS-2), so we have to allow that, too.
+                new SimpleEncoderTestCase(
+                    "CN=Comm\u00f3n Name",
+                    null,
+                    "30173115301306035504030C0C436F6D6DC3B36E204E616D65",
+                    "3021311F301D06035504031E160043006F006D006D00F3006E0020004E0061006D0065"),
+            },
+
+            new object[]
+            {
+                // E-mail addresses usually contain an @.
+                // @ is not a PrintableString character.
+                // The industry (and RFC-acknowledged) compromise on this is an IA5String.
+                new SimpleEncoderTestCase(
+                    "E=user@example.com",
+                    null,
+                    "3021311F301D06092A864886F70D010901161075736572406578616D706C652E636F6D",
+                    null),
+            },
+
+            new object[]
+            {
+                // Technically this 'email address' could be a PrintableString, but E just
+                // uses IA5String.
+                new SimpleEncoderTestCase(
+                    "E=Common Name",
+                    null,
+                    "301C311A301806092A864886F70D010901160B436F6D6D6F6E204E616D65",
+                    null),
+            },
+
+            new object[]
+            {
+                // An unknown OID in numeric form will parse just fine.
+                new SimpleEncoderTestCase(
+                    "1.1.1.1=Common Name",
+                    "OID.1.1.1.1=Common Name",
+                    "3016311430120603290101130B436F6D6D6F6E204E616D65",
+                    null),
+            },
+
+            new object[]
+            {
+                // An unknown OID with the OID.numericform form.
+                new SimpleEncoderTestCase(
+                    "OID.1.1.1.1=Common Name",
+                    null,
+                    "3016311430120603290101130B436F6D6D6F6E204E616D65",
+                    null),
+            },
+
+            new object[]
+            {
+                // Common Name in the raw numeric form.
+                new SimpleEncoderTestCase(
+                    "2.5.4.3=Common Name",
+                    "CN=Common Name",
+                    "3016311430120603550403130B436F6D6D6F6E204E616D65",
+                    null),
+            },
+
+            new object[]
+            {
+                // Common Name in the OID.-prefixed numeric form.
+                new SimpleEncoderTestCase(
+                    "OID.2.5.4.3=Common Name",
+                    "CN=Common Name",
+                    "3016311430120603550403130B436F6D6D6F6E204E616D65",
+                    null),
+            },
+
+            new object[]
+            {
+                // Common Name with a dangling separator.
+                new SimpleEncoderTestCase(
+                    "CN=Common Name,",
+                    "CN=Common Name",
+                    "3016311430120603550403130B436F6D6D6F6E204E616D65",
+                    null),
+            },
+
+            new object[]
+            {
+                // Unnecessarily quoted value
+                new SimpleEncoderTestCase(
+                    "CN=\"Common Name\"",
+                    "CN=Common Name",
+                    "3016311430120603550403130B436F6D6D6F6E204E616D65",
+                    null),
+            },
+
+            new object[]
+            {
+                // Quoted because of an embedded comma.  The quotes are not
+                // included in the encoded value, just the string form.
+                new SimpleEncoderTestCase(
+                    "CN=\"Name, Common\"",
+                    null,
+                    "3017311530130603550403130C4E616D652C20436F6D6D6F6E",
+                    null),
+            },
+
+            new object[]
+            {
+                // Contains two escaped quotation marks.
+                // Quotation mark is not a PrintableString character, so UTF8 (or BMP).
+                new SimpleEncoderTestCase(
+                    "CN=\"\"\"Common\"\" Name\"",
+                    null,
+                    "30183116301406035504030C0D22436F6D6D6F6E22204E616D65",
+                    "30253123302106035504031E1A00220043006F006D006D006F006E00220020004E0061006D0065"),
+            },
+
+            new object[]
+            {
+                // Unnecessarily quoted email address
+                new SimpleEncoderTestCase(
+                    "E=\"user@example.com\"",
+                    "E=user@example.com",
+                    "3021311F301D06092A864886F70D010901161075736572406578616D706C652E636F6D",
+                    null),
+            },
+
+            new object[]
+            {
+                // "email address" with an embedded quote.
+                // While this isn't a legal email address it is a valid IA5String.
+                new SimpleEncoderTestCase(
+                    "E=\"\"\"user\"\"@example.com\"",
+                    null,
+                    "30233121301F06092A864886F70D0109011612227573657222406578616D706C652E636F6D",
+                    null),
+            },
+
+            new object[]
+            {
+                // The RFCs have no statement like "when a BMPString would contain fewer octets,
+                // it should be preferred over UTF8String".  So we'll continue to call UTF-8
+                // preferred in this case (CN=nihongo)
+                new SimpleEncoderTestCase(
+                    "CN=\u65E5\u672C\u8A9E",
+                    null,
+                    "30143112301006035504030C09E697A5E69CACE8AA9E",
+                    "3011310F300D06035504031E0665E5672C8A9E"),
+            },
+
+            new object[]
+            {
+                // Leading and trailing whitespace is removed
+                new SimpleEncoderTestCase(
+                    "    CN  = Common Name             ",
+                    "CN=Common Name",
+                    "3016311430120603550403130B436F6D6D6F6E204E616D65",
+                    null),
+            },
+
+            new object[]
+            {
+                // This looks like it could be two RDNs, but it's only one.
+                new SimpleEncoderTestCase(
+                    "CN=\"Common Name, E=user@example.com\"",
+                    null,
+                    "302A3128302606035504030C1F436F6D6D6F6E204E616D652C20453D75736572406578616D706C652E636F6D",
+                    "30493147304506035504031E3E0043006F006D006D006F006E0020004E006100" +
+                        "6D0065002C00200045003D00750073006500720040006500780061006D007000" +
+                        "6C0065002E0063006F006D"),
+            },
+
+            new object[]
+            {
+                // Control codes are valid in the value portion (as the first character)
+                new SimpleEncoderTestCase(
+                    "CN=\u0008",
+                    null,
+                    "300C310A300806035504030C0108",
+                    "300D310B300906035504031E020008"),
+            },
+
+            new object[]
+            {
+                // Control codes are valid in the value portion (anywhere, really)
+                new SimpleEncoderTestCase(
+                    "CN=a     \u0008",
+                    null,
+                    "30123110300E06035504030C0761202020202008",
+                    "30193117301506035504031E0E0061002000200020002000200008"),
+            },
+
+            new object[]
+            {
+                // Empty values are legal.
+                new SimpleEncoderTestCase(
+                    "CN=",
+                    "CN=\"\"",
+                    "300B3109300706035504031300",
+                    null),
+            },
+
+            new object[]
+            {
+                // Contains two adjacent escaped quotes.
+                new SimpleEncoderTestCase(
+                    "CN=\"Adjacent Escaped\"\"\"\"Quotes\"",
+                    null,
+                    "30233121301F06035504030C1841646A6163656E742045736361706564222251756F746573",
+                    "303B3139303706035504031E3000410064006A006100630065006E00740020004500730063" +
+                        "00610070006500640022002200510075006F007400650073"),
+            },
+        };
+
+        public static IEnumerable<object[]> GetFlagBasedDnCases()
+        {
+            foreach (FlagVariantEncoderTestCases generator in s_flagVariantTestCases)
+            {
+                foreach (FlagControlledEncoderTestCase testCase in generator.GenerateTestCases())
+                {
+                    yield return new object[] {testCase };
+                }
+            }
+        }
+
+        public static object[][] SeparatorFlagCombinations =
+        {
+            new object[]
+            {
+                X500DistinguishedNameFlags.None,
+            },
+            new object[]
+            {
+                X500DistinguishedNameFlags.UseNewLines
+            },
+            new object[]
+            {
+                X500DistinguishedNameFlags.UseCommas
+            },
+            new object[]
+            {
+                X500DistinguishedNameFlags.UseCommas |
+                X500DistinguishedNameFlags.UseNewLines
+            },
+            new object[]
+            {
+                X500DistinguishedNameFlags.UseSemicolons
+            },
+            new object[]
+            {
+                X500DistinguishedNameFlags.UseSemicolons |
+                X500DistinguishedNameFlags.UseNewLines
+            },
+            new object[]
+            {
+                X500DistinguishedNameFlags.UseSemicolons |
+                X500DistinguishedNameFlags.UseCommas
+            },
+            new object[]
+            {
+                X500DistinguishedNameFlags.UseSemicolons |
+                X500DistinguishedNameFlags.UseCommas |
+                X500DistinguishedNameFlags.UseNewLines
+            },
+        };
+
+        private static readonly FlagVariantEncoderTestCases[] s_flagVariantTestCases =
+        {
+            new FlagVariantEncoderTestCases("CN=Common Name, E=user@example.com")
+            {
+                {
+                    X500DistinguishedNameFlags.None,
+                    "CN=Common Name, E=user@example.com",
+                    "3037311430120603550403130B436F6D6D6F6E204E616D65311F301D06092A86" +
+                        "4886F70D010901161075736572406578616D706C652E636F6D",
+                    null
+                },
+
+                // Since the delimiter used is a comma, and comma is in the special none group,
+                // this has no visible effect.
+                {
+                    X500DistinguishedNameFlags.UseCommas,
+                    "CN=Common Name, E=user@example.com",
+                    "3037311430120603550403130B436F6D6D6F6E204E616D65311F301D06092A86" +
+                        "4886F70D010901161075736572406578616D706C652E636F6D",
+                    null
+                },
+
+                // Parse reversed
+                {
+                    X500DistinguishedNameFlags.Reversed,
+                    "E=user@example.com, CN=Common Name",
+                    "3037311F301D06092A864886F70D010901161075736572406578616D706C652E" +
+                        "636F6D311430120603550403130B436F6D6D6F6E204E616D65",
+                    null
+                },
+
+                // Reversed and UseCommas aren't conflicting.  Since we did use commas, this is just Reversed.
+                {
+                    X500DistinguishedNameFlags.Reversed | X500DistinguishedNameFlags.UseCommas,
+                    "E=user@example.com, CN=Common Name",
+                    "3037311F301D06092A864886F70D010901161075736572406578616D706C652E" +
+                        "636F6D311430120603550403130B436F6D6D6F6E204E616D65",
+                    null
+                },
+
+                // Only Semicolons are delimiters, so this is one RDN with a value which isn't a PrintableString
+                {
+                    X500DistinguishedNameFlags.UseSemicolons,
+                    "CN=\"Common Name, E=user@example.com\"",
+                    "302A3128302606035504030C1F436F6D6D6F6E204E616D652C20453D75736572406578616D706C652E636F6D",
+                    "30493147304506035504031E3E0043006F006D006D006F006E0020004E006100" +
+                        "6D0065002C00200045003D00750073006500720040006500780061006D007000" +
+                        "6C0065002E0063006F006D"
+                },
+
+                // Reversed processing isn't quite the same as doing a scan from the right.
+                // This is CN only, not an invalid value.
+                {
+                    X500DistinguishedNameFlags.UseSemicolons | X500DistinguishedNameFlags.Reversed,
+                    "CN=\"Common Name, E=user@example.com\"",
+                    "302A3128302606035504030C1F436F6D6D6F6E204E616D652C20453D75736572406578616D706C652E636F6D",
+                    "30493147304506035504031E3E0043006F006D006D006F006E0020004E006100" +
+                        "6D0065002C00200045003D00750073006500720040006500780061006D007000" +
+                        "6C0065002E0063006F006D"
+                },
+            },
+
+            new FlagVariantEncoderTestCases("CN=\"Common Name, O=Organization\"")
+            {
+                // The quotes match, so this is just what it looks like.
+                {
+                    X500DistinguishedNameFlags.None,
+                    "CN=\"Common Name, O=Organization\"",
+                    "3026312430220603550403131B436F6D6D6F6E204E616D652C204F3D4F726761" +
+                        "6E697A6174696F6E",
+                    null
+                },
+
+                // If we ignore the quotes, this is now a CN with an embedded quote and an O with an embedded quote.
+                {
+                    X500DistinguishedNameFlags.DoNotUseQuotes,
+                    "CN=\"\"\"Common Name\", O=\"Organization\"\"\"",
+                    "302F3115301306035504030C0C22436F6D6D6F6E204E616D6531163014060355" +
+                        "040A0C0D4F7267616E697A6174696F6E22",
+                    "30483121301F06035504031E1800220043006F006D006D006F006E0020004E00" +
+                        "61006D006531233021060355040A1E1A004F007200670061006E0069007A0061" +
+                        "00740069006F006E0022"
+                },
+
+                // Reversed doesn't matter, there's only one value.
+                {
+                    X500DistinguishedNameFlags.Reversed,
+                    "CN=\"Common Name, O=Organization\"",
+                    "3026312430220603550403131B436F6D6D6F6E204E616D652C204F3D4F726761" +
+                        "6E697A6174696F6E",
+                    null
+                },
+
+                // Reversed with no quotes is different.
+                {
+                    X500DistinguishedNameFlags.DoNotUseQuotes | X500DistinguishedNameFlags.Reversed,
+                    "O=\"Organization\"\"\", CN=\"\"\"Common Name\"",
+                    "302F31163014060355040A0C0D4F7267616E697A6174696F6E22311530130603" +
+                        "5504030C0C22436F6D6D6F6E204E616D65",
+                    "304831233021060355040A1E1A004F007200670061006E0069007A0061007400" +
+                        "69006F006E00223121301F06035504031E1800220043006F006D006D006F006E" +
+                        "0020004E0061006D0065"
+                },
+            },
+
+            new FlagVariantEncoderTestCases("CN=@")
+            {
+                // A non-PrintableString value. Unix: UTF-8, Windows: BMP (UCS-2)
+                {
+                    X500DistinguishedNameFlags.None,
+                    "CN=@",
+                    "300C310A300806035504030C0140",
+                    "300D310B300906035504031E020040"
+                },
+
+                // Windows can emit the UTF-8 form, but you have to ask it to.
+                {
+                    X500DistinguishedNameFlags.UseUTF8Encoding,
+                    "CN=@",
+                    "300C310A300806035504030C0140",
+                    null
+                },
+
+                // Windows can also do the T61 (teletex) encoding.
+                // Unix doesn't honor this flag, it sticks with UTF-8
+                {
+                    X500DistinguishedNameFlags.UseT61Encoding,
+                    "CN=@",
+                    "300C310A300806035504030C0140",
+                    "300C310A30080603550403140140"
+                },
+            },
+
+            new FlagVariantEncoderTestCases("CN=a\nO=b\rOU=c\r\nL=d\n\n \n")
+            {
+                // One very-whitespaced value.  Note that the whatespace at the end
+                // was removed, even though the default-printed form has quotes.
+                {
+                    X500DistinguishedNameFlags.None,
+                    "CN=\"a\nO=b\rOU=c\r\nL=d\"",
+                    "301A3118301606035504030C0F610A4F3D620D4F553D630D0A4C3D64",
+                    "30293127302506035504031E1E0061000A004F003D0062000D004F0055003D00" +
+                        "63000D000A004C003D0064"
+                },
+
+                // \r and \n are the only delimiters that are allowed to
+                // appear consecutively.  That's because they're also whitespace.
+                {
+                    X500DistinguishedNameFlags.UseNewLines,
+                    "CN=a, O=b, OU=c, L=d",
+                    "3030310A30080603550403130161310A3008060355040A130162310A30080603" +
+                        "55040B130163310A30080603550407130164",
+                    null
+                },
+            },
+        };
+
+        public static readonly object[][] ParserBoundaryCases =
+        {
+            // The parser states referenced here are based on the managed implementation
+            // used by the Unix builds.
+
+            new object[]
+            {
+                // First RDN goes from = to , directly.
+                // First-to-second transition has no whitespace
+                // Second RDN goes from = to the end of the string.
+                // Parser ends in SeekValueStart without having done the loop in that state.
+                new SimpleEncoderTestCase(
+                    "CN=,O=",
+                    "CN=\"\", O=\"\"",
+                    "3016310930070603550403130031093007060355040A1300",
+                    null)
+            },
+
+            new object[]
+            {
+                // Same as above, but with abundant whitespace.
+                // Parser ends in SeekValueStart after having processed some whitespace
+                new SimpleEncoderTestCase(
+                    "  CN=                  ,    O=  ",
+                    "CN=\"\", O=\"\"",
+                    "3016310930070603550403130031093007060355040A1300",
+                    null)
+            },
+
+             new object[]
+            {
+                // Lets add some quotes for good measure.
+                // Parser ends in MaybeEndQuote
+                new SimpleEncoderTestCase(
+                    "  CN=                \"\"  ,    O= \"\"",
+                    "CN=\"\", O=\"\"",
+                    "3016310930070603550403130031093007060355040A1300",
+                    null)
+            },
+
+            new object[]
+            {
+                // Same as above, with trailing whitespace.
+                // Parser ends in SeekComma
+                new SimpleEncoderTestCase(
+                    "  CN=                \"\"  ,    O= \"\" ",
+                    "CN=\"\", O=\"\"",
+                    "3016310930070603550403130031093007060355040A1300",
+                    null)
+            },
+
+            new object[]
+            {
+                // Give the parser the comma it wanted, now it ends in SeekTag
+                new SimpleEncoderTestCase(
+                    "  CN=                \"\"  ,    O= \"\" ,",
+                    "CN=\"\", O=\"\"",
+                    "3016310930070603550403130031093007060355040A1300",
+                    null)
+            },
+
+            new object[]
+            {
+                // Parser ends in SeekValueEnd with no whitespace
+                new SimpleEncoderTestCase(
+                    "  CN=                \"\"  ,    O= a",
+                    "CN=\"\", O=a",
+                    "30173109300706035504031300310A3008060355040A130161",
+                    null)
+            },
+
+            new object[]
+            {
+                // Parser ends in SeekValueEnd after reading whitespace
+                new SimpleEncoderTestCase(
+                    "  CN=                \"\"  ,    O= a ",
+                    "CN=\"\", O=a",
+                    "30173109300706035504031300310A3008060355040A130161",
+                    null)
+            },
+        };
+
+        public class SimpleEncoderTestCase
+        {
+            private readonly string _normalized;
+            private readonly string _preferredEncodingHex;
+            private readonly string _bmpEncodingHex;
+
+            public string Input { get; private set; }
+
+            internal SimpleEncoderTestCase(
+                string input,
+                string normalized,
+                string preferredEncodingHex,
+                string bmpEncodingHex)
+            {
+                _normalized = normalized;
+                _preferredEncodingHex = preferredEncodingHex;
+                _bmpEncodingHex = bmpEncodingHex;
+                Input = input;
+            }
+
+            internal string GetNormalizedValue()
+            {
+                return _normalized ?? Input;
+            }
+
+            internal string GetPreferredEncoding()
+            {
+                return _preferredEncodingHex;
+            }
+
+            internal string GetBmpEncoding()
+            {
+                return _bmpEncodingHex;
+            }
+        }
+
+        public class FlagControlledEncoderTestCase : SimpleEncoderTestCase
+        {
+            public X500DistinguishedNameFlags Flags { get; private set; }
+
+            internal FlagControlledEncoderTestCase(
+                string input,
+                X500DistinguishedNameFlags flags,
+                string normalized,
+                string preferredEncodingHex,
+                string bmpEncodingHex)
+                : base(input, normalized, preferredEncodingHex, bmpEncodingHex)
+            {
+                Flags = flags;
+            }
+        }
+
+        public class FlagVariantEncoderTestCases : IEnumerable<FlagControlledEncoderTestCase>
+        {
+            private readonly string _template;
+            private readonly List<Variation> _variations = new List<Variation>();
+
+            internal FlagVariantEncoderTestCases(string template)
+            {
+                _template = template;
+            }
+
+            internal void Add(
+                X500DistinguishedNameFlags flags,
+                string output,
+                string preferredEncoding,
+                string bmpEncoding)
+            {
+                _variations.Add(new Variation(flags, ',', output, preferredEncoding, bmpEncoding));
+            }
+
+            internal IEnumerable<FlagControlledEncoderTestCase> GenerateTestCases()
+            {
+                if (_variations.Count == 0)
+                {
+                    throw new InvalidOperationException("No variations were added");
+                }
+
+                foreach (Variation variation in _variations)
+                {
+                    yield return new FlagControlledEncoderTestCase(
+                        _template,
+                        variation.Flags,
+                        variation.Output,
+                        variation.PreferredEncoding,
+                        variation.BmpEncoding);
+                }
+            }
+
+            private class Variation
+            {
+                public X500DistinguishedNameFlags Flags { get; private set; }
+                public char Separator { get; private set; }
+                public string Output { get; private set; }
+                public string PreferredEncoding { get; private set; }
+                public string BmpEncoding { get; private set; }
+
+                public Variation(
+                    X500DistinguishedNameFlags flags,
+                    char separator,
+                    string output,
+                    string preferredEncoding,
+                    string bmpEncoding)
+                {
+                    Flags = flags;
+                    Separator = separator;
+                    Output = output;
+                    PreferredEncoding = preferredEncoding;
+                    BmpEncoding = bmpEncoding;
+                }
+            }
+
+            IEnumerator<FlagControlledEncoderTestCase> IEnumerable<FlagControlledEncoderTestCase>.GetEnumerator()
+            {
+                return GenerateTestCases().GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GenerateTestCases().GetEnumerator();
+            }
+        }
+    }
+}


### PR DESCRIPTION
The Unix implementation matches the Windows behavior on the Use*
flags for choosing the RDN separator, but always uses the UTF-8
encoding instead of the UCS-2/BMP encoding (Windows will use UTF-8 as
an opt-in with a flag).

So new X500DistinguishedName(input, flags).Decode(false) will always
produce the same output string from both Windows and Unix, but the RawData
will differ.

Fixes #1993. (This is the last sub-issue)

cc: @stephentoub, @AtsushiKan, @morganbr