### PR TITLE
Adding EventSource events to System.Buffers

### DIFF
--- a/src/System.Buffers/src/Resources/Strings.resx
+++ b/src/System.Buffers/src/Resources/Strings.resx
@@ -117,4 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="InvalidDoubleReturn" xml:space="preserve">
+    <value>The specified Buffer has already been returned to the pool.</value>
+  </data>
 </root>

--- a/src/System.Buffers/src/System.Buffers.csproj
+++ b/src/System.Buffers/src/System.Buffers.csproj
@@ -11,8 +11,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System\Buffers\ArrayPool.cs" />
-    <Compile Include="System\Buffers\ArrayPoolBucket.cs" />
+    <Compile Include="System\Buffers\ArrayPoolEventSource.cs" />
     <Compile Include="System\Buffers\DefaultArrayPool.cs" />
+    <Compile Include="System\Buffers\DefaultArrayPoolBucket.cs" />
     <Compile Include="System\Buffers\Utilities.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Buffers/src/System/Buffers/ArrayPool.cs
+++ b/src/System.Buffers/src/System/Buffers/ArrayPool.cs
@@ -2,8 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Reflection;
-using System.Runtime.InteropServices;
+using System.Diagnostics.Tracing;
 using System.Threading;
 
 namespace System.Buffers
@@ -61,6 +60,12 @@ namespace System.Buffers
         {
             return new DefaultArrayPool<T>(maxArrayLength, numberOfArrays);
         }
+
+        /// <summary>
+        /// Gets the EventSource responsible for tracing events in the ArrayPool used for debugging
+        /// and diagnostics around Pool usage.
+        /// </summary>
+        public abstract EventSource TraceEventSource { get; }
 
         /// <summary>
         /// Retrieves a buffer from the pool that is at least the requested length. This buffer is loaned

--- a/src/System.Buffers/src/System/Buffers/ArrayPoolEventSource.cs
+++ b/src/System.Buffers/src/System/Buffers/ArrayPoolEventSource.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.Tracing;
+
+namespace System.Buffers
+{
+    public sealed class ArrayPoolEventSource : EventSource
+    {
+        public ArrayPoolEventSource() : base() { }
+
+        [Event(1, Message = "Rented Buffer {0} of size {1} from Bucket {2}", Level = EventLevel.Informational)]
+        public void BufferRented(int bufferId, int bufferSize, int bucketId) { WriteEvent(1, bufferId, bufferSize, bucketId); }
+
+        [Event(2, Message = "Returned Buffer {0} to Pool", Level = EventLevel.Informational)]
+        public void BufferReturned(int bufferId) { WriteEvent(2, bufferId); }
+
+        [Event(3, Message = "Buffer {0} of size {1} initially created in bucket {2}", Level = EventLevel.Informational)]
+        public void BufferCreated(int bufferId, int bufferSize, int bucketId) { WriteEvent(3, bufferId, bufferSize, bucketId); }
+
+        [Event(4, Message = "Buffer {0} allocated with size {1} on-demand due to Buffer exhaustion", Level = EventLevel.Informational)]
+        public void BufferAllocated(int bufferId, int bufferSize) { WriteEvent(4, bufferId, bufferSize); }
+
+        [Event(5, Message = "Buffer {0} allocated with size {1} due to size greater than configured maximum {2}", Level = EventLevel.Informational)]
+        public void BufferOverMaximumAllocated(int bufferId, int bufferSize, int maximumSize) { WriteEvent(5, bufferId, bufferSize, maximumSize); }
+
+        [Event(6, Message = "Bucket {0} exhausted of all pooled Buffers", Level = EventLevel.Informational)]
+        public void BucketExhausted(int bucketId, int bucketSize, int buffersInBucket) { WriteEvent(6, bucketId, bucketSize, buffersInBucket); }
+    }
+}

