### PR TITLE
Significantly reduce release logging overhead in System.Net.Sockets

### DIFF
--- a/src/Common/src/Interop/Windows/Winsock/SafeNativeOverlapped.cs
+++ b/src/Common/src/Interop/Windows/Winsock/SafeNativeOverlapped.cs
@@ -20,7 +20,10 @@ namespace System.Net.Sockets
         protected SafeNativeOverlapped()
             : this(IntPtr.Zero)
         {
-            GlobalLog.Print("SafeNativeOverlapped#" + LoggingHash.HashString(this) + "::ctor(null)");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("SafeNativeOverlapped#" + LoggingHash.HashString(this) + "::ctor(null)");
+            }
         }
 
         protected SafeNativeOverlapped(IntPtr handle)
@@ -34,7 +37,11 @@ namespace System.Net.Sockets
         {
             _safeCloseSocket = socketHandle;
 
-            GlobalLog.Print("SafeNativeOverlapped#" + LoggingHash.HashString(this) + "::ctor(socket#" + LoggingHash.HashString(socketHandle) + ")");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("SafeNativeOverlapped#" + LoggingHash.HashString(this) + "::ctor(socket#" + LoggingHash.HashString(socketHandle) + ")");
+            }
+
 #if DEBUG
             _safeCloseSocket.AddRef();
 #endif
@@ -45,7 +52,11 @@ namespace System.Net.Sockets
             if (disposing)
             {
                 // It is important that the boundHandle is released immediately to allow new overlapped operations.
-                GlobalLog.Print("SafeNativeOverlapped#" + LoggingHash.HashString(this) + "::Dispose(true)");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("SafeNativeOverlapped#" + LoggingHash.HashString(this) + "::Dispose(true)");
+                }
+
                 FreeNativeOverlapped();
             }
         }
@@ -57,7 +68,10 @@ namespace System.Net.Sockets
 
         protected override bool ReleaseHandle()
         {
-            GlobalLog.Print("SafeNativeOverlapped#" + LoggingHash.HashString(this) + "::ReleaseHandle()");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("SafeNativeOverlapped#" + LoggingHash.HashString(this) + "::ReleaseHandle()");
+            }
 
             FreeNativeOverlapped();
             return true;

--- a/src/Common/src/System/Net/ContextAwareResult.cs
+++ b/src/Common/src/System/Net/ContextAwareResult.cs
@@ -166,7 +166,7 @@ namespace System.Net
                 // don't need a context anyway.
                 if ((_flags & StateFlags.PostBlockFinished) == 0)
                 {
-                    if (_lock == null)
+                    if (_lock == null && GlobalLog.IsEnabled)
                     {
                         GlobalLog.AssertFormat("ContextAwareResult#{0}::ContextCopy|Must lock (StartPostingAsyncOp()) { ... FinishPostingAsyncOp(); } when calling ContextCopy (unless it's only called after FinishPostingAsyncOp).", LoggingHash.HashString(this));
                     }
@@ -196,7 +196,7 @@ namespace System.Net
             {
                 if (InternalPeekCompleted)
                 {
-                    if ((_flags & StateFlags.ThreadSafeContextCopy) == 0)
+                    if ((_flags & StateFlags.ThreadSafeContextCopy) == 0 && GlobalLog.IsEnabled)
                     {
                         GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|Called on completed result.", LoggingHash.HashString(this));
                     }
@@ -219,7 +219,7 @@ namespace System.Net
                 // don't need an identity anyway.
                 if ((_flags & StateFlags.PostBlockFinished) == 0)
                 {
-                    if (_lock == null)
+                    if (_lock == null && GlobalLog.IsEnabled)
                     {
                         GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|Must lock (StartPostingAsyncOp()) { ... FinishPostingAsyncOp(); } when calling Identity (unless it's only called after FinishPostingAsyncOp).", LoggingHash.HashString(this));
                     }
@@ -228,7 +228,7 @@ namespace System.Net
 
                 if (InternalPeekCompleted)
                 {
-                    if ((_flags & StateFlags.ThreadSafeContextCopy) == 0)
+                    if ((_flags & StateFlags.ThreadSafeContextCopy) == 0 && GlobalLog.IsEnabled)
                     {
                         GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|Result became completed during call.", LoggingHash.HashString(this));
                     }
@@ -363,15 +363,15 @@ namespace System.Net
         // Returns whether the operation completed sync or not.
         private bool CaptureOrComplete(ref ExecutionContext cachedContext, bool returnContext)
         {
-            if ((_flags & StateFlags.PostBlockStarted) == 0 && GlobalLog.IsEnabled)
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+
+            if ((_flags & StateFlags.PostBlockStarted) == 0 && globalLogEnabled)
             {
                 GlobalLog.AssertFormat("ContextAwareResult#{0}::CaptureOrComplete|Called without calling StartPostingAsyncOp.", LoggingHash.HashString(this));
             }
 
             // See if we're going to need to capture the context.
             bool capturingContext = AsyncCallback != null || (_flags & StateFlags.CaptureContext) != 0;
-
-            bool globalLogEnabled = GlobalLog.IsEnabled;
 
             // Peek if we've already completed, but don't fix CompletedSynchronously yet
             // Capture the identity if requested, unless we're going to capture the context anyway, unless

--- a/src/Common/src/System/Net/DebugSafeHandleMinusOneIsInvalid.cs
+++ b/src/Common/src/System/Net/DebugSafeHandleMinusOneIsInvalid.cs
@@ -29,7 +29,10 @@ namespace System.Net
         private void Trace()
         {
             _trace = "WARNING! GC-ed  >>" + this.GetType().FullName + "<< (should be explicitly closed) \r\n";
-            GlobalLog.Print("Creating SafeHandle, type = " + this.GetType().FullName);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Creating SafeHandle, type = " + this.GetType().FullName);
+            }
 #if TRACE_VERBOSE
             string stacktrace = Environment.StackTrace;
             _trace += stacktrace;

--- a/src/Common/src/System/Net/LazyAsyncResult.cs
+++ b/src/Common/src/System/Net/LazyAsyncResult.cs
@@ -70,7 +70,11 @@ namespace System.Net
         // If a derived class ever uses this and overloads Cleanup, this may need to change.
         internal LazyAsyncResult(object myObject, object myState, AsyncCallback myCallBack, object result)
         {
-            GlobalLog.Assert(result != DBNull.Value, "LazyAsyncResult#{0}::.ctor()|Result can't be set to DBNull - it's a special internal value.", LoggingHash.HashString(this));
+            if (result == DBNull.Value)
+            {
+                GlobalLog.AssertFormat("LazyAsyncResult#{0}::.ctor()|Result can't be set to DBNull - it's a special internal value.", LoggingHash.HashString(this));
+            }
+
             _asyncObject = myObject;
             _asyncState = myState;
             _asyncCallback = myCallBack;
@@ -295,8 +299,14 @@ namespace System.Net
                 // then the "result" parameter passed to InvokeCallback() will be ignored.
 
                 // It's an error to call after the result has been completed or with DBNull.
-                GlobalLog.Assert(value != DBNull.Value, "LazyAsyncResult#{0}::set_Result()|Result can't be set to DBNull - it's a special internal value.", LoggingHash.HashString(this));
-                GlobalLog.Assert(!InternalPeekCompleted, "LazyAsyncResult#{0}::set_Result()|Called on completed result.", LoggingHash.HashString(this));
+                if (value == DBNull.Value)
+                {
+                    GlobalLog.AssertFormat("LazyAsyncResult#{0}::set_Result()|Result can't be set to DBNull - it's a special internal value.", LoggingHash.HashString(this));
+                }
+                if (InternalPeekCompleted)
+                {
+                    GlobalLog.AssertFormat("LazyAsyncResult#{0}::set_Result()|Called on completed result.", LoggingHash.HashString(this));
+                }
                 _result = value;
             }
         }

--- a/src/Common/src/System/Net/LazyAsyncResult.cs
+++ b/src/Common/src/System/Net/LazyAsyncResult.cs
@@ -73,7 +73,9 @@ namespace System.Net
         // If a derived class ever uses this and overloads Cleanup, this may need to change.
         internal LazyAsyncResult(object myObject, object myState, AsyncCallback myCallBack, object result)
         {
-            if (result == DBNull.Value)
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+
+            if (result == DBNull.Value && globalLogEnabled)
             {
                 GlobalLog.AssertFormat("LazyAsyncResult#{0}::.ctor()|Result can't be set to DBNull - it's a special internal value.", LoggingHash.HashString(this));
             }
@@ -83,8 +85,6 @@ namespace System.Net
             _asyncCallback = myCallBack;
             _result = result;
             _intCompleted = 1;
-
-            bool globalLogEnabled = GlobalLog.IsEnabled;
 
             if (_asyncCallback != null)
             {

--- a/src/Common/src/System/Net/Logging/EventSourceLogging.cs
+++ b/src/Common/src/System/Net/Logging/EventSourceLogging.cs
@@ -8,7 +8,8 @@ namespace System.Net
     [EventSource(Name = "Microsoft-System-Net-Debug")]
     internal class EventSourceLogging : EventSource
     {
-        private static EventSourceLogging s_log = new EventSourceLogging();
+        private static readonly EventSourceLogging s_log = new EventSourceLogging();
+
         private EventSourceLogging() { }
 
         public static EventSourceLogging Log

--- a/src/Common/src/System/Net/Logging/GlobalLog.cs
+++ b/src/Common/src/System/Net/Logging/GlobalLog.cs
@@ -69,7 +69,7 @@ namespace System.Net
                 (kind & ~(ThreadKinds.OwnerMask | ThreadKinds.SyncMask)) |
                 source);
 
-            if (CurrentThreadKind != threadKind)
+            if (CurrentThreadKind != threadKind && IsEnabled)
             {
                 Print("Thread becomes:(" + CurrentThreadKind.ToString() + ")");
             }
@@ -101,7 +101,7 @@ namespace System.Net
 
                 ThreadKinds previous = ThreadKindStack.Pop();
 
-                if (CurrentThreadKind != previous)
+                if (CurrentThreadKind != previous && IsEnabled)
                 {
                     Print("Thread reverts:(" + CurrentThreadKind.ToString() + ")");
                 }

--- a/src/Common/src/System/Net/SafeCloseSocket.Windows.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Windows.cs
@@ -46,7 +46,10 @@ namespace System.Net.Sockets
                     if (_iocpBoundHandle == null)
                     {
                         // Bind the socket native _handle to the ThreadPool.
-                        GlobalLog.Print("SafeCloseSocket#" + LoggingHash.HashString(this) + "::BindToCompletionPort() calling ThreadPool.BindHandle()");
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.Print("SafeCloseSocket#" + LoggingHash.HashString(this) + "::BindToCompletionPort() calling ThreadPool.BindHandle()");
+                        }
 
                         try
                         {
@@ -107,7 +110,10 @@ namespace System.Net.Sockets
                 // case we need to do some recovery.
                 if (_blockable)
                 {
-                    GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") Following 'blockable' branch.");
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") Following 'blockable' branch.");
+                    }
 
                     errorCode = Interop.Winsock.closesocket(handle);
 #if DEBUG
@@ -115,7 +121,10 @@ namespace System.Net.Sockets
                     _closeSocketResult = errorCode;
 #endif
                     if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastWin32Error();
-                    GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") closesocket()#1:" + errorCode.ToString());
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") closesocket()#1:" + errorCode.ToString());
+                    }
 
                     // If it's not WSAEWOULDBLOCK, there's no more recourse - we either succeeded or failed.
                     if (errorCode != SocketError.WouldBlock)
@@ -131,7 +140,11 @@ namespace System.Net.Sockets
                         Interop.Winsock.IoctlSocketConstants.FIONBIO,
                         ref nonBlockCmd);
                     if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastWin32Error();
-                    GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") ioctlsocket()#1:" + errorCode.ToString());
+
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") ioctlsocket()#1:" + errorCode.ToString());
+                    }
 
                     // This can fail if there's a pending WSAEventSelect.  Try canceling it.
                     if (errorCode == SocketError.InvalidArgument)
