### PR TITLE
Add unique names for HttpNative and CryptoNative

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Easy.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Easy.cs
@@ -8,37 +8,37 @@ internal static partial class Interop
 {
     internal static partial class Http
     {
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_EasyCreate")]
         public static extern SafeCurlHandle EasyCreate();
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_EasyDestroy")]
         private static extern void EasyDestroy(IntPtr handle);
 
-        [DllImport(Libraries.HttpNative, CharSet = CharSet.Ansi)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_EasySetOptionString", CharSet = CharSet.Ansi)]
         public static extern CURLcode EasySetOptionString(SafeCurlHandle curl, CURLoption option, string value);
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_EasySetOptionLong")]
         public static extern CURLcode EasySetOptionLong(SafeCurlHandle curl, CURLoption option, long value);
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_EasySetOptionPointer")]
         public static extern CURLcode EasySetOptionPointer(SafeCurlHandle curl, CURLoption option, IntPtr value);
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_EasySetOptionPointer")]
         public static extern CURLcode EasySetOptionPointer(SafeCurlHandle curl, CURLoption option, SafeHandle value);
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_EasyGetErrorString")]
         public static extern IntPtr EasyGetErrorString(int code);
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_EasyGetInfoPointer")]
         public static extern CURLcode EasyGetInfoPointer(IntPtr handle, CURLINFO info, out IntPtr value);
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_EasyGetInfoLong")]
         public static extern CURLcode EasyGetInfoLong(SafeCurlHandle handle, CURLINFO info, out long value);
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_EasyPerform")]
         public static extern CURLcode EasyPerform(SafeCurlHandle curl);
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_EasyUnpause")]
         public static extern CURLcode EasyUnpause(SafeCurlHandle easy);
 
         public delegate CurlSeekResult SeekCallback(IntPtr userPointer, long offset, int origin);
@@ -47,14 +47,14 @@ internal static partial class Interop
 
         public delegate CURLcode SslCtxCallback(IntPtr curl, IntPtr sslCtx, IntPtr userPointer);
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_RegisterSeekCallback")]
         public static extern void RegisterSeekCallback(
             SafeCurlHandle curl,
             SeekCallback callback,
             IntPtr userPointer,
             ref SafeCallbackHandle callbackHandle);
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_RegisterReadWriteCallback")]
         public static extern void RegisterReadWriteCallback(
             SafeCurlHandle curl,
             ReadWriteFunction functionType,
@@ -62,14 +62,14 @@ internal static partial class Interop
             IntPtr userPointer,
             ref SafeCallbackHandle callbackHandle);
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_RegisterSslCtxCallback")]
         public static extern CURLcode RegisterSslCtxCallback(
             SafeCurlHandle curl,
             SslCtxCallback callback,
             IntPtr userPointer,
             ref SafeCallbackHandle callbackHandle);
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_FreeCallbackHandle")]
         private static extern void FreeCallbackHandle(IntPtr handle);
 
         // Curl options are of the format <type base> + <n>

--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Initialization.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Initialization.cs
@@ -36,7 +36,7 @@ internal static partial class Interop
             // No-op that exists to provide a hook for other static constructors
         }
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_EnsureCurlIsInitialized")]
         private static extern int EnsureCurlIsInitialized();
     }
 }

--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Multi.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Multi.cs
@@ -9,39 +9,39 @@ internal static partial class Interop
 {
     internal static partial class Http
     {
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_MultiCreate")]
         public static extern SafeCurlMultiHandle MultiCreate();
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_MultiDestroy")]
         private static extern CURLMcode MultiDestroy(IntPtr handle);
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_MultiAddHandle")]
         public static extern CURLMcode MultiAddHandle(SafeCurlMultiHandle multiHandle, SafeCurlHandle easyHandle);
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_MultiRemoveHandle")]
         public static extern CURLMcode MultiRemoveHandle(SafeCurlMultiHandle multiHandle, SafeCurlHandle easyHandle);
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_MultiWait")]
         public static extern CURLMcode MultiWait(
             SafeCurlMultiHandle multiHandle,
             SafeFileHandle extraFileDescriptor,
             out bool isExtraFileDescriptorActive,
             out bool isTimeout);
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_MultiPerform")]
         public static extern CURLMcode MultiPerform(SafeCurlMultiHandle multiHandle);
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_MultiInfoRead")]
         public static extern bool MultiInfoRead(
             SafeCurlMultiHandle multiHandle,
             out CURLMSG message,
             out IntPtr easyHandle,
             out CURLcode result);
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_MultiGetErrorString")]
         public static extern IntPtr MultiGetErrorString(int code);
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_MultiSetOptionLong")]
         public static extern CURLMcode MultiSetOptionLong(SafeCurlMultiHandle curl, CURLMoption option, long value);
 
         // Enum for constants defined for the enum CURLMcode in multi.h

--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.SList.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.SList.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Http
     {
-        [DllImport(Libraries.HttpNative, CharSet = CharSet.Ansi)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_SListAppend", CharSet = CharSet.Ansi)]
         private static extern IntPtr SListAppend(IntPtr slist, string headerValue);
 
         internal static bool SListAppend(SafeCurlSListHandle slist, string headerValue)
@@ -32,7 +32,7 @@ internal static partial class Interop
             }
         }
 
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_SListFreeAll")]
         private static extern void SListFreeAll(IntPtr slist);
 
         internal sealed class SafeCurlSListHandle : SafeHandle

--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.VersionInfo.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.VersionInfo.cs
@@ -7,7 +7,7 @@ internal static partial class Interop
 {
     internal static partial class Http
     {
-        [DllImport(Libraries.HttpNative)]
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_GetCurlVersionInfo")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool GetCurlVersionInfo(
             out int age,

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.GetIntegerBytes.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.GetIntegerBytes.cs
@@ -13,10 +13,10 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetAsn1IntegerDerSize")]
         private static extern int GetAsn1IntegerDerSize(SafeSharedAsn1IntegerHandle i);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EncodeAsn1Integer")]
         private static extern int EncodeAsn1Integer(SafeSharedAsn1IntegerHandle i, byte[] buf);
 
         internal static byte[] GetAsn1IntegerBytes(SafeSharedAsn1IntegerHandle asn1Integer)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.Print.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.Print.cs
@@ -10,13 +10,13 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodeAsn1TypeBytes")]
         private static extern SafeAsn1StringHandle DecodeAsn1TypeBytes(byte[] buf, int len, Asn1StringTypeFlags flags);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Asn1StringPrintEx")]
         private static extern int Asn1StringPrintEx(SafeBioHandle bio, SafeAsn1StringHandle str, Asn1StringPrintFlags flags);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Asn1StringPrintEx")]
         private static extern int Asn1StringPrintEx(SafeBioHandle bio, SafeSharedAsn1StringHandle str, Asn1StringPrintFlags flags);
 
         internal static string DerStringToManagedString(byte[] derString)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ASN1.cs
@@ -20,45 +20,45 @@ internal static partial class Interop
         internal const int NID_secp384r1 = 715; // NIST P-384
         internal const int NID_secp521r1 = 716; // NIST P-521
 
-        [DllImport(Libraries.CryptoNative, CharSet = CharSet.Ansi)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ObjTxt2Obj", CharSet = CharSet.Ansi)]
         internal static extern SafeAsn1ObjectHandle ObjTxt2Obj(string s);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ObjObj2Txt")]
         private static unsafe extern int ObjObj2Txt(byte* buf, int buf_len, IntPtr a);
 
-        [DllImport(Libraries.CryptoNative, CharSet = CharSet.Ansi)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetObjectDefinitionByName", CharSet = CharSet.Ansi)]
         internal static extern IntPtr GetObjectDefinitionByName(string friendlyName);
 
-        [DllImport(Libraries.CryptoNative, CharSet = CharSet.Ansi)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ObjSn2Nid", CharSet = CharSet.Ansi)]
         internal static extern int ObjSn2Nid(string sn);
 
         // Returns shared pointers, should not be tracked as a SafeHandle.
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ObjNid2Obj")]
         internal static extern IntPtr ObjNid2Obj(int nid);
         
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Asn1ObjectFree")]
         internal static extern void Asn1ObjectFree(IntPtr o);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodeAsn1BitString")]
         internal static extern SafeAsn1BitStringHandle DecodeAsn1BitString(byte[] buf, int len);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Asn1BitStringFree")]
         internal static extern void Asn1BitStringFree(IntPtr o);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodeAsn1OctetString")]
         internal static extern SafeAsn1OctetStringHandle DecodeAsn1OctetString(byte[] buf, int len);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Asn1OctetStringNew")]
         internal static extern SafeAsn1OctetStringHandle Asn1OctetStringNew();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Asn1OctetStringSet")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool Asn1OctetStringSet(SafeAsn1OctetStringHandle o, byte[] d, int len);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Asn1OctetStringFree")]
         internal static extern void Asn1OctetStringFree(IntPtr o);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Asn1StringFree")]
         internal static extern void Asn1StringFree(IntPtr o);
 
         internal static string GetOidValue(SafeSharedAsn1ObjectHandle asn1Object)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.BIO.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.BIO.cs
@@ -10,29 +10,29 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_CreateMemoryBio")]
         internal static extern SafeBioHandle CreateMemoryBio();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_BioNewFile")]
         internal static extern SafeBioHandle BioNewFile(string filename, string mode);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_BioDestroy")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool BioDestroy(IntPtr a);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_BioGets")]
         internal static extern int BioGets(SafeBioHandle b, byte[] buf, int size);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_BioRead")]
         internal static extern int BioRead(SafeBioHandle b, byte[] data, int len);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_BioWrite")]
         internal static extern int BioWrite(SafeBioHandle b, byte[] data, int len);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetMemoryBioSize")]
         internal static extern int GetMemoryBioSize(SafeBioHandle bio);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_BioCtrlPending")]
         internal static extern int BioCtrlPending(SafeBioHandle bio);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Bignum.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Bignum.cs
@@ -9,16 +9,16 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_BigNumDestroy")]
         internal static extern void BigNumDestroy(IntPtr a);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_BigNumFromBinary")]
         private static extern IntPtr BigNumFromBinary(byte[] s, int len);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_BigNumToBinary")]
         private static extern unsafe int BigNumToBinary(SafeBignumHandle a, byte* to);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetBigNumBytes")]
         private static extern int GetBigNumBytes(SafeBignumHandle a);
 
         private static IntPtr CreateBignumPtr(byte[] bigEndianValue)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
@@ -14,58 +14,58 @@ internal static partial class Interop
     {
         private delegate int NegativeSizeReadMethod<in THandle>(THandle handle, byte[] buf, int cBuf);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_BioTell")]
         internal static extern int BioTell(SafeBioHandle bio);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_BioSeek")]
         internal static extern int BioSeek(SafeBioHandle bio, int pos);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509Thumbprint")]
         private static extern int GetX509Thumbprint(SafeX509Handle x509, byte[] buf, int cBuf);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509NameRawBytes")]
         private static extern int GetX509NameRawBytes(IntPtr x509Name, byte[] buf, int cBuf);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ReadX509AsDerFromBio")]
         internal static extern SafeX509Handle ReadX509AsDerFromBio(SafeBioHandle bio);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509NotBefore")]
         internal static extern IntPtr GetX509NotBefore(SafeX509Handle x509);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509NotAfter")]
         internal static extern IntPtr GetX509NotAfter(SafeX509Handle x509);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509CrlNextUpdate")]
         internal static extern IntPtr GetX509CrlNextUpdate(SafeX509CrlHandle crl);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509Version")]
         internal static extern int GetX509Version(SafeX509Handle x509);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509SignatureAlgorithm")]
         internal static extern IntPtr GetX509SignatureAlgorithm(SafeX509Handle x509);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509PublicKeyAlgorithm")]
         internal static extern IntPtr GetX509PublicKeyAlgorithm(SafeX509Handle x509);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509PublicKeyParameterBytes")]
         private static extern int GetX509PublicKeyParameterBytes(SafeX509Handle x509, byte[] buf, int cBuf);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509PublicKeyBytes")]
         internal static extern IntPtr GetX509PublicKeyBytes(SafeX509Handle x509);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509EkuFieldCount")]
         internal static extern int GetX509EkuFieldCount(SafeEkuExtensionHandle eku);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509EkuField")]
         internal static extern IntPtr GetX509EkuField(SafeEkuExtensionHandle eku, int loc);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509NameInfo")]
         internal static extern SafeBioHandle GetX509NameInfo(SafeX509Handle x509, int nameType, [MarshalAs(UnmanagedType.Bool)] bool forIssuer);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetAsn1StringBytes")]
         private static extern int GetAsn1StringBytes(IntPtr asn1, byte[] buf, int cBuf);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_PushX509StackField")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool PushX509StackField(SafeX509StackHandle stack, SafeX509Handle x509);
 
@@ -74,10 +74,10 @@ internal static partial class Interop
             return Marshal.PtrToStringAnsi(GetX509RootStorePath_private());
         }
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "GetX509RootStorePath")]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509RootStorePath")]
         private static extern IntPtr GetX509RootStorePath_private();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SetX509ChainVerifyTime")]
         private static extern int SetX509ChainVerifyTime(
             SafeX509StoreCtxHandle ctx,
             int year,
@@ -88,10 +88,10 @@ internal static partial class Interop
             int second,
             [MarshalAs(UnmanagedType.Bool)] bool isDst);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_CheckX509IpAddress")]
         internal static extern int CheckX509IpAddress(SafeX509Handle x509, [In]byte[] addressBytes, int addressLen, string hostname, int cchHostname);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_CheckX509Hostname")]
         internal static extern int CheckX509Hostname(SafeX509Handle x509, string hostname, int cchHostname);
 
         internal static byte[] GetAsn1StringBytes(IntPtr asn1)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ERR.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ERR.cs
@@ -11,16 +11,16 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrGetError")]
         internal static extern ulong ErrGetError();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrGetErrorAlloc")]
         private static extern ulong ErrGetErrorAlloc([MarshalAs(UnmanagedType.Bool)] out bool isAllocFailure);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrReasonErrorString")]
         internal static extern IntPtr ErrReasonErrorString(ulong error);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrErrorStringN")]
         private static unsafe extern void ErrErrorStringN(ulong e, byte* buf, int len);
 
         private static unsafe string ErrErrorStringN(ulong error)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.Cipher.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.Cipher.cs
@@ -9,25 +9,25 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherCreate")]
         internal static extern SafeEvpCipherCtxHandle EvpCipherCreate(
             IntPtr cipher,
             byte[] key,
             byte[] iv,
             int enc);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherDestroy")]
         internal static extern void EvpCipherDestroy(IntPtr ctx);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherReset")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvpCipherReset(SafeEvpCipherCtxHandle ctx);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherCtxSetPadding")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvpCipherCtxSetPadding(SafeEvpCipherCtxHandle x, int padding);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherUpdate")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static unsafe extern bool EvpCipherUpdate(
             SafeEvpCipherCtxHandle ctx,
@@ -36,35 +36,35 @@ internal static partial class Interop
             byte* @in,
             int inl);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpCipherFinalEx")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern unsafe bool EvpCipherFinalEx(
             SafeEvpCipherCtxHandle ctx,
             byte* outm,
             out int outl);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpAes128Ecb")]
         internal static extern IntPtr EvpAes128Ecb();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpAes128Cbc")]
         internal static extern IntPtr EvpAes128Cbc();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpAes192Ecb")]
         internal static extern IntPtr EvpAes192Ecb();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpAes192Cbc")]
         internal static extern IntPtr EvpAes192Cbc();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpAes256Ecb")]
         internal static extern IntPtr EvpAes256Ecb();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpAes256Cbc")]
         internal static extern IntPtr EvpAes256Cbc();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDes3Ecb")]
         internal static extern IntPtr EvpDes3Ecb();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDes3Cbc")]
         internal static extern IntPtr EvpDes3Cbc();
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EVP.cs
@@ -9,42 +9,42 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpMdCtxCreate")]
         internal extern static SafeEvpMdCtxHandle EvpMdCtxCreate(IntPtr type);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpMdCtxDestroy")]
         internal extern static void EvpMdCtxDestroy(IntPtr ctx);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestReset")]
         internal extern static int EvpDigestReset(SafeEvpMdCtxHandle ctx, IntPtr type);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestUpdate")]
         internal extern static unsafe int EvpDigestUpdate(SafeEvpMdCtxHandle ctx, byte* d, int cnt);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpDigestFinalEx")]
         internal extern static unsafe int EvpDigestFinalEx(SafeEvpMdCtxHandle ctx, byte* md, ref uint s);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpMdSize")]
         internal extern static int EvpMdSize(IntPtr md);
 
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpMd5")]
         internal extern static IntPtr EvpMd5();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpSha1")]
         internal extern static IntPtr EvpSha1();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpSha256")]
         internal extern static IntPtr EvpSha256();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpSha384")]
         internal extern static IntPtr EvpSha384();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpSha512")]
         internal extern static IntPtr EvpSha512();
 
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetMaxMdSize")]
         private extern static int GetMaxMdSize();
 
         internal static readonly int EVP_MAX_MD_SIZE = GetMaxMdSize();

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcDsa.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcDsaSign")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EcDsaSign([In] byte[] dgst, int dlen, [Out] byte[] sig, [In, Out] ref int siglen, SafeEcKeyHandle ecKey);
 
@@ -18,11 +18,11 @@ internal static partial class Interop
          *      0: incorrect signature
          *     -1: error
          */
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcDsaVerify")]
         internal static extern int EcDsaVerify([In] byte[] dgst, int dgst_len, [In] byte[] sigbuf, int sig_len, SafeEcKeyHandle ecKey);
 
         // returns the maximum length of a DER encoded ECDSA signature created with this key.
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcDsaSize")]
         internal static extern int EcDsaSize(SafeEcKeyHandle ecKey);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcKey.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EcKey.cs
@@ -10,21 +10,21 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyDestroy")]
         internal static extern void EcKeyDestroy(IntPtr a);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyCreateByCurveName")]
         internal static extern SafeEcKeyHandle EcKeyCreateByCurveName(int nid);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyGenerateKey")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EcKeyGenerateKey(SafeEcKeyHandle eckey);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyUpRef")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EcKeyUpRef(IntPtr r);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyGetCurveName")]
         internal static extern int EcKeyGetCurveName(SafeEcKeyHandle ecKey);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.EcKey.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.EcKey.cs
@@ -9,10 +9,10 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPkeyGetEcKey")]
         internal static extern SafeEcKeyHandle EvpPkeyGetEcKey(SafeEvpPKeyHandle pkey);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPkeySetEcKey")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvpPkeySetEcKey(SafeEvpPKeyHandle pkey, SafeEcKeyHandle key);
     }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.Rsa.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.Rsa.cs
@@ -9,10 +9,10 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPkeyGetRsa")]
         internal static extern SafeRsaHandle EvpPkeyGetRsa(SafeEvpPKeyHandle pkey);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPkeySetRsa")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool EvpPkeySetRsa(SafeEvpPKeyHandle pkey, SafeRsaHandle rsa);
     }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.EvpPkey.cs
@@ -9,13 +9,13 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPkeyCreate")]
         internal static extern SafeEvpPKeyHandle EvpPkeyCreate();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EvpPkeyDestroy")]
         internal static extern void EvpPkeyDestroy(IntPtr pkey);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_UpRefEvpPkey")]
         internal static extern int UpRefEvpPkey(SafeEvpPKeyHandle handle);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Hmac.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Hmac.cs
@@ -9,19 +9,19 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacCreate")]
         internal extern static unsafe SafeHmacCtxHandle HmacCreate(byte* key, int keyLen, IntPtr md);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacDestroy")]
         internal extern static void HmacDestroy(IntPtr ctx);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacReset")]
         internal extern static int HmacReset(SafeHmacCtxHandle ctx);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacUpdate")]
         internal extern static unsafe int HmacUpdate(SafeHmacCtxHandle ctx, byte* data, int len);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_HmacFinal")]
         internal extern static unsafe int HmacFinal(SafeHmacCtxHandle ctx, byte* data, ref int len);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Initialization.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Initialization.cs
@@ -40,7 +40,7 @@ internal static partial class Interop
             // No-op that exists to provide a hook for other static constructors.
         }
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EnsureOpenSslInitialized")]
         private static extern int EnsureOpenSslInitialized();
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.LookupFriendlyNameByOid.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.LookupFriendlyNameByOid.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_LookupFriendlyNameByOid")]
         internal static extern int LookupFriendlyNameByOid(string oidValue, ref IntPtr friendlyNamePtr);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Pkcs12.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Pkcs12.cs
@@ -10,29 +10,29 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodePkcs12")]
         internal static unsafe extern SafePkcs12Handle DecodePkcs12(byte[] buf, int len);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodePkcs12FromBio")]
         internal static extern SafePkcs12Handle DecodePkcs12FromBio(SafeBioHandle bio);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Pkcs12Destroy")]
         internal static extern void Pkcs12Destroy(IntPtr p12);
 
-        [DllImport(Libraries.CryptoNative, CharSet = CharSet.Ansi)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Pkcs12Create", CharSet = CharSet.Ansi)]
         internal static extern SafePkcs12Handle Pkcs12Create(
             string pass,
             SafeEvpPKeyHandle pkey,
             SafeX509Handle cert,
             SafeX509StackHandle ca);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetPkcs12DerSize")]
         internal static extern int GetPkcs12DerSize(SafePkcs12Handle p12);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EncodePkcs12")]
         internal static extern int EncodePkcs12(SafePkcs12Handle p12, byte[] buf);
 
-        [DllImport(Libraries.CryptoNative, CharSet = CharSet.Ansi)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Pkcs12Parse", CharSet = CharSet.Ansi)]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool Pkcs12Parse(
             SafePkcs12Handle p12,

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Pkcs7.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Pkcs7.cs
@@ -9,31 +9,31 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_PemReadBioPkcs7")]
         internal static extern SafePkcs7Handle PemReadBioPkcs7(SafeBioHandle bp);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodePkcs7")]
         internal static extern SafePkcs7Handle DecodePkcs7(byte[] buf, int len);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_D2IPkcs7Bio")]
         internal static extern SafePkcs7Handle D2IPkcs7Bio(SafeBioHandle bp);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Pkcs7CreateSigned")]
         internal static extern SafePkcs7Handle Pkcs7CreateSigned();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Pkcs7Destroy")]
         internal static extern void Pkcs7Destroy(IntPtr p7);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetPkcs7Certificates")]
         private static extern int GetPkcs7Certificates(SafePkcs7Handle p7, out SafeSharedX509StackHandle certs);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_Pkcs7AddCertificate")]
         internal static extern bool Pkcs7AddCertificate(SafePkcs7Handle p7, IntPtr x509);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetPkcs7DerSize")]
         internal static extern int GetPkcs7DerSize(SafePkcs7Handle p7);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EncodePkcs7")]
         internal static extern int EncodePkcs7(SafePkcs7Handle p7, byte[] buf);
 
         internal static SafeSharedX509StackHandle GetPkcs7Certificates(SafePkcs7Handle p7)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.RAND.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.RAND.cs
@@ -7,7 +7,7 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetRandomBytes")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool GetRandomBytes(byte[] buf, int num);
     }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Rsa.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Rsa.cs
@@ -11,20 +11,20 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaCreate")]
         internal static extern SafeRsaHandle RsaCreate();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaUpRef")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool RsaUpRef(IntPtr rsa);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaDestroy")]
         internal static extern void RsaDestroy(IntPtr rsa);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodeRsaPublicKey")]
         internal static extern SafeRsaHandle DecodeRsaPublicKey(byte[] buf, int len);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaPublicEncrypt")]
         internal extern static int RsaPublicEncrypt(
             int flen,
             byte[] from,
@@ -32,7 +32,7 @@ internal static partial class Interop
             SafeRsaHandle rsa,
             RsaPadding padding);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaPrivateDecrypt")]
         internal extern static int RsaPrivateDecrypt(
             int flen,
             byte[] from,
@@ -40,17 +40,17 @@ internal static partial class Interop
             SafeRsaHandle rsa,
             RsaPadding padding);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaSize")]
         internal static extern int RsaSize(SafeRsaHandle rsa);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaGenerateKeyEx")]
         internal static extern int RsaGenerateKeyEx(SafeRsaHandle rsa, int bits, SafeBignumHandle e);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaSign")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool RsaSign(int type, byte[] m, int m_len, byte[] sigret, out int siglen, SafeRsaHandle rsa);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RsaVerify")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool RsaVerify(int type, byte[] m, int m_len, byte[] sigbuf, int siglen, SafeRsaHandle rsa);
 
@@ -96,7 +96,7 @@ internal static partial class Interop
             return rsaParameters;
         }
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetRsaParameters")]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool GetRsaParameters(
             SafeRsaHandle key,
@@ -109,7 +109,7 @@ internal static partial class Interop
             out IntPtr dmq1,
             out IntPtr iqmp);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SetRsaParameters")]
         internal static extern void SetRsaParameters(
             SafeRsaHandle key,
             byte[] n,

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Ssl.cs
@@ -17,43 +17,43 @@ internal static partial class Interop
     {
         internal delegate int SslCtxSetVerifyCallback(int preverify_ok, IntPtr x509_ctx);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EnsureLibSslInitialized")]
         internal static extern void EnsureLibSslInitialized();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslV2_3Method")]
         internal static extern IntPtr SslV2_3Method();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslV3Method")]
         internal static extern IntPtr SslV3Method();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_TlsV1Method")]
         internal static extern IntPtr TlsV1Method();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_TlsV1_1Method")]
         internal static extern IntPtr TlsV1_1Method();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_TlsV1_2Method")]
         internal static extern IntPtr TlsV1_2Method();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCreate")]
         internal static extern SafeSslHandle SslCreate(SafeSslContextHandle ctx);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetError")]
         internal static extern SslErrorCode SslGetError(SafeSslHandle ssl, int ret);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetError")]
         internal static extern SslErrorCode SslGetError(IntPtr ssl, int ret);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslDestroy")]
         internal static extern void SslDestroy(IntPtr ssl);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSetConnectState")]
         internal static extern void SslSetConnectState(SafeSslHandle ssl);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSetAcceptState")]
         internal static extern void SslSetAcceptState(SafeSslHandle ssl);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetVersion")]
         private static extern IntPtr SslGetVersion(SafeSslHandle ssl);
 
         internal static string GetProtocolVersion(SafeSslHandle ssl)
@@ -61,7 +61,7 @@ internal static partial class Interop
             return Marshal.PtrToStringAnsi(SslGetVersion(ssl));
         }
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetSslConnectionInfo")]
         internal static extern bool GetSslConnectionInfo(
             SafeSslHandle ssl,
             out int dataCipherAlg,
@@ -70,55 +70,55 @@ internal static partial class Interop
             out int dataKeySize,
             out int hashKeySize);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslWrite")]
         internal static unsafe extern int SslWrite(SafeSslHandle ssl, byte* buf, int num);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslRead")]
         internal static extern int SslRead(SafeSslHandle ssl, byte[] buf, int num);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_IsSslRenegotiatePending")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool IsSslRenegotiatePending(SafeSslHandle ssl);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslShutdown")]
         internal static extern int SslShutdown(IntPtr ssl);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSetBio")]
         internal static extern void SslSetBio(SafeSslHandle ssl, SafeBioHandle rbio, SafeBioHandle wbio);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslDoHandshake")]
         internal static extern int SslDoHandshake(SafeSslHandle ssl);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_IsSslStateOK")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool IsSslStateOK(SafeSslHandle ssl);
 
         // NOTE: this is just an (unsafe) overload to the BioWrite method from Interop.Bio.cs.
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_BioWrite")]
         internal static unsafe extern int BioWrite(SafeBioHandle b, byte* data, int len);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetPeerCertificate")]
         internal static extern SafeX509Handle SslGetPeerCertificate(SafeSslHandle ssl);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetPeerCertChain")]
         internal static extern SafeSharedX509StackHandle SslGetPeerCertChain(SafeSslHandle ssl);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetStreamSizes")]
         internal static extern void GetStreamSizes(out int header, out int trailer, out int maximumMessage);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetPeerFinished")]
         internal static extern int SslGetPeerFinished(SafeSslHandle ssl, IntPtr buf, int count);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetFinished")]
         internal static extern int SslGetFinished(SafeSslHandle ssl, IntPtr buf, int count);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslSessionReused")]
         internal static extern bool SslSessionReused(SafeSslHandle ssl);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslAddExtraChainCert")]
         internal static extern bool SslAddExtraChainCert(SafeSslHandle ssl, SafeX509Handle x509);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "SslGetClientCAList")]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslGetClientCAList")]
         private static extern SafeSharedX509NameStackHandle SslGetClientCAList_private(SafeSslHandle ssl);
 
         internal static SafeSharedX509NameStackHandle SslGetClientCAList(SafeSslHandle ssl)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtx.cs
@@ -12,16 +12,16 @@ internal static partial class Interop
         internal delegate int AppVerifyCallback(IntPtr storeCtx, IntPtr arg);
         internal delegate int ClientCertCallback(IntPtr ssl, out IntPtr x509, out IntPtr pkey);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxCreate")]
         internal static extern SafeSslContextHandle SslCtxCreate(IntPtr method);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxDestroy")]
         internal static extern void SslCtxDestroy(IntPtr ctx);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetCertVerifyCallback")]
         internal static extern void SslCtxSetCertVerifyCallback(SafeSslContextHandle ctx, AppVerifyCallback cb, IntPtr arg);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetClientCertCallback")]
         internal static extern void SslCtxSetClientCertCallback(SafeSslContextHandle ctx, ClientCertCallback callback);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtxOptions.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.SslCtxOptions.cs
@@ -14,28 +14,28 @@ internal static partial class Interop
 {
     internal static partial class Ssl
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SetProtocolOptions")]
         internal static extern void SetProtocolOptions(SafeSslContextHandle ctx, SslProtocols protocols);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxUseCertificate")]
         internal static extern int SslCtxUseCertificate(SafeSslContextHandle ctx, SafeX509Handle certPtr);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxUsePrivateKey")]
         internal static extern int SslCtxUsePrivateKey(SafeSslContextHandle ctx, SafeEvpPKeyHandle keyPtr);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxCheckPrivateKey")]
         internal static extern int SslCtxCheckPrivateKey(SafeSslContextHandle ctx);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetQuietShutdown")]
         internal static extern void SslCtxSetQuietShutdown(SafeSslContextHandle ctx);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetVerify")]
         internal static extern void SslCtxSetVerify(SafeSslContextHandle ctx, SslCtxSetVerifyCallback callback);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SetEncryptionPolicy")]
         internal static extern void SetEncryptionPolicy(SafeSslContextHandle ctx, EncryptionPolicy policy);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SslCtxSetClientCAList")]
         internal static extern void SslCtxSetClientCAList(SafeSslContextHandle ctx, SafeX509NameStackHandle x509NameStackPtr);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509.cs
@@ -13,34 +13,34 @@ internal static partial class Interop
     {
         internal delegate int X509StoreVerifyCallback(int ok, IntPtr ctx);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509EvpPublicKey")]
         internal static extern SafeEvpPKeyHandle GetX509EvpPublicKey(SafeX509Handle x509);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodeX509Crl")]
         internal static extern SafeX509CrlHandle DecodeX509Crl(byte[] buf, int len);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodeX509")]
         internal static extern SafeX509Handle DecodeX509(byte[] buf, int len);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509DerSize")]
         internal static extern int GetX509DerSize(SafeX509Handle x);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EncodeX509")]
         internal static extern int EncodeX509(SafeX509Handle x, byte[] buf);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509Destroy")]
         internal static extern void X509Destroy(IntPtr a);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509Duplicate")]
         internal static extern SafeX509Handle X509Duplicate(IntPtr handle);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509Duplicate")]
         internal static extern SafeX509Handle X509Duplicate(SafeX509Handle handle);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_PemReadX509FromBio")]
         internal static extern SafeX509Handle PemReadX509FromBio(SafeBioHandle bio);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "X509GetSerialNumber")]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509GetSerialNumber")]
         private static extern SafeSharedAsn1IntegerHandle X509GetSerialNumber_private(SafeX509Handle x);
 
         internal static SafeSharedAsn1IntegerHandle X509GetSerialNumber(SafeX509Handle x)
@@ -52,74 +52,74 @@ internal static partial class Interop
                 x);
         }
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509GetIssuerName")]
         internal static extern IntPtr X509GetIssuerName(SafeX509Handle x);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509GetSubjectName")]
         internal static extern IntPtr X509GetSubjectName(SafeX509Handle x);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509CheckPurpose")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool X509CheckPurpose(SafeX509Handle x, int id, int ca);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509CheckIssued")]
         internal static extern int X509CheckIssued(SafeX509Handle issuer, SafeX509Handle subject);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509IssuerNameHash")]
         internal static extern ulong X509IssuerNameHash(SafeX509Handle x);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509GetExtCount")]
         internal static extern int X509GetExtCount(SafeX509Handle x);
 
         // Returns a pointer already being tracked by the SafeX509Handle, shouldn't be SafeHandle tracked/freed.
         // Bounds checking is in place for "loc", IntPtr.Zero is returned on violations.
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509GetExt")]
         internal static extern IntPtr X509GetExt(SafeX509Handle x, int loc);
 
         // Returns a pointer already being tracked by a SafeX509Handle, shouldn't be SafeHandle tracked/freed.
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509ExtensionGetOid")]
         internal static extern IntPtr X509ExtensionGetOid(IntPtr ex);
 
         // Returns a pointer already being tracked by a SafeX509Handle, shouldn't be SafeHandle tracked/freed.
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509ExtensionGetData")]
         internal static extern IntPtr X509ExtensionGetData(IntPtr ex);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509ExtensionGetCritical")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool X509ExtensionGetCritical(IntPtr ex);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCreate")]
         internal static extern SafeX509StoreHandle X509StoreCreate();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreDestory")]
         internal static extern void X509StoreDestory(IntPtr v);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreAddCert")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool X509StoreAddCert(SafeX509StoreHandle ctx, SafeX509Handle x);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreAddCrl")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool X509StoreAddCrl(SafeX509StoreHandle ctx, SafeX509CrlHandle x);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreSetRevocationFlag")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool X509StoreSetRevocationFlag(SafeX509StoreHandle ctx, X509RevocationFlag revocationFlag);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxInit")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool X509StoreCtxInit(SafeX509StoreCtxHandle ctx, SafeX509StoreHandle store, SafeX509Handle x509);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509VerifyCert")]
         internal static extern int X509VerifyCert(SafeX509StoreCtxHandle ctx);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxGetError")]
         internal static extern X509VerifyStatusCode X509StoreCtxGetError(SafeX509StoreCtxHandle ctx);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxGetErrorDepth")]
         internal static extern int X509StoreCtxGetErrorDepth(SafeX509StoreCtxHandle ctx);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxSetVerifyCallback")]
         internal static extern void X509StoreCtxSetVerifyCallback(SafeX509StoreCtxHandle ctx, X509StoreVerifyCallback callback);
 
         internal static string GetX509VerifyCertErrorString(X509VerifyStatusCode n)
@@ -127,22 +127,22 @@ internal static partial class Interop
             return Marshal.PtrToStringAnsi(X509VerifyCertErrorString(n));
         }
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509VerifyCertErrorString")]
         private static extern IntPtr X509VerifyCertErrorString(X509VerifyStatusCode n);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509CrlDestroy")]
         internal static extern void X509CrlDestroy(IntPtr a);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_PemWriteBioX509Crl")]
         internal static extern int PemWriteBioX509Crl(SafeBioHandle bio, SafeX509CrlHandle crl);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_PemReadBioX509Crl")]
         internal static extern SafeX509CrlHandle PemReadBioX509Crl(SafeBioHandle bio);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509SubjectPublicKeyInfoDerSize")]
         internal static extern int GetX509SubjectPublicKeyInfoDerSize(SafeX509Handle x509);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EncodeX509SubjectPublicKeyInfo")]
         internal static extern int EncodeX509SubjectPublicKeyInfo(SafeX509Handle x509, byte[] buf);
 
         internal enum X509VerifyStatusCode : int

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Ext.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Ext.cs
@@ -9,20 +9,20 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509ExtensionCreateByObj")]
         internal static extern SafeX509ExtensionHandle X509ExtensionCreateByObj(
             SafeAsn1ObjectHandle oid,
             [MarshalAs(UnmanagedType.Bool)] bool isCritical,
             SafeAsn1OctetStringHandle data);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509ExtensionDestroy")]
         internal static extern int X509ExtensionDestroy(IntPtr x);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509V3ExtPrint")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool X509V3ExtPrint(SafeBioHandle buf, SafeX509ExtensionHandle ext);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodeX509BasicConstraints2Extension")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool DecodeX509BasicConstraints2Extension(
             byte[] encoded,
@@ -31,10 +31,10 @@ internal static partial class Interop
             [MarshalAs(UnmanagedType.Bool)] out bool hasPathLengthConstraint,
             out int pathLengthConstraint);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodeExtendedKeyUsage")]
         internal static extern SafeEkuExtensionHandle DecodeExtendedKeyUsage(byte[] buf, int len);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ExtendedKeyUsageDestory")]
         internal static extern void ExtendedKeyUsageDestory(IntPtr a);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Name.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Name.cs
@@ -11,36 +11,36 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509NameStackFieldCount")]
         internal static extern int GetX509NameStackFieldCount(SafeSharedX509NameStackHandle sk);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_PushX509NameStackField")]
         [return: MarshalAs(UnmanagedType.Bool)]
         internal static extern bool PushX509NameStackField(SafeX509NameStackHandle stack, SafeX509NameHandle x509_Name);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RecursiveFreeX509NameStack")]
         internal static extern void RecursiveFreeX509NameStack(IntPtr stack);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_NewX509NameStack")]
         internal static extern SafeX509NameStackHandle NewX509NameStack();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DuplicateX509Name")]
         internal static extern SafeX509NameHandle DuplicateX509Name(IntPtr x509Name);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "GetX509NameStackField")]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509NameStackField")]
         private static extern SafeSharedX509NameHandle GetX509NameStackField_private(SafeSharedX509NameStackHandle sk,
             int loc);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509NameRawBytes")]
         private static extern int GetX509NameRawBytes(SafeSharedX509NameHandle x509Name, byte[] buf, int cBuf);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_DecodeX509Name")]
         internal static extern SafeX509NameHandle DecodeX509Name(byte[] buf, int len);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509NameDestroy")]
         internal static extern void X509NameDestroy(IntPtr a);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509NameEntryCount")]
         internal static extern int GetX509NameEntryCount(SafeX509NameHandle x509Name);
 
         internal static X500DistinguishedName LoadX500Name(SafeSharedX509NameHandle namePtr)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509NameEntry.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509NameEntry.cs
