### PR TITLE
Add DataflowBlockOptions.ForceOrdered to Dataflow library

### DIFF
--- a/src/System.Threading.Tasks.Dataflow/src/Base/DataflowBlockOptions.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Base/DataflowBlockOptions.cs
@@ -48,7 +48,7 @@ namespace System.Threading.Tasks.Dataflow
     ///         <description>"{0} Id={1}"</description>
     ///     </item>
     ///     <item>
-    ///         <term>ForceOrdered</term>
+    ///         <term>EnsureOrdered</term>
     ///         <description>true</description>
     ///     </item>
     /// </list>
@@ -76,7 +76,7 @@ namespace System.Threading.Tasks.Dataflow
         /// <summary>The name format to use for creating a name for a block.</summary>
         private string _nameFormat = "{0} Id={1}"; // see NameFormat property for a description of format items
         /// <summary>Whether to force ordered processing of messages.</summary>
-        private bool _forceOrdered = true;
+        private bool _ensureOrdered = true;
 
         /// <summary>A default instance of <see cref="DataflowBlockOptions"/>.</summary>
         /// <remarks>
@@ -97,7 +97,7 @@ namespace System.Threading.Tasks.Dataflow
                     MaxMessagesPerTask = this.MaxMessagesPerTask,
                     BoundedCapacity = this.BoundedCapacity,
                     NameFormat = this.NameFormat,
-                    ForceOrdered = this.ForceOrdered
+                    EnsureOrdered = this.EnsureOrdered
                 };
         }
 
@@ -185,14 +185,14 @@ namespace System.Threading.Tasks.Dataflow
         /// order they were input, even if parallelism is employed by the block and the processing of a message N finishes 
         /// after the processing of a subsequent message N+1 (the block will reorder the results to maintain the input
         /// ordering prior to making those results available to a consumer).  Some blocks may allow this to be relaxed,
-        /// however.  Setting <see cref="ForceOrdered"/> to false tells a block that it may relax this ordering if
+        /// however.  Setting <see cref="EnsureOrdered"/> to false tells a block that it may relax this ordering if
         /// it's able to do so.  This can be beneficial if the immediacy of a processed result being made available
         /// is more important than the input-to-output ordering being maintained.
         /// </remarks>
-        public bool ForceOrdered
+        public bool EnsureOrdered
         {
-            get { return _forceOrdered; }
-            set { _forceOrdered = value; }
+            get { return _ensureOrdered; }
+            set { _ensureOrdered = value; }
         }
     }
 
@@ -230,7 +230,7 @@ namespace System.Threading.Tasks.Dataflow
     ///         <description>"{0} Id={1}"</description>
     ///     </item>
     ///     <item>
-    ///         <term>ForceOrdered</term>
+    ///         <term>EnsureOrdered</term>
     ///         <description>true</description>
     ///     </item>
     ///     <item>
@@ -268,7 +268,7 @@ namespace System.Threading.Tasks.Dataflow
                     MaxMessagesPerTask = this.MaxMessagesPerTask,
                     BoundedCapacity = this.BoundedCapacity,
                     NameFormat = this.NameFormat,
-                    ForceOrdered = this.ForceOrdered,
+                    EnsureOrdered = this.EnsureOrdered,
                     MaxDegreeOfParallelism = this.MaxDegreeOfParallelism,
                     SingleProducerConstrained = this.SingleProducerConstrained
                 };
@@ -362,7 +362,7 @@ namespace System.Threading.Tasks.Dataflow
     ///         <description>"{0} Id={1}"</description>
     ///     </item>
     ///     <item>
-    ///         <term>ForceOrdered</term>
+    ///         <term>EnsureOrdered</term>
     ///         <description>true</description>
     ///     </item>
     ///     <item>
@@ -400,7 +400,7 @@ namespace System.Threading.Tasks.Dataflow
                     MaxMessagesPerTask = this.MaxMessagesPerTask,
                     BoundedCapacity = this.BoundedCapacity,
                     NameFormat = this.NameFormat,
-                    ForceOrdered = this.ForceOrdered,
+                    EnsureOrdered = this.EnsureOrdered,
                     Greedy = this.Greedy,
                     MaxNumberOfGroups = this.MaxNumberOfGroups
                 };