@@ -140,14 +153,22 @@ namespace System.Net.Sockets
                             handle,
                             IntPtr.Zero,
                             Interop.Winsock.AsyncEventBits.FdNone);
-                        GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") WSAEventSelect():" + (errorCode == SocketError.SocketError ? (SocketError)Marshal.GetLastWin32Error() : errorCode).ToString());
+
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") WSAEventSelect():" + (errorCode == SocketError.SocketError ? (SocketError)Marshal.GetLastWin32Error() : errorCode).ToString());
+                        }
 
                         // Now retry the ioctl.
                         errorCode = Interop.Winsock.ioctlsocket(
                             handle,
                             Interop.Winsock.IoctlSocketConstants.FIONBIO,
                             ref nonBlockCmd);
-                        GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") ioctlsocket#2():" + (errorCode == SocketError.SocketError ? (SocketError)Marshal.GetLastWin32Error() : errorCode).ToString());
+
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") ioctlsocket#2():" + (errorCode == SocketError.SocketError ? (SocketError)Marshal.GetLastWin32Error() : errorCode).ToString());
+                        }
                     }
 
                     // If that succeeded, try again.
@@ -159,7 +180,10 @@ namespace System.Net.Sockets
                         _closeSocketResult = errorCode;
 #endif
                         if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastWin32Error();
-                        GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") closesocket#2():" + errorCode.ToString());
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") closesocket#2():" + errorCode.ToString());
+                        }
 
                         // If it's not WSAEWOULDBLOCK, there's no more recourse - we either succeeded or failed.
                         if (errorCode != SocketError.WouldBlock)
@@ -186,7 +210,10 @@ namespace System.Net.Sockets
                 _closeSocketLinger = errorCode;
 #endif
                 if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastWin32Error();
-                GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") setsockopt():" + errorCode.ToString());
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") setsockopt():" + errorCode.ToString());
+                }
 
                 if (errorCode != SocketError.Success && errorCode != SocketError.InvalidArgument && errorCode != SocketError.ProtocolOption)
                 {
@@ -199,7 +226,10 @@ namespace System.Net.Sockets
                 _closeSocketHandle = handle;
                 _closeSocketResult = errorCode;
 #endif
-                GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") closesocket#3():" + (errorCode == SocketError.SocketError ? (SocketError)Marshal.GetLastWin32Error() : errorCode).ToString());
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") closesocket#3():" + (errorCode == SocketError.SocketError ? (SocketError)Marshal.GetLastWin32Error() : errorCode).ToString());
+                }
 
                 return errorCode;
             }

--- a/src/Common/src/System/Net/SafeCloseSocket.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.cs
@@ -232,7 +232,7 @@ namespace System.Net.Sockets
                 }
                 catch (Exception exception)
                 {
-                    if (!ExceptionCheck.IsFatal(exception))
+                    if (!ExceptionCheck.IsFatal(exception) && GlobalLog.IsEnabled)
                     {
                         GlobalLog.Assert("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ")", exception.Message);
                     }
@@ -243,7 +243,10 @@ namespace System.Net.Sockets
                 {
                     _closeSocketThread = Environment.CurrentManagedThreadId;
                     _closeSocketTick = Environment.TickCount;
-                    GlobalLog.Assert(ret, "SafeCloseSocket::ReleaseHandle(handle:{0:x})|ReleaseHandle failed.", handle);
+                    if (!ret)
+                    {
+                        GlobalLog.AssertFormat("SafeCloseSocket::ReleaseHandle(handle:{0:x})|ReleaseHandle failed.", handle);
+                    }
                 }
 #endif
             }

--- a/src/Common/src/System/Net/SafeCloseSocket.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.cs
@@ -96,7 +96,10 @@ namespace System.Net.Sockets
             SafeCloseSocket ret = new SafeCloseSocket();
             CreateSocket(socket, ret);
 
-            GlobalLog.Print("SafeCloseSocket#" + LoggingHash.HashString(ret) + "::CreateSocket()");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("SafeCloseSocket#" + LoggingHash.HashString(ret) + "::CreateSocket()");
+            }
 
             return ret;
         }
@@ -138,9 +141,12 @@ namespace System.Net.Sockets
 
         protected override bool ReleaseHandle()
         {
-            GlobalLog.Print(
-                "SafeCloseSocket#" + LoggingHash.HashString(this) + "::ReleaseHandle() m_InnerSocket=" +
-                _innerSocket == null ? "null" : LoggingHash.HashString(_innerSocket));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print(
+                    "SafeCloseSocket#" + LoggingHash.HashString(this) + "::ReleaseHandle() m_InnerSocket=" +
+                    _innerSocket == null ? "null" : LoggingHash.HashString(_innerSocket));
+            }
 
             _released = true;
             InnerSafeCloseSocket innerSocket = _innerSocket == null ? null : Interlocked.Exchange<InnerSafeCloseSocket>(ref _innerSocket, null);
@@ -162,9 +168,12 @@ namespace System.Net.Sockets
 
         internal void CloseAsIs()
         {
-            GlobalLog.Print(
-                "SafeCloseSocket#" + LoggingHash.HashString(this) + "::CloseAsIs() m_InnerSocket=" +
-                _innerSocket == null ? "null" : LoggingHash.HashString(_innerSocket));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print(
+                    "SafeCloseSocket#" + LoggingHash.HashString(this) + "::CloseAsIs() m_InnerSocket=" +
+                    _innerSocket == null ? "null" : LoggingHash.HashString(_innerSocket));
+            }
 
 #if DEBUG
             // If this throws it could be very bad.
@@ -192,7 +201,7 @@ namespace System.Net.Sockets
             }
             catch (Exception exception)
             {
-                if (!ExceptionCheck.IsFatal(exception))
+                if (!ExceptionCheck.IsFatal(exception) && GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("SafeCloseSocket::CloseAsIs(handle:" + handle.ToString("x") + ")", exception.Message);
                 }
@@ -224,7 +233,10 @@ namespace System.Net.Sockets
                 try
                 {
 #endif
-                    GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ")");
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ")");
+                    }
 
                     SocketError errorCode = InnerReleaseHandle();
                     return ret = errorCode == SocketError.Success;
@@ -243,7 +255,7 @@ namespace System.Net.Sockets
                 {
                     _closeSocketThread = Environment.CurrentManagedThreadId;
                     _closeSocketTick = Environment.TickCount;
-                    if (!ret)
+                    if (!ret && GlobalLog.IsEnabled)
                     {
                         GlobalLog.AssertFormat("SafeCloseSocket::ReleaseHandle(handle:{0:x})|ReleaseHandle failed.", handle);
                     }
@@ -275,7 +287,10 @@ namespace System.Net.Sockets
             public void LogRemainingOperations()
             {
                 Interlocked.MemoryBarrier();
-                GlobalLog.Print("InnerSafeCloseSocket: Releasing with pending operations: " + _refCount);
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("InnerSafeCloseSocket: Releasing with pending operations: " + _refCount);
+                }
             }
 #endif
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Windows.cs
@@ -101,7 +101,10 @@ namespace System.Net.Sockets
 
         private void LogBuffer(long size)
         {
-            GlobalLog.Assert(SocketsEventSource.Log.IsEnabled(), "AcceptOverlappedAsyncResult#{0}::LogBuffer()|Logging is off!", LoggingHash.HashString(this));
+            if (!SocketsEventSource.Log.IsEnabled())
+            {
+                GlobalLog.AssertFormat("AcceptOverlappedAsyncResult#{0}::LogBuffer()|Logging is off!", LoggingHash.HashString(this));
+            }
             IntPtr pinnedBuffer = Marshal.UnsafeAddrOfPinnedArrayElement(_buffer, 0);
             if (pinnedBuffer != IntPtr.Zero)
             {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Windows.cs
@@ -65,7 +65,11 @@ namespace System.Net.Sockets
                     {
                         errorCode = (SocketError)Marshal.GetLastWin32Error();
                     }
-                    GlobalLog.Print("AcceptOverlappedAsyncResult#" + LoggingHash.HashString(this) + "::PostCallback() setsockopt handle:" + handle.ToString() + " AcceptSocket:" + LoggingHash.HashString(_acceptSocket) + " itsHandle:" + _acceptSocket.SafeHandle.DangerousGetHandle().ToString() + " returns:" + errorCode.ToString());
+
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Print("AcceptOverlappedAsyncResult#" + LoggingHash.HashString(this) + "::PostCallback() setsockopt handle:" + handle.ToString() + " AcceptSocket:" + LoggingHash.HashString(_acceptSocket) + " itsHandle:" + _acceptSocket.SafeHandle.DangerousGetHandle().ToString() + " returns:" + errorCode.ToString());
+                    }
                 }
                 catch (ObjectDisposedException)
                 {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Windows.cs
@@ -105,7 +105,7 @@ namespace System.Net.Sockets
 
         private void LogBuffer(long size)
         {
-            if (!SocketsEventSource.Log.IsEnabled())
+            if (!SocketsEventSource.Log.IsEnabled() && GlobalLog.IsEnabled)
             {
                 GlobalLog.AssertFormat("AcceptOverlappedAsyncResult#{0}::LogBuffer()|Logging is off!", LoggingHash.HashString(this));
             }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
@@ -26,9 +26,12 @@ namespace System.Net.Sockets
             : base(socket, asyncState, asyncCallback)
         {
             _cleanupCount = 1;
-            GlobalLog.Print(
-                "BaseOverlappedAsyncResult#" + LoggingHash.HashString(this) +
-                "(Socket#" + LoggingHash.HashString(socket) + ")");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print(
+                    "BaseOverlappedAsyncResult#" + LoggingHash.HashString(this) +
+                    "(Socket#" + LoggingHash.HashString(socket) + ")");
+            }
         }
 
         internal SafeNativeOverlapped NativeOverlapped
@@ -66,11 +69,14 @@ namespace System.Net.Sockets
             {
                 NativeOverlapped* overlapped = boundHandle.AllocateNativeOverlapped(s_ioCallback, this, objectsToPin);
                 _nativeOverlapped = new SafeNativeOverlapped(s.SafeHandle, overlapped);
-                GlobalLog.Print(
-                    "BaseOverlappedAsyncResult#" + LoggingHash.HashString(this) +
-                    "::boundHandle#" + LoggingHash.HashString(boundHandle) +
-                    "::AllocateNativeOverlapped. Return=" +
-                    _nativeOverlapped.DangerousGetHandle().ToString("x"));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print(
+                        "BaseOverlappedAsyncResult#" + LoggingHash.HashString(this) +
+                        "::boundHandle#" + LoggingHash.HashString(boundHandle) +
+                        "::AllocateNativeOverlapped. Return=" +
+                        _nativeOverlapped.DangerousGetHandle().ToString("x"));
+                }
             }
         }
 