--- a/src/System.Buffers/src/System/Buffers/DefaultArrayPool.cs
+++ b/src/System.Buffers/src/System/Buffers/DefaultArrayPool.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics.Tracing;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -11,7 +12,8 @@ namespace System.Buffers
     internal sealed class DefaultArrayPool<T> : ArrayPool<T>
     {
         private const int MinimiumArraySize = 16;
-        private ArrayPoolBucket<T>[] _buckets;
+        private DefaultArrayPoolBucket<T>[] _buckets;
+        private ArrayPoolEventSource _eventSource;
 
         internal DefaultArrayPool(int maxLength, int arraysPerBucket)
         {
@@ -20,26 +22,35 @@ namespace System.Buffers
             if (arraysPerBucket <= 0)
                 throw new ArgumentOutOfRangeException("arraysPerBucket");
 
+            _eventSource = new ArrayPoolEventSource();
+
             // Our bucketing algorithm has a minimum length of 16
             if (maxLength < MinimiumArraySize)
                 maxLength = MinimiumArraySize;
             
             int maxBuckets = Utilities.SelectBucketIndex(maxLength);
-            _buckets = new ArrayPoolBucket<T>[maxBuckets + 1];
+            _buckets = new DefaultArrayPoolBucket<T>[maxBuckets + 1];
             for (int i = 0; i < _buckets.Length; i++)
-                _buckets[i] = new ArrayPoolBucket<T>(Utilities.GetMaxSizeForBucket(i), arraysPerBucket);
+                _buckets[i] = new DefaultArrayPoolBucket<T>(Utilities.GetMaxSizeForBucket(i), arraysPerBucket, _eventSource);
         }
+
+        public override EventSource TraceEventSource
+        {
+            get
+            {
+                return _eventSource;
+            }
+         }
 
         public override T[] Rent(int minimumLength)
         {
             if (minimumLength <= 0)
                 throw new ArgumentOutOfRangeException("minimumLength");
 
+            T[] buffer = null;
             int index = Utilities.SelectBucketIndex(minimumLength);
             if (index < _buckets.Length)
             {
-                T[] buffer = null;
-
                 // Search for an array starting at the 'index' bucket. If the bucket
                 // is empty, bump up to the next higher bucket and try that one
                 for (int i = index; i < _buckets.Length; i++)
@@ -49,6 +60,7 @@ namespace System.Buffers
                     // If the bucket has an array left and returned it, give it to the caller
                     if (buffer != null)
                     {
+                        _eventSource.BufferRented(buffer.GetHashCode(), buffer.Length, _buckets[i].GetHashCode());
                         return buffer;
                     }
                 }
@@ -56,7 +68,14 @@ namespace System.Buffers
 
             // Gettings here means we have too big of a request OR all the buckets from 
             // index through _buckets.Length are taken so we need to allocate a buffer on-demand.
-            return new T[Utilities.GetMaxSizeForBucket(index)];
+            int maxLength = Utilities.GetMaxSizeForBucket(_buckets.Length);
+            buffer = new T[Utilities.GetMaxSizeForBucket(index)];
+            if (buffer.Length > maxLength) 
+                _eventSource.BufferOverMaximumAllocated(buffer.GetHashCode(), buffer.Length, maxLength);
+            else 
+                _eventSource.BufferAllocated(buffer.GetHashCode(), buffer.Length);
+
+            return buffer;
         }
 
         public override void Return(T[] buffer, bool clearArray = false)
@@ -73,6 +92,8 @@ namespace System.Buffers
 
                 _buckets[bucket].Return(buffer);
             }
+
+            _eventSource.BufferReturned(buffer.GetHashCode());
         }
     }
 }

--- a/src/System.Buffers/src/project.json
+++ b/src/System.Buffers/src/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "System.Diagnostics.Debug": "4.0.0",
+    "System.Diagnostics.Tracing": "4.0.0",
     "System.Resources.ResourceManager": "4.0.0",
     "System.Runtime": "4.0.0",
     "System.Threading": "4.0.0"

--- a/src/System.Buffers/tests/ArrayPool/ArrayPoolEventListener.cs
+++ b/src/System.Buffers/tests/ArrayPool/ArrayPoolEventListener.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.Tracing;
+
+namespace System.Buffers.ArrayPool.Tests
+{
+    public sealed class ArrayPoolEventListener : EventListener
+    {
+        protected override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+        }
+    }
+}

--- a/src/System.Buffers/tests/ArrayPool/UnitTests.cs
+++ b/src/System.Buffers/tests/ArrayPool/UnitTests.cs
@@ -211,5 +211,18 @@ namespace System.Buffers.ArrayPool.Tests
             Assert.NotNull(rented1);
             Assert.NotNull(rented2);
         }
+
+        [Fact]
+        public static void ReturningARentedBufferTwiceThrowsAnException()
+        {
+            using (ArrayPoolEventListener listener = new ArrayPoolEventListener())
+            {
+                ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, numberOfArrays: 2);
+                listener.EnableEvents(pool.TraceEventSource, Diagnostics.Tracing.EventLevel.Verbose);
+                byte[] rented1 = pool.Rent(16);
+                pool.Return(rented1);
+                Assert.Throws<InvalidOperationException>(() => pool.Return(rented1));
+            }
+        }
     }
 }

--- a/src/System.Buffers/tests/System.Buffers.Tests.csproj
+++ b/src/System.Buffers/tests/System.Buffers.Tests.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>System.Buffers.Tests</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="ArrayPool\ArrayPoolEventListener.cs" />
     <Compile Include="ArrayPool\UnitTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Buffers/tests/project.json
+++ b/src/System.Buffers/tests/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "System.Diagnostics.Tracing": "4.0.10",
     "System.Runtime": "4.0.21-rc2-23616",
     "System.Runtime.Extensions": "4.0.11-rc2-23616",
     "System.Resources.ResourceManager": "4.0.1-rc2-23616",


### PR DESCRIPTION
To aid in debugging and diagnostics, adding ETW events via EventSource to the System.Buffers default implementations. 