### PR TITLE
Unique names for System.Native.* exports

### DIFF
--- a/src/Common/src/Interop/Linux/System.Native/Interop.INotify.cs
+++ b/src/Common/src/Interop/Linux/System.Native/Interop.INotify.cs
@@ -10,13 +10,13 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_INotifyInit", SetLastError = true)]
         internal static extern SafeFileHandle INotifyInit();
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_INotifyAddWatch", SetLastError = true)]
         internal static extern int INotifyAddWatch(SafeFileHandle fd, string pathName, uint mask);
 
-        [DllImport(Libraries.SystemNative, SetLastError = true, EntryPoint = "INotifyRemoveWatch")]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_INotifyRemoveWatch", SetLastError = true)]
         private static extern int INotifyRemoveWatch_private(SafeFileHandle fd, int wd);
 
         internal static int INotifyRemoveWatch(SafeFileHandle fd, int wd)

--- a/src/Common/src/Interop/Linux/System.Native/Interop.NetworkChange.cs
+++ b/src/Common/src/Interop/Linux/System.Native/Interop.NetworkChange.cs
@@ -19,13 +19,13 @@ internal static partial class Interop
 
         public delegate void NetworkChangeEvent(NetworkChangeKind kind);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CreateNetworkChangeListenerSocket")]
         public static extern Error CreateNetworkChangeListenerSocket(out int socket);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CloseNetworkChangeListenerSocket")]
         public static extern Error CloseNetworkChangeListenerSocket(int socket);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReadSingleEvent")]
         public static extern NetworkChangeKind ReadSingleEvent(int socket);
     }
 }

--- a/src/Common/src/Interop/OSX/System.Native/Interop.ProtocolStatistics.cs
+++ b/src/Common/src/Interop/OSX/System.Native/Interop.ProtocolStatistics.cs
@@ -22,7 +22,7 @@ internal static partial class Interop
             private readonly int __padding;
         }
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetTcpGlobalStatistics")]
         public static unsafe extern int GetTcpGlobalStatistics(out TcpGlobalStatistics statistics);
 
         [StructLayoutAttribute(LayoutKind.Sequential)]
@@ -44,7 +44,7 @@ internal static partial class Interop
             public readonly int Forwarding;
         }
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv4GlobalStatistics")]
         public static unsafe extern int GetIPv4GlobalStatistics(out IPv4GlobalStatistics statistics);
 
         [StructLayoutAttribute(LayoutKind.Sequential)]
@@ -57,7 +57,7 @@ internal static partial class Interop
             public readonly ulong UdpListeners;
         }
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetUdpGlobalStatistics")]
         public static unsafe extern int GetUdpGlobalStatistics(out UdpGlobalStatistics statistics);
 
         [StructLayoutAttribute(LayoutKind.Sequential)]
@@ -87,7 +87,7 @@ internal static partial class Interop
             public readonly ulong TimestampRequestsSent;
         }
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIcmpv4GlobalStatistics")]
         public static unsafe extern int GetIcmpv4GlobalStatistics(out Icmpv4GlobalStatistics statistics);
 
         [StructLayoutAttribute(LayoutKind.Sequential)]
@@ -123,7 +123,7 @@ internal static partial class Interop
             public readonly ulong TimeExceededMessagesSent;
         }
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIcmpv6GlobalStatistics")]
         public static unsafe extern int GetIcmpv6GlobalStatistics(out Icmpv6GlobalStatistics statistics);
 
         public struct NativeIPInterfaceStatistics
@@ -143,10 +143,10 @@ internal static partial class Interop
             public readonly ulong InNoProto;
         }
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetNativeIPInterfaceStatistics")]
         public static unsafe extern int GetNativeIPInterfaceStatistics(string name, out NativeIPInterfaceStatistics stats);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetNumRoutes")]
         public static extern int GetNumRoutes();
     }
 }

--- a/src/Common/src/Interop/OSX/System.Native/Interop.TcpConnectionInfo.cs
+++ b/src/Common/src/Interop/OSX/System.Native/Interop.TcpConnectionInfo.cs
@@ -25,16 +25,16 @@ internal static partial class Interop
             public TcpState State;
         }
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetEstimatedTcpConnectionCount")]
         public unsafe static extern int GetEstimatedTcpConnectionCount();
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetActiveTcpConnectionInfos")]
         public unsafe static extern int GetActiveTcpConnectionInfos(NativeTcpConnectionInformation* infos, int* infoCount);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetEstimatedUdpListenerCount")]
         public unsafe static extern int GetEstimatedUdpListenerCount();
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetActiveUdpListeners")]
         public unsafe static extern int GetActiveUdpListeners(IPEndPointInfo* infos, int* infoCount);
     }    
 }

--- a/src/Common/src/Interop/Unix/Interop.Errors.cs
+++ b/src/Common/src/Interop/Unix/Interop.Errors.cs
@@ -175,13 +175,13 @@ internal static partial class Interop
             return Marshal.PtrToStringAnsi((IntPtr)message);
         }
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ConvertErrorPlatformToPal")]
         internal static extern Error ConvertErrorPlatformToPal(int platformErrno);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ConvertErrorPalToPlatform")]
         internal static extern int ConvertErrorPalToPlatform(Error error);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_StrErrorR")]
         private static unsafe extern byte* StrErrorR(int platformErrno, byte* buffer, int bufferSize);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Accept.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Accept.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Accept")]
         internal static extern unsafe Error Accept(int socket, byte* socketAddress, int* socketAddressLen, int* acceptedFd);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Access.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Access.cs
@@ -16,7 +16,7 @@ internal static partial class Interop
             R_OK = 4,   /* Check for read */
         }
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Access", SetLastError = true)]
         internal static extern int Access(string path, AccessMode mode);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Bind.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Bind.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Bind")]
         internal static extern unsafe Error Bind(int socket, byte* socketAddress, int socketAddressLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.ChDir.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ChDir.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ChDir", SetLastError = true)]
         internal static extern int ChDir(string path);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.ChMod.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ChMod.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ChMod", SetLastError = true)]
         internal static extern int ChMod(string path, int mode);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Close.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Close.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Close", SetLastError = true)]
         internal static extern int Close(IntPtr fd);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Connect.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Connect.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Connect")]
         internal static extern unsafe Error Connect(int socket, byte* socketAddress, int socketAddressLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Dup.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Dup.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Dup", SetLastError = true)]
         internal static extern SafeFileHandle Dup(SafeFileHandle oldfd);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.EnumerateInterfaceAddresses.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.EnumerateInterfaceAddresses.cs
@@ -31,13 +31,13 @@ internal static partial class Interop
         public unsafe delegate void LinkLayerAddressDiscoveredCallback(string ifaceName, LinkLayerAddressInfo* llAddress);
         public unsafe delegate void DnsAddessDiscoveredCallback(IpAddressInfo* gatewayAddress);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_EnumerateInterfaceAddresses")]
         public static extern int EnumerateInterfaceAddresses(
             IPv4AddressDiscoveredCallback ipv4Found,
             IPv6AddressDiscoveredCallback ipv6Found,
             LinkLayerAddressDiscoveredCallback linkLayerFound);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_EnumerateGatewayAddressesForInterface")]
         public static extern int EnumerateGatewayAddressesForInterface(uint interfaceIndex, DnsAddessDiscoveredCallback onGatewayFound);
 
     }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.FLock.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.FLock.cs
@@ -17,14 +17,14 @@ internal static partial class Interop
             LOCK_UN = 8,    /* unlock */
         }
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FLock", SetLastError = true)]
         internal static extern int FLock(SafeFileHandle fd, LockOperations operation);
 
         /// <summary>
         /// Exposing this for SafeFileHandle.ReleaseHandle() to call.
         /// Normal callers should use FLock(SafeFileHandle fd).
         /// </summary>
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FLock", SetLastError = true)]
         internal static extern int FLock(IntPtr fd, LockOperations operation);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.FSync.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.FSync.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FSync", SetLastError = true)]
         internal static extern int FSync(SafeFileHandle fd);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.FTruncate.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.FTruncate.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FTruncate", SetLastError = true)]
         internal static extern int FTruncate(SafeFileHandle fd, long length);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Fcntl.Pipe.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Fcntl.Pipe.cs
@@ -13,13 +13,13 @@ internal static partial class Interop
         {
             internal static readonly bool CanGetSetPipeSz = (FcntlCanGetSetPipeSz() != 0);
 
-            [DllImport(Libraries.SystemNative, EntryPoint="FcntlGetPipeSz", SetLastError=true)]
+            [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FcntlGetPipeSz", SetLastError=true)]
             internal static extern int GetPipeSz(SafePipeHandle fd);
 
-            [DllImport(Libraries.SystemNative, EntryPoint="FcntlSetPipeSz", SetLastError=true)]
+            [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FcntlSetPipeSz", SetLastError=true)]
             internal static extern int SetPipeSz(SafePipeHandle fd, int size);
 
-            [DllImport(Libraries.SystemNative)]
+            [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FcntlCanGetSetPipeSz")]
             private static extern int FcntlCanGetSetPipeSz();
         }
     }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Fcntl.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Fcntl.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
     {
         internal static class Fcntl
         {
-            [DllImport(Libraries.SystemNative, EntryPoint="FcntlSetIsNonBlocking", SetLastError=true)]
+            [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FcntlSetIsNonBlocking", SetLastError=true)]
             internal static extern int SetIsNonBlocking(IntPtr fd, int isNonBlocking);
         }
     }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.FdSet.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.FdSet.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FdSetSize")]
         private static extern int FdSetSize();
 
         private static readonly int FD_SETSIZE_BITS = FdSetSize();

--- a/src/Common/src/Interop/Unix/System.Native/Interop.FnMatch.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.FnMatch.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
             FNM_NONE = 0,
         }
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FnMatch", SetLastError = true)]
         internal static extern int FnMatch(string pattern, string path, FnMatchFlags flags);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.ForkAndExecProcess.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ForkAndExecProcess.cs
@@ -32,7 +32,7 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ForkAndExecProcess", SetLastError = true)]
         private static extern unsafe int ForkAndExecProcess(
             string filename, byte** argv, byte** envp, string cwd,
             int redirectStdin, int redirectStdout, int redirectStderr,

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetBytesAvailable.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetBytesAvailable.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetBytesAvailable")]
         internal static extern unsafe Error GetBytesAvailable(int socket, int* available);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetCwd.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetCwd.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetCwd", SetLastError = true)]
         private static unsafe extern byte* GetCwd(byte* buffer, int bufferLength);
 
         internal static unsafe string GetCwd()

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetDomainName.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetDomainName.cs
@@ -10,7 +10,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetDomainName", SetLastError = true)]
         private static extern unsafe int GetDomainName(byte* name, int len);
 
         internal static unsafe string GetDomainName()

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetEGid.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetEGid.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetEGid")]
         internal static extern uint GetEGid();
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetEUid.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetEUid.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetEUid")]
         internal static extern uint GetEUid();
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetHostName.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetHostName.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetHostName", SetLastError = true)]
         private unsafe static extern int GetHostName(byte* name, int nameLength);
 
         internal static unsafe string GetHostName()

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetNameInfo.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetNameInfo.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
             NI_NUMERICHOST  = 0x2,
         }
         
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetNameInfo")]
         internal static unsafe extern int GetNameInfo(
             byte* address, 
             uint addressLength,

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetPeerName.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetPeerName.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPeerName")]
         internal static extern unsafe Error GetPeerName(int socket, byte* socketAddress, int* socketAddressLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetPid.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetPid.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPid")]
         internal static extern int GetPid();
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetPwUid.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetPwUid.cs
@@ -19,7 +19,7 @@ internal static partial class Interop
             internal byte* Shell;
         };
 
-        [DllImport(Libraries.SystemNative, SetLastError = false)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPwUidR", SetLastError = false)]
         internal static extern unsafe int GetPwUidR(uint uid, out Passwd pwd, byte* buf, int bufLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetSetPriority.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetSetPriority.cs
@@ -16,10 +16,10 @@ internal static partial class Interop
             PRIO_USER       = 2,
         }
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPriority", SetLastError = true)]
         private static extern int GetPriority(PriorityWhich which, int who);
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetPriority", SetLastError = true)]
         internal static extern int SetPriority(PriorityWhich which, int who, int nice);
 
         /// <summary>

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetSid.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetSid.cs
@@ -7,7 +7,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSid")]
         internal static extern int GetSid(int pid);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetSockName.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetSockName.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSockName")]
         internal static extern unsafe Error GetSockName(int socket, byte* socketAddress, int* socketAddressLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetSockOpt.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetSockOpt.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSockOpt")]
         internal static extern unsafe Error GetSockOpt(int socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int* optionLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetSocketErrorOption.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetSocketErrorOption.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSocketErrorOption")]
         internal static extern unsafe Error GetSocketErrorOption(int socket, Error* socketError);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetTimestamp.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetTimestamp.cs
@@ -7,10 +7,10 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetTimestampResolution")]
         internal static extern bool GetTimestampResolution(out long resolution);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetTimestamp")]
         internal static extern bool GetTimestamp(out long timestamp);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetUnixArchitecture.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetUnixArchitecture.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetUnixArchitecture")]
         internal static extern int GetUnixArchitecture();
 
         internal enum ProcessorArchitecture

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetUnixVersion.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetUnixVersion.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, CharSet = CharSet.Ansi, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetUnixVersion", CharSet = CharSet.Ansi, SetLastError = true)]
         private static extern int GetUnixVersion(StringBuilder version, out int capacity);
 
         internal static string GetUnixVersion()

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetWindowWidth.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetWindowWidth.cs
@@ -17,7 +17,7 @@ internal static partial class Interop
             internal ushort YPixel;
         };
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetWindowSize", SetLastError = true)]
         internal static extern int GetWindowSize(out WinSize winSize);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.HostEntry.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.HostEntry.cs
@@ -41,19 +41,19 @@ internal static partial class Interop
             private int _handleType;          // Opaque handle type information.
         }
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetHostEntryForName")]
         internal static extern unsafe int GetHostEntryForName(string address, HostEntry* entry);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetHostByName")]
         internal static extern unsafe int GetHostByName(string address, HostEntry* entry);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetHostByAddress")]
         internal static extern unsafe int GetHostByAddress(IPAddress* address, HostEntry* entry);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetNextIPAddress")]
         internal static extern unsafe int GetNextIPAddress(HostEntry* entry, void** addressListHandle, IPAddress* endPoint);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FreeHostEntry")]
         internal static extern unsafe void FreeHostEntry(HostEntry* entry);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.IPAddress.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.IPAddress.cs
@@ -34,13 +34,13 @@ internal static partial class Interop
             internal uint ScopeId;                             // Scope ID (IPv6 only)
         }
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_IPv6StringToAddress", SetLastError = true)]
         internal static extern int IPv6StringToAddress(string address, string port, byte[] buffer, int bufferLength, out uint scope);
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_IPv4StringToAddress", SetLastError = true)]
         internal static extern int IPv4StringToAddress(string address, byte[] buffer, int bufferLength, out ushort port);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_IPAddressToString")]
         internal unsafe static extern int IPAddressToString(byte* address, int addressLength, bool isIPv6, byte* str, int stringLength, uint scope = 0);
 
         internal unsafe static uint IPAddressToString(byte[] address, bool isIPv6, StringBuilder addressString, uint scope = 0)

--- a/src/Common/src/Interop/Unix/System.Native/Interop.IPPacketInformation.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.IPPacketInformation.cs
@@ -14,10 +14,10 @@ internal static partial class Interop
             private int Padding;       // Pad out to 8-byte alignment
         }
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetControlMessageBufferSize")]
         internal static extern int GetControlMessageBufferSize(bool isIPv4, bool isIPv6);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_TryGetIPPacketInformation")]
         internal static extern unsafe bool TryGetIPPacketInformation(MessageHeader* messageHeader, bool isIPv4, IPPacketInformation* packetInfo);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.InitializeConsole.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.InitializeConsole.cs
@@ -7,7 +7,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_InitializeConsole")]
         internal static extern void InitializeConsole();
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.IsATty.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.IsATty.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_IsATty", SetLastError = true)]
         internal static extern bool IsATty(SafeFileHandle fd);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Kill.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Kill.cs
@@ -14,7 +14,7 @@ internal static partial class Interop
             SIGKILL = 9,
         }
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Kill", SetLastError = true)]
         internal static extern int Kill(int pid, Signals signal);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.LSeek.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.LSeek.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
             SEEK_END = 2
         }
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LSeek", SetLastError = true)]
         internal static extern long LSeek(SafeFileHandle fd, long offset, SeekWhence whence);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.LingerOption.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.LingerOption.cs
@@ -15,10 +15,10 @@ internal static partial class Interop
             public int Seconds; // Number of seconds to linger for
         }
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetLingerOption")]
         internal static extern unsafe Error GetLingerOption(int socket, LingerOption* option);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetLingerOption")]
         internal static extern unsafe Error SetLingerOption(int socket, LingerOption* option);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Link.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Link.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Link", SetLastError = true)]
         internal static extern int Link(string source, string link);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Listen.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Listen.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Listen")]
         internal static extern Error Listen(int socket, int backlog);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MAdvise.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MAdvise.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_MAdvise", SetLastError = true)]
         internal static extern int MAdvise(IntPtr addr, ulong length, MemoryAdvice advice);
 
         internal enum MemoryAdvice

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MLock.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MLock.cs
@@ -8,10 +8,10 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_MLock", SetLastError = true)]
         internal static extern int MLock(IntPtr addr, ulong len);
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_MUnlock", SetLastError = true)]
         internal static extern int MUnlock(IntPtr addr, ulong len);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MMap.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MMap.cs
@@ -28,7 +28,7 @@ internal static partial class Interop
         }
 
         // NOTE: Shim returns null pointer on failure, not non-null MAP_FAILED sentinel.
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_MMap", SetLastError = true)]
         internal static extern IntPtr MMap(
             IntPtr addr, ulong len, 
             MemoryMappedProtections prot, MemoryMappedFlags flags,

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MProtect.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MProtect.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_MProtect", SetLastError = true)]
         internal static extern int MProtect(IntPtr addr, ulong len, MemoryMappedProtections prot);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MSync.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MSync.cs
@@ -16,7 +16,7 @@ internal static partial class Interop
             MS_INVALIDATE = 0x10,
         }
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_MSync", SetLastError = true)]
         internal static extern int MSync(IntPtr addr, ulong len, MemoryMappedSyncFlags flags);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MUnmap.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MUnmap.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_MUnmap", SetLastError = true)]
         internal static extern int MUnmap(IntPtr addr, ulong len);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MapTcpState.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MapTcpState.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_MapTcpState")]
         internal static extern TcpState MapTcpState(int nativeState);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MemSet.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MemSet.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_MemSet")]
         internal static extern unsafe void* MemSet(void *s, int c, UIntPtr n);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MkDir.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MkDir.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_MkDir", SetLastError = true)]
         internal static extern int MkDir(string path, int mode);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MkFifo.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MkFifo.cs
@@ -7,7 +7,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_MkFifo", SetLastError = true)]
         internal static extern int MkFifo(string path, int mode);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MksTemps.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MksTemps.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_MksTemps", SetLastError = true)]
         internal static extern IntPtr MksTemps(
             byte[] template, 
             int suffixlen);

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MountPoints.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MountPoints.cs
@@ -75,13 +75,13 @@ internal static partial class Interop
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private unsafe delegate void MountPointFound(byte* name);
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetAllMountPoints", SetLastError = true)]
         private static extern int GetAllMountPoints(MountPointFound mpf);
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSpaceInfoForMountPoint", SetLastError = true)]
         internal static extern int GetSpaceInfoForMountPoint([MarshalAs(UnmanagedType.LPStr)]string name, out MountPointInformation mpi);
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetFormatInfoForMountPoint", SetLastError = true)]
         private unsafe static extern int GetFormatInfoForMountPoint(
             [MarshalAs(UnmanagedType.LPStr)]string name,
             byte* formatNameBuffer,

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MulticastOption.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MulticastOption.cs
@@ -30,16 +30,16 @@ internal static partial class Interop
             private int _padding;
         }
        
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv4MulticastOption")]
         internal static extern unsafe Error GetIPv4MulticastOption(int socket, MulticastOption multicastOption, IPv4MulticastOption* option);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv4MulticastOption")]
         internal static extern unsafe Error SetIPv4MulticastOption(int socket, MulticastOption multicastOption, IPv4MulticastOption* option);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv6MulticastOption")]
         internal static extern unsafe Error GetIPv6MulticastOption(int socket, MulticastOption multicastOption, IPv6MulticastOption* option);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv6MulticastOption")]
         internal static extern unsafe Error SetIPv6MulticastOption(int socket, MulticastOption multicastOption, IPv6MulticastOption* option);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Open.Pipe.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Open.Pipe.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "Open", SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Open", SetLastError = true)]
         internal static extern SafePipeHandle OpenPipe(string filename, OpenFlags flags, int mode);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Open.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Open.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Open", SetLastError = true)]
         internal static extern SafeFileHandle Open(string filename, OpenFlags flags, int mode);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.PathConf.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.PathConf.cs
@@ -63,10 +63,10 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_PathConf", SetLastError = true)]
         private static extern int PathConf(string path, PathConfName name);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetMaximumPath")]
         private static extern long GetMaximumPath();
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Pipe.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Pipe.cs
@@ -24,7 +24,7 @@ internal static partial class Interop
         /// </summary>
         internal const int WriteEndOfPipe = 1;
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Pipe", SetLastError = true)]
         internal static extern unsafe int Pipe(int* pipefd, PipeFlags flags = 0); // pipefd is an array of two ints
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.PlatformSocketSupport.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.PlatformSocketSupport.cs
@@ -7,10 +7,10 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_PlatformSupportsMultipleConnectAttempts")]
         internal static extern bool PlatformSupportsMultipleConnectAttempts();
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_PlatformSupportsDualModeIPv4PacketInfo")]
         internal static extern bool PlatformSupportsDualModeIPv4PacketInfo();
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Poll.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Poll.cs
@@ -34,7 +34,7 @@ internal static partial class Interop
         /// <param name="timeout">The amount of time to wait; -1 for infinite, 0 for immediate return, and a positive number is the number of milliseconds</param>
         /// <param name="triggered">The number of events triggered (i.e. the number of entries in pollEvents with a non-zero TriggeredEvents). May be zero in the event of a timeout.</param>
         /// <returns>An error or Error.SUCCESS.</returns>
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Poll")]
         internal static unsafe extern Error Poll(PollEvent* pollEvents, uint eventCount, int timeout, uint* triggered);
 
         /// <summary>

--- a/src/Common/src/Interop/Unix/System.Native/Interop.PosixFAdvise.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.PosixFAdvise.cs
@@ -29,7 +29,7 @@ internal static partial class Interop
         /// <returns>
         /// Returns 0 on success; otherwise, the error code is returned
         /// </returns>
-        [DllImport(Libraries.SystemNative, SetLastError = false /* this is explicitly called out in the man page */)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_PosixFAdvise", SetLastError = false /* this is explicitly called out in the man page */)]
         internal static extern int PosixFAdvise(SafeFileHandle fd, long offset, long length, FileAdvice advice);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.PrintF.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.PrintF.cs
@@ -12,7 +12,7 @@ internal static partial class Interop
         // Instead, since we only have a small and fixed number of call sites, we declare
         // an overload for each of the specific argument sets we need.
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_PrintF", SetLastError = true)]
         internal static extern unsafe int PrintF(string format, string arg1);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Read.Pipe.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Read.Pipe.cs
@@ -18,7 +18,7 @@ internal static partial class Interop
         /// Returns the number of bytes read on success; otherwise, -1 is returned
         /// Note - on fail. the position of the stream may change depending on the platform; consult man 2 read for more info
         /// </returns>
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Read", SetLastError = true)]
         internal static unsafe extern int Read(SafePipeHandle fd, byte* buffer, int count);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Read.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Read.cs
@@ -18,7 +18,7 @@ internal static partial class Interop
         /// Returns the number of bytes read on success; otherwise, -1 is returned
         /// Note - on fail. the position of the stream may change depending on the platform; consult man 2 read for more info
         /// </returns>
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Read", SetLastError = true)]
         internal static unsafe extern int Read(SafeFileHandle fd, byte* buffer, int count);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.ReadDir.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ReadDir.cs
@@ -38,16 +38,16 @@ internal static partial class Interop
             internal string     InodeName;
         }
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_OpenDir", SetLastError = true)]
         internal static extern Microsoft.Win32.SafeHandles.SafeDirectoryHandle OpenDir(string path);
 