@@ -85,16 +91,19 @@ namespace System.Net.Sockets
 
                 object returnObject = null;
 
-                if (asyncResult.InternalPeekCompleted)
+                if (asyncResult.InternalPeekCompleted && GlobalLog.IsEnabled)
                 {
                     GlobalLog.AssertFormat("BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|asyncResult.IsCompleted", LoggingHash.HashString(asyncResult));
                 }
 
-                GlobalLog.Print(
-                    "BaseOverlappedAsyncResult#" + LoggingHash.HashString(asyncResult) + "::CompletionPortCallback" +
-                    " errorCode:" + errorCode.ToString() +
-                    " numBytes:" + numBytes.ToString() +
-                    " pOverlapped:" + ((int)nativeOverlapped).ToString());
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print(
+                        "BaseOverlappedAsyncResult#" + LoggingHash.HashString(asyncResult) + "::CompletionPortCallback" +
+                        " errorCode:" + errorCode.ToString() +
+                        " numBytes:" + numBytes.ToString() +
+                        " pOverlapped:" + ((int)nativeOverlapped).ToString());
+                }
 
                 // Complete the IO and invoke the user's callback.
                 SocketError socketError = (SocketError)errorCode;
@@ -132,13 +141,13 @@ namespace System.Net.Sockets
                             if (!success)
                             {
                                 socketError = (SocketError)Marshal.GetLastWin32Error();
-                                if (socketError == 0)
+                                if (socketError == 0 && GlobalLog.IsEnabled)
                                 {
                                     GlobalLog.AssertFormat("BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|socketError:0 numBytes:{1}", LoggingHash.HashString(asyncResult), numBytes);
                                 }
                             }
 
-                            if (success)
+                            if (success && GlobalLog.IsEnabled)
                             {
                                 GlobalLog.AssertFormat("BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|Unexpectedly succeeded. errorCode:{1} numBytes:{2}", LoggingHash.HashString(asyncResult), errorCode, numBytes);
                             }
@@ -197,9 +206,12 @@ namespace System.Net.Sockets
         protected virtual void ForceReleaseUnmanagedStructures()
         {
             // Free the unmanaged memory if allocated.
-            GlobalLog.Print(
-                "BaseOverlappedAsyncResult#" + LoggingHash.HashString(this) +
-                "::ForceReleaseUnmanagedStructures");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print(
+                    "BaseOverlappedAsyncResult#" + LoggingHash.HashString(this) +
+                    "::ForceReleaseUnmanagedStructures");
+            }
 
             _nativeOverlapped.Dispose();
             _nativeOverlapped = null;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
@@ -85,7 +85,10 @@ namespace System.Net.Sockets
 
                 object returnObject = null;
 