--- a/src/System.Threading.Tasks.Dataflow/src/Base/DataflowBlockOptions.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Base/DataflowBlockOptions.cs
@@ -47,6 +47,10 @@ namespace System.Threading.Tasks.Dataflow
     ///         <term>NameFormat</term>
     ///         <description>"{0} Id={1}"</description>
     ///     </item>
+    ///     <item>
+    ///         <term>ForceOrdered</term>
+    ///         <description>true</description>
+    ///     </item>
     /// </list>
     /// Dataflow blocks capture the state of the options at their construction.  Subsequent changes
     /// to the provided <see cref="DataflowBlockOptions"/> instance should not affect the behavior
@@ -71,6 +75,8 @@ namespace System.Threading.Tasks.Dataflow
         private Int32 _boundedCapacity = Unbounded;
         /// <summary>The name format to use for creating a name for a block.</summary>
         private string _nameFormat = "{0} Id={1}"; // see NameFormat property for a description of format items
+        /// <summary>Whether to force ordered processing of messages.</summary>
+        private bool _forceOrdered = true;
 
         /// <summary>A default instance of <see cref="DataflowBlockOptions"/>.</summary>
         /// <remarks>
@@ -90,7 +96,8 @@ namespace System.Threading.Tasks.Dataflow
                     CancellationToken = this.CancellationToken,
                     MaxMessagesPerTask = this.MaxMessagesPerTask,
                     BoundedCapacity = this.BoundedCapacity,
-                    NameFormat = this.NameFormat
+                    NameFormat = this.NameFormat,
+                    ForceOrdered = this.ForceOrdered
                 };
         }
 
@@ -170,6 +177,13 @@ namespace System.Threading.Tasks.Dataflow
                 _nameFormat = value;
             }
         }
+
+        /// <summary>Gets whether ordered processing should be enforced on a block's handling of messages.</summary>
+        public bool ForceOrdered
+        {
+            get { return _forceOrdered; }
+            set { _forceOrdered = value; }
+        }
     }
 
     /// <summary>
@@ -206,6 +220,10 @@ namespace System.Threading.Tasks.Dataflow
     ///         <description>"{0} Id={1}"</description>
     ///     </item>
     ///     <item>
+    ///         <term>ForceOrdered</term>
+    ///         <description>true</description>
+    ///     </item>
+    ///     <item>
     ///         <term>MaxDegreeOfParallelism</term>
     ///         <description>1</description>
     ///     </item>
@@ -240,6 +258,7 @@ namespace System.Threading.Tasks.Dataflow
                     MaxMessagesPerTask = this.MaxMessagesPerTask,
                     BoundedCapacity = this.BoundedCapacity,
                     NameFormat = this.NameFormat,
+                    ForceOrdered = this.ForceOrdered,
                     MaxDegreeOfParallelism = this.MaxDegreeOfParallelism,
                     SingleProducerConstrained = this.SingleProducerConstrained
                 };
@@ -333,6 +352,10 @@ namespace System.Threading.Tasks.Dataflow
     ///         <description>"{0} Id={1}"</description>
     ///     </item>
     ///     <item>
+    ///         <term>ForceOrdered</term>
+    ///         <description>true</description>
+    ///     </item>
+    ///     <item>
     ///         <term>MaxNumberOfGroups</term>
     ///         <description>GroupingDataflowBlockOptions.Unbounded (-1)</description>
     ///     </item>
@@ -367,6 +390,7 @@ namespace System.Threading.Tasks.Dataflow
                     MaxMessagesPerTask = this.MaxMessagesPerTask,
                     BoundedCapacity = this.BoundedCapacity,
                     NameFormat = this.NameFormat,
+                    ForceOrdered = this.ForceOrdered,
                     Greedy = this.Greedy,
                     MaxNumberOfGroups = this.MaxNumberOfGroups
                 };

--- a/src/System.Threading.Tasks.Dataflow/src/Base/DataflowBlockOptions.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Base/DataflowBlockOptions.cs
@@ -178,7 +178,17 @@ namespace System.Threading.Tasks.Dataflow
             }
         }
 