-        [DllImport(Libraries.SystemNative, SetLastError = false)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetDirentSize", SetLastError = false)]
         internal static extern int GetDirentSize();
 
-        [DllImport(Libraries.SystemNative, SetLastError = false)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReadDirR", SetLastError = false)]
         private static unsafe extern int ReadDirR(SafeDirectoryHandle dir, byte* buffer, int bufferSize, out InternalDirectoryEntry outputEntry);
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CloseDir", SetLastError = true)]
         internal static extern int CloseDir(IntPtr dir);
 
         // The calling pattern for ReadDir is described in src/Native/System.Native/pal_readdir.cpp

--- a/src/Common/src/Interop/Unix/System.Native/Interop.ReadLink.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ReadLink.cs
@@ -17,7 +17,7 @@ internal static partial class Interop
         /// <returns>
         /// Returns the number of bytes placed into the buffer on success; otherwise, -1 is returned
         /// </returns>
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReadLink", SetLastError = true)]
         internal static unsafe extern int ReadLink(string path, byte[] buffer, int bufferSize);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReadStdinUnbuffered", SetLastError = true)]
         internal unsafe static extern int ReadStdinUnbuffered(byte* buffer, int bufferSize);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.ReceiveMessage.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ReceiveMessage.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReceiveMessage")]
         internal static extern unsafe Error ReceiveMessage(int socket, MessageHeader* messageHeader, SocketFlags flags, long* received);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.RegisterForCtrlC.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.RegisterForCtrlC.cs
@@ -15,10 +15,10 @@ internal partial class Interop
 
         internal delegate bool CtrlCallback(CtrlCode ctrlCode);
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_RegisterForCtrl", SetLastError = true)]
         internal static extern bool RegisterForCtrl(CtrlCallback handler);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_UnregisterForCtrl")]
         internal static extern void UnregisterForCtrl();
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Rename.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Rename.cs
@@ -16,7 +16,7 @@ internal static partial class Interop
         /// <returns>
         /// Returns 0 on succes; otherwise, returns -1
         /// </returns>
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Rename", SetLastError = true)]
         internal static extern int Rename(string oldPath, string newPath);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.ResourceLimits.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ResourceLimits.cs
@@ -30,10 +30,10 @@ internal static partial class Interop
             internal ulong MaximumLimit;
         }
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetRLimit", SetLastError = true)]
         internal static extern int GetRLimit(RlimitResources resourceType, out RLimit limits);
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetRLimit", SetLastError = true)]
         internal static extern int SetRLimit(RlimitResources resourceType, ref RLimit limits);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.RmDir.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.RmDir.cs
@@ -15,7 +15,7 @@ internal static partial class Interop
         /// <returns>
         /// Returns 0 on success; otherwise, returns -1
         /// </returns>
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_RmDir", SetLastError = true)]
         internal static extern int RmDir(string path);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SNPrintF.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SNPrintF.cs
@@ -26,7 +26,7 @@ internal static partial class Interop
         /// success; if the return value is equal to the size then the result may have been truncated. 
         /// On failure, returns a negative value.
         /// </returns>
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SNPrintF", SetLastError = true)]
         internal static unsafe extern int SNPrintF(byte* str, int size, string format, string arg1);
 
         /// <summary>
@@ -47,7 +47,7 @@ internal static partial class Interop
         /// success; if the return value is equal to the size then the result may have been truncated. 
         /// On failure, returns a negative value.
         /// </returns>
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SNPrintF", SetLastError = true)]
         internal static unsafe extern int SNPrintF(byte* str, int size, string format, int arg1);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SchedGetSetAffinity.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SchedGetSetAffinity.cs
@@ -8,10 +8,10 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SchedSetAffinity", SetLastError = true)]
         internal static extern int SchedSetAffinity(int pid, ref IntPtr mask);
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SchedGetAffinity", SetLastError = true)]
         internal static extern int SchedGetAffinity(int pid, out IntPtr mask);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Select.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Select.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Select")]
         internal static extern unsafe Error Select(int fdCount, uint* readFds, uint* writeFds, uint* errorFds, int microseconds, int* selected);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SendMessage.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SendMessage.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SendMessage")]
         internal static extern unsafe Error SendMessage(int socket, MessageHeader* messageHeader, SocketFlags flags, long* sent);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SetSockOpt.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SetSockOpt.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetSockOpt")]
         internal static extern unsafe Error SetSockOpt(int socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int optionLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.ShmOpen.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ShmOpen.cs
@@ -8,10 +8,10 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ShmOpen", SetLastError = true)]
         internal static extern SafeFileHandle ShmOpen(string name, OpenFlags flags, int mode);
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ShmUnlink", SetLastError = true)]
         internal static extern int ShmUnlink(string name);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Shutdown.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Shutdown.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Shutdown")]
         internal static extern Error Shutdown(int socket, SocketShutdown how);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Socket.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Socket.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Socket")]
         internal static extern unsafe Error Socket(AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType, int* socket);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SocketAddress.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SocketAddress.cs
@@ -9,31 +9,31 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPSocketAddressSizes")]
         internal static extern unsafe Error GetIPSocketAddressSizes(int* ipv4SocketAddressSize, int* ipv6SocketAddressSize);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetAddressFamily")]
         internal static extern unsafe Error GetAddressFamily(byte* socketAddress, int socketAddressLen, int* addressFamily);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetAddressFamily")]
         internal static extern unsafe Error SetAddressFamily(byte* socketAddress, int socketAddressLen, int addressFamily);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPort")]
         internal static extern unsafe Error GetPort(byte* socketAddress, int socketAddressLen, ushort* port);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetPort")]
         internal static extern unsafe Error SetPort(byte* socketAddress, int socketAddressLen, ushort port);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv4Address")]
         internal static extern unsafe Error GetIPv4Address(byte* socketAddress, int socketAddressLen, uint* address);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv4Address")]
         internal static extern unsafe Error SetIPv4Address(byte* socketAddress, int socketAddressLen, uint address);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv6Address")]
         internal static extern unsafe Error GetIPv6Address(byte* socketAddress, int socketAddressLen, byte* address, int addressLen, uint* scopeId);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv6Address")]
         internal static extern unsafe Error SetIPv6Address(byte* socketAddress, int socketAddressLen, byte* address, int addressLen, uint scopeId);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SocketEvent.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SocketEvent.cs
@@ -27,22 +27,22 @@ internal static partial class Interop
             private int _padding;
         }
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CreateSocketEventPort")]
         internal static extern unsafe Error CreateSocketEventPort(int* port);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CloseSocketEventPort")]
         internal static extern Error CloseSocketEventPort(int port);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CreateSocketEventBuffer")]
         internal static extern unsafe Error CreateSocketEventBuffer(int count, SocketEvent** buffer);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FreeSocketEventBuffer")]
         internal static extern unsafe Error FreeSocketEventBuffer(SocketEvent* buffer);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_TryChangeSocketEventRegistration")]
         internal static extern Error TryChangeSocketEventRegistration(int port, int socket, SocketEvents currentEvents, SocketEvents newEvents, IntPtr data);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_WaitForSocketEvents")]
         internal static extern unsafe Error WaitForSocketEvents(int port, SocketEvent* buffer, int* count);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Stat.Pipe.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Stat.Pipe.cs
@@ -9,7 +9,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FStat", SetLastError = true)]
         internal static extern int FStat(SafePipeHandle fd, out FileStatus output);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Stat.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Stat.cs
@@ -45,13 +45,13 @@ internal static partial class Interop
             HasBirthTime = 1,
         }
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FStat", SetLastError = true)]
         internal static extern int FStat(SafeFileHandle fd, out FileStatus output);
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Stat", SetLastError = true)]
         internal static extern int Stat(string path, out FileStatus output);
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_LStat", SetLastError = true)]
         internal static extern int LStat(string path, out FileStatus output);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.StdinReady.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.StdinReady.cs
@@ -7,7 +7,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_StdinReady")]
         internal unsafe static extern bool StdinReady();
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Sync.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Sync.cs
@@ -11,7 +11,7 @@ internal static partial class Interop
         /// <summary>
         /// Forces a write of all modified I/O buffers to their storage mediums.
         /// </summary>
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Sync")]
         internal static extern void Sync();
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SysConf.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SysConf.cs
@@ -13,7 +13,7 @@ internal static partial class Interop
             _SC_PAGESIZE = 2,
         }
 
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SysConf", SetLastError = true)]
         internal static extern long SysConf(SysConfName name);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SysLog.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SysLog.cs
@@ -51,7 +51,7 @@ internal static partial class Interop
         /// </param>
         /// <param name="message">The message to put in the log entry</param>
         /// <param name="arg1">Like printf, the argument is passed to the variadic part of the C++ function to wildcards in the message</param>
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SysLog")]
         internal static extern void SysLog(SysLogPriority priority, string message, string arg1);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.UTime.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.UTime.cs
@@ -22,7 +22,7 @@ internal static partial class Interop
         /// <returns>
         /// Returns 0 on success; otherwise, returns -1 
         /// </returns>
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_UTime", SetLastError = true)]
         internal static extern int UTime(string path, ref UTimBuf time);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Unlink.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Unlink.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Unlink", SetLastError = true)]
         internal static extern int Unlink(string pathname);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.WaitPid.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.WaitPid.cs
@@ -29,20 +29,20 @@ internal static partial class Interop
         /// 3) if WNOHANG is specified and there are no stopped or exited children, 0 is returned
         /// 4) on error, -1 is returned
         /// </returns>
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_WaitPid", SetLastError = true)]
         internal static extern int WaitPid(int pid, out int status, WaitPidOptions options);
 
         // The following 4 functions are wrappers around macros of the same name
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_WExitStatus")]
         internal static extern int WExitStatus(int status);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_WIfExited")]
         internal static extern bool WIfExited(int status);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_WIfSignaled")]
         internal static extern bool WIfSignaled(int status);
 
-        [DllImport(Libraries.SystemNative)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_WTermSig")]
         internal static extern int WTermSig(int status);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Write.Pipe.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Write.Pipe.cs
@@ -17,7 +17,7 @@ internal static partial class Interop
         /// <returns>
         /// Returns the number of bytes written on success; otherwise, returns -1 and sets errno
         /// </returns>
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Write", SetLastError = true)]
         internal static unsafe extern int Write(SafePipeHandle fd, byte* buffer, int bufferSize);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Write.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Write.cs
@@ -17,7 +17,7 @@ internal static partial class Interop
         /// <returns>
         /// Returns the number of bytes written on success; otherwise, returns -1 and sets errno
         /// </returns>
-        [DllImport(Libraries.SystemNative, SetLastError = true)]
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Write", SetLastError = true)]
         internal static unsafe extern int Write(SafeFileHandle fd, byte* buffer, int bufferSize);
     }
 }

--- a/src/Native/System.Native/pal_console.cpp
+++ b/src/Native/System.Native/pal_console.cpp
@@ -35,6 +35,14 @@ extern "C" int32_t SystemNative_GetWindowSize(WinSize* windowSize)
 #endif
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t IsATty(intptr_t fd)
+{
+    return SystemNative_IsATty(fd);
+}
+
 extern "C" int32_t SystemNative_IsATty(intptr_t fd)
 {
     return isatty(ToFileDescriptor(fd));
@@ -231,6 +239,14 @@ static bool InitializeSignalHandling()
     return true;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t RegisterForCtrl(CtrlCallback callback)
+{
+    return SystemNative_RegisterForCtrl(callback);
+}
+
 extern "C" int32_t SystemNative_RegisterForCtrl(CtrlCallback callback)
 {
     assert(callback != nullptr);
@@ -245,6 +261,14 @@ extern "C" int32_t SystemNative_RegisterForCtrl(CtrlCallback callback)
     }
 
     return 1;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" void UnregisterForCtrl()
+{
+    SystemNative_UnregisterForCtrl();
 }
 
 extern "C" void SystemNative_UnregisterForCtrl()

--- a/src/Native/System.Native/pal_console.cpp
+++ b/src/Native/System.Native/pal_console.cpp
@@ -16,7 +16,7 @@
 #include <unistd.h>
 #include <poll.h>
 
-extern "C" int32_t GetWindowSize(WinSize* windowSize)
+extern "C" int32_t SystemNative_GetWindowSize(WinSize* windowSize)
 {
     assert(windowSize != nullptr);
 
@@ -35,7 +35,7 @@ extern "C" int32_t GetWindowSize(WinSize* windowSize)
 #endif
 }
 
-extern "C" int32_t IsATty(intptr_t fd)
+extern "C" int32_t SystemNative_IsATty(intptr_t fd)
 {
     return isatty(ToFileDescriptor(fd));
 }
@@ -53,7 +53,7 @@ static void UninitializeConsole()
     }
 }
 
-extern "C" void InitializeConsole()
+extern "C" void SystemNative_InitializeConsole()
 {
     assert(!g_initialized);
 
@@ -74,7 +74,7 @@ extern "C" void InitializeConsole()
 #endif
 }
 
-extern "C" int32_t StdinReady()
+extern "C" int32_t SystemNative_StdinReady()
 {
     struct pollfd fd;
     fd.fd = STDIN_FILENO;
@@ -82,7 +82,7 @@ extern "C" int32_t StdinReady()
     return poll(&fd, 1, 0) > 0 ? 1 : 0;
 }
 
-extern "C" int32_t ReadStdinUnbuffered(void* buffer, int32_t bufferSize)
+extern "C" int32_t SystemNative_ReadStdinUnbuffered(void* buffer, int32_t bufferSize)
 {
     assert(buffer != nullptr || bufferSize == 0);
     assert(bufferSize >= 0);
@@ -231,7 +231,7 @@ static bool InitializeSignalHandling()
     return true;
 }
 
-extern "C" int32_t RegisterForCtrl(CtrlCallback callback)
+extern "C" int32_t SystemNative_RegisterForCtrl(CtrlCallback callback)
 {
     assert(callback != nullptr);
     assert(g_ctrlCallback == nullptr);
@@ -247,7 +247,7 @@ extern "C" int32_t RegisterForCtrl(CtrlCallback callback)
     return 1;
 }
 