-                GlobalLog.Assert(!asyncResult.InternalPeekCompleted, "BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|asyncResult.IsCompleted", LoggingHash.HashString(asyncResult));
+                if (asyncResult.InternalPeekCompleted)
+                {
+                    GlobalLog.AssertFormat("BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|asyncResult.IsCompleted", LoggingHash.HashString(asyncResult));
+                }
 
                 GlobalLog.Print(
                     "BaseOverlappedAsyncResult#" + LoggingHash.HashString(asyncResult) + "::CompletionPortCallback" +
@@ -129,10 +132,16 @@ namespace System.Net.Sockets
                             if (!success)
                             {
                                 socketError = (SocketError)Marshal.GetLastWin32Error();
-                                GlobalLog.Assert(socketError != 0, "BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|socketError:0 numBytes:{1}", LoggingHash.HashString(asyncResult), numBytes);
+                                if (socketError == 0)
+                                {
+                                    GlobalLog.AssertFormat("BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|socketError:0 numBytes:{1}", LoggingHash.HashString(asyncResult), numBytes);
+                                }
                             }
 
-                            GlobalLog.Assert(!success, "BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|Unexpectedly succeeded. errorCode:{1} numBytes:{2}", LoggingHash.HashString(asyncResult), errorCode, numBytes);
+                            if (success)
+                            {
+                                GlobalLog.AssertFormat("BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|Unexpectedly succeeded. errorCode:{1} numBytes:{2}", LoggingHash.HashString(asyncResult), errorCode, numBytes);
+                            }
                         }
                         catch (ObjectDisposedException)
                         {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
@@ -91,13 +91,13 @@ namespace System.Net.Sockets
 
                 object returnObject = null;
 
-                if (asyncResult.InternalPeekCompleted && GlobalLog.IsEnabled)
-                {
-                    GlobalLog.AssertFormat("BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|asyncResult.IsCompleted", LoggingHash.HashString(asyncResult));
-                }
-
                 if (GlobalLog.IsEnabled)
                 {
+                    if (asyncResult.InternalPeekCompleted)
+                    {
+                        GlobalLog.AssertFormat("BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|asyncResult.IsCompleted", LoggingHash.HashString(asyncResult));
+                    }
+
                     GlobalLog.Print(
                         "BaseOverlappedAsyncResult#" + LoggingHash.HashString(asyncResult) + "::CompletionPortCallback" +
                         " errorCode:" + errorCode.ToString() +

--- a/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.cs
@@ -29,9 +29,12 @@ namespace System.Net.Sockets
         // 3) failed.
         internal unsafe SocketError CheckAsyncCallOverlappedResult(SocketError errorCode)
         {
-            GlobalLog.Print(
-                "BaseOverlappedAsyncResult#" + LoggingHash.HashString(this) +
-                "::CheckAsyncCallOverlappedResult(" + errorCode.ToString() + ")");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print(
+                    "BaseOverlappedAsyncResult#" + LoggingHash.HashString(this) +
+                    "::CheckAsyncCallOverlappedResult(" + errorCode.ToString() + ")");
+            }
 
             if (errorCode == SocketError.Success || errorCode == SocketError.IOPending)
             {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/MultipleConnectAsync.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/MultipleConnectAsync.cs
@@ -49,12 +49,12 @@ namespace System.Net.Sockets
         {
             lock (_lockObject)
             {
-                if (GlobalLog.IsEnabled)
+                if (GlobalLog.IsEnabled &&
+                    endPoint.AddressFamily != AddressFamily.Unspecified &&
+                    endPoint.AddressFamily != AddressFamily.InterNetwork &&
+                    endPoint.AddressFamily != AddressFamily.InterNetworkV6)
                 {
-                    GlobalLog.Assert(endPoint.AddressFamily == AddressFamily.Unspecified ||
-                         endPoint.AddressFamily == AddressFamily.InterNetwork ||
-                         endPoint.AddressFamily == AddressFamily.InterNetworkV6,
-                         "MultipleConnectAsync.StartConnectAsync(): Unexpected endpoint address family - " + endPoint.AddressFamily.ToString());
+                    GlobalLog.Assert("MultipleConnectAsync.StartConnectAsync(): Unexpected endpoint address family - " + endPoint.AddressFamily.ToString());
                 }
 
                 _userArgs = args;
@@ -68,7 +68,10 @@ namespace System.Net.Sockets
                     return false;
                 }
 
-                GlobalLog.Assert(_state == State.NotStarted, "MultipleConnectAsync.StartConnectAsync(): Unexpected object state");
+                if (_state != State.NotStarted && GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("MultipleConnectAsync.StartConnectAsync(): Unexpected object state");
+                }
 
                 _state = State.DnsQuery;
 
@@ -109,12 +112,18 @@ namespace System.Net.Sockets
                     return true;
                 }
 
-                GlobalLog.Assert(_state == State.DnsQuery, "MultipleConnectAsync.DoDnsCallback(): Unexpected object state");
+                if (_state != State.DnsQuery && GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("MultipleConnectAsync.DoDnsCallback(): Unexpected object state");
+                }
 
                 try
                 {
                     _addressList = DnsAPMExtensions.EndGetHostAddresses(result);
-                    GlobalLog.Assert(_addressList != null, "MultipleConnectAsync.DoDnsCallback(): EndGetHostAddresses returned null!");
+                    if (_addressList == null && GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Assert("MultipleConnectAsync.DoDnsCallback(): EndGetHostAddresses returned null!");
+                    }
                 }
                 catch (Exception e)
                 {
@@ -239,8 +248,17 @@ namespace System.Net.Sockets
                 }
                 else
                 {
-                    GlobalLog.Assert(_state == State.UserConnectAttempt, "MultipleConnectAsync.InternalConnectCallback(): Unexpected object state");
-                    GlobalLog.Assert(RequiresUserConnectAttempt, "MultipleConnectAsync.InternalConnectCallback(): State.UserConnectAttempt without RequiresUserConnectAttempt");
+                    if (GlobalLog.IsEnabled)
+                    {
+                        if (_state != State.UserConnectAttempt)
+                        {
+                            GlobalLog.Assert("MultipleConnectAsync.InternalConnectCallback(): Unexpected object state");
+                        }
+                        if (!RequiresUserConnectAttempt)
+                        {
+                            GlobalLog.Assert("MultipleConnectAsync.InternalConnectCallback(): State.UserConnectAttempt without RequiresUserConnectAttempt");
+                        }
+                    }
 
                     if (args.SocketError == SocketError.Success)
                     {
@@ -285,7 +303,10 @@ namespace System.Net.Sockets
                     return new SocketException((int)SocketError.NoData);
                 }
 
-                GlobalLog.Assert(attemptAddress != null, "MultipleConnectAsync.AttemptConnection: attemptAddress is null!");
+                if (attemptAddress == null && GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("MultipleConnectAsync.AttemptConnection: attemptAddress is null!");
+                }
 
                 _internalArgs.RemoteEndPoint = new IPEndPoint(attemptAddress, _endPoint.Port);
 
@@ -293,7 +314,10 @@ namespace System.Net.Sockets
             }
             catch (Exception e)
             {
-                GlobalLog.Assert(!(e is ObjectDisposedException), "MultipleConnectAsync.AttemptConnection: unexpected ObjectDisposedException");
+                if (e is ObjectDisposedException && GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("MultipleConnectAsync.AttemptConnection: unexpected ObjectDisposedException");
+                }
                 return e;
             }
         }
@@ -314,7 +338,10 @@ namespace System.Net.Sockets
             }
             catch (Exception e)
             {
-                GlobalLog.Assert(!(e is ObjectDisposedException), "MultipleConnectAsync.AttemptConnection: unexpected ObjectDisposedException");
+                if (e is ObjectDisposedException && GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("MultipleConnectAsync.AttemptConnection: unexpected ObjectDisposedException");
+                }
                 return e;
             }
         }
@@ -323,7 +350,10 @@ namespace System.Net.Sockets
         {
             try
             {
-                GlobalLog.Assert(attemptSocket != null, "MultipleConnectAsync.AttemptConnection: attemptSocket is null!");
+                if (attemptSocket == null)
+                {
+                    GlobalLog.Assert("MultipleConnectAsync.AttemptConnection: attemptSocket is null!");
+                }
 
                 if (!attemptSocket.ConnectAsync(args))
                 {
@@ -456,7 +486,10 @@ namespace System.Net.Sockets
                         break;
 
                     default:
-                        GlobalLog.Assert("MultipleConnectAsync.Cancel(): Unexpected object state");
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.Assert("MultipleConnectAsync.Cancel(): Unexpected object state");
+                        }
                         break;
                 }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/MultipleConnectAsync.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/MultipleConnectAsync.cs
@@ -49,10 +49,13 @@ namespace System.Net.Sockets
         {
             lock (_lockObject)
             {
-                GlobalLog.Assert(endPoint.AddressFamily == AddressFamily.Unspecified ||
-                     endPoint.AddressFamily == AddressFamily.InterNetwork ||
-                     endPoint.AddressFamily == AddressFamily.InterNetworkV6,
-                     "MultipleConnectAsync.StartConnectAsync(): Unexpected endpoint address family - " + endPoint.AddressFamily.ToString());
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert(endPoint.AddressFamily == AddressFamily.Unspecified ||
+                         endPoint.AddressFamily == AddressFamily.InterNetwork ||
+                         endPoint.AddressFamily == AddressFamily.InterNetworkV6,
+                         "MultipleConnectAsync.StartConnectAsync(): Unexpected endpoint address family - " + endPoint.AddressFamily.ToString());
+                }
 
                 _userArgs = args;
                 _endPoint = endPoint;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/NetworkStream.cs
@@ -1018,7 +1018,10 @@ namespace System.Net.Sockets
         private int _currentWriteTimeout = -1;
         internal void SetSocketTimeoutOption(SocketShutdown mode, int timeout, bool silent)
         {
-            GlobalLog.Print("NetworkStream#" + LoggingHash.HashString(this) + "::SetSocketTimeoutOption() mode:" + mode + " silent:" + silent + " timeout:" + timeout + " m_CurrentReadTimeout:" + _currentReadTimeout + " m_CurrentWriteTimeout:" + _currentWriteTimeout);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("NetworkStream#" + LoggingHash.HashString(this) + "::SetSocketTimeoutOption() mode:" + mode + " silent:" + silent + " timeout:" + timeout + " m_CurrentReadTimeout:" + _currentReadTimeout + " m_CurrentWriteTimeout:" + _currentWriteTimeout);
+            }
             GlobalLog.ThreadContract(ThreadKinds.Unknown, "NetworkStream#" + LoggingHash.HashString(this) + "::SetSocketTimeoutOption");
 
             if (timeout < 0)
@@ -1054,7 +1057,11 @@ namespace System.Net.Sockets
         {
             if (_streamSocket != null)
             {
-                GlobalLog.Print("_streamSocket:");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("_streamSocket:");
+                }
+
                 _streamSocket.DebugMembers();
             }
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Windows.cs
@@ -112,7 +112,7 @@ namespace System.Net.Sockets
 
         private void LogBuffer(int size)
         {
-            if (!SocketsEventSource.Log.IsEnabled())
+            if (!SocketsEventSource.Log.IsEnabled() && GlobalLog.IsEnabled)
             {
                 GlobalLog.AssertFormat("OverlappedAsyncResult#{0}::LogBuffer()|Logging is off!", LoggingHash.HashString(this));
             }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Windows.cs
@@ -112,7 +112,11 @@ namespace System.Net.Sockets
 
         private void LogBuffer(int size)
         {
-            GlobalLog.Assert(SocketsEventSource.Log.IsEnabled(), "OverlappedAsyncResult#{0}::LogBuffer()|Logging is off!", LoggingHash.HashString(this));
+            if (!SocketsEventSource.Log.IsEnabled())
+            {
+                GlobalLog.AssertFormat("OverlappedAsyncResult#{0}::LogBuffer()|Logging is off!", LoggingHash.HashString(this));
+            }
+
             if (size > -1)
             {
                 if (_wsaBuffers != null)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/ReceiveMessageOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/ReceiveMessageOverlappedAsyncResult.Windows.cs
@@ -160,7 +160,7 @@ namespace System.Net.Sockets
 
         private void LogBuffer(int size)
         {
-            if (!SocketsEventSource.Log.IsEnabled())
+            if (!SocketsEventSource.Log.IsEnabled() && GlobalLog.IsEnabled)
             {
                 GlobalLog.AssertFormat("ReceiveMessageOverlappedAsyncResult#{0}::LogBuffer()|Logging is off!", LoggingHash.HashString(this));
             }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/ReceiveMessageOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/ReceiveMessageOverlappedAsyncResult.Windows.cs
@@ -160,7 +160,10 @@ namespace System.Net.Sockets
 
         private void LogBuffer(int size)
         {
-            GlobalLog.Assert(SocketsEventSource.Log.IsEnabled(), "ReceiveMessageOverlappedAsyncResult#{0}::LogBuffer()|Logging is off!", LoggingHash.HashString(this));
+            if (!SocketsEventSource.Log.IsEnabled())
+            {
+                GlobalLog.AssertFormat("ReceiveMessageOverlappedAsyncResult#{0}::LogBuffer()|Logging is off!", LoggingHash.HashString(this));
+            }
             SocketsEventSource.Dump(SocketsEventSource.MethodType.PostCompletion, _wsaBuffer->Pointer, Math.Min(_wsaBuffer->Length, size));
         }
     }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -758,7 +758,10 @@ namespace System.Net.Sockets
             if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::InternalBind() localEP:" + localEP.ToString());
-                GlobalLog.Assert(!(localEP is DnsEndPoint), "Calling InternalBind with a DnsEndPoint, about to get NotImplementedException");
+                if (localEP is DnsEndPoint)
+                {
+                    GlobalLog.Assert("Calling InternalBind with a DnsEndPoint, about to get NotImplementedException");
+                }
             }
 
             // Ask the EndPoint to generate a SocketAddress that we can pass down to native code.
@@ -1576,8 +1579,10 @@ namespace System.Net.Sockets
             }
             catch (ObjectDisposedException) { }
 #endif
-            GlobalLog.Dump(buffer, offset, bytesTransferred);
-
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Dump(buffer, offset, bytesTransferred);
+            }
             if (s_loggingEnabled)
             {
                 SocketsEventSource.Dump(SocketsEventSource.MethodType.Receive, buffer, offset, bytesTransferred);
@@ -1885,8 +1890,10 @@ namespace System.Net.Sockets
                 }
             }
 
-            GlobalLog.Dump(buffer, offset, bytesTransferred);
-
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Dump(buffer, offset, bytesTransferred);
+            }
             if (s_loggingEnabled)
             {
                 SocketsEventSource.Dump(SocketsEventSource.MethodType.ReceiveFrom, buffer, offset, size);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -3151,7 +3151,7 @@ namespace System.Net.Sockets
             // Throw an appropriate SocketException if the native call fails synchronously.
             if (errorCode != SocketError.Success)
             {
-                GlobalLog.Assert(errorCode != SocketError.Success, "Socket#{0}::DoBeginReceive()|GetLastWin32Error() returned zero.", LoggingHash.HashString(this));
+                GlobalLog.AssertFormat("Socket#{0}::DoBeginReceive()|GetLastWin32Error() returned zero.", LoggingHash.HashString(this));
 
                 // Update the internal state of this socket according to the error before throwing.
                 UpdateStatusAfterSocketError(errorCode);
@@ -5133,7 +5133,10 @@ namespace System.Net.Sockets
             }
             catch (ObjectDisposedException)
             {
-                GlobalLog.Assert("SafeCloseSocket::Dispose(handle:" + _handle.DangerousGetHandle().ToString("x") + ")", "Closing the handle threw ObjectDisposedException.");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("SafeCloseSocket::Dispose(handle:" + _handle.DangerousGetHandle().ToString("x") + ")", "Closing the handle threw ObjectDisposedException.");
+                }
             }
         }
 
@@ -5451,7 +5454,11 @@ namespace System.Net.Sockets
             // called if _rightEndPoint is not null, of that the endpoint is an IPEndPoint.
             if (_rightEndPoint == null)
             {
-                GlobalLog.Assert(endPointSnapshot.GetType() == typeof(IPEndPoint), "Socket#{0}::BeginConnectEx()|Socket not bound and endpoint not IPEndPoint.", LoggingHash.HashString(this));
+                if (endPointSnapshot.GetType() != typeof(IPEndPoint))
+                {
+                    GlobalLog.AssertFormat("Socket#{0}::BeginConnectEx()|Socket not bound and endpoint not IPEndPoint.", LoggingHash.HashString(this));
+                }
+
                 if (endPointSnapshot.AddressFamily == AddressFamily.InterNetwork)
                 {
                     InternalBind(new IPEndPoint(IPAddress.Any, 0));

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -184,7 +184,10 @@ namespace System.Net.Sockets
                 // This may throw ObjectDisposedException.
                 SocketError errorCode = SocketPal.GetAvailable(_handle, out argp);
 
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Available_get() Interop.Winsock.ioctlsocket returns errorCode:" + errorCode);
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Available_get() Interop.Winsock.ioctlsocket returns errorCode:" + errorCode);
+                }
 
                 // Throw an appropriate SocketException if the native call fails.
                 if (errorCode != SocketError.Success)
@@ -331,7 +334,10 @@ namespace System.Net.Sockets
                     throw new ObjectDisposedException(this.GetType().FullName);
                 }
 
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::set_Blocking() value:" + value.ToString() + " willBlock:" + _willBlock.ToString() + " willBlockInternal:" + _willBlockInternal.ToString());
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::set_Blocking() value:" + value.ToString() + " willBlock:" + _willBlock.ToString() + " willBlockInternal:" + _willBlockInternal.ToString());
+                }
 
                 bool current;
 