@@ -9,13 +9,13 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative, EntryPoint = "GetX509NameEntry")]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509NameEntry")]
         private static extern SafeSharedX509NameEntryHandle GetX509NameEntry_private(SafeX509NameHandle x509Name, int loc);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "GetX509NameEntryOid")]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509NameEntryOid")]
         private static extern SafeSharedAsn1ObjectHandle GetX509NameEntryOid_private(SafeSharedX509NameEntryHandle nameEntry);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "GetX509NameEntryData")]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509NameEntryData")]
         private static extern SafeSharedAsn1StringHandle GetX509NameEntryData_private(SafeSharedX509NameEntryHandle nameEntry);
 
         internal static SafeSharedX509NameEntryHandle GetX509NameEntry(SafeX509NameHandle x509Name, int loc)

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Stack.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509Stack.cs
@@ -9,30 +9,30 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_NewX509Stack")]
         internal static extern SafeX509StackHandle NewX509Stack();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_RecursiveFreeX509Stack")]
         internal static extern void RecursiveFreeX509Stack(IntPtr stack);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509StackFieldCount")]
         internal static extern int GetX509StackFieldCount(SafeX509StackHandle stack);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509StackFieldCount")]
         internal static extern int GetX509StackFieldCount(SafeSharedX509StackHandle stack);
 
         /// <summary>
         /// Gets a pointer to a certificate within a STACK_OF(X509). This pointer will later
         /// be freed, so it should be cloned via new X509Certificate2(IntPtr)
         /// </summary>
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509StackField")]
         internal static extern IntPtr GetX509StackField(SafeX509StackHandle stack, int loc);
 
         /// <summary>
         /// Gets a pointer to a certificate within a STACK_OF(X509). This pointer will later
         /// be freed, so it should be cloned via new X509Certificate2(IntPtr)
         /// </summary>
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509StackField")]
         internal static extern IntPtr GetX509StackField(SafeSharedX509StackHandle stack, int loc);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509StoreCtx.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.X509StoreCtx.cs