-        /// <summary>Gets whether ordered processing should be enforced on a block's handling of messages.</summary>
+        /// <summary>Gets or sets whether ordered processing should be enforced on a block's handling of messages.</summary>
+        /// <remarks>
+        /// By default, dataflow blocks enforce ordering on the processing of messages. This means that a
+        /// block like <see cref="TransformBlock{TInput, TOutput}"/> will ensure that messages are output in the same
+        /// order they were input, even if parallelism is employed by the block and the processing of a message N finishes 
+        /// after the processing of a subsequent message N+1 (the block will reorder the results to maintain the input
+        /// ordering prior to making those results available to a consumer).  Some blocks may allow this to be relaxed,
+        /// however.  Setting <see cref="ForceOrdered"/> to false tells a block that it may relax this ordering if
+        /// it's able to do so.  This can be beneficial if the immediacy of a processed result being made available
+        /// is more important than the input-to-output ordering being maintained.
+        /// </remarks>
         public bool ForceOrdered
         {
             get { return _forceOrdered; }

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/TransformBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/TransformBlock.cs
@@ -113,8 +113,8 @@ namespace System.Threading.Tasks.Dataflow
                 onItemsRemoved);
 
             // If parallelism is employed, we will need to support reordering messages that complete out-of-order.
-            // However, a developer can override this with ForceOrdered == false.
-            if (dataflowBlockOptions.SupportsParallelExecution && dataflowBlockOptions.ForceOrdered)
+            // However, a developer can override this with EnsureOrdered == false.
+            if (dataflowBlockOptions.SupportsParallelExecution && dataflowBlockOptions.EnsureOrdered)
             {
                 _reorderingBuffer = new ReorderingBuffer<TOutput>(this, (owningSource, message) => ((TransformBlock<TInput, TOutput>)owningSource)._source.AddMessage(message));
             }

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/TransformManyBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/TransformManyBlock.cs
@@ -124,8 +124,8 @@ namespace System.Threading.Tasks.Dataflow
                 onItemsRemoved);
 
             // If parallelism is employed, we will need to support reordering messages that complete out-of-order.
-            // However, a developer can override this with ForceOrdered == false.
-            if (dataflowBlockOptions.SupportsParallelExecution && dataflowBlockOptions.ForceOrdered)
+            // However, a developer can override this with EnsureOrdered == false.
+            if (dataflowBlockOptions.SupportsParallelExecution && dataflowBlockOptions.EnsureOrdered)
             {
                 _reorderingBuffer = new ReorderingBuffer<IEnumerable<TOutput>>(
                     this, (source, messages) => ((TransformManyBlock<TInput, TOutput>)source)._source.AddMessages(messages));

--- a/src/System.Threading.Tasks.Dataflow/src/Blocks/TransformManyBlock.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Blocks/TransformManyBlock.cs
@@ -37,6 +37,16 @@ namespace System.Threading.Tasks.Dataflow
         /// <summary>The source side.</summary>
         private readonly SourceCore<TOutput> _source;
 
+        /// <summary>Gets the object to use for writing to the source when multiple threads may be involved.</summary>
+        /// <remarks>
+        /// If a reordering buffer is used, it is safe for multiple threads to write to concurrently and handles safe 
+        /// access to the source. If there's no reordering buffer because no parallelism is used, then only one thread at
+        /// a time will try to access the source, anyway.  But, if there's no reordering buffer and parallelism is being
+        /// employed, then multiple threads may try to access the source concurrently, in which case we need to manually
+        /// synchronize all such access, and this lock is used for that purpose.
+        /// </remarks>
+        private object ParallelSourceLock { get { return _source; } }
+
         /// <summary>Initializes the <see cref="TransformManyBlock{TInput,TOutput}"/> with the specified function.</summary>
         /// <param name="transform">
         /// The function to invoke with each data element received.  All of the data from the returned <see cref="System.Collections.Generic.IEnumerable{TOutput}"/>
@@ -114,7 +124,8 @@ namespace System.Threading.Tasks.Dataflow
                 onItemsRemoved);
 
             // If parallelism is employed, we will need to support reordering messages that complete out-of-order.
