### PR TITLE
Clean up some globalization tests

### DIFF
--- a/src/System.Globalization/tests/CompareInfo/CompareInfoCompare2.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoCompare2.cs
@@ -57,17 +57,6 @@ namespace System.Globalization.Tests
             }
         }
 
-        // PosTest4: Test Hungarian Culture
-        [Fact]
-        public void TestHungarianCulture()
-        {
-            CultureInfo oldCi = CultureInfo.CurrentCulture;
-            CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("hu-HU");
-            TestStrings("dzsdzs", "ddzs");
-            CultureInfo.DefaultThreadCurrentCulture = oldCi;
-            TestStrings("\u00C0nimal", "A\u0300nimal");
-        }
-
         private void TestStrings(string str1, string str2)
         {
             int expectValue = PredictValue(str1, str2);

--- a/src/System.Globalization/tests/CompareInfo/CompareInfoIndexOf2.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoIndexOf2.cs
@@ -41,17 +41,6 @@ namespace System.Globalization.Tests
             }
         }
 
-        // PosTest3: Specific regression cases
-        [Fact]
-        public void RegressionTests()
-        {
-            CultureInfo oldCi = CultureInfo.CurrentCulture;
-            CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("hu-HU");
-            TestStrings("Foodzsdzsbar", "ddzs");
-            CultureInfo.DefaultThreadCurrentCulture = oldCi;
-            TestStrings("\u00C0nimal", "A\u0300");
-        }
-
         private void TestStrings(string str1, string str2)
         {
             int expectValue = PredictValue(str1, str2);

--- a/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetInstance.cs
+++ b/src/System.Globalization/tests/DateTimeFormatInfo/DateTimeFormatInfoGetInstance.cs
@@ -35,7 +35,6 @@ namespace System.Globalization.Tests
 
         // PosTest2: Call GetInstance to get an DateTimeFormatInfo instance when provider is null reference
         [Fact]
-        [ActiveIssue(3421, PlatformID.AnyUnix)] 
         public void PosTest2()
         {
             DateTimeFormatInfo info = DateTimeFormatInfo.GetInstance(null);
@@ -60,7 +59,6 @@ namespace System.Globalization.Tests
 
         // PosTest5: Call GetInstance to get an DateTimeFormatInfo instance when provider.GetFormat method does not support a DateTimeFormatInfo instance
         [Fact]
-        [ActiveIssue(3421, PlatformID.AnyUnix)]
         public void PosTest5()
         {
             DateTimeFormatInfo info = DateTimeFormatInfo.GetInstance(new TestIFormatProviderClass());


### PR DESCRIPTION
- Remove some legacy tests that were setting DefaultThreadCulture to
  "hu-HU". We have coverage elsewhere from tests that don't modify
  global shared state and the way the tests were written the
  modifications did not do what was expected (i.e. force TestStrings
  to use a different culture)

- Enable some tests disabled against #3421.  I believe that these were
  due to races in the tests which were screwing with the current
  culture for a thread in and not resetting it and these issues should
  be addressed now (I audited the code that actually sets
  CurrentCulture for a thread).

Fixes #3421