### PR TITLE
Move S.S.Cryptography.Algorithms package building to Open

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/pkg/System.Security.Cryptography.Algorithms.builds
+++ b/src/System.Security.Cryptography.Algorithms/pkg/System.Security.Cryptography.Algorithms.builds
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Security.Cryptography.Algorithms.pkgproj"/>
+    <Project Include="win\System.Security.Cryptography.Algorithms.pkgproj">
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
+    <Project Include="unix\System.Security.Cryptography.Algorithms.pkgproj">
+      <OSGroup>Linux</OSGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Security.Cryptography.Algorithms/pkg/System.Security.Cryptography.Algorithms.pkgproj
+++ b/src/System.Security.Cryptography.Algorithms/pkg/System.Security.Cryptography.Algorithms.pkgproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\ref\System.Security.Cryptography.Algorithms.csproj">
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Security.Cryptography.Algorithms.csproj">
+      <AdditionalProperties>TargetGroup=net46;OSGroup=Windows_NT</AdditionalProperties>
+    </ProjectReference>
+    <ProjectReference Include="win\System.Security.Cryptography.Algorithms.pkgproj" />
+    <ProjectReference Include="unix\System.Security.Cryptography.Algorithms.pkgproj" />
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.Cryptography.Algorithms/pkg/unix/System.Security.Cryptography.Algorithms.pkgproj
+++ b/src/System.Security.Cryptography.Algorithms/pkg/unix/System.Security.Cryptography.Algorithms.pkgproj
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>unix</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Security.Cryptography.Algorithms.builds">
+      <AdditionalProperties>FilterToOSGroup=Linux</AdditionalProperties>
+    </ProjectReference>
+  </ItemGroup>
+
+  <!-- The runtime.native.System.Security.Cryptography package hasn't moved to open yet-->
+  <ItemGroup>
+    <_FilePackageReference Include="runtime.native.System.Security.Cryptography">
+      <TargetFramework>dotnet54</TargetFramework>
+      <Version>4.0.0</Version>
+    </_FilePackageReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.Cryptography.Algorithms/pkg/unix/System.Security.Cryptography.Algorithms.pkgproj
+++ b/src/System.Security.Cryptography.Algorithms/pkg/unix/System.Security.Cryptography.Algorithms.pkgproj
@@ -21,5 +21,13 @@
     </_FilePackageReference>
   </ItemGroup>
 
+  <!-- Manual (reflection) dependencies to pre-released packages -->
+  <ItemGroup>
+    <_FilePackageReference Include="System.Security.Cryptography.OpenSsl">
+      <TargetFramework>dotnet54</TargetFramework>
+      <Version>4.0.0</Version>
+    </_FilePackageReference>
+  </ItemGroup>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Algorithms/pkg/win/System.Security.Cryptography.Algorithms.pkgproj
+++ b/src/System.Security.Cryptography.Algorithms/pkg/win/System.Security.Cryptography.Algorithms.pkgproj
@@ -16,6 +16,13 @@
     <ExternalOnTargetFramework Include="net" />
   </ItemGroup>
 
+  <!-- Manual (reflection) dependencies to pre-released packages -->
+  <ItemGroup>
+    <_FilePackageReference Include="System.Security.Cryptography.Cng">
+      <TargetFramework>dotnet54</TargetFramework>
+      <Version>4.0.0</Version>
+    </_FilePackageReference>
+  </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Algorithms/pkg/win/System.Security.Cryptography.Algorithms.pkgproj
+++ b/src/System.Security.Cryptography.Algorithms/pkg/win/System.Security.Cryptography.Algorithms.pkgproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>win7</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Security.Cryptography.Algorithms.builds">
+      <AdditionalProperties>FilterToOSGroup=Windows_NT</AdditionalProperties>
+    </ProjectReference>
+
+    <!-- don't use the dotnet implementation for any version of desktop, it's implementation comes from the reference package -->
+    <ExternalOnTargetFramework Include="net" />
+  </ItemGroup>
+
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
+++ b/src/System.Security.Cryptography.Algorithms/src/System.Security.Cryptography.Algorithms.csproj
@@ -16,6 +16,7 @@
     <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">dotnet5.4</PackageTargetFramework>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)'=='net46'">true</IsPartialFacadeAssembly>
     <PackageTargetRuntime Condition=" '$(TargetsWindows)' == 'true'">win7</PackageTargetRuntime>
+    <PackageTargetRuntime Condition=" '$(TargetGroup)' == 'net46'"></PackageTargetRuntime>
     <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true'">unix</PackageTargetRuntime>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'FreeBSD_Debug|AnyCPU'" />


### PR DESCRIPTION
This sets up the package building for S.S.C.Algorithms from the relevant `pkg` directory.  It also registers the forward runtime dependencies (Cng for Windows, OpenSsl for Unix) that RSA.Create (#2953) would need to ensure that it can always reflect instantiate the right type.

cc: @ericstj @weshaggard