-extern "C" void UnregisterForCtrl()
+extern "C" void SystemNative_UnregisterForCtrl()
 {
     assert(g_ctrlCallback != nullptr);
     g_ctrlCallback = nullptr;

--- a/src/Native/System.Native/pal_console.h
+++ b/src/Native/System.Native/pal_console.h
@@ -21,7 +21,7 @@ struct WinSize
  *
  * Returns 0 on success; otherwise, returns errorNo.
  */
-extern "C" int32_t GetWindowSize(WinSize* windowsSize);
+extern "C" int32_t SystemNative_GetWindowSize(WinSize* windowsSize);
 
 /**
  * Gets whether the specified file descriptor is for a terminal.
@@ -29,24 +29,24 @@ extern "C" int32_t GetWindowSize(WinSize* windowsSize);
  * Returns 1 if the file descriptor is referring to a terminal;
  * otherwise returns 0 and sets errno.
  */
-extern "C" int32_t IsATty(intptr_t fd);
+extern "C" int32_t SystemNative_IsATty(intptr_t fd);
 
 /**
  * Initializes the console for use by System.Console.
  */
-extern "C" void InitializeConsole();
+extern "C" void SystemNative_InitializeConsole();
 
 /**
  * Returns 1 if any input is waiting on stdin; otherwise, 0.
  */
-extern "C" int32_t StdinReady();
+extern "C" int32_t SystemNative_StdinReady();
 
 /**
  * Reads the number of bytes specified into the provided buffer from stdin.
  * in a non-echo and non-canonical mode.
  * Returns the number of bytes read on success; otherwise, -1 is returned an errno is set.
  */
-extern "C" int32_t ReadStdinUnbuffered(void* buffer, int32_t bufferSize);
+extern "C" int32_t SystemNative_ReadStdinUnbuffered(void* buffer, int32_t bufferSize);
 
 enum CtrlCode : int32_t
 {
@@ -66,7 +66,7 @@ typedef int32_t (*CtrlCallback)(CtrlCode signalCode);
  *
  * Returns 1 on success, 0 on failure.
  */
-extern "C" int32_t RegisterForCtrl(CtrlCallback callback);
+extern "C" int32_t SystemNative_RegisterForCtrl(CtrlCallback callback);
 
 /**
  * Unregisters the previously registered ctrlCCallback.
@@ -78,4 +78,4 @@ extern "C" int32_t RegisterForCtrl(CtrlCallback callback);
  * previously registered must remain valid until all ctrl handling activity
  * has quiesced.
  */
-extern "C" void UnregisterForCtrl();
+extern "C" void SystemNative_UnregisterForCtrl();

--- a/src/Native/System.Native/pal_errno.cpp
+++ b/src/Native/System.Native/pal_errno.cpp
@@ -9,6 +9,14 @@
 #include <string.h>
 #include <assert.h>
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error ConvertErrorPlatformToPal(int32_t platformErrno)
+{
+    return SystemNative_ConvertErrorPlatformToPal(platformErrno);
+}
+
 extern "C" Error SystemNative_ConvertErrorPlatformToPal(int32_t platformErrno)
 {
     switch (platformErrno)
@@ -179,6 +187,14 @@ extern "C" Error SystemNative_ConvertErrorPlatformToPal(int32_t platformErrno)
     }
 
     return PAL_ENONSTANDARD;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t ConvertErrorPalToPlatform(Error error)
+{
+    return SystemNative_ConvertErrorPalToPlatform(error);
 }
 
 extern "C" int32_t SystemNative_ConvertErrorPalToPlatform(Error error)
@@ -352,6 +368,14 @@ extern "C" int32_t SystemNative_ConvertErrorPalToPlatform(Error error)
     // because the platform values are not part of an enum.
     assert(false && "Unknown error code");
     return -1;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" const char* StrErrorR(int32_t platformErrno, char* buffer, int32_t bufferSize)
+{
+    return SystemNative_StrErrorR(platformErrno, buffer, bufferSize);
 }
 
 extern "C" const char* SystemNative_StrErrorR(int32_t platformErrno, char* buffer, int32_t bufferSize)

--- a/src/Native/System.Native/pal_errno.cpp
+++ b/src/Native/System.Native/pal_errno.cpp
@@ -9,7 +9,7 @@
 #include <string.h>
 #include <assert.h>
 
-extern "C" Error ConvertErrorPlatformToPal(int32_t platformErrno)
+extern "C" Error SystemNative_ConvertErrorPlatformToPal(int32_t platformErrno)
 {
     switch (platformErrno)
     {
@@ -181,7 +181,7 @@ extern "C" Error ConvertErrorPlatformToPal(int32_t platformErrno)
     return PAL_ENONSTANDARD;
 }
 
-extern "C" int32_t ConvertErrorPalToPlatform(Error error)
+extern "C" int32_t SystemNative_ConvertErrorPalToPlatform(Error error)
 {
     switch (error)
     {
@@ -354,7 +354,7 @@ extern "C" int32_t ConvertErrorPalToPlatform(Error error)
     return -1;
 }
 
-extern "C" const char* StrErrorR(int32_t platformErrno, char* buffer, int32_t bufferSize)
+extern "C" const char* SystemNative_StrErrorR(int32_t platformErrno, char* buffer, int32_t bufferSize)
 {
     assert(buffer != nullptr);
     assert(bufferSize > 0);

--- a/src/Native/System.Native/pal_errno.h
+++ b/src/Native/System.Native/pal_errno.h
@@ -122,14 +122,14 @@ enum Error : int32_t
  * Error above. If the value is not recognized, returns
  * PAL_ENONSTANDARD.
  */
-extern "C" Error ConvertErrorPlatformToPal(int32_t platformErrno);
+extern "C" Error SystemNative_ConvertErrorPlatformToPal(int32_t platformErrno);
 
 /**
  * Converts the given PAL Error value to a platform-specific errno
  * value. This is to be used when we want to synthesize a given error
  * and obtain the appropriate error message via StrErrorR.
  */
-extern "C" int32_t ConvertErrorPalToPlatform(Error error);
+extern "C" int32_t SystemNative_ConvertErrorPalToPlatform(Error error);
 
 /**
  * Obtains the system error message for the given raw numeric value
@@ -152,4 +152,4 @@ extern "C" int32_t ConvertErrorPalToPlatform(Error error);
  * returned and the buffer is filled with as much of the message
  * as possible and null-terminated.
  */
-extern "C" const char* StrErrorR(int32_t platformErrno, char* buffer, int32_t bufferSize);
+extern "C" const char* SystemNative_StrErrorR(int32_t platformErrno, char* buffer, int32_t bufferSize);

--- a/src/Native/System.Native/pal_interfaceaddresses.cpp
+++ b/src/Native/System.Native/pal_interfaceaddresses.cpp
@@ -26,7 +26,7 @@
 #include <net/route.h>
 #endif
 
-extern "C" int32_t EnumerateInterfaceAddresses(IPv4AddressFound onIpv4Found,
+extern "C" int32_t SystemNative_EnumerateInterfaceAddresses(IPv4AddressFound onIpv4Found,
                                                IPv6AddressFound onIpv6Found,
                                                LinkLayerAddressFound onLinkLayerFound)
 {
@@ -120,7 +120,7 @@ extern "C" int32_t EnumerateInterfaceAddresses(IPv4AddressFound onIpv4Found,
 }
 
 #if HAVE_RT_MSGHDR
-extern "C" int32_t EnumerateGatewayAddressesForInterface(uint32_t interfaceIndex, GatewayAddressFound onGatewayFound)
+extern "C" int32_t SystemNative_EnumerateGatewayAddressesForInterface(uint32_t interfaceIndex, GatewayAddressFound onGatewayFound)
 {
     int routeDumpName[] = {CTL_NET, AF_ROUTE, 0, AF_INET, NET_RT_DUMP, 0};
 

--- a/src/Native/System.Native/pal_io.cpp
+++ b/src/Native/System.Native/pal_io.cpp
@@ -146,6 +146,14 @@ static void ConvertFileStatus(const struct stat_& src, FileStatus* dst)
 #endif
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t Stat(const char* path, FileStatus* output)
+{
+    return SystemNative_Stat(path, output);
+}
+
 extern "C" int32_t SystemNative_Stat(const char* path, FileStatus* output)
 {
     struct stat_ result;
@@ -160,6 +168,14 @@ extern "C" int32_t SystemNative_Stat(const char* path, FileStatus* output)
     return ret;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t FStat(intptr_t fd, FileStatus* output)
+{
+    return SystemNative_FStat(fd, output);
+}
+
 extern "C" int32_t SystemNative_FStat(intptr_t fd, FileStatus* output)
 {
     struct stat_ result;
@@ -172,6 +188,14 @@ extern "C" int32_t SystemNative_FStat(intptr_t fd, FileStatus* output)
     }
 
     return ret;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t LStat(const char* path, FileStatus* output)
+{
+    return SystemNative_LStat(path, output);
 }
 
 extern "C" int32_t SystemNative_LStat(const char* path, FileStatus* output)
@@ -227,6 +251,14 @@ static int32_t ConvertOpenFlags(int32_t flags)
     return ret;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" intptr_t Open(const char* path, int32_t flags, int32_t mode)
+{
+    return SystemNative_Open(path, flags, mode);
+}
+
 extern "C" intptr_t SystemNative_Open(const char* path, int32_t flags, int32_t mode)
 {
     flags = ConvertOpenFlags(flags);
@@ -241,9 +273,25 @@ extern "C" intptr_t SystemNative_Open(const char* path, int32_t flags, int32_t m
     return result;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t Close(intptr_t fd)
+{
+    return SystemNative_Close(fd);
+}
+
 extern "C" int32_t SystemNative_Close(intptr_t fd)
 {
     return close(ToFileDescriptor(fd));
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" intptr_t Dup(intptr_t oldfd)
+{
+    return SystemNative_Dup(oldfd);
 }
 
 extern "C" intptr_t SystemNative_Dup(intptr_t oldfd)
@@ -253,11 +301,27 @@ extern "C" intptr_t SystemNative_Dup(intptr_t oldfd)
     return result;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t Unlink(const char* path)
+{
+    return SystemNative_Unlink(path);
+}
+
 extern "C" int32_t SystemNative_Unlink(const char* path)
 {
     int32_t result;
     while (CheckInterrupted(result = unlink(path)));
     return result;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" intptr_t ShmOpen(const char* name, int32_t flags, int32_t mode)
+{
+    return SystemNative_ShmOpen(name, flags, mode);
 }
 
 extern "C" intptr_t SystemNative_ShmOpen(const char* name, int32_t flags, int32_t mode)
@@ -276,6 +340,14 @@ extern "C" intptr_t SystemNative_ShmOpen(const char* name, int32_t flags, int32_
     errno = ENOTSUP;
     return -1;
 #endif
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t ShmUnlink(const char* name)
+{
+    return SystemNative_ShmUnlink(name);
 }
 
 extern "C" int32_t SystemNative_ShmUnlink(const char* name)
@@ -300,11 +372,27 @@ static void ConvertDirent(const dirent& entry, DirectoryEntry* outputEntry)
 #endif
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t GetDirentSize()
+{
+    return SystemNative_GetDirentSize();
+}
+
 extern "C" int32_t SystemNative_GetDirentSize()
 {
     // dirent should be under 2k in size
     static_assert(sizeof(dirent) < 2048, "");
     return sizeof(dirent);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t ReadDirR(DIR* dir, void* buffer, int32_t bufferSize, DirectoryEntry* outputEntry)
+{
+    return SystemNative_ReadDirR(dir, buffer, bufferSize, outputEntry);
 }
 
 // To reduce the number of string copies, this function calling pattern works as follows:
@@ -355,14 +443,38 @@ extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferS
     return 0;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" DIR* OpenDir(const char* path)
+{
+    return SystemNative_OpenDir(path);
+}
+
 extern "C" DIR* SystemNative_OpenDir(const char* path)
 {
     return opendir(path);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t CloseDir(DIR* dir)
+{
+    return SystemNative_CloseDir(dir);
+}
+
 extern "C" int32_t SystemNative_CloseDir(DIR* dir)
 {
     return closedir(dir);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t Pipe(int32_t pipeFds[2], int32_t flags)
+{
+    return SystemNative_Pipe(pipeFds, flags);
 }
 
 extern "C" int32_t SystemNative_Pipe(int32_t pipeFds[2], int32_t flags)
@@ -389,6 +501,14 @@ extern "C" int32_t SystemNative_Pipe(int32_t pipeFds[2], int32_t flags)
     return result;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t FcntlCanGetSetPipeSz()
+{
+    return SystemNative_FcntlCanGetSetPipeSz();
+}
+
 extern "C" int32_t SystemNative_FcntlCanGetSetPipeSz()
 {
 #if defined(F_GETPIPE_SZ) && defined(F_SETPIPE_SZ)
@@ -396,6 +516,14 @@ extern "C" int32_t SystemNative_FcntlCanGetSetPipeSz()
 #else
     return false;
 #endif
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t FcntlGetPipeSz(intptr_t fd)
+{
+    return SystemNative_FcntlGetPipeSz(fd);
 }
 
 extern "C" int32_t SystemNative_FcntlGetPipeSz(intptr_t fd)
@@ -411,6 +539,14 @@ extern "C" int32_t SystemNative_FcntlGetPipeSz(intptr_t fd)
 #endif
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t FcntlSetPipeSz(intptr_t fd, int32_t size)
+{
+    return SystemNative_FcntlSetPipeSz(fd, size);
+}
+
 extern "C" int32_t SystemNative_FcntlSetPipeSz(intptr_t fd, int32_t size)
 {
 #ifdef F_SETPIPE_SZ
@@ -422,6 +558,14 @@ extern "C" int32_t SystemNative_FcntlSetPipeSz(intptr_t fd, int32_t size)
     errno = ENOTSUP;
     return -1;
 #endif
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t FcntlSetIsNonBlocking(intptr_t fd, int32_t isNonBlocking)
+{
+    return SystemNative_FcntlSetIsNonBlocking(fd, isNonBlocking);
 }
 
 extern "C" int32_t SystemNative_FcntlSetIsNonBlocking(intptr_t fd, int32_t isNonBlocking)
@@ -446,11 +590,27 @@ extern "C" int32_t SystemNative_FcntlSetIsNonBlocking(intptr_t fd, int32_t isNon
     return fcntl(fileDescriptor, F_SETFL, flags);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t MkDir(const char* path, int32_t mode)
+{
+    return SystemNative_MkDir(path, mode);
+}
+
 extern "C" int32_t SystemNative_MkDir(const char* path, int32_t mode)
 {
     int32_t result;
     while (CheckInterrupted(result = mkdir(path, static_cast<mode_t>(mode))));
     return result;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t ChMod(const char* path, int32_t mode)
+{
+    return SystemNative_ChMod(path, mode);
 }
 
 extern "C" int32_t SystemNative_ChMod(const char* path, int32_t mode)
@@ -460,11 +620,27 @@ extern "C" int32_t SystemNative_ChMod(const char* path, int32_t mode)
     return result;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t MkFifo(const char* path, int32_t mode)
+{
+    return SystemNative_MkFifo(path, mode);
+}
+
 extern "C" int32_t SystemNative_MkFifo(const char* path, int32_t mode)
 {
     int32_t result;
     while (CheckInterrupted(result = mkfifo(path, static_cast<mode_t>(mode))));
     return result;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t FSync(intptr_t fd)
+{
+    return SystemNative_FSync(fd);
 }
 
 extern "C" int32_t SystemNative_FSync(intptr_t fd)
@@ -474,11 +650,27 @@ extern "C" int32_t SystemNative_FSync(intptr_t fd)
     return result;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t FLock(intptr_t fd, LockOperations operation)
+{
+    return SystemNative_FLock(fd, operation);
+}
+
 extern "C" int32_t SystemNative_FLock(intptr_t fd, LockOperations operation)
 {
     int32_t result;
     while (CheckInterrupted(result = flock(ToFileDescriptor(fd), operation)));
     return result;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t ChDir(const char* path)
+{
+    return SystemNative_ChDir(path);
 }
 
 extern "C" int32_t SystemNative_ChDir(const char* path)
@@ -488,14 +680,38 @@ extern "C" int32_t SystemNative_ChDir(const char* path)
     return result;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t Access(const char* path, AccessMode mode)
+{
+    return SystemNative_Access(path, mode);
+}
+
 extern "C" int32_t SystemNative_Access(const char* path, AccessMode mode)
 {
     return access(path, mode);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t FnMatch(const char* pattern, const char* path, FnMatchFlags flags)
+{
+    return SystemNative_FnMatch(pattern, path, flags);
+}
+
 extern "C" int32_t SystemNative_FnMatch(const char* pattern, const char* path, FnMatchFlags flags)
 {
     return fnmatch(pattern, path, flags);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int64_t LSeek(intptr_t fd, int64_t offset, SeekWhence whence)
+{
+    return SystemNative_LSeek(fd, offset, whence);
 }
 
 extern "C" int64_t SystemNative_LSeek(intptr_t fd, int64_t offset, SeekWhence whence)
@@ -505,11 +721,27 @@ extern "C" int64_t SystemNative_LSeek(intptr_t fd, int64_t offset, SeekWhence wh
     return result;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t Link(const char* source, const char* linkTarget)
+{
+    return SystemNative_Link(source, linkTarget);
+}
+
 extern "C" int32_t SystemNative_Link(const char* source, const char* linkTarget)
 {
     int32_t result;
     while (CheckInterrupted(result = link(source, linkTarget)));
     return result;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" intptr_t MksTemps(char* pathTemplate, int32_t suffixLength)
+{
+    return SystemNative_MksTemps(pathTemplate, suffixLength);
 }
 
 extern "C" intptr_t SystemNative_MksTemps(char* pathTemplate, int32_t suffixLength)
@@ -582,14 +814,27 @@ static int32_t ConvertMSyncFlags(int32_t flags)
     return ret;
 }
 
-extern "C" void* SystemNative_MMap(void* address,
-                      uint64_t length,
-                      int32_t protection, // bitwise OR of PAL_PROT_*
-                      int32_t flags,      // bitwise OR of PAL_MAP_*, but PRIVATE and SHARED are mutually exclusive.
-                      intptr_t fd,
-                      int64_t offset)
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" void* MMap(void* address,
+    uint64_t length,
+    int32_t protection, // bitwise OR of PAL_PROT_*
+    int32_t flags,      // bitwise OR of PAL_MAP_*, but PRIVATE and SHARED are mutually exclusive.
+    intptr_t fd,
+    int64_t offset)
 {
-    if (length > SIZE_MAX)
+    return SystemNative_MMap(address, length, protection, flags, fd, offset);
+}
+
+extern "C" void* SystemNative_MMap(void* address,
+    uint64_t length,
+    int32_t protection, // bitwise OR of PAL_PROT_*
+    int32_t flags,      // bitwise OR of PAL_MAP_*, but PRIVATE and SHARED are mutually exclusive.
+    intptr_t fd,
+    int64_t offset)
+{
+        if (length > SIZE_MAX)
     {
         errno = ERANGE;
         return nullptr;
@@ -615,6 +860,14 @@ extern "C" void* SystemNative_MMap(void* address,
     return ret;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t MUnmap(void* address, uint64_t length)
+{
+    return SystemNative_MUnmap(address, length);
+}
+
 extern "C" int32_t SystemNative_MUnmap(void* address, uint64_t length)
 {
     if (length > SIZE_MAX)
@@ -624,6 +877,14 @@ extern "C" int32_t SystemNative_MUnmap(void* address, uint64_t length)
     }
 
     return munmap(address, static_cast<size_t>(length));
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t MAdvise(void* address, uint64_t length, MemoryAdvice advice)
+{
+    return SystemNative_MAdvise(address, length, advice);
 }
 
 extern "C" int32_t SystemNative_MAdvise(void* address, uint64_t length, MemoryAdvice advice)
@@ -651,6 +912,14 @@ extern "C" int32_t SystemNative_MAdvise(void* address, uint64_t length, MemoryAd
     return -1;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t MLock(void* address, uint64_t length)
+{
+    return SystemNative_MLock(address, length);
+}
+
 extern "C" int32_t SystemNative_MLock(void* address, uint64_t length)
 {
     if (length > SIZE_MAX)
@@ -662,6 +931,14 @@ extern "C" int32_t SystemNative_MLock(void* address, uint64_t length)
     return mlock(address, static_cast<size_t>(length));
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t MUnlock(void* address, uint64_t length)
+{
+    return SystemNative_MUnlock(address, length);
+}
+
 extern "C" int32_t SystemNative_MUnlock(void* address, uint64_t length)
 {
     if (length > SIZE_MAX)
@@ -671,6 +948,14 @@ extern "C" int32_t SystemNative_MUnlock(void* address, uint64_t length)
     }
 
     return munlock(address, static_cast<size_t>(length));
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t MProtect(void* address, uint64_t length, int32_t protection)
+{
+    return SystemNative_MProtect(address, length, protection);
 }
 
 extern "C" int32_t SystemNative_MProtect(void* address, uint64_t length, int32_t protection)
@@ -691,6 +976,14 @@ extern "C" int32_t SystemNative_MProtect(void* address, uint64_t length, int32_t
     return mprotect(address, static_cast<size_t>(length), protection);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t MSync(void* address, uint64_t length, int32_t flags)
+{
+    return SystemNative_MSync(address, length, flags);
+}
+
 extern "C" int32_t SystemNative_MSync(void* address, uint64_t length, int32_t flags)
 {
     if (length > SIZE_MAX)
@@ -709,6 +1002,14 @@ extern "C" int32_t SystemNative_MSync(void* address, uint64_t length, int32_t fl
     return msync(address, static_cast<size_t>(length), flags);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int64_t SysConf(SysConfName name)
+{
+    return SystemNative_SysConf(name);
+}
+
 extern "C" int64_t SystemNative_SysConf(SysConfName name)
 {
     switch (name)
@@ -724,11 +1025,27 @@ extern "C" int64_t SystemNative_SysConf(SysConfName name)
     return -1;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t FTruncate(intptr_t fd, int64_t length)
+{
+    return SystemNative_FTruncate(fd, length);
+}
+
 extern "C" int32_t SystemNative_FTruncate(intptr_t fd, int64_t length)
 {
     int32_t result;
     while (CheckInterrupted(result = ftruncate(ToFileDescriptor(fd), length)));
     return result;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error Poll(PollEvent* pollEvents, uint32_t eventCount, int32_t milliseconds, uint32_t* triggered)
+{
+    return SystemNative_Poll(pollEvents, eventCount, milliseconds, triggered);
 }
 
 extern "C" Error SystemNative_Poll(PollEvent* pollEvents, uint32_t eventCount, int32_t milliseconds, uint32_t* triggered)
@@ -786,6 +1103,14 @@ extern "C" Error SystemNative_Poll(PollEvent* pollEvents, uint32_t eventCount, i
     return PAL_SUCCESS;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t PosixFAdvise(intptr_t fd, int64_t offset, int64_t length, FileAdvice advice)
+{
+    return SystemNative_PosixFAdvise(fd, offset, length, advice);
+}
+
 extern "C" int32_t SystemNative_PosixFAdvise(intptr_t fd, int64_t offset, int64_t length, FileAdvice advice)
 {
 #if HAVE_POSIX_ADVISE
@@ -797,6 +1122,14 @@ extern "C" int32_t SystemNative_PosixFAdvise(intptr_t fd, int64_t offset, int64_
     (void)fd, (void)offset, (void)length, (void)advice;
     return ENOTSUP;
 #endif
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t Read(intptr_t fd, void* buffer, int32_t bufferSize)
+{
+    return SystemNative_Read(fd, buffer, bufferSize);
 }
 
 extern "C" int32_t SystemNative_Read(intptr_t fd, void* buffer, int32_t bufferSize)
@@ -817,6 +1150,14 @@ extern "C" int32_t SystemNative_Read(intptr_t fd, void* buffer, int32_t bufferSi
     return static_cast<int32_t>(count);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t ReadLink(const char* path, char* buffer, int32_t bufferSize)
+{
+    return SystemNative_ReadLink(path, buffer, bufferSize);
+}
+
 extern "C" int32_t SystemNative_ReadLink(const char* path, char* buffer, int32_t bufferSize)
 {
     assert(buffer != nullptr || bufferSize == 0);
@@ -833,11 +1174,27 @@ extern "C" int32_t SystemNative_ReadLink(const char* path, char* buffer, int32_t
     return static_cast<int32_t>(count);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t Rename(const char* oldPath, const char* newPath)
+{
+    return SystemNative_Rename(oldPath, newPath);
+}
+
 extern "C" int32_t SystemNative_Rename(const char* oldPath, const char* newPath)
 {
     int32_t result;
     while (CheckInterrupted(result = rename(oldPath, newPath)));
     return result;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t RmDir(const char* path)
+{
+    return SystemNative_RmDir(path);
 }
 
 extern "C" int32_t SystemNative_RmDir(const char* path)
@@ -847,9 +1204,25 @@ extern "C" int32_t SystemNative_RmDir(const char* path)
     return result;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" void Sync()
+{
+    SystemNative_Sync();
+}
+
 extern "C" void SystemNative_Sync()
 {
     sync();
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t Write(intptr_t fd, const void* buffer, int32_t bufferSize)
+{
+    return SystemNative_Write(fd, buffer, bufferSize);
 }
 
 extern "C" int32_t SystemNative_Write(intptr_t fd, const void* buffer, int32_t bufferSize)

--- a/src/Native/System.Native/pal_io.cpp
+++ b/src/Native/System.Native/pal_io.cpp
@@ -146,7 +146,7 @@ static void ConvertFileStatus(const struct stat_& src, FileStatus* dst)
 #endif
 }
 
-extern "C" int32_t Stat(const char* path, FileStatus* output)
+extern "C" int32_t SystemNative_Stat(const char* path, FileStatus* output)
 {
     struct stat_ result;
     int ret;
@@ -160,7 +160,7 @@ extern "C" int32_t Stat(const char* path, FileStatus* output)
     return ret;
 }
 
-extern "C" int32_t FStat(intptr_t fd, FileStatus* output)
+extern "C" int32_t SystemNative_FStat(intptr_t fd, FileStatus* output)
 {
     struct stat_ result;
     int ret;
@@ -174,7 +174,7 @@ extern "C" int32_t FStat(intptr_t fd, FileStatus* output)
     return ret;
 }
 
-extern "C" int32_t LStat(const char* path, FileStatus* output)
+extern "C" int32_t SystemNative_LStat(const char* path, FileStatus* output)
 {
     struct stat_ result;
     int ret = lstat_(path, &result);
@@ -227,7 +227,7 @@ static int32_t ConvertOpenFlags(int32_t flags)
     return ret;
 }
 
-extern "C" intptr_t Open(const char* path, int32_t flags, int32_t mode)
+extern "C" intptr_t SystemNative_Open(const char* path, int32_t flags, int32_t mode)
 {
     flags = ConvertOpenFlags(flags);
     if (flags == -1)
@@ -241,26 +241,26 @@ extern "C" intptr_t Open(const char* path, int32_t flags, int32_t mode)
     return result;
 }
 
-extern "C" int32_t Close(intptr_t fd)
+extern "C" int32_t SystemNative_Close(intptr_t fd)
 {
     return close(ToFileDescriptor(fd));
 }
 
-extern "C" intptr_t Dup(intptr_t oldfd)
+extern "C" intptr_t SystemNative_Dup(intptr_t oldfd)
 {
     int result;
     while (CheckInterrupted(result = dup(ToFileDescriptor(oldfd))));
     return result;
 }
 
-extern "C" int32_t Unlink(const char* path)
+extern "C" int32_t SystemNative_Unlink(const char* path)
 {
     int32_t result;
     while (CheckInterrupted(result = unlink(path)));
     return result;
 }
 
-extern "C" intptr_t ShmOpen(const char* name, int32_t flags, int32_t mode)
+extern "C" intptr_t SystemNative_ShmOpen(const char* name, int32_t flags, int32_t mode)
 {
 #if HAVE_SHM_OPEN_THAT_WORKS_WELL_ENOUGH_WITH_MMAP
     flags = ConvertOpenFlags(flags);
@@ -278,7 +278,7 @@ extern "C" intptr_t ShmOpen(const char* name, int32_t flags, int32_t mode)
 #endif
 }
 
-extern "C" int32_t ShmUnlink(const char* name)
+extern "C" int32_t SystemNative_ShmUnlink(const char* name)
 {
     int32_t result;
     while (CheckInterrupted(result = shm_unlink(name)));
@@ -300,7 +300,7 @@ static void ConvertDirent(const dirent& entry, DirectoryEntry* outputEntry)
 #endif
 }
 
-extern "C" int32_t GetDirentSize()
+extern "C" int32_t SystemNative_GetDirentSize()
 {
     // dirent should be under 2k in size
     static_assert(sizeof(dirent) < 2048, "");
@@ -318,7 +318,7 @@ extern "C" int32_t GetDirentSize()
 //    in the byte[] buffer so the managed code and find it and copy it out of the
 //    buffer into a managed string that the caller of the framework can use, making
 //    the 2nd and final strcpy.
-extern "C" int32_t ReadDirR(DIR* dir, void* buffer, int32_t bufferSize, DirectoryEntry* outputEntry)
+extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferSize, DirectoryEntry* outputEntry)
 {
     assert(buffer != nullptr);
     assert(dir != nullptr);
@@ -355,17 +355,17 @@ extern "C" int32_t ReadDirR(DIR* dir, void* buffer, int32_t bufferSize, Director
     return 0;
 }
 
-extern "C" DIR* OpenDir(const char* path)
+extern "C" DIR* SystemNative_OpenDir(const char* path)
 {
     return opendir(path);
 }
 
-extern "C" int32_t CloseDir(DIR* dir)
+extern "C" int32_t SystemNative_CloseDir(DIR* dir)
 {
     return closedir(dir);
 }
 
-extern "C" int32_t Pipe(int32_t pipeFds[2], int32_t flags)
+extern "C" int32_t SystemNative_Pipe(int32_t pipeFds[2], int32_t flags)
 {
     switch (flags)
     {
@@ -389,7 +389,7 @@ extern "C" int32_t Pipe(int32_t pipeFds[2], int32_t flags)
     return result;
 }
 
-extern "C" int32_t FcntlCanGetSetPipeSz()
+extern "C" int32_t SystemNative_FcntlCanGetSetPipeSz()
 {
 #if defined(F_GETPIPE_SZ) && defined(F_SETPIPE_SZ)
     return true;
@@ -398,7 +398,7 @@ extern "C" int32_t FcntlCanGetSetPipeSz()
 #endif
 }
 
-extern "C" int32_t FcntlGetPipeSz(intptr_t fd)
+extern "C" int32_t SystemNative_FcntlGetPipeSz(intptr_t fd)
 {
 #ifdef F_GETPIPE_SZ
     int32_t result;
@@ -411,7 +411,7 @@ extern "C" int32_t FcntlGetPipeSz(intptr_t fd)
 #endif
 }
 
-extern "C" int32_t FcntlSetPipeSz(intptr_t fd, int32_t size)
+extern "C" int32_t SystemNative_FcntlSetPipeSz(intptr_t fd, int32_t size)
 {
 #ifdef F_SETPIPE_SZ
     int32_t result;
@@ -424,7 +424,7 @@ extern "C" int32_t FcntlSetPipeSz(intptr_t fd, int32_t size)
 #endif
 }
 
-extern "C" int32_t FcntlSetIsNonBlocking(intptr_t fd, int32_t isNonBlocking)
+extern "C" int32_t SystemNative_FcntlSetIsNonBlocking(intptr_t fd, int32_t isNonBlocking)
 {
     int fileDescriptor = ToFileDescriptor(fd);
 
@@ -446,73 +446,73 @@ extern "C" int32_t FcntlSetIsNonBlocking(intptr_t fd, int32_t isNonBlocking)
     return fcntl(fileDescriptor, F_SETFL, flags);
 }
 
-extern "C" int32_t MkDir(const char* path, int32_t mode)
+extern "C" int32_t SystemNative_MkDir(const char* path, int32_t mode)
 {
     int32_t result;
     while (CheckInterrupted(result = mkdir(path, static_cast<mode_t>(mode))));
     return result;
 }
 
-extern "C" int32_t ChMod(const char* path, int32_t mode)
+extern "C" int32_t SystemNative_ChMod(const char* path, int32_t mode)
 {
     int32_t result;
     while (CheckInterrupted(result = chmod(path, static_cast<mode_t>(mode))));
     return result;
 }
 
-extern "C" int32_t MkFifo(const char* path, int32_t mode)
+extern "C" int32_t SystemNative_MkFifo(const char* path, int32_t mode)
 {
     int32_t result;
     while (CheckInterrupted(result = mkfifo(path, static_cast<mode_t>(mode))));
     return result;
 }
 
-extern "C" int32_t FSync(intptr_t fd)
+extern "C" int32_t SystemNative_FSync(intptr_t fd)
 {
     int32_t result;
     while (CheckInterrupted(result = fsync(ToFileDescriptor(fd))));
     return result;
 }
 
-extern "C" int32_t FLock(intptr_t fd, LockOperations operation)
+extern "C" int32_t SystemNative_FLock(intptr_t fd, LockOperations operation)
 {
     int32_t result;
     while (CheckInterrupted(result = flock(ToFileDescriptor(fd), operation)));
     return result;
 }
 
-extern "C" int32_t ChDir(const char* path)
+extern "C" int32_t SystemNative_ChDir(const char* path)
 {
     int32_t result;
     while (CheckInterrupted(result = chdir(path)));
     return result;
 }
 
-extern "C" int32_t Access(const char* path, AccessMode mode)
+extern "C" int32_t SystemNative_Access(const char* path, AccessMode mode)
 {
     return access(path, mode);
 }
 
-extern "C" int32_t FnMatch(const char* pattern, const char* path, FnMatchFlags flags)
+extern "C" int32_t SystemNative_FnMatch(const char* pattern, const char* path, FnMatchFlags flags)
 {
     return fnmatch(pattern, path, flags);
 }
 
-extern "C" int64_t LSeek(intptr_t fd, int64_t offset, SeekWhence whence)
+extern "C" int64_t SystemNative_LSeek(intptr_t fd, int64_t offset, SeekWhence whence)
 {
     int64_t result;
     while (CheckInterrupted(result = lseek(ToFileDescriptor(fd), offset, whence)));
     return result;
 }
 
-extern "C" int32_t Link(const char* source, const char* linkTarget)
+extern "C" int32_t SystemNative_Link(const char* source, const char* linkTarget)
 {
     int32_t result;
     while (CheckInterrupted(result = link(source, linkTarget)));
     return result;
 }
 
-extern "C" intptr_t MksTemps(char* pathTemplate, int32_t suffixLength)
+extern "C" intptr_t SystemNative_MksTemps(char* pathTemplate, int32_t suffixLength)
 {
     intptr_t result;
     while (CheckInterrupted(result = mkstemps(pathTemplate, suffixLength)));
@@ -582,7 +582,7 @@ static int32_t ConvertMSyncFlags(int32_t flags)
     return ret;
 }
 
-extern "C" void* MMap(void* address,
+extern "C" void* SystemNative_MMap(void* address,
                       uint64_t length,
                       int32_t protection, // bitwise OR of PAL_PROT_*
                       int32_t flags,      // bitwise OR of PAL_MAP_*, but PRIVATE and SHARED are mutually exclusive.
@@ -615,7 +615,7 @@ extern "C" void* MMap(void* address,
     return ret;
 }
 
-extern "C" int32_t MUnmap(void* address, uint64_t length)
+extern "C" int32_t SystemNative_MUnmap(void* address, uint64_t length)
 {
     if (length > SIZE_MAX)
     {
@@ -626,7 +626,7 @@ extern "C" int32_t MUnmap(void* address, uint64_t length)
     return munmap(address, static_cast<size_t>(length));
 }
 
-extern "C" int32_t MAdvise(void* address, uint64_t length, MemoryAdvice advice)
+extern "C" int32_t SystemNative_MAdvise(void* address, uint64_t length, MemoryAdvice advice)
 {
     if (length > SIZE_MAX)
     {
@@ -651,7 +651,7 @@ extern "C" int32_t MAdvise(void* address, uint64_t length, MemoryAdvice advice)
     return -1;
 }
 
-extern "C" int32_t MLock(void* address, uint64_t length)
+extern "C" int32_t SystemNative_MLock(void* address, uint64_t length)
 {
     if (length > SIZE_MAX)
     {
@@ -662,7 +662,7 @@ extern "C" int32_t MLock(void* address, uint64_t length)
     return mlock(address, static_cast<size_t>(length));
 }
 
-extern "C" int32_t MUnlock(void* address, uint64_t length)
+extern "C" int32_t SystemNative_MUnlock(void* address, uint64_t length)
 {
     if (length > SIZE_MAX)
     {
@@ -673,7 +673,7 @@ extern "C" int32_t MUnlock(void* address, uint64_t length)
     return munlock(address, static_cast<size_t>(length));
 }
 
-extern "C" int32_t MProtect(void* address, uint64_t length, int32_t protection)
+extern "C" int32_t SystemNative_MProtect(void* address, uint64_t length, int32_t protection)
 {
     if (length > SIZE_MAX)
     {
@@ -691,7 +691,7 @@ extern "C" int32_t MProtect(void* address, uint64_t length, int32_t protection)
     return mprotect(address, static_cast<size_t>(length), protection);
 }
 
-extern "C" int32_t MSync(void* address, uint64_t length, int32_t flags)
+extern "C" int32_t SystemNative_MSync(void* address, uint64_t length, int32_t flags)
 {
     if (length > SIZE_MAX)
     {
@@ -709,7 +709,7 @@ extern "C" int32_t MSync(void* address, uint64_t length, int32_t flags)
     return msync(address, static_cast<size_t>(length), flags);
 }
 
-extern "C" int64_t SysConf(SysConfName name)
+extern "C" int64_t SystemNative_SysConf(SysConfName name)
 {
     switch (name)
     {
@@ -724,14 +724,14 @@ extern "C" int64_t SysConf(SysConfName name)
     return -1;
 }
 
-extern "C" int32_t FTruncate(intptr_t fd, int64_t length)
+extern "C" int32_t SystemNative_FTruncate(intptr_t fd, int64_t length)
 {
     int32_t result;
     while (CheckInterrupted(result = ftruncate(ToFileDescriptor(fd), length)));
     return result;
 }
 
-extern "C" Error Poll(PollEvent* pollEvents, uint32_t eventCount, int32_t milliseconds, uint32_t* triggered)
+extern "C" Error SystemNative_Poll(PollEvent* pollEvents, uint32_t eventCount, int32_t milliseconds, uint32_t* triggered)
 {
     if (pollEvents == nullptr || triggered == nullptr)
     {
@@ -764,7 +764,7 @@ extern "C" Error Poll(PollEvent* pollEvents, uint32_t eventCount, int32_t millis
         }
 
         *triggered = 0;
-        return ConvertErrorPlatformToPal(errno);
+        return SystemNative_ConvertErrorPlatformToPal(errno);
     }
 
     for (uint32_t i = 0; i < eventCount; i++)
@@ -786,7 +786,7 @@ extern "C" Error Poll(PollEvent* pollEvents, uint32_t eventCount, int32_t millis
     return PAL_SUCCESS;
 }
 
-extern "C" int32_t PosixFAdvise(intptr_t fd, int64_t offset, int64_t length, FileAdvice advice)
+extern "C" int32_t SystemNative_PosixFAdvise(intptr_t fd, int64_t offset, int64_t length, FileAdvice advice)
 {
 #if HAVE_POSIX_ADVISE
     int32_t result;
@@ -799,7 +799,7 @@ extern "C" int32_t PosixFAdvise(intptr_t fd, int64_t offset, int64_t length, Fil
 #endif
 }
 
-extern "C" int32_t Read(intptr_t fd, void* buffer, int32_t bufferSize)
+extern "C" int32_t SystemNative_Read(intptr_t fd, void* buffer, int32_t bufferSize)
 {
     assert(buffer != nullptr || bufferSize == 0);
     assert(bufferSize >= 0);
@@ -817,7 +817,7 @@ extern "C" int32_t Read(intptr_t fd, void* buffer, int32_t bufferSize)
     return static_cast<int32_t>(count);
 }
 
-extern "C" int32_t ReadLink(const char* path, char* buffer, int32_t bufferSize)
+extern "C" int32_t SystemNative_ReadLink(const char* path, char* buffer, int32_t bufferSize)
 {
     assert(buffer != nullptr || bufferSize == 0);
     assert(bufferSize >= 0);
@@ -833,26 +833,26 @@ extern "C" int32_t ReadLink(const char* path, char* buffer, int32_t bufferSize)
     return static_cast<int32_t>(count);
 }
 
-extern "C" int32_t Rename(const char* oldPath, const char* newPath)
+extern "C" int32_t SystemNative_Rename(const char* oldPath, const char* newPath)
 {
     int32_t result;
     while (CheckInterrupted(result = rename(oldPath, newPath)));
     return result;
 }
 
-extern "C" int32_t RmDir(const char* path)
+extern "C" int32_t SystemNative_RmDir(const char* path)
 {
     int32_t result;
     while (CheckInterrupted(result = rmdir(path)));
     return result;
 }
 
-extern "C" void Sync()
+extern "C" void SystemNative_Sync()
 {
     sync();
 }
 
-extern "C" int32_t Write(intptr_t fd, const void* buffer, int32_t bufferSize)
+extern "C" int32_t SystemNative_Write(intptr_t fd, const void* buffer, int32_t bufferSize)
 {
     assert(buffer != nullptr || bufferSize == 0);
     assert(bufferSize >= 0);
@@ -870,7 +870,7 @@ extern "C" int32_t Write(intptr_t fd, const void* buffer, int32_t bufferSize)
     return static_cast<int32_t>(count);
 }
 
-extern "C" intptr_t INotifyInit()
+extern "C" intptr_t SystemNative_INotifyInit()
 {
 #if HAVE_INOTIFY
     return inotify_init();
@@ -880,7 +880,7 @@ extern "C" intptr_t INotifyInit()
 #endif
 }
 
-extern "C" int32_t INotifyAddWatch(intptr_t fd, const char* pathName, uint32_t mask)
+extern "C" int32_t SystemNative_INotifyAddWatch(intptr_t fd, const char* pathName, uint32_t mask)
 {
     assert(fd >= 0);
     assert(pathName != nullptr);
@@ -894,7 +894,7 @@ extern "C" int32_t INotifyAddWatch(intptr_t fd, const char* pathName, uint32_t m
 #endif
 }
 
-extern "C" int32_t INotifyRemoveWatch(intptr_t fd, int32_t wd)
+extern "C" int32_t SystemNative_INotifyRemoveWatch(intptr_t fd, int32_t wd)
 {
     assert(fd >= 0);
     assert(wd >= 0);

--- a/src/Native/System.Native/pal_io.h
+++ b/src/Native/System.Native/pal_io.h
@@ -282,85 +282,85 @@ enum NotifyEvents : int32_t
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C" int32_t FStat(intptr_t fd, FileStatus* output);
+extern "C" int32_t SystemNative_FStat(intptr_t fd, FileStatus* output);
 
 /**
  * Get file status from a full path. Implemented as shim to stat(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C" int32_t Stat(const char* path, FileStatus* output);
+extern "C" int32_t SystemNative_Stat(const char* path, FileStatus* output);
 
 /**
  * Get file stats from a full path. Implemented as shim to lstat(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C" int32_t LStat(const char* path, FileStatus* output);
+extern "C" int32_t SystemNative_LStat(const char* path, FileStatus* output);
 
 /**
  * Open or create a file or device. Implemented as shim to open(2).
  *
  * Returns file descriptor or -1 for failure. Sets errno on failure.
  */
-extern "C" intptr_t Open(const char* path, int32_t flags, int32_t mode);
+extern "C" intptr_t SystemNative_Open(const char* path, int32_t flags, int32_t mode);
 
 /**
  * Close a file descriptor. Implemented as shim to open(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C" int32_t Close(intptr_t fd);
+extern "C" int32_t SystemNative_Close(intptr_t fd);
 
 /**
  * Duplicates a file descriptor.
  *
  * Returns the duplication descriptor for success, -1 for failure. Sets errno on failure.
  */
-extern "C" intptr_t Dup(intptr_t oldfd);
+extern "C" intptr_t SystemNative_Dup(intptr_t oldfd);
 
 /**
  * Delete an entry from the file system. Implemented as shim to unlink(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C" int32_t Unlink(const char* path);
+extern "C" int32_t SystemNative_Unlink(const char* path);
 
 /**
  * Open or create a shared memory object. Implemented as shim to shm_open(3).
  *
  * Returns file descriptor or -1 on fiailure. Sets errno on failure.
  */
-extern "C" intptr_t ShmOpen(const char* name, int32_t flags, int32_t mode);
+extern "C" intptr_t SystemNative_ShmOpen(const char* name, int32_t flags, int32_t mode);
 
 /**
  * Unlink a shared memory object. Implemented as shim to shm_unlink(3).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C" int32_t ShmUnlink(const char* name);
+extern "C" int32_t SystemNative_ShmUnlink(const char* name);
 
 /**
  * Returns the size of the dirent struct on the current architecture
  */
-extern "C" int32_t GetDirentSize();
+extern "C" int32_t SystemNative_GetDirentSize();
 
 /**
  * Re-entrant readdir that will retrieve the next dirent from the directory stream pointed to by dir.
  *
  * Returns 0 when data is retrieved; returns -1 when end-of-stream is reached; returns an error code on failure
  */
-extern "C" int32_t ReadDirR(DIR* dir, void* buffer, int32_t bufferSize, DirectoryEntry* outputEntry);
+extern "C" int32_t SystemNative_ReadDirR(DIR* dir, void* buffer, int32_t bufferSize, DirectoryEntry* outputEntry);
 
 /**
  * Returns a DIR struct containing info about the current path or NULL on failure; sets errno on fail.
  */
-extern "C" DIR* OpenDir(const char* path);
+extern "C" DIR* SystemNative_OpenDir(const char* path);
 
 /**
  * Closes the directory stream opened by opendir and returns 0 on success. On fail, -1 is returned and errno is set
  */
-extern "C" int32_t CloseDir(DIR* dir);
+extern "C" int32_t SystemNative_CloseDir(DIR* dir);
 
 /**
  * Creates a pipe. Implemented as shim to pipe(2) or pipe2(2) if available.
@@ -368,7 +368,7 @@ extern "C" int32_t CloseDir(DIR* dir);
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C" int32_t Pipe(int32_t pipefd[2], // [out] pipefds[0] gets read end, pipefd[1] gets write end.
+extern "C" int32_t SystemNative_Pipe(int32_t pipefd[2], // [out] pipefds[0] gets read end, pipefd[1] gets write end.
                         int32_t flags);    // 0 for defaults or PAL_O_CLOEXEC for close-on-exec
 
 // NOTE: Rather than a general fcntl shim, we opt to export separate functions
@@ -380,7 +380,7 @@ extern "C" int32_t Pipe(int32_t pipefd[2], // [out] pipefds[0] gets read end, pi
  *
  * Returns true (non-zero) if supported, false (zero) if not.
  */
-extern "C" int32_t FcntlCanGetSetPipeSz();
+extern "C" int32_t SystemNative_FcntlCanGetSetPipeSz();
 
 /**
  * Gets the capacity of a pipe.
@@ -389,7 +389,7 @@ extern "C" int32_t FcntlCanGetSetPipeSz();
  *
  * NOTE: Some platforms do not support this operation and will always fail with errno = ENOTSUP.
  */
-extern "C" int32_t FcntlGetPipeSz(intptr_t fd);
+extern "C" int32_t SystemNative_FcntlGetPipeSz(intptr_t fd);
 
 /**
  * Sets the capacity of a pipe.
@@ -398,56 +398,56 @@ extern "C" int32_t FcntlGetPipeSz(intptr_t fd);
  *
  * NOTE: Some platforms do not support this operation and will always fail with errno = ENOTSUP.
  */
-extern "C" int32_t FcntlSetPipeSz(intptr_t fd, int32_t size);
+extern "C" int32_t SystemNative_FcntlSetPipeSz(intptr_t fd, int32_t size);
 
 /**
  * Sets whether or not a file descriptor is non-blocking.
  *
  * Returns 0 for success, -1 for failure. Sets errno for failure.
  */
-extern "C" int32_t FcntlSetIsNonBlocking(intptr_t fd, int32_t isNonBlocking);
+extern "C" int32_t SystemNative_FcntlSetIsNonBlocking(intptr_t fd, int32_t isNonBlocking);
 
 /**
  * Create a directory. Implemented as a shim to mkdir(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno for failure.
  */
-extern "C" int32_t MkDir(const char* path, int32_t mode);
+extern "C" int32_t SystemNative_MkDir(const char* path, int32_t mode);
 
 /**
  * Change permissions of a file. Implemented as a shim to chmod(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno for failure.
  */
-extern "C" int32_t ChMod(const char* path, int32_t mode);
+extern "C" int32_t SystemNative_ChMod(const char* path, int32_t mode);
 
 /**
  * Create a FIFO (named pipe). Implemented as a shim to mkfifo(3).
  *
  * Returns 0 for success, -1 for failure. Sets errno for failure.
  */
-extern "C" int32_t MkFifo(const char* path, int32_t mode);
+extern "C" int32_t SystemNative_MkFifo(const char* path, int32_t mode);
 
 /**
  * Flushes all modified data and attribtues of the specified File Descriptor to the storage medium.
  *
  * Returns 0 for success; on fail, -1 is returned and errno is set.
  */
-extern "C" int32_t FSync(intptr_t fd);
+extern "C" int32_t SystemNative_FSync(intptr_t fd);
 
 /**
  * Changes the advisory lock status on a given File Descriptor
  *
  * Returns 0 on success; otherwise, -1 is returned and errno is set
  */
-extern "C" int32_t FLock(intptr_t fd, LockOperations operation);
+extern "C" int32_t SystemNative_FLock(intptr_t fd, LockOperations operation);
 
 /**
  * Changes the current working directory to be the specified path.
  *
  * Returns 0 on success; otherwise, returns -1 and errno is set
  */
-extern "C" int32_t ChDir(const char* path);
+extern "C" int32_t SystemNative_ChDir(const char* path);
 
 /**
  * Checks the access permissions of the current calling user on the specified path for the specified mode.
@@ -455,7 +455,7 @@ extern "C" int32_t ChDir(const char* path);
  * Returns -1 if the path cannot be found or the if desired access is not granted and errno is set; otherwise, returns
  * 0.
  */
-extern "C" int32_t Access(const char* path, AccessMode mode);
+extern "C" int32_t SystemNative_Access(const char* path, AccessMode mode);
 
 /**
  * Tests whether a pathname matches a specified pattern.
@@ -463,7 +463,7 @@ extern "C" int32_t Access(const char* path, AccessMode mode);
  * Returns 0 if the string matches; returns FNM_NOMATCH if the call succeeded but the
  * string does not match; otherwise, returns a non-zero error code.
  */
-extern "C" int32_t FnMatch(const char* pattern, const char* path, FnMatchFlags flags);
+extern "C" int32_t SystemNative_FnMatch(const char* pattern, const char* path, FnMatchFlags flags);
 
 /**
  * Seek to a specified location within a seekable stream
@@ -471,14 +471,14 @@ extern "C" int32_t FnMatch(const char* pattern, const char* path, FnMatchFlags f
  * On success, the resulting offet, in bytes, from the begining of the stream; otherwise,
  * returns -1 and errno is set.
  */
-extern "C" int64_t LSeek(intptr_t fd, int64_t offset, SeekWhence whence);
+extern "C" int64_t SystemNative_LSeek(intptr_t fd, int64_t offset, SeekWhence whence);
 
 /**
  * Creates a hard-link at link pointing to source.
  *
  * Returns 0 on success; otherwise, returns -1 and errno is set.
  */
-extern "C" int32_t Link(const char* source, const char* linkTarget);
+extern "C" int32_t SystemNative_Link(const char* source, const char* linkTarget);
 
 /**
  * Creates a file name that adheres to the specified template, creates the file on disk with
@@ -486,7 +486,7 @@ extern "C" int32_t Link(const char* source, const char* linkTarget);
  *
  * Returns a valid File Descriptor on success; otherwise, returns -1 and errno is set.
  */
-extern "C" intptr_t MksTemps(char* pathTemplate, int32_t suffixLength);
+extern "C" intptr_t SystemNative_MksTemps(char* pathTemplate, int32_t suffixLength);
 
 /**
  * Map file or device into memory. Implemented as shim to mmap(2).
@@ -496,7 +496,7 @@ extern "C" intptr_t MksTemps(char* pathTemplate, int32_t suffixLength);
  * Note that null failure result is a departure from underlying
  * mmap(2) using non-null sentinel.
  */
-extern "C" void* MMap(void* address,
+extern "C" void* SystemNative_MMap(void* address,
                       uint64_t length,
                       int32_t protection, // bitwise OR of PAL_PROT_*
                       int32_t flags,      // bitwise OR of PAL_MAP_*, but PRIVATE and SHARED are mutually exclusive.
@@ -508,42 +508,42 @@ extern "C" void* MMap(void* address,
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C" int32_t MUnmap(void* address, uint64_t length);
+extern "C" int32_t SystemNative_MUnmap(void* address, uint64_t length);
 
 /**
  * Give advice about use of memory. Implemented as shim to madvise(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C" int32_t MAdvise(void* address, uint64_t length, MemoryAdvice advice);
+extern "C" int32_t SystemNative_MAdvise(void* address, uint64_t length, MemoryAdvice advice);
 
 /**
  * Lock memory from being swapped out. Implemented as shim to mlock(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C" int32_t MLock(void* address, uint64_t length);
+extern "C" int32_t SystemNative_MLock(void* address, uint64_t length);
 
 /**
  * Unlock memory, allowing it to be swapped out. Implemented as shim to munlock(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C" int32_t MUnlock(void* address, uint64_t length);
+extern "C" int32_t SystemNative_MUnlock(void* address, uint64_t length);
 
 /**
  * Set protection on a region of memory. Implemented as shim to mprotect(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C" int32_t MProtect(void* address, uint64_t length, int32_t protection);
+extern "C" int32_t SystemNative_MProtect(void* address, uint64_t length, int32_t protection);
 
 /**
  * Sycnhronize a file with a memory map. Implemented as shim to mmap(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C" int32_t MSync(void* address, uint64_t length, int32_t flags);
+extern "C" int32_t SystemNative_MSync(void* address, uint64_t length, int32_t flags);
 
 /**
  * Get system configuration value. Implemented as shim to sysconf(3).
@@ -554,14 +554,14 @@ extern "C" int32_t MSync(void* address, uint64_t length, int32_t flags);
  * note that -1 can also be a meaningful successful return value, in
  * which case errno is unchanged.
  */
-extern "C" int64_t SysConf(SysConfName name);
+extern "C" int64_t SystemNative_SysConf(SysConfName name);
 
 /**
  * Truncate a file to given length. Implemented as shim to ftruncate(2).
  *
  * Returns 0 for success, -1 for failure. Sets errno on failure.
  */
-extern "C" int32_t FTruncate(intptr_t fd, int64_t length);
+extern "C" int32_t SystemNative_FTruncate(intptr_t fd, int64_t length);
 
 /**
  * Examines one or more file descriptors for the specified state(s) and blocks until the state(s) occur or the timeout
@@ -570,7 +570,7 @@ extern "C" int32_t FTruncate(intptr_t fd, int64_t length);
  * Returns an error or PAL_SUCCESS. `triggered` is set to the number of ready descriptors if any. The number of
  * triggered descriptors may be zero in the event of a timeout.
  */
-extern "C" Error Poll(PollEvent* pollEvents, uint32_t eventCount, int32_t milliseconds, uint32_t* triggered);
+extern "C" Error SystemNative_Poll(PollEvent* pollEvents, uint32_t eventCount, int32_t milliseconds, uint32_t* triggered);
 
 /**
  * Notifies the OS kernel that the specified file will be accessed in a particular way soon; this allows the kernel to
@@ -578,7 +578,7 @@ extern "C" Error Poll(PollEvent* pollEvents, uint32_t eventCount, int32_t millis
  *
  * Returns 0 on success; otherwise, the error code is returned and errno is NOT set.
  */
-extern "C" int32_t PosixFAdvise(intptr_t fd, int64_t offset, int64_t length, FileAdvice advice);
+extern "C" int32_t SystemNative_PosixFAdvise(intptr_t fd, int64_t offset, int64_t length, FileAdvice advice);
 
 /**
  * Reads the number of bytes specified into the provided buffer from the specified, opened file descriptor.
@@ -587,7 +587,7 @@ extern "C" int32_t PosixFAdvise(intptr_t fd, int64_t offset, int64_t length, Fil
  *
  * Note - on fail. the position of the stream may change depending on the platform; consult man 2 read for more info
  */
-extern "C" int32_t Read(intptr_t fd, void* buffer, int32_t bufferSize);
+extern "C" int32_t SystemNative_Read(intptr_t fd, void* buffer, int32_t bufferSize);
 
 /**
  * Takes a path to a symbolic link and attempts to place the link target path into the buffer. If the buffer is too
@@ -595,7 +595,7 @@ extern "C" int32_t Read(intptr_t fd, void* buffer, int32_t bufferSize);
  *
  * Returns the number of bytes placed into the buffer on success; otherwise, -1 is returned and errno is set.
  */
-extern "C" int32_t ReadLink(const char* path, char* buffer, int32_t bufferSize);
+extern "C" int32_t SystemNative_ReadLink(const char* path, char* buffer, int32_t bufferSize);
 
 /**
  * Renames a file, moving to the correct destination if necessary. There are many edge cases to this call, check man 2
@@ -603,26 +603,26 @@ extern "C" int32_t ReadLink(const char* path, char* buffer, int32_t bufferSize);
  *
  * Returns 0 on succes; otherwise, returns -1 and errno is set.
  */
-extern "C" int32_t Rename(const char* oldPath, const char* newPath);
+extern "C" int32_t SystemNative_Rename(const char* oldPath, const char* newPath);
 
 /**
  * Deletes the specified empty directory.
  *
  * Returns 0 on success; otherwise, returns -1 and errno is set.
  */
-extern "C" int32_t RmDir(const char* path);
+extern "C" int32_t SystemNative_RmDir(const char* path);
 
 /**
  * Forces a write of all modified I/O buffers to their storage mediums.
  */
-extern "C" void Sync();
+extern "C" void SystemNative_Sync();
 
 /**
  * Writes the specified buffer to the provided open file descriptor
  *
  * Returns the number of bytes written on success; otherwise, returns -1 and sets errno
  */
-extern "C" int32_t Write(intptr_t fd, const void* buffer, int32_t bufferSize);
+extern "C" int32_t SystemNative_Write(intptr_t fd, const void* buffer, int32_t bufferSize);
 
 /**
 * Initializes a new inotify instance and returns a file
@@ -631,7 +631,7 @@ extern "C" int32_t Write(intptr_t fd, const void* buffer, int32_t bufferSize);
 * Returns a new file descriptor on success.
 * On error, -1 is returned, and errno is set to indicate the error.
 */
-extern "C" intptr_t INotifyInit();
+extern "C" intptr_t SystemNative_INotifyInit();
 
 /**
 * Adds a new watch, or modifies an existing watch,
@@ -640,7 +640,7 @@ extern "C" intptr_t INotifyInit();
 * Returns a nonnegative watch descriptor on success.
 * On error -1 is returned and errno is set appropriately.
 */
-extern "C" int32_t INotifyAddWatch(intptr_t fd, const char* pathName, uint32_t mask);
+extern "C" int32_t SystemNative_INotifyAddWatch(intptr_t fd, const char* pathName, uint32_t mask);
 
 /**
 * Removes the watch associated with the watch descriptor wd
@@ -648,4 +648,4 @@ extern "C" int32_t INotifyAddWatch(intptr_t fd, const char* pathName, uint32_t m
 *
 * Returns 0 on success, or -1 if an error occurred (in which case, errno is set appropriately).
 */
-extern "C" int32_t INotifyRemoveWatch(intptr_t fd, int32_t wd);
+extern "C" int32_t SystemNative_INotifyRemoveWatch(intptr_t fd, int32_t wd);

--- a/src/Native/System.Native/pal_memory.cpp
+++ b/src/Native/System.Native/pal_memory.cpp
@@ -4,7 +4,7 @@
 #include "pal_memory.h"
 #include <string.h>
 
-extern "C" void* MemSet(void *s, int c, uintptr_t n)
+extern "C" void* SystemNative_MemSet(void *s, int c, uintptr_t n)
 {
     return memset(s, c, static_cast<size_t>(n));
 }

--- a/src/Native/System.Native/pal_memory.h
+++ b/src/Native/System.Native/pal_memory.h
@@ -10,4 +10,4 @@
  *
  * Returns a pointer to the memory.
  */
-extern "C" void* MemSet(void *s, int c, uintptr_t n);
+extern "C" void* SystemNative_MemSet(void *s, int c, uintptr_t n);

--- a/src/Native/System.Native/pal_mount.cpp
+++ b/src/Native/System.Native/pal_mount.cpp
@@ -57,12 +57,12 @@ static int32_t GetMountInfo(MountPointFound onFound)
 
 #endif
 
-extern "C" int32_t GetAllMountPoints(MountPointFound onFound)
+extern "C" int32_t SystemNative_GetAllMountPoints(MountPointFound onFound)
 {
     return GetMountInfo(onFound);
 }
 
-extern "C" int32_t GetSpaceInfoForMountPoint(const char* name, MountPointInformation* mpi)
+extern "C" int32_t SystemNative_GetSpaceInfoForMountPoint(const char* name, MountPointInformation* mpi)
 {
     assert(name != nullptr);
     assert(mpi != nullptr);
@@ -92,7 +92,7 @@ extern "C" int32_t GetSpaceInfoForMountPoint(const char* name, MountPointInforma
 }
 
 extern "C" int32_t
-GetFormatInfoForMountPoint(const char* name, char* formatNameBuffer, int32_t bufferLength, int64_t* formatType)
+SystemNative_GetFormatInfoForMountPoint(const char* name, char* formatNameBuffer, int32_t bufferLength, int64_t* formatType)
 {
     assert((formatNameBuffer != nullptr) && (formatType != nullptr));
     assert(bufferLength > 0);

--- a/src/Native/System.Native/pal_mount.h
+++ b/src/Native/System.Native/pal_mount.h
@@ -25,7 +25,7 @@ typedef void (*MountPointFound)(const char* name);
 /**
  * Gets the space information for the given mount point and populates the input struct with the data.
  */
-extern "C" int32_t GetSpaceInfoForMountPoint(const char* name, MountPointInformation* mpi);
+extern "C" int32_t SystemNative_GetSpaceInfoForMountPoint(const char* name, MountPointInformation* mpi);
 
 /**
  * Gets the format information about the given mount point.
@@ -37,11 +37,11 @@ extern "C" int32_t GetSpaceInfoForMountPoint(const char* name, MountPointInforma
  * back, depending on what the platform gives us, and let C# reason on it in an easy way.
  */
 extern "C" int32_t
-GetFormatInfoForMountPoint(const char* name, char* formatNameBuffer, int32_t bufferLength, int64_t* formatType);
+SystemNative_GetFormatInfoForMountPoint(const char* name, char* formatNameBuffer, int32_t bufferLength, int64_t* formatType);
 
 /**
  * Enumerate all mount points on the system and call the input
  * function pointer once-per-mount-point to prevent heap allocs
  * as much as possible.
  */
-extern "C" int32_t GetAllMountPoints(MountPointFound onFound);
+extern "C" int32_t SystemNative_GetAllMountPoints(MountPointFound onFound);

--- a/src/Native/System.Native/pal_networkchange.cpp
+++ b/src/Native/System.Native/pal_networkchange.cpp
@@ -19,7 +19,7 @@
 
 #pragma clang diagnostic ignored "-Wcast-align" // NLMSG_* macros trigger this
 
-extern "C" Error CreateNetworkChangeListenerSocket(int32_t* retSocket)
+extern "C" Error SystemNative_CreateNetworkChangeListenerSocket(int32_t* retSocket)
 {
     sockaddr_nl sa = {};
     sa.nl_family = AF_NETLINK;
@@ -28,25 +28,25 @@ extern "C" Error CreateNetworkChangeListenerSocket(int32_t* retSocket)
     if (sock == -1)
     {
         *retSocket = -1;
-        return ConvertErrorPlatformToPal(errno);
+        return SystemNative_ConvertErrorPlatformToPal(errno);
     }
     if (bind(sock, reinterpret_cast<sockaddr*>(&sa), sizeof(sa)) != 0)
     {
         *retSocket = -1;
-        return ConvertErrorPlatformToPal(errno);
+        return SystemNative_ConvertErrorPlatformToPal(errno);
     }
 
     *retSocket = sock;
     return PAL_SUCCESS;
 }
 
-extern "C" Error CloseNetworkChangeListenerSocket(int32_t socket)
+extern "C" Error SystemNative_CloseNetworkChangeListenerSocket(int32_t socket)
 {
     int err = close(socket);
-    return err == 0 ? PAL_SUCCESS : ConvertErrorPlatformToPal(errno);
+    return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
-extern "C" NetworkChangeKind ReadSingleEvent(int32_t sock)
+extern "C" NetworkChangeKind SystemNative_ReadSingleEvent(int32_t sock)
 {
     char buffer[4096];
     iovec iov = {buffer, sizeof(buffer)};

--- a/src/Native/System.Native/pal_networkchange.h
+++ b/src/Native/System.Native/pal_networkchange.h
@@ -17,5 +17,5 @@ enum class NetworkChangeKind : int32_t
 
 typedef void (*NetworkChangeEvent)(NetworkChangeKind notificationKind);
 
-extern "C" NetworkChangeKind ReadSingleEvent(int sock);
+extern "C" NetworkChangeKind SystemNative_ReadSingleEvent(int sock);
 NetworkChangeKind ReadNewLinkMessage(nlmsghdr* hdr);

--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -193,7 +193,7 @@ static int32_t ConvertGetAddrInfoAndGetNameInfoErrorsToPal(int32_t error)
 }
 
 extern "C" int32_t
-IPv6StringToAddress(const uint8_t* address, const uint8_t* port, uint8_t* buffer, int32_t bufferLength, uint32_t* scope)
+SystemNative_IPv6StringToAddress(const uint8_t* address, const uint8_t* port, uint8_t* buffer, int32_t bufferLength, uint32_t* scope)
 {
     assert(buffer != nullptr);
     assert(bufferLength == NUM_BYTES_IN_IPV6_ADDRESS);
@@ -214,7 +214,7 @@ IPv6StringToAddress(const uint8_t* address, const uint8_t* port, uint8_t* buffer
     return ConvertGetAddrInfoAndGetNameInfoErrorsToPal(result);
 }
 
-extern "C" int32_t IPv4StringToAddress(const uint8_t* address, uint8_t* buffer, int32_t bufferLength, uint16_t* port)
+extern "C" int32_t SystemNative_IPv4StringToAddress(const uint8_t* address, uint8_t* buffer, int32_t bufferLength, uint16_t* port)
 {
     assert(buffer != nullptr);
     assert(bufferLength == NUM_BYTES_IN_IPV4_ADDRESS);
@@ -256,7 +256,7 @@ static void AppendScopeIfNecessary(uint8_t* string, int32_t stringLength, uint32
     (void)n; // Silence an unused variable warning in release mode
 }
 
-extern "C" int32_t IPAddressToString(
+extern "C" int32_t SystemNative_IPAddressToString(
     const uint8_t* address, int32_t addressLength, bool isIPv6, uint8_t* string, int32_t stringLength, uint32_t scope)
 {
     assert(address != nullptr);
@@ -303,7 +303,7 @@ extern "C" int32_t IPAddressToString(
     return 0;
 }
 
-extern "C" int32_t GetHostEntryForName(const uint8_t* address, HostEntry* entry)
+extern "C" int32_t SystemNative_GetHostEntryForName(const uint8_t* address, HostEntry* entry)
 {
     if (address == nullptr || entry == nullptr)
     {
@@ -422,7 +422,7 @@ static int GetHostByNameHelper(const uint8_t* hostname, hostent** entry)
 }
 #endif
 
-extern "C" int32_t GetHostByName(const uint8_t* hostname, HostEntry* entry)
+extern "C" int32_t SystemNative_GetHostByName(const uint8_t* hostname, HostEntry* entry)
 {
     if (hostname == nullptr || entry == nullptr)
     {
@@ -492,7 +492,7 @@ static int GetHostByAddrHelper(const uint8_t* addr, const socklen_t addrLen, int
 }
 #endif
 
-extern "C" int32_t GetHostByAddress(const IPAddress* address, HostEntry* entry)
+extern "C" int32_t SystemNative_GetHostByAddress(const IPAddress* address, HostEntry* entry)
 {
     if (address == nullptr || entry == nullptr)
     {
@@ -622,7 +622,7 @@ static int32_t GetNextIPAddressFromHostEnt(hostent** hostEntry, IPAddress* addre
     return PAL_EAI_SUCCESS;
 }
 
-extern "C" int32_t GetNextIPAddress(const HostEntry* hostEntry, void** addressListHandle, IPAddress* endPoint)
+extern "C" int32_t SystemNative_GetNextIPAddress(const HostEntry* hostEntry, void** addressListHandle, IPAddress* endPoint)
 {
     if (hostEntry == nullptr || addressListHandle == nullptr || endPoint == nullptr)
     {
@@ -642,7 +642,7 @@ extern "C" int32_t GetNextIPAddress(const HostEntry* hostEntry, void** addressLi
     }
 }
 
-extern "C" void FreeHostEntry(HostEntry* entry)
+extern "C" void SystemNative_FreeHostEntry(HostEntry* entry)
 {
     if (entry != nullptr)
     {
@@ -684,7 +684,7 @@ inline int32_t ConvertGetNameInfoFlagsToPal(int32_t flags)
     return outFlags;
 }
 
-extern "C" int32_t GetNameInfo(const uint8_t* address,
+extern "C" int32_t SystemNative_GetNameInfo(const uint8_t* address,
                                int32_t addressLength,
                                bool isIPv6,
                                uint8_t* host,
@@ -729,7 +729,7 @@ extern "C" int32_t GetNameInfo(const uint8_t* address,
     return ConvertGetAddrInfoAndGetNameInfoErrorsToPal(result);
 }
 
-extern "C" int32_t GetDomainName(uint8_t* name, int32_t nameLength)
+extern "C" int32_t SystemNative_GetDomainName(uint8_t* name, int32_t nameLength)
 {
     assert(name != nullptr);
     assert(nameLength > 0);
@@ -743,7 +743,7 @@ extern "C" int32_t GetDomainName(uint8_t* name, int32_t nameLength)
     return getdomainname(reinterpret_cast<char*>(name), namelen);
 }
 
-extern "C" int32_t GetHostName(uint8_t* name, int32_t nameLength)
+extern "C" int32_t SystemNative_GetHostName(uint8_t* name, int32_t nameLength)
 {
     assert(name != nullptr);
     assert(nameLength > 0);
@@ -760,7 +760,7 @@ static bool IsInBounds(const TType* base, size_t len, const TField* value)
     return valueAddr >= baseAddr && (valueAddr + sizeof(TField)) <= (baseAddr + len);
 }
 
-extern "C" Error GetIPSocketAddressSizes(int32_t* ipv4SocketAddressSize, int32_t* ipv6SocketAddressSize)
+extern "C" Error SystemNative_GetIPSocketAddressSizes(int32_t* ipv4SocketAddressSize, int32_t* ipv6SocketAddressSize)
 {
     if (ipv4SocketAddressSize == nullptr || ipv6SocketAddressSize == nullptr)
     {
@@ -828,7 +828,7 @@ static bool TryConvertAddressFamilyPalToPlatform(int32_t palAddressFamily, sa_fa
     }
 }
 
-extern "C" Error GetAddressFamily(const uint8_t* socketAddress, int32_t socketAddressLen, int32_t* addressFamily)
+extern "C" Error SystemNative_GetAddressFamily(const uint8_t* socketAddress, int32_t socketAddressLen, int32_t* addressFamily)
 {
     if (socketAddress == nullptr || addressFamily == nullptr || socketAddressLen < 0)
     {
@@ -849,7 +849,7 @@ extern "C" Error GetAddressFamily(const uint8_t* socketAddress, int32_t socketAd
     return PAL_SUCCESS;
 }
 
-extern "C" Error SetAddressFamily(uint8_t* socketAddress, int32_t socketAddressLen, int32_t addressFamily)
+extern "C" Error SystemNative_SetAddressFamily(uint8_t* socketAddress, int32_t socketAddressLen, int32_t addressFamily)
 {
     auto* sockAddr = reinterpret_cast<sockaddr*>(socketAddress);
     if (sockAddr == nullptr || socketAddressLen < 0 ||
@@ -866,7 +866,7 @@ extern "C" Error SetAddressFamily(uint8_t* socketAddress, int32_t socketAddressL
     return PAL_SUCCESS;
 }
 
-extern "C" Error GetPort(const uint8_t* socketAddress, int32_t socketAddressLen, uint16_t* port)
+extern "C" Error SystemNative_GetPort(const uint8_t* socketAddress, int32_t socketAddressLen, uint16_t* port)
 {
     if (socketAddress == nullptr)
     {
@@ -908,7 +908,7 @@ extern "C" Error GetPort(const uint8_t* socketAddress, int32_t socketAddressLen,
     }
 }
 
-extern "C" Error SetPort(uint8_t* socketAddress, int32_t socketAddressLen, uint16_t port)
+extern "C" Error SystemNative_SetPort(uint8_t* socketAddress, int32_t socketAddressLen, uint16_t port)
 {
     if (socketAddress == nullptr)
     {
@@ -950,7 +950,7 @@ extern "C" Error SetPort(uint8_t* socketAddress, int32_t socketAddressLen, uint1
     }
 }
 
-extern "C" Error GetIPv4Address(const uint8_t* socketAddress, int32_t socketAddressLen, uint32_t* address)
+extern "C" Error SystemNative_GetIPv4Address(const uint8_t* socketAddress, int32_t socketAddressLen, uint32_t* address)
 {
     if (socketAddress == nullptr || address == nullptr || socketAddressLen < 0 ||
         static_cast<size_t>(socketAddressLen) < sizeof(sockaddr_in))
@@ -973,7 +973,7 @@ extern "C" Error GetIPv4Address(const uint8_t* socketAddress, int32_t socketAddr
     return PAL_SUCCESS;
 }
 
-extern "C" Error SetIPv4Address(uint8_t* socketAddress, int32_t socketAddressLen, uint32_t address)
+extern "C" Error SystemNative_SetIPv4Address(uint8_t* socketAddress, int32_t socketAddressLen, uint32_t address)
 {
     if (socketAddress == nullptr || socketAddressLen < 0 || static_cast<size_t>(socketAddressLen) < sizeof(sockaddr_in))
     {
@@ -998,7 +998,7 @@ extern "C" Error SetIPv4Address(uint8_t* socketAddress, int32_t socketAddressLen
     return PAL_SUCCESS;
 }
 
-extern "C" Error GetIPv6Address(
+extern "C" Error SystemNative_GetIPv6Address(
     const uint8_t* socketAddress, int32_t socketAddressLen, uint8_t* address, int32_t addressLen, uint32_t* scopeId)
 {
     if (socketAddress == nullptr || address == nullptr || scopeId == nullptr || socketAddressLen < 0 ||
@@ -1026,7 +1026,7 @@ extern "C" Error GetIPv6Address(
 }
 
 extern "C" Error
-SetIPv6Address(uint8_t* socketAddress, int32_t socketAddressLen, uint8_t* address, int32_t addressLen, uint32_t scopeId)
+SystemNative_SetIPv6Address(uint8_t* socketAddress, int32_t socketAddressLen, uint8_t* address, int32_t addressLen, uint32_t scopeId)
 {
     if (socketAddress == nullptr || address == nullptr || socketAddressLen < 0 ||
         static_cast<size_t>(socketAddressLen) < sizeof(sockaddr_in6) || addressLen < NUM_BYTES_IN_IPV6_ADDRESS)
@@ -1066,7 +1066,7 @@ static void ConvertMessageHeaderToMsghdr(msghdr* header, const MessageHeader& me
     };
 }
 
-extern "C" int32_t GetControlMessageBufferSize(int32_t isIPv4, int32_t isIPv6)
+extern "C" int32_t SystemNative_GetControlMessageBufferSize(int32_t isIPv4, int32_t isIPv6)
 {
     // Note: it is possible that the address family of the socket is neither
     //       AF_INET nor AF_INET6. In this case both inputs will be false and
@@ -1120,7 +1120,7 @@ static int32_t GetIPv6PacketInformation(cmsghdr* controlMessage, IPPacketInforma
 }
 
 extern "C" int32_t
-TryGetIPPacketInformation(MessageHeader* messageHeader, int32_t isIPv4, IPPacketInformation* packetInfo)
+SystemNative_TryGetIPPacketInformation(MessageHeader* messageHeader, int32_t isIPv4, IPPacketInformation* packetInfo)
 {
     if (messageHeader == nullptr || packetInfo == nullptr)
     {
@@ -1174,7 +1174,7 @@ static bool GetMulticastOptionName(int32_t multicastOption, bool isIPv6, int& op
     }
 }
 
-extern "C" Error GetIPv4MulticastOption(int32_t socket, int32_t multicastOption, IPv4MulticastOption* option)
+extern "C" Error SystemNative_GetIPv4MulticastOption(int32_t socket, int32_t multicastOption, IPv4MulticastOption* option)
 {
     if (option == nullptr)
     {
@@ -1192,7 +1192,7 @@ extern "C" Error GetIPv4MulticastOption(int32_t socket, int32_t multicastOption,
     int err = getsockopt(socket, IPPROTO_IP, optionName, &opt, &len);
     if (err != 0)
     {
-        return ConvertErrorPlatformToPal(errno);
+        return SystemNative_ConvertErrorPlatformToPal(errno);
     }
 
     *option = {.MulticastAddress = opt.imr_multiaddr.s_addr,
@@ -1201,7 +1201,7 @@ extern "C" Error GetIPv4MulticastOption(int32_t socket, int32_t multicastOption,
     return PAL_SUCCESS;
 }
 
-extern "C" Error SetIPv4MulticastOption(int32_t socket, int32_t multicastOption, IPv4MulticastOption* option)
+extern "C" Error SystemNative_SetIPv4MulticastOption(int32_t socket, int32_t multicastOption, IPv4MulticastOption* option)
 {
     if (option == nullptr)
     {
@@ -1218,10 +1218,10 @@ extern "C" Error SetIPv4MulticastOption(int32_t socket, int32_t multicastOption,
                     .imr_address = {.s_addr = option->LocalAddress},
                     .imr_ifindex = option->InterfaceIndex};
     int err = setsockopt(socket, IPPROTO_IP, optionName, &opt, sizeof(opt));
-    return err == 0 ? PAL_SUCCESS : ConvertErrorPlatformToPal(errno);
+    return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
-extern "C" Error GetIPv6MulticastOption(int32_t socket, int32_t multicastOption, IPv6MulticastOption* option)
+extern "C" Error SystemNative_GetIPv6MulticastOption(int32_t socket, int32_t multicastOption, IPv6MulticastOption* option)
 {
     if (option == nullptr)
     {
@@ -1239,7 +1239,7 @@ extern "C" Error GetIPv6MulticastOption(int32_t socket, int32_t multicastOption,
     int err = getsockopt(socket, IPPROTO_IP, optionName, &opt, &len);
     if (err != 0)
     {
-        return ConvertErrorPlatformToPal(errno);
+        return SystemNative_ConvertErrorPlatformToPal(errno);
     }
 
     ConvertIn6AddrToByteArray(&option->Address.Address[0], NUM_BYTES_IN_IPV6_ADDRESS, opt.ipv6mr_multiaddr);
@@ -1247,7 +1247,7 @@ extern "C" Error GetIPv6MulticastOption(int32_t socket, int32_t multicastOption,
     return PAL_SUCCESS;
 }
 
-extern "C" Error SetIPv6MulticastOption(int32_t socket, int32_t multicastOption, IPv6MulticastOption* option)
+extern "C" Error SystemNative_SetIPv6MulticastOption(int32_t socket, int32_t multicastOption, IPv6MulticastOption* option)
 {
     if (option == nullptr)
     {
@@ -1264,7 +1264,7 @@ extern "C" Error SetIPv6MulticastOption(int32_t socket, int32_t multicastOption,
     ConvertByteArrayToIn6Addr(opt.ipv6mr_multiaddr, &option->Address.Address[0], NUM_BYTES_IN_IPV6_ADDRESS);
 
     int err = setsockopt(socket, IPPROTO_IP, optionName, &opt, sizeof(opt));
-    return err == 0 ? PAL_SUCCESS : ConvertErrorPlatformToPal(errno);
+    return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
 #if defined(__APPLE__) && __APPLE__
@@ -1304,7 +1304,7 @@ constexpr int32_t GetMaxLingerTime()
 }
 #endif
 
-extern "C" Error GetLingerOption(int32_t socket, LingerOption* option)
+extern "C" Error SystemNative_GetLingerOption(int32_t socket, LingerOption* option)
 {
     if (option == nullptr)
     {
@@ -1316,14 +1316,14 @@ extern "C" Error GetLingerOption(int32_t socket, LingerOption* option)
     int err = getsockopt(socket, SOL_SOCKET, LINGER_OPTION_NAME, &opt, &len);
     if (err != 0)
     {
-        return ConvertErrorPlatformToPal(errno);
+        return SystemNative_ConvertErrorPlatformToPal(errno);
     }
 
     *option = {.OnOff = opt.l_onoff, .Seconds = opt.l_linger};
     return PAL_SUCCESS;
 }
 
-extern "C" Error SetLingerOption(int32_t socket, LingerOption* option)
+extern "C" Error SystemNative_SetLingerOption(int32_t socket, LingerOption* option)
 {
     if (option == nullptr)
     {
@@ -1337,7 +1337,7 @@ extern "C" Error SetLingerOption(int32_t socket, LingerOption* option)
 
     linger opt = {.l_onoff = option->OnOff, .l_linger = option->Seconds};
     int err = setsockopt(socket, SOL_SOCKET, LINGER_OPTION_NAME, &opt, sizeof(opt));
-    return err == 0 ? PAL_SUCCESS : ConvertErrorPlatformToPal(errno);
+    return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
 static bool ConvertSocketFlagsPalToPlatform(int32_t palFlags, int& platformFlags)
@@ -1370,7 +1370,7 @@ static int32_t ConvertSocketFlagsPlatformToPal(int platformFlags)
            ((platformFlags & MSG_CTRUNC) == 0 ? 0 : PAL_MSG_CTRUNC);
 }
 
-extern "C" Error ReceiveMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* received)
+extern "C" Error SystemNative_ReceiveMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* received)
 {
     if (messageHeader == nullptr || received == nullptr || messageHeader->SocketAddressLen < 0 ||
         messageHeader->ControlBufferLen < 0 || messageHeader->IOVectorCount < 0)
@@ -1406,10 +1406,10 @@ extern "C" Error ReceiveMessage(int32_t socket, MessageHeader* messageHeader, in
     }
 
     *received = 0;
-    return ConvertErrorPlatformToPal(errno);
+    return SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
-extern "C" Error SendMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* sent)
+extern "C" Error SystemNative_SendMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* sent)
 {
     if (messageHeader == nullptr || sent == nullptr || messageHeader->SocketAddressLen < 0 ||
         messageHeader->ControlBufferLen < 0 || messageHeader->IOVectorCount < 0)
@@ -1434,10 +1434,10 @@ extern "C" Error SendMessage(int32_t socket, MessageHeader* messageHeader, int32
     }
 
     *sent = 0;
-    return ConvertErrorPlatformToPal(errno);
+    return SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
-extern "C" Error Accept(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen, int32_t* acceptedSocket)
+extern "C" Error SystemNative_Accept(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen, int32_t* acceptedSocket)
 {
     if (socketAddress == nullptr || socketAddressLen == nullptr || acceptedSocket == nullptr || *socketAddressLen < 0)
     {
@@ -1449,7 +1449,7 @@ extern "C" Error Accept(int32_t socket, uint8_t* socketAddress, int32_t* socketA
     if (accepted == -1)
     {
         *acceptedSocket = -1;
-        return ConvertErrorPlatformToPal(errno);
+        return SystemNative_ConvertErrorPlatformToPal(errno);
     }
 
     assert(addrLen <= static_cast<socklen_t>(*socketAddressLen));
@@ -1458,7 +1458,7 @@ extern "C" Error Accept(int32_t socket, uint8_t* socketAddress, int32_t* socketA
     return PAL_SUCCESS;
 }
 
-extern "C" Error Bind(int32_t socket, uint8_t* socketAddress, int32_t socketAddressLen)
+extern "C" Error SystemNative_Bind(int32_t socket, uint8_t* socketAddress, int32_t socketAddressLen)
 {
     if (socketAddress == nullptr || socketAddressLen < 0)
     {
@@ -1466,10 +1466,10 @@ extern "C" Error Bind(int32_t socket, uint8_t* socketAddress, int32_t socketAddr
     }
 
     int err = bind(socket, reinterpret_cast<sockaddr*>(socketAddress), static_cast<socklen_t>(socketAddressLen));
-    return err == 0 ? PAL_SUCCESS : ConvertErrorPlatformToPal(errno);
+    return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
-extern "C" Error Connect(int32_t socket, uint8_t* socketAddress, int32_t socketAddressLen)
+extern "C" Error SystemNative_Connect(int32_t socket, uint8_t* socketAddress, int32_t socketAddressLen)
 {
     if (socketAddress == nullptr || socketAddressLen < 0)
     {
@@ -1477,10 +1477,10 @@ extern "C" Error Connect(int32_t socket, uint8_t* socketAddress, int32_t socketA
     }
 
     int err = connect(socket, reinterpret_cast<sockaddr*>(socketAddress), static_cast<socklen_t>(socketAddressLen));
-    return err == 0 ? PAL_SUCCESS : ConvertErrorPlatformToPal(errno);
+    return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
-extern "C" Error GetPeerName(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen)
+extern "C" Error SystemNative_GetPeerName(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen)
 {
     if (socketAddress == nullptr || socketAddressLen == nullptr || *socketAddressLen < 0)
     {
@@ -1491,7 +1491,7 @@ extern "C" Error GetPeerName(int32_t socket, uint8_t* socketAddress, int32_t* so
     int err = getpeername(socket, reinterpret_cast<sockaddr*>(socketAddress), &addrLen);
     if (err != 0)
     {
-        return ConvertErrorPlatformToPal(errno);
+        return SystemNative_ConvertErrorPlatformToPal(errno);
     }
 
     assert(addrLen <= static_cast<socklen_t>(*socketAddressLen));
@@ -1499,7 +1499,7 @@ extern "C" Error GetPeerName(int32_t socket, uint8_t* socketAddress, int32_t* so
     return PAL_SUCCESS;
 }
 
-extern "C" Error GetSockName(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen)
+extern "C" Error SystemNative_GetSockName(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen)
 {
     if (socketAddress == nullptr || socketAddressLen == nullptr || *socketAddressLen < 0)
     {
@@ -1510,7 +1510,7 @@ extern "C" Error GetSockName(int32_t socket, uint8_t* socketAddress, int32_t* so
     int err = getsockname(socket, reinterpret_cast<sockaddr*>(socketAddress), &addrLen);
     if (err != 0)
     {
-        return ConvertErrorPlatformToPal(errno);
+        return SystemNative_ConvertErrorPlatformToPal(errno);
     }
 
     assert(addrLen <= static_cast<socklen_t>(*socketAddressLen));
@@ -1518,13 +1518,13 @@ extern "C" Error GetSockName(int32_t socket, uint8_t* socketAddress, int32_t* so
     return PAL_SUCCESS;
 }
 
-extern "C" Error Listen(int32_t socket, int32_t backlog)
+extern "C" Error SystemNative_Listen(int32_t socket, int32_t backlog)
 {
     int err = listen(socket, backlog);
-    return err == 0 ? PAL_SUCCESS : ConvertErrorPlatformToPal(errno);
+    return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
-extern "C" Error Shutdown(int32_t socket, int32_t socketShutdown)
+extern "C" Error SystemNative_Shutdown(int32_t socket, int32_t socketShutdown)
 {
     int how;
     switch (socketShutdown)
@@ -1546,10 +1546,10 @@ extern "C" Error Shutdown(int32_t socket, int32_t socketShutdown)
     }
 
     int err = shutdown(socket, how);
-    return err == 0 ? PAL_SUCCESS : ConvertErrorPlatformToPal(errno);
+    return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
-extern "C" Error GetSocketErrorOption(int32_t socket, Error* error)
+extern "C" Error SystemNative_GetSocketErrorOption(int32_t socket, Error* error)
 {
     if (error == nullptr)
     {
@@ -1561,11 +1561,11 @@ extern "C" Error GetSocketErrorOption(int32_t socket, Error* error)
     int err = getsockopt(socket, SOL_SOCKET, SO_ERROR, &socketErrno, &optLen);
     if (err != 0)
     {
-        return ConvertErrorPlatformToPal(errno);
+        return SystemNative_ConvertErrorPlatformToPal(errno);
     }
 
     assert(optLen == sizeof(socketErrno));
-    *error = ConvertErrorPlatformToPal(socketErrno);
+    *error = SystemNative_ConvertErrorPlatformToPal(socketErrno);
     return PAL_SUCCESS;
 }
 
@@ -1781,7 +1781,7 @@ static bool TryGetPlatformSocketOption(int32_t socketOptionName, int32_t socketO
     }
 }
 
-extern "C" Error GetSockOpt(
+extern "C" Error SystemNative_GetSockOpt(
     int32_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t* optionLen)
 {
     if (optionLen == nullptr || *optionLen < 0)
@@ -1799,7 +1799,7 @@ extern "C" Error GetSockOpt(
     int err = getsockopt(socket, optLevel, optName, optionValue, &optLen);
     if (err != 0)
     {
-        return ConvertErrorPlatformToPal(errno);
+        return SystemNative_ConvertErrorPlatformToPal(errno);
     }
 
     assert(optLen <= static_cast<socklen_t>(*optionLen));
@@ -1808,7 +1808,7 @@ extern "C" Error GetSockOpt(
 }
 
 extern "C" Error
-SetSockOpt(int32_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t optionLen)
+SystemNative_SetSockOpt(int32_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t optionLen)
 {
     if (optionLen < 0)
     {
@@ -1822,7 +1822,7 @@ SetSockOpt(int32_t socket, int32_t socketOptionLevel, int32_t socketOptionName, 
     }
 
     int err = setsockopt(socket, optLevel, optName, optionValue, static_cast<socklen_t>(optionLen));
-    return err == 0 ? PAL_SUCCESS : ConvertErrorPlatformToPal(errno);
+    return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
 static bool TryConvertSocketTypePalToPlatform(int32_t palSocketType, int* platformSocketType)
@@ -1889,7 +1889,7 @@ static bool TryConvertProtocolTypePalToPlatform(int32_t palProtocolType, int* pl
     }
 }
 
-extern "C" Error Socket(int32_t addressFamily, int32_t socketType, int32_t protocolType, int32_t* createdSocket)
+extern "C" Error SystemNative_Socket(int32_t addressFamily, int32_t socketType, int32_t protocolType, int32_t* createdSocket)
 {
     if (createdSocket == nullptr)
     {
@@ -1918,7 +1918,7 @@ extern "C" Error Socket(int32_t addressFamily, int32_t socketType, int32_t proto
     }
 
     *createdSocket = socket(platformAddressFamily, platformSocketType, platformProtocolType);
-    return *createdSocket != -1 ? PAL_SUCCESS : ConvertErrorPlatformToPal(errno);
+    return *createdSocket != -1 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
 const int FD_SETSIZE_BYTES = FD_SETSIZE / 8;
@@ -1997,13 +1997,13 @@ static void ConvertFdSetPalToPlatform(fd_set& platformSet, uint32_t* palSet, int
 #endif
 }
 
-extern "C" int32_t FdSetSize()
+extern "C" int32_t SystemNative_FdSetSize()
 {
     return FD_SETSIZE;
 }
 
 extern "C" Error
-Select(int32_t fdCount, uint32_t* readFdSet, uint32_t* writeFdSet, uint32_t* errorFdSet, int32_t microseconds, int32_t* selected)
+SystemNative_Select(int32_t fdCount, uint32_t* readFdSet, uint32_t* writeFdSet, uint32_t* errorFdSet, int32_t microseconds, int32_t* selected)
 {
     if (selected == nullptr)
     {
@@ -2049,7 +2049,7 @@ Select(int32_t fdCount, uint32_t* readFdSet, uint32_t* writeFdSet, uint32_t* err
     int rv = select(fdCount, readFds, writeFds, errorFds, timeout);
     if (rv == -1)
     {
-        return ConvertErrorPlatformToPal(errno);
+        return SystemNative_ConvertErrorPlatformToPal(errno);
     }
 
     if (readFdSet != nullptr)
@@ -2071,7 +2071,7 @@ Select(int32_t fdCount, uint32_t* readFdSet, uint32_t* writeFdSet, uint32_t* err
     return PAL_SUCCESS;
 }
 
-extern "C" Error GetBytesAvailable(int32_t socket, int32_t* available)
+extern "C" Error SystemNative_GetBytesAvailable(int32_t socket, int32_t* available)
 {
     if (available == nullptr)
     {
@@ -2082,7 +2082,7 @@ extern "C" Error GetBytesAvailable(int32_t socket, int32_t* available)
     int err = ioctl(socket, FIONREAD, &avail);
     if (err == -1)
     {
-        return ConvertErrorPlatformToPal(errno);
+        return SystemNative_ConvertErrorPlatformToPal(errno);
     }
 
     *available = static_cast<int32_t>(avail);
@@ -2117,7 +2117,7 @@ static Error CreateSocketEventPortInner(int32_t* port)
     if (epollFd == -1)
     {
         *port = -1;
-        return ConvertErrorPlatformToPal(errno);
+        return SystemNative_ConvertErrorPlatformToPal(errno);
     }
 
     *port = epollFd;
@@ -2127,7 +2127,7 @@ static Error CreateSocketEventPortInner(int32_t* port)
 static Error CloseSocketEventPortInner(int32_t port)
 {
     int err = close(port);
-    return err == 0 ? PAL_SUCCESS : ConvertErrorPlatformToPal(errno);
+    return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
 static Error TryChangeSocketEventRegistrationInner(
@@ -2147,7 +2147,7 @@ static Error TryChangeSocketEventRegistrationInner(
 
     epoll_event evt = {.events = GetEPollEvents(newEvents) | EPOLLET, .data = {.ptr = reinterpret_cast<void*>(data)}};
     int err = epoll_ctl(port, op, socket, &evt);
-    return err == 0 ? PAL_SUCCESS : ConvertErrorPlatformToPal(errno);
+    return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
 static void ConvertEventEPollToSocketAsync(SocketEvent* sae, epoll_event* epoll)
@@ -2179,7 +2179,7 @@ static Error WaitForSocketEventsInner(int32_t port, SocketEvent* buffer, int32_t
     if (numEvents == -1)
     {
         *count = 0;
-        return ConvertErrorPlatformToPal(errno);
+        return SystemNative_ConvertErrorPlatformToPal(errno);
     }
 
     // We should never see 0 events. Given an infinite timeout, epoll_wait will never return
@@ -2266,7 +2266,7 @@ static Error CreateSocketEventPortInner(int32_t* port)
     if (kqueueFd == -1)
     {
         *port = -1;
-        return ConvertErrorPlatformToPal(errno);
+        return SystemNative_ConvertErrorPlatformToPal(errno);
     }
 
     *port = kqueueFd;
@@ -2276,7 +2276,7 @@ static Error CreateSocketEventPortInner(int32_t* port)
 static Error CloseSocketEventPortInner(int32_t port)
 {
     int err = close(port);
-    return err == 0 ? PAL_SUCCESS : ConvertErrorPlatformToPal(errno);
+    return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
 static Error TryChangeSocketEventRegistrationInner(
@@ -2317,7 +2317,7 @@ static Error TryChangeSocketEventRegistrationInner(
     }
 
     int err = kevent(port, events, i, nullptr, 0, nullptr);
-    return err == 0 ? PAL_SUCCESS : ConvertErrorPlatformToPal(errno);
+    return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
 static Error WaitForSocketEventsInner(int32_t port, SocketEvent* buffer, int32_t* count)
@@ -2331,7 +2331,7 @@ static Error WaitForSocketEventsInner(int32_t port, SocketEvent* buffer, int32_t
     if (numEvents == -1)
     {
         *count = -1;
-        return ConvertErrorPlatformToPal(errno);
+        return SystemNative_ConvertErrorPlatformToPal(errno);
     }
 
     // We should never see 0 events. Given an infinite timeout, kevent will never return
@@ -2356,7 +2356,7 @@ static Error WaitForSocketEventsInner(int32_t port, SocketEvent* buffer, int32_t
 #error Asynchronous sockets require epoll or kqueue support.
 #endif
 
-extern "C" Error CreateSocketEventPort(int32_t* port)
+extern "C" Error SystemNative_CreateSocketEventPort(int32_t* port)
 {
     if (port == nullptr)
     {
@@ -2366,12 +2366,12 @@ extern "C" Error CreateSocketEventPort(int32_t* port)
     return CreateSocketEventPortInner(port);
 }
 
-extern "C" Error CloseSocketEventPort(int32_t port)
+extern "C" Error SystemNative_CloseSocketEventPort(int32_t port)
 {
     return CloseSocketEventPortInner(port);
 }
 
-extern "C" Error CreateSocketEventBuffer(int32_t count, SocketEvent** buffer)
+extern "C" Error SystemNative_CreateSocketEventBuffer(int32_t count, SocketEvent** buffer)
 {
     if (buffer == nullptr || count < 0)
     {
@@ -2389,14 +2389,14 @@ extern "C" Error CreateSocketEventBuffer(int32_t count, SocketEvent** buffer)
     return PAL_SUCCESS;
 }
 
-extern "C" Error FreeSocketEventBuffer(SocketEvent* buffer)
+extern "C" Error SystemNative_FreeSocketEventBuffer(SocketEvent* buffer)
 {
     free(buffer);
     return PAL_SUCCESS;
 }
 
 extern "C" Error
-TryChangeSocketEventRegistration(int32_t port, int32_t socket, int32_t currentEvents, int32_t newEvents, uintptr_t data)
+SystemNative_TryChangeSocketEventRegistration(int32_t port, int32_t socket, int32_t currentEvents, int32_t newEvents, uintptr_t data)
 {
     const int32_t SupportedEvents = PAL_SA_READ | PAL_SA_WRITE | PAL_SA_READCLOSE | PAL_SA_CLOSE | PAL_SA_ERROR;
 
@@ -2414,7 +2414,7 @@ TryChangeSocketEventRegistration(int32_t port, int32_t socket, int32_t currentEv
         port, socket, static_cast<SocketEvents>(currentEvents), static_cast<SocketEvents>(newEvents), data);
 }
 
-extern "C" Error WaitForSocketEvents(int32_t port, SocketEvent* buffer, int32_t* count)
+extern "C" Error SystemNative_WaitForSocketEvents(int32_t port, SocketEvent* buffer, int32_t* count)
 {
     if (buffer == nullptr || count == nullptr || *count < 0)
     {
@@ -2424,7 +2424,7 @@ extern "C" Error WaitForSocketEvents(int32_t port, SocketEvent* buffer, int32_t*
     return WaitForSocketEventsInner(port, buffer, count);
 }
 
-extern "C" int32_t PlatformSupportsMultipleConnectAttempts()
+extern "C" int32_t SystemNative_PlatformSupportsMultipleConnectAttempts()
 {
 #if HAVE_SUPPORT_FOR_MULTIPLE_CONNECT_ATTEMPTS
     return 1;
@@ -2433,7 +2433,7 @@ extern "C" int32_t PlatformSupportsMultipleConnectAttempts()
 #endif
 }
 
-extern "C" int32_t PlatformSupportsDualModeIPv4PacketInfo()
+extern "C" int32_t SystemNative_PlatformSupportsDualModeIPv4PacketInfo()
 {
 #if HAVE_SUPPORT_FOR_DUAL_MODE_IPV4_PACKET_INFO
     return 1;

--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -192,6 +192,14 @@ static int32_t ConvertGetAddrInfoAndGetNameInfoErrorsToPal(int32_t error)
     return -1;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t IPv6StringToAddress(const uint8_t* address, const uint8_t* port, uint8_t* buffer, int32_t bufferLength, uint32_t* scope)
+{
+    return SystemNative_IPv6StringToAddress(address, port, buffer, bufferLength, scope);
+}
+
 extern "C" int32_t
 SystemNative_IPv6StringToAddress(const uint8_t* address, const uint8_t* port, uint8_t* buffer, int32_t bufferLength, uint32_t* scope)
 {
@@ -212,6 +220,14 @@ SystemNative_IPv6StringToAddress(const uint8_t* address, const uint8_t* port, ui
     }
 
     return ConvertGetAddrInfoAndGetNameInfoErrorsToPal(result);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t IPv4StringToAddress(const uint8_t* address, uint8_t* buffer, int32_t bufferLength, uint16_t* port)
+{
+    return SystemNative_IPv4StringToAddress(address, buffer, bufferLength, port);
 }
 
 extern "C" int32_t SystemNative_IPv4StringToAddress(const uint8_t* address, uint8_t* buffer, int32_t bufferLength, uint16_t* port)
@@ -254,6 +270,15 @@ static void AppendScopeIfNecessary(uint8_t* string, int32_t stringLength, uint32
     int n = snprintf(reinterpret_cast<char*>(&string[i]), capacity, "%%%d", scope);
     assert(static_cast<size_t>(n) < capacity);
     (void)n; // Silence an unused variable warning in release mode
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t IPAddressToString(
+    const uint8_t* address, int32_t addressLength, bool isIPv6, uint8_t* string, int32_t stringLength, uint32_t scope)
+{
+    return SystemNative_IPAddressToString(address, addressLength, isIPv6, string, stringLength, scope);
 }
 
 extern "C" int32_t SystemNative_IPAddressToString(
@@ -301,6 +326,14 @@ extern "C" int32_t SystemNative_IPAddressToString(
     }
 
     return 0;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t GetHostEntryForName(const uint8_t* address, HostEntry* entry)
+{
+    return SystemNative_GetHostEntryForName(address, entry);
 }
 
 extern "C" int32_t SystemNative_GetHostEntryForName(const uint8_t* address, HostEntry* entry)
@@ -422,6 +455,14 @@ static int GetHostByNameHelper(const uint8_t* hostname, hostent** entry)
 }
 #endif
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t GetHostByName(const uint8_t* hostname, HostEntry* entry)
+{
+    return SystemNative_GetHostByName(hostname, entry);
+}
+
 extern "C" int32_t SystemNative_GetHostByName(const uint8_t* hostname, HostEntry* entry)
 {
     if (hostname == nullptr || entry == nullptr)
@@ -491,6 +532,14 @@ static int GetHostByAddrHelper(const uint8_t* addr, const socklen_t addrLen, int
     }
 }
 #endif
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t GetHostByAddress(const IPAddress* address, HostEntry* entry)
+{
+    return SystemNative_GetHostByAddress(address, entry);
+}
 
 extern "C" int32_t SystemNative_GetHostByAddress(const IPAddress* address, HostEntry* entry)
 {
@@ -622,6 +671,14 @@ static int32_t GetNextIPAddressFromHostEnt(hostent** hostEntry, IPAddress* addre
     return PAL_EAI_SUCCESS;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t GetNextIPAddress(const HostEntry* hostEntry, void** addressListHandle, IPAddress* endPoint)
+{
+    return SystemNative_GetNextIPAddress(hostEntry, addressListHandle, endPoint);
+}
+
 extern "C" int32_t SystemNative_GetNextIPAddress(const HostEntry* hostEntry, void** addressListHandle, IPAddress* endPoint)
 {
     if (hostEntry == nullptr || addressListHandle == nullptr || endPoint == nullptr)
@@ -640,6 +697,14 @@ extern "C" int32_t SystemNative_GetNextIPAddress(const HostEntry* hostEntry, voi
         default:
             return PAL_EAI_BADARG;
     }
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" void FreeHostEntry(HostEntry* entry)
+{
+    return SystemNative_FreeHostEntry(entry);
 }
 
 extern "C" void SystemNative_FreeHostEntry(HostEntry* entry)
@@ -682,6 +747,28 @@ inline int32_t ConvertGetNameInfoFlagsToPal(int32_t flags)
     }
 
     return outFlags;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t GetNameInfo(const uint8_t* address,
+    int32_t addressLength,
+    bool isIPv6,
+    uint8_t* host,
+    int32_t hostLength,
+    uint8_t* service,
+    int32_t serviceLength,
+    int32_t flags)
+{
+    return SystemNative_GetNameInfo(address,
+        addressLength,
+        isIPv6,
+        host,
+        hostLength,
+        service,
+        serviceLength,
+        flags);
 }
 
 extern "C" int32_t SystemNative_GetNameInfo(const uint8_t* address,
@@ -729,6 +816,14 @@ extern "C" int32_t SystemNative_GetNameInfo(const uint8_t* address,
     return ConvertGetAddrInfoAndGetNameInfoErrorsToPal(result);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t GetDomainName(uint8_t* name, int32_t nameLength)
+{
+    return SystemNative_GetDomainName(name, nameLength);
+}
+
 extern "C" int32_t SystemNative_GetDomainName(uint8_t* name, int32_t nameLength)
 {
     assert(name != nullptr);
@@ -741,6 +836,14 @@ extern "C" int32_t SystemNative_GetDomainName(uint8_t* name, int32_t nameLength)
 #endif
 
     return getdomainname(reinterpret_cast<char*>(name), namelen);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t GetHostName(uint8_t* name, int32_t nameLength)
+{
+    return SystemNative_GetHostName(name, nameLength);
 }
 
 extern "C" int32_t SystemNative_GetHostName(uint8_t* name, int32_t nameLength)
@@ -758,6 +861,14 @@ static bool IsInBounds(const TType* base, size_t len, const TField* value)
     auto* baseAddr = reinterpret_cast<const uint8_t*>(base);
     auto* valueAddr = reinterpret_cast<const uint8_t*>(value);
     return valueAddr >= baseAddr && (valueAddr + sizeof(TField)) <= (baseAddr + len);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error GetIPSocketAddressSizes(int32_t* ipv4SocketAddressSize, int32_t* ipv6SocketAddressSize)
+{
+    return SystemNative_GetIPSocketAddressSizes(ipv4SocketAddressSize, ipv6SocketAddressSize);
 }
 
 extern "C" Error SystemNative_GetIPSocketAddressSizes(int32_t* ipv4SocketAddressSize, int32_t* ipv6SocketAddressSize)
@@ -828,6 +939,14 @@ static bool TryConvertAddressFamilyPalToPlatform(int32_t palAddressFamily, sa_fa
     }
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error GetAddressFamily(const uint8_t* socketAddress, int32_t socketAddressLen, int32_t* addressFamily)
+{
+    return SystemNative_GetAddressFamily(socketAddress, socketAddressLen, addressFamily);
+}
+
 extern "C" Error SystemNative_GetAddressFamily(const uint8_t* socketAddress, int32_t socketAddressLen, int32_t* addressFamily)
 {
     if (socketAddress == nullptr || addressFamily == nullptr || socketAddressLen < 0)
@@ -849,6 +968,14 @@ extern "C" Error SystemNative_GetAddressFamily(const uint8_t* socketAddress, int
     return PAL_SUCCESS;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error SetAddressFamily(uint8_t* socketAddress, int32_t socketAddressLen, int32_t addressFamily)
+{
+    return SystemNative_SetAddressFamily(socketAddress, socketAddressLen, addressFamily);
+}
+
 extern "C" Error SystemNative_SetAddressFamily(uint8_t* socketAddress, int32_t socketAddressLen, int32_t addressFamily)
 {
     auto* sockAddr = reinterpret_cast<sockaddr*>(socketAddress);
@@ -864,6 +991,14 @@ extern "C" Error SystemNative_SetAddressFamily(uint8_t* socketAddress, int32_t s
     }
 
     return PAL_SUCCESS;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error GetPort(const uint8_t* socketAddress, int32_t socketAddressLen, uint16_t* port)
+{
+    return SystemNative_GetPort(socketAddress, socketAddressLen, port);
 }
 
 extern "C" Error SystemNative_GetPort(const uint8_t* socketAddress, int32_t socketAddressLen, uint16_t* port)
@@ -908,6 +1043,14 @@ extern "C" Error SystemNative_GetPort(const uint8_t* socketAddress, int32_t sock
     }
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error SetPort(uint8_t* socketAddress, int32_t socketAddressLen, uint16_t port)
+{
+    return SystemNative_SetPort(socketAddress, socketAddressLen, port);
+}
+
 extern "C" Error SystemNative_SetPort(uint8_t* socketAddress, int32_t socketAddressLen, uint16_t port)
 {
     if (socketAddress == nullptr)
@@ -950,6 +1093,14 @@ extern "C" Error SystemNative_SetPort(uint8_t* socketAddress, int32_t socketAddr
     }
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error GetIPv4Address(const uint8_t* socketAddress, int32_t socketAddressLen, uint32_t* address)
+{
+    return SystemNative_GetIPv4Address(socketAddress, socketAddressLen, address);
+}
+
 extern "C" Error SystemNative_GetIPv4Address(const uint8_t* socketAddress, int32_t socketAddressLen, uint32_t* address)
 {
     if (socketAddress == nullptr || address == nullptr || socketAddressLen < 0 ||
@@ -971,6 +1122,14 @@ extern "C" Error SystemNative_GetIPv4Address(const uint8_t* socketAddress, int32
 
     *address = reinterpret_cast<const sockaddr_in*>(socketAddress)->sin_addr.s_addr;
     return PAL_SUCCESS;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error SetIPv4Address(uint8_t* socketAddress, int32_t socketAddressLen, uint32_t address)
+{
+    return SystemNative_SetIPv4Address(socketAddress, socketAddressLen, address);
 }
 
 extern "C" Error SystemNative_SetIPv4Address(uint8_t* socketAddress, int32_t socketAddressLen, uint32_t address)
@@ -996,6 +1155,15 @@ extern "C" Error SystemNative_SetIPv4Address(uint8_t* socketAddress, int32_t soc
     inetSockAddr->sin_family = AF_INET;
     inetSockAddr->sin_addr.s_addr = address;
     return PAL_SUCCESS;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error GetIPv6Address(
+    const uint8_t* socketAddress, int32_t socketAddressLen, uint8_t* address, int32_t addressLen, uint32_t* scopeId)
+{
+    return SystemNative_GetIPv6Address(socketAddress, socketAddressLen, address, addressLen, scopeId);
 }
 
 extern "C" Error SystemNative_GetIPv6Address(
@@ -1054,6 +1222,14 @@ SystemNative_SetIPv6Address(uint8_t* socketAddress, int32_t socketAddressLen, ui
     return PAL_SUCCESS;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error SetIPv6Address(uint8_t* socketAddress, int32_t socketAddressLen, uint8_t* address, int32_t addressLen, uint32_t scopeId)
+{
+    return SystemNative_SetIPv6Address(socketAddress, socketAddressLen, address, addressLen, scopeId);
+}
+
 static void ConvertMessageHeaderToMsghdr(msghdr* header, const MessageHeader& messageHeader)
 {
     *header = {
@@ -1064,6 +1240,14 @@ static void ConvertMessageHeaderToMsghdr(msghdr* header, const MessageHeader& me
         .msg_control = messageHeader.ControlBuffer,
         .msg_controllen = static_cast<decltype(header->msg_controllen)>(messageHeader.ControlBufferLen),
     };
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t GetControlMessageBufferSize(int32_t isIPv4, int32_t isIPv6)
+{
+    return SystemNative_GetControlMessageBufferSize(isIPv4, isIPv6);
 }
 
 extern "C" int32_t SystemNative_GetControlMessageBufferSize(int32_t isIPv4, int32_t isIPv6)
@@ -1117,6 +1301,14 @@ static int32_t GetIPv6PacketInformation(cmsghdr* controlMessage, IPPacketInforma
     packetInfo->InterfaceIndex = static_cast<int32_t>(pktinfo->ipi6_ifindex);
 
     return 1;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t TryGetIPPacketInformation(MessageHeader* messageHeader, int32_t isIPv4, IPPacketInformation* packetInfo)
+{
+    return SystemNative_TryGetIPPacketInformation(messageHeader, isIPv4, packetInfo);
 }
 
 extern "C" int32_t
@@ -1174,6 +1366,14 @@ static bool GetMulticastOptionName(int32_t multicastOption, bool isIPv6, int& op
     }
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error GetIPv4MulticastOption(int32_t socket, int32_t multicastOption, IPv4MulticastOption* option)
+{
+    return SystemNative_GetIPv4MulticastOption(socket, multicastOption, option);
+}
+
 extern "C" Error SystemNative_GetIPv4MulticastOption(int32_t socket, int32_t multicastOption, IPv4MulticastOption* option)
 {
     if (option == nullptr)
@@ -1201,6 +1401,14 @@ extern "C" Error SystemNative_GetIPv4MulticastOption(int32_t socket, int32_t mul
     return PAL_SUCCESS;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error SetIPv4MulticastOption(int32_t socket, int32_t multicastOption, IPv4MulticastOption* option)
+{
+    return SystemNative_SetIPv4MulticastOption(socket, multicastOption, option);
+}
+
 extern "C" Error SystemNative_SetIPv4MulticastOption(int32_t socket, int32_t multicastOption, IPv4MulticastOption* option)
 {
     if (option == nullptr)
@@ -1219,6 +1427,14 @@ extern "C" Error SystemNative_SetIPv4MulticastOption(int32_t socket, int32_t mul
                     .imr_ifindex = option->InterfaceIndex};
     int err = setsockopt(socket, IPPROTO_IP, optionName, &opt, sizeof(opt));
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error GetIPv6MulticastOption(int32_t socket, int32_t multicastOption, IPv6MulticastOption* option)
+{
+    return SystemNative_GetIPv6MulticastOption(socket, multicastOption, option);
 }
 
 extern "C" Error SystemNative_GetIPv6MulticastOption(int32_t socket, int32_t multicastOption, IPv6MulticastOption* option)
@@ -1245,6 +1461,14 @@ extern "C" Error SystemNative_GetIPv6MulticastOption(int32_t socket, int32_t mul
     ConvertIn6AddrToByteArray(&option->Address.Address[0], NUM_BYTES_IN_IPV6_ADDRESS, opt.ipv6mr_multiaddr);
     option->InterfaceIndex = static_cast<int32_t>(opt.ipv6mr_interface);
     return PAL_SUCCESS;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error SetIPv6MulticastOption(int32_t socket, int32_t multicastOption, IPv6MulticastOption* option)
+{
+    return SystemNative_SetIPv6MulticastOption(socket, multicastOption, option);
 }
 
 extern "C" Error SystemNative_SetIPv6MulticastOption(int32_t socket, int32_t multicastOption, IPv6MulticastOption* option)
@@ -1304,6 +1528,14 @@ constexpr int32_t GetMaxLingerTime()
 }
 #endif
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error GetLingerOption(int32_t socket, LingerOption* option)
+{
+    return SystemNative_GetLingerOption(socket, option);
+}
+
 extern "C" Error SystemNative_GetLingerOption(int32_t socket, LingerOption* option)
 {
     if (option == nullptr)
@@ -1321,6 +1553,14 @@ extern "C" Error SystemNative_GetLingerOption(int32_t socket, LingerOption* opti
 
     *option = {.OnOff = opt.l_onoff, .Seconds = opt.l_linger};
     return PAL_SUCCESS;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error SetLingerOption(int32_t socket, LingerOption* option)
+{
+    return SystemNative_SetLingerOption(socket, option);
 }
 
 extern "C" Error SystemNative_SetLingerOption(int32_t socket, LingerOption* option)
@@ -1370,6 +1610,14 @@ static int32_t ConvertSocketFlagsPlatformToPal(int platformFlags)
            ((platformFlags & MSG_CTRUNC) == 0 ? 0 : PAL_MSG_CTRUNC);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error ReceiveMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* received)
+{
+    return SystemNative_ReceiveMessage(socket, messageHeader, flags, received);
+}
+
 extern "C" Error SystemNative_ReceiveMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* received)
 {
     if (messageHeader == nullptr || received == nullptr || messageHeader->SocketAddressLen < 0 ||
@@ -1409,6 +1657,14 @@ extern "C" Error SystemNative_ReceiveMessage(int32_t socket, MessageHeader* mess
     return SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error SendMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* sent)
+{
+    return SystemNative_SendMessage(socket, messageHeader, flags, sent);
+}
+
 extern "C" Error SystemNative_SendMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* sent)
 {
     if (messageHeader == nullptr || sent == nullptr || messageHeader->SocketAddressLen < 0 ||
@@ -1437,6 +1693,14 @@ extern "C" Error SystemNative_SendMessage(int32_t socket, MessageHeader* message
     return SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error Accept(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen, int32_t* acceptedSocket)
+{
+    return SystemNative_Accept(socket, socketAddress, socketAddressLen, acceptedSocket);
+}
+
 extern "C" Error SystemNative_Accept(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen, int32_t* acceptedSocket)
 {
     if (socketAddress == nullptr || socketAddressLen == nullptr || acceptedSocket == nullptr || *socketAddressLen < 0)
@@ -1458,6 +1722,14 @@ extern "C" Error SystemNative_Accept(int32_t socket, uint8_t* socketAddress, int
     return PAL_SUCCESS;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error Bind(int32_t socket, uint8_t* socketAddress, int32_t socketAddressLen)
+{
+    return SystemNative_Bind(socket, socketAddress, socketAddressLen);
+}
+
 extern "C" Error SystemNative_Bind(int32_t socket, uint8_t* socketAddress, int32_t socketAddressLen)
 {
     if (socketAddress == nullptr || socketAddressLen < 0)
@@ -1469,6 +1741,14 @@ extern "C" Error SystemNative_Bind(int32_t socket, uint8_t* socketAddress, int32
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error Connect(int32_t socket, uint8_t* socketAddress, int32_t socketAddressLen)
+{
+    return SystemNative_Connect(socket, socketAddress, socketAddressLen);
+}
+
 extern "C" Error SystemNative_Connect(int32_t socket, uint8_t* socketAddress, int32_t socketAddressLen)
 {
     if (socketAddress == nullptr || socketAddressLen < 0)
@@ -1478,6 +1758,14 @@ extern "C" Error SystemNative_Connect(int32_t socket, uint8_t* socketAddress, in
 
     int err = connect(socket, reinterpret_cast<sockaddr*>(socketAddress), static_cast<socklen_t>(socketAddressLen));
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error GetPeerName(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen)
+{
+    return SystemNative_GetPeerName(socket, socketAddress, socketAddressLen);
 }
 
 extern "C" Error SystemNative_GetPeerName(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen)
@@ -1499,6 +1787,14 @@ extern "C" Error SystemNative_GetPeerName(int32_t socket, uint8_t* socketAddress
     return PAL_SUCCESS;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error GetSockName(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen)
+{
+    return SystemNative_GetSockName(socket, socketAddress, socketAddressLen);
+}
+
 extern "C" Error SystemNative_GetSockName(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen)
 {
     if (socketAddress == nullptr || socketAddressLen == nullptr || *socketAddressLen < 0)
@@ -1518,10 +1814,26 @@ extern "C" Error SystemNative_GetSockName(int32_t socket, uint8_t* socketAddress
     return PAL_SUCCESS;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error Listen(int32_t socket, int32_t backlog)
+{
+    return SystemNative_Listen(socket, backlog);
+}
+
 extern "C" Error SystemNative_Listen(int32_t socket, int32_t backlog)
 {
     int err = listen(socket, backlog);
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error Shutdown(int32_t socket, int32_t socketShutdown)
+{
+    return SystemNative_Shutdown(socket, socketShutdown);
 }
 
 extern "C" Error SystemNative_Shutdown(int32_t socket, int32_t socketShutdown)
@@ -1547,6 +1859,14 @@ extern "C" Error SystemNative_Shutdown(int32_t socket, int32_t socketShutdown)
 
     int err = shutdown(socket, how);
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error GetSocketErrorOption(int32_t socket, Error* error)
+{
+    return SystemNative_GetSocketErrorOption(socket, error);
 }
 
 extern "C" Error SystemNative_GetSocketErrorOption(int32_t socket, Error* error)
@@ -1781,6 +2101,14 @@ static bool TryGetPlatformSocketOption(int32_t socketOptionName, int32_t socketO
     }
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error GetSockOpt(int32_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t* optionLen)
+{
+    return SystemNative_GetSockOpt(socket, socketOptionLevel, socketOptionName, optionValue, optionLen);
+}
+
 extern "C" Error SystemNative_GetSockOpt(
     int32_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t* optionLen)
 {
@@ -1805,6 +2133,14 @@ extern "C" Error SystemNative_GetSockOpt(
     assert(optLen <= static_cast<socklen_t>(*optionLen));
     *optionLen = static_cast<int32_t>(optLen);
     return PAL_SUCCESS;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error SetSockOpt(int32_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t optionLen)
+{
+    return SystemNative_SetSockOpt(socket, socketOptionLevel, socketOptionName, optionValue, optionLen);
 }
 
 extern "C" Error
@@ -1887,6 +2223,14 @@ static bool TryConvertProtocolTypePalToPlatform(int32_t palProtocolType, int* pl
             *platformProtocolType = static_cast<int>(palProtocolType);
             return false;
     }
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error Socket(int32_t addressFamily, int32_t socketType, int32_t protocolType, int32_t* createdSocket)
+{
+    return SystemNative_Socket(addressFamily, socketType, protocolType, createdSocket);
 }
 
 extern "C" Error SystemNative_Socket(int32_t addressFamily, int32_t socketType, int32_t protocolType, int32_t* createdSocket)
@@ -1997,9 +2341,25 @@ static void ConvertFdSetPalToPlatform(fd_set& platformSet, uint32_t* palSet, int
 #endif
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t FdSetSize()
+{
+    return SystemNative_FdSetSize();
+}
+
 extern "C" int32_t SystemNative_FdSetSize()
 {
     return FD_SETSIZE;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error Select(int32_t fdCount, uint32_t* readFdSet, uint32_t* writeFdSet, uint32_t* errorFdSet, int32_t microseconds, int32_t* selected)
+{
+    return SystemNative_Select(fdCount, readFdSet, writeFdSet, errorFdSet, microseconds, selected);
 }
 
 extern "C" Error
@@ -2069,6 +2429,14 @@ SystemNative_Select(int32_t fdCount, uint32_t* readFdSet, uint32_t* writeFdSet, 
 
     *selected = rv;
     return PAL_SUCCESS;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error GetBytesAvailable(int32_t socket, int32_t* available)
+{
+    return SystemNative_GetBytesAvailable(socket, available);
 }
 
 extern "C" Error SystemNative_GetBytesAvailable(int32_t socket, int32_t* available)
@@ -2356,6 +2724,14 @@ static Error WaitForSocketEventsInner(int32_t port, SocketEvent* buffer, int32_t
 #error Asynchronous sockets require epoll or kqueue support.
 #endif
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error CreateSocketEventPort(int32_t* port)
+{
+    return SystemNative_CreateSocketEventPort(port);
+}
+
 extern "C" Error SystemNative_CreateSocketEventPort(int32_t* port)
 {
     if (port == nullptr)
@@ -2366,9 +2742,25 @@ extern "C" Error SystemNative_CreateSocketEventPort(int32_t* port)
     return CreateSocketEventPortInner(port);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error CloseSocketEventPort(int32_t port)
+{
+    return SystemNative_CloseSocketEventPort(port);
+}
+
 extern "C" Error SystemNative_CloseSocketEventPort(int32_t port)
 {
     return CloseSocketEventPortInner(port);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error CreateSocketEventBuffer(int32_t count, SocketEvent** buffer)
+{
+    return SystemNative_CreateSocketEventBuffer(count, buffer);
 }
 
 extern "C" Error SystemNative_CreateSocketEventBuffer(int32_t count, SocketEvent** buffer)
@@ -2389,10 +2781,26 @@ extern "C" Error SystemNative_CreateSocketEventBuffer(int32_t count, SocketEvent
     return PAL_SUCCESS;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error FreeSocketEventBuffer(SocketEvent* buffer)
+{
+    return SystemNative_FreeSocketEventBuffer(buffer);
+}
+
 extern "C" Error SystemNative_FreeSocketEventBuffer(SocketEvent* buffer)
 {
     free(buffer);
     return PAL_SUCCESS;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error TryChangeSocketEventRegistration(int32_t port, int32_t socket, int32_t currentEvents, int32_t newEvents, uintptr_t data)
+{
+    return SystemNative_TryChangeSocketEventRegistration(port, socket, currentEvents, newEvents, data);
 }
 
 extern "C" Error
@@ -2414,6 +2822,14 @@ SystemNative_TryChangeSocketEventRegistration(int32_t port, int32_t socket, int3
         port, socket, static_cast<SocketEvents>(currentEvents), static_cast<SocketEvents>(newEvents), data);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" Error WaitForSocketEvents(int32_t port, SocketEvent* buffer, int32_t* count)
+{
+    return SystemNative_WaitForSocketEvents(port, buffer, count);
+}
+
 extern "C" Error SystemNative_WaitForSocketEvents(int32_t port, SocketEvent* buffer, int32_t* count)
 {
     if (buffer == nullptr || count == nullptr || *count < 0)
@@ -2424,6 +2840,14 @@ extern "C" Error SystemNative_WaitForSocketEvents(int32_t port, SocketEvent* buf
     return WaitForSocketEventsInner(port, buffer, count);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t PlatformSupportsMultipleConnectAttempts()
+{
+    return SystemNative_PlatformSupportsMultipleConnectAttempts();
+}
+
 extern "C" int32_t SystemNative_PlatformSupportsMultipleConnectAttempts()
 {
 #if HAVE_SUPPORT_FOR_MULTIPLE_CONNECT_ATTEMPTS
@@ -2431,6 +2855,14 @@ extern "C" int32_t SystemNative_PlatformSupportsMultipleConnectAttempts()
 #else
     return 0;
 #endif
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t PlatformSupportsDualModeIPv4PacketInfo()
+{
+    return SystemNative_PlatformSupportsDualModeIPv4PacketInfo();
 }
 
 extern "C" int32_t SystemNative_PlatformSupportsDualModeIPv4PacketInfo()

--- a/src/Native/System.Native/pal_networking.h
+++ b/src/Native/System.Native/pal_networking.h
@@ -294,29 +294,29 @@ struct SocketEvent
 /**
  * Converts string-representations of IP Addresses to
  */
-extern "C" int32_t IPv6StringToAddress(
+extern "C" int32_t SystemNative_IPv6StringToAddress(
     const uint8_t* address, const uint8_t* port, uint8_t* buffer, int32_t bufferLength, uint32_t* scope);
 
-extern "C" int32_t IPv4StringToAddress(const uint8_t* address, uint8_t* buffer, int32_t bufferLength, uint16_t* port);
+extern "C" int32_t SystemNative_IPv4StringToAddress(const uint8_t* address, uint8_t* buffer, int32_t bufferLength, uint16_t* port);
 
-extern "C" int32_t IPAddressToString(const uint8_t* address,
+extern "C" int32_t SystemNative_IPAddressToString(const uint8_t* address,
                                      int32_t addressLength,
                                      bool isIPv6,
                                      uint8_t* string,
                                      int32_t stringLength,
                                      uint32_t scope = 0);
 
-extern "C" int32_t GetHostEntryForName(const uint8_t* address, HostEntry* entry);
+extern "C" int32_t SystemNative_GetHostEntryForName(const uint8_t* address, HostEntry* entry);
 
-extern "C" int32_t GetHostByName(const uint8_t* hostname, HostEntry* entry);
+extern "C" int32_t SystemNative_GetHostByName(const uint8_t* hostname, HostEntry* entry);
 
-extern "C" int32_t GetHostByAddress(const IPAddress* address, HostEntry* entry);
+extern "C" int32_t SystemNative_GetHostByAddress(const IPAddress* address, HostEntry* entry);
 
-extern "C" int32_t GetNextIPAddress(const HostEntry* entry, void** addressListHandle, IPAddress* endPoint);
+extern "C" int32_t SystemNative_GetNextIPAddress(const HostEntry* entry, void** addressListHandle, IPAddress* endPoint);
 
-extern "C" void FreeHostEntry(HostEntry* entry);
+extern "C" void SystemNative_FreeHostEntry(HostEntry* entry);
 
-extern "C" int32_t GetNameInfo(const uint8_t* address,
+extern "C" int32_t SystemNative_GetNameInfo(const uint8_t* address,
                                int32_t addressLength,
                                bool isIPv6,
                                uint8_t* host,
@@ -325,92 +325,92 @@ extern "C" int32_t GetNameInfo(const uint8_t* address,
                                int32_t serviceLength,
                                int32_t flags);
 
-extern "C" int32_t GetDomainName(uint8_t* name, int32_t nameLength);
+extern "C" int32_t SystemNative_GetDomainName(uint8_t* name, int32_t nameLength);
 
-extern "C" int32_t GetHostName(uint8_t* name, int32_t nameLength);
+extern "C" int32_t SystemNative_GetHostName(uint8_t* name, int32_t nameLength);
 
-extern "C" Error GetIPSocketAddressSizes(int32_t* ipv4SocketAddressSize, int32_t* ipv6SocketAddressSize);
+extern "C" Error SystemNative_GetIPSocketAddressSizes(int32_t* ipv4SocketAddressSize, int32_t* ipv6SocketAddressSize);
 
-extern "C" Error GetAddressFamily(const uint8_t* socketAddress, int32_t socketAddressLen, int32_t* addressFamily);
+extern "C" Error SystemNative_GetAddressFamily(const uint8_t* socketAddress, int32_t socketAddressLen, int32_t* addressFamily);
 
-extern "C" Error SetAddressFamily(uint8_t* socketAddress, int32_t socketAddressLen, int32_t addressFamily);
+extern "C" Error SystemNative_SetAddressFamily(uint8_t* socketAddress, int32_t socketAddressLen, int32_t addressFamily);
 
-extern "C" Error GetPort(const uint8_t* socketAddress, int32_t socketAddressLen, uint16_t* port);
+extern "C" Error SystemNative_GetPort(const uint8_t* socketAddress, int32_t socketAddressLen, uint16_t* port);
 
-extern "C" Error SetPort(uint8_t* socketAddress, int32_t socketAddressLen, uint16_t port);
+extern "C" Error SystemNative_SetPort(uint8_t* socketAddress, int32_t socketAddressLen, uint16_t port);
 
-extern "C" Error GetIPv4Address(const uint8_t* socketAddress, int32_t socketAddressLen, uint32_t* address);
+extern "C" Error SystemNative_GetIPv4Address(const uint8_t* socketAddress, int32_t socketAddressLen, uint32_t* address);
 
-extern "C" Error SetIPv4Address(uint8_t* socketAddress, int32_t socketAddressLen, uint32_t address);
+extern "C" Error SystemNative_SetIPv4Address(uint8_t* socketAddress, int32_t socketAddressLen, uint32_t address);
 
-extern "C" Error GetIPv6Address(
+extern "C" Error SystemNative_GetIPv6Address(
     const uint8_t* socketAddress, int32_t socketAddressLen, uint8_t* address, int32_t addressLen, uint32_t* scopeId);
 
-extern "C" int32_t GetControlMessageBufferSize(int32_t isIPv4, int32_t isIPv6);
+extern "C" int32_t SystemNative_GetControlMessageBufferSize(int32_t isIPv4, int32_t isIPv6);
 
 extern "C" int32_t
-TryGetIPPacketInformation(MessageHeader* messageHeader, int32_t isIPv4, IPPacketInformation* packetInfo);
+SystemNative_TryGetIPPacketInformation(MessageHeader* messageHeader, int32_t isIPv4, IPPacketInformation* packetInfo);
 
-extern "C" Error GetIPv4MulticastOption(int32_t socket, int32_t multicastOption, IPv4MulticastOption* option);
+extern "C" Error SystemNative_GetIPv4MulticastOption(int32_t socket, int32_t multicastOption, IPv4MulticastOption* option);
 
-extern "C" Error SetIPv4MulticastOption(int32_t socket, int32_t multicastOption, IPv4MulticastOption* option);
+extern "C" Error SystemNative_SetIPv4MulticastOption(int32_t socket, int32_t multicastOption, IPv4MulticastOption* option);
 
-extern "C" Error GetIPv6MulticastOption(int32_t socket, int32_t multicastOption, IPv6MulticastOption* option);
+extern "C" Error SystemNative_GetIPv6MulticastOption(int32_t socket, int32_t multicastOption, IPv6MulticastOption* option);
 
-extern "C" Error SetIPv6MulticastOption(int32_t socket, int32_t multicastOption, IPv6MulticastOption* option);
+extern "C" Error SystemNative_SetIPv6MulticastOption(int32_t socket, int32_t multicastOption, IPv6MulticastOption* option);
 
-extern "C" Error GetLingerOption(int32_t socket, LingerOption* option);
+extern "C" Error SystemNative_GetLingerOption(int32_t socket, LingerOption* option);
 
-extern "C" Error SetLingerOption(int32_t socket, LingerOption* option);
+extern "C" Error SystemNative_SetLingerOption(int32_t socket, LingerOption* option);
 
-extern "C" Error ReceiveMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* received);
+extern "C" Error SystemNative_ReceiveMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* received);
 
-extern "C" Error SendMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* sent);
+extern "C" Error SystemNative_SendMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* sent);
 
-extern "C" Error Accept(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen, int32_t* acceptedSocket);
+extern "C" Error SystemNative_Accept(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen, int32_t* acceptedSocket);
 
-extern "C" Error Bind(int32_t socket, uint8_t* socketAddress, int32_t socketAddressLen);
+extern "C" Error SystemNative_Bind(int32_t socket, uint8_t* socketAddress, int32_t socketAddressLen);
 
-extern "C" Error Connect(int32_t socket, uint8_t* socketAddress, int32_t socketAddressLen);
+extern "C" Error SystemNative_Connect(int32_t socket, uint8_t* socketAddress, int32_t socketAddressLen);
 
-extern "C" Error GetPeerName(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen);
+extern "C" Error SystemNative_GetPeerName(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen);
 
-extern "C" Error GetSockName(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen);
+extern "C" Error SystemNative_GetSockName(int32_t socket, uint8_t* socketAddress, int32_t* socketAddressLen);
 
-extern "C" Error Listen(int32_t socket, int32_t backlog);
+extern "C" Error SystemNative_Listen(int32_t socket, int32_t backlog);
 
-extern "C" Error Shutdown(int32_t socket, int32_t socketShutdown);
+extern "C" Error SystemNative_Shutdown(int32_t socket, int32_t socketShutdown);
 
-extern "C" Error GetSocketErrorOption(int32_t socket, Error* error);
+extern "C" Error SystemNative_GetSocketErrorOption(int32_t socket, Error* error);
 
-extern "C" Error GetSockOpt(
+extern "C" Error SystemNative_GetSockOpt(
     int32_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t* optionLen);
 
-extern "C" Error SetSockOpt(
+extern "C" Error SystemNative_SetSockOpt(
     int32_t socket, int32_t socketOptionLevel, int32_t socketOptionName, uint8_t* optionValue, int32_t optionLen);
 
-extern "C" Error Socket(int32_t addressFamily, int32_t socketType, int32_t protocolType, int32_t* createdSocket);
+extern "C" Error SystemNative_Socket(int32_t addressFamily, int32_t socketType, int32_t protocolType, int32_t* createdSocket);
 
-extern "C" int32_t FdSetSize();
+extern "C" int32_t SystemNative_FdSetSize();
 
-extern "C" Error Select(
+extern "C" Error SystemNative_Select(
     int32_t fdCount, uint32_t* readFdSet, uint32_t* writeFdSet, uint32_t* errorFdSet, int32_t microseconds, int32_t* selected);
 
-extern "C" Error GetBytesAvailable(int32_t socket, int32_t* available);
+extern "C" Error SystemNative_GetBytesAvailable(int32_t socket, int32_t* available);
 
-extern "C" Error CreateSocketEventPort(int32_t* port);
+extern "C" Error SystemNative_CreateSocketEventPort(int32_t* port);
 
-extern "C" Error CloseSocketEventPort(int32_t port);
+extern "C" Error SystemNative_CloseSocketEventPort(int32_t port);
 
-extern "C" Error CreateSocketEventBuffer(int32_t count, SocketEvent** buffer);
+extern "C" Error SystemNative_CreateSocketEventBuffer(int32_t count, SocketEvent** buffer);
 
-extern "C" Error FreeSocketEventBuffer(SocketEvent* buffer);
+extern "C" Error SystemNative_FreeSocketEventBuffer(SocketEvent* buffer);
 
-extern "C" Error TryChangeSocketEventRegistration(
+extern "C" Error SystemNative_TryChangeSocketEventRegistration(
     int32_t port, int32_t socket, int32_t currentEvents, int32_t newEvents, uintptr_t data);
 
-extern "C" Error WaitForSocketEvents(int32_t port, SocketEvent* buffer, int32_t* count);
+extern "C" Error SystemNative_WaitForSocketEvents(int32_t port, SocketEvent* buffer, int32_t* count);
 
-extern "C" int32_t PlatformSupportsMultipleConnectAttempts();
+extern "C" int32_t SystemNative_PlatformSupportsMultipleConnectAttempts();
 
-extern "C" int32_t PlatformSupportsDualModeIPv4PacketInfo();
+extern "C" int32_t SystemNative_PlatformSupportsDualModeIPv4PacketInfo();

--- a/src/Native/System.Native/pal_networkstatistics.cpp
+++ b/src/Native/System.Native/pal_networkstatistics.cpp
@@ -41,7 +41,7 @@ int32_t ReadSysctlVar(const char* name, RetType* value)
     return sysctlbyname(name, value, &oldlenp, newp, newlen);
 }
 
-extern "C" int32_t GetTcpGlobalStatistics(TcpGlobalStatistics* retStats)
+extern "C" int32_t SystemNative_GetTcpGlobalStatistics(TcpGlobalStatistics* retStats)
 {
     assert(retStats != nullptr);
 
@@ -70,7 +70,7 @@ extern "C" int32_t GetTcpGlobalStatistics(TcpGlobalStatistics* retStats)
     return 0;
 }
 
-extern "C" int32_t GetIPv4GlobalStatistics(IPv4GlobalStatistics* retStats)
+extern "C" int32_t SystemNative_GetIPv4GlobalStatistics(IPv4GlobalStatistics* retStats)
 {
     assert(retStats != nullptr);
 
@@ -109,7 +109,7 @@ extern "C" int32_t GetIPv4GlobalStatistics(IPv4GlobalStatistics* retStats)
     return 0;
 }
 
-extern "C" int32_t GetUdpGlobalStatistics(UdpGlobalStatistics* retStats)
+extern "C" int32_t SystemNative_GetUdpGlobalStatistics(UdpGlobalStatistics* retStats)
 {
     assert(retStats != nullptr);
 
@@ -135,7 +135,7 @@ extern "C" int32_t GetUdpGlobalStatistics(UdpGlobalStatistics* retStats)
     return 0;
 }
 
-extern "C" int32_t GetIcmpv4GlobalStatistics(Icmpv4GlobalStatistics* retStats)
+extern "C" int32_t SystemNative_GetIcmpv4GlobalStatistics(Icmpv4GlobalStatistics* retStats)
 {
     assert(retStats != nullptr);
 
@@ -175,7 +175,7 @@ extern "C" int32_t GetIcmpv4GlobalStatistics(Icmpv4GlobalStatistics* retStats)
     return 0;
 }
 
-extern "C" int32_t GetIcmpv6GlobalStatistics(Icmpv6GlobalStatistics* retStats)
+extern "C" int32_t SystemNative_GetIcmpv6GlobalStatistics(Icmpv6GlobalStatistics* retStats)
 {
     assert(retStats != nullptr);
 
@@ -221,7 +221,7 @@ extern "C" int32_t GetIcmpv6GlobalStatistics(Icmpv6GlobalStatistics* retStats)
     return 0;
 }
 
-extern "C" int32_t GetEstimatedTcpConnectionCount()
+extern "C" int32_t SystemNative_GetEstimatedTcpConnectionCount()
 {
     int32_t count;
     ReadSysctlVar("net.inet.tcp.pcbcount", &count);
@@ -238,7 +238,7 @@ size_t GetEstimatedTcpPcbSize()
     return oldlenp;
 }
 
-extern "C" int32_t GetActiveTcpConnectionInfos(NativeTcpConnectionInformation* infos, int32_t* infoCount)
+extern "C" int32_t SystemNative_GetActiveTcpConnectionInfos(NativeTcpConnectionInformation* infos, int32_t* infoCount)
 {
     assert(infos != nullptr);
     assert(infoCount != nullptr);
@@ -309,7 +309,7 @@ extern "C" int32_t GetActiveTcpConnectionInfos(NativeTcpConnectionInformation* i
     return 0;
 }
 
-extern "C" int32_t GetEstimatedUdpListenerCount()
+extern "C" int32_t SystemNative_GetEstimatedUdpListenerCount()
 {
     int32_t count;
     ReadSysctlVar("net.inet.udp.pcbcount", &count);
@@ -326,7 +326,7 @@ size_t GetEstimatedUdpPcbSize()
     return oldlenp;
 }
 
-extern "C" int32_t GetActiveUdpListeners(IPEndPointInfo* infos, int32_t* infoCount)
+extern "C" int32_t SystemNative_GetActiveUdpListeners(IPEndPointInfo* infos, int32_t* infoCount)
 {
     assert(infos != nullptr);
     assert(infoCount != nullptr);
@@ -385,7 +385,7 @@ extern "C" int32_t GetActiveUdpListeners(IPEndPointInfo* infos, int32_t* infoCou
     return 0;
 }
 
-extern "C" int32_t GetNativeIPInterfaceStatistics(char* interfaceName, NativeIPInterfaceStatistics* retStats)
+extern "C" int32_t SystemNative_GetNativeIPInterfaceStatistics(char* interfaceName, NativeIPInterfaceStatistics* retStats)
 {
     assert(interfaceName != nullptr && retStats != nullptr);
     unsigned int interfaceIndex = if_nametoindex(interfaceName);
@@ -447,7 +447,7 @@ extern "C" int32_t GetNativeIPInterfaceStatistics(char* interfaceName, NativeIPI
     return -1;
 }
 
-extern "C" int32_t GetNumRoutes()
+extern "C" int32_t SystemNative_GetNumRoutes()
 {
     int routeDumpMib[] = {CTL_NET, PF_ROUTE, 0, 0, NET_RT_DUMP, 0};
 

--- a/src/Native/System.Native/pal_process.cpp
+++ b/src/Native/System.Native/pal_process.cpp
@@ -81,6 +81,34 @@ static void CloseIfOpen(int fd)
     }
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t ForkAndExecProcess(const char* filename,
+    char* const argv[],
+    char* const envp[],
+    const char* cwd,
+    int32_t redirectStdin,
+    int32_t redirectStdout,
+    int32_t redirectStderr,
+    int32_t* childPid,
+    int32_t* stdinFd,
+    int32_t* stdoutFd,
+    int32_t* stderrFd)
+{
+    return SystemNative_ForkAndExecProcess(filename,
+        argv,
+        envp,
+        cwd,
+        redirectStdin,
+        redirectStdout,
+        redirectStderr,
+        childPid,
+        stdinFd,
+        stdoutFd,
+        stderrFd);
+}
+
 extern "C" int32_t SystemNative_ForkAndExecProcess(const char* filename,
                                       char* const argv[],
                                       char* const envp[],
@@ -258,6 +286,14 @@ static void ConvertFromPalRLimitToManaged(const rlimit& native, RLimit& pal)
     pal.MaximumLimit = ConvertFromNativeRLimitInfinityToManagedIfNecessary(native.rlim_max);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t GetRLimit(RLimitResources resourceType, RLimit* limits)
+{
+    return SystemNative_GetRLimit(resourceType, limits);
+}
+
 extern "C" int32_t SystemNative_GetRLimit(RLimitResources resourceType, RLimit* limits)
 {
     assert(limits != nullptr);
@@ -277,6 +313,14 @@ extern "C" int32_t SystemNative_GetRLimit(RLimitResources resourceType, RLimit* 
     return result;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t SetRLimit(RLimitResources resourceType, const RLimit* limits)
+{
+    return SystemNative_SetRLimit(resourceType, limits);
+}
+
 extern "C" int32_t SystemNative_SetRLimit(RLimitResources resourceType, const RLimit* limits)
 {
     assert(limits != nullptr);
@@ -287,9 +331,25 @@ extern "C" int32_t SystemNative_SetRLimit(RLimitResources resourceType, const RL
     return setrlimit(platformLimit, &internalLimit);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t Kill(int32_t pid, int32_t signal)
+{
+    return SystemNative_Kill(pid, signal);
+}
+
 extern "C" int32_t SystemNative_Kill(int32_t pid, int32_t signal)
 {
     return kill(pid, signal);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t GetPid()
+{
+    return SystemNative_GetPid();
 }
 
 extern "C" int32_t SystemNative_GetPid()
@@ -297,14 +357,38 @@ extern "C" int32_t SystemNative_GetPid()
     return getpid();
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t GetSid(int32_t pid)
+{
+    return SystemNative_GetSid(pid);
+}
+
 extern "C" int32_t SystemNative_GetSid(int32_t pid)
 {
     return getsid(pid);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" void SysLog(SysLogPriority priority, const char* message, const char* arg1)
+{
+    SystemNative_SysLog(priority, message, arg1);
+}
+
 extern "C" void SystemNative_SysLog(SysLogPriority priority, const char* message, const char* arg1)
 {
     syslog(static_cast<int>(priority), message, arg1);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t WaitPid(int32_t pid, int32_t* status, WaitPidOptions options)
+{
+    return SystemNative_WaitPid(pid, status, options);
 }
 
 extern "C" int32_t SystemNative_WaitPid(int32_t pid, int32_t* status, WaitPidOptions options)
@@ -316,9 +400,25 @@ extern "C" int32_t SystemNative_WaitPid(int32_t pid, int32_t* status, WaitPidOpt
     return result;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t WExitStatus(int32_t status)
+{
+    return SystemNative_WExitStatus(status);
+}
+
 extern "C" int32_t SystemNative_WExitStatus(int32_t status)
 {
     return WEXITSTATUS(status);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t WIfExited(int32_t status)
+{
+    return SystemNative_WIfExited(status);
 }
 
 extern "C" int32_t SystemNative_WIfExited(int32_t status)
@@ -326,14 +426,38 @@ extern "C" int32_t SystemNative_WIfExited(int32_t status)
     return WIFEXITED(status);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t WIfSignaled(int32_t status)
+{
+    return SystemNative_WIfSignaled(status);
+}
+
 extern "C" int32_t SystemNative_WIfSignaled(int32_t status)
 {
     return WIFSIGNALED(status);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t WTermSig(int32_t status)
+{
+    return SystemNative_WTermSig(status);
+}
+
 extern "C" int32_t SystemNative_WTermSig(int32_t status)
 {
     return WTERMSIG(status);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int64_t PathConf(const char* path, PathConfName name)
+{
+    return SystemNative_PathConf(path, name);
 }
 
 extern "C" int64_t SystemNative_PathConf(const char* path, PathConfName name)
@@ -380,6 +504,14 @@ extern "C" int64_t SystemNative_PathConf(const char* path, PathConfName name)
     return pathconf(path, confValue);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int64_t GetMaximumPath()
+{
+    return SystemNative_GetMaximumPath();
+}
+
 extern "C" int64_t SystemNative_GetMaximumPath()
 {
     int64_t result = pathconf("/", _PC_PATH_MAX);
@@ -409,6 +541,14 @@ extern "C" int32_t SystemNative_SetPriority(PriorityWhich which, int32_t who, in
 #else
     return setpriority(which, static_cast<id_t>(who), nice);
 #endif
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" char* GetCwd(char* buffer, int32_t bufferSize)
+{
+    return SystemNative_GetCwd(buffer, bufferSize);
 }
 
 extern "C" char* SystemNative_GetCwd(char* buffer, int32_t bufferSize)

--- a/src/Native/System.Native/pal_process.cpp
+++ b/src/Native/System.Native/pal_process.cpp
@@ -81,7 +81,7 @@ static void CloseIfOpen(int fd)
     }
 }
 
-extern "C" int32_t ForkAndExecProcess(const char* filename,
+extern "C" int32_t SystemNative_ForkAndExecProcess(const char* filename,
                                       char* const argv[],
                                       char* const envp[],
                                       const char* cwd,
@@ -258,7 +258,7 @@ static void ConvertFromPalRLimitToManaged(const rlimit& native, RLimit& pal)
     pal.MaximumLimit = ConvertFromNativeRLimitInfinityToManagedIfNecessary(native.rlim_max);
 }
 
-extern "C" int32_t GetRLimit(RLimitResources resourceType, RLimit* limits)
+extern "C" int32_t SystemNative_GetRLimit(RLimitResources resourceType, RLimit* limits)
 {
     assert(limits != nullptr);
 
@@ -277,7 +277,7 @@ extern "C" int32_t GetRLimit(RLimitResources resourceType, RLimit* limits)
     return result;
 }
 
-extern "C" int32_t SetRLimit(RLimitResources resourceType, const RLimit* limits)
+extern "C" int32_t SystemNative_SetRLimit(RLimitResources resourceType, const RLimit* limits)
 {
     assert(limits != nullptr);
 
@@ -287,27 +287,27 @@ extern "C" int32_t SetRLimit(RLimitResources resourceType, const RLimit* limits)
     return setrlimit(platformLimit, &internalLimit);
 }
 
-extern "C" int32_t Kill(int32_t pid, int32_t signal)
+extern "C" int32_t SystemNative_Kill(int32_t pid, int32_t signal)
 {
     return kill(pid, signal);
 }
 
-extern "C" int32_t GetPid()
+extern "C" int32_t SystemNative_GetPid()
 {
     return getpid();
 }
 
-extern "C" int32_t GetSid(int32_t pid)
+extern "C" int32_t SystemNative_GetSid(int32_t pid)
 {
     return getsid(pid);
 }
 
-extern "C" void SysLog(SysLogPriority priority, const char* message, const char* arg1)
+extern "C" void SystemNative_SysLog(SysLogPriority priority, const char* message, const char* arg1)
 {
     syslog(static_cast<int>(priority), message, arg1);
 }
 
-extern "C" int32_t WaitPid(int32_t pid, int32_t* status, WaitPidOptions options)
+extern "C" int32_t SystemNative_WaitPid(int32_t pid, int32_t* status, WaitPidOptions options)
 {
     assert(status != nullptr);
 
@@ -316,27 +316,27 @@ extern "C" int32_t WaitPid(int32_t pid, int32_t* status, WaitPidOptions options)
     return result;
 }
 
-extern "C" int32_t WExitStatus(int32_t status)
+extern "C" int32_t SystemNative_WExitStatus(int32_t status)
 {
     return WEXITSTATUS(status);
 }
 
-extern "C" int32_t WIfExited(int32_t status)
+extern "C" int32_t SystemNative_WIfExited(int32_t status)
 {
     return WIFEXITED(status);
 }
 
-extern "C" int32_t WIfSignaled(int32_t status)
+extern "C" int32_t SystemNative_WIfSignaled(int32_t status)
 {
     return WIFSIGNALED(status);
 }
 
-extern "C" int32_t WTermSig(int32_t status)
+extern "C" int32_t SystemNative_WTermSig(int32_t status)
 {
     return WTERMSIG(status);
 }
 
-extern "C" int64_t PathConf(const char* path, PathConfName name)
+extern "C" int64_t SystemNative_PathConf(const char* path, PathConfName name)
 {
     int32_t confValue = -1;
     switch (name)
@@ -380,7 +380,7 @@ extern "C" int64_t PathConf(const char* path, PathConfName name)
     return pathconf(path, confValue);
 }
 
-extern "C" int64_t GetMaximumPath()
+extern "C" int64_t SystemNative_GetMaximumPath()
 {
     int64_t result = pathconf("/", _PC_PATH_MAX);
     if (result == -1)
@@ -391,7 +391,7 @@ extern "C" int64_t GetMaximumPath()
     return result;
 }
 
-extern "C" int32_t GetPriority(PriorityWhich which, int32_t who)
+extern "C" int32_t SystemNative_GetPriority(PriorityWhich which, int32_t who)
 {
     // GetPriority uses errno 0 to show succes to make sure we don't have a stale value
     errno = 0;
@@ -402,7 +402,7 @@ extern "C" int32_t GetPriority(PriorityWhich which, int32_t who)
 #endif
 }
 
-extern "C" int32_t SetPriority(PriorityWhich which, int32_t who, int32_t nice)
+extern "C" int32_t SystemNative_SetPriority(PriorityWhich which, int32_t who, int32_t nice)
 {
 #if PRIORITY_REQUIRES_INT_WHO
     return setpriority(which, who, nice);
@@ -411,7 +411,7 @@ extern "C" int32_t SetPriority(PriorityWhich which, int32_t who, int32_t nice)
 #endif
 }
 
-extern "C" char* GetCwd(char* buffer, int32_t bufferSize)
+extern "C" char* SystemNative_GetCwd(char* buffer, int32_t bufferSize)
 {
     assert(bufferSize >= 0);
 
@@ -425,7 +425,7 @@ extern "C" char* GetCwd(char* buffer, int32_t bufferSize)
 }
 
 #if HAVE_SCHED_SETAFFINITY
-extern "C" int32_t SchedSetAffinity(int32_t pid, intptr_t* mask)
+extern "C" int32_t SystemNative_SchedSetAffinity(int32_t pid, intptr_t* mask)
 {
     assert(mask != nullptr);
 
@@ -449,7 +449,7 @@ extern "C" int32_t SchedSetAffinity(int32_t pid, intptr_t* mask)
 #endif
 
 #if HAVE_SCHED_GETAFFINITY
-extern "C" int32_t SchedGetAffinity(int32_t pid, intptr_t* mask)
+extern "C" int32_t SystemNative_SchedGetAffinity(int32_t pid, intptr_t* mask)
 {
     assert(mask != nullptr);
 

--- a/src/Native/System.Native/pal_process.h
+++ b/src/Native/System.Native/pal_process.h
@@ -17,7 +17,7 @@
  * is failure; if failure, error information is provided in errno.
  */
 extern "C" int32_t
-ForkAndExecProcess(const char* filename,   // filename argument to execve
+SystemNative_ForkAndExecProcess(const char* filename,   // filename argument to execve
                    char* const argv[],     // argv argument to execve
                    char* const envp[],     // envp argument to execve
                    const char* cwd,        // path passed to chdir in child process
@@ -164,40 +164,40 @@ struct CpuSetBits
  * Get the current limit for the specified resource of the current process.
  * Returns 0 on success; returns -1 on failure and errno is set to the error reason.
  */
-extern "C" int32_t GetRLimit(RLimitResources resourceType, RLimit* limits);
+extern "C" int32_t SystemNative_GetRLimit(RLimitResources resourceType, RLimit* limits);
 
 /**
  * Set the soft and hard limits for the specified resource.
  * Only a super-user can increase hard limits for the current process.
  * Returns 0 on success; returns -1 on failure and errno is set to the error reason.
  */
-extern "C" int32_t SetRLimit(RLimitResources resourceType, const RLimit* limits);
+extern "C" int32_t SystemNative_SetRLimit(RLimitResources resourceType, const RLimit* limits);
 
 /**
  * Kill the specified process (or process group) identified by the supplied pid; the
  * process or process group will be killed by the specified signal.
  * Returns 0 on success; on failure, -1 is returned and errno is set
  */
-extern "C" int32_t Kill(int32_t pid, int32_t signal);
+extern "C" int32_t SystemNative_Kill(int32_t pid, int32_t signal);
 
 /**
  * Returns the Process ID of the current executing process.
  * This call should never fail
  */
-extern "C" int32_t GetPid();
+extern "C" int32_t SystemNative_GetPid();
 
 /**
  * Returns the sessions ID of the specified process; if 0 is passed in, returns the
  * session ID of the current process.
  * Returns a session ID on success; otherwise, returns -1 and sets errno.
  */
-extern "C" int32_t GetSid(int32_t pid);
+extern "C" int32_t SystemNative_GetSid(int32_t pid);
 
 /**
  * Write a message to the system logger, which in turn writes the message to the system console, log files, etc.
  * See man 3 syslog for more info
  */
-extern "C" void SysLog(SysLogPriority priority, const char* message, const char* arg1);
+extern "C" void SystemNative_SysLog(SysLogPriority priority, const char* message, const char* arg1);
 
 /**
  * Waits for child process(s) or gathers resource utilization information about child processes
@@ -208,18 +208,18 @@ extern "C" void SysLog(SysLogPriority priority, const char* message, const char*
  * 3) if WNOHANG is specified and there are no stopped or exited children, 0 is returned
  * 4) on error, -1 is returned and errno is set
  */
-extern "C" int32_t WaitPid(int32_t pid, int32_t* status, WaitPidOptions options);
+extern "C" int32_t SystemNative_WaitPid(int32_t pid, int32_t* status, WaitPidOptions options);
 
 /**
  * The four functions below are wrappers around the platform-specific macros of the same name.
  */
-extern "C" int32_t WExitStatus(int32_t status);
+extern "C" int32_t SystemNative_WExitStatus(int32_t status);
 
-extern "C" int32_t WIfExited(int32_t status);
+extern "C" int32_t SystemNative_WIfExited(int32_t status);
 
-extern "C" int32_t WIfSignaled(int32_t status);
+extern "C" int32_t SystemNative_WIfSignaled(int32_t status);
 
-extern "C" int32_t WTermSig(int32_t status);
+extern "C" int32_t SystemNative_WTermSig(int32_t status);
 
 /**
  * Gets the configurable limit or variable for system path or file descriptor options.
@@ -227,14 +227,14 @@ extern "C" int32_t WTermSig(int32_t status);
  * Returns the requested variable value on success; if the variable does not have a limit, -1 is returned and errno
  * is not set; otherwise, -1 is returned and errno is set.
  */
-extern "C" int64_t PathConf(const char* path, PathConfName name);
+extern "C" int64_t SystemNative_PathConf(const char* path, PathConfName name);
 
 /**
  * Gets the current (or default, on failure) Maximum Path allowed by the system.
  *
  * This is called out explicitly, rather than using PathConf, since the default value changes depending on the platform.
  */
-extern "C" int64_t GetMaximumPath();
+extern "C" int64_t SystemNative_GetMaximumPath();
 
 /**
  * Gets the priority (nice value) of a certain execution group.
@@ -243,19 +243,19 @@ extern "C" int64_t GetMaximumPath();
  * valid nice value, meaning we can't use that value to determine valid output or not. Errno is set on failure so
  * we need to reset errno before a call and check the value if we get -1.
  */
-extern "C" int32_t GetPriority(PriorityWhich which, int32_t who);
+extern "C" int32_t SystemNative_GetPriority(PriorityWhich which, int32_t who);
 
 /**
  * Sets the priority (nice value) of a certain execution group.
  *
  * Returns 0 on success; otherwise, -1 and errno is set.
  */
-extern "C" int32_t SetPriority(PriorityWhich which, int32_t who, int32_t nice);
+extern "C" int32_t SystemNative_SetPriority(PriorityWhich which, int32_t who, int32_t nice);
 
 /**
  * Gets the current working directory of the currently executing process.
  */
-extern "C" char* GetCwd(char* buffer, int32_t bufferSize);
+extern "C" char* SystemNative_GetCwd(char* buffer, int32_t bufferSize);
 
 #if HAVE_SCHED_SETAFFINITY
 /**
@@ -263,7 +263,7 @@ extern "C" char* GetCwd(char* buffer, int32_t bufferSize);
  *
  * Returns 0 on success; otherwise, -1 is returned and errno is set
  */
-extern "C" int32_t SchedSetAffinity(int32_t pid, intptr_t* mask);
+extern "C" int32_t SystemNative_SchedSetAffinity(int32_t pid, intptr_t* mask);
 #endif
 
 #if HAVE_SCHED_GETAFFINITY
@@ -272,5 +272,5 @@ extern "C" int32_t SchedSetAffinity(int32_t pid, intptr_t* mask);
  *
  * Returns 0 on success; otherwise, -1 is returned and errno is set.
  */
-extern "C" int32_t SchedGetAffinity(int32_t pid, intptr_t* mask);
+extern "C" int32_t SystemNative_SchedGetAffinity(int32_t pid, intptr_t* mask);
 #endif

--- a/src/Native/System.Native/pal_runtimeinformation.cpp
+++ b/src/Native/System.Native/pal_runtimeinformation.cpp
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include <sys/utsname.h>
 
-extern "C" int32_t GetUnixVersion(char* version, int* capacity)
+extern "C" int32_t SystemNative_GetUnixVersion(char* version, int* capacity)
 {
     struct utsname _utsname;
     if (uname(&_utsname) != -1)
@@ -26,7 +26,7 @@ extern "C" int32_t GetUnixVersion(char* version, int* capacity)
  0 - x86
  1 - x64
  2 - ARM */
-extern "C" int32_t GetUnixArchitecture()
+extern "C" int32_t SystemNative_GetUnixArchitecture()
 {
 #if defined(ARM)
     return ARCH_ARM;

--- a/src/Native/System.Native/pal_runtimeinformation.h
+++ b/src/Native/System.Native/pal_runtimeinformation.h
@@ -5,9 +5,9 @@
 
 #include "pal_types.h"
 
-extern "C" int32_t GetUnixVersion(char* version, int* capacity);
+extern "C" int32_t SystemNative_GetUnixVersion(char* version, int* capacity);
 
-extern "C" int32_t GetUnixArchitecture();
+extern "C" int32_t SystemNative_GetUnixArchitecture();
 
 enum 
 {

--- a/src/Native/System.Native/pal_string.cpp
+++ b/src/Native/System.Native/pal_string.cpp
@@ -10,7 +10,7 @@
 #include <stdio.h>
 #include <string.h>
 
-extern "C" int32_t SNPrintF(char* string, int32_t size, const char* format, ...)
+extern "C" int32_t SystemNative_SNPrintF(char* string, int32_t size, const char* format, ...)
 {
     assert(string != nullptr || size == 0);
     assert(size >= 0);
@@ -26,7 +26,7 @@ extern "C" int32_t SNPrintF(char* string, int32_t size, const char* format, ...)
     return result;
 }
 
-extern "C" int32_t PrintF(const char* format, ...)
+extern "C" int32_t SystemNative_PrintF(const char* format, ...)
 {
     va_list arguments;
     va_start(arguments, format);

--- a/src/Native/System.Native/pal_string.h
+++ b/src/Native/System.Native/pal_string.h
@@ -13,7 +13,7 @@
  * success; if the return value is equal to the size then the result may have been truncated.
  * On failure, returns a negative value.
  */
-extern "C" int32_t SNPrintF(char* string, int32_t size, const char* format, ...);
+extern "C" int32_t SystemNative_SNPrintF(char* string, int32_t size, const char* format, ...);
 
 /**
  * printf is difficult to represent in C# due to the argument list, so the C# PInvoke
@@ -22,4 +22,4 @@ extern "C" int32_t SNPrintF(char* string, int32_t size, const char* format, ...)
  * Returns the number of characters written to the output stream on success; otherwise, returns
  * a negative number and errno and ferror are both set.
  */
-extern "C" int32_t PrintF(const char* format, ...);
+extern "C" int32_t SystemNative_PrintF(const char* format, ...);

--- a/src/Native/System.Native/pal_tcpstate.cpp
+++ b/src/Native/System.Native/pal_tcpstate.cpp
@@ -13,7 +13,7 @@
 #error System must have TCP states defined in either tcp.h or tcp_fsm.h.
 #endif
 
-extern "C" TcpState MapTcpState(int32_t tcpState)
+extern "C" TcpState SystemNative_MapTcpState(int32_t tcpState)
 {
     switch (tcpState)
     {

--- a/src/Native/System.Native/pal_tcpstate.h
+++ b/src/Native/System.Native/pal_tcpstate.h
@@ -19,4 +19,4 @@ enum TcpState
     DeleteTcb
 };
 
-extern "C" TcpState MapTcpState(int32_t tcpState);
+extern "C" TcpState SystemNative_MapTcpState(int32_t tcpState);

--- a/src/Native/System.Native/pal_time.cpp
+++ b/src/Native/System.Native/pal_time.cpp
@@ -25,7 +25,7 @@ static void ConvertUTimBuf(const UTimBuf& pal, utimbuf& native)
     native.modtime = static_cast<time_t>(pal.ModTime);
 }
 
-extern "C" int32_t UTime(const char* path, UTimBuf* times)
+extern "C" int32_t SystemNative_UTime(const char* path, UTimBuf* times)
 {
     assert(times != nullptr);
 
@@ -37,7 +37,7 @@ extern "C" int32_t UTime(const char* path, UTimBuf* times)
     return result;
 }
 
-extern "C" int32_t GetTimestampResolution(uint64_t* resolution)
+extern "C" int32_t SystemNative_GetTimestampResolution(uint64_t* resolution)
 {
     assert(resolution);
 
@@ -77,7 +77,7 @@ extern "C" int32_t GetTimestampResolution(uint64_t* resolution)
 #endif
 }
 
-extern "C" int32_t GetTimestamp(uint64_t* timestamp)
+extern "C" int32_t SystemNative_GetTimestamp(uint64_t* timestamp)
 {
     assert(timestamp);
 

--- a/src/Native/System.Native/pal_time.cpp
+++ b/src/Native/System.Native/pal_time.cpp
@@ -25,6 +25,14 @@ static void ConvertUTimBuf(const UTimBuf& pal, utimbuf& native)
     native.modtime = static_cast<time_t>(pal.ModTime);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t UTime(const char* path, UTimBuf* times)
+{
+    return SystemNative_UTime(path, times);
+}
+
 extern "C" int32_t SystemNative_UTime(const char* path, UTimBuf* times)
 {
     assert(times != nullptr);
@@ -35,6 +43,14 @@ extern "C" int32_t SystemNative_UTime(const char* path, UTimBuf* times)
     int32_t result;
     while (CheckInterrupted(result = utime(path, &temp)));
     return result;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t GetTimestampResolution(uint64_t* resolution)
+{
+    return SystemNative_GetTimestampResolution(resolution);
 }
 
 extern "C" int32_t SystemNative_GetTimestampResolution(uint64_t* resolution)
@@ -75,6 +91,14 @@ extern "C" int32_t SystemNative_GetTimestampResolution(uint64_t* resolution)
     return 1;
 
 #endif
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t GetTimestamp(uint64_t* timestamp)
+{
+    return SystemNative_GetTimestamp(timestamp);
 }
 
 extern "C" int32_t SystemNative_GetTimestamp(uint64_t* timestamp)

--- a/src/Native/System.Native/pal_time.h
+++ b/src/Native/System.Native/pal_time.h
@@ -16,18 +16,18 @@ struct UTimBuf
  *
  * Returns 0 on success; otherwise, returns -1 and errno is set.
  */
-extern "C" int32_t UTime(const char* path, UTimBuf* time);
+extern "C" int32_t SystemNative_UTime(const char* path, UTimBuf* time);
 
 /**
  * Gets the resolution of the timestamp, in counts per second.
  *
  * Returns 1 on success; otherwise, 0 on failure.
  */
-extern "C" int32_t GetTimestampResolution(uint64_t* resolution);
+extern "C" int32_t SystemNative_GetTimestampResolution(uint64_t* resolution);
 
 /**
  * Gets a high-resolution timestamp that can be used for time-interval measurements.
  *
  * Returns 1 on success; otherwise, 0 on failure.
  */
-extern "C" int32_t GetTimestamp(uint64_t* timestamp);
+extern "C" int32_t SystemNative_GetTimestamp(uint64_t* timestamp);

--- a/src/Native/System.Native/pal_uid.cpp
+++ b/src/Native/System.Native/pal_uid.cpp
@@ -12,7 +12,7 @@
 #include <sys/types.h>
 #include <pwd.h>
 
-extern "C" int32_t GetPwUidR(uint32_t uid, Passwd* pwd, char* buf, int32_t buflen)
+extern "C" int32_t SystemNative_GetPwUidR(uint32_t uid, Passwd* pwd, char* buf, int32_t buflen)
 {
     assert(pwd != nullptr);
     assert(buf != nullptr);
@@ -53,12 +53,12 @@ extern "C" int32_t GetPwUidR(uint32_t uid, Passwd* pwd, char* buf, int32_t bufle
     return 0;
 }
 
-extern "C" uint32_t GetEUid()
+extern "C" uint32_t SystemNative_GetEUid()
 {
     return geteuid();
 }
 
-extern "C" uint32_t GetEGid()
+extern "C" uint32_t SystemNative_GetEGid()
 {
     return getegid();
 }

--- a/src/Native/System.Native/pal_uid.cpp
+++ b/src/Native/System.Native/pal_uid.cpp
@@ -12,6 +12,14 @@
 #include <sys/types.h>
 #include <pwd.h>
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" int32_t GetPwUidR(uint32_t uid, Passwd* pwd, char* buf, int32_t buflen)
+{
+    return SystemNative_GetPwUidR(uid, pwd, buf, buflen);
+}
+
 extern "C" int32_t SystemNative_GetPwUidR(uint32_t uid, Passwd* pwd, char* buf, int32_t buflen)
 {
     assert(pwd != nullptr);
@@ -53,9 +61,25 @@ extern "C" int32_t SystemNative_GetPwUidR(uint32_t uid, Passwd* pwd, char* buf, 
     return 0;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" uint32_t GetEUid()
+{
+    return SystemNative_GetEUid();
+}
+
 extern "C" uint32_t SystemNative_GetEUid()
 {
     return geteuid();
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method
+// to keep tests running in CI. This will be removed once the managed assemblies
+// are synced up with the native assemblies.
+extern "C" uint32_t GetEGid()
+{
+    return SystemNative_GetEGid();
 }
 
 extern "C" uint32_t SystemNative_GetEGid()

--- a/src/Native/System.Native/pal_uid.h
+++ b/src/Native/System.Native/pal_uid.h
@@ -27,7 +27,7 @@ struct Passwd
 * number for any other failure.
 *
 */
-extern "C" int32_t GetPwUidR(uint32_t uid, Passwd* pwd, char* buf, int32_t buflen);
+extern "C" int32_t SystemNative_GetPwUidR(uint32_t uid, Passwd* pwd, char* buf, int32_t buflen);
 
 /**
 * Gets and returns the effective user's identity.
@@ -35,7 +35,7 @@ extern "C" int32_t GetPwUidR(uint32_t uid, Passwd* pwd, char* buf, int32_t bufle
 *
 * Always succeeds.
 */
-extern "C" uint32_t GetEUid();
+extern "C" uint32_t SystemNative_GetEUid();
 
 /**
 * Gets and returns the effective group's identity.
@@ -43,4 +43,4 @@ extern "C" uint32_t GetEUid();
 *
 * Always succeeds.
 */
-extern "C" uint32_t GetEGid();
+extern "C" uint32_t SystemNative_GetEGid();


### PR DESCRIPTION
The methods exported from System.Native.* shims have short generic names, like Close or Stat. Making them more unique by adding "SystemNative_" prefix to each method name.

This is a partial fix for #4818.  I split just the System.Native exports out first.  Will do the rest in a forthcoming PR.

@stephentoub @sokket @jkotas @nguerrera @weshaggard @bartonjs 