### PR TITLE
Adding EventSource ETW tracing to the System.Buffers code

### DIFF
--- a/src/System.Buffers/src/Resources/Strings.resx
+++ b/src/System.Buffers/src/Resources/Strings.resx
@@ -117,4 +117,16 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="event_BufferRented" xml:space="preserve">
+    <value>Rented Buffer {0} of size {1} from Pool {2} and Bucket {3}</value>
+  </data>
+  <data name="event_BufferAllocated" xml:space="preserve">
+    <value>Buffer {0} of size {1} created in Pool {2} and Bucket {3} with allocation reason {4}</value>
+  </data>
+  <data name="event_BufferReturned" xml:space="preserve">
+    <value>Returned Buffer {0} to Pool {1}</value>
+  </data>
+  <data name="event_BucketExhausted" xml:space="preserve">
+    <value>Bucket {0}, with {2} maximum buffers, exhausted of all Buffers of size {1} in Pool {3}</value>
+  </data>
 </root>

--- a/src/System.Buffers/src/System.Buffers.csproj
+++ b/src/System.Buffers/src/System.Buffers.csproj
@@ -5,14 +5,16 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <ProjectGuid>{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}</ProjectGuid>
     <PackageTargetFramework>dotnet5.2</PackageTargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="System\Buffers\ArrayPool.cs" />
-    <Compile Include="System\Buffers\ArrayPoolBucket.cs" />
+    <Compile Include="System\Buffers\ArrayPoolEventSource.cs" />
     <Compile Include="System\Buffers\DefaultArrayPool.cs" />
+    <Compile Include="System\Buffers\DefaultArrayPoolBucket.cs" />
     <Compile Include="System\Buffers\Utilities.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Buffers/src/System/Buffers/ArrayPool.cs
+++ b/src/System.Buffers/src/System/Buffers/ArrayPool.cs
@@ -2,8 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Reflection;
-using System.Runtime.InteropServices;
+using System.Diagnostics.Tracing;
 using System.Threading;
 
 namespace System.Buffers

--- a/src/System.Buffers/src/System/Buffers/ArrayPoolEventSource.cs
+++ b/src/System.Buffers/src/System/Buffers/ArrayPoolEventSource.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.Tracing;
+
+namespace System.Buffers
+{
+    [EventSource(
+        Guid = "20b30044-b729-457e-8dda-8b41b5dd02e6", 
+        Name = "System.Buffers.BufferPoolEventSource",
+        LocalizationResources = "FxResources.System.Buffers.SR")]
+    internal sealed class ArrayPoolEventSource : EventSource
+    {
+        internal readonly static ArrayPoolEventSource Log = new ArrayPoolEventSource();
+
+        internal enum BufferAllocationReason : int
+        {
+            Pooled,
+            OverMaximumSize,
+            PoolExhausted
+        }
+
+        [Event(1, Level = EventLevel.Informational)]
+        internal void BufferRented(int bufferId, int bufferSize, int poolId, int bucketId) { WriteEventHelper(1, bufferId, bufferSize, poolId, bucketId); }
+
+        [Event(2, Level = EventLevel.Informational)]
+        internal void BufferAllocated(int bufferId, int bufferSize, int poolId, int bucketId, BufferAllocationReason reason)
+        {
+            unsafe
+            {
+                 EventData* payload = stackalloc EventData[5];
+                 payload[0].Size = sizeof(int);
+                 payload[0].DataPointer = ((IntPtr) (&bufferId));
+                 payload[1].Size = sizeof(int);
+                 payload[1].DataPointer = ((IntPtr) (&bufferSize));
+                 payload[2].Size = sizeof(int);
+                 payload[2].DataPointer = ((IntPtr) (&poolId));
+                 payload[3].Size = sizeof(int);
+                 payload[3].DataPointer = ((IntPtr) (&bucketId));
+                 payload[4].Size = sizeof(BufferAllocationReason);
+                 payload[4].DataPointer = ((IntPtr) (&reason));
+                 WriteEventCore(2, 5, payload);
+             }
+        }
+
+        [Event(3, Level = EventLevel.Informational)]
+        internal void BufferReturned(int bufferId, int poolId) { WriteEvent(3, bufferId, poolId); }
+
+        [Event(4, Level = EventLevel.Warning)]
+        internal void BucketExhausted(int bucketId, int bucketSize, int buffersInBucket, int poolId) { WriteEventHelper(4, bucketId, bucketSize, buffersInBucket, poolId); }
+        
+        [NonEvent]
+        private unsafe void WriteEventHelper(int eventId, int arg0, int arg1, int arg2, int arg3)
+        {
+            if (IsEnabled())
+            {
+                unsafe
+                {
+                    EventData* payload = stackalloc EventData[4];
+                    payload[0].Size = sizeof(int);
+                    payload[0].DataPointer = ((IntPtr) (&arg0));
+                    payload[1].Size = sizeof(int);
+                    payload[1].DataPointer = ((IntPtr) (&arg1));
+                    payload[2].Size = sizeof(int);
+                    payload[2].DataPointer = ((IntPtr) (&arg2));
+                    payload[3].Size = sizeof(int);
+                    payload[3].DataPointer = ((IntPtr) (&arg3));
+                    WriteEventCore(eventId, 4, payload);
+                }
+            }
+        }
+    }
+}

--- a/src/System.Buffers/src/System/Buffers/Utilities.cs
+++ b/src/System.Buffers/src/System/Buffers/Utilities.cs
@@ -34,5 +34,20 @@ namespace System.Buffers
                 return result;
             }
         }
+
+        internal static int GetPoolId<T>(ArrayPool<T> pool)
+        {
+            return pool.GetHashCode();
+        }
+
+        internal static int GetBufferId<T>(T[] buffer)
+        {
+            return buffer.GetHashCode();
+        }
+
+        internal static int GetBucketId<T>(DefaultArrayPoolBucket<T> bucket)
+        {
+            return bucket.GetHashCode();
+        }
     }
 }

--- a/src/System.Buffers/src/project.json
+++ b/src/System.Buffers/src/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "System.Diagnostics.Debug": "4.0.0",
+    "System.Diagnostics.Tracing": "4.0.0",
     "System.Resources.ResourceManager": "4.0.0",
     "System.Runtime": "4.0.0",
     "System.Threading": "4.0.0"

--- a/src/System.Buffers/tests/System.Buffers.Tests.csproj
+++ b/src/System.Buffers/tests/System.Buffers.Tests.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="ArrayPool\UnitTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.Buffers.csproj">

--- a/src/System.Buffers/tests/project.json
+++ b/src/System.Buffers/tests/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "System.Diagnostics.Tracing": "4.0.10",
     "System.Runtime": "4.0.21-rc2-23616",
     "System.Runtime.Extensions": "4.0.11-rc2-23616",
     "System.Resources.ResourceManager": "4.0.1-rc2-23616",


### PR DESCRIPTION
This adds EventSource events to the Buffer Pool default implementation so consumers can attach listeners to aid in debugging code consuming the Buffer Pool as well as to measure performance and usage statistics around consumption of the Buffer Pool.

/cc @KrzysztofCwalina 