### PR TITLE
Fix #3610

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -837,21 +837,25 @@ namespace System.Net.Sockets
                 if (_socketAddressGCHandle.IsAllocated)
                 {
                     _socketAddressGCHandle.Free();
+                    _pinnedSocketAddress = null;
                 }
 
                 if (_wsaMessageBufferGCHandle.IsAllocated)
                 {
                     _wsaMessageBufferGCHandle.Free();
+                    _ptrWSAMessageBuffer = IntPtr.Zero;
                 }
 
                 if (_wsaRecvMsgWSABufferArrayGCHandle.IsAllocated)
                 {
                     _wsaRecvMsgWSABufferArrayGCHandle.Free();
+                    _ptrWSARecvMsgWSABufferArray = IntPtr.Zero;
                 }
 
                 if (_controlBufferGCHandle.IsAllocated)
                 {
                     _controlBufferGCHandle.Free();
+                    _ptrControlBuffer = IntPtr.Zero;
                 }
             }
         }

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -449,28 +449,24 @@ namespace System.Net.Sockets.Tests
             Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);
         }
 
-        [ActiveIssue(3610)]
         [Fact]
         public void SendToRecvFromAsync_Single_Datagram_UDP_IPv6()
         {
             SendToRecvFromAsync_Datagram_UDP(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
         }
 
-        [ActiveIssue(3610)]
         [Fact]
         public void SendToRecvFromAsync_Single_Datagram_UDP_IPv4()
         {
             SendToRecvFromAsync_Datagram_UDP(IPAddress.Loopback, IPAddress.Loopback);
         }
 
-        [ActiveIssue(3610)]
         [Fact]
         public void SendToRecvFromAsync_UdpClient_Single_Datagram_UDP_IPv6()
         {
             SendToRecvFromAsync_UdpClient_Datagram_UDP(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
         }
 
-        [ActiveIssue(3610)]
         [Fact]
         public void SendToRecvFromAsync_UdpClient_Single_Datagram_UDP_IPv4()
         {


### PR DESCRIPTION
Fixes #3610.  These tests were failing due to a problem with re-use of `SocketAsyncEventArgs` objects.  `args.SetBuffer(null, 0, 0)` unpins the buffer, and other miscellaneous items.  Subsequent re-use of the `SocketAsyncEventArgs` object is supposed to pin whatever buffers, etc., are current, but will only do so if the previous cached pointers appear to be invalid.

86241bd4e80971e803b1c7440888fee23afaa1d3 fixed this for the buffer itself; this change implements the same pattern for the other pinned items.

@stoub, @pgavlin, @CIPop 