@@ -362,7 +368,10 @@ namespace System.Net.Sockets
         {
             get
             {
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Connected() _isConnected:" + _isConnected);
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Connected() _isConnected:" + _isConnected);
+                }
 
                 if (_nonBlockingConnectInProgress && Poll(0, SelectMode.SelectWrite))
                 {
@@ -705,7 +714,10 @@ namespace System.Net.Sockets
                 throw new ArgumentNullException("localEP");
             }
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Bind() localEP:" + localEP.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Bind() localEP:" + localEP.ToString());
+            }
 
             EndPoint endPointSnapshot = localEP;
             IPEndPoint ipSnapshot = localEP as IPEndPoint;
@@ -743,8 +755,11 @@ namespace System.Net.Sockets
                 throw new ObjectDisposedException(GetType().FullName);
             }
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::InternalBind() localEP:" + localEP.ToString());
-            GlobalLog.Assert(!(localEP is DnsEndPoint), "Calling InternalBind with a DnsEndPoint, about to get NotImplementedException");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::InternalBind() localEP:" + localEP.ToString());
+                GlobalLog.Assert(!(localEP is DnsEndPoint), "Calling InternalBind with a DnsEndPoint, about to get NotImplementedException");
+            }
 
             // Ask the EndPoint to generate a SocketAddress that we can pass down to native code.
             EndPoint endPointSnapshot = localEP;
@@ -831,7 +846,10 @@ namespace System.Net.Sockets
             }
 
             ValidateBlockingMode();
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Connect() DST:" + LoggingHash.ObjectToString(remoteEP));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Connect() DST:" + LoggingHash.ObjectToString(remoteEP));
+            }
 
             DnsEndPoint dnsEP = remoteEP as DnsEndPoint;
             if (dnsEP != null)
@@ -1063,7 +1081,10 @@ namespace System.Net.Sockets
                 throw new ObjectDisposedException(this.GetType().FullName);
             }
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Listen() backlog:" + backlog.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Listen() backlog:" + backlog.ToString());
+            }
 
             // No access permissions are necessary here because the verification is done for Bind.
 
@@ -1130,7 +1151,10 @@ namespace System.Net.Sockets
             }
 
             ValidateBlockingMode();
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Accept() SRC:" + LoggingHash.ObjectToString(LocalEndPoint));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Accept() SRC:" + LoggingHash.ObjectToString(LocalEndPoint));
+            }
 
             Internals.SocketAddress socketAddress = IPEndPointExtensions.Serialize(_rightEndPoint);
 
@@ -1221,7 +1245,10 @@ namespace System.Net.Sockets
             }
 
             ValidateBlockingMode();
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Send() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Send() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint));
+            }
 
             int bytesTransferred;
             errorCode = SocketPal.Send(_handle, buffers, socketFlags, out bytesTransferred);
@@ -1304,7 +1331,10 @@ namespace System.Net.Sockets
 
             errorCode = SocketError.Success;
             ValidateBlockingMode();
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Send() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " size:" + size);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Send() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " size:" + size);
+            }
 
             // This can throw ObjectDisposedException.
             int bytesTransferred;
@@ -1335,14 +1365,14 @@ namespace System.Net.Sockets
                 }
             }
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Send() Interop.Winsock.send returns:" + bytesTransferred.ToString());
-            GlobalLog.Dump(buffer, offset, bytesTransferred);
-            if (s_loggingEnabled)
+            if (GlobalLog.IsEnabled)
             {
-                SocketsEventSource.Dump(SocketsEventSource.MethodType.Send, buffer, offset, size);
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Send() Interop.Winsock.send returns:" + bytesTransferred.ToString());
+                GlobalLog.Dump(buffer, offset, bytesTransferred);
             }
             if (s_loggingEnabled)
             {
+                SocketsEventSource.Dump(SocketsEventSource.MethodType.Send, buffer, offset, size);
                 NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "Send", bytesTransferred);
             }
             return bytesTransferred;
@@ -1378,7 +1408,10 @@ namespace System.Net.Sockets
             }
 
             ValidateBlockingMode();
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SendTo() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " size:" + size + " remoteEP:" + LoggingHash.ObjectToString(remoteEP));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SendTo() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " size:" + size + " remoteEP:" + LoggingHash.ObjectToString(remoteEP));
+            }
 
             // CheckCacheRemote will check ConnectPermission for remoteEP.
             EndPoint endPointSnapshot = remoteEP;
@@ -1419,14 +1452,14 @@ namespace System.Net.Sockets
                 }
             }
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SendTo() returning bytesTransferred:" + bytesTransferred.ToString());
-            GlobalLog.Dump(buffer, offset, bytesTransferred);
-            if (s_loggingEnabled)
+            if (GlobalLog.IsEnabled)
             {
-                SocketsEventSource.Dump(SocketsEventSource.MethodType.SendTo, buffer, offset, size);
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SendTo() returning bytesTransferred:" + bytesTransferred.ToString());
+                GlobalLog.Dump(buffer, offset, bytesTransferred);
             }
             if (s_loggingEnabled)
             {
+                SocketsEventSource.Dump(SocketsEventSource.MethodType.SendTo, buffer, offset, size);
                 NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "SendTo", bytesTransferred);
             }
             return bytesTransferred;
@@ -1502,7 +1535,10 @@ namespace System.Net.Sockets
             }
 
             ValidateBlockingMode();
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Receive() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " size:" + size);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Receive() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " size:" + size);
+            }
 
             int bytesTransferred;
             errorCode = SocketPal.Receive(_handle, buffer, offset, size, socketFlags, out bytesTransferred);
@@ -1593,7 +1629,10 @@ namespace System.Net.Sockets
 
 
             ValidateBlockingMode();
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Receive() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Receive() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint));
+            }
 
             int bytesTransferred;
             errorCode = SocketPal.Receive(_handle, buffers, ref socketFlags, out bytesTransferred);
@@ -1780,7 +1819,10 @@ namespace System.Net.Sockets
             }
 
             ValidateBlockingMode();
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::ReceiveFrom() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " size:" + size + " remoteEP:" + remoteEP.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::ReceiveFrom() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " size:" + size + " remoteEP:" + remoteEP.ToString());
+            }
 
             // We don't do a CAS demand here because the contents of remoteEP aren't used by
             // WSARecvFrom; all that matters is that we generate a unique-to-this-call SocketAddress
@@ -1884,7 +1926,10 @@ namespace System.Net.Sockets
             // This can throw ObjectDisposedException.
             SocketError errorCode = SocketPal.Ioctl(_handle, ioControlCode, optionInValue, optionOutValue, out realOptionLength);
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::IOControl() Interop.Winsock.WSAIoctl returns errorCode:" + errorCode);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::IOControl() Interop.Winsock.WSAIoctl returns errorCode:" + errorCode);
+            }
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -1919,7 +1964,10 @@ namespace System.Net.Sockets
             // This can throw ObjectDisposedException.
             SocketError errorCode = SocketPal.IoctlInternal(_handle, ioControlCode, optionInValue, inValueSize, optionOutValue, outValueSize, out realOptionLength);
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::IOControl() Interop.Winsock.WSAIoctl returns errorCode:" + errorCode);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::IOControl() Interop.Winsock.WSAIoctl returns errorCode:" + errorCode);
+            }
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -1945,7 +1993,11 @@ namespace System.Net.Sockets
                 throw new ObjectDisposedException(this.GetType().FullName);
             }
             CheckSetOptionPermissions(optionLevel, optionName);
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetSocketOption(): optionLevel:" + optionLevel.ToString() + " optionName:" + optionName.ToString() + " optionValue:" + optionValue.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetSocketOption(): optionLevel:" + optionLevel.ToString() + " optionName:" + optionName.ToString() + " optionValue:" + optionValue.ToString());
+            }
+
             SetSocketOption(optionLevel, optionName, optionValue, false);
         }
 
@@ -1958,12 +2010,18 @@ namespace System.Net.Sockets
 
             CheckSetOptionPermissions(optionLevel, optionName);
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetSocketOption(): optionLevel:" + optionLevel.ToString() + " optionName:" + optionName.ToString() + " optionValue:" + optionValue.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetSocketOption(): optionLevel:" + optionLevel.ToString() + " optionName:" + optionName.ToString() + " optionValue:" + optionValue.ToString());
+            }
 
             // This can throw ObjectDisposedException.
             SocketError errorCode = SocketPal.SetSockOpt(_handle, optionLevel, optionName, optionValue);
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetSocketOption() Interop.Winsock.setsockopt returns errorCode:" + errorCode);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetSocketOption() Interop.Winsock.setsockopt returns errorCode:" + errorCode);
+            }
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -2001,7 +2059,10 @@ namespace System.Net.Sockets
 
             CheckSetOptionPermissions(optionLevel, optionName);
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetSocketOption(): optionLevel:" + optionLevel.ToString() + " optionName:" + optionName.ToString() + " optionValue:" + optionValue.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetSocketOption(): optionLevel:" + optionLevel.ToString() + " optionName:" + optionName.ToString() + " optionValue:" + optionValue.ToString());
+            }
 
             if (optionLevel == SocketOptionLevel.Socket && optionName == SocketOptionName.Linger)
             {
@@ -2071,7 +2132,10 @@ namespace System.Net.Sockets
                 optionName,
                 out optionValue);
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::GetSocketOption() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::GetSocketOption() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
+            }
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -2106,7 +2170,10 @@ namespace System.Net.Sockets
                 optionValue,
                 ref optionLength);
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::GetSocketOption() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::GetSocketOption() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
+            }
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -2140,7 +2207,10 @@ namespace System.Net.Sockets
                 optionValue,
                 ref realOptionLength);
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::GetSocketOption() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::GetSocketOption() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
+            }
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -2175,7 +2245,10 @@ namespace System.Net.Sockets
 
             bool status;
             SocketError errorCode = SocketPal.Poll(_handle, microSeconds, mode, out status);
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Poll() Interop.Winsock.select returns socketCount:" + (int)errorCode);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Poll() Interop.Winsock.select returns socketCount:" + (int)errorCode);
+            }
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -2484,7 +2557,10 @@ namespace System.Net.Sockets
             castedAsyncResult.InternalWaitForCompletion();
             castedAsyncResult.EndCalled = true;
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::EndConnect() asyncResult:" + LoggingHash.HashString(asyncResult));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::EndConnect() asyncResult:" + LoggingHash.HashString(asyncResult));
+            }
 
             if (castedAsyncResult.Result is Exception)
             {
@@ -2621,7 +2697,11 @@ namespace System.Net.Sockets
 
         private SocketError DoBeginSend(byte[] buffer, int offset, int size, SocketFlags socketFlags, OverlappedAsyncResult asyncResult)
         {
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginSend() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " size:" + size.ToString());
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+            if (globalLogEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginSend() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " size:" + size.ToString());
+            }
 
             // Guarantee to call CheckAsyncCallOverlappedResult if we call SetUnamangedStructures with a cache in order to
             // avoid a Socket leak in case of error.