-            if (dataflowBlockOptions.SupportsParallelExecution)
+            // However, a developer can override this with ForceOrdered == false.
+            if (dataflowBlockOptions.SupportsParallelExecution && dataflowBlockOptions.ForceOrdered)
             {
                 _reorderingBuffer = new ReorderingBuffer<IEnumerable<TOutput>>(
                     this, (source, messages) => ((TransformManyBlock<TInput, TOutput>)source)._source.AddMessages(messages));
@@ -459,7 +470,18 @@ namespace System.Threading.Tasks.Dataflow
             Contract.Requires(_reorderingBuffer == null, "Expected not to have a reordering buffer");
             Contract.Requires(outputItems is TOutput[] || outputItems is List<TOutput>, "outputItems must be a list we've already vetted as trusted");
             if (_target.IsBounded) UpdateBoundingCountWithOutputCount(count: ((ICollection<TOutput>)outputItems).Count);
-            _source.AddMessages(outputItems);
+
+            if (_target.DataflowBlockOptions.MaxDegreeOfParallelism == 1)
+            {
+                _source.AddMessages(outputItems);
+            }
+            else
+            {
+                lock (ParallelSourceLock)
+                {
+                    _source.AddMessages(outputItems);
+                }
+            }
         }
 
         /// <summary>
@@ -469,6 +491,8 @@ namespace System.Threading.Tasks.Dataflow
         /// <param name="outputItems">The untrusted enumerable.</param>
         private void StoreOutputItemsNonReorderedWithIteration(IEnumerable<TOutput> outputItems)
         {
+            bool isSerial = _target.DataflowBlockOptions.MaxDegreeOfParallelism == 1;
+
             // If we're bounding, we need to increment the bounded count
             // for each individual item as we enumerate it.
             if (_target.IsBounded)
@@ -484,7 +508,18 @@ namespace System.Threading.Tasks.Dataflow
                     {
                         if (outputFirstItem) _target.ChangeBoundingCount(count: 1);
                         else outputFirstItem = true;
-                        _source.AddMessage(item);
+
+                        if (isSerial)
+                        {
+                            _source.AddMessage(item);
+                        }
+                        else
+                        {
+                            lock (ParallelSourceLock) // don't hold lock while enumerating
+                            {
+                                _source.AddMessage(item);
+                            }
+                        }
                     }
                 }
                 finally
@@ -495,7 +530,19 @@ namespace System.Threading.Tasks.Dataflow
             // If we're not bounding, just output each individual item.
             else
             {
-                foreach (TOutput item in outputItems) _source.AddMessage(item);
+                if (isSerial)
+                {
+                    foreach (TOutput item in outputItems)
+                        _source.AddMessage(item);
+                }
+                else
+                {
+                    lock (ParallelSourceLock) // don't hold lock while enumerating
+                    {
+                        foreach (TOutput item in outputItems)
+                            _source.AddMessage(item);
+                    }
+                }
             }
         }
 

--- a/src/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.WP8.csproj
+++ b/src/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.WP8.csproj
@@ -6,7 +6,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Threading.Tasks.Dataflow</RootNamespace>
     <AssemblyName>System.Threading.Tasks.Dataflow</AssemblyName>
-    <AssemblyVersion>4.5.26.0</AssemblyVersion>
+    <AssemblyVersion>4.6.0.0</AssemblyVersion>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile>Profile78</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/src/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.csproj
+++ b/src/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.csproj
@@ -6,7 +6,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Threading.Tasks.Dataflow</RootNamespace>
     <AssemblyName>System.Threading.Tasks.Dataflow</AssemblyName>
-    <AssemblyVersion>4.5.26.0</AssemblyVersion>
+    <AssemblyVersion>4.6.0.0</AssemblyVersion>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/DataflowBlockOptionsTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/DataflowBlockOptionsTests.cs
@@ -34,7 +34,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 Assert.Equal(expected: CancellationToken.None, actual: dbo.CancellationToken);
                 Assert.Equal(expected: -1, actual: DataflowBlockOptions.Unbounded);
                 Assert.Equal(expected: @"{0} Id={1}", actual: dbo.NameFormat);
-                Assert.Equal(expected: true, actual: dbo.ForceOrdered);
+                Assert.Equal(expected: true, actual: dbo.EnsureOrdered);
             };
 
             verifyBaseDefaults(new DataflowBlockOptions());
@@ -82,7 +82,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
 
             foreach (bool value in DataflowTestHelpers.BooleanValues)
             {
-                SetAndTest(dbo, (o, v) => o.ForceOrdered = v, o => o.ForceOrdered, value);
+                SetAndTest(dbo, (o, v) => o.EnsureOrdered = v, o => o.EnsureOrdered, value);
             }
 
             foreach (bool value in DataflowTestHelpers.BooleanValues)

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/DataflowBlockOptionsTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/DataflowBlockOptionsTests.cs
@@ -34,6 +34,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
                 Assert.Equal(expected: CancellationToken.None, actual: dbo.CancellationToken);
                 Assert.Equal(expected: -1, actual: DataflowBlockOptions.Unbounded);
                 Assert.Equal(expected: @"{0} Id={1}", actual: dbo.NameFormat);
