### PR TITLE
Update to buildtools 144, Fix x-plat build breaks

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -11,7 +11,7 @@
 
   <!-- Build Tools Versions -->
   <PropertyGroup>
-    <BuildToolsVersion>1.0.25-prerelease-00142</BuildToolsVersion>
+    <BuildToolsVersion>1.0.25-prerelease-00144</BuildToolsVersion>
     <DnxVersion>1.0.0-rc2-16128</DnxVersion>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'!='Unix'">dnx-coreclr-win-x86.$(DnxVersion)</DnxPackageName>
     <DnxPackageName Condition="'$(DnxPackageName)' == '' and '$(OsEnvironment)'=='Unix'">dnx-mono.$(DnxVersion)</DnxPackageName>

--- a/src/.nuget/packages.Unix.config
+++ b/src/.nuget/packages.Unix.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00142" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00144" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
   <package id="dnx-mono" version="1.0.0-rc2-16128" />
   <package id="Microsoft.Net.ToolsetCompilers" version="1.0.0-rc3-20150510-01" />

--- a/src/.nuget/packages.Windows_NT.config
+++ b/src/.nuget/packages.Windows_NT.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00142" />
+  <package id="Microsoft.DotNet.BuildTools" version="1.0.25-prerelease-00144" />
   <package id="dnx-coreclr-win-x86" version="1.0.0-rc2-16128" />
   <package id="Microsoft.DotNet.BuildTools.ApiTools" version="1.0.0-prerelease" />
 </packages>

--- a/src/System.IO.Compression/src/System.IO.Compression.csproj
+++ b/src/System.IO.Compression/src/System.IO.Compression.csproj
@@ -7,7 +7,6 @@
   <PropertyGroup>
     <AssemblyName>System.IO.Compression</AssemblyName>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
-    <UseECMAKey>true</UseECMAKey>
     <OutputType>Library</OutputType>
     <ProjectGuid>{5471BFE8-8071-466F-838E-5ADAA779E742}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
Includes three changes since 142 (current version):

https://github.com/dotnet/buildtools/commit/a9cf8da8270218d66cb59cdc8b9604127aef5da1
https://github.com/dotnet/buildtools/commit/e3209b29c3fbb6e112987aabb9712acc5d8e9851
https://github.com/dotnet/buildtools/commit/4f9a9ee485350c0c13f140d8192e55a222c5539e

This should fix some of the issues encountered when building x-plat (part of #5199). Partial facades targeting net46 should now build properly.

Also, I would imagine the build should be marginally faster x-plat because I've deleted the fall-back target that restored NuGet packages in order to retrieve the contract assembly for GenFacades. So less things should be downloaded there in general.

@weshaggard , @clrjunkie