@@ -2629,11 +2709,17 @@ namespace System.Net.Sockets
             try
             {
                 // Get the Send going.
-                GlobalLog.Print("BeginSend: asyncResult:" + LoggingHash.HashString(asyncResult) + " size:" + size.ToString());
+                if (globalLogEnabled)
+                {
+                    GlobalLog.Print("BeginSend: asyncResult:" + LoggingHash.HashString(asyncResult) + " size:" + size.ToString());
+                }
 
                 errorCode = SocketPal.SendAsync(_handle, buffer, offset, size, socketFlags, asyncResult);
 
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginSend() Interop.Winsock.WSASend returns:" + errorCode.ToString() + " size:" + size.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+                if (globalLogEnabled)
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginSend() Interop.Winsock.WSASend returns:" + errorCode.ToString() + " size:" + size.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+                }
             }
             finally
             {
@@ -2711,18 +2797,28 @@ namespace System.Net.Sockets
 
         private SocketError DoBeginSend(IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, OverlappedAsyncResult asyncResult)
         {
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginSend() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " buffers:" + buffers);
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+            if (globalLogEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginSend() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " buffers:" + buffers);
+            }
 
             // Guarantee to call CheckAsyncCallOverlappedResult if we call SetUnamangedStructures with a cache in order to
             // avoid a Socket leak in case of error.
             SocketError errorCode = SocketError.SocketError;
             try
             {
-                GlobalLog.Print("BeginSend: asyncResult:" + LoggingHash.HashString(asyncResult));
+                if (globalLogEnabled)
+                {
+                    GlobalLog.Print("BeginSend: asyncResult:" + LoggingHash.HashString(asyncResult));
+                }
 
                 errorCode = SocketPal.SendAsync(_handle, buffers, socketFlags, asyncResult);
 
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginSend() Interop.Winsock.WSASend returns:" + errorCode.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+                if (globalLogEnabled)
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginSend() Interop.Winsock.WSASend returns:" + errorCode.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+                }
             }
             finally
             {
@@ -2806,7 +2902,10 @@ namespace System.Net.Sockets
                 }
             }
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::EndSend() bytesTransferred:" + bytesTransferred.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::EndSend() bytesTransferred:" + bytesTransferred.ToString());
+            }
 
             // Throw an appropriate SocketException if the native call failed asynchronously.
             errorCode = (SocketError)castedAsyncResult.ErrorCode;
@@ -2901,7 +3000,11 @@ namespace System.Net.Sockets
 
         private void DoBeginSendTo(byte[] buffer, int offset, int size, SocketFlags socketFlags, EndPoint endPointSnapshot, Internals.SocketAddress socketAddress, OverlappedAsyncResult asyncResult)
         {
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginSendTo() size:" + size.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginSendTo() size:" + size.ToString());
+            }
+
             EndPoint oldEndPoint = _rightEndPoint;
 
             // Guarantee to call CheckAsyncCallOverlappedResult if we call SetUnamangedStructures with a cache in order to
@@ -2916,7 +3019,10 @@ namespace System.Net.Sockets
 
                 errorCode = SocketPal.SendToAsync(_handle, buffer, offset, size, socketFlags, socketAddress, asyncResult);
 
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginSendTo() Interop.Winsock.WSASend returns:" + errorCode.ToString() + " size:" + size + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginSendTo() Interop.Winsock.WSASend returns:" + errorCode.ToString() + " size:" + size + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+                }
             }
             catch (ObjectDisposedException)
             {
@@ -2942,7 +3048,10 @@ namespace System.Net.Sockets
                 throw socketException;
             }
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginSendTo() size:" + size.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginSendTo() size:" + size.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+            }
         }
 
         // Routine Description:
@@ -2999,7 +3108,10 @@ namespace System.Net.Sockets
                 }
             }
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::EndSendTo() bytesTransferred:" + bytesTransferred.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::EndSendTo() bytesTransferred:" + bytesTransferred.ToString());
+            }
 
             // Throw an appropriate SocketException if the native call failed asynchronously.
             if ((SocketError)castedAsyncResult.ErrorCode != SocketError.Success)
@@ -3129,7 +3241,10 @@ namespace System.Net.Sockets
 
         private SocketError DoBeginReceive(byte[] buffer, int offset, int size, SocketFlags socketFlags, OverlappedAsyncResult asyncResult)
         {
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginReceive() size:" + size.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginReceive() size:" + size.ToString());
+            }
 
 #if DEBUG
             IntPtr lastHandle = _handle.DangerousGetHandle();
@@ -3141,7 +3256,10 @@ namespace System.Net.Sockets
             {
                 errorCode = SocketPal.ReceiveAsync(_handle, buffer, offset, size, socketFlags, asyncResult);
 
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginReceive() Interop.Winsock.WSARecv returns:" + errorCode.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginReceive() Interop.Winsock.WSARecv returns:" + errorCode.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+                }
             }
             finally
             {
@@ -3151,7 +3269,10 @@ namespace System.Net.Sockets
             // Throw an appropriate SocketException if the native call fails synchronously.
             if (errorCode != SocketError.Success)
             {
-                GlobalLog.AssertFormat("Socket#{0}::DoBeginReceive()|GetLastWin32Error() returned zero.", LoggingHash.HashString(this));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.AssertFormat("Socket#{0}::DoBeginReceive()|GetLastWin32Error() returned zero.", LoggingHash.HashString(this));
+                }
 
                 // Update the internal state of this socket according to the error before throwing.
                 UpdateStatusAfterSocketError(errorCode);
@@ -3244,7 +3365,10 @@ namespace System.Net.Sockets
             {
                 errorCode = SocketPal.ReceiveAsync(_handle, buffers, socketFlags, asyncResult);
 
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginReceive() Interop.Winsock.WSARecv returns:" + errorCode.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginReceive() Interop.Winsock.WSARecv returns:" + errorCode.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+                }
             }
             finally
             {
@@ -3379,7 +3503,11 @@ namespace System.Net.Sockets
             {
                 NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginReceiveMessageFrom", "");
             }
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginReceiveMessageFrom() size:" + size.ToString());
+
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginReceiveMessageFrom() size:" + size.ToString());
+            }
 
             if (CleanedUp)
             {
@@ -3448,12 +3576,19 @@ namespace System.Net.Sockets
                     // That same map is implemented here just in case.
                     if (errorCode == SocketError.MessageSize)
                     {
-                        GlobalLog.Assert("Socket#" + LoggingHash.HashString(this) + "::BeginReceiveMessageFrom()|Returned WSAEMSGSIZE!");
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.Assert("Socket#" + LoggingHash.HashString(this) + "::BeginReceiveMessageFrom()|Returned WSAEMSGSIZE!");
+                        }
+
                         errorCode = SocketError.IOPending;
                     }
                 }
 
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginReceiveMessageFrom() Interop.Winsock.WSARecvMsg returns:" + errorCode.ToString() + " size:" + size.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginReceiveMessageFrom() Interop.Winsock.WSARecvMsg returns:" + errorCode.ToString() + " size:" + size.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+                }
             }
             catch (ObjectDisposedException)
             {
@@ -3493,7 +3628,11 @@ namespace System.Net.Sockets
                 }
             }
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginReceiveMessageFrom() size:" + size.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginReceiveMessageFrom() size:" + size.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+            }
+
             if (s_loggingEnabled)
             {
                 NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginReceiveMessageFrom", asyncResult);
@@ -3565,7 +3704,10 @@ namespace System.Net.Sockets
                 }
             }
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::EndReceiveMessageFrom() bytesTransferred:" + bytesTransferred.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::EndReceiveMessageFrom() bytesTransferred:" + bytesTransferred.ToString());
+            }
 
             // Throw an appropriate SocketException if the native call failed asynchronously.
             if ((SocketError)castedAsyncResult.ErrorCode != SocketError.Success && (SocketError)castedAsyncResult.ErrorCode != SocketError.MessageSize)
@@ -3689,7 +3831,10 @@ namespace System.Net.Sockets
         private void DoBeginReceiveFrom(byte[] buffer, int offset, int size, SocketFlags socketFlags, EndPoint endPointSnapshot, Internals.SocketAddress socketAddress, OverlappedAsyncResult asyncResult)
         {
             EndPoint oldEndPoint = _rightEndPoint;
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginReceiveFrom() size:" + size.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginReceiveFrom() size:" + size.ToString());
+            }
 
             // Guarantee to call CheckAsyncCallOverlappedResult if we call SetUnamangedStructures with a cache in order to
             // avoid a Socket leak in case of error.
@@ -3706,7 +3851,10 @@ namespace System.Net.Sockets
 
                 errorCode = SocketPal.ReceiveFromAsync(_handle, buffer, offset, size, socketFlags, socketAddress, asyncResult);
 
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginReceiveFrom() Interop.Winsock.WSARecvFrom returns:" + errorCode.ToString() + " size:" + size.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginReceiveFrom() Interop.Winsock.WSARecvFrom returns:" + errorCode.ToString() + " size:" + size.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+                }
             }
             catch (ObjectDisposedException)
             {
@@ -3732,7 +3880,10 @@ namespace System.Net.Sockets
                 throw socketException;
             }
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginReceiveFrom() size:" + size.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginReceiveFrom() size:" + size.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+            }
         }
 
         // Routine Description:
@@ -3814,7 +3965,10 @@ namespace System.Net.Sockets
                 }
             }
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::EndReceiveFrom() bytesTransferred:" + bytesTransferred.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::EndReceiveFrom() bytesTransferred:" + bytesTransferred.ToString());
+            }
 
             // Throw an appropriate SocketException if the native call failed asynchronously.
             if ((SocketError)castedAsyncResult.ErrorCode != SocketError.Success)
@@ -3924,14 +4078,20 @@ namespace System.Net.Sockets
             SafeCloseSocket acceptHandle;
             asyncResult.AcceptSocket = GetOrCreateAcceptSocket(acceptSocket, false, "acceptSocket", out acceptHandle);
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginAccept() AcceptSocket:" + LoggingHash.HashString(acceptSocket));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginAccept() AcceptSocket:" + LoggingHash.HashString(acceptSocket));
+            }
 
             int socketAddressSize = _rightEndPoint.Serialize().Size;
             SocketError errorCode = SocketPal.AcceptAsync(this, _handle, acceptHandle, receiveSize, socketAddressSize, asyncResult);
 
             errorCode = asyncResult.CheckAsyncCallOverlappedResult(errorCode);
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginAccept() Interop.Winsock.AcceptEx returns:" + errorCode.ToString() + LoggingHash.HashString(asyncResult));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginAccept() Interop.Winsock.AcceptEx returns:" + errorCode.ToString() + LoggingHash.HashString(asyncResult));
+            }
 
             // Throw an appropriate SocketException if the native call fails synchronously.
             if (errorCode != SocketError.Success)