+                Assert.Equal(expected: true, actual: dbo.ForceOrdered);
             };
 
             verifyBaseDefaults(new DataflowBlockOptions());
@@ -77,6 +78,11 @@ namespace System.Threading.Tasks.Dataflow.Tests
             foreach (string value in new[] { "none", "foo {0}", "foo {0} bar {1}", "kaboom {0} {1} {2}" })
             {
                 SetAndTest(dbo, (o, v) => o.NameFormat = v, o => o.NameFormat, value);
+            }
+
+            foreach (bool value in DataflowTestHelpers.BooleanValues)
+            {
+                SetAndTest(dbo, (o, v) => o.ForceOrdered = v, o => o.ForceOrdered, value);
             }
 
             foreach (bool value in DataflowTestHelpers.BooleanValues)

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/TransformBlockTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/TransformBlockTests.cs
@@ -551,18 +551,18 @@ namespace System.Threading.Tasks.Dataflow.Tests
         [InlineData(1, DataflowBlockOptions.Unbounded, null)]
         [InlineData(2, 2, true)]
         [InlineData(2, 1, false)] // no force ordered, but dop == 1, so it doesn't matter
-        public async Task TestOrdering_Sync_OrderedEnabled(int mmpt, int dop, bool? forceOrdered)
+        public async Task TestOrdering_Sync_OrderedEnabled(int mmpt, int dop, bool? EnsureOrdered)
         {
             const int iters = 1000;
 
             var options = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = dop, MaxMessagesPerTask = mmpt };
-            if (forceOrdered == null)
+            if (EnsureOrdered == null)
             {
-                Assert.True(options.ForceOrdered);
+                Assert.True(options.EnsureOrdered);
             }
             else
             {
-                options.ForceOrdered = forceOrdered.Value;
+                options.EnsureOrdered = EnsureOrdered.Value;
             }
 
             var tb = new TransformBlock<int, int>(i => i, options);
@@ -584,18 +584,18 @@ namespace System.Threading.Tasks.Dataflow.Tests
         [InlineData(1, DataflowBlockOptions.Unbounded, null)]
         [InlineData(2, 2, true)]
         [InlineData(2, 1, false)] // no force ordered, but dop == 1, so it doesn't matter
-        public async Task TestOrdering_Async_OrderedEnabled(int mmpt, int dop, bool? forceOrdered)
+        public async Task TestOrdering_Async_OrderedEnabled(int mmpt, int dop, bool? EnsureOrdered)
         {
             const int iters = 1000;
 
             var options = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = dop, MaxMessagesPerTask = mmpt };
-            if (forceOrdered == null)
+            if (EnsureOrdered == null)
             {
-                Assert.True(options.ForceOrdered);
+                Assert.True(options.EnsureOrdered);
             }
             else
             {
-                options.ForceOrdered = forceOrdered.Value;
+                options.EnsureOrdered = EnsureOrdered.Value;
             }
 
             var tb = new TransformBlock<int, int>(i => Task.FromResult(i), options);
@@ -613,7 +613,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
         {
             // If ordering were enabled, this test would hang.
 
-            var options = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = DataflowBlockOptions.Unbounded, ForceOrdered = false };
+            var options = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = DataflowBlockOptions.Unbounded, EnsureOrdered = false };
 
             var tasks = new TaskCompletionSource<int>[10];
             for (int i = 0; i < tasks.Length; i++)
@@ -639,7 +639,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
         {
             // If ordering were enabled, this test would hang.
 
-            var options = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = 2, ForceOrdered = false };
+            var options = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = 2, EnsureOrdered = false };
 
             var mres = new ManualResetEventSlim();
             var tb = new TransformBlock<int, int>(i =>

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/TransformManyBlockTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/TransformManyBlockTests.cs
@@ -651,26 +651,128 @@ namespace System.Threading.Tasks.Dataflow.Tests
             }
         }
 
