### PR TITLE
Fix behavior difference when XmlSerializer deserializes out-of-range byte values

### DIFF
--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -2707,3 +2707,8 @@ public class TypeWithTimeSpanProperty
 {
     public TimeSpan TimeSpanProperty;
 }
+
+public class TypeWithByteProperty
+{
+    public byte ByteProperty;
+}

--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializationReaderILGen.cs
@@ -886,15 +886,8 @@ namespace System.Xml.Serialization
                 }
                 else
                 {
-                    string formatterName = mapping.TypeDesc.FormatterName;
-                    // Workaround for ToByte -> SL's ToInt16
-                    if (formatterName == "Byte")
-                        formatterName = "Int16";
-                    // Workaround for ToUInt16 -> SL's ToInt32
-                    else if (formatterName == "UInt16")
-                        formatterName = "Int32";
                     ToXXX = typeof(XmlConvert).GetMethod(
-                        "To" + formatterName,
+                        "To" + mapping.TypeDesc.FormatterName,
                         CodeGenerator.StaticBindingFlags,
                         new Type[] { argType }
                         );
@@ -943,16 +936,6 @@ namespace System.Xml.Serialization
                     ilg.Ldc(false);
                 }
                 ilg.Call(ToXXX);
-                // If use XmlConvert, ..
-                if (!mapping.TypeDesc.HasCustomFormatter)
-                {
-                    // Workaround for ToByte -> SL's ToInt16
-                    if (mapping.TypeDesc.FormatterName == "Byte")
-                        ilg.ConvertValue(typeof(Int16), typeof(Byte));
-                    // Workaround for ToUInt16 -> SL's ToInt32
-                    else if (mapping.TypeDesc.FormatterName == "UInt16")
-                        ilg.ConvertValue(typeof(Int32), typeof(UInt16));
-                }
             }
         }
 

--- a/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
+++ b/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
@@ -1624,7 +1624,11 @@ public static partial class XmlSerializerTests
   <ByteProperty>123</ByteProperty>
 </TypeWithByteProperty>");
         Assert.StrictEqual(obj.ByteProperty, deserializedObj.ByteProperty);
+    }
 
+    [Fact]
+    public static void Xml_DeserializeOutOfRangeByteProperty()
+    {
         //Deserialize an instance with out-of-range value for the byte property, expecting exception from deserialization process
         var serializer = new XmlSerializer(typeof(TypeWithByteProperty));
         using (var stream = new MemoryStream())
@@ -1637,8 +1641,8 @@ public static partial class XmlSerializerTests
 </TypeWithByteProperty>");
             writer.Flush();
             stream.Position = 0;
-            Assert.Throws<InvalidOperationException>(() => { 
-                deserializedObj = (TypeWithByteProperty)serializer.Deserialize(stream);
+            Assert.Throws<InvalidOperationException>(() => {
+                var deserializedObj = (TypeWithByteProperty)serializer.Deserialize(stream);
             });
         }
     }

--- a/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
+++ b/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
@@ -1614,6 +1614,35 @@ public static partial class XmlSerializerTests
         Assert.StrictEqual(obj.TimeSpanProperty, deserializedObj.TimeSpanProperty);
     }
 
+    [Fact]
+    public static void Xml_TypeWithByteProperty()
+    {
+        var obj = new TypeWithByteProperty() {ByteProperty = 123};
+        var deserializedObj = SerializeAndDeserialize(obj,
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<TypeWithByteProperty xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+  <ByteProperty>123</ByteProperty>
+</TypeWithByteProperty>");
+        Assert.StrictEqual(obj.ByteProperty, deserializedObj.ByteProperty);
+
+        //Deserialize an instance with out-of-range value for the byte property, expecting exception from deserialization process
+        var serializer = new XmlSerializer(typeof(TypeWithByteProperty));
+        using (var stream = new MemoryStream())
+        {
+            var writer = new StreamWriter(stream);
+            writer.Write(
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<TypeWithByteProperty xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+  <ByteProperty>-1</ByteProperty>
+</TypeWithByteProperty>");
+            writer.Flush();
+            stream.Position = 0;
+            Assert.Throws<InvalidOperationException>(() => { 
+                deserializedObj = (TypeWithByteProperty)serializer.Deserialize(stream);
+            });
+        }
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, Func<XmlSerializer> serializerFactory = null,
         bool skipStringCompare = false, XmlSerializerNamespaces xns = null)
     {


### PR DESCRIPTION
Deserializing out-of-range byte value using XmlSerializer succeeds whereas it fails on Desktop.
The reason was due to additional conditionals were used as workaround for issues on Silverlight.
This change will make the behavior consistent with Desktop which is to throw InvalidOperationException when reading invalid value for byte data type.

Fix #4668 
@SGuyGe @shmao