### PR TITLE
Change the default keysize of RSAOpenSsl to 2048

### DIFF
--- a/src/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/System.Security.Cryptography.OpenSsl/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -20,7 +20,7 @@ namespace System.Security.Cryptography
         private Lazy<SafeRsaHandle> _key;
 
         public RSAOpenSsl()
-            : this(1024)
+            : this(2048)
         {
         }
 


### PR DESCRIPTION
The original 1024 was to match RSACryptoServiceProvider, but with RSACng now being the preferred implementation on Windows we're upping the Unix version to match.

cc: @morganbr @AtsushiKan