@@ -4058,12 +4218,18 @@ namespace System.Net.Sockets
                 throw new ObjectDisposedException(this.GetType().FullName);
             }
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Shutdown() how:" + how.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Shutdown() how:" + how.ToString());
+            }
 
             // This can throw ObjectDisposedException.
             SocketError errorCode = SocketPal.Shutdown(_handle, _isConnected, _isDisconnected, how);
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Shutdown() Interop.Winsock.shutdown returns errorCode:" + errorCode);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Shutdown() Interop.Winsock.shutdown returns errorCode:" + errorCode);
+            }
 
             // Skip good cases: success, socket already closed.
             if (errorCode != SocketError.Success && errorCode != SocketError.NotSocket)
@@ -4986,7 +5152,10 @@ namespace System.Net.Sockets
                 _rightEndPoint = endPointSnapshot;
             }
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoConnect() connection to:" + endPointSnapshot.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoConnect() connection to:" + endPointSnapshot.ToString());
+            }
 
             // Update state and performance counters.
             SetToConnected();
@@ -5006,7 +5175,11 @@ namespace System.Net.Sockets
 
             try
             {
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Dispose() disposing:true CleanedUp:" + CleanedUp.ToString());
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Dispose() disposing:true CleanedUp:" + CleanedUp.ToString());
+                }
+
                 if (s_loggingEnabled)
                 {
                     NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Dispose", null);
@@ -5057,7 +5230,11 @@ namespace System.Net.Sockets
                 if (timeout == 0)
                 {
                     // Abortive.
-                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Dispose() Calling _handle.Dispose()");
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Dispose() Calling _handle.Dispose()");
+                    }
+
                     _handle.Dispose();
                 }
                 else
@@ -5069,20 +5246,30 @@ namespace System.Net.Sockets
                     {
                         bool willBlock;
                         errorCode = SocketPal.SetBlocking(_handle, false, out willBlock);
-                        GlobalLog.Print("SafeCloseSocket::Dispose(handle:" + _handle.DangerousGetHandle().ToString("x") + ") ioctlsocket(FIONBIO):" + errorCode.ToString());
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.Print("SafeCloseSocket::Dispose(handle:" + _handle.DangerousGetHandle().ToString("x") + ") ioctlsocket(FIONBIO):" + errorCode.ToString());
+                        }
                     }
 
                     if (timeout < 0)
                     {
                         // Close with existing user-specified linger option.
-                        GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Dispose() Calling _handle.CloseAsIs()");
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Dispose() Calling _handle.CloseAsIs()");
+                        }
+
                         _handle.CloseAsIs();
                     }
                     else
                     {
                         // Since our timeout is in ms and linger is in seconds, implement our own sortof linger here.
                         errorCode = SocketPal.Shutdown(_handle, _isConnected, _isDisconnected, SocketShutdown.Send);
-                        GlobalLog.Print("SafeCloseSocket::Dispose(handle:" + _handle.DangerousGetHandle().ToString("x") + ") shutdown():" + errorCode.ToString());
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.Print("SafeCloseSocket::Dispose(handle:" + _handle.DangerousGetHandle().ToString("x") + ") shutdown():" + errorCode.ToString());
+                        }
 
                         // This should give us a timeout in milliseconds.
                         errorCode = SocketPal.SetSockOpt(
@@ -5090,7 +5277,10 @@ namespace System.Net.Sockets
                             SocketOptionLevel.Socket,
                             SocketOptionName.ReceiveTimeout,
                             timeout);
-                        GlobalLog.Print("SafeCloseSocket::Dispose(handle:" + _handle.DangerousGetHandle().ToString("x") + ") setsockopt():" + errorCode.ToString());
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.Print("SafeCloseSocket::Dispose(handle:" + _handle.DangerousGetHandle().ToString("x") + ") setsockopt():" + errorCode.ToString());
+                        }
 
                         if (errorCode != SocketError.Success)
                         {
@@ -5100,7 +5290,10 @@ namespace System.Net.Sockets
                         {
                             int unused;
                             errorCode = SocketPal.Receive(_handle, null, 0, 0, SocketFlags.None, out unused);
-                            GlobalLog.Print("SafeCloseSocket::Dispose(handle:" + _handle.DangerousGetHandle().ToString("x") + ") recv():" + errorCode.ToString());
+                            if (GlobalLog.IsEnabled)
+                            {
+                                GlobalLog.Print("SafeCloseSocket::Dispose(handle:" + _handle.DangerousGetHandle().ToString("x") + ") recv():" + errorCode.ToString());
+                            }
 
                             if (errorCode != (SocketError)0)
                             {
@@ -5112,7 +5305,10 @@ namespace System.Net.Sockets
                                 // We got a FIN or data.  Use ioctlsocket to find out which.
                                 int dataAvailable = 0;
                                 errorCode = SocketPal.GetAvailable(_handle, out dataAvailable);
-                                GlobalLog.Print("SafeCloseSocket::Dispose(handle:" + _handle.DangerousGetHandle().ToString("x") + ") ioctlsocket(FIONREAD):" + errorCode.ToString());
+                                if (GlobalLog.IsEnabled)
+                                {
+                                    GlobalLog.Print("SafeCloseSocket::Dispose(handle:" + _handle.DangerousGetHandle().ToString("x") + ") ioctlsocket(FIONREAD):" + errorCode.ToString());
+                                }
 
                                 if (errorCode != SocketError.Success || dataAvailable != 0)
                                 {
@@ -5142,7 +5338,11 @@ namespace System.Net.Sockets
 
         public void Dispose()
         {
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Dispose() timeout = " + _closeTimeout);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Dispose() timeout = " + _closeTimeout);
+            }
+
             if (s_loggingEnabled)
             {
                 NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Dispose", null);
@@ -5163,7 +5363,10 @@ namespace System.Net.Sockets
         // This version does not throw.
         internal void InternalShutdown(SocketShutdown how)
         {
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::InternalShutdown() how:" + how.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::InternalShutdown() how:" + how.ToString());
+            }
 
             if (CleanedUp || _handle.IsInvalid)
             {
@@ -5210,10 +5413,17 @@ namespace System.Net.Sockets
 
         internal unsafe void SetSocketOption(SocketOptionLevel optionLevel, SocketOptionName optionName, int optionValue, bool silent)
         {
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetSocketOption() optionLevel:" + optionLevel + " optionName:" + optionName + " optionValue:" + optionValue + " silent:" + silent);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetSocketOption() optionLevel:" + optionLevel + " optionName:" + optionName + " optionValue:" + optionValue + " silent:" + silent);
+            }
+
             if (silent && (CleanedUp || _handle.IsInvalid))
             {
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetSocketOption() skipping the call");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetSocketOption() skipping the call");
+                }
                 return;
             }
             SocketError errorCode = SocketError.Success;
@@ -5221,7 +5431,10 @@ namespace System.Net.Sockets
             {
                 errorCode = SocketPal.SetSockOpt(_handle, optionLevel, optionName, optionValue);
 
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetSocketOption() Interop.Winsock.setsockopt returns errorCode:" + errorCode);
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetSocketOption() Interop.Winsock.setsockopt returns errorCode:" + errorCode);
+                }
             }
             catch
             {
@@ -5262,7 +5475,10 @@ namespace System.Net.Sockets
         {
             SocketError errorCode = SocketPal.SetMulticastOption(_handle, optionName, MR);
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::setMulticastOption() Interop.Winsock.setsockopt returns errorCode:" + errorCode);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::setMulticastOption() Interop.Winsock.setsockopt returns errorCode:" + errorCode);
+            }
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -5283,7 +5499,10 @@ namespace System.Net.Sockets
         {
             SocketError errorCode = SocketPal.SetIPv6MulticastOption(_handle, optionName, MR);
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::setIPv6MulticastOption() Interop.Winsock.setsockopt returns errorCode:" + errorCode);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::setIPv6MulticastOption() Interop.Winsock.setsockopt returns errorCode:" + errorCode);
+            }
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -5303,7 +5522,10 @@ namespace System.Net.Sockets
         {
             SocketError errorCode = SocketPal.SetLingerOption(_handle, lref);
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::setLingerOption() Interop.Winsock.setsockopt returns errorCode:" + errorCode);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::setLingerOption() Interop.Winsock.setsockopt returns errorCode:" + errorCode);
+            }
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -5324,7 +5546,10 @@ namespace System.Net.Sockets
             LingerOption lingerOption;
             SocketError errorCode = SocketPal.GetLingerOption(_handle, out lingerOption);
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::getLingerOpt() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::getLingerOpt() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
+            }
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -5347,8 +5572,10 @@ namespace System.Net.Sockets
             MulticastOption multicastOption;
             SocketError errorCode = SocketPal.GetMulticastOption(_handle, optionName, out multicastOption);
 
-
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::getMulticastOpt() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::getMulticastOpt() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
+            }
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -5372,7 +5599,10 @@ namespace System.Net.Sockets
             IPv6MulticastOption multicastOption;
             SocketError errorCode = SocketPal.GetIPv6MulticastOption(_handle, optionName, out multicastOption);
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::getIPv6MulticastOpt() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::getIPv6MulticastOpt() Interop.Winsock.getsockopt returns errorCode:" + errorCode);
+            }
 
             // Throw an appropriate SocketException if the native call fails.
             if (errorCode != SocketError.Success)
@@ -5415,7 +5645,10 @@ namespace System.Net.Sockets
                 errorCode = SocketError.NotSocket;
             }
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::InternalSetBlocking() Interop.Winsock.ioctlsocket returns errorCode:" + errorCode);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::InternalSetBlocking() Interop.Winsock.ioctlsocket returns errorCode:" + errorCode);
+            }
 
             // We will update only internal state but only on successfull win32 call
             // so if the native call fails, the state will remain the same.
@@ -5454,7 +5687,7 @@ namespace System.Net.Sockets
             // called if _rightEndPoint is not null, of that the endpoint is an IPEndPoint.
             if (_rightEndPoint == null)
             {
-                if (endPointSnapshot.GetType() != typeof(IPEndPoint))
+                if (endPointSnapshot.GetType() != typeof(IPEndPoint) && GlobalLog.IsEnabled)
                 {
                     GlobalLog.AssertFormat("Socket#{0}::BeginConnectEx()|Socket not bound and endpoint not IPEndPoint.", LoggingHash.HashString(this));
                 }
@@ -5504,7 +5737,10 @@ namespace System.Net.Sockets
                 SetToConnected();
             }
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginConnectEx() Interop.Winsock.connect returns:" + errorCode.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginConnectEx() Interop.Winsock.connect returns:" + errorCode.ToString());
+            }
 
             errorCode = asyncResult.CheckAsyncCallOverlappedResult(errorCode);
 