-        [Fact]
-        public async Task TestOrdering()
+        [Theory]
+        [InlineData(DataflowBlockOptions.Unbounded, 1, null)]
+        [InlineData(DataflowBlockOptions.Unbounded, 2, null)]
+        [InlineData(DataflowBlockOptions.Unbounded, DataflowBlockOptions.Unbounded, null)]
+        [InlineData(1, 1, null)]
+        [InlineData(1, 2, null)]
+        [InlineData(1, DataflowBlockOptions.Unbounded, null)]
+        [InlineData(2, 2, true)]
+        [InlineData(2, 1, false)] // no force ordered, but dop == 1, so it doesn't matter
+        public async Task TestOrdering_Sync_OrderedEnabled(int mmpt, int dop, bool? forceOrdered)
         {
-            const int iters = 9999;
-            foreach (int mmpt in new[] { DataflowBlockOptions.Unbounded, 1 })
-            foreach (int dop in new[] { 1, 2, DataflowBlockOptions.Unbounded })
+            const int iters = 1000;
+
+            var options = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = dop, MaxMessagesPerTask = mmpt };
+            if (forceOrdered == null)
             {
-                var options = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = dop, MaxMessagesPerTask = mmpt };
-                var tb = new TransformManyBlock<int, int>(i => new[] { i, i + 1, i + 2 }, options);
-                for (int i = 0; i < iters; i += 3)
-                {
-                    Assert.True(tb.Post(i));
-                }
-                for (int i = 0; i < iters; i++)
-                {
-                    Assert.Equal(expected: i, actual: await tb.ReceiveAsync());
-                }
-                tb.Complete();
-                await tb.Completion;
+                Assert.True(options.ForceOrdered);
             }
+            else
+            {
+                options.ForceOrdered = forceOrdered.Value;
+            }
+
+            var tb = new TransformManyBlock<int, int>(i => new[] { i }, options);
+            tb.PostRange(0, iters);
+            for (int i = 0; i < iters; i++)
+            {
+                Assert.Equal(expected: i, actual: await tb.ReceiveAsync());
+            }
+            tb.Complete();
+            await tb.Completion;
+        }
+
+        [Theory]
+        [InlineData(DataflowBlockOptions.Unbounded, 1, null)]
+        [InlineData(DataflowBlockOptions.Unbounded, 2, null)]
+        [InlineData(DataflowBlockOptions.Unbounded, DataflowBlockOptions.Unbounded, null)]
+        [InlineData(1, 1, null)]
+        [InlineData(1, 2, null)]
+        [InlineData(1, DataflowBlockOptions.Unbounded, null)]
+        [InlineData(2, 2, true)]
+        [InlineData(2, 1, false)] // no force ordered, but dop == 1, so it doesn't matter
+        public async Task TestOrdering_Async_OrderedEnabled(int mmpt, int dop, bool? forceOrdered)
+        {
+            const int iters = 1000;
+
+            var options = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = dop, MaxMessagesPerTask = mmpt };
+            if (forceOrdered == null)
+            {
+                Assert.True(options.ForceOrdered);
+            }
+            else
+            {
+                options.ForceOrdered = forceOrdered.Value;
+            }
+
+            var tb = new TransformManyBlock<int, int>(i => Task.FromResult(Enumerable.Repeat(i, 1)), options);
+            tb.PostRange(0, iters);
+            for (int i = 0; i < iters; i++)
+            {
+                Assert.Equal(expected: i, actual: await tb.ReceiveAsync());
+            }
+            tb.Complete();
+            await tb.Completion;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task TestOrdering_Async_OrderedDisabled(bool trustedEnumeration)
+        {
+            // If ordering were enabled, this test would hang.
+
+            var options = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = DataflowBlockOptions.Unbounded, ForceOrdered = false };
+
+            var tasks = new TaskCompletionSource<IEnumerable<int>>[10];
+            for (int i = 0; i < tasks.Length; i++)
+            {
+                tasks[i] = new TaskCompletionSource<IEnumerable<int>>();
+            }
+
+            var tb = new TransformManyBlock<int, int>(i => tasks[i].Task, options);
+            tb.PostRange(0, tasks.Length);
+
+            for (int i = tasks.Length - 1; i >= 0; i--)
+            {
+                tasks[i].SetResult(trustedEnumeration ?
+                    new[] { i } :
+                    Enumerable.Repeat(i, 1));
+                Assert.Equal(expected: i, actual: await tb.ReceiveAsync());
+            }
+
+            tb.Complete();
+            await tb.Completion;
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task TestOrdering_Sync_OrderedDisabled(bool trustedEnumeration)
+        {
+            // If ordering were enabled, this test would hang.
+
+            var options = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = 2, ForceOrdered = false };
+
+            var mres = new ManualResetEventSlim();
+            var tb = new TransformManyBlock<int, int>(i =>
+            {
+                if (i == 0) mres.Wait();
+                return trustedEnumeration ?
+                    new[] { i } :
+                    Enumerable.Repeat(i, 1);
+            }, options);
+            tb.Post(0);
+            tb.Post(1);
+
+            Assert.Equal(1, await tb.ReceiveAsync());
+            mres.Set();
+            Assert.Equal(0, await tb.ReceiveAsync());
+
+            tb.Complete();
+            await tb.Completion;
         }
     }
 }

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/TransformManyBlockTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/TransformManyBlockTests.cs
@@ -660,18 +660,18 @@ namespace System.Threading.Tasks.Dataflow.Tests
         [InlineData(1, DataflowBlockOptions.Unbounded, null)]
         [InlineData(2, 2, true)]
         [InlineData(2, 1, false)] // no force ordered, but dop == 1, so it doesn't matter
