### PR TITLE
Revert "Add reflection dependencies for S.S.C.Algorithms"

### DIFF
--- a/src/System.Security.Cryptography.Algorithms/pkg/unix/System.Security.Cryptography.Algorithms.pkgproj
+++ b/src/System.Security.Cryptography.Algorithms/pkg/unix/System.Security.Cryptography.Algorithms.pkgproj
@@ -21,13 +21,5 @@
     </_FilePackageReference>
   </ItemGroup>
 
-  <!-- Manual (reflection) dependencies to pre-released packages -->
-  <ItemGroup>
-    <_FilePackageReference Include="System.Security.Cryptography.OpenSsl">
-      <TargetFramework>dotnet54</TargetFramework>
-      <Version>4.0.0</Version>
-    </_FilePackageReference>
-  </ItemGroup>
-
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Security.Cryptography.Algorithms/pkg/win/System.Security.Cryptography.Algorithms.pkgproj
+++ b/src/System.Security.Cryptography.Algorithms/pkg/win/System.Security.Cryptography.Algorithms.pkgproj
@@ -16,13 +16,6 @@
     <ExternalOnTargetFramework Include="net" />
   </ItemGroup>
 
-  <!-- Manual (reflection) dependencies to pre-released packages -->
-  <ItemGroup>
-    <_FilePackageReference Include="System.Security.Cryptography.Cng">
-      <TargetFramework>dotnet54</TargetFramework>
-      <Version>4.0.0</Version>
-    </_FilePackageReference>
-  </ItemGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
This reverts commit bc19d6df360348baa25b6a6b01a18850df01f2ee.

NuGet detected the co-dependency as a cycle, and that broke things once the package published.

cc: @weshaggard 