@@ -5526,7 +5762,11 @@ namespace System.Net.Sockets
             // This is a nop if the context isn't being flowed.
             asyncResult.FinishPostingAsyncOp(ref Caches.ConnectClosureCache);
 
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginConnectEx() to:" + endPointSnapshot.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginConnectEx() to:" + endPointSnapshot.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
+            }
+
             if (s_loggingEnabled)
             {
                 NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginConnectEx", asyncResult);
@@ -5803,7 +6043,10 @@ namespace System.Net.Sockets
             // some point in time update the perf counter as well.
             _isConnected = true;
             _isDisconnected = false;
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetToConnected() now connected.");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetToConnected() now connected.");
+            }
             if (s_perfCountersEnabled)
             {
                 SocketPerfCounter.Instance.Increment(SocketPerfCounterName.SocketConnectionsEstablished);
@@ -5812,7 +6055,11 @@ namespace System.Net.Sockets
 
         internal void SetToDisconnected()
         {
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetToDisconnected()");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetToDisconnected()");
+            }
+
             if (!_isConnected)
             {
                 // Socket was already disconnected.
@@ -5824,7 +6071,7 @@ namespace System.Net.Sockets
             _isConnected = false;
             _isDisconnected = true;
 
-            if (!CleanedUp)
+            if (!CleanedUp && GlobalLog.IsEnabled)
             {
                 // If socket is still alive cancel WSAEventSelect().
                 GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::SetToDisconnected()");
@@ -5843,7 +6090,11 @@ namespace System.Net.Sockets
         {
             // If we already know the socket is disconnected
             // we don't need to do anything else.
-            GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::UpdateStatusAfterSocketError(socketException)");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::UpdateStatusAfterSocketError(socketException)");
+            }
+
             if (s_loggingEnabled)
             {
                 NetEventSource.PrintError(NetEventSource.ComponentType.Socket, this, "UpdateStatusAfterSocketError", errorCode.ToString());
@@ -5854,7 +6105,11 @@ namespace System.Net.Sockets
                     errorCode != SocketError.TimedOut)))
             {
                 // The socket is no longer a valid socket.
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::UpdateStatusAfterSocketError(socketException) Invalidating socket.");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::UpdateStatusAfterSocketError(socketException) Invalidating socket.");
+                }
+
                 SetToDisconnected();
             }
         }
@@ -5873,7 +6128,8 @@ namespace System.Net.Sockets
         #endregion
 
         [System.Diagnostics.Conditional("TRACE_VERBOSE")]
-        internal void DebugMembers() {
+        internal void DebugMembers()
+        {
             GlobalLog.Print("_handle:" + _handle.DangerousGetHandle().ToString("x") );
             GlobalLog.Print("_isConnected: " + _isConnected);
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -132,21 +132,27 @@ namespace System.Net.Sockets
             if (_preAllocatedOverlapped != null)
             {
                 overlapped = boundHandle.AllocateNativeOverlapped(_preAllocatedOverlapped);
-                GlobalLog.Print(
-                    "SocketAsyncEventArgs#" + LoggingHash.HashString(this) +
-                    "::boundHandle#" + LoggingHash.HashString(boundHandle) +
-                    "::AllocateNativeOverlapped(m_PreAllocatedOverlapped=" +
-                    LoggingHash.HashString(_preAllocatedOverlapped) +
-                    "). Returned = " + ((IntPtr)overlapped).ToString("x"));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print(
+                        "SocketAsyncEventArgs#" + LoggingHash.HashString(this) +
+                        "::boundHandle#" + LoggingHash.HashString(boundHandle) +
+                        "::AllocateNativeOverlapped(m_PreAllocatedOverlapped=" +
+                        LoggingHash.HashString(_preAllocatedOverlapped) +
+                        "). Returned = " + ((IntPtr)overlapped).ToString("x"));
+                }
             }
             else
             {
                 overlapped = boundHandle.AllocateNativeOverlapped(CompletionPortCallback, this, null);
-                GlobalLog.Print(
-                    "SocketAsyncEventArgs#" + LoggingHash.HashString(this) +
-                    "::boundHandle#" + LoggingHash.HashString(boundHandle) +
-                    "::AllocateNativeOverlapped(pinData=null)" +
-                    "). Returned = " + ((IntPtr)overlapped).ToString("x"));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print(
+                        "SocketAsyncEventArgs#" + LoggingHash.HashString(this) +
+                        "::boundHandle#" + LoggingHash.HashString(boundHandle) +
+                        "::AllocateNativeOverlapped(pinData=null)" +
+                        "). Returned = " + ((IntPtr)overlapped).ToString("x"));
+                }
             }
 
             Debug.Assert(overlapped != null, "NativeOverlapped is null.");
@@ -869,10 +875,13 @@ namespace System.Net.Sockets
                 if (_buffer != null)
                 {
                     _preAllocatedOverlapped = new PreAllocatedOverlapped(CompletionPortCallback, this, _buffer);
-                    GlobalLog.Print(
-                        "SocketAsyncEventArgs#" + LoggingHash.HashString(this) +
-                        "::SetupOverlappedSingle: new PreAllocatedOverlapped pinSingleBuffer=true, non-null buffer: " +
-                        LoggingHash.HashString(_preAllocatedOverlapped));
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Print(
+                            "SocketAsyncEventArgs#" + LoggingHash.HashString(this) +
+                            "::SetupOverlappedSingle: new PreAllocatedOverlapped pinSingleBuffer=true, non-null buffer: " +
+                            LoggingHash.HashString(_preAllocatedOverlapped));
+                    }
 
                     _pinnedSingleBuffer = _buffer;
                     _pinnedSingleBufferOffset = _offset;
@@ -886,10 +895,13 @@ namespace System.Net.Sockets
                 else
                 {
                     _preAllocatedOverlapped = new PreAllocatedOverlapped(CompletionPortCallback, this, null);
-                    GlobalLog.Print(
-                        "SocketAsyncEventArgs#" + LoggingHash.HashString(this) +
-                        "::SetupOverlappedSingle: new PreAllocatedOverlapped pinSingleBuffer=true, null buffer: " +
-                        LoggingHash.HashString(_preAllocatedOverlapped));
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Print(
+                            "SocketAsyncEventArgs#" + LoggingHash.HashString(this) +
+                            "::SetupOverlappedSingle: new PreAllocatedOverlapped pinSingleBuffer=true, null buffer: " +
+                            LoggingHash.HashString(_preAllocatedOverlapped));
+                    }
 
                     _pinnedSingleBuffer = null;
                     _pinnedSingleBufferOffset = 0;
@@ -904,10 +916,13 @@ namespace System.Net.Sockets
             else
             {
                 _preAllocatedOverlapped = new PreAllocatedOverlapped(CompletionPortCallback, this, _acceptBuffer);
-                GlobalLog.Print(
-                    "SocketAsyncEventArgs#" + LoggingHash.HashString(this) +
-                    "::SetupOverlappedSingle: new PreAllocatedOverlapped pinSingleBuffer=false: " +
-                    LoggingHash.HashString(_preAllocatedOverlapped));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print(
+                        "SocketAsyncEventArgs#" + LoggingHash.HashString(this) +
+                        "::SetupOverlappedSingle: new PreAllocatedOverlapped pinSingleBuffer=false: " +
+                        LoggingHash.HashString(_preAllocatedOverlapped));
+                }
 
                 _pinnedAcceptBuffer = _acceptBuffer;
                 _ptrAcceptBuffer = Marshal.UnsafeAddrOfPinnedArrayElement(_acceptBuffer, 0);
@@ -942,9 +957,12 @@ namespace System.Net.Sockets
 
             // Pin buffers and fill in WSABuffer descriptor pointers and lengths.
             _preAllocatedOverlapped = new PreAllocatedOverlapped(CompletionPortCallback, this, _objectsToPin);
-            GlobalLog.Print(
-                "SocketAsyncEventArgs#" + LoggingHash.HashString(this) + "::SetupOverlappedMultiple: new PreAllocatedOverlapped." +
-                LoggingHash.HashString(_preAllocatedOverlapped));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print(
+                    "SocketAsyncEventArgs#" + LoggingHash.HashString(this) + "::SetupOverlappedMultiple: new PreAllocatedOverlapped." +
+                    LoggingHash.HashString(_preAllocatedOverlapped));
+            }
 
             for (int i = 0; i < tempList.Length; i++)
             {
@@ -986,9 +1004,12 @@ namespace System.Net.Sockets
 
             // Pin buffers.
             _preAllocatedOverlapped = new PreAllocatedOverlapped(CompletionPortCallback, this, _objectsToPin);
-            GlobalLog.Print(
-                "SocketAsyncEventArgs#" + LoggingHash.HashString(this) + "::SetupOverlappedSendPackets: new PreAllocatedOverlapped: " +
-                LoggingHash.HashString(_preAllocatedOverlapped));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print(
+                    "SocketAsyncEventArgs#" + LoggingHash.HashString(this) + "::SetupOverlappedSendPackets: new PreAllocatedOverlapped: " +
+                    LoggingHash.HashString(_preAllocatedOverlapped));
+            }
 
             // Get pointer to native descriptor.
             _ptrSendPacketsDescriptor = Marshal.UnsafeAddrOfPinnedArrayElement(_sendPacketsDescriptor, 0);

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -508,7 +508,10 @@ namespace System.Net.Sockets
                 {
                     // Otherwise we're doing a normal ConnectAsync - cancel it by closing the socket.
                     // _currentSocket will only be null if _multipleConnect was set, so we don't have to check.
-                    GlobalLog.Assert(_currentSocket != null, "SocketAsyncEventArgs::CancelConnectAsync - CurrentSocket and MultipleConnect both null!");
+                    if (_currentSocket == null && GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Assert("SocketAsyncEventArgs::CancelConnectAsync - CurrentSocket and MultipleConnect both null!");
+                    }
                     _currentSocket.Dispose();
                 }
             }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Windows.cs
@@ -694,7 +694,10 @@ namespace System.Net.Sockets
                         IntPtr.Zero);
             }
 
-            GlobalLog.Print("Socket::Select() Interop.Winsock.select returns socketCount:" + socketCount);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket::Select() Interop.Winsock.select returns socketCount:" + socketCount);
+            }
 
             if ((SocketError)socketCount == SocketError.SocketError)
             {


### PR DESCRIPTION
Logging work that's happening in System.Net.Sockets in release builds and even when logging is disabled is resulting in significant impact on both memory allocated and on throughput.

This set of commits adjusts how the logging is done so that work which happens at the call site only occurs if logging is enabled, if an assertion's condition fails, etc.  This includes lots of string allocation, array allocation, array copies, hashing, etc.

@pgavlin shared with me a simple set of tests that just have a client connect up to a server and receive a bunch of data.  Prior to these changes, running this test with 4096 clients receiving 128 bytes each, the test client allocated ~45MB.  After these changes, the client allocated only ~15MB.  Throughput on the client also improved by ~20% on my machine.  (This is on Windows with a release build of System.Net.Sockets.dll and with logging disabled.)

cc: @pgavlin, @CIPop, @davidsh, @ericeil, @josguil 

Example before:
![image](https://cloud.githubusercontent.com/assets/2642209/12184632/620b0a1e-b564-11e5-9d48-b45e9884809b.png)

Example after:
![image](https://cloud.githubusercontent.com/assets/2642209/12184576/0b3dce42-b564-11e5-9e3c-99871f89631c.png)