### PR TITLE
Add netcore50 source build for System.Reflection.Context

### DIFF
--- a/src/System.Reflection.Context/System.Reflection.Context.sln
+++ b/src/System.Reflection.Context/System.Reflection.Context.sln
@@ -1,0 +1,41 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Reflection.Context", "src\System.Reflection.Context.csproj", "{404DB891-B5AF-41E6-B89D-29E3F4573C4F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{F7E06955-4DAA-4C19-885A-CF02917F4D91}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{2CC35A3F-E502-4E9F-A46B-EF54F6F567CE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Reflection.Context", "ref\System.Reflection.Context.csproj", "{0F892412-310A-4369-8721-6700EBF26B20}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		netcore50_Debug|Any CPU = netcore50_Debug|Any CPU
+		netcore50_Release|Any CPU = netcore50_Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{404DB891-B5AF-41E6-B89D-29E3F4573C4F}.Debug|Any CPU.ActiveCfg = netcore50_Debug|Any CPU
+		{404DB891-B5AF-41E6-B89D-29E3F4573C4F}.Debug|Any CPU.Build.0 = netcore50_Debug|Any CPU
+		{404DB891-B5AF-41E6-B89D-29E3F4573C4F}.netcore50_Debug|Any CPU.ActiveCfg = netcore50_Debug|Any CPU
+		{404DB891-B5AF-41E6-B89D-29E3F4573C4F}.netcore50_Debug|Any CPU.Build.0 = netcore50_Debug|Any CPU
+		{404DB891-B5AF-41E6-B89D-29E3F4573C4F}.netcore50_Release|Any CPU.ActiveCfg = netcore50_Release|Any CPU
+		{404DB891-B5AF-41E6-B89D-29E3F4573C4F}.netcore50_Release|Any CPU.Build.0 = netcore50_Release|Any CPU
+		{0F892412-310A-4369-8721-6700EBF26B20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F892412-310A-4369-8721-6700EBF26B20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F892412-310A-4369-8721-6700EBF26B20}.netcore50_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F892412-310A-4369-8721-6700EBF26B20}.netcore50_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F892412-310A-4369-8721-6700EBF26B20}.netcore50_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F892412-310A-4369-8721-6700EBF26B20}.netcore50_Release|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{404DB891-B5AF-41E6-B89D-29E3F4573C4F} = {2CC35A3F-E502-4E9F-A46B-EF54F6F567CE}
+		{0F892412-310A-4369-8721-6700EBF26B20} = {F7E06955-4DAA-4C19-885A-CF02917F4D91}
+	EndGlobalSection
+EndGlobal

--- a/src/System.Reflection.Context/src/System.Reflection.Context.builds
+++ b/src/System.Reflection.Context/src/System.Reflection.Context.builds
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Reflection.Context.csproj">
+      <TargetGroup>netcore50</TargetGroup>
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Reflection.Context/src/System.Reflection.Context.csproj
+++ b/src/System.Reflection.Context/src/System.Reflection.Context.csproj
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <UseECMAKey Condition="'$(UseECMAKey)' == ''">true</UseECMAKey>
+    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>dotnet5.2</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETPlatform,Version=v5.2</NuGetTargetMoniker>
+    <ProjectGuid>{404DB891-B5AF-41E6-B89D-29E3F4573C4F}</ProjectGuid>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the options -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50_Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="System\Reflection\Context\CustomReflectionContext.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection.Context/src/System/Reflection/Context/CustomReflectionContext.cs
+++ b/src/System.Reflection.Context/src/System/Reflection/Context/CustomReflectionContext.cs
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using global::System;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace System.Reflection.Context
 {
@@ -25,22 +22,22 @@ namespace System.Reflection.Context
             throw new PlatformNotSupportedException();
         }
 
-        protected PropertyInfo CreateProperty(Type propertyType, String name, Func<Object, Object> getter, Action<Object, Object> setter)
+        protected PropertyInfo CreateProperty(Type propertyType, string name, Func<object, object> getter, Action<object, object> setter)
         {
             throw new PlatformNotSupportedException();
         }
 
-        protected PropertyInfo CreateProperty(Type propertyType, String name, Func<Object, Object> getter, Action<Object, Object> setter, IEnumerable<Attribute> propertyCustomAttributes, IEnumerable<Attribute> getterCustomAttributes, IEnumerable<Attribute> setterCustomAttributes)
+        protected PropertyInfo CreateProperty(Type propertyType, string name, Func<object, object> getter, Action<object, object> setter, IEnumerable<Attribute> propertyCustomAttributes, IEnumerable<Attribute> getterCustomAttributes, IEnumerable<Attribute> setterCustomAttributes)
         {
             throw new PlatformNotSupportedException();
         }
 
-        protected virtual IEnumerable<Object> GetCustomAttributes(MemberInfo member, IEnumerable<Object> declaredAttributes)
+        protected virtual IEnumerable<object> GetCustomAttributes(MemberInfo member, IEnumerable<object> declaredAttributes)
         {
             throw new PlatformNotSupportedException();
         }
 
-        protected virtual IEnumerable<Object> GetCustomAttributes(ParameterInfo parameter, IEnumerable<Object> declaredAttributes)
+        protected virtual IEnumerable<object> GetCustomAttributes(ParameterInfo parameter, IEnumerable<object> declaredAttributes)
         {
             throw new PlatformNotSupportedException();
         }

--- a/src/System.Reflection.Context/src/System/Reflection/Context/CustomReflectionContext.cs
+++ b/src/System.Reflection.Context/src/System/Reflection/Context/CustomReflectionContext.cs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using global::System;
+using global::System.Reflection;
+using global::System.Diagnostics;
+using global::System.Collections.Generic;
+
+namespace System.Reflection.Context
+{
+    public abstract class CustomReflectionContext : ReflectionContext
+    {
+        protected CustomReflectionContext()
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected CustomReflectionContext(ReflectionContext source)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected virtual IEnumerable<PropertyInfo> AddProperties(Type type)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected PropertyInfo CreateProperty(Type propertyType, String name, Func<Object, Object> getter, Action<Object, Object> setter)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected PropertyInfo CreateProperty(Type propertyType, String name, Func<Object, Object> getter, Action<Object, Object> setter, IEnumerable<Attribute> propertyCustomAttributes, IEnumerable<Attribute> getterCustomAttributes, IEnumerable<Attribute> setterCustomAttributes)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected virtual IEnumerable<Object> GetCustomAttributes(MemberInfo member, IEnumerable<Object> declaredAttributes)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        protected virtual IEnumerable<Object> GetCustomAttributes(ParameterInfo parameter, IEnumerable<Object> declaredAttributes)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public override Assembly MapAssembly(Assembly assembly)
+        {
+            throw new PlatformNotSupportedException();
+        }
+
+        public override TypeInfo MapType(TypeInfo type)
+        {
+            throw new PlatformNotSupportedException();
+        }
+    }
+}

--- a/src/System.Reflection.Context/src/project.json
+++ b/src/System.Reflection.Context/src/project.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {
+    "System.Reflection.Primitives": "4.0.0",
+    "System.Reflection": "4.0.0",
+    "System.Runtime": "4.0.0"
+  },
+  "frameworks": {
+    "dotnet5.2": {}
+  }
+}


### PR DESCRIPTION
We don't have any tests for this library, primarily because this is just a stub, all of the members throw PlatformNotSupportedException. I did some minor cleanup of the single source file in the second commit.

There is a .NET Framework version of this library, but it shipped in-box, so we don't need to build anything here for the NuGet package (other than the contract assembly which is already here).

@weshaggard 