### PR TITLE
Fix some x-plat build breaks

### DIFF
--- a/src/Microsoft.VisualBasic/pkg/Microsoft.VisualBasic.builds
+++ b/src/Microsoft.VisualBasic/pkg/Microsoft.VisualBasic.builds
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="Microsoft.VisualBasic.pkgproj"/>
+    <Project Include="Microsoft.VisualBasic.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/Microsoft.VisualBasic/src/Microsoft.VisualBasic.builds
+++ b/src/Microsoft.VisualBasic/src/Microsoft.VisualBasic.builds
@@ -2,7 +2,8 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="Microsoft.VisualBasic.vbproj" />
+    <!-- Temporary workaround, VisualBasic projects cannot be built on non-Windows platforms. See issue #5230. -->
+    <Project Include="Microsoft.VisualBasic.vbproj" Condition="'$(OSEnvironment)' == 'Windows_NT'" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Runtime.WindowsRuntime.UI.Xaml/src/System.Runtime.WindowsRuntime.UI.Xaml.csproj
+++ b/src/System.Runtime.WindowsRuntime.UI.Xaml/src/System.Runtime.WindowsRuntime.UI.Xaml.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyName>System.Runtime.WindowsRuntime.UI.Xaml</AssemblyName>
     <ProjectGuid>{263DA4F1-C3BC-4B43-98E7-9F38B419A131}</ProjectGuid>
-    <UseECMAKey>true</UseECMAKey>
+    <UseECMAKey Condition="'$(UseECMAKey)' == ''">true</UseECMAKey>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)'==''">dotnet5.3</PackageTargetFramework>
     <PackageTargetRuntime>win8</PackageTargetRuntime>


### PR DESCRIPTION
* Disable Microsoft.VisualBasic on non-Windows platforms, see #5230 
* System.Runtime.WindowsRuntime.UI.Xaml was overriding UseECMAKey even when set to false. This shouldn't be overridden because the ECMA key can't be used on x-plat builds.

Part of #5199 