-        public async Task TestOrdering_Sync_OrderedEnabled(int mmpt, int dop, bool? forceOrdered)
+        public async Task TestOrdering_Sync_OrderedEnabled(int mmpt, int dop, bool? EnsureOrdered)
         {
             const int iters = 1000;
 
             var options = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = dop, MaxMessagesPerTask = mmpt };
-            if (forceOrdered == null)
+            if (EnsureOrdered == null)
             {
-                Assert.True(options.ForceOrdered);
+                Assert.True(options.EnsureOrdered);
             }
             else
             {
-                options.ForceOrdered = forceOrdered.Value;
+                options.EnsureOrdered = EnsureOrdered.Value;
             }
 
             var tb = new TransformManyBlock<int, int>(i => new[] { i }, options);
@@ -693,18 +693,18 @@ namespace System.Threading.Tasks.Dataflow.Tests
         [InlineData(1, DataflowBlockOptions.Unbounded, null)]
         [InlineData(2, 2, true)]
         [InlineData(2, 1, false)] // no force ordered, but dop == 1, so it doesn't matter
-        public async Task TestOrdering_Async_OrderedEnabled(int mmpt, int dop, bool? forceOrdered)
+        public async Task TestOrdering_Async_OrderedEnabled(int mmpt, int dop, bool? EnsureOrdered)
         {
             const int iters = 1000;
 
             var options = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = dop, MaxMessagesPerTask = mmpt };
-            if (forceOrdered == null)
+            if (EnsureOrdered == null)
             {
-                Assert.True(options.ForceOrdered);
+                Assert.True(options.EnsureOrdered);
             }
             else
             {
-                options.ForceOrdered = forceOrdered.Value;
+                options.EnsureOrdered = EnsureOrdered.Value;
             }
 
             var tb = new TransformManyBlock<int, int>(i => Task.FromResult(Enumerable.Repeat(i, 1)), options);
@@ -724,7 +724,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
         {
             // If ordering were enabled, this test would hang.
 
-            var options = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = DataflowBlockOptions.Unbounded, ForceOrdered = false };
+            var options = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = DataflowBlockOptions.Unbounded, EnsureOrdered = false };
 
             var tasks = new TaskCompletionSource<IEnumerable<int>>[10];
             for (int i = 0; i < tasks.Length; i++)
@@ -754,7 +754,7 @@ namespace System.Threading.Tasks.Dataflow.Tests
         {
             // If ordering were enabled, this test would hang.
 
-            var options = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = 2, ForceOrdered = false };
+            var options = new ExecutionDataflowBlockOptions { MaxDegreeOfParallelism = 2, EnsureOrdered = false };
 
             var mres = new ManualResetEventSlim();
             var tb = new TransformManyBlock<int, int>(i =>


### PR DESCRIPTION
Adds the DataflowBlockOptions.ForceOrdered option, and utilizes it from TransformBlock and TransformManyBlock.

Fixes #536 
cc: @AlfredoMS, @mellinoe 

@ericstj, is there anything I need to do around assembly versionining?