@@ -9,19 +9,19 @@ internal static partial class Interop
 {
     internal static partial class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxCreate")]
         internal static extern SafeX509StoreCtxHandle X509StoreCtxCreate();
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxDestroy")]
         internal static extern void X509StoreCtxDestroy(IntPtr v);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxGetChain")]
         internal static extern SafeX509StackHandle X509StoreCtxGetChain(SafeX509StoreCtxHandle ctx);
 
-        [DllImport(Libraries.CryptoNative, EntryPoint = "X509StoreCtxGetSharedUntrusted")]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxGetSharedUntrusted")]
         private static extern SafeSharedX509StackHandle X509StoreCtxGetSharedUntrusted_private(SafeX509StoreCtxHandle ctx);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_X509StoreCtxGetTargetCert")]
         internal static extern IntPtr X509StoreCtxGetTargetCert(SafeX509StoreCtxHandle ctx);
 
         internal static SafeSharedX509StackHandle X509StoreCtxGetSharedUntrusted(SafeX509StoreCtxHandle ctx)

--- a/src/Native/System.Net.Http.Native/pal_curlinit.cpp
+++ b/src/Native/System.Net.Http.Native/pal_curlinit.cpp
@@ -7,7 +7,7 @@
 #include <pthread.h>
 #include <curl/curl.h>
 
-extern "C" int32_t EnsureCurlIsInitialized()
+extern "C" int32_t HttpNative_EnsureCurlIsInitialized()
 {
     static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
     static bool initializationAttempted = false;

--- a/src/Native/System.Net.Http.Native/pal_curlinit.h
+++ b/src/Native/System.Net.Http.Native/pal_curlinit.h
@@ -14,4 +14,4 @@
  *
  * Returns 0 on success and non-zero on failure.
  */
-extern "C" int32_t EnsureCurlIsInitialized();
+extern "C" int32_t HttpNative_EnsureCurlIsInitialized();

--- a/src/Native/System.Net.Http.Native/pal_easy.h
+++ b/src/Native/System.Net.Http.Native/pal_easy.h
@@ -116,7 +116,7 @@ Creates a new CURL instance.
 
 Returns the new CURL instance or nullptr if something went wrong.
 */
-extern "C" CURL* EasyCreate();
+extern "C" CURL* HttpNative_EasyCreate();
 
 /*
 Cleans up and deletes a CURL instance.
@@ -124,51 +124,51 @@ Cleans up and deletes a CURL instance.
 No-op if handle is null.
 The given CURL pointer is invalid after this call.
 */
-extern "C" void EasyDestroy(CURL* handle);
+extern "C" void HttpNative_EasyDestroy(CURL* handle);
 
 /*
 Shims the curl_easy_setopt function, which takes a variable number of
 arguments, but must be a long, a function pointer, an object pointer or a curl_off_t,
 depending on what option is supplied.
 */
-extern "C" int32_t EasySetOptionString(CURL* handle, PAL_CURLoption option, const char* value);
-extern "C" int32_t EasySetOptionLong(CURL* handle, PAL_CURLoption option, int64_t value);
-extern "C" int32_t EasySetOptionPointer(CURL* handle, PAL_CURLoption option, void* value);
+extern "C" int32_t HttpNative_EasySetOptionString(CURL* handle, PAL_CURLoption option, const char* value);
+extern "C" int32_t HttpNative_EasySetOptionLong(CURL* handle, PAL_CURLoption option, int64_t value);
+extern "C" int32_t HttpNative_EasySetOptionPointer(CURL* handle, PAL_CURLoption option, void* value);
 
 /*
 Returns a string describing the CURLcode error code.
 */
-extern "C" const char* EasyGetErrorString(PAL_CURLcode code);
+extern "C" const char* HttpNative_EasyGetErrorString(PAL_CURLcode code);
 
 /*
 Shims the curl_easy_setopt function, which takes a variable number of
 arguments.
 */
-extern "C" int32_t EasyGetInfoPointer(CURL* handle, PAL_CURLINFO info, void** value);
-extern "C" int32_t EasyGetInfoLong(CURL* handle, PAL_CURLINFO info, int64_t* value);
+extern "C" int32_t HttpNative_EasyGetInfoPointer(CURL* handle, PAL_CURLINFO info, void** value);
+extern "C" int32_t HttpNative_EasyGetInfoLong(CURL* handle, PAL_CURLINFO info, int64_t* value);
 
 /*
 Shims the curl_easy_perform function.
 
 Returns CURLE_OK (0) if everything was ok, non-zero means an error occurred.
 */
-extern "C" int32_t EasyPerform(CURL* handle);
+extern "C" int32_t HttpNative_EasyPerform(CURL* handle);
 
 /*
 Unpauses the CURL request.
 
 Returns CURLE_OK (0) if everything was ok, non-zero means an error occurred.
 */
-extern "C" int32_t EasyUnpause(CURL* handle);
+extern "C" int32_t HttpNative_EasyUnpause(CURL* handle);
 
 // the function pointer definition for the callback used in RegisterSeekCallback
-typedef int32_t(*SeekCallback)(void* userPointer, int64_t offset, int32_t origin);
+typedef int32_t (*SeekCallback)(void* userPointer, int64_t offset, int32_t origin);
 
 // the function pointer definition for the callback used in RegisterReadWriteCallback
-typedef uint64_t(*ReadWriteCallback)(uint8_t* buffer, uint64_t bufferSize, uint64_t nitems, void* userPointer);
+typedef uint64_t (*ReadWriteCallback)(uint8_t* buffer, uint64_t bufferSize, uint64_t nitems, void* userPointer);
 
 // the function pointer definition for the callback used in RegisterSslCtxCallback
-typedef int32_t(*SslCtxCallback)(CURL* curl, void* sslCtx, void* userPointer);
+typedef int32_t (*SslCtxCallback)(CURL* curl, void* sslCtx, void* userPointer);
 
 /*
 The object that is returned from RegisterXXXCallback functions.
@@ -182,12 +182,17 @@ Registers a callback in libcurl for seeking in an input stream.
 This function gets called by libcurl to seek to a certain position in the input stream
 and can be used to fast forward a file in a resumed upload.
 */
-extern "C" void RegisterSeekCallback(CURL* curl, SeekCallback callback, void* userPointer, CallbackHandle** callbackHandle);
+extern "C" void
+HttpNative_RegisterSeekCallback(CURL* curl, SeekCallback callback, void* userPointer, CallbackHandle** callbackHandle);
 
 /*
 Registers a callback in libcurl for reading/writing input/output streams.
 */
-extern "C" void RegisterReadWriteCallback(CURL* curl, ReadWriteFunction functionType, ReadWriteCallback callback, void* userPointer, CallbackHandle** callbackHandle);
+extern "C" void HttpNative_RegisterReadWriteCallback(CURL* curl,
+                                                     ReadWriteFunction functionType,
+                                                     ReadWriteCallback callback,
+                                                     void* userPointer,
+                                                     CallbackHandle** callbackHandle);
 
 /*
 Registers a callback in libcurl for initializing SSL connections.
@@ -198,9 +203,12 @@ to modify the behaviour of the SSL initialization.
 
 Returns a CURLcode that describes whether registering the callback was successful or not.
 */
-extern "C" int32_t RegisterSslCtxCallback(CURL* curl, SslCtxCallback callback, void *userPointer, CallbackHandle** callbackHandle);
+extern "C" int32_t HttpNative_RegisterSslCtxCallback(CURL* curl,
+                                                     SslCtxCallback callback,
+                                                     void* userPointer,
+                                                     CallbackHandle** callbackHandle);
 
 /*
 Frees the CallbackHandle created by a RegisterXXXCallback function.
 */
-extern "C" void FreeCallbackHandle(CallbackHandle* callbackHandle);
+extern "C" void HttpNative_FreeCallbackHandle(CallbackHandle* callbackHandle);

--- a/src/Native/System.Net.Http.Native/pal_multi.cpp
+++ b/src/Native/System.Net.Http.Native/pal_multi.cpp
@@ -24,37 +24,35 @@ static_assert(PAL_CURLPIPE_MULTIPLEX == CURLPIPE_MULTIPLEX, "");
 
 static_assert(PAL_CURLMSG_DONE == CURLMSG_DONE, "");
 
-extern "C" CURLM* MultiCreate()
+extern "C" CURLM* HttpNative_MultiCreate()
 {
     return curl_multi_init();
 }
 
-extern "C" int32_t MultiDestroy(CURLM* multiHandle)
+extern "C" int32_t HttpNative_MultiDestroy(CURLM* multiHandle)
 {
     return curl_multi_cleanup(multiHandle);
 }
 
-extern "C" int32_t MultiAddHandle(CURLM* multiHandle, CURL* easyHandle)
+extern "C" int32_t HttpNative_MultiAddHandle(CURLM* multiHandle, CURL* easyHandle)
 {
     return curl_multi_add_handle(multiHandle, easyHandle);
 }
 
-extern "C" int32_t MultiRemoveHandle(CURLM* multiHandle, CURL* easyHandle)
+extern "C" int32_t HttpNative_MultiRemoveHandle(CURLM* multiHandle, CURL* easyHandle)
 {
     return curl_multi_remove_handle(multiHandle, easyHandle);
 }
 
-extern "C" int32_t MultiWait(CURLM* multiHandle, intptr_t extraFileDescriptor, int32_t* isExtraFileDescriptorActive, int32_t* isTimeout)
+extern "C" int32_t HttpNative_MultiWait(CURLM* multiHandle,
+                                        intptr_t extraFileDescriptor,
+                                        int32_t* isExtraFileDescriptorActive,
+                                        int32_t* isTimeout)
 {
     assert(isExtraFileDescriptorActive != nullptr);
     assert(isTimeout != nullptr);
 
-    curl_waitfd extraFds =
-    {
-        .fd = ToFileDescriptor(extraFileDescriptor),
-        .events = CURL_WAIT_POLLIN,
-        .revents = 0
-    };
+    curl_waitfd extraFds = {.fd = ToFileDescriptor(extraFileDescriptor), .events = CURL_WAIT_POLLIN, .revents = 0};
 
     // Even with our cancellation mechanism, we specify a timeout so that
     // just in case something goes wrong we can recover gracefully.  This timeout is relatively long.
@@ -72,13 +70,13 @@ extern "C" int32_t MultiWait(CURLM* multiHandle, intptr_t extraFileDescriptor, i
     return result;
 }
 
-extern "C" int32_t MultiPerform(CURLM* multiHandle)
+extern "C" int32_t HttpNative_MultiPerform(CURLM* multiHandle)
 {
     int running_handles;
     return curl_multi_perform(multiHandle, &running_handles);
 }
 
-extern "C" int32_t MultiInfoRead(CURLM* multiHandle, int32_t* message, CURL** easyHandle, int32_t* result)
+extern "C" int32_t HttpNative_MultiInfoRead(CURLM* multiHandle, int32_t* message, CURL** easyHandle, int32_t* result)
 {
     assert(message != nullptr);
     assert(easyHandle != nullptr);
@@ -102,12 +100,12 @@ extern "C" int32_t MultiInfoRead(CURLM* multiHandle, int32_t* message, CURL** ea
     return 1;
 }
 
-extern "C" const char* MultiGetErrorString(PAL_CURLMcode code)
+extern "C" const char* HttpNative_MultiGetErrorString(PAL_CURLMcode code)
 {
     return curl_multi_strerror(static_cast<CURLMcode>(code));
 }
 
-extern "C" int32_t MultiSetOptionLong(CURLM* handle, PAL_CURLMoption option, int64_t value)
+extern "C" int32_t HttpNative_MultiSetOptionLong(CURLM* handle, PAL_CURLMoption option, int64_t value)
 {
     return curl_multi_setopt(handle, static_cast<CURLMoption>(option), value);
 }

--- a/src/Native/System.Net.Http.Native/pal_multi.h
+++ b/src/Native/System.Net.Http.Native/pal_multi.h
@@ -39,28 +39,28 @@ Creates a new CURLM instance.
 
 Returns the new CURLM instance or nullptr if something went wrong.
 */
-extern "C" CURLM* MultiCreate();
+extern "C" CURLM* HttpNative_MultiCreate();
 
 /*
 Cleans up and removes a whole multi stack.
 
 Returns CURLM_OK on success, otherwise an error code.
 */
-extern "C" int32_t MultiDestroy(CURLM* multiHandle);
+extern "C" int32_t HttpNative_MultiDestroy(CURLM* multiHandle);
 
 /*
 Shims the curl_multi_add_handle function.
 
 Returns CURLM_OK on success, otherwise an error code.
 */
-extern "C" int32_t MultiAddHandle(CURLM* multiHandle, CURL* easyHandle);
+extern "C" int32_t HttpNative_MultiAddHandle(CURLM* multiHandle, CURL* easyHandle);
 
 /*
 Shims the curl_multi_remove_handle function.
 
 Returns CURLM_OK on success, otherwise an error code.
 */
-extern "C" int32_t MultiRemoveHandle(CURLM* multiHandle, CURL* easyHandle);
+extern "C" int32_t HttpNative_MultiRemoveHandle(CURLM* multiHandle, CURL* easyHandle);
 
 /*
 Shims the curl_multi_wait function.
@@ -70,7 +70,10 @@ Returns CURLM_OK on success, otherwise an error code.
 isExtraFileDescriptorActive is set to a value indicating whether extraFileDescriptor has new data received.
 isTimeout is set to a value indicating whether a timeout was encountered before any file descriptors had events occur.
 */
-extern "C" int32_t MultiWait(CURLM* multiHandle, intptr_t extraFileDescriptor, int32_t* isExtraFileDescriptorActive, int32_t* isTimeout);
+extern "C" int32_t HttpNative_MultiWait(CURLM* multiHandle,
+                                        intptr_t extraFileDescriptor,
+                                        int32_t* isExtraFileDescriptorActive,
+                                        int32_t* isTimeout);
 
 /*
 Reads/writes available data from each easy handle.
@@ -78,23 +81,23 @@ Shims the curl_multi_perform function.
 
 Returns CURLM_OK on success, otherwise an error code.
 */
-extern "C" int32_t MultiPerform(CURLM* multiHandle);
+extern "C" int32_t HttpNative_MultiPerform(CURLM* multiHandle);
 
 /*
 Ask the multi handle if there are any messages/informationals from the individual transfers.
 Shims the curl_multi_info_read function.
 
-Returns 1 if a CURLMsg was retrieved and the out variables are set, 
+Returns 1 if a CURLMsg was retrieved and the out variables are set,
 otherwise 0 when there are no more messages to retrieve.
 */
-extern "C" int32_t MultiInfoRead(CURLM* multiHandle, int32_t* message, CURL** easyHandle, int32_t* result);
+extern "C" int32_t HttpNative_MultiInfoRead(CURLM* multiHandle, int32_t* message, CURL** easyHandle, int32_t* result);
 
 /*
 Returns a string describing the CURLMcode error code.
 */
-extern "C" const char* MultiGetErrorString(PAL_CURLMcode code);
+extern "C" const char* HttpNative_MultiGetErrorString(PAL_CURLMcode code);
 
 /*
 Shims the curl_multi_setopt function
 */
-extern "C" int32_t MultiSetOptionLong(CURLM* handle, PAL_CURLMoption option, int64_t value);
+extern "C" int32_t HttpNative_MultiSetOptionLong(CURLM* handle, PAL_CURLMoption option, int64_t value);

--- a/src/Native/System.Net.Http.Native/pal_slist.cpp
+++ b/src/Native/System.Net.Http.Native/pal_slist.cpp
@@ -3,12 +3,12 @@
 
 #include "pal_slist.h"
 
-extern "C" curl_slist* SListAppend(curl_slist* list, const char* headerValue)
+extern "C" curl_slist* HttpNative_SListAppend(curl_slist* list, const char* headerValue)
 {
     return curl_slist_append(list, headerValue);
 }
 
-extern "C" void SListFreeAll(curl_slist* list)
+extern "C" void HttpNative_SListFreeAll(curl_slist* list)
 {
     curl_slist_free_all(list);
 }

--- a/src/Native/System.Net.Http.Native/pal_slist.h
+++ b/src/Native/System.Net.Http.Native/pal_slist.h
@@ -12,9 +12,9 @@ Appends a specified string to a linked list of strings.
 
 Returns a null pointer if anything went wrong, otherwise the new list pointer.
 */
-extern "C" curl_slist* SListAppend(curl_slist* list, const char* headerValue);
+extern "C" curl_slist* HttpNative_SListAppend(curl_slist* list, const char* headerValue);
 
 /*
 Removes all traces of a previously built curl_slist linked list.
 */
-extern "C" void SListFreeAll(curl_slist* list);
+extern "C" void HttpNative_SListFreeAll(curl_slist* list);

--- a/src/Native/System.Net.Http.Native/pal_versioninfo.cpp
+++ b/src/Native/System.Net.Http.Native/pal_versioninfo.cpp
@@ -6,11 +6,10 @@
 
 #include <curl/curl.h>
 
-extern "C" int32_t GetCurlVersionInfo(
-    int32_t* age, 
-    int32_t* supportsSsl, 
-    int32_t* supportsAutoDecompression,
-    int32_t* supportsHttp2Multiplexing)
+extern "C" int32_t HttpNative_GetCurlVersionInfo(int32_t* age,
+                                                 int32_t* supportsSsl,
+                                                 int32_t* supportsAutoDecompression,
+                                                 int32_t* supportsHttp2Multiplexing)
 {
     curl_version_info_data* versionInfo = curl_version_info(CURLVERSION_NOW);
 

--- a/src/Native/System.Net.Http.Native/pal_versioninfo.h
+++ b/src/Native/System.Net.Http.Native/pal_versioninfo.h
@@ -10,8 +10,7 @@ Gets the curl version information.
 
 Returns 1 upon success, otherwise 0.
 */
-extern "C" int32_t GetCurlVersionInfo(
-    int32_t* age, 
-    int32_t* supportsSsl, 
-    int32_t* supportsAutoDecompression,
-    int32_t* supportsHttp2Multiplexing);
+extern "C" int32_t HttpNative_GetCurlVersionInfo(int32_t* age,
+                                                 int32_t* supportsSsl,
+                                                 int32_t* supportsAutoDecompression,
+                                                 int32_t* supportsHttp2Multiplexing);

--- a/src/Native/System.Security.Cryptography.Native/openssl.c
+++ b/src/Native/System.Security.Cryptography.Native/openssl.c
@@ -70,7 +70,7 @@ Return values:
 1: Data was copied
 Any negative value: The input buffer size was reported as insufficient. A buffer of size ABS(return) is required.
 */
-int32_t GetX509Thumbprint(X509* x509, uint8_t* pBuf, int32_t cBuf)
+extern int32_t CryptoNative_GetX509Thumbprint(X509* x509, uint8_t* pBuf, int32_t cBuf)
 {
     if (!x509)
     {
@@ -97,7 +97,7 @@ Return values:
 NULL if the validity cannot be determined, a pointer to the ASN1_TIME structure for the NotBefore value
 otherwise.
 */
-ASN1_TIME* GetX509NotBefore(X509* x509)
+extern ASN1_TIME* CryptoNative_GetX509NotBefore(X509* x509)
 {
     if (x509 && x509->cert_info && x509->cert_info->validity)
     {
@@ -118,7 +118,7 @@ Return values:
 NULL if the validity cannot be determined, a pointer to the ASN1_TIME structure for the NotAfter value
 otherwise.
 */
-ASN1_TIME* GetX509NotAfter(X509* x509)
+extern ASN1_TIME* CryptoNative_GetX509NotAfter(X509* x509)
 {
     if (x509 && x509->cert_info && x509->cert_info->validity)
     {
@@ -139,7 +139,7 @@ Return values:
 NULL if the validity cannot be determined, a pointer to the ASN1_TIME structure for the NextUpdate value
 otherwise.
 */
-ASN1_TIME* GetX509CrlNextUpdate(X509_CRL* crl)
+extern ASN1_TIME* CryptoNative_GetX509CrlNextUpdate(X509_CRL* crl)
 {
     if (crl)
     {
@@ -163,7 +163,7 @@ The encoded value of the version, otherwise:
   1: X509v2
   2: X509v3
 */
-int GetX509Version(X509* x509)
+extern int CryptoNative_GetX509Version(X509* x509)
 {
     if (x509 && x509->cert_info)
     {
@@ -185,7 +185,7 @@ Return values:
 NULL if the algorithm cannot be determined, otherwise a pointer to the OpenSSL ASN1_OBJECT structure
 describing the object type.
 */
-ASN1_OBJECT* GetX509PublicKeyAlgorithm(X509* x509)
+extern ASN1_OBJECT* CryptoNative_GetX509PublicKeyAlgorithm(X509* x509)
 {
     if (x509 && x509->cert_info && x509->cert_info->key && x509->cert_info->key->algor)
     {
@@ -206,7 +206,7 @@ Return values:
 NULL if the algorithm cannot be determined, otherwise a pointer to the OpenSSL ASN1_OBJECT structure
 describing the object type.
 */
-ASN1_OBJECT* GetX509SignatureAlgorithm(X509* x509)
+extern ASN1_OBJECT* CryptoNative_GetX509SignatureAlgorithm(X509* x509)
 {
     if (x509 && x509->sig_alg && x509->sig_alg->algorithm)
     {
@@ -228,7 +228,7 @@ Return values:
 1: Data was copied
 Any negative value: The input buffer size was reported as insufficient. A buffer of size ABS(return) is required.
 */
-int32_t GetX509PublicKeyParameterBytes(X509* x509, uint8_t* pBuf, int32_t cBuf)
+extern int32_t CryptoNative_GetX509PublicKeyParameterBytes(X509* x509, uint8_t* pBuf, int32_t cBuf)
 {
     if (!x509 || !x509->cert_info || !x509->cert_info->key || !x509->cert_info->key->algor)
     {
@@ -265,7 +265,7 @@ Return values:
 NULL if the public key cannot be determined, a pointer to the ASN1_BIT_STRING structure representing
 the public key.
 */
-ASN1_BIT_STRING* GetX509PublicKeyBytes(X509* x509)
+extern ASN1_BIT_STRING* CryptoNative_GetX509PublicKeyBytes(X509* x509)
 {
     if (x509 && x509->cert_info && x509->cert_info->key)
     {
@@ -308,7 +308,7 @@ Remarks:
 
  So this function will really work on all of them.
 */
-int32_t GetAsn1StringBytes(ASN1_STRING* asn1, uint8_t* pBuf, int32_t cBuf)
+extern int32_t CryptoNative_GetAsn1StringBytes(ASN1_STRING* asn1, uint8_t* pBuf, int32_t cBuf)
 {
     if (!asn1 || cBuf < 0)
     {
@@ -343,7 +343,7 @@ Return values:
 1: Data was copied
 Any negative value: The input buffer size was reported as insufficient. A buffer of size ABS(return) is required.
 */
-int32_t GetX509NameRawBytes(X509_NAME* x509Name, uint8_t* pBuf, int32_t cBuf)
+extern int32_t CryptoNative_GetX509NameRawBytes(X509_NAME* x509Name, uint8_t* pBuf, int32_t cBuf)
 {
     if (!x509Name || !x509Name->bytes || cBuf < 0)
     {
@@ -393,7 +393,7 @@ Return values:
 0 if the field count cannot be determined, or the count of OIDs present in the EKU.
 Note that 0 does not always indicate an error, merely that GetX509EkuField should not be called.
 */
-int GetX509EkuFieldCount(EXTENDED_KEY_USAGE* eku)
+extern int CryptoNative_GetX509EkuFieldCount(EXTENDED_KEY_USAGE* eku)
 {
     return sk_ASN1_OBJECT_num(eku);
 }
@@ -409,7 +409,7 @@ Return values:
 NULL if eku is NULL or loc is out of bounds, otherwise a pointer to the ASN1_OBJECT structure encoding
 that particular OID.
 */
-ASN1_OBJECT* GetX509EkuField(EXTENDED_KEY_USAGE* eku, int32_t loc)
+extern ASN1_OBJECT* CryptoNative_GetX509EkuField(EXTENDED_KEY_USAGE* eku, int32_t loc)
 {
     return sk_ASN1_OBJECT_value(eku, loc);
 }
@@ -425,7 +425,7 @@ Return values:
 NULL if the certificate is invalid or no name information could be found, otherwise a pointer to a
 memory-backed BIO structure which contains the answer to the GetNameInfo query
 */
-BIO* GetX509NameInfo(X509* x509, int32_t nameType, int32_t forIssuer)
+extern BIO* CryptoNative_GetX509NameInfo(X509* x509, int32_t nameType, int32_t forIssuer)
 {
     static const char szOidUpn[] = "1.3.6.1.4.1.311.20.2.3";
 
@@ -804,7 +804,7 @@ Return values:
 0 if the hostname is not a match
 Any negative number indicates an error in the arguments.
 */
-int32_t CheckX509Hostname(X509* x509, const char* hostname, int32_t cchHostname)
+extern int32_t CryptoNative_CheckX509Hostname(X509* x509, const char* hostname, int32_t cchHostname)
 {
     if (!x509)
         return -2;
@@ -887,7 +887,7 @@ Return values:
 0 if the hostname is not a match
 Any negative number indicates an error in the arguments.
 */
-int32_t CheckX509IpAddress(
+extern int32_t CryptoNative_CheckX509IpAddress(
     X509* x509, const uint8_t* addressBytes, int32_t addressBytesLen, const char* hostname, int32_t cchHostname)
 {
     if (!x509)
@@ -975,7 +975,7 @@ Return values:
 0 if the field count cannot be determined, or the count of certificates in STACK_OF(X509)
 Note that 0 does not always indicate an error, merely that GetX509StackField should not be called.
 */
-int32_t GetX509StackFieldCount(STACK_OF(X509) * stack)
+extern int32_t CryptoNative_GetX509StackFieldCount(STACK_OF(X509) * stack)
 {
     return sk_X509_num(stack);
 }
@@ -991,7 +991,7 @@ Return values:
 NULL if stack is NULL or loc is out of bounds, otherwise a pointer to the X509 structure encoding
 that particular element.
 */
-X509* GetX509StackField(STACK_OF(X509) * stack, int loc)
+extern X509* CryptoNative_GetX509StackField(STACK_OF(X509) * stack, int loc)
 {
     return sk_X509_value(stack, loc);
 }
@@ -1003,7 +1003,7 @@ RecursiveFreeX509Stack
 Used by System.Security.Cryptography.X509Certificates' OpenSslX509ChainProcessor to free a stack
 when done with it.
 */
-void RecursiveFreeX509Stack(STACK_OF(X509) * stack)
+extern void CryptoNative_RecursiveFreeX509Stack(STACK_OF(X509) * stack)
 {
     sk_X509_pop_free(stack, X509_free);
 }
@@ -1019,14 +1019,14 @@ Return values:
 0 if ctx is NULL, if ctx has no X509_VERIFY_PARAM, or the date inputs don't produce a valid time_t;
 1 on success.
 */
-int32_t SetX509ChainVerifyTime(X509_STORE_CTX* ctx,
-                               int32_t year,
-                               int32_t month,
-                               int32_t day,
-                               int32_t hour,
-                               int32_t minute,
-                               int32_t second,
-                               int32_t isDst)
+extern int32_t CryptoNative_SetX509ChainVerifyTime(X509_STORE_CTX* ctx,
+                                                   int32_t year,
+                                                   int32_t month,
+                                                   int32_t day,
+                                                   int32_t hour,
+                                                   int32_t minute,
+                                                   int32_t second,
+                                                   int32_t isDst)
 {
     if (!ctx)
     {
@@ -1062,7 +1062,7 @@ Return values:
 The directory which would be applied for X509_LOOKUP_add_dir(ctx, NULL). That is, the value of the
 SSL_CERT_DIR environment variable, or the value of the X509_CERT_DIR compile-time constant.
 */
-const char* GetX509RootStorePath()
+extern const char* CryptoNative_GetX509RootStorePath()
 {
     const char* dir = getenv(X509_get_default_cert_dir_env());
 
@@ -1085,7 +1085,7 @@ Return values:
 If bio containns a valid DER-encoded X509 object, a pointer to that X509 structure that was deserialized,
 otherwise NULL.
 */
-X509* ReadX509AsDerFromBio(BIO* bio)
+extern X509* CryptoNative_ReadX509AsDerFromBio(BIO* bio)
 {
     return d2i_X509_bio(bio, NULL);
 }
@@ -1105,7 +1105,7 @@ behavior on non-file, non-null BIO objects.
 See also:
 OpenSSL's BIO_tell
 */
-int32_t BioTell(BIO* bio)
+extern int32_t CryptoNative_BioTell(BIO* bio)
 {
     if (!bio)
     {
@@ -1132,7 +1132,7 @@ otherwise unspecified
 See also:
 OpenSSL's BIO_seek
 */
-int32_t BioSeek(BIO* bio, int32_t ofs)
+extern int32_t CryptoNative_BioSeek(BIO* bio, int32_t ofs)
 {
     if (!bio)
     {
@@ -1152,7 +1152,7 @@ of X509* to OpenSSL.
 Return values:
 A STACK_OF(X509*) with no comparator.
 */
-STACK_OF(X509) * NewX509Stack()
+extern STACK_OF(X509) * CryptoNative_NewX509Stack()
 {
     return sk_X509_new_null();
 }
@@ -1168,7 +1168,7 @@ Return values:
 1 on success
 0 on a NULL stack, or an error within sk_X509_push
 */
-int32_t PushX509StackField(STACK_OF(X509) * stack, X509 * x509)
+extern int32_t CryptoNative_PushX509StackField(STACK_OF(X509) * stack, X509* x509)
 {
     if (!stack)
     {
@@ -1189,7 +1189,7 @@ Returns a bool to managed code.
 1 for success
 0 for failure
 */
-int32_t GetRandomBytes(uint8_t* buf, int32_t num)
+extern int32_t CryptoNative_GetRandomBytes(uint8_t* buf, int32_t num)
 {
     int ret = RAND_bytes(buf, num);
 
@@ -1209,7 +1209,7 @@ Return values:
 -1 indicates OpenSSL signalled an error, CryptographicException should be raised.
 -2 indicates an error in the input arguments
 */
-int32_t LookupFriendlyNameByOid(const char* oidValue, const char** friendlyName)
+extern int32_t CryptoNative_LookupFriendlyNameByOid(const char* oidValue, const char** friendlyName)
 {
     ASN1_OBJECT* oid;
     int nid;
@@ -1319,7 +1319,7 @@ Return values:
 0 on success
 non-zero on failure
 */
-int32_t EnsureOpenSslInitialized()
+extern int32_t CryptoNative_EnsureOpenSslInitialized()
 {
     int ret = 0;
     int numLocks = 0;

--- a/src/Native/System.Security.Cryptography.Native/openssl.c
+++ b/src/Native/System.Security.Cryptography.Native/openssl.c
@@ -86,6 +86,14 @@ extern int32_t CryptoNative_GetX509Thumbprint(X509* x509, uint8_t* pBuf, int32_t
     return 1;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern int32_t GetX509Thumbprint(X509* x509, uint8_t* pBuf, int32_t cBuf)
+{
+    return CryptoNative_GetX509Thumbprint(x509, pBuf, cBuf);
+}
+
 /*
 Function:
 GetX509NotBefore
@@ -105,6 +113,14 @@ extern ASN1_TIME* CryptoNative_GetX509NotBefore(X509* x509)
     }
 
     return NULL;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern ASN1_TIME* GetX509NotBefore(X509* x509)
+{
+    return CryptoNative_GetX509NotBefore(x509);
 }
 
 /*
@@ -128,6 +144,14 @@ extern ASN1_TIME* CryptoNative_GetX509NotAfter(X509* x509)
     return NULL;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern ASN1_TIME* GetX509NotAfter(X509* x509)
+{
+    return CryptoNative_GetX509NotAfter(x509);
+}
+
 /*
 Function:
 GetX509CrlNextUpdate
@@ -147,6 +171,14 @@ extern ASN1_TIME* CryptoNative_GetX509CrlNextUpdate(X509_CRL* crl)
     }
 
     return NULL;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern ASN1_TIME* GetX509CrlNextUpdate(X509_CRL* crl)
+{
+    return CryptoNative_GetX509CrlNextUpdate(crl);
 }
 
 /*
@@ -174,6 +206,14 @@ extern int CryptoNative_GetX509Version(X509* x509)
     return -1;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern int GetX509Version(X509* x509)
+{
+    return CryptoNative_GetX509Version(x509);
+}
+
 /*
 Function:
 GetX509PublicKeyAlgorithm
@@ -195,6 +235,15 @@ extern ASN1_OBJECT* CryptoNative_GetX509PublicKeyAlgorithm(X509* x509)
     return NULL;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern ASN1_OBJECT* GetX509PublicKeyAlgorithm(X509* x509)
+{
+    return CryptoNative_GetX509PublicKeyAlgorithm(x509);
+}
+
+
 /*
 Function:
 GetX509SignatureAlgorithm
@@ -214,6 +263,14 @@ extern ASN1_OBJECT* CryptoNative_GetX509SignatureAlgorithm(X509* x509)
     }
 
     return NULL;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern ASN1_OBJECT* GetX509SignatureAlgorithm(X509* x509)
+{
+    return CryptoNative_GetX509SignatureAlgorithm(x509);
 }
 
 /*
@@ -254,6 +311,15 @@ extern int32_t CryptoNative_GetX509PublicKeyParameterBytes(X509* x509, uint8_t* 
     return 0;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern int32_t GetX509PublicKeyParameterBytes(X509* x509, uint8_t* pBuf, int32_t cBuf)
+{
+    return CryptoNative_GetX509PublicKeyParameterBytes(x509, pBuf, cBuf);
+}
+
+
 /*
 Function:
 GetX509PublicKeyBytes
@@ -274,6 +340,15 @@ extern ASN1_BIT_STRING* CryptoNative_GetX509PublicKeyBytes(X509* x509)
 
     return NULL;
 }
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern ASN1_BIT_STRING* GetX509PublicKeyBytes(X509* x509)
+{
+    return CryptoNative_GetX509PublicKeyBytes(x509);
+}
+
 
 /*
 Function:
@@ -331,6 +406,14 @@ extern int32_t CryptoNative_GetAsn1StringBytes(ASN1_STRING* asn1, uint8_t* pBuf,
     return 1;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern int32_t GetAsn1StringBytes(ASN1_STRING* asn1, uint8_t* pBuf, int32_t cBuf)
+{
+    return CryptoNative_GetAsn1StringBytes(asn1, pBuf, cBuf);
+}
+
 /*
 Function:
 GetX509NameRawBytes
@@ -382,6 +465,14 @@ extern int32_t CryptoNative_GetX509NameRawBytes(X509_NAME* x509Name, uint8_t* pB
     return 1;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern int32_t GetX509NameRawBytes(X509_NAME* x509Name, uint8_t* pBuf, int32_t cBuf)
+{
+    return CryptoNative_GetX509NameRawBytes(x509Name, pBuf, cBuf);
+}
+
 /*
 Function:
 GetX509EkuFieldCount
@@ -398,6 +489,14 @@ extern int CryptoNative_GetX509EkuFieldCount(EXTENDED_KEY_USAGE* eku)
     return sk_ASN1_OBJECT_num(eku);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern int GetX509EkuFieldCount(EXTENDED_KEY_USAGE* eku)
+{
+    return CryptoNative_GetX509EkuFieldCount(eku);
+}
+
 /*
 Function:
 GetX509EkuField
@@ -412,6 +511,14 @@ that particular OID.
 extern ASN1_OBJECT* CryptoNative_GetX509EkuField(EXTENDED_KEY_USAGE* eku, int32_t loc)
 {
     return sk_ASN1_OBJECT_value(eku, loc);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern ASN1_OBJECT* GetX509EkuField(EXTENDED_KEY_USAGE* eku, int32_t loc)
+{
+    return CryptoNative_GetX509EkuField(eku, loc);
 }
 
 /*
@@ -669,6 +776,14 @@ extern BIO* CryptoNative_GetX509NameInfo(X509* x509, int32_t nameType, int32_t f
     return NULL;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern BIO* GetX509NameInfo(X509* x509, int32_t nameType, int32_t forIssuer)
+{
+    return CryptoNative_GetX509NameInfo(x509, nameType, forIssuer);
+}
+
 /*
 Function:
 CheckX509HostnameMatch
@@ -875,6 +990,14 @@ extern int32_t CryptoNative_CheckX509Hostname(X509* x509, const char* hostname, 
     return success;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern int32_t CheckX509Hostname(X509* x509, const char* hostname, int32_t cchHostname)
+{
+    return CryptoNative_CheckX509Hostname(x509, hostname, cchHostname);
+}
+
 /*
 Function:
 CheckX509IpAddress
@@ -964,6 +1087,16 @@ extern int32_t CryptoNative_CheckX509IpAddress(
 
     return success;
 }
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern int32_t CheckX509IpAddress(
+    X509* x509, const uint8_t* addressBytes, int32_t addressBytesLen, const char* hostname, int32_t cchHostname)
+{
+    return CryptoNative_CheckX509IpAddress(x509, addressBytes, addressBytesLen, hostname, cchHostname);
+}
+
 /*
 Function:
 GetX509StackFieldCount
@@ -978,6 +1111,14 @@ Note that 0 does not always indicate an error, merely that GetX509StackField sho
 extern int32_t CryptoNative_GetX509StackFieldCount(STACK_OF(X509) * stack)
 {
     return sk_X509_num(stack);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern int32_t GetX509StackFieldCount(STACK_OF(X509) * stack)
+{
+    return CryptoNative_GetX509StackFieldCount(stack);
 }
 
 /*
@@ -996,6 +1137,14 @@ extern X509* CryptoNative_GetX509StackField(STACK_OF(X509) * stack, int loc)
     return sk_X509_value(stack, loc);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern X509* GetX509StackField(STACK_OF(X509) * stack, int loc)
+{
+    return CryptoNative_GetX509StackField(stack, loc);
+}
+
 /*
 Function:
 RecursiveFreeX509Stack
@@ -1006,6 +1155,14 @@ when done with it.
 extern void CryptoNative_RecursiveFreeX509Stack(STACK_OF(X509) * stack)
 {
     sk_X509_pop_free(stack, X509_free);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern void RecursiveFreeX509Stack(STACK_OF(X509) * stack)
+{
+    CryptoNative_RecursiveFreeX509Stack(stack);
 }
 
 /*
@@ -1051,6 +1208,27 @@ extern int32_t CryptoNative_SetX509ChainVerifyTime(X509_STORE_CTX* ctx,
     return 1;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern int32_t SetX509ChainVerifyTime(X509_STORE_CTX* ctx,
+    int32_t year,
+    int32_t month,
+    int32_t day,
+    int32_t hour,
+    int32_t minute,
+    int32_t second,
+    int32_t isDst)
+{
+    return CryptoNative_SetX509ChainVerifyTime(ctx,
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+        isDst);
+}
 /*
 Function:
 GetX509RootStorePath
@@ -1074,6 +1252,14 @@ extern const char* CryptoNative_GetX509RootStorePath()
     return dir;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern const char* GetX509RootStorePath()
+{
+    return CryptoNative_GetX509RootStorePath();
+}
+
 /*
 Function:
 ReadX509AsDerFromBio
@@ -1088,6 +1274,14 @@ otherwise NULL.
 extern X509* CryptoNative_ReadX509AsDerFromBio(BIO* bio)
 {
     return d2i_X509_bio(bio, NULL);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern X509* ReadX509AsDerFromBio(BIO* bio)
+{
+    return CryptoNative_ReadX509AsDerFromBio(bio);
 }
 
 /*
@@ -1113,6 +1307,14 @@ extern int32_t CryptoNative_BioTell(BIO* bio)
     }
 
     return BIO_tell(bio);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern int32_t BioTell(BIO* bio)
+{
+    return CryptoNative_BioTell(bio);
 }
 
 /*
@@ -1142,6 +1344,14 @@ extern int32_t CryptoNative_BioSeek(BIO* bio, int32_t ofs)
     return BIO_seek(bio, ofs);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern int32_t BioSeek(BIO* bio, int32_t ofs)
+{
+    return CryptoNative_BioSeek(bio, ofs);
+}
+
 /*
 Function:
 NewX509Stack
@@ -1155,6 +1365,14 @@ A STACK_OF(X509*) with no comparator.
 extern STACK_OF(X509) * CryptoNative_NewX509Stack()
 {
     return sk_X509_new_null();
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern STACK_OF(X509) * NewX509Stack()
+{
+    return CryptoNative_NewX509Stack();
 }
 
 /*
@@ -1178,6 +1396,14 @@ extern int32_t CryptoNative_PushX509StackField(STACK_OF(X509) * stack, X509* x50
     return sk_X509_push(stack, x509);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern int32_t PushX509StackField(STACK_OF(X509) * stack, X509* x509)
+{
+    return CryptoNative_PushX509StackField(stack, x509);
+}
+
 /*
 Function:
 GetRandomBytes
@@ -1194,6 +1420,14 @@ extern int32_t CryptoNative_GetRandomBytes(uint8_t* buf, int32_t num)
     int ret = RAND_bytes(buf, num);
 
     return ret == 1;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern int32_t GetRandomBytes(uint8_t* buf, int32_t num)
+{
+    return CryptoNative_GetRandomBytes(buf, num);
 }
 
 /*
@@ -1257,6 +1491,14 @@ extern int32_t CryptoNative_LookupFriendlyNameByOid(const char* oidValue, const 
     }
 
     return 0;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern int32_t LookupFriendlyNameByOid(const char* oidValue, const char** friendlyName)
+{
+    return CryptoNative_LookupFriendlyNameByOid(oidValue, friendlyName);
 }
 
 // Lock used to make sure EnsureopenSslInitialized itself is thread safe
@@ -1407,4 +1649,12 @@ done:
 
     pthread_mutex_unlock(&g_initLock);
     return ret;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern int32_t EnsureOpenSslInitialized()
+{
+    return CryptoNative_EnsureOpenSslInitialized();
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_asn1.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_asn1.cpp
@@ -11,14 +11,38 @@ static_assert(PAL_NID_secp224r1 == NID_secp224r1, "");
 static_assert(PAL_NID_secp384r1 == NID_secp384r1, "");
 static_assert(PAL_NID_secp521r1 == NID_secp521r1, "");
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const ASN1_OBJECT* ObjTxt2Obj(const char* s)
+{
+    return CryptoNative_ObjTxt2Obj(s);
+}
+
 extern "C" const ASN1_OBJECT* CryptoNative_ObjTxt2Obj(const char* s)
 {
     return OBJ_txt2obj(s, true);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t ObjObj2Txt(char* buf, int32_t buf_len, const ASN1_OBJECT* a)
+{
+    return CryptoNative_ObjObj2Txt(buf, buf_len, a);
+}
+
 extern "C" int32_t CryptoNative_ObjObj2Txt(char* buf, int32_t buf_len, const ASN1_OBJECT* a)
 {
     return OBJ_obj2txt(buf, buf_len, a, true);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const ASN1_OBJECT* GetObjectDefinitionByName(const char* friendlyName)
+{
+    return CryptoNative_GetObjectDefinitionByName(friendlyName);
 }
 
 extern "C" const ASN1_OBJECT* CryptoNative_GetObjectDefinitionByName(const char* friendlyName)
@@ -38,9 +62,25 @@ extern "C" const ASN1_OBJECT* CryptoNative_GetObjectDefinitionByName(const char*
     return OBJ_nid2obj(nid);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t ObjSn2Nid(const char* sn)
+{
+    return CryptoNative_ObjSn2Nid(sn);
+}
+
 extern "C" int32_t CryptoNative_ObjSn2Nid(const char* sn)
 {
     return OBJ_sn2nid(sn);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" ASN1_OBJECT* ObjNid2Obj(int32_t nid)
+{
+    return CryptoNative_ObjNid2Obj(nid);
 }
 
 extern "C" ASN1_OBJECT* CryptoNative_ObjNid2Obj(int32_t nid)
@@ -48,9 +88,25 @@ extern "C" ASN1_OBJECT* CryptoNative_ObjNid2Obj(int32_t nid)
     return OBJ_nid2obj(nid);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void Asn1ObjectFree(ASN1_OBJECT* a)
+{
+    return CryptoNative_Asn1ObjectFree(a);
+}
+
 extern "C" void CryptoNative_Asn1ObjectFree(ASN1_OBJECT* a)
 {
     ASN1_OBJECT_free(a);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" ASN1_BIT_STRING* DecodeAsn1BitString(const uint8_t* buf, int32_t len)
+{
+    return CryptoNative_DecodeAsn1BitString(buf, len);
 }
 
 extern "C" ASN1_BIT_STRING* CryptoNative_DecodeAsn1BitString(const uint8_t* buf, int32_t len)
@@ -63,9 +119,25 @@ extern "C" ASN1_BIT_STRING* CryptoNative_DecodeAsn1BitString(const uint8_t* buf,
     return d2i_ASN1_BIT_STRING(nullptr, &buf, len);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void Asn1BitStringFree(ASN1_STRING* a)
+{
+    return CryptoNative_Asn1BitStringFree(a);
+}
+
 extern "C" void CryptoNative_Asn1BitStringFree(ASN1_STRING* a)
 {
     ASN1_BIT_STRING_free(a);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" ASN1_OCTET_STRING* DecodeAsn1OctetString(const uint8_t* buf, int32_t len)
+{
+    return CryptoNative_DecodeAsn1OctetString(buf, len);
 }
 
 extern "C" ASN1_OCTET_STRING* CryptoNative_DecodeAsn1OctetString(const uint8_t* buf, int32_t len)
@@ -78,9 +150,25 @@ extern "C" ASN1_OCTET_STRING* CryptoNative_DecodeAsn1OctetString(const uint8_t* 
     return d2i_ASN1_OCTET_STRING(nullptr, &buf, len);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" ASN1_OCTET_STRING* Asn1OctetStringNew()
+{
+    return CryptoNative_Asn1OctetStringNew();
+}
+
 extern "C" ASN1_OCTET_STRING* CryptoNative_Asn1OctetStringNew()
 {
     return ASN1_OCTET_STRING_new();
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t Asn1OctetStringSet(ASN1_OCTET_STRING* s, const uint8_t* data, int32_t len)
+{
+    return CryptoNative_Asn1OctetStringSet(s, data, len);
 }
 
 extern "C" int32_t CryptoNative_Asn1OctetStringSet(ASN1_OCTET_STRING* s, const uint8_t* data, int32_t len)
@@ -88,9 +176,25 @@ extern "C" int32_t CryptoNative_Asn1OctetStringSet(ASN1_OCTET_STRING* s, const u
     return ASN1_OCTET_STRING_set(s, data, len);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void Asn1OctetStringFree(ASN1_STRING* a)
+{
+    return CryptoNative_Asn1OctetStringFree(a);
+}
+
 extern "C" void CryptoNative_Asn1OctetStringFree(ASN1_STRING* a)
 {
     ASN1_OCTET_STRING_free(a);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void Asn1StringFree(ASN1_STRING* a)
+{
+    return CryptoNative_Asn1StringFree(a);
 }
 
 extern "C" void CryptoNative_Asn1StringFree(ASN1_STRING* a)
@@ -98,9 +202,25 @@ extern "C" void CryptoNative_Asn1StringFree(ASN1_STRING* a)
     ASN1_STRING_free(a);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t GetAsn1IntegerDerSize(ASN1_INTEGER* i)
+{
+    return CryptoNative_GetAsn1IntegerDerSize(i);
+}
+
 extern "C" int32_t CryptoNative_GetAsn1IntegerDerSize(ASN1_INTEGER* i)
 {
     return i2d_ASN1_INTEGER(i, nullptr);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t EncodeAsn1Integer(ASN1_INTEGER* i, uint8_t* buf)
+{
+    return CryptoNative_EncodeAsn1Integer(i, buf);
 }
 
 extern "C" int32_t CryptoNative_EncodeAsn1Integer(ASN1_INTEGER* i, uint8_t* buf)

--- a/src/Native/System.Security.Cryptography.Native/pal_asn1.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_asn1.cpp
@@ -11,17 +11,17 @@ static_assert(PAL_NID_secp224r1 == NID_secp224r1, "");
 static_assert(PAL_NID_secp384r1 == NID_secp384r1, "");
 static_assert(PAL_NID_secp521r1 == NID_secp521r1, "");
 
-extern "C" const ASN1_OBJECT* ObjTxt2Obj(const char* s)
+extern "C" const ASN1_OBJECT* CryptoNative_ObjTxt2Obj(const char* s)
 {
     return OBJ_txt2obj(s, true);
 }
 
-extern "C" int32_t ObjObj2Txt(char* buf, int32_t buf_len, const ASN1_OBJECT* a)
+extern "C" int32_t CryptoNative_ObjObj2Txt(char* buf, int32_t buf_len, const ASN1_OBJECT* a)
 {
     return OBJ_obj2txt(buf, buf_len, a, true);
 }
 
-extern "C" const ASN1_OBJECT* GetObjectDefinitionByName(const char* friendlyName)
+extern "C" const ASN1_OBJECT* CryptoNative_GetObjectDefinitionByName(const char* friendlyName)
 {
     int nid = OBJ_ln2nid(friendlyName);
 
@@ -38,22 +38,22 @@ extern "C" const ASN1_OBJECT* GetObjectDefinitionByName(const char* friendlyName
     return OBJ_nid2obj(nid);
 }
 
-extern "C" int32_t ObjSn2Nid(const char* sn)
+extern "C" int32_t CryptoNative_ObjSn2Nid(const char* sn)
 {
     return OBJ_sn2nid(sn);
 }
 
-extern "C" ASN1_OBJECT* ObjNid2Obj(int32_t nid)
+extern "C" ASN1_OBJECT* CryptoNative_ObjNid2Obj(int32_t nid)
 {
     return OBJ_nid2obj(nid);
 }
 
-extern "C" void Asn1ObjectFree(ASN1_OBJECT* a)
+extern "C" void CryptoNative_Asn1ObjectFree(ASN1_OBJECT* a)
 {
     ASN1_OBJECT_free(a);
 }
 
-extern "C" ASN1_BIT_STRING* DecodeAsn1BitString(const uint8_t* buf, int32_t len)
+extern "C" ASN1_BIT_STRING* CryptoNative_DecodeAsn1BitString(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
     {
@@ -63,12 +63,12 @@ extern "C" ASN1_BIT_STRING* DecodeAsn1BitString(const uint8_t* buf, int32_t len)
     return d2i_ASN1_BIT_STRING(nullptr, &buf, len);
 }
 
-extern "C" void Asn1BitStringFree(ASN1_STRING* a)
+extern "C" void CryptoNative_Asn1BitStringFree(ASN1_STRING* a)
 {
     ASN1_BIT_STRING_free(a);
 }
 
-extern "C" ASN1_OCTET_STRING* DecodeAsn1OctetString(const uint8_t* buf, int32_t len)
+extern "C" ASN1_OCTET_STRING* CryptoNative_DecodeAsn1OctetString(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
     {
@@ -78,32 +78,32 @@ extern "C" ASN1_OCTET_STRING* DecodeAsn1OctetString(const uint8_t* buf, int32_t 
     return d2i_ASN1_OCTET_STRING(nullptr, &buf, len);
 }
 
-extern "C" ASN1_OCTET_STRING* Asn1OctetStringNew()
+extern "C" ASN1_OCTET_STRING* CryptoNative_Asn1OctetStringNew()
 {
     return ASN1_OCTET_STRING_new();
 }
 
-extern "C" int32_t Asn1OctetStringSet(ASN1_OCTET_STRING* s, const uint8_t* data, int32_t len)
+extern "C" int32_t CryptoNative_Asn1OctetStringSet(ASN1_OCTET_STRING* s, const uint8_t* data, int32_t len)
 {
     return ASN1_OCTET_STRING_set(s, data, len);
 }
 
-extern "C" void Asn1OctetStringFree(ASN1_STRING* a)
+extern "C" void CryptoNative_Asn1OctetStringFree(ASN1_STRING* a)
 {
     ASN1_OCTET_STRING_free(a);
 }
 
-extern "C" void Asn1StringFree(ASN1_STRING* a)
+extern "C" void CryptoNative_Asn1StringFree(ASN1_STRING* a)
 {
     ASN1_STRING_free(a);
 }
 
-extern "C" int32_t GetAsn1IntegerDerSize(ASN1_INTEGER* i)
+extern "C" int32_t CryptoNative_GetAsn1IntegerDerSize(ASN1_INTEGER* i)
 {
     return i2d_ASN1_INTEGER(i, nullptr);
 }
 
-extern "C" int32_t EncodeAsn1Integer(ASN1_INTEGER* i, uint8_t* buf)
+extern "C" int32_t CryptoNative_EncodeAsn1Integer(ASN1_INTEGER* i, uint8_t* buf)
 {
     return i2d_ASN1_INTEGER(i, &buf);
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_asn1.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_asn1.h
@@ -20,79 +20,79 @@ enum SupportedAlgorithmNids
 /*
 Direct shim to OBJ_txt2obj.
 */
-extern "C" const ASN1_OBJECT* ObjTxt2Obj(const char* s);
+extern "C" const ASN1_OBJECT* CryptoNative_ObjTxt2Obj(const char* s);
 
 /*
 Direct shim to OBJ_obj2txt.
 */
-extern "C" int32_t ObjObj2Txt(char* buf, int32_t buf_len, const ASN1_OBJECT* a);
+extern "C" int32_t CryptoNative_ObjObj2Txt(char* buf, int32_t buf_len, const ASN1_OBJECT* a);
 
 /*
 Retrieves the ASN1_OBJECT for the specified friendly name.
 
 Can return nullptr if there isn't a corresponding shared object.
 */
-extern "C" const ASN1_OBJECT* GetObjectDefinitionByName(const char* friendlyName);
+extern "C" const ASN1_OBJECT* CryptoNative_GetObjectDefinitionByName(const char* friendlyName);
 
 /*
 Direct shim to OBJ_sn2nid.
 */
-extern "C" int32_t ObjSn2Nid(const char* sn);
+extern "C" int32_t CryptoNative_ObjSn2Nid(const char* sn);
 
 /*
 Direct shim to OBJ_nid2obj.
 */
-extern "C" ASN1_OBJECT* ObjNid2Obj(int32_t nid);
+extern "C" ASN1_OBJECT* CryptoNative_ObjNid2Obj(int32_t nid);
 
 /*
 Direct shim to ASN1_OBJECT_free.
 */
-extern "C" void Asn1ObjectFree(ASN1_OBJECT* a);
+extern "C" void CryptoNative_Asn1ObjectFree(ASN1_OBJECT* a);
 
 /*
 Shims the d2i_ASN1_BIT_STRING method and makes it easier to invoke from managed code.
 */
-extern "C" ASN1_BIT_STRING* DecodeAsn1BitString(const uint8_t* buf, int32_t len);
+extern "C" ASN1_BIT_STRING* CryptoNative_DecodeAsn1BitString(const uint8_t* buf, int32_t len);
 
 /*
 Direct shim to ASN1_BIT_STRING_free.
 */
-extern "C" void Asn1BitStringFree(ASN1_STRING* a);
+extern "C" void CryptoNative_Asn1BitStringFree(ASN1_STRING* a);
 
 /*
 Shims the d2i_ASN1_OCTET_STRING method and makes it easier to invoke from managed code.
 */
-extern "C" ASN1_OCTET_STRING* DecodeAsn1OctetString(const uint8_t* buf, int32_t len);
+extern "C" ASN1_OCTET_STRING* CryptoNative_DecodeAsn1OctetString(const uint8_t* buf, int32_t len);
 
 /*
 Direct shim to ASN1_OCTET_STRING_new.
 */
-extern "C" ASN1_OCTET_STRING* Asn1OctetStringNew();
+extern "C" ASN1_OCTET_STRING* CryptoNative_Asn1OctetStringNew();
 
 /*
 Direct shim to ASN1_OCTET_STRING_set.
 */
-extern "C" int32_t Asn1OctetStringSet(ASN1_OCTET_STRING* s, const uint8_t* data, int32_t len);
+extern "C" int32_t CryptoNative_Asn1OctetStringSet(ASN1_OCTET_STRING* s, const uint8_t* data, int32_t len);
 
 /*
 Direct shim to ASN1_OCTET_STRING_free.
 */
-extern "C" void Asn1OctetStringFree(ASN1_STRING* a);
+extern "C" void CryptoNative_Asn1OctetStringFree(ASN1_STRING* a);
 
 /*
 Direct shim to ASN1_STRING_free.
 */
-extern "C" void Asn1StringFree(ASN1_STRING* a);
+extern "C" void CryptoNative_Asn1StringFree(ASN1_STRING* a);
 
 /*
 Returns the number of bytes it will take to convert
 the ASN1_INTEGER to a DER format.
 */
-extern "C" int32_t GetAsn1IntegerDerSize(ASN1_INTEGER* i);
+extern "C" int32_t CryptoNative_GetAsn1IntegerDerSize(ASN1_INTEGER* i);
 
 /*
 Shims the i2d_ASN1_INTEGER method.
 
 Returns the number of bytes written to buf.
 */
-extern "C" int32_t EncodeAsn1Integer(ASN1_INTEGER* i, uint8_t* buf);
+extern "C" int32_t CryptoNative_EncodeAsn1Integer(ASN1_INTEGER* i, uint8_t* buf);

--- a/src/Native/System.Security.Cryptography.Native/pal_asn1_print.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_asn1_print.cpp
@@ -23,6 +23,14 @@ static_assert(PAL_B_ASN1_SEQUENCE == B_ASN1_SEQUENCE, "");
 
 static_assert(PAL_ASN1_STRFLGS_UTF8_CONVERT == ASN1_STRFLGS_UTF8_CONVERT, "");
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" ASN1_STRING* DecodeAsn1TypeBytes(const uint8_t* buf, int32_t len, Asn1StringTypeFlags type)
+{
+    return CryptoNative_DecodeAsn1TypeBytes(buf, len, type);
+}
+
 extern "C" ASN1_STRING* CryptoNative_DecodeAsn1TypeBytes(const uint8_t* buf, int32_t len, Asn1StringTypeFlags type)
 {
     if (!buf || !len)
@@ -31,6 +39,14 @@ extern "C" ASN1_STRING* CryptoNative_DecodeAsn1TypeBytes(const uint8_t* buf, int
     }
 
     return d2i_ASN1_type_bytes(nullptr, &buf, len, type);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t Asn1StringPrintEx(BIO* out, ASN1_STRING* str, Asn1StringPrintFlags flags)
+{
+    return CryptoNative_Asn1StringPrintEx(out, str, flags);
 }
 
 extern "C" int32_t CryptoNative_Asn1StringPrintEx(BIO* out, ASN1_STRING* str, Asn1StringPrintFlags flags)

--- a/src/Native/System.Security.Cryptography.Native/pal_asn1_print.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_asn1_print.cpp
@@ -23,7 +23,7 @@ static_assert(PAL_B_ASN1_SEQUENCE == B_ASN1_SEQUENCE, "");
 
 static_assert(PAL_ASN1_STRFLGS_UTF8_CONVERT == ASN1_STRFLGS_UTF8_CONVERT, "");
 
-extern "C" ASN1_STRING* DecodeAsn1TypeBytes(const uint8_t* buf, int32_t len, Asn1StringTypeFlags type)
+extern "C" ASN1_STRING* CryptoNative_DecodeAsn1TypeBytes(const uint8_t* buf, int32_t len, Asn1StringTypeFlags type)
 {
     if (!buf || !len)
     {
@@ -33,7 +33,7 @@ extern "C" ASN1_STRING* DecodeAsn1TypeBytes(const uint8_t* buf, int32_t len, Asn
     return d2i_ASN1_type_bytes(nullptr, &buf, len, type);
 }
 
-extern "C" int32_t Asn1StringPrintEx(BIO* out, ASN1_STRING* str, Asn1StringPrintFlags flags)
+extern "C" int32_t CryptoNative_Asn1StringPrintEx(BIO* out, ASN1_STRING* str, Asn1StringPrintFlags flags)
 {
     return ASN1_STRING_print_ex(out, str, flags);
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_asn1_print.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_asn1_print.h
@@ -6,7 +6,7 @@
 #include <openssl/asn1.h>
 
 /*
-Flags for the 'type' parameter of DecodeAsn1TypeBytes.
+Flags for the 'type' parameter of CryptoNative_DecodeAsn1TypeBytes.
 */
 enum Asn1StringTypeFlags : int32_t
 {
@@ -30,7 +30,7 @@ enum Asn1StringTypeFlags : int32_t
 };
 
 /*
-Flags for the 'flags' parameter of Asn1StringPrintEx.
+Flags for the 'flags' parameter of CryptoNative_Asn1StringPrintEx.
 */
 enum Asn1StringPrintFlags : uint64_t
 {
@@ -40,9 +40,9 @@ enum Asn1StringPrintFlags : uint64_t
 /*
 Shims the d2i_ASN1_type_bytes method and makes it easier to invoke from managed code.
 */
-extern "C" ASN1_STRING* DecodeAsn1TypeBytes(const uint8_t* buf, int32_t len, Asn1StringTypeFlags type);
+extern "C" ASN1_STRING* CryptoNative_DecodeAsn1TypeBytes(const uint8_t* buf, int32_t len, Asn1StringTypeFlags type);
 
 /*
 Direct shim to ASN1_STRING_print_ex.
 */
-extern "C" int32_t Asn1StringPrintEx(BIO* out, ASN1_STRING* str, Asn1StringPrintFlags flags);
+extern "C" int32_t CryptoNative_Asn1StringPrintEx(BIO* out, ASN1_STRING* str, Asn1StringPrintFlags flags);

--- a/src/Native/System.Security.Cryptography.Native/pal_bignum.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_bignum.cpp
@@ -3,7 +3,7 @@
 
 #include "pal_bignum.h"
 
-extern "C" void BigNumDestroy(BIGNUM* a)
+extern "C" void CryptoNative_BigNumDestroy(BIGNUM* a)
 {
     if (a != nullptr)
     {
@@ -11,7 +11,7 @@ extern "C" void BigNumDestroy(BIGNUM* a)
     }
 }
 
-extern "C" BIGNUM* BigNumFromBinary(const uint8_t* s, int32_t len)
+extern "C" BIGNUM* CryptoNative_BigNumFromBinary(const uint8_t* s, int32_t len)
 {
     if (!s || !len)
     {
@@ -21,7 +21,7 @@ extern "C" BIGNUM* BigNumFromBinary(const uint8_t* s, int32_t len)
     return BN_bin2bn(s, len, nullptr);
 }
 
-extern "C" int32_t BigNumToBinary(const BIGNUM* a, uint8_t* to)
+extern "C" int32_t CryptoNative_BigNumToBinary(const BIGNUM* a, uint8_t* to)
 {
     if (!a || !to)
     {
@@ -31,7 +31,7 @@ extern "C" int32_t BigNumToBinary(const BIGNUM* a, uint8_t* to)
     return BN_bn2bin(a, to);
 }
 
-extern "C" int32_t GetBigNumBytes(const BIGNUM* a)
+extern "C" int32_t CryptoNative_GetBigNumBytes(const BIGNUM* a)
 {
     if (!a)
     {

--- a/src/Native/System.Security.Cryptography.Native/pal_bignum.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_bignum.cpp
@@ -3,12 +3,28 @@
 
 #include "pal_bignum.h"
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void BigNumDestroy(BIGNUM* a)
+{
+    return CryptoNative_BigNumDestroy(a);
+}
+
 extern "C" void CryptoNative_BigNumDestroy(BIGNUM* a)
 {
     if (a != nullptr)
     {
         BN_clear_free(a);
     }
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" BIGNUM* BigNumFromBinary(const uint8_t* s, int32_t len)
+{
+    return CryptoNative_BigNumFromBinary(s, len);
 }
 
 extern "C" BIGNUM* CryptoNative_BigNumFromBinary(const uint8_t* s, int32_t len)
@@ -21,6 +37,14 @@ extern "C" BIGNUM* CryptoNative_BigNumFromBinary(const uint8_t* s, int32_t len)
     return BN_bin2bn(s, len, nullptr);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t BigNumToBinary(const BIGNUM* a, uint8_t* to)
+{
+    return CryptoNative_BigNumToBinary(a, to);
+}
+
 extern "C" int32_t CryptoNative_BigNumToBinary(const BIGNUM* a, uint8_t* to)
 {
     if (!a || !to)
@@ -29,6 +53,14 @@ extern "C" int32_t CryptoNative_BigNumToBinary(const BIGNUM* a, uint8_t* to)
     }
 
     return BN_bn2bin(a, to);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t GetBigNumBytes(const BIGNUM* a)
+{
+    return CryptoNative_GetBigNumBytes(a);
 }
 
 extern "C" int32_t CryptoNative_GetBigNumBytes(const BIGNUM* a)

--- a/src/Native/System.Security.Cryptography.Native/pal_bignum.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_bignum.h
@@ -15,19 +15,19 @@ No-op if a is null.
 The given BIGNUM pointer is invalid after this call.
 Always succeeds.
 */
-extern "C" void BigNumDestroy(BIGNUM* a);
+extern "C" void CryptoNative_BigNumDestroy(BIGNUM* a);
 
 /*
 Shims the BN_bin2bn method.
 */
-extern "C" BIGNUM* BigNumFromBinary(const uint8_t* s, int32_t len);
+extern "C" BIGNUM* CryptoNative_BigNumFromBinary(const uint8_t* s, int32_t len);
 
 /*
 Shims the BN_bn2bin method.
 */
-extern "C" int32_t BigNumToBinary(const BIGNUM* a, uint8_t* to);
+extern "C" int32_t CryptoNative_BigNumToBinary(const BIGNUM* a, uint8_t* to);
 
 /*
 Returns the number of bytes needed to export a BIGNUM.
 */
-extern "C" int32_t GetBigNumBytes(const BIGNUM* a);
+extern "C" int32_t CryptoNative_GetBigNumBytes(const BIGNUM* a);

--- a/src/Native/System.Security.Cryptography.Native/pal_bio.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_bio.cpp
@@ -5,9 +5,25 @@
 
 #include <assert.h>
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" BIO* CreateMemoryBio()
+{
+    return CryptoNative_CreateMemoryBio();
+}
+
 extern "C" BIO* CryptoNative_CreateMemoryBio()
 {
     return BIO_new(BIO_s_mem());
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" BIO* BioNewFile(const char* filename, const char* mode)
+{
+    return CryptoNative_BioNewFile(filename, mode);
 }
 
 extern "C" BIO* CryptoNative_BioNewFile(const char* filename, const char* mode)
@@ -15,9 +31,25 @@ extern "C" BIO* CryptoNative_BioNewFile(const char* filename, const char* mode)
     return BIO_new_file(filename, mode);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t BioDestroy(BIO* a)
+{
+    return CryptoNative_BioDestroy(a);
+}
+
 extern "C" int32_t CryptoNative_BioDestroy(BIO* a)
 {
     return BIO_free(a);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t BioGets(BIO* b, char* buf, int32_t size)
+{
+    return CryptoNative_BioGets(b, buf, size);
 }
 
 extern "C" int32_t CryptoNative_BioGets(BIO* b, char* buf, int32_t size)
@@ -25,14 +57,38 @@ extern "C" int32_t CryptoNative_BioGets(BIO* b, char* buf, int32_t size)
     return BIO_gets(b, buf, size);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t BioRead(BIO* b, void* buf, int32_t len)
+{
+    return CryptoNative_BioRead(b, buf, len);
+}
+
 extern "C" int32_t CryptoNative_BioRead(BIO* b, void* buf, int32_t len)
 {
     return BIO_read(b, buf, len);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t BioWrite(BIO* b, const void* buf, int32_t len)
+{
+    return CryptoNative_BioWrite(b, buf, len);
+}
+
 extern "C" int32_t CryptoNative_BioWrite(BIO* b, const void* buf, int32_t len)
 {
     return BIO_write(b, buf, len);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t GetMemoryBioSize(BIO* bio)
+{
+    return CryptoNative_GetMemoryBioSize(bio);
 }
 
 extern "C" int32_t CryptoNative_GetMemoryBioSize(BIO* bio)
@@ -43,6 +99,14 @@ extern "C" int32_t CryptoNative_GetMemoryBioSize(BIO* bio)
     // an int32.
     assert(ret <= INT32_MAX);
     return static_cast<int32_t>(ret);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t BioCtrlPending(BIO* bio)
+{
+    return CryptoNative_BioCtrlPending(bio);
 }
 
 extern "C" int32_t CryptoNative_BioCtrlPending(BIO* bio)

--- a/src/Native/System.Security.Cryptography.Native/pal_bio.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_bio.cpp
@@ -5,37 +5,37 @@
 
 #include <assert.h>
 
-extern "C" BIO* CreateMemoryBio()
+extern "C" BIO* CryptoNative_CreateMemoryBio()
 {
     return BIO_new(BIO_s_mem());
 }
 
-extern "C" BIO* BioNewFile(const char* filename, const char* mode)
+extern "C" BIO* CryptoNative_BioNewFile(const char* filename, const char* mode)
 {
     return BIO_new_file(filename, mode);
 }
 
-extern "C" int32_t BioDestroy(BIO* a)
+extern "C" int32_t CryptoNative_BioDestroy(BIO* a)
 {
     return BIO_free(a);
 }
 
-extern "C" int32_t BioGets(BIO* b, char* buf, int32_t size)
+extern "C" int32_t CryptoNative_BioGets(BIO* b, char* buf, int32_t size)
 {
     return BIO_gets(b, buf, size);
 }
 
-extern "C" int32_t BioRead(BIO* b, void* buf, int32_t len)
+extern "C" int32_t CryptoNative_BioRead(BIO* b, void* buf, int32_t len)
 {
     return BIO_read(b, buf, len);
 }
 
-extern "C" int32_t BioWrite(BIO* b, const void* buf, int32_t len)
+extern "C" int32_t CryptoNative_BioWrite(BIO* b, const void* buf, int32_t len)
 {
     return BIO_write(b, buf, len);
 }
 
-extern "C" int32_t GetMemoryBioSize(BIO* bio)
+extern "C" int32_t CryptoNative_GetMemoryBioSize(BIO* bio)
 {
     long ret = BIO_get_mem_data(bio, nullptr);
 
@@ -45,7 +45,7 @@ extern "C" int32_t GetMemoryBioSize(BIO* bio)
     return static_cast<int32_t>(ret);
 }
 
-extern "C" int32_t BioCtrlPending(BIO* bio)
+extern "C" int32_t CryptoNative_BioCtrlPending(BIO* bio)
 {
     size_t result = BIO_ctrl_pending(bio);
     assert(result <= INT32_MAX);

--- a/src/Native/System.Security.Cryptography.Native/pal_bio.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_bio.h
@@ -8,12 +8,12 @@
 /*
 Creates a new memory-backed BIO instance.
 */
-extern "C" BIO* CreateMemoryBio();
+extern "C" BIO* CryptoNative_CreateMemoryBio();
 
 /*
 Direct shim to BIO_new_file.
 */
-extern "C" BIO* BioNewFile(const char* filename, const char* mode);
+extern "C" BIO* CryptoNative_BioNewFile(const char* filename, const char* mode);
 
 /*
 Cleans up and deletes a BIO instance.
@@ -24,33 +24,33 @@ Implemented by:
 No-op if a is null.
 The given BIO pointer is invalid after this call.
 */
-extern "C" int32_t BioDestroy(BIO* a);
+extern "C" int32_t CryptoNative_BioDestroy(BIO* a);
 
 /*
 Direct shim to BIO_gets.
 */
-extern "C" int32_t BioGets(BIO* b, char* buf, int32_t size);
+extern "C" int32_t CryptoNative_BioGets(BIO* b, char* buf, int32_t size);
 
 /*
 Direct shim to BIO_read.
 */
-extern "C" int32_t BioRead(BIO* b, void* buf, int32_t len);
+extern "C" int32_t CryptoNative_BioRead(BIO* b, void* buf, int32_t len);
 
 /*
 Direct shim to BIO_write.
 */
-extern "C" int32_t BioWrite(BIO* b, const void* buf, int32_t len);
+extern "C" int32_t CryptoNative_BioWrite(BIO* b, const void* buf, int32_t len);
 
 /*
 Gets the size of data available in the BIO.
 
 Shims the BIO_get_mem_data method.
 */
-extern "C" int32_t GetMemoryBioSize(BIO* bio);
+extern "C" int32_t CryptoNative_GetMemoryBioSize(BIO* bio);
 
 /*
 Shims the BIO_ctrl_pending method.
 
 Returns the number of pending characters in the BIOs read and write buffers.
 */
-extern "C" int32_t BioCtrlPending(BIO* bio);
+extern "C" int32_t CryptoNative_BioCtrlPending(BIO* bio);

--- a/src/Native/System.Security.Cryptography.Native/pal_ecdsa.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_ecdsa.cpp
@@ -4,7 +4,8 @@
 #include "pal_ecdsa.h"
 #include "pal_utilities.h"
 
-extern "C" int32_t EcDsaSign(const uint8_t* dgst, int32_t dgstlen, uint8_t* sig, int32_t* siglen, EC_KEY* key)
+extern "C" int32_t
+CryptoNative_EcDsaSign(const uint8_t* dgst, int32_t dgstlen, uint8_t* sig, int32_t* siglen, EC_KEY* key)
 {
     if (!siglen)
     {
@@ -17,12 +18,13 @@ extern "C" int32_t EcDsaSign(const uint8_t* dgst, int32_t dgstlen, uint8_t* sig,
     return ret;
 }
 
-extern "C" int32_t EcDsaVerify(const uint8_t* dgst, int32_t dgstlen, const uint8_t* sig, int32_t siglen, EC_KEY* key)
+extern "C" int32_t
+CryptoNative_EcDsaVerify(const uint8_t* dgst, int32_t dgstlen, const uint8_t* sig, int32_t siglen, EC_KEY* key)
 {
     return ECDSA_verify(0, dgst, dgstlen, sig, siglen, key);
 }
 
-extern "C" int32_t EcDsaSize(const EC_KEY* key)
+extern "C" int32_t CryptoNative_EcDsaSize(const EC_KEY* key)
 {
     return ECDSA_size(key);
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_ecdsa.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_ecdsa.cpp
@@ -4,6 +4,14 @@
 #include "pal_ecdsa.h"
 #include "pal_utilities.h"
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t EcDsaSign(const uint8_t* dgst, int32_t dgstlen, uint8_t* sig, int32_t* siglen, EC_KEY* key)
+{
+    return CryptoNative_EcDsaSign(dgst, dgstlen, sig, siglen, key);
+}
+
 extern "C" int32_t
 CryptoNative_EcDsaSign(const uint8_t* dgst, int32_t dgstlen, uint8_t* sig, int32_t* siglen, EC_KEY* key)
 {
@@ -18,10 +26,27 @@ CryptoNative_EcDsaSign(const uint8_t* dgst, int32_t dgstlen, uint8_t* sig, int32
     return ret;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t
+EcDsaVerify(const uint8_t* dgst, int32_t dgstlen, const uint8_t* sig, int32_t siglen, EC_KEY* key)
+{
+    return CryptoNative_EcDsaVerify(dgst, dgstlen, sig, siglen, key);
+}
+
 extern "C" int32_t
 CryptoNative_EcDsaVerify(const uint8_t* dgst, int32_t dgstlen, const uint8_t* sig, int32_t siglen, EC_KEY* key)
 {
     return ECDSA_verify(0, dgst, dgstlen, sig, siglen, key);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t EcDsaSize(const EC_KEY* key)
+{
+    return CryptoNative_EcDsaSize(key);
 }
 
 extern "C" int32_t CryptoNative_EcDsaSize(const EC_KEY* key)

--- a/src/Native/System.Security.Cryptography.Native/pal_ecdsa.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_ecdsa.h
@@ -10,18 +10,20 @@ Shims the ECDSA_sign method.
 
 Returns 1 on success, otherwise 0.
 */
-extern "C" int32_t EcDsaSign(const uint8_t* dgst, int32_t dgstlen, uint8_t* sig, int32_t* siglen, EC_KEY* key);
+extern "C" int32_t
+CryptoNative_EcDsaSign(const uint8_t* dgst, int32_t dgstlen, uint8_t* sig, int32_t* siglen, EC_KEY* key);
 
 /*
 Shims the ECDSA_verify method.
 
 Returns 1 for a correct signature, 0 for an incorrect signature, -1 on error.
 */
-extern "C" int32_t EcDsaVerify(const uint8_t* dgst, int32_t dgstlen, const uint8_t* sig, int32_t siglen, EC_KEY* key);
+extern "C" int32_t
+CryptoNative_EcDsaVerify(const uint8_t* dgst, int32_t dgstlen, const uint8_t* sig, int32_t siglen, EC_KEY* key);
 
 /*
 Shims the ECDSA_size method.
 
 Returns the maximum length of a DER encoded ECDSA signature created with this key.
 */
-extern "C" int32_t EcDsaSize(const EC_KEY* key);
+extern "C" int32_t CryptoNative_EcDsaSize(const EC_KEY* key);

--- a/src/Native/System.Security.Cryptography.Native/pal_eckey.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_eckey.cpp
@@ -6,9 +6,25 @@
 #include <assert.h>
 #include <openssl/objects.h>
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void EcKeyDestroy(EC_KEY* r)
+{
+    return CryptoNative_EcKeyDestroy(r);
+}
+
 extern "C" void CryptoNative_EcKeyDestroy(EC_KEY* r)
 {
     EC_KEY_free(r);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" EC_KEY* EcKeyCreateByCurveName(int32_t nid)
+{
+    return CryptoNative_EcKeyCreateByCurveName(nid);
 }
 
 extern "C" EC_KEY* CryptoNative_EcKeyCreateByCurveName(int32_t nid)
@@ -16,14 +32,38 @@ extern "C" EC_KEY* CryptoNative_EcKeyCreateByCurveName(int32_t nid)
     return EC_KEY_new_by_curve_name(nid);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t EcKeyGenerateKey(EC_KEY* eckey)
+{
+    return CryptoNative_EcKeyGenerateKey(eckey);
+}
+
 extern "C" int32_t CryptoNative_EcKeyGenerateKey(EC_KEY* eckey)
 {
     return EC_KEY_generate_key(eckey);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t EcKeyUpRef(EC_KEY* r)
+{
+    return CryptoNative_EcKeyUpRef(r);
+}
+
 extern "C" int32_t CryptoNative_EcKeyUpRef(EC_KEY* r)
 {
     return EC_KEY_up_ref(r);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t EcKeyGetCurveName(const EC_KEY* key)
+{
+    return CryptoNative_EcKeyGetCurveName(key);
 }
 
 extern "C" int32_t CryptoNative_EcKeyGetCurveName(const EC_KEY* key)

--- a/src/Native/System.Security.Cryptography.Native/pal_eckey.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_eckey.cpp
@@ -6,27 +6,27 @@
 #include <assert.h>
 #include <openssl/objects.h>
 
-extern "C" void EcKeyDestroy(EC_KEY* r)
+extern "C" void CryptoNative_EcKeyDestroy(EC_KEY* r)
 {
     EC_KEY_free(r);
 }
 
-extern "C" EC_KEY* EcKeyCreateByCurveName(int32_t nid)
+extern "C" EC_KEY* CryptoNative_EcKeyCreateByCurveName(int32_t nid)
 {
     return EC_KEY_new_by_curve_name(nid);
 }
 
-extern "C" int32_t EcKeyGenerateKey(EC_KEY* eckey)
+extern "C" int32_t CryptoNative_EcKeyGenerateKey(EC_KEY* eckey)
 {
     return EC_KEY_generate_key(eckey);
 }
 
-extern "C" int32_t EcKeyUpRef(EC_KEY* r)
+extern "C" int32_t CryptoNative_EcKeyUpRef(EC_KEY* r)
 {
     return EC_KEY_up_ref(r);
 }
 
-extern "C" int32_t EcKeyGetCurveName(const EC_KEY* key)
+extern "C" int32_t CryptoNative_EcKeyGetCurveName(const EC_KEY* key)
 {
     if (key == nullptr)
     {

--- a/src/Native/System.Security.Cryptography.Native/pal_eckey.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_eckey.h
@@ -14,32 +14,32 @@ No-op if r is null.
 The given EC_KEY pointer is invalid after this call.
 Always succeeds.
 */
-extern "C" void EcKeyDestroy(EC_KEY* r);
+extern "C" void CryptoNative_EcKeyDestroy(EC_KEY* r);
 
 /*
 Shims the EC_KEY_new_by_curve_name method.
 
 Returns the new EC_KEY instance.
 */
-extern "C" EC_KEY* EcKeyCreateByCurveName(int32_t nid);
+extern "C" EC_KEY* CryptoNative_EcKeyCreateByCurveName(int32_t nid);
 
 /*
 Shims the EC_KEY_generate_key method.
 
 Returns 1 upon success, otherwise 0.
 */
-extern "C" int32_t EcKeyGenerateKey(EC_KEY* eckey);
+extern "C" int32_t CryptoNative_EcKeyGenerateKey(EC_KEY* eckey);
 
 /*
 Shims the EC_KEY_up_ref method.
 
 Returns 1 upon success, otherwise 0.
 */
-extern "C" int32_t EcKeyUpRef(EC_KEY* r);
+extern "C" int32_t CryptoNative_EcKeyUpRef(EC_KEY* r);
 
 /*
 Gets the curve name for the specified EC_KEY.
 
 Returns the NID of the curve name.
 */
-extern "C" int32_t EcKeyGetCurveName(const EC_KEY* key);
+extern "C" int32_t CryptoNative_EcKeyGetCurveName(const EC_KEY* key);

--- a/src/Native/System.Security.Cryptography.Native/pal_err.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_err.cpp
@@ -6,12 +6,12 @@
 
 #include <openssl/err.h>
 
-extern "C" uint64_t ErrGetError()
+extern "C" uint64_t CryptoNative_ErrGetError()
 {
     return ERR_get_error();
 }
 
-extern "C" uint64_t ErrGetErrorAlloc(int32_t* isAllocFailure)
+extern "C" uint64_t CryptoNative_ErrGetErrorAlloc(int32_t* isAllocFailure)
 {
     unsigned long err = ERR_get_error();
 
@@ -23,12 +23,12 @@ extern "C" uint64_t ErrGetErrorAlloc(int32_t* isAllocFailure)
     return err;
 }
 
-extern "C" const char* ErrReasonErrorString(uint64_t error)
+extern "C" const char* CryptoNative_ErrReasonErrorString(uint64_t error)
 {
     return ERR_reason_error_string(static_cast<unsigned long>(error));
 }
 
-extern "C" void ErrErrorStringN(uint64_t e, char* buf, int32_t len)
+extern "C" void CryptoNative_ErrErrorStringN(uint64_t e, char* buf, int32_t len)
 {
     ERR_error_string_n(static_cast<unsigned long>(e), buf, UnsignedCast(len));
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_err.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_err.cpp
@@ -6,9 +6,25 @@
 
 #include <openssl/err.h>
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" uint64_t ErrGetError()
+{
+    return CryptoNative_ErrGetError();
+}
+
 extern "C" uint64_t CryptoNative_ErrGetError()
 {
     return ERR_get_error();
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" uint64_t ErrGetErrorAlloc(int32_t* isAllocFailure)
+{
+    return CryptoNative_ErrGetErrorAlloc(isAllocFailure);
 }
 
 extern "C" uint64_t CryptoNative_ErrGetErrorAlloc(int32_t* isAllocFailure)
@@ -23,9 +39,25 @@ extern "C" uint64_t CryptoNative_ErrGetErrorAlloc(int32_t* isAllocFailure)
     return err;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const char* ErrReasonErrorString(uint64_t error)
+{
+    return CryptoNative_ErrReasonErrorString(error);
+}
+
 extern "C" const char* CryptoNative_ErrReasonErrorString(uint64_t error)
 {
     return ERR_reason_error_string(static_cast<unsigned long>(error));
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void ErrErrorStringN(uint64_t e, char* buf, int32_t len)
+{
+    return CryptoNative_ErrErrorStringN(e, buf, len);
 }
 
 extern "C" void CryptoNative_ErrErrorStringN(uint64_t e, char* buf, int32_t len)

--- a/src/Native/System.Security.Cryptography.Native/pal_err.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_err.h
@@ -6,22 +6,22 @@
 /*
 Shims the ERR_get_error method.
 */
-extern "C" uint64_t ErrGetError();
+extern "C" uint64_t CryptoNative_ErrGetError();
 
 /*
 Shim to ERR_get_error which also returns whether the error
 was caused by an allocation failure.
 */
-extern "C" uint64_t ErrGetErrorAlloc(int32_t* isAllocFailure);
+extern "C" uint64_t CryptoNative_ErrGetErrorAlloc(int32_t* isAllocFailure);
 
 /*
 Shims the ERR_reason_error_string method.
 
 Returns the string for the specified error.
 */
-extern "C" const char* ErrReasonErrorString(uint64_t error);
+extern "C" const char* CryptoNative_ErrReasonErrorString(uint64_t error);
 
 /*
 Direct shim to ERR_error_string_n.
 */
-extern "C" void ErrErrorStringN(uint64_t e, char* buf, int32_t len);
+extern "C" void CryptoNative_ErrErrorStringN(uint64_t e, char* buf, int32_t len);

--- a/src/Native/System.Security.Cryptography.Native/pal_evp.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp.cpp
@@ -7,7 +7,7 @@
 
 #define SUCCESS 1
 
-extern "C" EVP_MD_CTX* EvpMdCtxCreate(const EVP_MD* type)
+extern "C" EVP_MD_CTX* CryptoNative_EvpMdCtxCreate(const EVP_MD* type)
 {
     EVP_MD_CTX* ctx = EVP_MD_CTX_create();
     if (ctx == nullptr)
@@ -26,7 +26,7 @@ extern "C" EVP_MD_CTX* EvpMdCtxCreate(const EVP_MD* type)
     return ctx;
 }
 
-extern "C" void EvpMdCtxDestroy(EVP_MD_CTX* ctx)
+extern "C" void CryptoNative_EvpMdCtxDestroy(EVP_MD_CTX* ctx)
 {
     if (ctx != nullptr)
     {
@@ -34,17 +34,17 @@ extern "C" void EvpMdCtxDestroy(EVP_MD_CTX* ctx)
     }
 }
 
-extern "C" int32_t EvpDigestReset(EVP_MD_CTX* ctx, const EVP_MD* type)
+extern "C" int32_t CryptoNative_EvpDigestReset(EVP_MD_CTX* ctx, const EVP_MD* type)
 {
     return EVP_DigestInit_ex(ctx, type, nullptr);
 }
 
-extern "C" int32_t EvpDigestUpdate(EVP_MD_CTX* ctx, const void* d, size_t cnt)
+extern "C" int32_t CryptoNative_EvpDigestUpdate(EVP_MD_CTX* ctx, const void* d, size_t cnt)
 {
     return EVP_DigestUpdate(ctx, d, cnt);
 }
 
-extern "C" int32_t EvpDigestFinalEx(EVP_MD_CTX* ctx, uint8_t* md, uint32_t* s)
+extern "C" int32_t CryptoNative_EvpDigestFinalEx(EVP_MD_CTX* ctx, uint8_t* md, uint32_t* s)
 {
     unsigned int size;
     int32_t ret = EVP_DigestFinal_ex(ctx, md, &size);
@@ -56,37 +56,37 @@ extern "C" int32_t EvpDigestFinalEx(EVP_MD_CTX* ctx, uint8_t* md, uint32_t* s)
     return ret;
 }
 
-extern "C" int32_t EvpMdSize(const EVP_MD* md)
+extern "C" int32_t CryptoNative_EvpMdSize(const EVP_MD* md)
 {
     return EVP_MD_size(md);
 }
 
-extern "C" const EVP_MD* EvpMd5()
+extern "C" const EVP_MD* CryptoNative_EvpMd5()
 {
     return EVP_md5();
 }
 
-extern "C" const EVP_MD* EvpSha1()
+extern "C" const EVP_MD* CryptoNative_EvpSha1()
 {
     return EVP_sha1();
 }
 
-extern "C" const EVP_MD* EvpSha256()
+extern "C" const EVP_MD* CryptoNative_EvpSha256()
 {
     return EVP_sha256();
 }
 
-extern "C" const EVP_MD* EvpSha384()
+extern "C" const EVP_MD* CryptoNative_EvpSha384()
 {
     return EVP_sha384();
 }
 
-extern "C" const EVP_MD* EvpSha512()
+extern "C" const EVP_MD* CryptoNative_EvpSha512()
 {
     return EVP_sha512();
 }
 
-extern "C" int32_t GetMaxMdSize()
+extern "C" int32_t CryptoNative_GetMaxMdSize()
 {
     return EVP_MAX_MD_SIZE;
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_evp.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp.cpp
@@ -7,6 +7,14 @@
 
 #define SUCCESS 1
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" EVP_MD_CTX* EvpMdCtxCreate(const EVP_MD* type)
+{
+    return CryptoNative_EvpMdCtxCreate(type);
+}
+
 extern "C" EVP_MD_CTX* CryptoNative_EvpMdCtxCreate(const EVP_MD* type)
 {
     EVP_MD_CTX* ctx = EVP_MD_CTX_create();
@@ -26,6 +34,14 @@ extern "C" EVP_MD_CTX* CryptoNative_EvpMdCtxCreate(const EVP_MD* type)
     return ctx;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void EvpMdCtxDestroy(EVP_MD_CTX* ctx)
+{
+    return CryptoNative_EvpMdCtxDestroy(ctx);
+}
+
 extern "C" void CryptoNative_EvpMdCtxDestroy(EVP_MD_CTX* ctx)
 {
     if (ctx != nullptr)
@@ -34,14 +50,38 @@ extern "C" void CryptoNative_EvpMdCtxDestroy(EVP_MD_CTX* ctx)
     }
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t EvpDigestReset(EVP_MD_CTX* ctx, const EVP_MD* type)
+{
+    return CryptoNative_EvpDigestReset(ctx, type);
+}
+
 extern "C" int32_t CryptoNative_EvpDigestReset(EVP_MD_CTX* ctx, const EVP_MD* type)
 {
     return EVP_DigestInit_ex(ctx, type, nullptr);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t EvpDigestUpdate(EVP_MD_CTX* ctx, const void* d, size_t cnt)
+{
+    return CryptoNative_EvpDigestUpdate(ctx, d, cnt);
+}
+
 extern "C" int32_t CryptoNative_EvpDigestUpdate(EVP_MD_CTX* ctx, const void* d, size_t cnt)
 {
     return EVP_DigestUpdate(ctx, d, cnt);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t EvpDigestFinalEx(EVP_MD_CTX* ctx, uint8_t* md, uint32_t* s)
+{
+    return CryptoNative_EvpDigestFinalEx(ctx, md, s);
 }
 
 extern "C" int32_t CryptoNative_EvpDigestFinalEx(EVP_MD_CTX* ctx, uint8_t* md, uint32_t* s)
@@ -56,9 +96,25 @@ extern "C" int32_t CryptoNative_EvpDigestFinalEx(EVP_MD_CTX* ctx, uint8_t* md, u
     return ret;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t EvpMdSize(const EVP_MD* md)
+{
+    return CryptoNative_EvpMdSize(md);
+}
+
 extern "C" int32_t CryptoNative_EvpMdSize(const EVP_MD* md)
 {
     return EVP_MD_size(md);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const EVP_MD* EvpMd5()
+{
+    return CryptoNative_EvpMd5();
 }
 
 extern "C" const EVP_MD* CryptoNative_EvpMd5()
@@ -66,9 +122,25 @@ extern "C" const EVP_MD* CryptoNative_EvpMd5()
     return EVP_md5();
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const EVP_MD* EvpSha1()
+{
+    return CryptoNative_EvpSha1();
+}
+
 extern "C" const EVP_MD* CryptoNative_EvpSha1()
 {
     return EVP_sha1();
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const EVP_MD* EvpSha256()
+{
+    return CryptoNative_EvpSha256();
 }
 
 extern "C" const EVP_MD* CryptoNative_EvpSha256()
@@ -76,14 +148,38 @@ extern "C" const EVP_MD* CryptoNative_EvpSha256()
     return EVP_sha256();
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const EVP_MD* EvpSha384()
+{
+    return CryptoNative_EvpSha384();
+}
+
 extern "C" const EVP_MD* CryptoNative_EvpSha384()
 {
     return EVP_sha384();
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const EVP_MD* EvpSha512()
+{
+    return CryptoNative_EvpSha512();
+}
+
 extern "C" const EVP_MD* CryptoNative_EvpSha512()
 {
     return EVP_sha512();
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t GetMaxMdSize()
+{
+    return CryptoNative_GetMaxMdSize();
 }
 
 extern "C" int32_t CryptoNative_GetMaxMdSize()

--- a/src/Native/System.Security.Cryptography.Native/pal_evp.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp.h
@@ -13,7 +13,7 @@ Implemented by:
 
 Returns new EVP_MD_CTX on success, nullptr on failure.
 */
-extern "C" EVP_MD_CTX* EvpMdCtxCreate(const EVP_MD* type);
+extern "C" EVP_MD_CTX* CryptoNative_EvpMdCtxCreate(const EVP_MD* type);
 
 /*
 Cleans up and deletes an EVP_MD_CTX instance created by EvpMdCtxCreate.
@@ -25,12 +25,12 @@ No-op if ctx is null.
 The given EVP_MD_CTX pointer is invalid after this call.
 Always succeeds.
 */
-extern "C" void EvpMdCtxDestroy(EVP_MD_CTX* ctx);
+extern "C" void CryptoNative_EvpMdCtxDestroy(EVP_MD_CTX* ctx);
 
 /*
 Resets an EVP_MD_CTX instance for a new computation.
 */
-extern "C" int32_t EvpDigestReset(EVP_MD_CTX* ctx, const EVP_MD* type);
+extern "C" int32_t CryptoNative_EvpDigestReset(EVP_MD_CTX* ctx, const EVP_MD* type);
 
 /*
 Function:
@@ -38,7 +38,7 @@ EvpDigestUpdate
 
 Direct shim to EVP_DigestUpdate.
 */
-extern "C" int32_t EvpDigestUpdate(EVP_MD_CTX* ctx, const void* d, size_t cnt);
+extern "C" int32_t CryptoNative_EvpDigestUpdate(EVP_MD_CTX* ctx, const void* d, size_t cnt);
 
 /*
 Function:
@@ -46,7 +46,7 @@ EvpDigestFinalEx
 
 Direct shim to EVP_DigestFinal_ex.
 */
-extern "C" int32_t EvpDigestFinalEx(EVP_MD_CTX* ctx, uint8_t* md, uint32_t* s);
+extern "C" int32_t CryptoNative_EvpDigestFinalEx(EVP_MD_CTX* ctx, uint8_t* md, uint32_t* s);
 
 /*
 Function:
@@ -54,7 +54,7 @@ EvpMdSize
 
 Direct shim to EVP_MD_size.
 */
-extern "C" int32_t EvpMdSize(const EVP_MD* md);
+extern "C" int32_t CryptoNative_EvpMdSize(const EVP_MD* md);
 
 /*
 Function:
@@ -62,7 +62,7 @@ EvpMd5
 
 Direct shim to EVP_md5.
 */
-extern "C" const EVP_MD* EvpMd5();
+extern "C" const EVP_MD* CryptoNative_EvpMd5();
 
 /*
 Function:
@@ -70,7 +70,7 @@ EvpSha1
 
 Direct shim to EVP_sha1.
 */
-extern "C" const EVP_MD* EvpSha1();
+extern "C" const EVP_MD* CryptoNative_EvpSha1();
 
 /*
 Function:
@@ -78,7 +78,7 @@ EvpSha256
 
 Direct shim to EVP_sha256.
 */
-extern "C" const EVP_MD* EvpSha256();
+extern "C" const EVP_MD* CryptoNative_EvpSha256();
 
 /*
 Function:
@@ -86,7 +86,7 @@ EvpSha384
 
 Direct shim to EVP_sha384.
 */
-extern "C" const EVP_MD* EvpSha384();
+extern "C" const EVP_MD* CryptoNative_EvpSha384();
 
 /*
 Function:
@@ -94,7 +94,7 @@ EvpSha512
 
 Direct shim to EVP_sha512.
 */
-extern "C" const EVP_MD* EvpSha512();
+extern "C" const EVP_MD* CryptoNative_EvpSha512();
 
 /*
 Function:
@@ -102,4 +102,4 @@ GetMaxMdSize
 
 Returns the maxium bytes for a message digest.
 */
-extern "C" int32_t GetMaxMdSize();
+extern "C" int32_t CryptoNative_GetMaxMdSize();

--- a/src/Native/System.Security.Cryptography.Native/pal_evp_cipher.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp_cipher.cpp
@@ -9,7 +9,8 @@
 #define SUCCESS 1
 #define KEEP_CURRENT_DIRECTION -1
 
-extern "C" EVP_CIPHER_CTX* EvpCipherCreate(const EVP_CIPHER* type, uint8_t* key, unsigned char* iv, int32_t enc)
+extern "C" EVP_CIPHER_CTX*
+CryptoNative_EvpCipherCreate(const EVP_CIPHER* type, uint8_t* key, unsigned char* iv, int32_t enc)
 {
     std::unique_ptr<EVP_CIPHER_CTX> ctx(new (std::nothrow) EVP_CIPHER_CTX);
     if (ctx == nullptr)
@@ -29,7 +30,7 @@ extern "C" EVP_CIPHER_CTX* EvpCipherCreate(const EVP_CIPHER* type, uint8_t* key,
     return ctx.release();
 }
 
-extern "C" void EvpCipherDestroy(EVP_CIPHER_CTX* ctx)
+extern "C" void CryptoNative_EvpCipherDestroy(EVP_CIPHER_CTX* ctx)
 {
     if (ctx != nullptr)
     {
@@ -38,7 +39,7 @@ extern "C" void EvpCipherDestroy(EVP_CIPHER_CTX* ctx)
     }
 }
 
-extern "C" int32_t EvpCipherReset(EVP_CIPHER_CTX* ctx)
+extern "C" int32_t CryptoNative_EvpCipherReset(EVP_CIPHER_CTX* ctx)
 {
     // EVP_CipherInit_ex with all nulls preserves the algorithm, resets the IV,
     // and maintains the key.
@@ -52,12 +53,13 @@ extern "C" int32_t EvpCipherReset(EVP_CIPHER_CTX* ctx)
     return EVP_CipherInit_ex(ctx, nullptr, nullptr, nullptr, nullptr, KEEP_CURRENT_DIRECTION);
 }
 
-extern "C" int32_t EvpCipherCtxSetPadding(EVP_CIPHER_CTX* x, int32_t padding)
+extern "C" int32_t CryptoNative_EvpCipherCtxSetPadding(EVP_CIPHER_CTX* x, int32_t padding)
 {
     return EVP_CIPHER_CTX_set_padding(x, padding);
 }
 
-extern "C" int32_t EvpCipherUpdate(EVP_CIPHER_CTX* ctx, uint8_t* out, int32_t* outl, unsigned char* in, int32_t inl)
+extern "C" int32_t
+CryptoNative_EvpCipherUpdate(EVP_CIPHER_CTX* ctx, uint8_t* out, int32_t* outl, unsigned char* in, int32_t inl)
 {
     int outLength;
     int32_t ret = EVP_CipherUpdate(ctx, out, &outLength, in, inl);
@@ -69,7 +71,7 @@ extern "C" int32_t EvpCipherUpdate(EVP_CIPHER_CTX* ctx, uint8_t* out, int32_t* o
     return ret;
 }
 
-extern "C" int32_t EvpCipherFinalEx(EVP_CIPHER_CTX* ctx, uint8_t* outm, int32_t* outl)
+extern "C" int32_t CryptoNative_EvpCipherFinalEx(EVP_CIPHER_CTX* ctx, uint8_t* outm, int32_t* outl)
 {
     int outLength;
     int32_t ret = EVP_CipherFinal_ex(ctx, outm, &outLength);
@@ -81,42 +83,42 @@ extern "C" int32_t EvpCipherFinalEx(EVP_CIPHER_CTX* ctx, uint8_t* outm, int32_t*
     return ret;
 }
 
-extern "C" const EVP_CIPHER* EvpAes128Ecb()
+extern "C" const EVP_CIPHER* CryptoNative_EvpAes128Ecb()
 {
     return EVP_aes_128_ecb();
 }
 
-extern "C" const EVP_CIPHER* EvpAes128Cbc()
+extern "C" const EVP_CIPHER* CryptoNative_EvpAes128Cbc()
 {
     return EVP_aes_128_cbc();
 }
 
-extern "C" const EVP_CIPHER* EvpAes192Ecb()
+extern "C" const EVP_CIPHER* CryptoNative_EvpAes192Ecb()
 {
     return EVP_aes_192_ecb();
 }
 
-extern "C" const EVP_CIPHER* EvpAes192Cbc()
+extern "C" const EVP_CIPHER* CryptoNative_EvpAes192Cbc()
 {
     return EVP_aes_192_cbc();
 }
 
-extern "C" const EVP_CIPHER* EvpAes256Ecb()
+extern "C" const EVP_CIPHER* CryptoNative_EvpAes256Ecb()
 {
     return EVP_aes_256_ecb();
 }
 
-extern "C" const EVP_CIPHER* EvpAes256Cbc()
+extern "C" const EVP_CIPHER* CryptoNative_EvpAes256Cbc()
 {
     return EVP_aes_256_cbc();
 }
 
-extern "C" const EVP_CIPHER* EvpDes3Ecb()
+extern "C" const EVP_CIPHER* CryptoNative_EvpDes3Ecb()
 {
     return EVP_des_ede3();
 }
 
-extern "C" const EVP_CIPHER* EvpDes3Cbc()
+extern "C" const EVP_CIPHER* CryptoNative_EvpDes3Cbc()
 {
     return EVP_des_ede3_cbc();
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_evp_cipher.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp_cipher.cpp
@@ -9,6 +9,15 @@
 #define SUCCESS 1
 #define KEEP_CURRENT_DIRECTION -1
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" EVP_CIPHER_CTX*
+EvpCipherCreate(const EVP_CIPHER* type, uint8_t* key, unsigned char* iv, int32_t enc)
+{
+    return CryptoNative_EvpCipherCreate(type, key, iv, enc);
+}
+
 extern "C" EVP_CIPHER_CTX*
 CryptoNative_EvpCipherCreate(const EVP_CIPHER* type, uint8_t* key, unsigned char* iv, int32_t enc)
 {
@@ -30,6 +39,14 @@ CryptoNative_EvpCipherCreate(const EVP_CIPHER* type, uint8_t* key, unsigned char
     return ctx.release();
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void EvpCipherDestroy(EVP_CIPHER_CTX* ctx)
+{
+    return CryptoNative_EvpCipherDestroy(ctx);
+}
+
 extern "C" void CryptoNative_EvpCipherDestroy(EVP_CIPHER_CTX* ctx)
 {
     if (ctx != nullptr)
@@ -37,6 +54,14 @@ extern "C" void CryptoNative_EvpCipherDestroy(EVP_CIPHER_CTX* ctx)
         EVP_CIPHER_CTX_cleanup(ctx);
         delete ctx;
     }
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t EvpCipherReset(EVP_CIPHER_CTX* ctx)
+{
+    return CryptoNative_EvpCipherReset(ctx);
 }
 
 extern "C" int32_t CryptoNative_EvpCipherReset(EVP_CIPHER_CTX* ctx)
@@ -53,9 +78,26 @@ extern "C" int32_t CryptoNative_EvpCipherReset(EVP_CIPHER_CTX* ctx)
     return EVP_CipherInit_ex(ctx, nullptr, nullptr, nullptr, nullptr, KEEP_CURRENT_DIRECTION);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t EvpCipherCtxSetPadding(EVP_CIPHER_CTX* x, int32_t padding)
+{
+    return CryptoNative_EvpCipherCtxSetPadding(x, padding);
+}
+
 extern "C" int32_t CryptoNative_EvpCipherCtxSetPadding(EVP_CIPHER_CTX* x, int32_t padding)
 {
     return EVP_CIPHER_CTX_set_padding(x, padding);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t
+EvpCipherUpdate(EVP_CIPHER_CTX* ctx, uint8_t* out, int32_t* outl, unsigned char* in, int32_t inl)
+{
+    return CryptoNative_EvpCipherUpdate(ctx, out, outl, in, inl);
 }
 
 extern "C" int32_t
@@ -71,6 +113,14 @@ CryptoNative_EvpCipherUpdate(EVP_CIPHER_CTX* ctx, uint8_t* out, int32_t* outl, u
     return ret;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t EvpCipherFinalEx(EVP_CIPHER_CTX* ctx, uint8_t* outm, int32_t* outl)
+{
+    return CryptoNative_EvpCipherFinalEx(ctx, outm, outl);
+}
+
 extern "C" int32_t CryptoNative_EvpCipherFinalEx(EVP_CIPHER_CTX* ctx, uint8_t* outm, int32_t* outl)
 {
     int outLength;
@@ -83,9 +133,25 @@ extern "C" int32_t CryptoNative_EvpCipherFinalEx(EVP_CIPHER_CTX* ctx, uint8_t* o
     return ret;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const EVP_CIPHER* EvpAes128Ecb()
+{
+    return CryptoNative_EvpAes128Ecb();
+}
+
 extern "C" const EVP_CIPHER* CryptoNative_EvpAes128Ecb()
 {
     return EVP_aes_128_ecb();
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const EVP_CIPHER* EvpAes128Cbc()
+{
+    return CryptoNative_EvpAes128Cbc();
 }
 
 extern "C" const EVP_CIPHER* CryptoNative_EvpAes128Cbc()
@@ -93,9 +159,25 @@ extern "C" const EVP_CIPHER* CryptoNative_EvpAes128Cbc()
     return EVP_aes_128_cbc();
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const EVP_CIPHER* EvpAes192Ecb()
+{
+    return CryptoNative_EvpAes192Ecb();
+}
+
 extern "C" const EVP_CIPHER* CryptoNative_EvpAes192Ecb()
 {
     return EVP_aes_192_ecb();
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const EVP_CIPHER* EvpAes192Cbc()
+{
+    return CryptoNative_EvpAes192Cbc();
 }
 
 extern "C" const EVP_CIPHER* CryptoNative_EvpAes192Cbc()
@@ -103,9 +185,25 @@ extern "C" const EVP_CIPHER* CryptoNative_EvpAes192Cbc()
     return EVP_aes_192_cbc();
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const EVP_CIPHER* EvpAes256Ecb()
+{
+    return CryptoNative_EvpAes256Ecb();
+}
+
 extern "C" const EVP_CIPHER* CryptoNative_EvpAes256Ecb()
 {
     return EVP_aes_256_ecb();
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const EVP_CIPHER* EvpAes256Cbc()
+{
+    return CryptoNative_EvpAes256Cbc();
 }
 
 extern "C" const EVP_CIPHER* CryptoNative_EvpAes256Cbc()
@@ -113,9 +211,25 @@ extern "C" const EVP_CIPHER* CryptoNative_EvpAes256Cbc()
     return EVP_aes_256_cbc();
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const EVP_CIPHER* EvpDes3Ecb()
+{
+    return CryptoNative_EvpDes3Ecb();
+}
+
 extern "C" const EVP_CIPHER* CryptoNative_EvpDes3Ecb()
 {
     return EVP_des_ede3();
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const EVP_CIPHER* EvpDes3Cbc()
+{
+    return CryptoNative_EvpDes3Cbc();
 }
 
 extern "C" const EVP_CIPHER* CryptoNative_EvpDes3Cbc()

--- a/src/Native/System.Security.Cryptography.Native/pal_evp_cipher.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp_cipher.h
@@ -14,7 +14,8 @@ Implemented by:
 
 Returns new EVP_CIPHER_CTX on success, nullptr on failure.
 */
-extern "C" EVP_CIPHER_CTX* EvpCipherCreate(const EVP_CIPHER* type, uint8_t* key, unsigned char* iv, int32_t enc);
+extern "C" EVP_CIPHER_CTX*
+CryptoNative_EvpCipherCreate(const EVP_CIPHER* type, uint8_t* key, unsigned char* iv, int32_t enc);
 
 /*
 Cleans up and deletes an EVP_CIPHER_CTX instance created by EvpCipherCreate.
@@ -27,7 +28,7 @@ No-op if ctx is null.
 The given EVP_CIPHER_CTX pointer is invalid after this call.
 Always succeeds.
 */
-extern "C" void EvpCipherDestroy(EVP_CIPHER_CTX* ctx);
+extern "C" void CryptoNative_EvpCipherDestroy(EVP_CIPHER_CTX* ctx);
 
 /*
 Function:
@@ -35,7 +36,7 @@ EvpCipherReset
 
 Resets an EVP_CIPHER_CTX instance for a new computation.
 */
-extern "C" int32_t EvpCipherReset(EVP_CIPHER_CTX* ctx);
+extern "C" int32_t CryptoNative_EvpCipherReset(EVP_CIPHER_CTX* ctx);
 
 /*
 Function:
@@ -43,7 +44,7 @@ EvpCipherCtxSetPadding
 
 Direct shim to EVP_CIPHER_CTX_set_padding.
 */
-extern "C" int32_t EvpCipherCtxSetPadding(EVP_CIPHER_CTX* x, int32_t padding);
+extern "C" int32_t CryptoNative_EvpCipherCtxSetPadding(EVP_CIPHER_CTX* x, int32_t padding);
 
 /*
 Function:
@@ -51,7 +52,8 @@ EvpCipherUpdate
 
 Direct shim to EVP_CipherUpdate.
 */
-extern "C" int32_t EvpCipherUpdate(EVP_CIPHER_CTX* ctx, uint8_t* out, int32_t* outl, unsigned char* in, int32_t inl);
+extern "C" int32_t
+CryptoNative_EvpCipherUpdate(EVP_CIPHER_CTX* ctx, uint8_t* out, int32_t* outl, unsigned char* in, int32_t inl);
 
 /*
 Function:
@@ -59,7 +61,7 @@ EvpCipherFinalEx
 
 Direct shim to EVP_CipherFinal_ex.
 */
-extern "C" int32_t EvpCipherFinalEx(EVP_CIPHER_CTX* ctx, uint8_t* outm, int32_t* outl);
+extern "C" int32_t CryptoNative_EvpCipherFinalEx(EVP_CIPHER_CTX* ctx, uint8_t* outm, int32_t* outl);
 
 /*
 Function:
@@ -67,7 +69,7 @@ EvpAes128Ecb
 
 Direct shim to EVP_aes_128_ecb.
 */
-extern "C" const EVP_CIPHER* EvpAes128Ecb();
+extern "C" const EVP_CIPHER* CryptoNative_EvpAes128Ecb();
 
 /*
 Function:
@@ -75,7 +77,7 @@ EvpAes128Cbc
 
 Direct shim to EVP_aes_128_cbc.
 */
-extern "C" const EVP_CIPHER* EvpAes128Cbc();
+extern "C" const EVP_CIPHER* CryptoNative_EvpAes128Cbc();
 
 /*
 Function:
@@ -83,7 +85,7 @@ EvpAes192Ecb
 
 Direct shim to EVP_aes_192_ecb.
 */
-extern "C" const EVP_CIPHER* EvpAes192Ecb();
+extern "C" const EVP_CIPHER* CryptoNative_EvpAes192Ecb();
 
 /*
 Function:
@@ -91,7 +93,7 @@ EvpAes192Cbc
 
 Direct shim to EVP_aes_192_cbc.
 */
-extern "C" const EVP_CIPHER* EvpAes192Cbc();
+extern "C" const EVP_CIPHER* CryptoNative_EvpAes192Cbc();
 
 /*
 Function:
@@ -99,7 +101,7 @@ EvpAes256Ecb
 
 Direct shim to EVP_aes_256_ecb.
 */
-extern "C" const EVP_CIPHER* EvpAes256Ecb();
+extern "C" const EVP_CIPHER* CryptoNative_EvpAes256Ecb();
 
 /*
 Function:
@@ -107,7 +109,7 @@ EvpAes256Cbc
 
 Direct shim to EVP_aes_256_cbc.
 */
-extern "C" const EVP_CIPHER* EvpAes256Cbc();
+extern "C" const EVP_CIPHER* CryptoNative_EvpAes256Cbc();
 
 /*
 Function:
@@ -115,7 +117,7 @@ EvpDes3Ecb
 
 Direct shim to EVP_des_ede3.
 */
-extern "C" const EVP_CIPHER* EvpDes3Ecb();
+extern "C" const EVP_CIPHER* CryptoNative_EvpDes3Ecb();
 
 /*
 Function:
@@ -123,4 +125,4 @@ EvpDes3Cbc
 
 Direct shim to EVP_des_ede3_cbc.
 */
-extern "C" const EVP_CIPHER* EvpDes3Cbc();
+extern "C" const EVP_CIPHER* CryptoNative_EvpDes3Cbc();

--- a/src/Native/System.Security.Cryptography.Native/pal_evp_pkey.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp_pkey.cpp
@@ -3,9 +3,25 @@
 
 #include "pal_evp_pkey.h"
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" EVP_PKEY* EvpPkeyCreate()
+{
+    return CryptoNative_EvpPkeyCreate();
+}
+
 extern "C" EVP_PKEY* CryptoNative_EvpPkeyCreate()
 {
     return EVP_PKEY_new();
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void EvpPkeyDestroy(EVP_PKEY* pkey)
+{
+    return CryptoNative_EvpPkeyDestroy(pkey);
 }
 
 extern "C" void CryptoNative_EvpPkeyDestroy(EVP_PKEY* pkey)
@@ -14,6 +30,14 @@ extern "C" void CryptoNative_EvpPkeyDestroy(EVP_PKEY* pkey)
     {
         EVP_PKEY_free(pkey);
     }
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t UpRefEvpPkey(EVP_PKEY* pkey)
+{
+    return CryptoNative_UpRefEvpPkey(pkey);
 }
 
 extern "C" int32_t CryptoNative_UpRefEvpPkey(EVP_PKEY* pkey)

--- a/src/Native/System.Security.Cryptography.Native/pal_evp_pkey.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp_pkey.cpp
@@ -3,12 +3,12 @@
 
 #include "pal_evp_pkey.h"
 
-extern "C" EVP_PKEY* EvpPkeyCreate()
+extern "C" EVP_PKEY* CryptoNative_EvpPkeyCreate()
 {
     return EVP_PKEY_new();
 }
 
-extern "C" void EvpPkeyDestroy(EVP_PKEY* pkey)
+extern "C" void CryptoNative_EvpPkeyDestroy(EVP_PKEY* pkey)
 {
     if (pkey != nullptr)
     {
@@ -16,7 +16,7 @@ extern "C" void EvpPkeyDestroy(EVP_PKEY* pkey)
     }
 }
 
-extern "C" int32_t UpRefEvpPkey(EVP_PKEY* pkey)
+extern "C" int32_t CryptoNative_UpRefEvpPkey(EVP_PKEY* pkey)
 {
     if (!pkey)
     {

--- a/src/Native/System.Security.Cryptography.Native/pal_evp_pkey.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp_pkey.h
@@ -10,7 +10,7 @@ Shims the EVP_PKEY_new method.
 
 Returns the new EVP_PKEY instance.
 */
-extern "C" EVP_PKEY* EvpPkeyCreate();
+extern "C" EVP_PKEY* CryptoNative_EvpPkeyCreate();
 
 /*
 Cleans up and deletes a EVP_PKEY instance.
@@ -21,7 +21,7 @@ No-op if pkey is null.
 The given EVP_PKEY pointer is invalid after this call.
 Always succeeds.
 */
-extern "C" void EvpPkeyDestroy(EVP_PKEY* pkey);
+extern "C" void CryptoNative_EvpPkeyDestroy(EVP_PKEY* pkey);
 
 /*
 Used by System.Security.Cryptography.X509Certificates' OpenSslX509CertificateReader when
@@ -30,4 +30,4 @@ duplicating a private key context as part of duplicating the Pal object.
 Returns the number (as of this call) of references to the EVP_PKEY. Anything less than
 2 is an error, because the key is already in the process of being freed.
 */
-extern "C" int32_t UpRefEvpPkey(EVP_PKEY* pkey);
+extern "C" int32_t CryptoNative_UpRefEvpPkey(EVP_PKEY* pkey);

--- a/src/Native/System.Security.Cryptography.Native/pal_evp_pkey_eckey.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp_pkey_eckey.cpp
@@ -3,12 +3,12 @@
 
 #include "pal_evp_pkey_eckey.h"
 
-extern "C" EC_KEY* EvpPkeyGetEcKey(EVP_PKEY* pkey)
+extern "C" EC_KEY* CryptoNative_EvpPkeyGetEcKey(EVP_PKEY* pkey)
 {
     return EVP_PKEY_get1_EC_KEY(pkey);
 }
 
-extern "C" int32_t EvpPkeySetEcKey(EVP_PKEY* pkey, EC_KEY* key)
+extern "C" int32_t CryptoNative_EvpPkeySetEcKey(EVP_PKEY* pkey, EC_KEY* key)
 {
     return EVP_PKEY_set1_EC_KEY(pkey, key);
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_evp_pkey_eckey.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp_pkey_eckey.cpp
@@ -3,9 +3,25 @@
 
 #include "pal_evp_pkey_eckey.h"
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" EC_KEY* EvpPkeyGetEcKey(EVP_PKEY* pkey)
+{
+    return CryptoNative_EvpPkeyGetEcKey(pkey);
+}
+
 extern "C" EC_KEY* CryptoNative_EvpPkeyGetEcKey(EVP_PKEY* pkey)
 {
     return EVP_PKEY_get1_EC_KEY(pkey);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t EvpPkeySetEcKey(EVP_PKEY* pkey, EC_KEY* key)
+{
+    return CryptoNative_EvpPkeySetEcKey(pkey, key);
 }
 
 extern "C" int32_t CryptoNative_EvpPkeySetEcKey(EVP_PKEY* pkey, EC_KEY* key)

--- a/src/Native/System.Security.Cryptography.Native/pal_evp_pkey_eckey.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp_pkey_eckey.h
@@ -11,7 +11,7 @@ Shims the EVP_PKEY_get1_EC_KEY method.
 
 Returns the EC_KEY instance for the EVP_PKEY.
 */
-extern "C" EC_KEY* EvpPkeyGetEcKey(EVP_PKEY* pkey);
+extern "C" EC_KEY* CryptoNative_EvpPkeyGetEcKey(EVP_PKEY* pkey);
 
 /*
 Shims the EVP_PKEY_set1_EC_KEY method to set the EC_KEY
@@ -19,4 +19,4 @@ instance on the EVP_KEY.
 
 Returns 1 upon success, otherwise 0.
 */
-extern "C" int32_t EvpPkeySetEcKey(EVP_PKEY* pkey, EC_KEY* key);
+extern "C" int32_t CryptoNative_EvpPkeySetEcKey(EVP_PKEY* pkey, EC_KEY* key);

--- a/src/Native/System.Security.Cryptography.Native/pal_evp_pkey_rsa.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp_pkey_rsa.cpp
@@ -3,12 +3,12 @@
 
 #include "pal_evp_pkey_rsa.h"
 
-extern "C" RSA* EvpPkeyGetRsa(EVP_PKEY* pkey)
+extern "C" RSA* CryptoNative_EvpPkeyGetRsa(EVP_PKEY* pkey)
 {
     return EVP_PKEY_get1_RSA(pkey);
 }
 
-extern "C" int32_t EvpPkeySetRsa(EVP_PKEY* pkey, RSA* rsa)
+extern "C" int32_t CryptoNative_EvpPkeySetRsa(EVP_PKEY* pkey, RSA* rsa)
 {
     return EVP_PKEY_set1_RSA(pkey, rsa);
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_evp_pkey_rsa.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp_pkey_rsa.cpp
@@ -3,9 +3,25 @@
 
 #include "pal_evp_pkey_rsa.h"
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" RSA* EvpPkeyGetRsa(EVP_PKEY* pkey)
+{
+    return CryptoNative_EvpPkeyGetRsa(pkey);
+}
+
 extern "C" RSA* CryptoNative_EvpPkeyGetRsa(EVP_PKEY* pkey)
 {
     return EVP_PKEY_get1_RSA(pkey);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t EvpPkeySetRsa(EVP_PKEY* pkey, RSA* rsa)
+{
+    return CryptoNative_EvpPkeySetRsa(pkey, rsa);
 }
 
 extern "C" int32_t CryptoNative_EvpPkeySetRsa(EVP_PKEY* pkey, RSA* rsa)

--- a/src/Native/System.Security.Cryptography.Native/pal_evp_pkey_rsa.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_evp_pkey_rsa.h
@@ -10,7 +10,7 @@ Shims the EVP_PKEY_get1_RSA method.
 
 Returns the RSA instance for the EVP_PKEY.
 */
-extern "C" RSA* EvpPkeyGetRsa(EVP_PKEY* pkey);
+extern "C" RSA* CryptoNative_EvpPkeyGetRsa(EVP_PKEY* pkey);
 
 /*
 Shims the EVP_PKEY_set1_RSA method to set the RSA
@@ -18,4 +18,4 @@ instance on the EVP_KEY.
 
 Returns 1 upon success, otherwise 0.
 */
-extern "C" int32_t EvpPkeySetRsa(EVP_PKEY* pkey, RSA* rsa);
+extern "C" int32_t CryptoNative_EvpPkeySetRsa(EVP_PKEY* pkey, RSA* rsa);

--- a/src/Native/System.Security.Cryptography.Native/pal_hmac.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_hmac.cpp
@@ -32,6 +32,14 @@ inline static auto HmacCall(F func, Args... args) -> NonVoidResultOf<F(Args...)>
     return func(args...);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" HMAC_CTX* HmacCreate(const uint8_t* key, int32_t keyLen, const EVP_MD* md)
+{
+    return CryptoNative_HmacCreate(key, keyLen, md);
+}
+
 extern "C" HMAC_CTX* CryptoNative_HmacCreate(const uint8_t* key, int32_t keyLen, const EVP_MD* md)
 {
     assert(key != nullptr || keyLen == 0);
@@ -62,6 +70,14 @@ extern "C" HMAC_CTX* CryptoNative_HmacCreate(const uint8_t* key, int32_t keyLen,
     return ctx.release();
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void HmacDestroy(HMAC_CTX* ctx)
+{
+    return CryptoNative_HmacDestroy(ctx);
+}
+
 extern "C" void CryptoNative_HmacDestroy(HMAC_CTX* ctx)
 {
     if (ctx != nullptr)
@@ -71,11 +87,27 @@ extern "C" void CryptoNative_HmacDestroy(HMAC_CTX* ctx)
     }
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t HmacReset(HMAC_CTX* ctx)
+{
+    return CryptoNative_HmacReset(ctx);
+}
+
 extern "C" int32_t CryptoNative_HmacReset(HMAC_CTX* ctx)
 {
     assert(ctx != nullptr);
 
     return HmacCall(HMAC_Init_ex, ctx, nullptr, 0, nullptr, nullptr);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t HmacUpdate(HMAC_CTX* ctx, const uint8_t* data, int32_t len)
+{
+    return CryptoNative_HmacUpdate(ctx, data, len);
 }
 
 extern "C" int32_t CryptoNative_HmacUpdate(HMAC_CTX* ctx, const uint8_t* data, int32_t len)
@@ -90,6 +122,14 @@ extern "C" int32_t CryptoNative_HmacUpdate(HMAC_CTX* ctx, const uint8_t* data, i
     }
 
     return HmacCall(HMAC_Update, ctx, data, UnsignedCast(len));
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t HmacFinal(HMAC_CTX* ctx, uint8_t* md, int32_t* len)
+{
+    return CryptoNative_HmacFinal(ctx, md, len);
 }
 
 extern "C" int32_t CryptoNative_HmacFinal(HMAC_CTX* ctx, uint8_t* md, int32_t* len)

--- a/src/Native/System.Security.Cryptography.Native/pal_hmac.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_hmac.cpp
@@ -32,7 +32,7 @@ inline static auto HmacCall(F func, Args... args) -> NonVoidResultOf<F(Args...)>
     return func(args...);
 }
 
-extern "C" HMAC_CTX* HmacCreate(const uint8_t* key, int32_t keyLen, const EVP_MD* md)
+extern "C" HMAC_CTX* CryptoNative_HmacCreate(const uint8_t* key, int32_t keyLen, const EVP_MD* md)
 {
     assert(key != nullptr || keyLen == 0);
     assert(keyLen >= 0);
@@ -62,7 +62,7 @@ extern "C" HMAC_CTX* HmacCreate(const uint8_t* key, int32_t keyLen, const EVP_MD
     return ctx.release();
 }
 
-extern "C" void HmacDestroy(HMAC_CTX* ctx)
+extern "C" void CryptoNative_HmacDestroy(HMAC_CTX* ctx)
 {
     if (ctx != nullptr)
     {
@@ -71,14 +71,14 @@ extern "C" void HmacDestroy(HMAC_CTX* ctx)
     }
 }
 
-extern "C" int32_t HmacReset(HMAC_CTX* ctx)
+extern "C" int32_t CryptoNative_HmacReset(HMAC_CTX* ctx)
 {
     assert(ctx != nullptr);
 
     return HmacCall(HMAC_Init_ex, ctx, nullptr, 0, nullptr, nullptr);
 }
 
-extern "C" int32_t HmacUpdate(HMAC_CTX* ctx, const uint8_t* data, int32_t len)
+extern "C" int32_t CryptoNative_HmacUpdate(HMAC_CTX* ctx, const uint8_t* data, int32_t len)
 {
     assert(ctx != nullptr);
     assert(data != nullptr || len == 0);
@@ -92,7 +92,7 @@ extern "C" int32_t HmacUpdate(HMAC_CTX* ctx, const uint8_t* data, int32_t len)
     return HmacCall(HMAC_Update, ctx, data, UnsignedCast(len));
 }
 
-extern "C" int32_t HmacFinal(HMAC_CTX* ctx, uint8_t* md, int32_t* len)
+extern "C" int32_t CryptoNative_HmacFinal(HMAC_CTX* ctx, uint8_t* md, int32_t* len)
 {
     assert(ctx != nullptr);
     assert(len != nullptr);

--- a/src/Native/System.Security.Cryptography.Native/pal_hmac.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_hmac.h
@@ -22,7 +22,7 @@ typedef struct env_md_st EVP_MD;
  *
  * Returns new HMAC_CTX on success, nullptr on failure.
  */
-extern "C" HMAC_CTX* HmacCreate(const uint8_t* key, int32_t keyLen, const EVP_MD* md);
+extern "C" HMAC_CTX* CryptoNative_HmacCreate(const uint8_t* key, int32_t keyLen, const EVP_MD* md);
 
 /**
  * Cleans up and deletes an HMAC_CTX instance created by HmacCreate.
@@ -35,14 +35,14 @@ extern "C" HMAC_CTX* HmacCreate(const uint8_t* key, int32_t keyLen, const EVP_MD
  * The given HMAC_CTX pointer is invalid after this call.
  * Always succeeds.
  */
-extern "C" void HmacDestroy(HMAC_CTX* ctx);
+extern "C" void CryptoNative_HmacDestroy(HMAC_CTX* ctx);
 
 /**
  * Resets an HMAC_CTX instance for a new computation, preserving the key and EVP_MD.
  *
  * Implemented by passing all null/0 values but ctx to HMAC_Init_ex.
 */
-extern "C" int32_t HmacReset(HMAC_CTX* ctx);
+extern "C" int32_t CryptoNative_HmacReset(HMAC_CTX* ctx);
 
 /**
  * Appends data to the computation.
@@ -51,7 +51,7 @@ extern "C" int32_t HmacReset(HMAC_CTX* ctx);
  *
  * Returns 1 for success or 0 for failure. (Always succeeds on platforms where HMAC_Update returns void.)
  */
-extern "C" int32_t HmacUpdate(HMAC_CTX* ctx, const uint8_t* data, int32_t len);
+extern "C" int32_t CryptoNative_HmacUpdate(HMAC_CTX* ctx, const uint8_t* data, int32_t len);
 
 /**
  * Finalizes the computation and obtains the result.
@@ -60,4 +60,4 @@ extern "C" int32_t HmacUpdate(HMAC_CTX* ctx, const uint8_t* data, int32_t len);
  *
  * Returns 1 for success or 0 for failure. (Always succeeds on platforms where HMAC_Update returns void.)
  */
-extern "C" int32_t HmacFinal(HMAC_CTX* ctx, uint8_t* md, int32_t* len);
+extern "C" int32_t CryptoNative_HmacFinal(HMAC_CTX* ctx, uint8_t* md, int32_t* len);

--- a/src/Native/System.Security.Cryptography.Native/pal_pkcs12.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_pkcs12.cpp
@@ -3,6 +3,14 @@
 
 #include "pal_pkcs12.h"
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" PKCS12* DecodePkcs12(const uint8_t* buf, int32_t len)
+{
+    return CryptoNative_DecodePkcs12(buf, len);
+}
+
 extern "C" PKCS12* CryptoNative_DecodePkcs12(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
@@ -13,9 +21,25 @@ extern "C" PKCS12* CryptoNative_DecodePkcs12(const uint8_t* buf, int32_t len)
     return d2i_PKCS12(nullptr, &buf, len);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" PKCS12* DecodePkcs12FromBio(BIO* bio)
+{
+    return CryptoNative_DecodePkcs12FromBio(bio);
+}
+
 extern "C" PKCS12* CryptoNative_DecodePkcs12FromBio(BIO* bio)
 {
     return d2i_PKCS12_bio(bio, nullptr);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void Pkcs12Destroy(PKCS12* p12)
+{
+    return CryptoNative_Pkcs12Destroy(p12);
 }
 
 extern "C" void CryptoNative_Pkcs12Destroy(PKCS12* p12)
@@ -26,10 +50,26 @@ extern "C" void CryptoNative_Pkcs12Destroy(PKCS12* p12)
     }
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" PKCS12* Pkcs12Create(char* pass, EVP_PKEY* pkey, X509* cert, X509Stack* ca)
+{
+    return CryptoNative_Pkcs12Create(pass, pkey, cert, ca);
+}
+
 extern "C" PKCS12* CryptoNative_Pkcs12Create(char* pass, EVP_PKEY* pkey, X509* cert, X509Stack* ca)
 {
     return PKCS12_create(
         pass, nullptr, pkey, cert, ca, NID_undef, NID_undef, PKCS12_DEFAULT_ITER, PKCS12_DEFAULT_ITER, 0);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t GetPkcs12DerSize(PKCS12* p12)
+{
+    return CryptoNative_GetPkcs12DerSize(p12);
 }
 
 extern "C" int32_t CryptoNative_GetPkcs12DerSize(PKCS12* p12)
@@ -37,9 +77,25 @@ extern "C" int32_t CryptoNative_GetPkcs12DerSize(PKCS12* p12)
     return i2d_PKCS12(p12, nullptr);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t EncodePkcs12(PKCS12* p12, uint8_t* buf)
+{
+    return CryptoNative_EncodePkcs12(p12, buf);
+}
+
 extern "C" int32_t CryptoNative_EncodePkcs12(PKCS12* p12, uint8_t* buf)
 {
     return i2d_PKCS12(p12, &buf);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t Pkcs12Parse(PKCS12* p12, const char* pass, EVP_PKEY** pkey, X509** cert, X509Stack** ca)
+{
+    return CryptoNative_Pkcs12Parse(p12, pass, pkey, cert, ca);
 }
 
 extern "C" int32_t CryptoNative_Pkcs12Parse(PKCS12* p12, const char* pass, EVP_PKEY** pkey, X509** cert, X509Stack** ca)

--- a/src/Native/System.Security.Cryptography.Native/pal_pkcs12.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_pkcs12.cpp
@@ -3,7 +3,7 @@
 
 #include "pal_pkcs12.h"
 
-extern "C" PKCS12* DecodePkcs12(const uint8_t* buf, int32_t len)
+extern "C" PKCS12* CryptoNative_DecodePkcs12(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
     {
@@ -13,12 +13,12 @@ extern "C" PKCS12* DecodePkcs12(const uint8_t* buf, int32_t len)
     return d2i_PKCS12(nullptr, &buf, len);
 }
 
-extern "C" PKCS12* DecodePkcs12FromBio(BIO* bio)
+extern "C" PKCS12* CryptoNative_DecodePkcs12FromBio(BIO* bio)
 {
     return d2i_PKCS12_bio(bio, nullptr);
 }
 
-extern "C" void Pkcs12Destroy(PKCS12* p12)
+extern "C" void CryptoNative_Pkcs12Destroy(PKCS12* p12)
 {
     if (p12 != nullptr)
     {
@@ -26,23 +26,23 @@ extern "C" void Pkcs12Destroy(PKCS12* p12)
     }
 }
 
-extern "C" PKCS12* Pkcs12Create(char* pass, EVP_PKEY* pkey, X509* cert, X509Stack* ca)
+extern "C" PKCS12* CryptoNative_Pkcs12Create(char* pass, EVP_PKEY* pkey, X509* cert, X509Stack* ca)
 {
     return PKCS12_create(
         pass, nullptr, pkey, cert, ca, NID_undef, NID_undef, PKCS12_DEFAULT_ITER, PKCS12_DEFAULT_ITER, 0);
 }
 
-extern "C" int32_t GetPkcs12DerSize(PKCS12* p12)
+extern "C" int32_t CryptoNative_GetPkcs12DerSize(PKCS12* p12)
 {
     return i2d_PKCS12(p12, nullptr);
 }
 
-extern "C" int32_t EncodePkcs12(PKCS12* p12, uint8_t* buf)
+extern "C" int32_t CryptoNative_EncodePkcs12(PKCS12* p12, uint8_t* buf)
 {
     return i2d_PKCS12(p12, &buf);
 }
 
-extern "C" int32_t Pkcs12Parse(PKCS12* p12, const char* pass, EVP_PKEY** pkey, X509** cert, X509Stack** ca)
+extern "C" int32_t CryptoNative_Pkcs12Parse(PKCS12* p12, const char* pass, EVP_PKEY** pkey, X509** cert, X509Stack** ca)
 {
     return PKCS12_parse(p12, pass, pkey, cert, ca);
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_pkcs12.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_pkcs12.h
@@ -8,14 +8,14 @@
 /*
 Shims the d2i_PKCS12 method and makes it easier to invoke from managed code.
 */
-extern "C" PKCS12* DecodePkcs12(const uint8_t* buf, int32_t len);
+extern "C" PKCS12* CryptoNative_DecodePkcs12(const uint8_t* buf, int32_t len);
 
 /*
 Shims the d2i_PKCS12_bio method.
 
 Returns the new PKCS12 instance.
 */
-extern "C" PKCS12* DecodePkcs12FromBio(BIO* bio);
+extern "C" PKCS12* CryptoNative_DecodePkcs12FromBio(BIO* bio);
 
 /*
 Cleans up and deletes a PKCS12 instance.
@@ -26,31 +26,32 @@ No-op if p12 is null.
 The given PKCS12 pointer is invalid after this call.
 Always succeeds.
 */
-extern "C" void Pkcs12Destroy(PKCS12* p12);
+extern "C" void CryptoNative_Pkcs12Destroy(PKCS12* p12);
 
 /*
 Shims the PKCS12_create method.
 
 Returns the new PKCS12 instance.
 */
-extern "C" PKCS12* Pkcs12Create(char* pass, EVP_PKEY* pkey, X509* cert, X509Stack* ca);
+extern "C" PKCS12* CryptoNative_Pkcs12Create(char* pass, EVP_PKEY* pkey, X509* cert, X509Stack* ca);
 
 /*
 Returns the number of bytes it will take to convert
 the PKCS12 to a DER format.
 */
-extern "C" int32_t GetPkcs12DerSize(PKCS12* p12);
+extern "C" int32_t CryptoNative_GetPkcs12DerSize(PKCS12* p12);
 
 /*
 Shims the i2d_PKCS12 method.
 
 Returns the number of bytes written to buf.
 */
-extern "C" int32_t EncodePkcs12(PKCS12* p12, uint8_t* buf);
+extern "C" int32_t CryptoNative_EncodePkcs12(PKCS12* p12, uint8_t* buf);
 
 /*
 Shims the PKCS12_parse method.
 
 Returns 1 on success, otherwise 0.
 */
-extern "C" int32_t Pkcs12Parse(PKCS12* p12, const char* pass, EVP_PKEY** pkey, X509** cert, X509Stack** ca);
+extern "C" int32_t
+CryptoNative_Pkcs12Parse(PKCS12* p12, const char* pass, EVP_PKEY** pkey, X509** cert, X509Stack** ca);

--- a/src/Native/System.Security.Cryptography.Native/pal_pkcs7.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_pkcs7.cpp
@@ -5,9 +5,25 @@
 
 #include <openssl/pem.h>
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" PKCS7* PemReadBioPkcs7(BIO* bp)
+{
+    return CryptoNative_PemReadBioPkcs7(bp);
+}
+
 extern "C" PKCS7* CryptoNative_PemReadBioPkcs7(BIO* bp)
 {
     return PEM_read_bio_PKCS7(bp, nullptr, nullptr, nullptr);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" PKCS7* DecodePkcs7(const uint8_t* buf, int32_t len)
+{
+    return CryptoNative_DecodePkcs7(buf, len);
 }
 
 extern "C" PKCS7* CryptoNative_DecodePkcs7(const uint8_t* buf, int32_t len)
@@ -20,9 +36,25 @@ extern "C" PKCS7* CryptoNative_DecodePkcs7(const uint8_t* buf, int32_t len)
     return d2i_PKCS7(nullptr, &buf, len);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" PKCS7* D2IPkcs7Bio(BIO* bp)
+{
+    return CryptoNative_D2IPkcs7Bio(bp);
+}
+
 extern "C" PKCS7* CryptoNative_D2IPkcs7Bio(BIO* bp)
 {
     return d2i_PKCS7_bio(bp, nullptr);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" PKCS7* Pkcs7CreateSigned()
+{
+    return CryptoNative_Pkcs7CreateSigned();
 }
 
 extern "C" PKCS7* CryptoNative_Pkcs7CreateSigned()
@@ -43,12 +75,28 @@ extern "C" PKCS7* CryptoNative_Pkcs7CreateSigned()
     return pkcs7;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void Pkcs7Destroy(PKCS7* p7)
+{
+    return CryptoNative_Pkcs7Destroy(p7);
+}
+
 extern "C" void CryptoNative_Pkcs7Destroy(PKCS7* p7)
 {
     if (p7 != nullptr)
     {
         PKCS7_free(p7);
     }
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t GetPkcs7Certificates(PKCS7* p7, X509Stack** certs)
+{
+    return CryptoNative_GetPkcs7Certificates(p7, certs);
 }
 
 extern "C" int32_t CryptoNative_GetPkcs7Certificates(PKCS7* p7, X509Stack** certs)
@@ -71,6 +119,14 @@ extern "C" int32_t CryptoNative_GetPkcs7Certificates(PKCS7* p7, X509Stack** cert
     return 0;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t Pkcs7AddCertificate(PKCS7* p7, X509* x509)
+{
+    return CryptoNative_Pkcs7AddCertificate(p7, x509);
+}
+
 extern "C" int32_t CryptoNative_Pkcs7AddCertificate(PKCS7* p7, X509* x509)
 {
     if (p7 == nullptr || x509 == nullptr)
@@ -81,9 +137,25 @@ extern "C" int32_t CryptoNative_Pkcs7AddCertificate(PKCS7* p7, X509* x509)
     return PKCS7_add_certificate(p7, x509);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t GetPkcs7DerSize(PKCS7* p7)
+{
+    return CryptoNative_GetPkcs7DerSize(p7);
+}
+
 extern "C" int32_t CryptoNative_GetPkcs7DerSize(PKCS7* p7)
 {
     return i2d_PKCS7(p7, nullptr);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t EncodePkcs7(PKCS7* p7, uint8_t* buf)
+{
+    return CryptoNative_EncodePkcs7(p7, buf);
 }
 
 extern "C" int32_t CryptoNative_EncodePkcs7(PKCS7* p7, uint8_t* buf)

--- a/src/Native/System.Security.Cryptography.Native/pal_pkcs7.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_pkcs7.cpp
@@ -5,12 +5,12 @@
 
 #include <openssl/pem.h>
 
-extern "C" PKCS7* PemReadBioPkcs7(BIO* bp)
+extern "C" PKCS7* CryptoNative_PemReadBioPkcs7(BIO* bp)
 {
     return PEM_read_bio_PKCS7(bp, nullptr, nullptr, nullptr);
 }
 
-extern "C" PKCS7* DecodePkcs7(const uint8_t* buf, int32_t len)
+extern "C" PKCS7* CryptoNative_DecodePkcs7(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
     {
@@ -20,12 +20,12 @@ extern "C" PKCS7* DecodePkcs7(const uint8_t* buf, int32_t len)
     return d2i_PKCS7(nullptr, &buf, len);
 }
 
-extern "C" PKCS7* D2IPkcs7Bio(BIO* bp)
+extern "C" PKCS7* CryptoNative_D2IPkcs7Bio(BIO* bp)
 {
     return d2i_PKCS7_bio(bp, nullptr);
 }
 
-extern "C" PKCS7* Pkcs7CreateSigned()
+extern "C" PKCS7* CryptoNative_Pkcs7CreateSigned()
 {
     PKCS7* pkcs7 = PKCS7_new();
 
@@ -34,8 +34,7 @@ extern "C" PKCS7* Pkcs7CreateSigned()
         return nullptr;
     }
 
-    if (!PKCS7_set_type(pkcs7, NID_pkcs7_signed) ||
-        !PKCS7_content_new(pkcs7, NID_pkcs7_data))
+    if (!PKCS7_set_type(pkcs7, NID_pkcs7_signed) || !PKCS7_content_new(pkcs7, NID_pkcs7_data))
     {
         PKCS7_free(pkcs7);
         return nullptr;
@@ -44,7 +43,7 @@ extern "C" PKCS7* Pkcs7CreateSigned()
     return pkcs7;
 }
 
-extern "C" void Pkcs7Destroy(PKCS7* p7)
+extern "C" void CryptoNative_Pkcs7Destroy(PKCS7* p7)
 {
     if (p7 != nullptr)
     {
@@ -52,7 +51,7 @@ extern "C" void Pkcs7Destroy(PKCS7* p7)
     }
 }
 
-extern "C" int32_t GetPkcs7Certificates(PKCS7* p7, X509Stack** certs)
+extern "C" int32_t CryptoNative_GetPkcs7Certificates(PKCS7* p7, X509Stack** certs)
 {
     if (!p7 || !certs)
     {
@@ -72,7 +71,7 @@ extern "C" int32_t GetPkcs7Certificates(PKCS7* p7, X509Stack** certs)
     return 0;
 }
 
-extern "C" int32_t Pkcs7AddCertificate(PKCS7* p7, X509* x509)
+extern "C" int32_t CryptoNative_Pkcs7AddCertificate(PKCS7* p7, X509* x509)
 {
     if (p7 == nullptr || x509 == nullptr)
     {
@@ -82,12 +81,12 @@ extern "C" int32_t Pkcs7AddCertificate(PKCS7* p7, X509* x509)
     return PKCS7_add_certificate(p7, x509);
 }
 
-extern "C" int32_t GetPkcs7DerSize(PKCS7* p7)
+extern "C" int32_t CryptoNative_GetPkcs7DerSize(PKCS7* p7)
 {
     return i2d_PKCS7(p7, nullptr);
 }
 
-extern "C" int32_t EncodePkcs7(PKCS7* p7, uint8_t* buf)
+extern "C" int32_t CryptoNative_EncodePkcs7(PKCS7* p7, uint8_t* buf)
 {
     return i2d_PKCS7(p7, &buf);
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_pkcs7.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_pkcs7.h
@@ -12,12 +12,12 @@ Direct shim to PEM_read_bio_PKCS7.
 
 Returns the new PKCS7 instance.
 */
-extern "C" PKCS7* PemReadBioPkcs7(BIO* bp);
+extern "C" PKCS7* CryptoNative_PemReadBioPkcs7(BIO* bp);
 
 /*
 Shims the d2i_PKCS7 method and makes it easier to invoke from managed code.
 */
-extern "C" PKCS7* DecodePkcs7(const uint8_t* buf, int32_t len);
+extern "C" PKCS7* CryptoNative_DecodePkcs7(const uint8_t* buf, int32_t len);
 
 /*
 Reads a PKCS7 instance in DER format from a BIO.
@@ -26,7 +26,7 @@ Direct shim to d2i_PKCS7_bio.
 
 Returns the new PKCS7 instance.
 */
-extern "C" PKCS7* D2IPkcs7Bio(BIO* bp);
+extern "C" PKCS7* CryptoNative_D2IPkcs7Bio(BIO* bp);
 
 /*
 Create a new PKCS7 instance and prepare it to be a signed PKCS7
@@ -34,7 +34,7 @@ with a data payload.
 
 Returns the new PKCS7 instance.
 */
-extern "C" PKCS7* Pkcs7CreateSigned();
+extern "C" PKCS7* CryptoNative_Pkcs7CreateSigned();
 
 /*
 Cleans up and deletes a PKCS7 instance.
@@ -45,7 +45,7 @@ No-op if p7 is null.
 The given PKCS7 pointer is invalid after this call.
 Always succeeds.
 */
-extern "C" void Pkcs7Destroy(PKCS7* p7);
+extern "C" void CryptoNative_Pkcs7Destroy(PKCS7* p7);
 
 /*
 Function:
@@ -59,22 +59,22 @@ Return values:
 1 when the file format is understood, and *certs is assigned to the
 certificate contents of the structure.
 */
-extern "C" int32_t GetPkcs7Certificates(PKCS7* p7, X509Stack** certs);
+extern "C" int32_t CryptoNative_GetPkcs7Certificates(PKCS7* p7, X509Stack** certs);
 
 /*
 Shims the PKCS7_add_certificate function and makes it easier to invoke from managed code.
 */
-extern "C" int32_t Pkcs7AddCertificate(PKCS7* p7, X509* x509);
+extern "C" int32_t CryptoNative_Pkcs7AddCertificate(PKCS7* p7, X509* x509);
 
 /*
 Returns the number of bytes it will take to convert
 the PKCS7 to a DER format.
 */
-extern "C" int32_t GetPkcs7DerSize(PKCS7* p7);
+extern "C" int32_t CryptoNative_GetPkcs7DerSize(PKCS7* p7);
 
 /*
 Shims the i2d_PKCS7 method.
 
 Returns the number of bytes written to buf.
 */
-extern "C" int32_t EncodePkcs7(PKCS7* p7, uint8_t* buf);
+extern "C" int32_t CryptoNative_EncodePkcs7(PKCS7* p7, uint8_t* buf);

--- a/src/Native/System.Security.Cryptography.Native/pal_rsa.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_rsa.cpp
@@ -4,17 +4,17 @@
 #include "pal_rsa.h"
 #include "pal_utilities.h"
 
-extern "C" RSA* RsaCreate()
+extern "C" RSA* CryptoNative_RsaCreate()
 {
     return RSA_new();
 }
 
-extern "C" int32_t RsaUpRef(RSA* rsa)
+extern "C" int32_t CryptoNative_RsaUpRef(RSA* rsa)
 {
     return RSA_up_ref(rsa);
 }
 
-extern "C" void RsaDestroy(RSA* rsa)
+extern "C" void CryptoNative_RsaDestroy(RSA* rsa)
 {
     if (rsa != nullptr)
     {
@@ -22,7 +22,7 @@ extern "C" void RsaDestroy(RSA* rsa)
     }
 }
 
-extern "C" RSA* DecodeRsaPublicKey(const uint8_t* buf, int32_t len)
+extern "C" RSA* CryptoNative_DecodeRsaPublicKey(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
     {
@@ -39,29 +39,32 @@ static int GetOpenSslPadding(RsaPadding padding)
     return padding == Pkcs1 ? RSA_PKCS1_PADDING : RSA_PKCS1_OAEP_PADDING;
 }
 
-extern "C" int32_t RsaPublicEncrypt(int32_t flen, const uint8_t* from, uint8_t* to, RSA* rsa, RsaPadding padding)
+extern "C" int32_t
+CryptoNative_RsaPublicEncrypt(int32_t flen, const uint8_t* from, uint8_t* to, RSA* rsa, RsaPadding padding)
 {
     int openSslPadding = GetOpenSslPadding(padding);
     return RSA_public_encrypt(flen, from, to, rsa, openSslPadding);
 }
 
-extern "C" int32_t RsaPrivateDecrypt(int32_t flen, const uint8_t* from, uint8_t* to, RSA* rsa, RsaPadding padding)
+extern "C" int32_t
+CryptoNative_RsaPrivateDecrypt(int32_t flen, const uint8_t* from, uint8_t* to, RSA* rsa, RsaPadding padding)
 {
     int openSslPadding = GetOpenSslPadding(padding);
     return RSA_private_decrypt(flen, from, to, rsa, openSslPadding);
 }
 
-extern "C" int32_t RsaSize(RSA* rsa)
+extern "C" int32_t CryptoNative_RsaSize(RSA* rsa)
 {
     return RSA_size(rsa);
 }
 
-extern "C" int32_t RsaGenerateKeyEx(RSA* rsa, int32_t bits, BIGNUM* e)
+extern "C" int32_t CryptoNative_RsaGenerateKeyEx(RSA* rsa, int32_t bits, BIGNUM* e)
 {
     return RSA_generate_key_ex(rsa, bits, e, nullptr);
 }
 
-extern "C" int32_t RsaSign(int32_t type, const uint8_t* m, int32_t mlen, uint8_t* sigret, int32_t* siglen, RSA* rsa)
+extern "C" int32_t
+CryptoNative_RsaSign(int32_t type, const uint8_t* m, int32_t mlen, uint8_t* sigret, int32_t* siglen, RSA* rsa)
 {
     if (!siglen)
     {
@@ -76,20 +79,21 @@ extern "C" int32_t RsaSign(int32_t type, const uint8_t* m, int32_t mlen, uint8_t
     return ret;
 }
 
-extern "C" int32_t RsaVerify(int32_t type, const uint8_t* m, int32_t mlen, uint8_t* sigbuf, int32_t siglen, RSA* rsa)
+extern "C" int32_t
+CryptoNative_RsaVerify(int32_t type, const uint8_t* m, int32_t mlen, uint8_t* sigbuf, int32_t siglen, RSA* rsa)
 {
     return RSA_verify(type, m, UnsignedCast(mlen), sigbuf, UnsignedCast(siglen), rsa);
 }
 
-extern "C" int32_t GetRsaParameters(const RSA* rsa,
-                                    BIGNUM** n,
-                                    BIGNUM** e,
-                                    BIGNUM** d,
-                                    BIGNUM** p,
-                                    BIGNUM** dmp1,
-                                    BIGNUM** q,
-                                    BIGNUM** dmq1,
-                                    BIGNUM** iqmp)
+extern "C" int32_t CryptoNative_GetRsaParameters(const RSA* rsa,
+                                                 BIGNUM** n,
+                                                 BIGNUM** e,
+                                                 BIGNUM** d,
+                                                 BIGNUM** p,
+                                                 BIGNUM** dmp1,
+                                                 BIGNUM** q,
+                                                 BIGNUM** dmq1,
+                                                 BIGNUM** iqmp)
 {
     if (!rsa || !n || !e || !d || !p || !dmp1 || !q || !dmq1 || !iqmp)
     {
@@ -145,23 +149,23 @@ static void SetRsaParameter(BIGNUM** rsaFieldAddress, uint8_t* buffer, int32_t b
     }
 }
 
-extern "C" void SetRsaParameters(RSA* rsa,
-                                 uint8_t* n,
-                                 int32_t nLength,
-                                 uint8_t* e,
-                                 int32_t eLength,
-                                 uint8_t* d,
-                                 int32_t dLength,
-                                 uint8_t* p,
-                                 int32_t pLength,
-                                 uint8_t* dmp1,
-                                 int32_t dmp1Length,
-                                 uint8_t* q,
-                                 int32_t qLength,
-                                 uint8_t* dmq1,
-                                 int32_t dmq1Length,
-                                 uint8_t* iqmp,
-                                 int32_t iqmpLength)
+extern "C" void CryptoNative_SetRsaParameters(RSA* rsa,
+                                              uint8_t* n,
+                                              int32_t nLength,
+                                              uint8_t* e,
+                                              int32_t eLength,
+                                              uint8_t* d,
+                                              int32_t dLength,
+                                              uint8_t* p,
+                                              int32_t pLength,
+                                              uint8_t* dmp1,
+                                              int32_t dmp1Length,
+                                              uint8_t* q,
+                                              int32_t qLength,
+                                              uint8_t* dmq1,
+                                              int32_t dmq1Length,
+                                              uint8_t* iqmp,
+                                              int32_t iqmpLength)
 {
     if (!rsa)
     {

--- a/src/Native/System.Security.Cryptography.Native/pal_rsa.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_rsa.cpp
@@ -4,14 +4,38 @@
 #include "pal_rsa.h"
 #include "pal_utilities.h"
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" RSA* RsaCreate()
+{
+    return CryptoNative_RsaCreate();
+}
+
 extern "C" RSA* CryptoNative_RsaCreate()
 {
     return RSA_new();
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t RsaUpRef(RSA* rsa)
+{
+    return CryptoNative_RsaUpRef(rsa);
+}
+
 extern "C" int32_t CryptoNative_RsaUpRef(RSA* rsa)
 {
     return RSA_up_ref(rsa);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void RsaDestroy(RSA* rsa)
+{
+    return CryptoNative_RsaDestroy(rsa);
 }
 
 extern "C" void CryptoNative_RsaDestroy(RSA* rsa)
@@ -20,6 +44,14 @@ extern "C" void CryptoNative_RsaDestroy(RSA* rsa)
     {
         RSA_free(rsa);
     }
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" RSA* DecodeRsaPublicKey(const uint8_t* buf, int32_t len)
+{
+    return CryptoNative_DecodeRsaPublicKey(buf, len);
 }
 
 extern "C" RSA* CryptoNative_DecodeRsaPublicKey(const uint8_t* buf, int32_t len)
@@ -39,11 +71,29 @@ static int GetOpenSslPadding(RsaPadding padding)
     return padding == Pkcs1 ? RSA_PKCS1_PADDING : RSA_PKCS1_OAEP_PADDING;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t
+RsaPublicEncrypt(int32_t flen, const uint8_t* from, uint8_t* to, RSA* rsa, RsaPadding padding)
+{
+    return CryptoNative_RsaPublicEncrypt(flen, from, to, rsa, padding);
+}
+
 extern "C" int32_t
 CryptoNative_RsaPublicEncrypt(int32_t flen, const uint8_t* from, uint8_t* to, RSA* rsa, RsaPadding padding)
 {
     int openSslPadding = GetOpenSslPadding(padding);
     return RSA_public_encrypt(flen, from, to, rsa, openSslPadding);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t
+RsaPrivateDecrypt(int32_t flen, const uint8_t* from, uint8_t* to, RSA* rsa, RsaPadding padding)
+{
+    return CryptoNative_RsaPrivateDecrypt(flen, from, to, rsa, padding);
 }
 
 extern "C" int32_t
@@ -53,14 +103,39 @@ CryptoNative_RsaPrivateDecrypt(int32_t flen, const uint8_t* from, uint8_t* to, R
     return RSA_private_decrypt(flen, from, to, rsa, openSslPadding);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t RsaSize(RSA* rsa)
+{
+    return CryptoNative_RsaSize(rsa);
+}
+
 extern "C" int32_t CryptoNative_RsaSize(RSA* rsa)
 {
     return RSA_size(rsa);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t RsaGenerateKeyEx(RSA* rsa, int32_t bits, BIGNUM* e)
+{
+    return CryptoNative_RsaGenerateKeyEx(rsa, bits, e);
+}
+
 extern "C" int32_t CryptoNative_RsaGenerateKeyEx(RSA* rsa, int32_t bits, BIGNUM* e)
 {
     return RSA_generate_key_ex(rsa, bits, e, nullptr);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t
+RsaSign(int32_t type, const uint8_t* m, int32_t mlen, uint8_t* sigret, int32_t* siglen, RSA* rsa)
+{
+    return CryptoNative_RsaSign(type, m, mlen, sigret, siglen, rsa);
 }
 
 extern "C" int32_t
@@ -79,12 +154,45 @@ CryptoNative_RsaSign(int32_t type, const uint8_t* m, int32_t mlen, uint8_t* sigr
     return ret;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t
+RsaVerify(int32_t type, const uint8_t* m, int32_t mlen, uint8_t* sigbuf, int32_t siglen, RSA* rsa)
+{
+    return CryptoNative_RsaVerify(type, m, mlen, sigbuf, siglen, rsa);
+}
+
 extern "C" int32_t
 CryptoNative_RsaVerify(int32_t type, const uint8_t* m, int32_t mlen, uint8_t* sigbuf, int32_t siglen, RSA* rsa)
 {
     return RSA_verify(type, m, UnsignedCast(mlen), sigbuf, UnsignedCast(siglen), rsa);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t GetRsaParameters(const RSA* rsa,
+    BIGNUM** n,
+    BIGNUM** e,
+    BIGNUM** d,
+    BIGNUM** p,
+    BIGNUM** dmp1,
+    BIGNUM** q,
+    BIGNUM** dmq1,
+    BIGNUM** iqmp)
+{
+    return CryptoNative_GetRsaParameters(rsa,
+        n,
+        e,
+        d,
+        p,
+        dmp1,
+        q,
+        dmq1,
+        iqmp);
+}
+    
 extern "C" int32_t CryptoNative_GetRsaParameters(const RSA* rsa,
                                                  BIGNUM** n,
                                                  BIGNUM** e,
@@ -147,6 +255,46 @@ static void SetRsaParameter(BIGNUM** rsaFieldAddress, uint8_t* buffer, int32_t b
             *rsaFieldAddress = bigNum;
         }
     }
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void SetRsaParameters(RSA* rsa,
+    uint8_t* n,
+    int32_t nLength,
+    uint8_t* e,
+    int32_t eLength,
+    uint8_t* d,
+    int32_t dLength,
+    uint8_t* p,
+    int32_t pLength,
+    uint8_t* dmp1,
+    int32_t dmp1Length,
+    uint8_t* q,
+    int32_t qLength,
+    uint8_t* dmq1,
+    int32_t dmq1Length,
+    uint8_t* iqmp,
+    int32_t iqmpLength)
+{
+    return CryptoNative_SetRsaParameters(rsa,
+        n,
+        nLength,
+        e,
+        eLength,
+        d,
+        dLength,
+        p,
+        pLength,
+        dmp1,
+        dmp1Length,
+        q,
+        qLength,
+        dmq1,
+        dmq1Length,
+        iqmp,
+        iqmpLength);
 }
 
 extern "C" void CryptoNative_SetRsaParameters(RSA* rsa,

--- a/src/Native/System.Security.Cryptography.Native/pal_rsa.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_rsa.h
@@ -20,14 +20,14 @@ Shims the RSA_new method.
 
 Returns the new RSA instance.
 */
-extern "C" RSA* RsaCreate();
+extern "C" RSA* CryptoNative_RsaCreate();
 
 /*
 Shims the RSA_up_ref method.
 
 Returns 1 upon success, otherwise 0.
 */
-extern "C" int32_t RsaUpRef(RSA* rsa);
+extern "C" int32_t CryptoNative_RsaUpRef(RSA* rsa);
 
 /*
 Cleans up and deletes a RSA instance.
@@ -38,87 +38,91 @@ No-op if rsa is null.
 The given RSA pointer is invalid after this call.
 Always succeeds.
 */
-extern "C" void RsaDestroy(RSA* rsa);
+extern "C" void CryptoNative_RsaDestroy(RSA* rsa);
 
 /*
 Shims the d2i_RSAPublicKey method and makes it easier to invoke from managed code.
 */
-extern "C" RSA* DecodeRsaPublicKey(const uint8_t* buf, int32_t len);
+extern "C" RSA* CryptoNative_DecodeRsaPublicKey(const uint8_t* buf, int32_t len);
 
 /*
 Shims the RSA_public_encrypt method.
 
 Returns the size of the signature, or -1 on error.
 */
-extern "C" int32_t RsaPublicEncrypt(int32_t flen, const uint8_t* from, uint8_t* to, RSA* rsa, RsaPadding padding);
+extern "C" int32_t
+CryptoNative_RsaPublicEncrypt(int32_t flen, const uint8_t* from, uint8_t* to, RSA* rsa, RsaPadding padding);
 
 /*
 Shims the RSA_private_decrypt method.
 
 Returns the size of the signature, or -1 on error.
 */
-extern "C" int32_t RsaPrivateDecrypt(int32_t flen, const uint8_t* from, uint8_t* to, RSA* rsa, RsaPadding padding);
+extern "C" int32_t
+CryptoNative_RsaPrivateDecrypt(int32_t flen, const uint8_t* from, uint8_t* to, RSA* rsa, RsaPadding padding);
 
 /*
 Shims the RSA_size method.
 
 Returns the RSA modulus size in bytes.
 */
-extern "C" int32_t RsaSize(RSA* rsa);
+extern "C" int32_t CryptoNative_RsaSize(RSA* rsa);
 
 /*
 Shims the RSA_generate_key_ex method.
 
 Returns 1 upon success, otherwise 0.
 */
-extern "C" int32_t RsaGenerateKeyEx(RSA* rsa, int32_t bits, BIGNUM* e);
+extern "C" int32_t CryptoNative_RsaGenerateKeyEx(RSA* rsa, int32_t bits, BIGNUM* e);
 
 /*
 Shims the RSA_sign method.
 
 Returns 1 upon success, otherwise 0.
 */
-extern "C" int32_t RsaSign(int32_t type, const uint8_t* m, int32_t mlen, uint8_t* sigret, int32_t* siglen, RSA* rsa);
+extern "C" int32_t
+CryptoNative_RsaSign(int32_t type, const uint8_t* m, int32_t mlen, uint8_t* sigret, int32_t* siglen, RSA* rsa);
 
 /*
 Shims the RSA_verify method.
 
 Returns 1 upon success, otherwise 0.
 */
-extern "C" int32_t RsaVerify(int32_t type, const uint8_t* m, int32_t mlen, uint8_t* sigbuf, int32_t siglen, RSA* rsa);
+extern "C" int32_t
+CryptoNative_RsaVerify(int32_t type, const uint8_t* m, int32_t mlen, uint8_t* sigbuf, int32_t siglen, RSA* rsa);
 
 /*
 Gets all the parameters from the RSA instance.
 
 Returns 1 upon success, otherwise 0.
 */
-extern "C" int32_t GetRsaParameters(const RSA* rsa,
-                                    BIGNUM** n,
-                                    BIGNUM** e,
-                                    BIGNUM** d,
-                                    BIGNUM** p,
-                                    BIGNUM** dmp1,
-                                    BIGNUM** q,
-                                    BIGNUM** dmq1,
-                                    BIGNUM** iqmp);
+extern "C" int32_t CryptoNative_GetRsaParameters(const RSA* rsa,
+                                                 BIGNUM** n,
+                                                 BIGNUM** e,
+                                                 BIGNUM** d,
+                                                 BIGNUM** p,
+                                                 BIGNUM** dmp1,
+                                                 BIGNUM** q,
+                                                 BIGNUM** dmq1,
+                                                 BIGNUM** iqmp);
 
 /*
 Sets all the parameters on the RSA instance.
 */
-extern "C" void SetRsaParameters(RSA* rsa,
-                                 uint8_t* n,
-                                 int32_t nLength,
-                                 uint8_t* e,
-                                 int32_t eLength,
-                                 uint8_t* d,
-                                 int32_t dLength,
-                                 uint8_t* p,
-                                 int32_t pLength,
-                                 uint8_t* dmp1,
-                                 int32_t dmp1Length,
-                                 uint8_t* q,
-                                 int32_t qLength,
-                                 uint8_t* dmq1,
-                                 int32_t dmq1Length,
-                                 uint8_t* iqmp,
-                                 int32_t iqmpLength);
+extern "C" void CryptoNative_SetRsaParameters(RSA* rsa,
+                                              uint8_t* n,
+                                              int32_t nLength,
+                                              uint8_t* e,
+                                              int32_t eLength,
+                                              uint8_t* d,
+                                              int32_t dLength,
+                                              uint8_t* p,
+                                              int32_t pLength,
+                                              uint8_t* dmp1,
+                                              int32_t dmp1Length,
+                                              uint8_t* q,
+                                              int32_t qLength,
+                                              uint8_t* dmq1,
+                                              int32_t dmq1Length,
+                                              uint8_t* iqmp,
+                                              int32_t iqmpLength);

--- a/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -13,10 +13,26 @@ static_assert(PAL_SSL_ERROR_WANT_WRITE == SSL_ERROR_WANT_WRITE, "");
 static_assert(PAL_SSL_ERROR_SYSCALL == SSL_ERROR_SYSCALL, "");
 static_assert(PAL_SSL_ERROR_ZERO_RETURN == SSL_ERROR_ZERO_RETURN, "");
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void EnsureLibSslInitialized()
+{
+    return CryptoNative_EnsureLibSslInitialized();
+}
+
 extern "C" void CryptoNative_EnsureLibSslInitialized()
 {
     SSL_library_init();
     SSL_load_error_strings();
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const SSL_METHOD* SslV2_3Method()
+{
+    return CryptoNative_SslV2_3Method();
 }
 
 extern "C" const SSL_METHOD* CryptoNative_SslV2_3Method()
@@ -26,6 +42,14 @@ extern "C" const SSL_METHOD* CryptoNative_SslV2_3Method()
     return method;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const SSL_METHOD* SslV3Method()
+{
+    return CryptoNative_SslV3Method();
+}
+
 extern "C" const SSL_METHOD* CryptoNative_SslV3Method()
 {
     const SSL_METHOD* method = SSLv3_method();
@@ -33,11 +57,27 @@ extern "C" const SSL_METHOD* CryptoNative_SslV3Method()
     return method;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const SSL_METHOD* TlsV1Method()
+{
+    return CryptoNative_TlsV1Method();
+}
+
 extern "C" const SSL_METHOD* CryptoNative_TlsV1Method()
 {
     const SSL_METHOD* method = TLSv1_method();
     assert(method != nullptr);
     return method;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const SSL_METHOD* TlsV1_1Method()
+{
+    return CryptoNative_TlsV1_1Method();
 }
 
 extern "C" const SSL_METHOD* CryptoNative_TlsV1_1Method()
@@ -51,6 +91,14 @@ extern "C" const SSL_METHOD* CryptoNative_TlsV1_1Method()
 #endif
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const SSL_METHOD* TlsV1_2Method()
+{
+    return CryptoNative_TlsV1_2Method();
+}
+
 extern "C" const SSL_METHOD* CryptoNative_TlsV1_2Method()
 {
 #if HAVE_TLS_V1_2
@@ -62,9 +110,25 @@ extern "C" const SSL_METHOD* CryptoNative_TlsV1_2Method()
 #endif
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" SSL_CTX* SslCtxCreate(SSL_METHOD* method)
+{
+    return CryptoNative_SslCtxCreate(method);
+}
+
 extern "C" SSL_CTX* CryptoNative_SslCtxCreate(SSL_METHOD* method)
 {
     return SSL_CTX_new(method);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void SetProtocolOptions(SSL_CTX* ctx, SslProtocols protocols)
+{
+    return CryptoNative_SetProtocolOptions(ctx, protocols);
 }
 
 extern "C" void CryptoNative_SetProtocolOptions(SSL_CTX* ctx, SslProtocols protocols)
@@ -99,14 +163,38 @@ extern "C" void CryptoNative_SetProtocolOptions(SSL_CTX* ctx, SslProtocols proto
     SSL_CTX_set_options(ctx, protocolOptions);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" SSL* SslCreate(SSL_CTX* ctx)
+{
+    return CryptoNative_SslCreate(ctx);
+}
+
 extern "C" SSL* CryptoNative_SslCreate(SSL_CTX* ctx)
 {
     return SSL_new(ctx);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t SslGetError(SSL* ssl, int32_t ret)
+{
+    return CryptoNative_SslGetError(ssl, ret);
+}
+
 extern "C" int32_t CryptoNative_SslGetError(SSL* ssl, int32_t ret)
 {
     return SSL_get_error(ssl, ret);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void SslDestroy(SSL* ssl)
+{
+    return CryptoNative_SslDestroy(ssl);
 }
 
 extern "C" void CryptoNative_SslDestroy(SSL* ssl)
@@ -117,6 +205,14 @@ extern "C" void CryptoNative_SslDestroy(SSL* ssl)
     }
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void SslCtxDestroy(SSL_CTX* ctx)
+{
+    return CryptoNative_SslCtxDestroy(ctx);
+}
+
 extern "C" void CryptoNative_SslCtxDestroy(SSL_CTX* ctx)
 {
     if (ctx)
@@ -125,9 +221,25 @@ extern "C" void CryptoNative_SslCtxDestroy(SSL_CTX* ctx)
     }
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void SslSetConnectState(SSL* ssl)
+{
+    return CryptoNative_SslSetConnectState(ssl);
+}
+
 extern "C" void CryptoNative_SslSetConnectState(SSL* ssl)
 {
     SSL_set_connect_state(ssl);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void SslSetAcceptState(SSL* ssl)
+{
+    return CryptoNative_SslSetAcceptState(ssl);
 }
 
 extern "C" void CryptoNative_SslSetAcceptState(SSL* ssl)
@@ -135,9 +247,25 @@ extern "C" void CryptoNative_SslSetAcceptState(SSL* ssl)
     SSL_set_accept_state(ssl);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const char* SslGetVersion(SSL* ssl)
+{
+    return CryptoNative_SslGetVersion(ssl);
+}
+
 extern "C" const char* CryptoNative_SslGetVersion(SSL* ssl)
 {
     return SSL_get_version(ssl);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t SslGetFinished(SSL* ssl, void* buf, int32_t count)
+{
+    return CryptoNative_SslGetFinished(ssl, buf, count);
 }
 
 extern "C" int32_t CryptoNative_SslGetFinished(SSL* ssl, void* buf, int32_t count)
@@ -147,11 +275,27 @@ extern "C" int32_t CryptoNative_SslGetFinished(SSL* ssl, void* buf, int32_t coun
     return static_cast<int32_t>(result);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t SslGetPeerFinished(SSL* ssl, void* buf, int32_t count)
+{
+    return CryptoNative_SslGetPeerFinished(ssl, buf, count);
+}
+
 extern "C" int32_t CryptoNative_SslGetPeerFinished(SSL* ssl, void* buf, int32_t count)
 {
     size_t result = SSL_get_peer_finished(ssl, buf, size_t(count));
     assert(result <= INT32_MAX);
     return static_cast<int32_t>(result);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t SslSessionReused(SSL* ssl)
+{
+    return CryptoNative_SslSessionReused(ssl);
 }
 
 extern "C" int32_t CryptoNative_SslSessionReused(SSL* ssl)
@@ -440,6 +584,19 @@ GetHashAlgorithmTypeAndSize(const SSL_CIPHER* cipher, HashAlgorithmType* dataHas
     return;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t GetSslConnectionInfo(SSL* ssl,
+                                        CipherAlgorithmType* dataCipherAlg,
+                                        ExchangeAlgorithmType* keyExchangeAlg,
+                                        HashAlgorithmType* dataHashAlg,
+                                        int32_t* dataKeySize,
+                                        DataHashSize* hashKeySize)
+{
+    return CryptoNative_GetSslConnectionInfo(ssl, dataCipherAlg, keyExchangeAlg, dataHashAlg, dataKeySize, hashKeySize);
+}
+
 extern "C" int32_t CryptoNative_GetSslConnectionInfo(SSL* ssl,
                                                      CipherAlgorithmType* dataCipherAlg,
                                                      ExchangeAlgorithmType* keyExchangeAlg,
@@ -484,9 +641,25 @@ err:
     return 0;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t SslWrite(SSL* ssl, const void* buf, int32_t num)
+{
+    return CryptoNative_SslWrite(ssl, buf, num);
+}
+
 extern "C" int32_t CryptoNative_SslWrite(SSL* ssl, const void* buf, int32_t num)
 {
     return SSL_write(ssl, buf, num);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t SslRead(SSL* ssl, void* buf, int32_t num)
+{
+    return CryptoNative_SslRead(ssl, buf, num);
 }
 
 extern "C" int32_t CryptoNative_SslRead(SSL* ssl, void* buf, int32_t num)
@@ -494,9 +667,25 @@ extern "C" int32_t CryptoNative_SslRead(SSL* ssl, void* buf, int32_t num)
     return SSL_read(ssl, buf, num);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t IsSslRenegotiatePending(SSL* ssl)
+{
+    return CryptoNative_IsSslRenegotiatePending(ssl);
+}
+
 extern "C" int32_t CryptoNative_IsSslRenegotiatePending(SSL* ssl)
 {
     return SSL_renegotiate_pending(ssl) != 0;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t SslShutdown(SSL* ssl)
+{
+    return CryptoNative_SslShutdown(ssl);
 }
 
 extern "C" int32_t CryptoNative_SslShutdown(SSL* ssl)
@@ -504,9 +693,25 @@ extern "C" int32_t CryptoNative_SslShutdown(SSL* ssl)
     return SSL_shutdown(ssl);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void SslSetBio(SSL* ssl, BIO* rbio, BIO* wbio)
+{
+    return CryptoNative_SslSetBio(ssl, rbio, wbio);
+}
+
 extern "C" void CryptoNative_SslSetBio(SSL* ssl, BIO* rbio, BIO* wbio)
 {
     SSL_set_bio(ssl, rbio, wbio);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t SslDoHandshake(SSL* ssl)
+{
+    return CryptoNative_SslDoHandshake(ssl);
 }
 
 extern "C" int32_t CryptoNative_SslDoHandshake(SSL* ssl)
@@ -514,9 +719,25 @@ extern "C" int32_t CryptoNative_SslDoHandshake(SSL* ssl)
     return SSL_do_handshake(ssl);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t IsSslStateOK(SSL* ssl)
+{
+    return CryptoNative_IsSslStateOK(ssl);
+}
+
 extern "C" int32_t CryptoNative_IsSslStateOK(SSL* ssl)
 {
     return SSL_state(ssl) == SSL_ST_OK;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509* SslGetPeerCertificate(SSL* ssl)
+{
+    return CryptoNative_SslGetPeerCertificate(ssl);
 }
 
 extern "C" X509* CryptoNative_SslGetPeerCertificate(SSL* ssl)
@@ -524,9 +745,25 @@ extern "C" X509* CryptoNative_SslGetPeerCertificate(SSL* ssl)
     return SSL_get_peer_certificate(ssl);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509Stack* SslGetPeerCertChain(SSL* ssl)
+{
+    return CryptoNative_SslGetPeerCertChain(ssl);
+}
+
 extern "C" X509Stack* CryptoNative_SslGetPeerCertChain(SSL* ssl)
 {
     return SSL_get_peer_cert_chain(ssl);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t SslCtxUseCertificate(SSL_CTX* ctx, X509* x)
+{
+    return CryptoNative_SslCtxUseCertificate(ctx, x);
 }
 
 extern "C" int32_t CryptoNative_SslCtxUseCertificate(SSL_CTX* ctx, X509* x)
@@ -534,9 +771,25 @@ extern "C" int32_t CryptoNative_SslCtxUseCertificate(SSL_CTX* ctx, X509* x)
     return SSL_CTX_use_certificate(ctx, x);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t SslCtxUsePrivateKey(SSL_CTX* ctx, EVP_PKEY* pkey)
+{
+    return CryptoNative_SslCtxUsePrivateKey(ctx, pkey);
+}
+
 extern "C" int32_t CryptoNative_SslCtxUsePrivateKey(SSL_CTX* ctx, EVP_PKEY* pkey)
 {
     return SSL_CTX_use_PrivateKey(ctx, pkey);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t SslCtxCheckPrivateKey(SSL_CTX* ctx)
+{
+    return CryptoNative_SslCtxCheckPrivateKey(ctx);
 }
 
 extern "C" int32_t CryptoNative_SslCtxCheckPrivateKey(SSL_CTX* ctx)
@@ -544,9 +797,25 @@ extern "C" int32_t CryptoNative_SslCtxCheckPrivateKey(SSL_CTX* ctx)
     return SSL_CTX_check_private_key(ctx);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void SslCtxSetQuietShutdown(SSL_CTX* ctx)
+{
+    return CryptoNative_SslCtxSetQuietShutdown(ctx);
+}
+
 extern "C" void CryptoNative_SslCtxSetQuietShutdown(SSL_CTX* ctx)
 {
     SSL_CTX_set_quiet_shutdown(ctx, 1);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509NameStack* SslGetClientCAList(SSL* ssl)
+{
+    return CryptoNative_SslGetClientCAList(ssl);
 }
 
 extern "C" X509NameStack* CryptoNative_SslGetClientCAList(SSL* ssl)
@@ -554,11 +823,28 @@ extern "C" X509NameStack* CryptoNative_SslGetClientCAList(SSL* ssl)
     return SSL_get_client_CA_list(ssl);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void SslCtxSetVerify(SSL_CTX* ctx, SslCtxSetVerifyCallback callback)
+{
+    return CryptoNative_SslCtxSetVerify(ctx, callback);
+}
+
 extern "C" void CryptoNative_SslCtxSetVerify(SSL_CTX* ctx, SslCtxSetVerifyCallback callback)
 {
     int mode = SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
 
     SSL_CTX_set_verify(ctx, mode, callback);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void
+SslCtxSetCertVerifyCallback(SSL_CTX* ctx, SslCtxSetCertVerifyCallbackCallback callback, void* arg)
+{
+    return CryptoNative_SslCtxSetCertVerifyCallback(ctx, callback, arg);
 }
 
 extern "C" void
@@ -571,6 +857,14 @@ CryptoNative_SslCtxSetCertVerifyCallback(SSL_CTX* ctx, SslCtxSetCertVerifyCallba
 // below string is corresponding to "AllowNoEncryption"
 #define SSL_TXT_Separator ":"
 #define SSL_TXT_AllIncludingNull SSL_TXT_ALL SSL_TXT_Separator SSL_TXT_eNULL
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void SetEncryptionPolicy(SSL_CTX* ctx, EncryptionPolicy policy)
+{
+    return CryptoNative_SetEncryptionPolicy(ctx, policy);
+}
 
 extern "C" void CryptoNative_SetEncryptionPolicy(SSL_CTX* ctx, EncryptionPolicy policy)
 {
@@ -595,14 +889,38 @@ extern "C" void CryptoNative_SetEncryptionPolicy(SSL_CTX* ctx, EncryptionPolicy 
     SSL_CTX_set_cipher_list(ctx, cipherString);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void SslCtxSetClientCAList(SSL_CTX* ctx, X509NameStack* list)
+{
+    return CryptoNative_SslCtxSetClientCAList(ctx, list);
+}
+
 extern "C" void CryptoNative_SslCtxSetClientCAList(SSL_CTX* ctx, X509NameStack* list)
 {
     SSL_CTX_set_client_CA_list(ctx, list);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void SslCtxSetClientCertCallback(SSL_CTX* ctx, SslClientCertCallback callback)
+{
+    return CryptoNative_SslCtxSetClientCertCallback(ctx, callback);
+}
+
 extern "C" void CryptoNative_SslCtxSetClientCertCallback(SSL_CTX* ctx, SslClientCertCallback callback)
 {
     SSL_CTX_set_client_cert_cb(ctx, callback);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void GetStreamSizes(int32_t* header, int32_t* trailer, int32_t* maximumMessage)
+{
+    return CryptoNative_GetStreamSizes(header, trailer, maximumMessage);
 }
 
 extern "C" void CryptoNative_GetStreamSizes(int32_t* header, int32_t* trailer, int32_t* maximumMessage)
@@ -626,6 +944,14 @@ extern "C" void CryptoNative_GetStreamSizes(int32_t* header, int32_t* trailer, i
     {
         *maximumMessage = SSL3_RT_MAX_PLAIN_LENGTH;
     }
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t SslAddExtraChainCert(SSL* ssl, X509* x509)
+{
+    return CryptoNative_SslAddExtraChainCert(ssl, x509);
 }
 
 extern "C" int32_t CryptoNative_SslAddExtraChainCert(SSL* ssl, X509* x509)

--- a/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -13,34 +13,34 @@ static_assert(PAL_SSL_ERROR_WANT_WRITE == SSL_ERROR_WANT_WRITE, "");
 static_assert(PAL_SSL_ERROR_SYSCALL == SSL_ERROR_SYSCALL, "");
 static_assert(PAL_SSL_ERROR_ZERO_RETURN == SSL_ERROR_ZERO_RETURN, "");
 
-extern "C" void EnsureLibSslInitialized()
+extern "C" void CryptoNative_EnsureLibSslInitialized()
 {
     SSL_library_init();
     SSL_load_error_strings();
 }
 
-extern "C" const SSL_METHOD* SslV2_3Method()
+extern "C" const SSL_METHOD* CryptoNative_SslV2_3Method()
 {
     const SSL_METHOD* method = SSLv23_method();
     assert(method != nullptr);
     return method;
 }
 
-extern "C" const SSL_METHOD* SslV3Method()
+extern "C" const SSL_METHOD* CryptoNative_SslV3Method()
 {
     const SSL_METHOD* method = SSLv3_method();
     assert(method != nullptr);
     return method;
 }
 
-extern "C" const SSL_METHOD* TlsV1Method()
+extern "C" const SSL_METHOD* CryptoNative_TlsV1Method()
 {
     const SSL_METHOD* method = TLSv1_method();
     assert(method != nullptr);
     return method;
 }
 
-extern "C" const SSL_METHOD* TlsV1_1Method()
+extern "C" const SSL_METHOD* CryptoNative_TlsV1_1Method()
 {
 #if HAVE_TLS_V1_1
     const SSL_METHOD* method = TLSv1_1_method();
@@ -51,7 +51,7 @@ extern "C" const SSL_METHOD* TlsV1_1Method()
 #endif
 }
 
-extern "C" const SSL_METHOD* TlsV1_2Method()
+extern "C" const SSL_METHOD* CryptoNative_TlsV1_2Method()
 {
 #if HAVE_TLS_V1_2
     const SSL_METHOD* method = TLSv1_2_method();
@@ -62,12 +62,12 @@ extern "C" const SSL_METHOD* TlsV1_2Method()
 #endif
 }
 
-extern "C" SSL_CTX* SslCtxCreate(SSL_METHOD* method)
+extern "C" SSL_CTX* CryptoNative_SslCtxCreate(SSL_METHOD* method)
 {
     return SSL_CTX_new(method);
 }
 
-extern "C" void SetProtocolOptions(SSL_CTX* ctx, SslProtocols protocols)
+extern "C" void CryptoNative_SetProtocolOptions(SSL_CTX* ctx, SslProtocols protocols)
 {
     long protocolOptions = 0;
 
@@ -99,17 +99,17 @@ extern "C" void SetProtocolOptions(SSL_CTX* ctx, SslProtocols protocols)
     SSL_CTX_set_options(ctx, protocolOptions);
 }
 
-extern "C" SSL* SslCreate(SSL_CTX* ctx)
+extern "C" SSL* CryptoNative_SslCreate(SSL_CTX* ctx)
 {
     return SSL_new(ctx);
 }
 
-extern "C" int32_t SslGetError(SSL* ssl, int32_t ret)
+extern "C" int32_t CryptoNative_SslGetError(SSL* ssl, int32_t ret)
 {
     return SSL_get_error(ssl, ret);
 }
 
-extern "C" void SslDestroy(SSL* ssl)
+extern "C" void CryptoNative_SslDestroy(SSL* ssl)
 {
     if (ssl)
     {
@@ -117,7 +117,7 @@ extern "C" void SslDestroy(SSL* ssl)
     }
 }
 
-extern "C" void SslCtxDestroy(SSL_CTX* ctx)
+extern "C" void CryptoNative_SslCtxDestroy(SSL_CTX* ctx)
 {
     if (ctx)
     {
@@ -125,38 +125,38 @@ extern "C" void SslCtxDestroy(SSL_CTX* ctx)
     }
 }
 
-extern "C" void SslSetConnectState(SSL* ssl)
+extern "C" void CryptoNative_SslSetConnectState(SSL* ssl)
 {
     SSL_set_connect_state(ssl);
 }
 
-extern "C" void SslSetAcceptState(SSL* ssl)
+extern "C" void CryptoNative_SslSetAcceptState(SSL* ssl)
 {
     SSL_set_accept_state(ssl);
 }
 
-extern "C" const char* SslGetVersion(SSL* ssl)
+extern "C" const char* CryptoNative_SslGetVersion(SSL* ssl)
 {
     return SSL_get_version(ssl);
 }
 
-extern "C" int32_t SslGetFinished(SSL* ssl, void* buf, int32_t count)
+extern "C" int32_t CryptoNative_SslGetFinished(SSL* ssl, void* buf, int32_t count)
 {
-	size_t result = SSL_get_finished(ssl, buf, size_t(count));
-	assert(result <= INT32_MAX);
-	return static_cast<int32_t>(result);
+    size_t result = SSL_get_finished(ssl, buf, size_t(count));
+    assert(result <= INT32_MAX);
+    return static_cast<int32_t>(result);
 }
 
-extern "C" int32_t SslGetPeerFinished(SSL* ssl, void* buf, int32_t count)
+extern "C" int32_t CryptoNative_SslGetPeerFinished(SSL* ssl, void* buf, int32_t count)
 {
-	size_t result = SSL_get_peer_finished(ssl, buf, size_t(count));
-	assert(result <= INT32_MAX);
-	return static_cast<int32_t>(result);
+    size_t result = SSL_get_peer_finished(ssl, buf, size_t(count));
+    assert(result <= INT32_MAX);
+    return static_cast<int32_t>(result);
 }
 
-extern "C" int32_t SslSessionReused(SSL* ssl)
+extern "C" int32_t CryptoNative_SslSessionReused(SSL* ssl)
 {
-	return SSL_session_reused(ssl) == 1;
+    return SSL_session_reused(ssl) == 1;
 }
 
 /*
@@ -440,12 +440,12 @@ GetHashAlgorithmTypeAndSize(const SSL_CIPHER* cipher, HashAlgorithmType* dataHas
     return;
 }
 
-extern "C" int32_t GetSslConnectionInfo(SSL* ssl,
-                                        CipherAlgorithmType* dataCipherAlg,
-                                        ExchangeAlgorithmType* keyExchangeAlg,
-                                        HashAlgorithmType* dataHashAlg,
-                                        int32_t* dataKeySize,
-                                        DataHashSize* hashKeySize)
+extern "C" int32_t CryptoNative_GetSslConnectionInfo(SSL* ssl,
+                                                     CipherAlgorithmType* dataCipherAlg,
+                                                     ExchangeAlgorithmType* keyExchangeAlg,
+                                                     HashAlgorithmType* dataHashAlg,
+                                                     int32_t* dataKeySize,
+                                                     DataHashSize* hashKeySize)
 {
     const SSL_CIPHER* cipher;
 
@@ -484,84 +484,85 @@ err:
     return 0;
 }
 
-extern "C" int32_t SslWrite(SSL* ssl, const void* buf, int32_t num)
+extern "C" int32_t CryptoNative_SslWrite(SSL* ssl, const void* buf, int32_t num)
 {
     return SSL_write(ssl, buf, num);
 }
 
-extern "C" int32_t SslRead(SSL* ssl, void* buf, int32_t num)
+extern "C" int32_t CryptoNative_SslRead(SSL* ssl, void* buf, int32_t num)
 {
     return SSL_read(ssl, buf, num);
 }
 
-extern "C" int32_t IsSslRenegotiatePending(SSL* ssl)
+extern "C" int32_t CryptoNative_IsSslRenegotiatePending(SSL* ssl)
 {
     return SSL_renegotiate_pending(ssl) != 0;
 }
 
-extern "C" int32_t SslShutdown(SSL* ssl)
+extern "C" int32_t CryptoNative_SslShutdown(SSL* ssl)
 {
     return SSL_shutdown(ssl);
 }
 
-extern "C" void SslSetBio(SSL* ssl, BIO* rbio, BIO* wbio)
+extern "C" void CryptoNative_SslSetBio(SSL* ssl, BIO* rbio, BIO* wbio)
 {
     SSL_set_bio(ssl, rbio, wbio);
 }
 
-extern "C" int32_t SslDoHandshake(SSL* ssl)
+extern "C" int32_t CryptoNative_SslDoHandshake(SSL* ssl)
 {
     return SSL_do_handshake(ssl);
 }
 
-extern "C" int32_t IsSslStateOK(SSL* ssl)
+extern "C" int32_t CryptoNative_IsSslStateOK(SSL* ssl)
 {
     return SSL_state(ssl) == SSL_ST_OK;
 }
 
-extern "C" X509* SslGetPeerCertificate(SSL* ssl)
+extern "C" X509* CryptoNative_SslGetPeerCertificate(SSL* ssl)
 {
     return SSL_get_peer_certificate(ssl);
 }
 
-extern "C" X509Stack* SslGetPeerCertChain(SSL* ssl)
+extern "C" X509Stack* CryptoNative_SslGetPeerCertChain(SSL* ssl)
 {
     return SSL_get_peer_cert_chain(ssl);
 }
 
-extern "C" int32_t SslCtxUseCertificate(SSL_CTX* ctx, X509* x)
+extern "C" int32_t CryptoNative_SslCtxUseCertificate(SSL_CTX* ctx, X509* x)
 {
     return SSL_CTX_use_certificate(ctx, x);
 }
 
-extern "C" int32_t SslCtxUsePrivateKey(SSL_CTX* ctx, EVP_PKEY* pkey)
+extern "C" int32_t CryptoNative_SslCtxUsePrivateKey(SSL_CTX* ctx, EVP_PKEY* pkey)
 {
     return SSL_CTX_use_PrivateKey(ctx, pkey);
 }
 
-extern "C" int32_t SslCtxCheckPrivateKey(SSL_CTX* ctx)
+extern "C" int32_t CryptoNative_SslCtxCheckPrivateKey(SSL_CTX* ctx)
 {
     return SSL_CTX_check_private_key(ctx);
 }
 
-extern "C" void SslCtxSetQuietShutdown(SSL_CTX* ctx)
+extern "C" void CryptoNative_SslCtxSetQuietShutdown(SSL_CTX* ctx)
 {
     SSL_CTX_set_quiet_shutdown(ctx, 1);
 }
 
-extern "C" X509NameStack* SslGetClientCAList(SSL* ssl)
+extern "C" X509NameStack* CryptoNative_SslGetClientCAList(SSL* ssl)
 {
     return SSL_get_client_CA_list(ssl);
 }
 
-extern "C" void SslCtxSetVerify(SSL_CTX* ctx, SslCtxSetVerifyCallback callback)
+extern "C" void CryptoNative_SslCtxSetVerify(SSL_CTX* ctx, SslCtxSetVerifyCallback callback)
 {
     int mode = SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
 
     SSL_CTX_set_verify(ctx, mode, callback);
 }
 
-extern "C" void SslCtxSetCertVerifyCallback(SSL_CTX* ctx, SslCtxSetCertVerifyCallbackCallback callback, void* arg)
+extern "C" void
+CryptoNative_SslCtxSetCertVerifyCallback(SSL_CTX* ctx, SslCtxSetCertVerifyCallbackCallback callback, void* arg)
 {
     SSL_CTX_set_cert_verify_callback(ctx, callback, arg);
 }
@@ -571,7 +572,7 @@ extern "C" void SslCtxSetCertVerifyCallback(SSL_CTX* ctx, SslCtxSetCertVerifyCal
 #define SSL_TXT_Separator ":"
 #define SSL_TXT_AllIncludingNull SSL_TXT_ALL SSL_TXT_Separator SSL_TXT_eNULL
 
-extern "C" void SetEncryptionPolicy(SSL_CTX* ctx, EncryptionPolicy policy)
+extern "C" void CryptoNative_SetEncryptionPolicy(SSL_CTX* ctx, EncryptionPolicy policy)
 {
     const char* cipherString = nullptr;
     switch (policy)
@@ -594,17 +595,17 @@ extern "C" void SetEncryptionPolicy(SSL_CTX* ctx, EncryptionPolicy policy)
     SSL_CTX_set_cipher_list(ctx, cipherString);
 }
 
-extern "C" void SslCtxSetClientCAList(SSL_CTX* ctx, X509NameStack* list)
+extern "C" void CryptoNative_SslCtxSetClientCAList(SSL_CTX* ctx, X509NameStack* list)
 {
     SSL_CTX_set_client_CA_list(ctx, list);
 }
 
-extern "C" void SslCtxSetClientCertCallback(SSL_CTX* ctx, SslClientCertCallback callback)
+extern "C" void CryptoNative_SslCtxSetClientCertCallback(SSL_CTX* ctx, SslClientCertCallback callback)
 {
     SSL_CTX_set_client_cert_cb(ctx, callback);
 }
 
-extern "C" void GetStreamSizes(int32_t* header, int32_t* trailer, int32_t* maximumMessage)
+extern "C" void CryptoNative_GetStreamSizes(int32_t* header, int32_t* trailer, int32_t* maximumMessage)
 {
     if (header)
     {
@@ -627,15 +628,14 @@ extern "C" void GetStreamSizes(int32_t* header, int32_t* trailer, int32_t* maxim
     }
 }
 
-
-extern "C" int32_t SslAddExtraChainCert(SSL* ssl, X509* x509)
+extern "C" int32_t CryptoNative_SslAddExtraChainCert(SSL* ssl, X509* x509)
 {
     if (!x509 || !ssl)
     {
         return 0;
     }
 
-    SSL_CTX *ssl_ctx = SSL_get_SSL_CTX(ssl);
+    SSL_CTX* ssl_ctx = SSL_get_SSL_CTX(ssl);
     if (SSL_CTX_add_extra_chain_cert(ssl_ctx, x509) == 1)
     {
         return 1;

--- a/src/Native/System.Security.Cryptography.Native/pal_ssl.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_ssl.h
@@ -117,72 +117,72 @@ typedef int32_t (*SslCtxSetVerifyCallback)(int32_t, X509_STORE_CTX*);
 typedef int32_t (*SslCtxSetCertVerifyCallbackCallback)(X509_STORE_CTX*, void* arg);
 
 // the function pointer definition for the callback used in SslCtxSetClientCertCallback
-typedef int32_t (*SslClientCertCallback)(SSL *ssl, X509 **x509, EVP_PKEY **pkey);
+typedef int32_t (*SslClientCertCallback)(SSL* ssl, X509** x509, EVP_PKEY** pkey);
 /*
 Ensures that libssl is correctly initialized and ready to use.
 */
-extern "C" void EnsureLibSslInitialized();
+extern "C" void CryptoNative_EnsureLibSslInitialized();
 
 /*
 Shims the SSLv23_method method.
 
 Returns the requested SSL_METHOD.
 */
-extern "C" const SSL_METHOD* SslV2_3Method();
+extern "C" const SSL_METHOD* CryptoNative_SslV2_3Method();
 
 /*
 Shims the SSLv3_method method.
 
 Returns the requested SSL_METHOD.
 */
-extern "C" const SSL_METHOD* SslV3Method();
+extern "C" const SSL_METHOD* CryptoNative_SslV3Method();
 
 /*
 Shims the TLSv1_method method.
 
 Returns the requested SSL_METHOD.
 */
-extern "C" const SSL_METHOD* TlsV1Method();
+extern "C" const SSL_METHOD* CryptoNative_TlsV1Method();
 
 /*
 Shims the TLSv1_1_method method.
 
 Returns the requested SSL_METHOD.
 */
-extern "C" const SSL_METHOD* TlsV1_1Method();
+extern "C" const SSL_METHOD* CryptoNative_TlsV1_1Method();
 
 /*
 Shims the TLSv1_2_method method.
 
 Returns the requested SSL_METHOD.
 */
-extern "C" const SSL_METHOD* TlsV1_2Method();
+extern "C" const SSL_METHOD* CryptoNative_TlsV1_2Method();
 
 /*
 Shims the SSL_CTX_new method.
 
 Returns the new SSL_CTX instance.
 */
-extern "C" SSL_CTX* SslCtxCreate(SSL_METHOD* method);
+extern "C" SSL_CTX* CryptoNative_SslCtxCreate(SSL_METHOD* method);
 
 /*
 Sets the specified protocols in the SSL_CTX options.
 */
-extern "C" void SetProtocolOptions(SSL_CTX* ctx, SslProtocols protocols);
+extern "C" void CryptoNative_SetProtocolOptions(SSL_CTX* ctx, SslProtocols protocols);
 
 /*
 Shims the SSL_new method.
 
 Returns the new SSL instance.
 */
-extern "C" SSL* SslCreate(SSL_CTX* ctx);
+extern "C" SSL* CryptoNative_SslCreate(SSL_CTX* ctx);
 
 /*
 Shims the SSL_get_error method.
 
 Returns the error code for the specified result.
 */
-extern "C" int32_t SslGetError(SSL* ssl, int32_t ret);
+extern "C" int32_t CryptoNative_SslGetError(SSL* ssl, int32_t ret);
 
 /*
 Cleans up and deletes an SSL instance.
@@ -193,7 +193,7 @@ No-op if ssl is null.
 The given X509 SSL is invalid after this call.
 Always succeeds.
 */
-extern "C" void SslDestroy(SSL* ssl);
+extern "C" void CryptoNative_SslDestroy(SSL* ssl);
 
 /*
 Cleans up and deletes an SSL_CTX instance.
@@ -204,24 +204,24 @@ No-op if ctx is null.
 The given X509 SSL_CTX is invalid after this call.
 Always succeeds.
 */
-extern "C" void SslCtxDestroy(SSL_CTX* ctx);
+extern "C" void CryptoNative_SslCtxDestroy(SSL_CTX* ctx);
 
 /*
 Shims the SSL_set_connect_state method.
 */
-extern "C" void SslSetConnectState(SSL* ssl);
+extern "C" void CryptoNative_SslSetConnectState(SSL* ssl);
 
 /*
 Shims the SSL_set_accept_state method.
 */
-extern "C" void SslSetAcceptState(SSL* ssl);
+extern "C" void CryptoNative_SslSetAcceptState(SSL* ssl);
 
 /*
 Shims the SSL_get_version method.
 
 Returns the protocol version string for the SSL instance.
 */
-extern "C" const char* SslGetVersion(SSL* ssl);
+extern "C" const char* CryptoNative_SslGetVersion(SSL* ssl);
 
 /*
 Returns the connection information for the SSL instance.
@@ -229,12 +229,12 @@ Returns the connection information for the SSL instance.
 Returns 1 upon success, otherwise 0.
 */
 
-extern "C" int32_t GetSslConnectionInfo(SSL* ssl,
-                                        CipherAlgorithmType* dataCipherAlg,
-                                        ExchangeAlgorithmType* keyExchangeAlg,
-                                        HashAlgorithmType* dataHashAlg,
-                                        int32_t* dataKeySize,
-                                        DataHashSize* hashKeySize);
+extern "C" int32_t CryptoNative_GetSslConnectionInfo(SSL* ssl,
+                                                     CipherAlgorithmType* dataCipherAlg,
+                                                     ExchangeAlgorithmType* keyExchangeAlg,
+                                                     HashAlgorithmType* dataHashAlg,
+                                                     int32_t* dataKeySize,
+                                                     DataHashSize* hashKeySize);
 
 /*
 Shims the SSL_write method.
@@ -242,7 +242,7 @@ Shims the SSL_write method.
 Returns the positive number of bytes written when successful, 0 or a negative number
 when an error is encountered.
 */
-extern "C" int32_t SslWrite(SSL* ssl, const void* buf, int32_t num);
+extern "C" int32_t CryptoNative_SslWrite(SSL* ssl, const void* buf, int32_t num);
 
 /*
 Shims the SSL_read method.
@@ -250,14 +250,14 @@ Shims the SSL_read method.
 Returns the positive number of bytes read when successful, 0 or a negative number
 when an error is encountered.
 */
-extern "C" int32_t SslRead(SSL* ssl, void* buf, int32_t num);
+extern "C" int32_t CryptoNative_SslRead(SSL* ssl, void* buf, int32_t num);
 
 /*
 Shims the SSL_renegotiate_pending method.
 
 Returns 1 when negotiation is requested; 0 once a handshake has finished.
 */
-extern "C" int32_t IsSslRenegotiatePending(SSL* ssl);
+extern "C" int32_t CryptoNative_IsSslRenegotiatePending(SSL* ssl);
 
 /*
 Shims the SSL_shutdown method.
@@ -267,12 +267,12 @@ Returns:
 0 if the shutdown is not yet finished;
 <0 if the shutdown was not successful because a fatal error.
 */
-extern "C" int32_t SslShutdown(SSL* ssl);
+extern "C" int32_t CryptoNative_SslShutdown(SSL* ssl);
 
 /*
 Shims the SSL_set_bio method.
 */
-extern "C" void SslSetBio(SSL* ssl, BIO* rbio, BIO* wbio);
+extern "C" void CryptoNative_SslSetBio(SSL* ssl, BIO* rbio, BIO* wbio);
 
 /*
 Shims the SSL_do_handshake method.
@@ -283,107 +283,108 @@ Returns:
 and by the specifications of the TLS/SSL protocol;
 <0 if the handshake was not successful because of a fatal error.
 */
-extern "C" int32_t SslDoHandshake(SSL* ssl);
+extern "C" int32_t CryptoNative_SslDoHandshake(SSL* ssl);
 
 /*
 Gets a value indicating whether the SSL_state is SSL_ST_OK.
 
 Returns 1 if the state is OK, otherwise 0.
 */
-extern "C" int32_t IsSslStateOK(SSL* ssl);
+extern "C" int32_t CryptoNative_IsSslStateOK(SSL* ssl);
 
 /*
 Shims the SSL_get_peer_certificate method.
 
 Returns the certificate presented by the peer.
 */
-extern "C" X509* SslGetPeerCertificate(SSL* ssl);
+extern "C" X509* CryptoNative_SslGetPeerCertificate(SSL* ssl);
 
 /*
 Shims the SSL_get_peer_cert_chain method.
 
 Returns the certificate chain presented by the peer.
 */
-extern "C" X509Stack* SslGetPeerCertChain(SSL* ssl);
+extern "C" X509Stack* CryptoNative_SslGetPeerCertChain(SSL* ssl);
 
 /*
 Shims the SSL_CTX_use_certificate method.
 
 Returns 1 upon success, otherwise 0.
 */
-extern "C" int32_t SslCtxUseCertificate(SSL_CTX* ctx, X509* x);
+extern "C" int32_t CryptoNative_SslCtxUseCertificate(SSL_CTX* ctx, X509* x);
 
 /*
 Shims the SSL_CTX_use_PrivateKey method.
 
 Returns 1 upon success, otherwise 0.
 */
-extern "C" int32_t SslCtxUsePrivateKey(SSL_CTX* ctx, EVP_PKEY* pkey);
+extern "C" int32_t CryptoNative_SslCtxUsePrivateKey(SSL_CTX* ctx, EVP_PKEY* pkey);
 
 /*
 Shims the SSL_CTX_check_private_key method.
 
 Returns 1 upon success, otherwise 0.
 */
-extern "C" int32_t SslCtxCheckPrivateKey(SSL_CTX* ctx);
+extern "C" int32_t CryptoNative_SslCtxCheckPrivateKey(SSL_CTX* ctx);
 
 /*
 Shims the SSL_CTX_set_quiet_shutdown method.
 */
-extern "C" void SslCtxSetQuietShutdown(SSL_CTX* ctx);
+extern "C" void CryptoNative_SslCtxSetQuietShutdown(SSL_CTX* ctx);
 
 /*
 Shims the SSL_get_client_CA_list method.
 
 Returns the list of CA names explicity set.
 */
-extern "C" X509NameStack* SslGetClientCAList(SSL* ssl);
+extern "C" X509NameStack* CryptoNative_SslGetClientCAList(SSL* ssl);
 
 /*
 Shims the SSL_CTX_set_verify method.
 */
-extern "C" void SslCtxSetVerify(SSL_CTX* ctx, SslCtxSetVerifyCallback callback);
+extern "C" void CryptoNative_SslCtxSetVerify(SSL_CTX* ctx, SslCtxSetVerifyCallback callback);
 
 /*
 Shims the SSL_CTX_set_cert_verify_callback method.
 */
-extern "C" void SslCtxSetCertVerifyCallback(SSL_CTX* ctx, SslCtxSetCertVerifyCallbackCallback callback, void* arg);
+extern "C" void
+CryptoNative_SslCtxSetCertVerifyCallback(SSL_CTX* ctx, SslCtxSetCertVerifyCallbackCallback callback, void* arg);
 
 /*
 Sets the specified encryption policy on the SSL_CTX.
 */
-extern "C" void SetEncryptionPolicy(SSL_CTX* ctx, EncryptionPolicy policy);
+extern "C" void CryptoNative_SetEncryptionPolicy(SSL_CTX* ctx, EncryptionPolicy policy);
 
 /*
 Shims the SSL_CTX_set_client_CA_list method.
 */
-extern "C" void SslCtxSetClientCAList(SSL_CTX* ctx, X509NameStack* list);
+extern "C" void CryptoNative_SslCtxSetClientCAList(SSL_CTX* ctx, X509NameStack* list);
 
 /*
 Shims the SSL_CTX_set_client_cert_cb method
 */
-extern "C" void SslCtxSetClientCertCallback(SSL_CTX* ctx, SslClientCertCallback callback);
+extern "C" void CryptoNative_SslCtxSetClientCertCallback(SSL_CTX* ctx, SslClientCertCallback callback);
 
 /*
 Gets the SSL stream sizes to use.
 */
-extern "C" void GetStreamSizes(int32_t* header, int32_t* trailer, int32_t* maximumMessage);
+extern "C" void CryptoNative_GetStreamSizes(int32_t* header, int32_t* trailer, int32_t* maximumMessage);
 
 /*
 Shims the SSL_get_finished method.
 */
-extern "C" int32_t SslGetFinished(SSL* ssl, void* buf, int32_t count);
+extern "C" int32_t CryptoNative_SslGetFinished(SSL* ssl, void* buf, int32_t count);
 
 /*
 Shims the SSL_get_peer_finished method.
 */
-extern "C" int32_t SslGetPeerFinished(SSL* ssl, void* buf, int32_t count);
+extern "C" int32_t CryptoNative_SslGetPeerFinished(SSL* ssl, void* buf, int32_t count);
 
 /*
 Returns true/false based on if existing ssl session was re-used or not.
 Shims the SSL_session_reused macro.
 */
-extern "C" int32_t SslSessionReused(SSL* ssl);
+extern "C" int32_t CryptoNative_SslSessionReused(SSL* ssl);
 
 /*
 adds the given certificate to the extra chain certificates associated with ctx that is associated with the ssl.
@@ -391,4 +392,4 @@ adds the given certificate to the extra chain certificates associated with ctx t
 libssl frees the x509 object.
 Returns 1 if success and 0 in case of failure
 */
-extern "C" int32_t SslAddExtraChainCert(SSL* ssl, X509* x509);
+extern "C" int32_t CryptoNative_SslAddExtraChainCert(SSL* ssl, X509* x509);

--- a/src/Native/System.Security.Cryptography.Native/pal_x509.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509.cpp
@@ -44,6 +44,14 @@ static_assert(PAL_X509_V_ERR_INVALID_EXTENSION == X509_V_ERR_INVALID_EXTENSION, 
 static_assert(PAL_X509_V_ERR_INVALID_POLICY_EXTENSION == X509_V_ERR_INVALID_POLICY_EXTENSION, "");
 static_assert(PAL_X509_V_ERR_NO_EXPLICIT_POLICY == X509_V_ERR_NO_EXPLICIT_POLICY, "");
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" EVP_PKEY* GetX509EvpPublicKey(X509* x509)
+{
+    return CryptoNative_GetX509EvpPublicKey(x509);
+}
+
 extern "C" EVP_PKEY* CryptoNative_GetX509EvpPublicKey(X509* x509)
 {
     if (!x509)
@@ -53,6 +61,14 @@ extern "C" EVP_PKEY* CryptoNative_GetX509EvpPublicKey(X509* x509)
 
     // X509_get_X509_PUBKEY returns an interior pointer, so should not be freed
     return X509_PUBKEY_get(X509_get_X509_PUBKEY(x509));
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509_CRL* DecodeX509Crl(const uint8_t* buf, int32_t len)
+{
+    return CryptoNative_DecodeX509Crl(buf, len);
 }
 
 extern "C" X509_CRL* CryptoNative_DecodeX509Crl(const uint8_t* buf, int32_t len)
@@ -65,6 +81,14 @@ extern "C" X509_CRL* CryptoNative_DecodeX509Crl(const uint8_t* buf, int32_t len)
     return d2i_X509_CRL(nullptr, &buf, len);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509* DecodeX509(const uint8_t* buf, int32_t len)
+{
+    return CryptoNative_DecodeX509(buf, len);
+}
+
 extern "C" X509* CryptoNative_DecodeX509(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
@@ -75,14 +99,38 @@ extern "C" X509* CryptoNative_DecodeX509(const uint8_t* buf, int32_t len)
     return d2i_X509(nullptr, &buf, len);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t GetX509DerSize(X509* x)
+{
+    return CryptoNative_GetX509DerSize(x);
+}
+
 extern "C" int32_t CryptoNative_GetX509DerSize(X509* x)
 {
     return i2d_X509(x, nullptr);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t EncodeX509(X509* x, uint8_t* buf)
+{
+    return CryptoNative_EncodeX509(x, buf);
+}
+
 extern "C" int32_t CryptoNative_EncodeX509(X509* x, uint8_t* buf)
 {
     return i2d_X509(x, &buf);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void X509Destroy(X509* a)
+{
+    return CryptoNative_X509Destroy(a);
 }
 
 extern "C" void CryptoNative_X509Destroy(X509* a)
@@ -93,9 +141,25 @@ extern "C" void CryptoNative_X509Destroy(X509* a)
     }
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509* X509Duplicate(X509* x509)
+{
+    return CryptoNative_X509Duplicate(x509);
+}
+
 extern "C" X509* CryptoNative_X509Duplicate(X509* x509)
 {
     return X509_dup(x509);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509* PemReadX509FromBio(BIO* bio)
+{
+    return CryptoNative_PemReadX509FromBio(bio);
 }
 
 extern "C" X509* CryptoNative_PemReadX509FromBio(BIO* bio)
@@ -103,9 +167,25 @@ extern "C" X509* CryptoNative_PemReadX509FromBio(BIO* bio)
     return PEM_read_bio_X509_AUX(bio, nullptr, nullptr, nullptr);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" ASN1_INTEGER* X509GetSerialNumber(X509* x509)
+{
+    return CryptoNative_X509GetSerialNumber(x509);
+}
+
 extern "C" ASN1_INTEGER* CryptoNative_X509GetSerialNumber(X509* x509)
 {
     return X509_get_serialNumber(x509);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509_NAME* X509GetIssuerName(X509* x509)
+{
+    return CryptoNative_X509GetIssuerName(x509);
 }
 
 extern "C" X509_NAME* CryptoNative_X509GetIssuerName(X509* x509)
@@ -113,9 +193,25 @@ extern "C" X509_NAME* CryptoNative_X509GetIssuerName(X509* x509)
     return X509_get_issuer_name(x509);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509_NAME* X509GetSubjectName(X509* x509)
+{
+    return CryptoNative_X509GetSubjectName(x509);
+}
+
 extern "C" X509_NAME* CryptoNative_X509GetSubjectName(X509* x509)
 {
     return X509_get_subject_name(x509);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t X509CheckPurpose(X509* x, int32_t id, int32_t ca)
+{
+    return CryptoNative_X509CheckPurpose(x, id, ca);
 }
 
 extern "C" int32_t CryptoNative_X509CheckPurpose(X509* x, int32_t id, int32_t ca)
@@ -123,9 +219,25 @@ extern "C" int32_t CryptoNative_X509CheckPurpose(X509* x, int32_t id, int32_t ca
     return X509_check_purpose(x, id, ca);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t X509CheckIssued(X509* issuer, X509* subject)
+{
+    return CryptoNative_X509CheckIssued(issuer, subject);
+}
+
 extern "C" int32_t CryptoNative_X509CheckIssued(X509* issuer, X509* subject)
 {
     return X509_check_issued(issuer, subject);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" uint64_t X509IssuerNameHash(X509* x)
+{
+    return CryptoNative_X509IssuerNameHash(x);
 }
 
 extern "C" uint64_t CryptoNative_X509IssuerNameHash(X509* x)
@@ -133,9 +245,25 @@ extern "C" uint64_t CryptoNative_X509IssuerNameHash(X509* x)
     return X509_issuer_name_hash(x);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t X509GetExtCount(X509* x)
+{
+    return CryptoNative_X509GetExtCount(x);
+}
+
 extern "C" int32_t CryptoNative_X509GetExtCount(X509* x)
 {
     return X509_get_ext_count(x);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509_EXTENSION* X509GetExt(X509* x, int32_t loc)
+{
+    return CryptoNative_X509GetExt(x, loc);
 }
 
 extern "C" X509_EXTENSION* CryptoNative_X509GetExt(X509* x, int32_t loc)
@@ -143,9 +271,25 @@ extern "C" X509_EXTENSION* CryptoNative_X509GetExt(X509* x, int32_t loc)
     return X509_get_ext(x, loc);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" ASN1_OBJECT* X509ExtensionGetOid(X509_EXTENSION* x)
+{
+    return CryptoNative_X509ExtensionGetOid(x);
+}
+
 extern "C" ASN1_OBJECT* CryptoNative_X509ExtensionGetOid(X509_EXTENSION* x)
 {
     return X509_EXTENSION_get_object(x);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" ASN1_OCTET_STRING* X509ExtensionGetData(X509_EXTENSION* x)
+{
+    return CryptoNative_X509ExtensionGetData(x);
 }
 
 extern "C" ASN1_OCTET_STRING* CryptoNative_X509ExtensionGetData(X509_EXTENSION* x)
@@ -153,14 +297,38 @@ extern "C" ASN1_OCTET_STRING* CryptoNative_X509ExtensionGetData(X509_EXTENSION* 
     return X509_EXTENSION_get_data(x);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t X509ExtensionGetCritical(X509_EXTENSION* x)
+{
+    return CryptoNative_X509ExtensionGetCritical(x);
+}
+
 extern "C" int32_t CryptoNative_X509ExtensionGetCritical(X509_EXTENSION* x)
 {
     return X509_EXTENSION_get_critical(x);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509_STORE* X509StoreCreate()
+{
+    return CryptoNative_X509StoreCreate();
+}
+
 extern "C" X509_STORE* CryptoNative_X509StoreCreate()
 {
     return X509_STORE_new();
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void X509StoreDestory(X509_STORE* v)
+{
+    return CryptoNative_X509StoreDestory(v);
 }
 
 extern "C" void CryptoNative_X509StoreDestory(X509_STORE* v)
@@ -171,14 +339,38 @@ extern "C" void CryptoNative_X509StoreDestory(X509_STORE* v)
     }
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t X509StoreAddCert(X509_STORE* ctx, X509* x)
+{
+    return CryptoNative_X509StoreAddCert(ctx, x);
+}
+
 extern "C" int32_t CryptoNative_X509StoreAddCert(X509_STORE* ctx, X509* x)
 {
     return X509_STORE_add_cert(ctx, x);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t X509StoreAddCrl(X509_STORE* ctx, X509_CRL* x)
+{
+    return CryptoNative_X509StoreAddCrl(ctx, x);
+}
+
 extern "C" int32_t CryptoNative_X509StoreAddCrl(X509_STORE* ctx, X509_CRL* x)
 {
     return X509_STORE_add_crl(ctx, x);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t X509StoreSetRevocationFlag(X509_STORE* ctx, X509RevocationFlag revocationFlag)
+{
+    return CryptoNative_X509StoreSetRevocationFlag(ctx, revocationFlag);
 }
 
 extern "C" int32_t CryptoNative_X509StoreSetRevocationFlag(X509_STORE* ctx, X509RevocationFlag revocationFlag)
@@ -193,9 +385,25 @@ extern "C" int32_t CryptoNative_X509StoreSetRevocationFlag(X509_STORE* ctx, X509
     return X509_STORE_set_flags(ctx, verifyFlags);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509_STORE_CTX* X509StoreCtxCreate()
+{
+    return CryptoNative_X509StoreCtxCreate();
+}
+
 extern "C" X509_STORE_CTX* CryptoNative_X509StoreCtxCreate()
 {
     return X509_STORE_CTX_new();
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void X509StoreCtxDestroy(X509_STORE_CTX* v)
+{
+    return CryptoNative_X509StoreCtxDestroy(v);
 }
 
 extern "C" void CryptoNative_X509StoreCtxDestroy(X509_STORE_CTX* v)
@@ -206,9 +414,25 @@ extern "C" void CryptoNative_X509StoreCtxDestroy(X509_STORE_CTX* v)
     }
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t X509StoreCtxInit(X509_STORE_CTX* ctx, X509_STORE* store, X509* x509)
+{
+    return CryptoNative_X509StoreCtxInit(ctx, store, x509);
+}
+
 extern "C" int32_t CryptoNative_X509StoreCtxInit(X509_STORE_CTX* ctx, X509_STORE* store, X509* x509)
 {
     return X509_STORE_CTX_init(ctx, store, x509, nullptr);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t X509VerifyCert(X509_STORE_CTX* ctx)
+{
+    return CryptoNative_X509VerifyCert(ctx);
 }
 
 extern "C" int32_t CryptoNative_X509VerifyCert(X509_STORE_CTX* ctx)
@@ -216,9 +440,25 @@ extern "C" int32_t CryptoNative_X509VerifyCert(X509_STORE_CTX* ctx)
     return X509_verify_cert(ctx);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509Stack* X509StoreCtxGetChain(X509_STORE_CTX* ctx)
+{
+    return CryptoNative_X509StoreCtxGetChain(ctx);
+}
+
 extern "C" X509Stack* CryptoNative_X509StoreCtxGetChain(X509_STORE_CTX* ctx)
 {
     return X509_STORE_CTX_get1_chain(ctx);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509Stack* X509StoreCtxGetSharedUntrusted(X509_STORE_CTX* ctx)
+{
+    return CryptoNative_X509StoreCtxGetSharedUntrusted(ctx);
 }
 
 extern "C" X509Stack* CryptoNative_X509StoreCtxGetSharedUntrusted(X509_STORE_CTX* ctx)
@@ -226,9 +466,25 @@ extern "C" X509Stack* CryptoNative_X509StoreCtxGetSharedUntrusted(X509_STORE_CTX
     return ctx ? ctx->untrusted : nullptr;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509* X509StoreCtxGetTargetCert(X509_STORE_CTX* ctx)
+{
+    return CryptoNative_X509StoreCtxGetTargetCert(ctx);
+}
+
 extern "C" X509* CryptoNative_X509StoreCtxGetTargetCert(X509_STORE_CTX* ctx)
 {
     return ctx ? ctx->cert : nullptr;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509VerifyStatusCode X509StoreCtxGetError(X509_STORE_CTX* ctx)
+{
+    return CryptoNative_X509StoreCtxGetError(ctx);
 }
 
 extern "C" X509VerifyStatusCode CryptoNative_X509StoreCtxGetError(X509_STORE_CTX* ctx)
@@ -236,9 +492,25 @@ extern "C" X509VerifyStatusCode CryptoNative_X509StoreCtxGetError(X509_STORE_CTX
     return static_cast<X509VerifyStatusCode>(X509_STORE_CTX_get_error(ctx));
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void X509StoreCtxSetVerifyCallback(X509_STORE_CTX* ctx, X509StoreVerifyCallback callback)
+{
+    return CryptoNative_X509StoreCtxSetVerifyCallback(ctx, callback);
+}
+
 extern "C" void CryptoNative_X509StoreCtxSetVerifyCallback(X509_STORE_CTX* ctx, X509StoreVerifyCallback callback)
 {
     X509_STORE_CTX_set_verify_cb(ctx, callback);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t X509StoreCtxGetErrorDepth(X509_STORE_CTX* ctx)
+{
+    return CryptoNative_X509StoreCtxGetErrorDepth(ctx);
 }
 
 extern "C" int32_t CryptoNative_X509StoreCtxGetErrorDepth(X509_STORE_CTX* ctx)
@@ -246,9 +518,25 @@ extern "C" int32_t CryptoNative_X509StoreCtxGetErrorDepth(X509_STORE_CTX* ctx)
     return X509_STORE_CTX_get_error_depth(ctx);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" const char* X509VerifyCertErrorString(X509VerifyStatusCode n)
+{
+    return CryptoNative_X509VerifyCertErrorString(n);
+}
+
 extern "C" const char* CryptoNative_X509VerifyCertErrorString(X509VerifyStatusCode n)
 {
     return X509_verify_cert_error_string(n);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void X509CrlDestroy(X509_CRL* a)
+{
+    return CryptoNative_X509CrlDestroy(a);
 }
 
 extern "C" void CryptoNative_X509CrlDestroy(X509_CRL* a)
@@ -259,14 +547,38 @@ extern "C" void CryptoNative_X509CrlDestroy(X509_CRL* a)
     }
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t PemWriteBioX509Crl(BIO* bio, X509_CRL* crl)
+{
+    return CryptoNative_PemWriteBioX509Crl(bio, crl);
+}
+
 extern "C" int32_t CryptoNative_PemWriteBioX509Crl(BIO* bio, X509_CRL* crl)
 {
     return PEM_write_bio_X509_CRL(bio, crl);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509_CRL* PemReadBioX509Crl(BIO* bio)
+{
+    return CryptoNative_PemReadBioX509Crl(bio);
+}
+
 extern "C" X509_CRL* CryptoNative_PemReadBioX509Crl(BIO* bio)
 {
     return PEM_read_bio_X509_CRL(bio, nullptr, nullptr, nullptr);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t GetX509SubjectPublicKeyInfoDerSize(X509* x509)
+{
+    return CryptoNative_GetX509SubjectPublicKeyInfoDerSize(x509);
 }
 
 extern "C" int32_t CryptoNative_GetX509SubjectPublicKeyInfoDerSize(X509* x509)
@@ -278,6 +590,14 @@ extern "C" int32_t CryptoNative_GetX509SubjectPublicKeyInfoDerSize(X509* x509)
 
     // X509_get_X509_PUBKEY returns an interior pointer, so should not be freed
     return i2d_X509_PUBKEY(X509_get_X509_PUBKEY(x509), nullptr);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t EncodeX509SubjectPublicKeyInfo(X509* x509, uint8_t* buf)
+{
+    return CryptoNative_EncodeX509SubjectPublicKeyInfo(x509, buf);
 }
 
 extern "C" int32_t CryptoNative_EncodeX509SubjectPublicKeyInfo(X509* x509, uint8_t* buf)

--- a/src/Native/System.Security.Cryptography.Native/pal_x509.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509.cpp
@@ -44,7 +44,7 @@ static_assert(PAL_X509_V_ERR_INVALID_EXTENSION == X509_V_ERR_INVALID_EXTENSION, 
 static_assert(PAL_X509_V_ERR_INVALID_POLICY_EXTENSION == X509_V_ERR_INVALID_POLICY_EXTENSION, "");
 static_assert(PAL_X509_V_ERR_NO_EXPLICIT_POLICY == X509_V_ERR_NO_EXPLICIT_POLICY, "");
 
-extern "C" EVP_PKEY* GetX509EvpPublicKey(X509* x509)
+extern "C" EVP_PKEY* CryptoNative_GetX509EvpPublicKey(X509* x509)
 {
     if (!x509)
     {
@@ -55,7 +55,7 @@ extern "C" EVP_PKEY* GetX509EvpPublicKey(X509* x509)
     return X509_PUBKEY_get(X509_get_X509_PUBKEY(x509));
 }
 
-extern "C" X509_CRL* DecodeX509Crl(const uint8_t* buf, int32_t len)
+extern "C" X509_CRL* CryptoNative_DecodeX509Crl(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
     {
@@ -65,7 +65,7 @@ extern "C" X509_CRL* DecodeX509Crl(const uint8_t* buf, int32_t len)
     return d2i_X509_CRL(nullptr, &buf, len);
 }
 
-extern "C" X509* DecodeX509(const uint8_t* buf, int32_t len)
+extern "C" X509* CryptoNative_DecodeX509(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
     {
@@ -75,17 +75,17 @@ extern "C" X509* DecodeX509(const uint8_t* buf, int32_t len)
     return d2i_X509(nullptr, &buf, len);
 }
 
-extern "C" int32_t GetX509DerSize(X509* x)
+extern "C" int32_t CryptoNative_GetX509DerSize(X509* x)
 {
     return i2d_X509(x, nullptr);
 }
 
-extern "C" int32_t EncodeX509(X509* x, uint8_t* buf)
+extern "C" int32_t CryptoNative_EncodeX509(X509* x, uint8_t* buf)
 {
     return i2d_X509(x, &buf);
 }
 
-extern "C" void X509Destroy(X509* a)
+extern "C" void CryptoNative_X509Destroy(X509* a)
 {
     if (a != nullptr)
     {
@@ -93,77 +93,77 @@ extern "C" void X509Destroy(X509* a)
     }
 }
 
-extern "C" X509* X509Duplicate(X509* x509)
+extern "C" X509* CryptoNative_X509Duplicate(X509* x509)
 {
     return X509_dup(x509);
 }
 
-extern "C" X509* PemReadX509FromBio(BIO* bio)
+extern "C" X509* CryptoNative_PemReadX509FromBio(BIO* bio)
 {
     return PEM_read_bio_X509_AUX(bio, nullptr, nullptr, nullptr);
 }
 
-extern "C" ASN1_INTEGER* X509GetSerialNumber(X509* x509)
+extern "C" ASN1_INTEGER* CryptoNative_X509GetSerialNumber(X509* x509)
 {
     return X509_get_serialNumber(x509);
 }
 
-extern "C" X509_NAME* X509GetIssuerName(X509* x509)
+extern "C" X509_NAME* CryptoNative_X509GetIssuerName(X509* x509)
 {
     return X509_get_issuer_name(x509);
 }
 
-extern "C" X509_NAME* X509GetSubjectName(X509* x509)
+extern "C" X509_NAME* CryptoNative_X509GetSubjectName(X509* x509)
 {
     return X509_get_subject_name(x509);
 }
 
-extern "C" int32_t X509CheckPurpose(X509* x, int32_t id, int32_t ca)
+extern "C" int32_t CryptoNative_X509CheckPurpose(X509* x, int32_t id, int32_t ca)
 {
     return X509_check_purpose(x, id, ca);
 }
 
-extern "C" int32_t X509CheckIssued(X509* issuer, X509* subject)
+extern "C" int32_t CryptoNative_X509CheckIssued(X509* issuer, X509* subject)
 {
     return X509_check_issued(issuer, subject);
 }
 
-extern "C" uint64_t X509IssuerNameHash(X509* x)
+extern "C" uint64_t CryptoNative_X509IssuerNameHash(X509* x)
 {
     return X509_issuer_name_hash(x);
 }
 
-extern "C" int32_t X509GetExtCount(X509* x)
+extern "C" int32_t CryptoNative_X509GetExtCount(X509* x)
 {
     return X509_get_ext_count(x);
 }
 
-extern "C" X509_EXTENSION* X509GetExt(X509* x, int32_t loc)
+extern "C" X509_EXTENSION* CryptoNative_X509GetExt(X509* x, int32_t loc)
 {
     return X509_get_ext(x, loc);
 }
 
-extern "C" ASN1_OBJECT* X509ExtensionGetOid(X509_EXTENSION* x)
+extern "C" ASN1_OBJECT* CryptoNative_X509ExtensionGetOid(X509_EXTENSION* x)
 {
     return X509_EXTENSION_get_object(x);
 }
 
-extern "C" ASN1_OCTET_STRING* X509ExtensionGetData(X509_EXTENSION* x)
+extern "C" ASN1_OCTET_STRING* CryptoNative_X509ExtensionGetData(X509_EXTENSION* x)
 {
     return X509_EXTENSION_get_data(x);
 }
 
-extern "C" int32_t X509ExtensionGetCritical(X509_EXTENSION* x)
+extern "C" int32_t CryptoNative_X509ExtensionGetCritical(X509_EXTENSION* x)
 {
     return X509_EXTENSION_get_critical(x);
 }
 
-extern "C" X509_STORE* X509StoreCreate()
+extern "C" X509_STORE* CryptoNative_X509StoreCreate()
 {
     return X509_STORE_new();
 }
 
-extern "C" void X509StoreDestory(X509_STORE* v)
+extern "C" void CryptoNative_X509StoreDestory(X509_STORE* v)
 {
     if (v != nullptr)
     {
@@ -171,17 +171,17 @@ extern "C" void X509StoreDestory(X509_STORE* v)
     }
 }
 
-extern "C" int32_t X509StoreAddCert(X509_STORE* ctx, X509* x)
+extern "C" int32_t CryptoNative_X509StoreAddCert(X509_STORE* ctx, X509* x)
 {
     return X509_STORE_add_cert(ctx, x);
 }
 
-extern "C" int32_t X509StoreAddCrl(X509_STORE* ctx, X509_CRL* x)
+extern "C" int32_t CryptoNative_X509StoreAddCrl(X509_STORE* ctx, X509_CRL* x)
 {
     return X509_STORE_add_crl(ctx, x);
 }
 
-extern "C" int32_t X509StoreSetRevocationFlag(X509_STORE* ctx, X509RevocationFlag revocationFlag)
+extern "C" int32_t CryptoNative_X509StoreSetRevocationFlag(X509_STORE* ctx, X509RevocationFlag revocationFlag)
 {
     unsigned long verifyFlags = X509_V_FLAG_CRL_CHECK;
 
@@ -193,12 +193,12 @@ extern "C" int32_t X509StoreSetRevocationFlag(X509_STORE* ctx, X509RevocationFla
     return X509_STORE_set_flags(ctx, verifyFlags);
 }
 
-extern "C" X509_STORE_CTX* X509StoreCtxCreate()
+extern "C" X509_STORE_CTX* CryptoNative_X509StoreCtxCreate()
 {
     return X509_STORE_CTX_new();
 }
 
-extern "C" void X509StoreCtxDestroy(X509_STORE_CTX* v)
+extern "C" void CryptoNative_X509StoreCtxDestroy(X509_STORE_CTX* v)
 {
     if (v != nullptr)
     {
@@ -206,52 +206,52 @@ extern "C" void X509StoreCtxDestroy(X509_STORE_CTX* v)
     }
 }
 
-extern "C" int32_t X509StoreCtxInit(X509_STORE_CTX* ctx, X509_STORE* store, X509* x509)
+extern "C" int32_t CryptoNative_X509StoreCtxInit(X509_STORE_CTX* ctx, X509_STORE* store, X509* x509)
 {
     return X509_STORE_CTX_init(ctx, store, x509, nullptr);
 }
 
-extern "C" int32_t X509VerifyCert(X509_STORE_CTX* ctx)
+extern "C" int32_t CryptoNative_X509VerifyCert(X509_STORE_CTX* ctx)
 {
     return X509_verify_cert(ctx);
 }
 
-extern "C" X509Stack* X509StoreCtxGetChain(X509_STORE_CTX* ctx)
+extern "C" X509Stack* CryptoNative_X509StoreCtxGetChain(X509_STORE_CTX* ctx)
 {
     return X509_STORE_CTX_get1_chain(ctx);
 }
 
-extern "C" X509Stack* X509StoreCtxGetSharedUntrusted(X509_STORE_CTX* ctx)
+extern "C" X509Stack* CryptoNative_X509StoreCtxGetSharedUntrusted(X509_STORE_CTX* ctx)
 {
     return ctx ? ctx->untrusted : nullptr;
 }
 
-extern "C" X509* X509StoreCtxGetTargetCert(X509_STORE_CTX* ctx)
+extern "C" X509* CryptoNative_X509StoreCtxGetTargetCert(X509_STORE_CTX* ctx)
 {
     return ctx ? ctx->cert : nullptr;
 }
 
-extern "C" X509VerifyStatusCode X509StoreCtxGetError(X509_STORE_CTX* ctx)
+extern "C" X509VerifyStatusCode CryptoNative_X509StoreCtxGetError(X509_STORE_CTX* ctx)
 {
     return static_cast<X509VerifyStatusCode>(X509_STORE_CTX_get_error(ctx));
 }
 
-extern "C" void X509StoreCtxSetVerifyCallback(X509_STORE_CTX* ctx, X509StoreVerifyCallback callback)
+extern "C" void CryptoNative_X509StoreCtxSetVerifyCallback(X509_STORE_CTX* ctx, X509StoreVerifyCallback callback)
 {
     X509_STORE_CTX_set_verify_cb(ctx, callback);
 }
 
-extern "C" int32_t X509StoreCtxGetErrorDepth(X509_STORE_CTX* ctx)
+extern "C" int32_t CryptoNative_X509StoreCtxGetErrorDepth(X509_STORE_CTX* ctx)
 {
     return X509_STORE_CTX_get_error_depth(ctx);
 }
 
-extern "C" const char* X509VerifyCertErrorString(X509VerifyStatusCode n)
+extern "C" const char* CryptoNative_X509VerifyCertErrorString(X509VerifyStatusCode n)
 {
     return X509_verify_cert_error_string(n);
 }
 
-extern "C" void X509CrlDestroy(X509_CRL* a)
+extern "C" void CryptoNative_X509CrlDestroy(X509_CRL* a)
 {
     if (a != nullptr)
     {
@@ -259,17 +259,17 @@ extern "C" void X509CrlDestroy(X509_CRL* a)
     }
 }
 
-extern "C" int32_t PemWriteBioX509Crl(BIO* bio, X509_CRL* crl)
+extern "C" int32_t CryptoNative_PemWriteBioX509Crl(BIO* bio, X509_CRL* crl)
 {
     return PEM_write_bio_X509_CRL(bio, crl);
 }
 
-extern "C" X509_CRL* PemReadBioX509Crl(BIO* bio)
+extern "C" X509_CRL* CryptoNative_PemReadBioX509Crl(BIO* bio)
 {
     return PEM_read_bio_X509_CRL(bio, nullptr, nullptr, nullptr);
 }
 
-extern "C" int32_t GetX509SubjectPublicKeyInfoDerSize(X509* x509)
+extern "C" int32_t CryptoNative_GetX509SubjectPublicKeyInfoDerSize(X509* x509)
 {
     if (!x509)
     {
@@ -280,7 +280,7 @@ extern "C" int32_t GetX509SubjectPublicKeyInfoDerSize(X509* x509)
     return i2d_X509_PUBKEY(X509_get_X509_PUBKEY(x509), nullptr);
 }
 
-extern "C" int32_t EncodeX509SubjectPublicKeyInfo(X509* x509, uint8_t* buf)
+extern "C" int32_t CryptoNative_EncodeX509SubjectPublicKeyInfo(X509* x509, uint8_t* buf)
 {
     if (!x509)
     {

--- a/src/Native/System.Security.Cryptography.Native/pal_x509.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509.h
@@ -68,30 +68,30 @@ GetX509EvpPublicKey
 
 Returns a EVP_PKEY* equivalent to the public key of the certificate.
 */
-extern "C" EVP_PKEY* GetX509EvpPublicKey(X509* x509);
+extern "C" EVP_PKEY* CryptoNative_GetX509EvpPublicKey(X509* x509);
 
 /*
 Shims the d2i_X509_CRL method and makes it easier to invoke from managed code.
 */
-extern "C" X509_CRL* DecodeX509Crl(const uint8_t* buf, int32_t len);
+extern "C" X509_CRL* CryptoNative_DecodeX509Crl(const uint8_t* buf, int32_t len);
 
 /*
 Shims the d2i_X509 method and makes it easier to invoke from managed code.
 */
-extern "C" X509* DecodeX509(const uint8_t* buf, int32_t len);
+extern "C" X509* CryptoNative_DecodeX509(const uint8_t* buf, int32_t len);
 
 /*
 Returns the number of bytes it will take to convert
 the X509 to a DER format.
 */
-extern "C" int32_t GetX509DerSize(X509* x);
+extern "C" int32_t CryptoNative_GetX509DerSize(X509* x);
 
 /*
 Shims the i2d_X509 method.
 
 Returns the number of bytes written to buf.
 */
-extern "C" int32_t EncodeX509(X509* x, uint8_t* buf);
+extern "C" int32_t CryptoNative_EncodeX509(X509* x, uint8_t* buf);
 
 /*
 Cleans up and deletes an X509 instance.
@@ -102,193 +102,193 @@ No-op if a is null.
 The given X509 pointer is invalid after this call.
 Always succeeds.
 */
-extern "C" void X509Destroy(X509* a);
+extern "C" void CryptoNative_X509Destroy(X509* a);
 
 /*
 Shims the X509_dup method.
 
 Returns the duplicated X509 instance.
 */
-extern "C" X509* X509Duplicate(X509* x509);
+extern "C" X509* CryptoNative_X509Duplicate(X509* x509);
 
 /*
 Shims the PEM_read_bio_X509_AUX method.
 
 Returns the read X509 instance.
 */
-extern "C" X509* PemReadX509FromBio(BIO* bio);
+extern "C" X509* CryptoNative_PemReadX509FromBio(BIO* bio);
 
 /*
 Shims the X509_get_serialNumber method.
 
 Returns the ASN1_INTEGER for the serial number.
 */
-extern "C" ASN1_INTEGER* X509GetSerialNumber(X509* x509);
+extern "C" ASN1_INTEGER* CryptoNative_X509GetSerialNumber(X509* x509);
 
 /*
 Shims the X509_get_issuer_name method.
 
 Returns the ASN1_INTEGER for the issuer name.
 */
-extern "C" X509_NAME* X509GetIssuerName(X509* x509);
+extern "C" X509_NAME* CryptoNative_X509GetIssuerName(X509* x509);
 
 /*
 Shims the X509_get_subject_name method.
 
 Returns the X509_NAME for the subject name.
 */
-extern "C" X509_NAME* X509GetSubjectName(X509* x509);
+extern "C" X509_NAME* CryptoNative_X509GetSubjectName(X509* x509);
 
 /*
 Shims the X509_check_purpose method.
 */
-extern "C" int32_t X509CheckPurpose(X509* x, int32_t id, int32_t ca);
+extern "C" int32_t CryptoNative_X509CheckPurpose(X509* x, int32_t id, int32_t ca);
 
 /*
 Shims the X509_check_issued method.
 */
-extern "C" int32_t X509CheckIssued(X509* issuer, X509* subject);
+extern "C" int32_t CryptoNative_X509CheckIssued(X509* issuer, X509* subject);
 
 /*
 Shims the X509_issuer_name_hash method.
 */
-extern "C" uint64_t X509IssuerNameHash(X509* x);
+extern "C" uint64_t CryptoNative_X509IssuerNameHash(X509* x);
 
 /*
 Shims the X509_get_ext_count method.
 */
-extern "C" int32_t X509GetExtCount(X509* x);
+extern "C" int32_t CryptoNative_X509GetExtCount(X509* x);
 
 /*
 Shims the X509_get_ext method.
 */
-extern "C" X509_EXTENSION* X509GetExt(X509* x, int32_t loc);
+extern "C" X509_EXTENSION* CryptoNative_X509GetExt(X509* x, int32_t loc);
 
 /*
 Shims the X509_EXTENSION_get_object method.
 */
-extern "C" ASN1_OBJECT* X509ExtensionGetOid(X509_EXTENSION* x);
+extern "C" ASN1_OBJECT* CryptoNative_X509ExtensionGetOid(X509_EXTENSION* x);
 
 /*
 Shims the X509_EXTENSION_get_data method.
 */
-extern "C" ASN1_OCTET_STRING* X509ExtensionGetData(X509_EXTENSION* x);
+extern "C" ASN1_OCTET_STRING* CryptoNative_X509ExtensionGetData(X509_EXTENSION* x);
 
 /*
 Shims the X509_EXTENSION_get_critical method.
 */
-extern "C" int32_t X509ExtensionGetCritical(X509_EXTENSION* x);
+extern "C" int32_t CryptoNative_X509ExtensionGetCritical(X509_EXTENSION* x);
 
 /*
 Shims the X509_STORE_new method.
 */
-extern "C" X509_STORE* X509StoreCreate();
+extern "C" X509_STORE* CryptoNative_X509StoreCreate();
 
 /*
 Shims the X509_STORE_free method.
 */
-extern "C" void X509StoreDestory(X509_STORE* v);
+extern "C" void CryptoNative_X509StoreDestory(X509_STORE* v);
 
 /*
 Shims the X509_STORE_add_cert method.
 */
-extern "C" int32_t X509StoreAddCert(X509_STORE* ctx, X509* x);
+extern "C" int32_t CryptoNative_X509StoreAddCert(X509_STORE* ctx, X509* x);
 
 /*
 Shims the X509_STORE_add_crl method.
 */
-extern "C" int32_t X509StoreAddCrl(X509_STORE* ctx, X509_CRL* x);
+extern "C" int32_t CryptoNative_X509StoreAddCrl(X509_STORE* ctx, X509_CRL* x);
 
 /*
 Sets the correct flags on the X509_STORE for the specified X509RevocationFlag.
 
 Shims the X509_STORE_set_flags method.
 */
-extern "C" int32_t X509StoreSetRevocationFlag(X509_STORE* ctx, X509RevocationFlag revocationFlag);
+extern "C" int32_t CryptoNative_X509StoreSetRevocationFlag(X509_STORE* ctx, X509RevocationFlag revocationFlag);
 
 /*
 Shims the X509_STORE_CTX_new method.
 */
-extern "C" X509_STORE_CTX* X509StoreCtxCreate();
+extern "C" X509_STORE_CTX* CryptoNative_X509StoreCtxCreate();
 
 /*
 Shims the X509_STORE_CTX_free method.
 */
-extern "C" void X509StoreCtxDestroy(X509_STORE_CTX* v);
+extern "C" void CryptoNative_X509StoreCtxDestroy(X509_STORE_CTX* v);
 
 /*
 Shims the X509_STORE_CTX_init method.
 */
-extern "C" int32_t X509StoreCtxInit(X509_STORE_CTX* ctx, X509_STORE* store, X509* x509);
+extern "C" int32_t CryptoNative_X509StoreCtxInit(X509_STORE_CTX* ctx, X509_STORE* store, X509* x509);
 
 /*
 Shims the X509_verify_cert method.
 */
-extern "C" int32_t X509VerifyCert(X509_STORE_CTX* ctx);
+extern "C" int32_t CryptoNative_X509VerifyCert(X509_STORE_CTX* ctx);
 
 /*
 Shims the X509_STORE_CTX_get1_chain method.
 */
-extern "C" X509Stack* X509StoreCtxGetChain(X509_STORE_CTX* ctx);
+extern "C" X509Stack* CryptoNative_X509StoreCtxGetChain(X509_STORE_CTX* ctx);
 
 /*
 Returns the interior pointer to the "untrusted" certificates collection for this X509_STORE_CTX
 */
-extern "C" X509Stack* X509StoreCtxGetSharedUntrusted(X509_STORE_CTX* ctx);
+extern "C" X509Stack* CryptoNative_X509StoreCtxGetSharedUntrusted(X509_STORE_CTX* ctx);
 
 /*
 Returns the interior pointer to the target certificate for an X509 certificate chain
 */
-extern "C" X509* X509StoreCtxGetTargetCert(X509_STORE_CTX* ctx);
+extern "C" X509* CryptoNative_X509StoreCtxGetTargetCert(X509_STORE_CTX* ctx);
 
 /*
 Shims the X509_STORE_CTX_get_error method.
 */
-extern "C" X509VerifyStatusCode X509StoreCtxGetError(X509_STORE_CTX* ctx);
+extern "C" X509VerifyStatusCode CryptoNative_X509StoreCtxGetError(X509_STORE_CTX* ctx);
 
 /*
 Shims the X509_STORE_CTX_get_error_depth method.
 */
-extern "C" int32_t X509StoreCtxGetErrorDepth(X509_STORE_CTX* ctx);
+extern "C" int32_t CryptoNative_X509StoreCtxGetErrorDepth(X509_STORE_CTX* ctx);
 
 /*
 Shims the X509_STORE_CTX_set_verify_cb function.
 */
-extern "C" void X509StoreCtxSetVerifyCallback(X509_STORE_CTX* ctx, X509StoreVerifyCallback callback);
+extern "C" void CryptoNative_X509StoreCtxSetVerifyCallback(X509_STORE_CTX* ctx, X509StoreVerifyCallback callback);
 
 /*
 Shims the X509_verify_cert_error_string method.
 */
-extern "C" const char* X509VerifyCertErrorString(X509VerifyStatusCode n);
+extern "C" const char* CryptoNative_X509VerifyCertErrorString(X509VerifyStatusCode n);
 
 /*
 Shims the X509_CRL_free method.
 */
-extern "C" void X509CrlDestroy(X509_CRL* a);
+extern "C" void CryptoNative_X509CrlDestroy(X509_CRL* a);
 
 /*
 Shims the PEM_write_bio_X509_CRL method.
 
 Returns the number of bytes written.
 */
-extern "C" int32_t PemWriteBioX509Crl(BIO* bio, X509_CRL* crl);
+extern "C" int32_t CryptoNative_PemWriteBioX509Crl(BIO* bio, X509_CRL* crl);
 
 /*
 Shims the PEM_read_bio_X509_CRL method.
 
 The new X509_CRL instance.
 */
-extern "C" X509_CRL* PemReadBioX509Crl(BIO* bio);
+extern "C" X509_CRL* CryptoNative_PemReadBioX509Crl(BIO* bio);
 
 /*
 Returns the number of bytes it will take to convert the SubjectPublicKeyInfo
 portion of the X509 to DER format.
 */
-extern "C" int32_t GetX509SubjectPublicKeyInfoDerSize(X509* x);
+extern "C" int32_t CryptoNative_GetX509SubjectPublicKeyInfoDerSize(X509* x);
 
 /*
 Shims the i2d_X509_PUBKEY method, providing X509_get_X509_PUBKEY(x) as the input.
 
 Returns the number of bytes written to buf.
 */
-extern "C" int32_t EncodeX509SubjectPublicKeyInfo(X509* x, uint8_t* buf);
+extern "C" int32_t CryptoNative_EncodeX509SubjectPublicKeyInfo(X509* x, uint8_t* buf);

--- a/src/Native/System.Security.Cryptography.Native/pal_x509_name.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509_name.cpp
@@ -3,14 +3,38 @@
 
 #include "pal_x509_name.h"
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t GetX509NameStackFieldCount(X509NameStack* sk)
+{
+    return CryptoNative_GetX509NameStackFieldCount(sk);
+}
+
 extern "C" int32_t CryptoNative_GetX509NameStackFieldCount(X509NameStack* sk)
 {
     return sk_X509_NAME_num(sk);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509_NAME* GetX509NameStackField(X509NameStack* sk, int32_t loc)
+{
+    return CryptoNative_GetX509NameStackField(sk, loc);
+}
+
 extern "C" X509_NAME* CryptoNative_GetX509NameStackField(X509NameStack* sk, int32_t loc)
 {
     return sk_X509_NAME_value(sk, loc);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509_NAME* DecodeX509Name(const uint8_t* buf, int32_t len)
+{
+    return CryptoNative_DecodeX509Name(buf, len);
 }
 
 extern "C" X509_NAME* CryptoNative_DecodeX509Name(const uint8_t* buf, int32_t len)
@@ -23,6 +47,14 @@ extern "C" X509_NAME* CryptoNative_DecodeX509Name(const uint8_t* buf, int32_t le
     return d2i_X509_NAME(nullptr, &buf, len);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void X509NameDestroy(X509_NAME* a)
+{
+    return CryptoNative_X509NameDestroy(a);
+}
+
 extern "C" void CryptoNative_X509NameDestroy(X509_NAME* a)
 {
     if (a != nullptr)
@@ -31,9 +63,25 @@ extern "C" void CryptoNative_X509NameDestroy(X509_NAME* a)
     }
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" STACK_OF(X509_NAME) * NewX509NameStack()
+{
+    return CryptoNative_NewX509NameStack();
+}
+
 extern "C" STACK_OF(X509_NAME) * CryptoNative_NewX509NameStack()
 {
     return sk_X509_NAME_new_null();
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t PushX509NameStackField(STACK_OF(X509_NAME) * stack, X509_NAME* x509Name)
+{
+    return CryptoNative_PushX509NameStackField(stack, x509Name);
 }
 
 extern "C" int32_t CryptoNative_PushX509NameStackField(STACK_OF(X509_NAME) * stack, X509_NAME* x509Name)
@@ -46,9 +94,25 @@ extern "C" int32_t CryptoNative_PushX509NameStackField(STACK_OF(X509_NAME) * sta
     return sk_X509_NAME_push(stack, x509Name);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void RecursiveFreeX509NameStack(STACK_OF(X509_NAME) * stack)
+{
+    return CryptoNative_RecursiveFreeX509NameStack(stack);
+}
+
 extern "C" void CryptoNative_RecursiveFreeX509NameStack(STACK_OF(X509_NAME) * stack)
 {
     sk_X509_NAME_pop_free(stack, X509_NAME_free);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509_NAME* DuplicateX509Name(X509_NAME* x509Name)
+{
+    return CryptoNative_DuplicateX509Name(x509Name);
 }
 
 extern "C" X509_NAME* CryptoNative_DuplicateX509Name(X509_NAME* x509Name)
@@ -56,9 +120,25 @@ extern "C" X509_NAME* CryptoNative_DuplicateX509Name(X509_NAME* x509Name)
     return X509_NAME_dup(x509Name);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t GetX509NameEntryCount(X509_NAME* x509Name)
+{
+    return CryptoNative_GetX509NameEntryCount(x509Name);
+}
+
 extern "C" int32_t CryptoNative_GetX509NameEntryCount(X509_NAME* x509Name)
 {
     return X509_NAME_entry_count(x509Name);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509_NAME_ENTRY* GetX509NameEntry(X509_NAME* x509Name, int32_t loc)
+{
+    return CryptoNative_GetX509NameEntry(x509Name, loc);
 }
 
 extern "C" X509_NAME_ENTRY* CryptoNative_GetX509NameEntry(X509_NAME* x509Name, int32_t loc)
@@ -66,9 +146,25 @@ extern "C" X509_NAME_ENTRY* CryptoNative_GetX509NameEntry(X509_NAME* x509Name, i
     return X509_NAME_get_entry(x509Name, loc);
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" ASN1_OBJECT* GetX509NameEntryOid(X509_NAME_ENTRY* nameEntry)
+{
+    return CryptoNative_GetX509NameEntryOid(nameEntry);
+}
+
 extern "C" ASN1_OBJECT* CryptoNative_GetX509NameEntryOid(X509_NAME_ENTRY* nameEntry)
 {
     return X509_NAME_ENTRY_get_object(nameEntry);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" ASN1_STRING* GetX509NameEntryData(X509_NAME_ENTRY* nameEntry)
+{
+    return CryptoNative_GetX509NameEntryData(nameEntry);
 }
 
 extern "C" ASN1_STRING* CryptoNative_GetX509NameEntryData(X509_NAME_ENTRY* nameEntry)

--- a/src/Native/System.Security.Cryptography.Native/pal_x509_name.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509_name.cpp
@@ -3,17 +3,17 @@
 
 #include "pal_x509_name.h"
 
-extern "C" int32_t GetX509NameStackFieldCount(X509NameStack* sk)
+extern "C" int32_t CryptoNative_GetX509NameStackFieldCount(X509NameStack* sk)
 {
     return sk_X509_NAME_num(sk);
 }
 
-extern "C" X509_NAME* GetX509NameStackField(X509NameStack* sk, int32_t loc)
+extern "C" X509_NAME* CryptoNative_GetX509NameStackField(X509NameStack* sk, int32_t loc)
 {
     return sk_X509_NAME_value(sk, loc);
 }
 
-extern "C" X509_NAME* DecodeX509Name(const uint8_t* buf, int32_t len)
+extern "C" X509_NAME* CryptoNative_DecodeX509Name(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
     {
@@ -23,7 +23,7 @@ extern "C" X509_NAME* DecodeX509Name(const uint8_t* buf, int32_t len)
     return d2i_X509_NAME(nullptr, &buf, len);
 }
 
-extern "C" void X509NameDestroy(X509_NAME* a)
+extern "C" void CryptoNative_X509NameDestroy(X509_NAME* a)
 {
     if (a != nullptr)
     {
@@ -31,12 +31,12 @@ extern "C" void X509NameDestroy(X509_NAME* a)
     }
 }
 
-extern "C" STACK_OF(X509_NAME) * NewX509NameStack()
+extern "C" STACK_OF(X509_NAME) * CryptoNative_NewX509NameStack()
 {
     return sk_X509_NAME_new_null();
 }
 
-extern "C" int32_t PushX509NameStackField(STACK_OF(X509_NAME) * stack, X509_NAME * x509Name)
+extern "C" int32_t CryptoNative_PushX509NameStackField(STACK_OF(X509_NAME) * stack, X509_NAME* x509Name)
 {
     if (!stack)
     {
@@ -46,32 +46,32 @@ extern "C" int32_t PushX509NameStackField(STACK_OF(X509_NAME) * stack, X509_NAME
     return sk_X509_NAME_push(stack, x509Name);
 }
 
-extern "C" void RecursiveFreeX509NameStack(STACK_OF(X509_NAME) * stack)
+extern "C" void CryptoNative_RecursiveFreeX509NameStack(STACK_OF(X509_NAME) * stack)
 {
     sk_X509_NAME_pop_free(stack, X509_NAME_free);
 }
 
-extern "C" X509_NAME* DuplicateX509Name(X509_NAME* x509Name)
+extern "C" X509_NAME* CryptoNative_DuplicateX509Name(X509_NAME* x509Name)
 {
     return X509_NAME_dup(x509Name);
 }
 
-extern "C" int32_t GetX509NameEntryCount(X509_NAME* x509Name)
+extern "C" int32_t CryptoNative_GetX509NameEntryCount(X509_NAME* x509Name)
 {
     return X509_NAME_entry_count(x509Name);
 }
 
-extern "C" X509_NAME_ENTRY* GetX509NameEntry(X509_NAME* x509Name, int32_t loc)
+extern "C" X509_NAME_ENTRY* CryptoNative_GetX509NameEntry(X509_NAME* x509Name, int32_t loc)
 {
     return X509_NAME_get_entry(x509Name, loc);
 }
 
-extern "C" ASN1_OBJECT* GetX509NameEntryOid(X509_NAME_ENTRY* nameEntry)
+extern "C" ASN1_OBJECT* CryptoNative_GetX509NameEntryOid(X509_NAME_ENTRY* nameEntry)
 {
     return X509_NAME_ENTRY_get_object(nameEntry);
 }
 
-extern "C" ASN1_STRING* GetX509NameEntryData(X509_NAME_ENTRY* nameEntry)
+extern "C" ASN1_STRING* CryptoNative_GetX509NameEntryData(X509_NAME_ENTRY* nameEntry)
 {
     return X509_NAME_ENTRY_get_data(nameEntry);
 }

--- a/src/Native/System.Security.Cryptography.Native/pal_x509_name.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509_name.h
@@ -11,17 +11,17 @@ GetX509NameStackFieldCount
 
 Direct shim to sk_X509_NAME_num
 */
-extern "C" int32_t GetX509NameStackFieldCount(X509NameStack* sk);
+extern "C" int32_t CryptoNative_GetX509NameStackFieldCount(X509NameStack* sk);
 
 /*
 Direct shim to sk_X509_NAME_value
 */
-extern "C" X509_NAME* GetX509NameStackField(X509NameStack* sk, int32_t loc);
+extern "C" X509_NAME* CryptoNative_GetX509NameStackField(X509NameStack* sk, int32_t loc);
 
 /*
 Shims the d2i_X509_NAME method and makes it easier to invoke from managed code.
 */
-extern "C" X509_NAME* DecodeX509Name(const uint8_t* buf, int32_t len);
+extern "C" X509_NAME* CryptoNative_DecodeX509Name(const uint8_t* buf, int32_t len);
 
 /*
 Cleans up and deletes an X509_NAME instance.
@@ -32,7 +32,7 @@ No-op if a is null.
 The given X509_NAME pointer is invalid after this call.
 Always succeeds.
 */
-extern "C" void X509NameDestroy(X509_NAME* a);
+extern "C" void CryptoNative_X509NameDestroy(X509_NAME* a);
 
 /*
 Function:
@@ -40,7 +40,7 @@ NewX509NameStack
 
 Direct shim to sk_X509_NAME_new_null
 */
-extern "C" STACK_OF(X509_NAME) * NewX509NameStack();
+extern "C" STACK_OF(X509_NAME) * CryptoNative_NewX509NameStack();
 
 /*
 Function:
@@ -51,7 +51,7 @@ Return values:
 1 on success
 0 on a NULL stack, or an error within sk_X509_NAME_push
 */
-extern "C" int32_t PushX509NameStackField(STACK_OF(X509_NAME) * stack, X509_NAME * x509Name);
+extern "C" int32_t CryptoNative_PushX509NameStackField(STACK_OF(X509_NAME) * stack, X509_NAME* x509Name);
 
 /*
 Function:
@@ -59,7 +59,7 @@ RecursiveFreeX509NameStack
 
 Direct shim to sk_X509_NAME_pop_free
 */
-extern "C" void RecursiveFreeX509NameStack(STACK_OF(X509_NAME) * stack);
+extern "C" void CryptoNative_RecursiveFreeX509NameStack(STACK_OF(X509_NAME) * stack);
 
 /*
 Function:
@@ -67,24 +67,24 @@ DuplicateX509Name
 
 Direct shim to X509_NAME_dup
 */
-extern "C" X509_NAME* DuplicateX509Name(X509_NAME* x509Name);
+extern "C" X509_NAME* CryptoNative_DuplicateX509Name(X509_NAME* x509Name);
 
 /*
 Direct shim to X509_NAME_entry_count
 */
-extern "C" int32_t GetX509NameEntryCount(X509_NAME* x509Name);
+extern "C" int32_t CryptoNative_GetX509NameEntryCount(X509_NAME* x509Name);
 
 /*
 Direct shim to X509_NAME_get_entry
 */
-extern "C" X509_NAME_ENTRY* GetX509NameEntry(X509_NAME* x509Name, int32_t loc);
+extern "C" X509_NAME_ENTRY* CryptoNative_GetX509NameEntry(X509_NAME* x509Name, int32_t loc);
 
 /*
 Direct shim to X509_NAME_ENTRY_get_object
 */
-extern "C" ASN1_OBJECT* GetX509NameEntryOid(X509_NAME_ENTRY* nameEntry);
+extern "C" ASN1_OBJECT* CryptoNative_GetX509NameEntryOid(X509_NAME_ENTRY* nameEntry);
 
 /*
 Direct shim to X509_NAME_ENTRY_get_data
 */
-extern "C" ASN1_STRING* GetX509NameEntryData(X509_NAME_ENTRY* nameEntry);
+extern "C" ASN1_STRING* CryptoNative_GetX509NameEntryData(X509_NAME_ENTRY* nameEntry);

--- a/src/Native/System.Security.Cryptography.Native/pal_x509ext.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509ext.cpp
@@ -5,12 +5,13 @@
 
 #include <assert.h>
 
-extern "C" X509_EXTENSION* X509ExtensionCreateByObj(ASN1_OBJECT* obj, int32_t isCritical, ASN1_OCTET_STRING* data)
+extern "C" X509_EXTENSION*
+CryptoNative_X509ExtensionCreateByObj(ASN1_OBJECT* obj, int32_t isCritical, ASN1_OCTET_STRING* data)
 {
     return X509_EXTENSION_create_by_OBJ(nullptr, obj, isCritical, data);
 }
 
-extern "C" void X509ExtensionDestroy(X509_EXTENSION* a)
+extern "C" void CryptoNative_X509ExtensionDestroy(X509_EXTENSION* a)
 {
     if (a != nullptr)
     {
@@ -18,16 +19,16 @@ extern "C" void X509ExtensionDestroy(X509_EXTENSION* a)
     }
 }
 
-extern "C" int32_t X509V3ExtPrint(BIO* out, X509_EXTENSION* ext)
+extern "C" int32_t CryptoNative_X509V3ExtPrint(BIO* out, X509_EXTENSION* ext)
 {
     return X509V3_EXT_print(out, ext, X509V3_EXT_DEFAULT, /*indent*/ 0);
 }
 
-extern "C" int32_t DecodeX509BasicConstraints2Extension(const uint8_t* encoded,
-                                                        int32_t encodedLength,
-                                                        int32_t* certificateAuthority,
-                                                        int32_t* hasPathLengthConstraint,
-                                                        int32_t* pathLengthConstraint)
+extern "C" int32_t CryptoNative_DecodeX509BasicConstraints2Extension(const uint8_t* encoded,
+                                                                     int32_t encodedLength,
+                                                                     int32_t* certificateAuthority,
+                                                                     int32_t* hasPathLengthConstraint,
+                                                                     int32_t* pathLengthConstraint)
 {
     if (!certificateAuthority || !hasPathLengthConstraint || !pathLengthConstraint)
     {
@@ -66,7 +67,7 @@ extern "C" int32_t DecodeX509BasicConstraints2Extension(const uint8_t* encoded,
     return result;
 }
 
-extern "C" EXTENDED_KEY_USAGE* DecodeExtendedKeyUsage(const uint8_t* buf, int32_t len)
+extern "C" EXTENDED_KEY_USAGE* CryptoNative_DecodeExtendedKeyUsage(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
     {
@@ -76,7 +77,7 @@ extern "C" EXTENDED_KEY_USAGE* DecodeExtendedKeyUsage(const uint8_t* buf, int32_
     return d2i_EXTENDED_KEY_USAGE(nullptr, &buf, len);
 }
 
-extern "C" void ExtendedKeyUsageDestory(EXTENDED_KEY_USAGE* a)
+extern "C" void CryptoNative_ExtendedKeyUsageDestory(EXTENDED_KEY_USAGE* a)
 {
     if (a != nullptr)
     {

--- a/src/Native/System.Security.Cryptography.Native/pal_x509ext.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509ext.cpp
@@ -5,10 +5,27 @@
 
 #include <assert.h>
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" X509_EXTENSION*
+X509ExtensionCreateByObj(ASN1_OBJECT* obj, int32_t isCritical, ASN1_OCTET_STRING* data)
+{
+    return CryptoNative_X509ExtensionCreateByObj(obj, isCritical, data);
+}
+
 extern "C" X509_EXTENSION*
 CryptoNative_X509ExtensionCreateByObj(ASN1_OBJECT* obj, int32_t isCritical, ASN1_OCTET_STRING* data)
 {
     return X509_EXTENSION_create_by_OBJ(nullptr, obj, isCritical, data);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void X509ExtensionDestroy(X509_EXTENSION* a)
+{
+    return CryptoNative_X509ExtensionDestroy(a);
 }
 
 extern "C" void CryptoNative_X509ExtensionDestroy(X509_EXTENSION* a)
@@ -19,11 +36,35 @@ extern "C" void CryptoNative_X509ExtensionDestroy(X509_EXTENSION* a)
     }
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" int32_t X509V3ExtPrint(BIO* out, X509_EXTENSION* ext)
+{
+    return CryptoNative_X509V3ExtPrint(out, ext);
+}
+
 extern "C" int32_t CryptoNative_X509V3ExtPrint(BIO* out, X509_EXTENSION* ext)
 {
     return X509V3_EXT_print(out, ext, X509V3_EXT_DEFAULT, /*indent*/ 0);
 }
 
+extern "C" int32_t DecodeX509BasicConstraints2Extension(const uint8_t* encoded,
+                                                        int32_t encodedLength,
+                                                        int32_t* certificateAuthority,
+                                                        int32_t* hasPathLengthConstraint,
+                                                        int32_t* pathLengthConstraint)
+{
+    return CryptoNative_DecodeX509BasicConstraints2Extension(encoded,
+        encodedLength,
+        certificateAuthority,
+        hasPathLengthConstraint,
+        pathLengthConstraint);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
 extern "C" int32_t CryptoNative_DecodeX509BasicConstraints2Extension(const uint8_t* encoded,
                                                                      int32_t encodedLength,
                                                                      int32_t* certificateAuthority,
@@ -67,6 +108,14 @@ extern "C" int32_t CryptoNative_DecodeX509BasicConstraints2Extension(const uint8
     return result;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" EXTENDED_KEY_USAGE* DecodeExtendedKeyUsage(const uint8_t* buf, int32_t len)
+{
+    return CryptoNative_DecodeExtendedKeyUsage(buf, len);
+}
+
 extern "C" EXTENDED_KEY_USAGE* CryptoNative_DecodeExtendedKeyUsage(const uint8_t* buf, int32_t len)
 {
     if (!buf || !len)
@@ -75,6 +124,14 @@ extern "C" EXTENDED_KEY_USAGE* CryptoNative_DecodeExtendedKeyUsage(const uint8_t
     }
 
     return d2i_EXTENDED_KEY_USAGE(nullptr, &buf, len);
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.
+extern "C" void ExtendedKeyUsageDestory(EXTENDED_KEY_USAGE* a)
+{
+    return CryptoNative_ExtendedKeyUsageDestory(a);
 }
 
 extern "C" void CryptoNative_ExtendedKeyUsageDestory(EXTENDED_KEY_USAGE* a)

--- a/src/Native/System.Security.Cryptography.Native/pal_x509ext.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509ext.h
@@ -12,7 +12,8 @@ Implemented by calling X509_EXTENSION_create_by_OBJ
 
 Returns new X509_EXTENSION on success, nullptr on failure.
 */
-extern "C" X509_EXTENSION* X509ExtensionCreateByObj(ASN1_OBJECT* obj, int32_t isCritical, ASN1_OCTET_STRING* data);
+extern "C" X509_EXTENSION*
+CryptoNative_X509ExtensionCreateByObj(ASN1_OBJECT* obj, int32_t isCritical, ASN1_OCTET_STRING* data);
 
 /*
 Cleans up and deletes an X509_EXTENSION instance.
@@ -23,14 +24,14 @@ No-op if a is null.
 The given X509_EXTENSION pointer is invalid after this call.
 Always succeeds.
 */
-extern "C" void X509ExtensionDestroy(X509_EXTENSION* a);
+extern "C" void CryptoNative_X509ExtensionDestroy(X509_EXTENSION* a);
 
 /*
 Shims the X509V3_EXT_print method.
 
 Returns 1 on success, otherwise 0 if there was an error.
 */
-extern "C" int32_t X509V3ExtPrint(BIO* out, X509_EXTENSION* ext);
+extern "C" int32_t CryptoNative_X509V3ExtPrint(BIO* out, X509_EXTENSION* ext);
 
 /*
 Decodes the X509 BASIC_CONSTRAINTS information and fills the out variables:
@@ -41,16 +42,16 @@ Decodes the X509 BASIC_CONSTRAINTS information and fills the out variables:
 Returns 1 if the BASIC_CONSTRAINTS information was successfully decoded,
 otherwise 0.
 */
-extern "C" int32_t DecodeX509BasicConstraints2Extension(const uint8_t* encoded,
-                                                        int32_t encodedLength,
-                                                        int32_t* certificateAuthority,
-                                                        int32_t* hasPathLengthConstraint,
-                                                        int32_t* pathLengthConstraint);
+extern "C" int32_t CryptoNative_DecodeX509BasicConstraints2Extension(const uint8_t* encoded,
+                                                                     int32_t encodedLength,
+                                                                     int32_t* certificateAuthority,
+                                                                     int32_t* hasPathLengthConstraint,
+                                                                     int32_t* pathLengthConstraint);
 
 /*
 Shims the d2i_EXTENDED_KEY_USAGE method and makes it easier to invoke from managed code.
 */
-extern "C" EXTENDED_KEY_USAGE* DecodeExtendedKeyUsage(const uint8_t* buf, int32_t len);
+extern "C" EXTENDED_KEY_USAGE* CryptoNative_DecodeExtendedKeyUsage(const uint8_t* buf, int32_t len);
 
 /*
 Cleans up and deletes an EXTENDED_KEY_USAGE instance.
@@ -61,4 +62,4 @@ No-op if a is null.
 The given EXTENDED_KEY_USAGE pointer is invalid after this call.
 Always succeeds.
 */
-extern "C" void ExtendedKeyUsageDestory(EXTENDED_KEY_USAGE* a);
+extern "C" void CryptoNative_ExtendedKeyUsageDestory(EXTENDED_KEY_USAGE* a);

--- a/src/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslTests.cs
+++ b/src/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslTests.cs
@@ -277,13 +277,13 @@ internal static partial class Interop
 {
     internal static class Crypto
     {
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyCreateByCurveName")]
         internal static extern IntPtr EcKeyCreateByCurveName(int nid);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyGenerateKey")]
         internal static extern int EcKeyGenerateKey(IntPtr ecKey);
 
-        [DllImport(Libraries.CryptoNative)]
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_EcKeyDestroy")]
         internal static extern void EcKeyDestroy(IntPtr r);
     }
 }


### PR DESCRIPTION
The methods exported from System.Net.Http.Native.* and System.Security.Cryptography.Native.* shims have short generic names. Making them more unique by adding "HttpNative_" and "CryptoNative_" prefix to each method name.

Partial fix for #4818.  Only Compression is left.
@stephentoub @sokket @bartonjs @nguerrera 