### PR TITLE
Guard logging usage behind IsEnabled checks in the rest of System.Net.*

### DIFF
--- a/src/Common/src/Interop/Windows/SChannel/SslConnectionInfo.cs
+++ b/src/Common/src/Interop/Windows/SChannel/SslConnectionInfo.cs
@@ -37,7 +37,10 @@ namespace System.Net
                 }
                 catch (OverflowException)
                 {
-                    GlobalLog.Assert(false, "SslConnectionInfo::.ctor", "Negative size.");
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Assert("SslConnectionInfo::.ctor", "Negative size.");
+                    }
                     throw;
                 }
             }

--- a/src/Common/src/Interop/Windows/secur32/SSPIWrapper.cs
+++ b/src/Common/src/Interop/Windows/secur32/SSPIWrapper.cs
@@ -424,10 +424,19 @@ namespace System.Net
                                 }
                             }
                         }
-                        
+
                         // Backup validate the new sizes.
-                        GlobalLog.Assert(iBuffer.offset >= 0 && iBuffer.offset <= (iBuffer.token == null ? 0 : iBuffer.token.Length), "SSPIWrapper::EncryptDecryptHelper|'offset' out of range.  [{0}]", iBuffer.offset);
-                        GlobalLog.Assert(iBuffer.size >= 0 && iBuffer.size <= (iBuffer.token == null ? 0 : iBuffer.token.Length - iBuffer.offset), "SSPIWrapper::EncryptDecryptHelper|'size' out of range.  [{0}]", iBuffer.size);
+                        if (GlobalLog.IsEnabled)
+                        {
+                            if (iBuffer.offset == 0 || iBuffer.offset > (iBuffer.token == null ? 0 : iBuffer.token.Length))
+                            {
+                                GlobalLog.AssertFormat("SSPIWrapper::EncryptDecryptHelper|'offset' out of range.  [{0}]", iBuffer.offset);
+                            }
+                            if (iBuffer.size == 0 || iBuffer.size > (iBuffer.token == null ? 0 : iBuffer.token.Length - iBuffer.offset))
+                            {
+                                GlobalLog.AssertFormat("SSPIWrapper::EncryptDecryptHelper|'size' out of range.  [{0}]", iBuffer.size);
+                            }
+                        }
                     }
 
                     if (errorCode != 0 && NetEventSource.Log.IsEnabled())

--- a/src/Common/src/Interop/Windows/secur32/SecSizes.cs
+++ b/src/Common/src/Interop/Windows/secur32/SecSizes.cs
@@ -28,7 +28,10 @@ namespace System.Net
                 }
                 catch (OverflowException)
                 {
-                    GlobalLog.Assert(false, "SecSizes::.ctor", "Negative size.");
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Assert("SecSizes::.ctor", "Negative size.");
+                    }
                     throw;
                 }
             }

--- a/src/Common/src/Interop/Windows/secur32/SecuritySafeHandles.cs
+++ b/src/Common/src/Interop/Windows/secur32/SecuritySafeHandles.cs
@@ -225,10 +225,14 @@ namespace System.Net.Security
             ref Interop.Secur32.AuthIdentity authdata,
             out SafeFreeCredentials outCredential)
         {
-            GlobalLog.Print("SafeFreeCredentials::AcquireCredentialsHandle#1("
-                            + package + ", "
-                            + intent + ", "
-                            + authdata + ")");
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+            if (globalLogEnabled)
+            {
+                GlobalLog.Print("SafeFreeCredentials::AcquireCredentialsHandle#1("
+                                + package + ", "
+                                + intent + ", "
+                                + authdata + ")");
+            }
 
             int errorCode = -1;
             long timeStamp;
@@ -246,9 +250,12 @@ namespace System.Net.Security
                             ref outCredential._handle,
                             out timeStamp);
 #if TRACE_VERBOSE
-            GlobalLog.Print("Unmanaged::AcquireCredentialsHandle() returns 0x"
-                            + String.Format("{0:x}", errorCode)
-                            + ", handle = " + outCredential.ToString());
+            if (globalLogEnabled)
+            {
+                GlobalLog.Print("Unmanaged::AcquireCredentialsHandle() returns 0x"
+                                + String.Format("{0:x}", errorCode)
+                                + ", handle = " + outCredential.ToString());
+            }
 #endif
 
             if (errorCode != 0)
@@ -264,9 +271,13 @@ namespace System.Net.Security
             Interop.Secur32.CredentialUse intent,
             out SafeFreeCredentials outCredential)
         {
-            GlobalLog.Print("SafeFreeCredentials::AcquireDefaultCredential("
-                            + package + ", "
-                            + intent + ")");
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+            if (globalLogEnabled)
+            {
+                GlobalLog.Print("SafeFreeCredentials::AcquireDefaultCredential("
+                                + package + ", "
+                                + intent + ")");
+            }
 
             int errorCode = -1;
             long timeStamp;
@@ -285,9 +296,12 @@ namespace System.Net.Security
                             out timeStamp);
 
 #if TRACE_VERBOSE
-            GlobalLog.Print("Unmanaged::AcquireCredentialsHandle() returns 0x"
-                            + errorCode.ToString("x")
-                            + ", handle = " + outCredential.ToString());
+            if (globalLogEnabled)
+            {
+                GlobalLog.Print("Unmanaged::AcquireCredentialsHandle() returns 0x"
+                                + errorCode.ToString("x")
+                                + ", handle = " + outCredential.ToString());
+            }
 #endif
 
             if (errorCode != 0)
@@ -333,10 +347,14 @@ namespace System.Net.Security
             ref Interop.Secur32.SecureCredential authdata,
             out SafeFreeCredentials outCredential)
         {
-            GlobalLog.Print("SafeFreeCredentials::AcquireCredentialsHandle#2("
-                            + package + ", "
-                            + intent + ", "
-                            + authdata + ")");
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+            if (globalLogEnabled)
+            {
+                GlobalLog.Print("SafeFreeCredentials::AcquireCredentialsHandle#2("
+                                + package + ", "
+                                + intent + ", "
+                                + authdata + ")");
+            }
 
             int errorCode = -1;
             long timeStamp;
@@ -372,9 +390,12 @@ namespace System.Net.Security
             }
 
 #if TRACE_VERBOSE
-            GlobalLog.Print("Unmanaged::AcquireCredentialsHandle() returns 0x"
-                            + errorCode.ToString("x")
-                            + ", handle = " + outCredential.ToString());
+            if (globalLogEnabled)
+            {
+                GlobalLog.Print("Unmanaged::AcquireCredentialsHandle() returns 0x"
+                                + errorCode.ToString("x")
+                                + ", handle = " + outCredential.ToString());
+            }
 #endif
 
             if (errorCode != 0)
@@ -504,26 +525,39 @@ namespace System.Net.Security
             SecurityBuffer outSecBuffer,
             ref Interop.Secur32.ContextFlags outFlags)
         {
+            bool globalLogEnabled = GlobalLog.IsEnabled;
 #if TRACE_VERBOSE
-            GlobalLog.Enter("SafeDeleteContext::InitializeSecurityContext");
-            GlobalLog.Print("    credential       = " + inCredentials.ToString());
-            GlobalLog.Print("    refContext       = " + LoggingHash.ObjectToString(refContext));
-            GlobalLog.Print("    targetName       = " + targetName);
-            GlobalLog.Print("    inFlags          = " + inFlags);
-            GlobalLog.Print("    reservedI        = 0x0");
-            GlobalLog.Print("    endianness       = " + endianness);
+            if (globalLogEnabled)
+            {
+                GlobalLog.Enter("SafeDeleteContext::InitializeSecurityContext");
+                GlobalLog.Print("    credential       = " + inCredentials.ToString());
+                GlobalLog.Print("    refContext       = " + LoggingHash.ObjectToString(refContext));
+                GlobalLog.Print("    targetName       = " + targetName);
+                GlobalLog.Print("    inFlags          = " + inFlags);
+                GlobalLog.Print("    reservedI        = 0x0");
+                GlobalLog.Print("    endianness       = " + endianness);
 
-            if (inSecBuffers == null)
-            {
-                GlobalLog.Print("    inSecBuffers     = (null)");
-            }
-            else
-            {
-                GlobalLog.Print("    inSecBuffers[]   = length:" + inSecBuffers.Length);
+                if (inSecBuffers == null)
+                {
+                    GlobalLog.Print("    inSecBuffers     = (null)");
+                }
+                else
+                {
+                    GlobalLog.Print("    inSecBuffers[]   = length:" + inSecBuffers.Length);
+                }
             }
 #endif
-            GlobalLog.Assert(outSecBuffer != null, "SafeDeleteContext::InitializeSecurityContext()|outSecBuffer != null");
-            GlobalLog.Assert(inSecBuffer == null || inSecBuffers == null, "SafeDeleteContext::InitializeSecurityContext()|inSecBuffer == null || inSecBuffers == null");
+            if (globalLogEnabled)
+            {
+                if (outSecBuffer == null)
+                {
+                    GlobalLog.Assert("SafeDeleteContext::InitializeSecurityContext()|outSecBuffer != null");
+                }
+                if (inSecBuffer != null && inSecBuffers != null)
+                {
+                    GlobalLog.Assert("SafeDeleteContext::InitializeSecurityContext()|inSecBuffer == null || inSecBuffers == null");
+                }
+            }
 
             if (inCredentials == null)
             {
@@ -595,7 +629,10 @@ namespace System.Net.Security
                                     inUnmanagedBuffer[index].token = Marshal.UnsafeAddrOfPinnedArrayElement(securityBuffer.token, securityBuffer.offset);
                                 }
 #if TRACE_VERBOSE
-                                GlobalLog.Print("SecBuffer: cbBuffer:" + securityBuffer.size + " BufferType:" + securityBuffer.type);
+                                if (globalLogEnabled)
+                                {
+                                    GlobalLog.Print("SecBuffer: cbBuffer:" + securityBuffer.size + " BufferType:" + securityBuffer.type);
+                                }
 #endif
                             }
                         }
@@ -647,7 +684,11 @@ namespace System.Net.Security
                                             outFreeContextBuffer);
                         }
 
-                        GlobalLog.Print("SafeDeleteContext:InitializeSecurityContext  Marshalling OUT buffer");
+                        if (globalLogEnabled)
+                        {
+                            GlobalLog.Print("SafeDeleteContext:InitializeSecurityContext  Marshalling OUT buffer");
+                        }
+                        
                         // Get unmanaged buffer with index 0 as the only one passed into PInvoke.
                         outSecBuffer.size = outUnmanagedBuffer[0].count;
                         outSecBuffer.type = outUnmanagedBuffer[0].type;
@@ -686,7 +727,10 @@ namespace System.Net.Security
                 }
             }
 
-            GlobalLog.Leave("SafeDeleteContext::InitializeSecurityContext() unmanaged InitializeSecurityContext()", "errorCode:0x" + errorCode.ToString("x8") + " refContext:" + LoggingHash.ObjectToString(refContext));
+            if (globalLogEnabled)
+            {
+                GlobalLog.Leave("SafeDeleteContext::InitializeSecurityContext() unmanaged InitializeSecurityContext()", "errorCode:0x" + errorCode.ToString("x8") + " refContext:" + LoggingHash.ObjectToString(refContext));
+            }
 
             return errorCode;
         }
@@ -789,24 +833,37 @@ namespace System.Net.Security
             SecurityBuffer outSecBuffer,
             ref Interop.Secur32.ContextFlags outFlags)
         {
+            bool globalLogEnabled = GlobalLog.IsEnabled;
 #if TRACE_VERBOSE
-            GlobalLog.Enter("SafeDeleteContext::AcceptSecurityContex");
-            GlobalLog.Print("    credential       = " + inCredentials.ToString());
-            GlobalLog.Print("    refContext       = " + LoggingHash.ObjectToString(refContext));
-
-            GlobalLog.Print("    inFlags          = " + inFlags);
-
-            if (inSecBuffers == null)
+            if (globalLogEnabled)
             {
-                GlobalLog.Print("    inSecBuffers     = (null)");
-            }
-            else
-            {
-                GlobalLog.Print("    inSecBuffers[]   = length:" + inSecBuffers.Length);
+                GlobalLog.Enter("SafeDeleteContext::AcceptSecurityContex");
+                GlobalLog.Print("    credential       = " + inCredentials.ToString());
+                GlobalLog.Print("    refContext       = " + LoggingHash.ObjectToString(refContext));
+
+                GlobalLog.Print("    inFlags          = " + inFlags);
+
+                if (inSecBuffers == null)
+                {
+                    GlobalLog.Print("    inSecBuffers     = (null)");
+                }
+                else
+                {
+                    GlobalLog.Print("    inSecBuffers[]   = length:" + inSecBuffers.Length);
+                }
             }
 #endif
-            GlobalLog.Assert(outSecBuffer != null, "SafeDeleteContext::AcceptSecurityContext()|outSecBuffer != null");
-            GlobalLog.Assert(inSecBuffer == null || inSecBuffers == null, "SafeDeleteContext::AcceptSecurityContext()|inSecBuffer == null || inSecBuffers == null");
+            if (globalLogEnabled)
+            {
+                if (outSecBuffer == null)
+                {
+                    GlobalLog.Assert("SafeDeleteContext::AcceptSecurityContext()|outSecBuffer != null");
+                }
+                if (inSecBuffer != null && inSecBuffers != null)
+                {
+                    GlobalLog.Assert("SafeDeleteContext::AcceptSecurityContext()|inSecBuffer == null || inSecBuffers == null");
+                }
+            }
 
             if (inCredentials == null)
             {
@@ -878,7 +935,10 @@ namespace System.Net.Security
                                     inUnmanagedBuffer[index].token = Marshal.UnsafeAddrOfPinnedArrayElement(securityBuffer.token, securityBuffer.offset);
                                 }
 #if TRACE_VERBOSE
-                                GlobalLog.Print("SecBuffer: cbBuffer:" + securityBuffer.size + " BufferType:" + securityBuffer.type);
+                                if (globalLogEnabled)
+                                {
+                                    GlobalLog.Print("SecBuffer: cbBuffer:" + securityBuffer.size + " BufferType:" + securityBuffer.type);
+                                }
 #endif
                             }
                         }
@@ -923,7 +983,11 @@ namespace System.Net.Security
                                         ref outFlags,
                                         outFreeContextBuffer);
 
-                        GlobalLog.Print("SafeDeleteContext:AcceptSecurityContext  Marshalling OUT buffer");
+                        if (globalLogEnabled)
+                        {
+                            GlobalLog.Print("SafeDeleteContext:AcceptSecurityContext  Marshalling OUT buffer");
+                        }
+                        
                         // Get unmanaged buffer with index 0 as the only one passed into PInvoke.
                         outSecBuffer.size = outUnmanagedBuffer[0].count;
                         outSecBuffer.type = outUnmanagedBuffer[0].type;
@@ -963,7 +1027,10 @@ namespace System.Net.Security
                 }
             }
 
-            GlobalLog.Leave("SafeDeleteContext::AcceptSecurityContex() unmanaged AcceptSecurityContex()", "errorCode:0x" + errorCode.ToString("x8") + " refContext:" + LoggingHash.ObjectToString(refContext));
+            if (globalLogEnabled)
+            {
+                GlobalLog.Leave("SafeDeleteContext::AcceptSecurityContex() unmanaged AcceptSecurityContex()", "errorCode:0x" + errorCode.ToString("x8") + " refContext:" + LoggingHash.ObjectToString(refContext));
+            }
 
             return errorCode;
         }
@@ -1056,12 +1123,20 @@ namespace System.Net.Security
             ref SafeDeleteContext refContext,
             SecurityBuffer[] inSecBuffers)
         {
-            GlobalLog.Enter("SafeDeleteContext::CompleteAuthToken");
-            GlobalLog.Print("    refContext       = " + LoggingHash.ObjectToString(refContext));
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+            if (globalLogEnabled)
+            {
+                GlobalLog.Enter("SafeDeleteContext::CompleteAuthToken");
+                GlobalLog.Print("    refContext       = " + LoggingHash.ObjectToString(refContext));
 #if TRACE_VERBOSE
-            GlobalLog.Print("    inSecBuffers[]   = length:" + inSecBuffers.Length);
+                GlobalLog.Print("    inSecBuffers[]   = length:" + inSecBuffers.Length);
 #endif
-            GlobalLog.Assert(inSecBuffers != null, "SafeDeleteContext::CompleteAuthToken()|inSecBuffers == null");
+                if (inSecBuffers == null)
+                {
+                    GlobalLog.Assert("SafeDeleteContext::CompleteAuthToken()|inSecBuffers == null");
+                }
+            }
+
             var inSecurityBufferDescriptor = new Interop.Secur32.SecurityBufferDescriptor(inSecBuffers.Length);
 
             int errorCode = (int)Interop.SecurityStatus.InvalidHandle;
@@ -1099,7 +1174,10 @@ namespace System.Net.Security
                             inUnmanagedBuffer[index].token = Marshal.UnsafeAddrOfPinnedArrayElement(securityBuffer.token, securityBuffer.offset);
                         }
 #if TRACE_VERBOSE
-                        GlobalLog.Print("SecBuffer: cbBuffer:" + securityBuffer.size + " BufferType:" + securityBuffer.type);
+                        if (globalLogEnabled)
+                        {
+                            GlobalLog.Print("SecBuffer: cbBuffer:" + securityBuffer.size + " BufferType:" + securityBuffer.type);
+                        }
 #endif
                     }
                 }
@@ -1142,7 +1220,10 @@ namespace System.Net.Security
                 }
             }
 
-            GlobalLog.Leave("SafeDeleteContext::CompleteAuthToken() unmanaged CompleteAuthToken()", "errorCode:0x" + errorCode.ToString("x8") + " refContext:" + LoggingHash.ObjectToString(refContext));
+            if (globalLogEnabled)
+            {
+                GlobalLog.Leave("SafeDeleteContext::CompleteAuthToken() unmanaged CompleteAuthToken()", "errorCode:0x" + errorCode.ToString("x8") + " refContext:" + LoggingHash.ObjectToString(refContext));
+            }
 
             return errorCode;
         }

--- a/src/Common/src/Interop/Windows/secur32/StreamSizes.cs
+++ b/src/Common/src/Interop/Windows/secur32/StreamSizes.cs
@@ -30,7 +30,10 @@ namespace System.Net
                 }
                 catch (OverflowException)
                 {
-                    GlobalLog.Assert(false, "StreamSizes::.ctor", "Negative size.");
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Assert("StreamSizes::.ctor", "Negative size.");
+                    }
                     throw;
                 }
             }

--- a/src/Common/src/System/Net/ContextAwareResult.cs
+++ b/src/Common/src/System/Net/ContextAwareResult.cs
@@ -491,7 +491,11 @@ namespace System.Net
 
         private void CompleteCallback(object state)
         {
-            GlobalLog.Print("ContextAwareResult#" + LoggingHash.HashString(this) + "::CompleteCallback() Context set, calling callback.");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("ContextAwareResult#" + LoggingHash.HashString(this) + "::CompleteCallback() Context set, calling callback.");
+            }
+
             base.Complete(IntPtr.Zero);
         }
     }

--- a/src/Common/src/System/Net/DebugCriticalHandleMinusOneIsInvalid.cs
+++ b/src/Common/src/System/Net/DebugCriticalHandleMinusOneIsInvalid.cs
@@ -29,7 +29,10 @@ namespace System.Net
         private void Trace()
         {
             _trace = "WARNING! GC-ed  >>" + this.GetType().FullName + "<< (should be excplicitly closed) \r\n";
-            GlobalLog.Print("Creating SafeHandle, type = " + this.GetType().FullName);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Creating SafeHandle, type = " + this.GetType().FullName);
+            }
 #if TRACE_VERBOSE
             string stacktrace = Environment.StackTrace;
             _trace += stacktrace;
@@ -39,7 +42,10 @@ namespace System.Net
         ~DebugCriticalHandleMinusOneIsInvalid()
         {
             GlobalLog.SetThreadSource(ThreadKinds.Finalization);
-            GlobalLog.Print(_trace);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print(_trace);
+            }
         }
     }
 #endif // DEBUG

--- a/src/Common/src/System/Net/DebugCriticalHandleZeroOrMinusOneIsInvalid.cs
+++ b/src/Common/src/System/Net/DebugCriticalHandleZeroOrMinusOneIsInvalid.cs
@@ -29,7 +29,10 @@ namespace System.Net
         private void Trace()
         {
             _trace = "WARNING! GC-ed  >>" + this.GetType().FullName + "<< (should be excplicitly closed) \r\n";
-            GlobalLog.Print("Creating SafeHandle, type = " + this.GetType().FullName);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Creating SafeHandle, type = " + this.GetType().FullName);
+            }
 #if TRACE_VERBOSE
             string stacktrace = Environment.StackTrace;
             _trace += stacktrace;
@@ -39,7 +42,10 @@ namespace System.Net
         ~DebugCriticalHandleZeroOrMinusOneIsInvalid()
         {
             GlobalLog.SetThreadSource(ThreadKinds.Finalization);
-            GlobalLog.Print(_trace);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print(_trace);
+            }
         }
     }
 #endif // DEBUG

--- a/src/Common/src/System/Net/DebugSafeHandle.cs
+++ b/src/Common/src/System/Net/DebugSafeHandle.cs
@@ -44,7 +44,10 @@ namespace System.Net
         ~DebugSafeHandle()
         {
             GlobalLog.SetThreadSource(ThreadKinds.Finalization);
-            GlobalLog.Print(_trace);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print(_trace);
+            }
         }
     }
 #endif // DEBUG

--- a/src/Common/src/System/Net/DebugSafeHandleMinusOneIsInvalid.cs
+++ b/src/Common/src/System/Net/DebugSafeHandleMinusOneIsInvalid.cs
@@ -42,7 +42,10 @@ namespace System.Net
         ~DebugSafeHandleMinusOneIsInvalid()
         {
             GlobalLog.SetThreadSource(ThreadKinds.Finalization);
-            GlobalLog.Print(_trace);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print(_trace);
+            }
         }
     }
 #endif // DEBUG

--- a/src/Common/src/System/Net/InternalException.cs
+++ b/src/Common/src/System/Net/InternalException.cs
@@ -7,7 +7,10 @@ namespace System.Net
     {
         internal InternalException()
         {
-            GlobalLog.Assert("InternalException thrown.");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Assert("InternalException thrown.");
+            }
         }
     }
 }

--- a/src/Common/src/System/Net/LazyAsyncResult.cs
+++ b/src/Common/src/System/Net/LazyAsyncResult.cs
@@ -440,14 +440,19 @@ namespace System.Net
             ThreadContext threadContext = CurrentThreadContext;
             try
             {
+                bool globalLogEnabled = GlobalLog.IsEnabled;
+
                 ++threadContext._nestedIOCount;
                 if (_asyncCallback != null)
                 {
-                    GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::Complete() invoking callback");
+                    if (globalLogEnabled)
+                    {
+                        GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::Complete() invoking callback");
+                    }
 
                     if (threadContext._nestedIOCount >= ForceAsyncCount)
                     {
-                        if (GlobalLog.IsEnabled)
+                        if (globalLogEnabled)
                         {
                             GlobalLog.Print("LazyAsyncResult::Complete *** OFFLOADED the user callback ***");
                         }
@@ -466,7 +471,7 @@ namespace System.Net
                         _asyncCallback(this);
                     }
                 }
-                else if (GlobalLog.IsEnabled)
+                else if (globalLogEnabled)
                 {
                     GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::Complete() no callback to invoke");
                 }

--- a/src/Common/src/System/Net/Logging/GlobalLog.cs
+++ b/src/Common/src/System/Net/Logging/GlobalLog.cs
@@ -183,24 +183,6 @@ namespace System.Net
             EventSourceLogging.Log.FunctionStart(functionName, parameters);
         }
 
-        // TODO #5144: The Assert(bool, ...) overloads should be removed.  They lead to bad
-        // habits, with code doing work at the call sites to generate the messages, data, etc.
-        public static void Assert(bool condition, string message)
-        {
-            if (!condition)
-            {
-                Assert(message);
-            }
-        }
-
-        public static void Assert(bool condition, string messageFormat, params object[] data)
-        {
-            if (!condition)
-            {
-                AssertFormat(messageFormat, data);
-            }
-        }
-
         public static void AssertFormat(string messageFormat, params object[] data)
         {
             string fullMessage = string.Format(CultureInfo.InvariantCulture, messageFormat, data);

--- a/src/Common/src/System/Net/Logging/Logging.cs
+++ b/src/Common/src/System/Net/Logging/Logging.cs
@@ -207,7 +207,10 @@ namespace System.Net
                     s_cacheTraceSource = new NclTraceSource(TraceSourceCacheName);
                     s_traceSourceHttpName = new NclTraceSource(TraceSourceHttpName);
 
-                    GlobalLog.Print("Initalizating tracing");
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Print("Initalizating tracing");
+                    }
 
                     try
                     {

--- a/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
@@ -114,20 +114,28 @@ namespace System.Net.Sockets
                     _asyncContext.Close();
                 }
 
+                bool globalLogEnabled = GlobalLog.IsEnabled;
+
                 // If _blockable was set in BlockingRelease, it's safe to block here, which means
                 // we can honor the linger options set on the socket.  It also means closesocket() might return WSAEWOULDBLOCK, in which
                 // case we need to do some recovery.
                 if (_blockable)
                 {
-                    GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") Following 'blockable' branch.");
+                    if (globalLogEnabled)
+                    {
+                        GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") Following 'blockable' branch.");
+                    }
 
                     errorCode = Interop.Sys.Close(handle);
                     if (errorCode == -1)
                     {
                         errorCode = (int)Interop.Sys.GetLastError();
                     }
-                    GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") close()#1:" + errorCode.ToString());
 
+                    if (globalLogEnabled)
+                    {
+                        GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") close()#1:" + errorCode.ToString());
+                    }
 #if DEBUG
                     _closeSocketHandle = handle;
                     _closeSocketResult = SocketPal.GetSocketErrorForErrorCode((Interop.Error)errorCode);
@@ -151,7 +159,10 @@ namespace System.Net.Sockets
                         // The socket successfully made blocking; retry the close().
                         errorCode = Interop.Sys.Close(handle);
 
-                        GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") close()#2:" + errorCode.ToString());
+                        if (globalLogEnabled)
+                        {
+                            GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") close()#2:" + errorCode.ToString());
+                        }
 #if DEBUG
                         _closeSocketHandle = handle;
                         _closeSocketResult = SocketPal.GetSocketErrorForErrorCode((Interop.Error)errorCode);
@@ -176,7 +187,10 @@ namespace System.Net.Sockets
 #if DEBUG
                 _closeSocketLinger = SocketPal.GetSocketErrorForErrorCode((Interop.Error)errorCode);
 #endif
-                GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") setsockopt():" + errorCode.ToString());
+                if (globalLogEnabled)
+                {
+                    GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") setsockopt():" + errorCode.ToString());
+                }
 
                 if (errorCode != 0 && errorCode != (int)Interop.Error.EINVAL && errorCode != (int)Interop.Error.ENOPROTOOPT)
                 {
@@ -189,7 +203,10 @@ namespace System.Net.Sockets
                 _closeSocketHandle = handle;
                 _closeSocketResult = SocketPal.GetSocketErrorForErrorCode((Interop.Error)errorCode);
 #endif
-                GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") close#3():" + (errorCode == -1 ? (int)Interop.Sys.GetLastError() : errorCode).ToString());
+                if (globalLogEnabled)
+                {
+                    GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") close#3():" + (errorCode == -1 ? (int)Interop.Sys.GetLastError() : errorCode).ToString());
+                }
 
                 return SocketPal.GetSocketErrorForErrorCode((Interop.Error)errorCode);
             }

--- a/src/Common/src/System/Net/SafeCloseSocket.Windows.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Windows.cs
@@ -104,13 +104,14 @@ namespace System.Net.Sockets
             private SocketError InnerReleaseHandle()
             {
                 SocketError errorCode;
+                bool globalLogEnabled = GlobalLog.IsEnabled;
 
                 // If _blockable was set in BlockingRelease, it's safe to block here, which means
                 // we can honor the linger options set on the socket.  It also means closesocket() might return WSAEWOULDBLOCK, in which
                 // case we need to do some recovery.
                 if (_blockable)
                 {
-                    if (GlobalLog.IsEnabled)
+                    if (globalLogEnabled)
                     {
                         GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") Following 'blockable' branch.");
                     }
@@ -121,7 +122,7 @@ namespace System.Net.Sockets
                     _closeSocketResult = errorCode;
 #endif
                     if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastWin32Error();
-                    if (GlobalLog.IsEnabled)
+                    if (globalLogEnabled)
                     {
                         GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") closesocket()#1:" + errorCode.ToString());
                     }
@@ -141,7 +142,7 @@ namespace System.Net.Sockets
                         ref nonBlockCmd);
                     if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastWin32Error();
 
-                    if (GlobalLog.IsEnabled)
+                    if (globalLogEnabled)
                     {
                         GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") ioctlsocket()#1:" + errorCode.ToString());
                     }
@@ -154,7 +155,7 @@ namespace System.Net.Sockets
                             IntPtr.Zero,
                             Interop.Winsock.AsyncEventBits.FdNone);
 
-                        if (GlobalLog.IsEnabled)
+                        if (globalLogEnabled)
                         {
                             GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") WSAEventSelect():" + (errorCode == SocketError.SocketError ? (SocketError)Marshal.GetLastWin32Error() : errorCode).ToString());
                         }
@@ -165,7 +166,7 @@ namespace System.Net.Sockets
                             Interop.Winsock.IoctlSocketConstants.FIONBIO,
                             ref nonBlockCmd);
 
-                        if (GlobalLog.IsEnabled)
+                        if (globalLogEnabled)
                         {
                             GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") ioctlsocket#2():" + (errorCode == SocketError.SocketError ? (SocketError)Marshal.GetLastWin32Error() : errorCode).ToString());
                         }
@@ -180,7 +181,7 @@ namespace System.Net.Sockets
                         _closeSocketResult = errorCode;
 #endif
                         if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastWin32Error();
-                        if (GlobalLog.IsEnabled)
+                        if (globalLogEnabled)
                         {
                             GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") closesocket#2():" + errorCode.ToString());
                         }
@@ -210,7 +211,7 @@ namespace System.Net.Sockets
                 _closeSocketLinger = errorCode;
 #endif
                 if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastWin32Error();
-                if (GlobalLog.IsEnabled)
+                if (globalLogEnabled)
                 {
                     GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") setsockopt():" + errorCode.ToString());
                 }
@@ -226,7 +227,7 @@ namespace System.Net.Sockets
                 _closeSocketHandle = handle;
                 _closeSocketResult = errorCode;
 #endif
-                if (GlobalLog.IsEnabled)
+                if (globalLogEnabled)
                 {
                     GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") closesocket#3():" + (errorCode == SocketError.SocketError ? (SocketError)Marshal.GetLastWin32Error() : errorCode).ToString());
                 }

--- a/src/System.Net.NameResolution/src/System/Net/DNS.cs
+++ b/src/System.Net.NameResolution/src/System/Net/DNS.cs
@@ -25,7 +25,11 @@ namespace System.Net
             if (NetEventSource.Log.IsEnabled()) NetEventSource.Enter(NetEventSource.ComponentType.Socket, "DNS", "GetHostByName", hostName);
             IPHostEntry ipHostEntry = null;
 
-            GlobalLog.Print("Dns.GetHostByName: " + hostName);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Dns.GetHostByName: " + hostName);
+            }
+
             NameResolutionPal.EnsureSocketsAreInitialized();
 
             if (hostName.Length > MaxHostName // If 255 chars, the last one must be a dot.
@@ -75,7 +79,11 @@ namespace System.Net
         // Does internal IPAddress reverse and then forward lookups (for Legacy and current public methods).
         internal static IPHostEntry InternalGetHostByAddress(IPAddress address, bool includeIPv6)
         {
-            GlobalLog.Print("Dns.InternalGetHostByAddress: " + address.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Dns.InternalGetHostByAddress: " + address.ToString());
+            }
+            
             //
             // IPv6 Changes: We need to use the new getnameinfo / getaddrinfo functions
             //               for resolution of IPv6 addresses.
@@ -156,7 +164,11 @@ namespace System.Net
         /// </devdoc>
         public static string GetHostName()
         {
-            GlobalLog.Print("Dns.GetHostName");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Dns.GetHostName");
+            }
+
             return NameResolutionPal.GetHostName();
         }
 
@@ -220,7 +232,10 @@ namespace System.Net
                 throw new ArgumentNullException("hostName");
             }
 
-            GlobalLog.Print("Dns.HostResolutionBeginHelper: " + hostName);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Dns.HostResolutionBeginHelper: " + hostName);
+            }
 
             // See if it's an IP Address.
             IPAddress address;
@@ -276,7 +291,10 @@ namespace System.Net
                 throw new ArgumentException(SR.net_invalid_ip_addr, "address");
             }
 
-            GlobalLog.Print("Dns.HostResolutionBeginHelper: " + address);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Dns.HostResolutionBeginHelper: " + address);
+            }
 
             // Set up the context, possibly flow.
             ResolveAsyncResult asyncResult = new ResolveAsyncResult(address, null, includeIPv6, state, requestCallback);
@@ -317,7 +335,10 @@ namespace System.Net
                 throw new InvalidOperationException(SR.Format(SR.net_io_invalidendcall, "EndResolve"));
             }
 
-            GlobalLog.Print("Dns.HostResolutionEndHelper");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Dns.HostResolutionEndHelper");
+            }
 
             castedResult.InternalWaitForCompletion();
             castedResult.EndCalled = true;

--- a/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
+++ b/src/System.Net.NameResolution/src/System/Net/NameResolutionPal.Windows.cs
@@ -50,7 +50,10 @@ namespace System.Net
             if (Host.h_name != IntPtr.Zero)
             {
                 HostEntry.HostName = Marshal.PtrToStringAnsi(Host.h_name);
-                GlobalLog.Print("HostEntry.HostName: " + HostEntry.HostName);
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("HostEntry.HostName: " + HostEntry.HostName);
+                }
             }
 
             // decode h_addr_list to ArrayList of IP addresses.
@@ -87,7 +90,10 @@ namespace System.Net
                                         ((uint)IPAddressToAdd >> 24));
 #endif
 
-                GlobalLog.Print("currentArrayElement: " + currentArrayElement.ToString() + " nativePointer: " + nativePointer.ToString() + " IPAddressToAdd:" + IPAddressToAdd.ToString());
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("currentArrayElement: " + currentArrayElement.ToString() + " nativePointer: " + nativePointer.ToString() + " IPAddressToAdd:" + IPAddressToAdd.ToString());
+                }
 
                 //
                 // ...and add it to the list
@@ -114,7 +120,10 @@ namespace System.Net
 
             while (nativePointer != IntPtr.Zero)
             {
-                GlobalLog.Print("currentArrayElement: " + ((long)currentArrayElement).ToString() + "nativePointer: " + ((long)nativePointer).ToString());
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("currentArrayElement: " + ((long)currentArrayElement).ToString() + "nativePointer: " + ((long)nativePointer).ToString());
+                }
 
                 //
                 // if it's not null it points to an Alias,

--- a/src/System.Net.NameResolution/tests/PalTests/Fakes/GlobalLog.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/Fakes/GlobalLog.cs
@@ -5,10 +5,6 @@ namespace System.Net
 {
     public static class GlobalLog
     {
-        public static void Assert(bool condition, string arg1, string arg2, object arg3)
-        {
-        }
-
         public static void Assert(string message)
         {
         }
@@ -20,6 +16,8 @@ namespace System.Net
         internal static void SetThreadSource(ThreadKinds source)
         {
         }
+
+        public static bool IsEnabled { get { return false; } }
     }
 
     [Flags]

--- a/src/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -718,7 +718,10 @@ namespace System.Net
             {
                 // Only set by HttpListenerRequest::Cookies_get()
 #if !NETNative_SystemNetHttp
-                GlobalLog.Assert(value == CookieVariant.Rfc2965, "Cookie#{0}::set_Variant()|value:{1}", Logging.HashString(this), value);
+                if (GlobalLog.IsEnabled && value != CookieVariant.Rfc2965)
+                {
+                    GlobalLog.AssertFormat("Cookie#{0}::set_Variant()|value:{1}", Logging.HashString(this), value);
+                }
 #endif
                 _cookieVariant = value;
             }

--- a/src/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -858,23 +858,26 @@ namespace System.Net
         internal void Dump()
         {
 #if !NETNative_SystemNetHttp
-            GlobalLog.Print("Cookie: " + ToString() + "->\n"
-                            + "\tComment    = " + Comment + "\n"
-                            + "\tCommentUri = " + CommentUri + "\n"
-                            + "\tDiscard    = " + Discard + "\n"
-                            + "\tDomain     = " + Domain + "\n"
-                            + "\tExpired    = " + Expired + "\n"
-                            + "\tExpires    = " + Expires + "\n"
-                            + "\tName       = " + Name + "\n"
-                            + "\tPath       = " + Path + "\n"
-                            + "\tPort       = " + Port + "\n"
-                            + "\tSecure     = " + Secure + "\n"
-                            + "\tTimeStamp  = " + TimeStamp + "\n"
-                            + "\tValue      = " + Value + "\n"
-                            + "\tVariant    = " + Variant + "\n"
-                            + "\tVersion    = " + Version + "\n"
-                            + "\tHttpOnly    = " + HttpOnly + "\n"
-                            );
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Cookie: " + ToString() + "->\n"
+                                + "\tComment    = " + Comment + "\n"
+                                + "\tCommentUri = " + CommentUri + "\n"
+                                + "\tDiscard    = " + Discard + "\n"
+                                + "\tDomain     = " + Domain + "\n"
+                                + "\tExpired    = " + Expired + "\n"
+                                + "\tExpires    = " + Expires + "\n"
+                                + "\tName       = " + Name + "\n"
+                                + "\tPath       = " + Path + "\n"
+                                + "\tPort       = " + Port + "\n"
+                                + "\tSecure     = " + Secure + "\n"
+                                + "\tTimeStamp  = " + TimeStamp + "\n"
+                                + "\tValue      = " + Value + "\n"
+                                + "\tVariant    = " + Variant + "\n"
+                                + "\tVersion    = " + Version + "\n"
+                                + "\tHttpOnly    = " + HttpOnly + "\n"
+                                );
+            }
 #endif
         }
 #endif

--- a/src/System.Net.Primitives/src/System/Net/CookieCollection.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieCollection.cs
@@ -215,10 +215,13 @@ namespace System.Net
 #if DEBUG
         internal void Dump()
         {
-            GlobalLog.Print("CookieCollection:");
-            foreach (Cookie cookie in this)
+            if (GlobalLog.IsEnabled)
             {
-                cookie.Dump();
+                GlobalLog.Print("CookieCollection:");
+                foreach (Cookie cookie in this)
+                {
+                    cookie.Dump();
+                }
             }
         }
 #endif

--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -658,7 +658,12 @@ namespace System.Net
 
         internal CookieCollection CookieCutter(Uri uri, string headerName, string setCookieHeader, bool isThrow)
         {
-            GlobalLog.Print("CookieContainer#" + Logging.HashString(this) + "::CookieCutter() uri:" + uri + " headerName:" + headerName + " setCookieHeader:" + setCookieHeader + " isThrow:" + isThrow);
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+            if (globalLogEnabled)
+            {
+                GlobalLog.Print("CookieContainer#" + Logging.HashString(this) + "::CookieCutter() uri:" + uri + " headerName:" + headerName + " setCookieHeader:" + setCookieHeader + " isThrow:" + isThrow);
+            }
+
             CookieCollection cookies = new CookieCollection();
             CookieVariant variant = CookieVariant.Unknown;
             if (headerName == null)
@@ -683,7 +688,11 @@ namespace System.Net
                 do
                 {
                     Cookie cookie = parser.Get();
-                    GlobalLog.Print("CookieContainer#" + Logging.HashString(this) + "::CookieCutter() CookieParser returned cookie:" + Logging.ObjectToString(cookie));
+                    if (globalLogEnabled)
+                    {
+                        GlobalLog.Print("CookieContainer#" + Logging.HashString(this) + "::CookieCutter() CookieParser returned cookie:" + Logging.ObjectToString(cookie));
+                    }
+
                     if (cookie == null)
                     {
                         break;

--- a/src/System.Net.Primitives/src/System/Net/CredentialCache.cs
+++ b/src/System.Net.Primitives/src/System/Net/CredentialCache.cs
@@ -56,7 +56,10 @@ namespace System.Net
 
             CredentialKey key = new CredentialKey(uriPrefix, authenticationType);
 
-            GlobalLog.Print("CredentialCache::Add() Adding key:[" + key.ToString() + "], cred:[" + credential.Domain + "],[" + credential.UserName + "]");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("CredentialCache::Add() Adding key:[" + key.ToString() + "], cred:[" + credential.Domain + "],[" + credential.UserName + "]");
+            }
 
             _cache.Add(key, credential);
             if (credential is SystemNetworkCredential)
@@ -93,7 +96,10 @@ namespace System.Net
 
             CredentialHostKey key = new CredentialHostKey(host, port, authenticationType);
 
-            GlobalLog.Print("CredentialCache::Add() Adding key:[" + key.ToString() + "], cred:[" + credential.Domain + "],[" + credential.UserName + "]");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("CredentialCache::Add() Adding key:[" + key.ToString() + "], cred:[" + credential.Domain + "],[" + credential.UserName + "]");
+            }
 
             _cacheForHosts.Add(key, credential);
             if (credential is SystemNetworkCredential)
@@ -121,7 +127,10 @@ namespace System.Net
 
             CredentialKey key = new CredentialKey(uriPrefix, authenticationType);
 
-            GlobalLog.Print("CredentialCache::Remove() Removing key:[" + key.ToString() + "]");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("CredentialCache::Remove() Removing key:[" + key.ToString() + "]");
+            }
 
             if (_cache[key] is SystemNetworkCredential)
             {
@@ -149,7 +158,10 @@ namespace System.Net
 
             CredentialHostKey key = new CredentialHostKey(host, port, authenticationType);
 
-            GlobalLog.Print("CredentialCache::Remove() Removing key:[" + key.ToString() + "]");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("CredentialCache::Remove() Removing key:[" + key.ToString() + "]");
+            }
 
             if (_cacheForHosts[key] is SystemNetworkCredential)
             {
@@ -176,7 +188,11 @@ namespace System.Net
                 throw new ArgumentNullException("authenticationType");
             }
 
-            GlobalLog.Print("CredentialCache::GetCredential(uriPrefix=\"" + uriPrefix + "\", authType=\"" + authenticationType + "\")");
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+            if (globalLogEnabled)
+            {
+                GlobalLog.Print("CredentialCache::GetCredential(uriPrefix=\"" + uriPrefix + "\", authType=\"" + authenticationType + "\")");
+            }
 
             int longestMatchPrefix = -1;
             NetworkCredential mostSpecificMatch = null;
@@ -202,8 +218,10 @@ namespace System.Net
                 }
             }
 
-            GlobalLog.Print("CredentialCache::GetCredential returning " + ((mostSpecificMatch == null) ? "null" : "(" + mostSpecificMatch.UserName + ":" + mostSpecificMatch.Domain + ")"));
-
+            if (globalLogEnabled)
+            {
+                GlobalLog.Print("CredentialCache::GetCredential returning " + ((mostSpecificMatch == null) ? "null" : "(" + mostSpecificMatch.UserName + ":" + mostSpecificMatch.Domain + ")"));
+            }
             return mostSpecificMatch;
         }
 
@@ -227,7 +245,11 @@ namespace System.Net
                 throw new ArgumentOutOfRangeException("port");
             }
 
-            GlobalLog.Print("CredentialCache::GetCredential(host=\"" + host + ":" + port.ToString() + "\", authenticationType=\"" + authenticationType + "\")");
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+            if (globalLogEnabled)
+            {
+                GlobalLog.Print("CredentialCache::GetCredential(host=\"" + host + ":" + port.ToString() + "\", authenticationType=\"" + authenticationType + "\")");
+            }
 
             NetworkCredential match = null;
 
@@ -245,7 +267,10 @@ namespace System.Net
                 }
             }
 
-            GlobalLog.Print("CredentialCache::GetCredential returning " + ((match == null) ? "null" : "(" + match.UserName + ":" + match.Domain + ")"));
+            if (globalLogEnabled)
+            {
+                GlobalLog.Print("CredentialCache::GetCredential returning " + ((match == null) ? "null" : "(" + match.UserName + ":" + match.Domain + ")"));
+            }
             return match;
         }
 
@@ -376,7 +401,10 @@ namespace System.Net
                 return false;
             }
 
-            GlobalLog.Print("CredentialKey::Match(" + Host.ToString() + ":" + Port.ToString() + " & " + host.ToString() + ":" + port.ToString() + ")");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("CredentialKey::Match(" + Host.ToString() + ":" + Port.ToString() + " & " + host.ToString() + ":" + port.ToString() + ")");
+            }
             return true;
         }
 
@@ -405,7 +433,10 @@ namespace System.Net
                 string.Equals(Host, other.Host, StringComparison.OrdinalIgnoreCase) &&
                 Port == other.Port;
 
-            GlobalLog.Print("CredentialKey::Equals(" + ToString() + ", " + other.ToString() + ") returns " + equals.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("CredentialKey::Equals(" + ToString() + ", " + other.ToString() + ") returns " + equals.ToString());
+            }
             return equals;
         }
 
@@ -448,7 +479,10 @@ namespace System.Net
                 return false;
             }
 
-            GlobalLog.Print("CredentialKey::Match(" + UriPrefix.ToString() + " & " + uri.ToString() + ")");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("CredentialKey::Match(" + UriPrefix.ToString() + " & " + uri.ToString() + ")");
+            }
 
             return IsPrefix(uri, UriPrefix);
         }
@@ -503,8 +537,10 @@ namespace System.Net
                 string.Equals(AuthenticationType, other.AuthenticationType, StringComparison.OrdinalIgnoreCase) &&
                 UriPrefix.Equals(other.UriPrefix);
 
-            GlobalLog.Print("CredentialKey::Equals(" + ToString() + ", " + other.ToString() + ") returns " + equals.ToString());
-
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("CredentialKey::Equals(" + ToString() + ", " + other.ToString() + ") returns " + equals.ToString());
+            }
             return equals;
         }
 

--- a/src/System.Net.Primitives/src/System/Net/SocketException.cs
+++ b/src/System.Net.Primitives/src/System/Net/SocketException.cs
@@ -23,7 +23,10 @@ namespace System.Net.Sockets
         /// </devdoc>
         public SocketException() : base(Marshal.GetLastWin32Error())
         {
-            GlobalLog.Print("SocketException::.ctor() " + NativeErrorCode.ToString() + ":" + Message);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("SocketException::.ctor() " + NativeErrorCode.ToString() + ":" + Message);
+            }
         }
 
         internal SocketException(EndPoint endPoint) : base(Marshal.GetLastWin32Error())
@@ -38,7 +41,10 @@ namespace System.Net.Sockets
         /// </devdoc>
         public SocketException(int errorCode) : base(errorCode)
         {
-            GlobalLog.Print("SocketException::.ctor(int) " + NativeErrorCode.ToString() + ":" + Message);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("SocketException::.ctor(int) " + NativeErrorCode.ToString() + ":" + Message);
+            }
         }
 
         internal SocketException(int errorCode, EndPoint endPoint) : base(errorCode)

--- a/src/System.Net.Primitives/tests/PalTests/Fakes/GlobalLog.cs
+++ b/src/System.Net.Primitives/tests/PalTests/Fakes/GlobalLog.cs
@@ -5,10 +5,6 @@ namespace System.Net
 {
     public static class GlobalLog
     {
-        public static void Assert(bool condition, string arg1, string arg2, object arg3)
-        {
-        }
-
         public static void Assert(string message)
         {
         }
@@ -16,5 +12,7 @@ namespace System.Net
         public static void Print(string message)
         {
         }
+
+        public static bool IsEnabled { get { return false; } }
     }
 }

--- a/src/System.Net.Primitives/tests/UnitTests/Fakes/GlobalLog.cs
+++ b/src/System.Net.Primitives/tests/UnitTests/Fakes/GlobalLog.cs
@@ -5,16 +5,18 @@ namespace System.Net
 {
     public static class GlobalLog
     {
-        public static void Assert(bool condition, string arg1, string arg2, object arg3)
+        public static void Assert(string message)
         {
         }
 
-        public static void Assert(string message)
+        public static void AssertFormat(string messageFormat, params object[] data)
         {
         }
 
         public static void Print(string message)
         {
         }
+
+        public static bool IsEnabled { get { return false; } }
     }
 }

--- a/src/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
@@ -92,7 +92,12 @@ namespace System.Net
                 return null;
             }
 
-            GlobalLog.Enter("CertificateValidationPal.Unix SecureChannel#" + LoggingHash.HashString(securityContext) + "::GetRemoteCertificate()");
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+            if (globalLogEnabled)
+            {
+                GlobalLog.Enter("CertificateValidationPal.Unix SecureChannel#" + LoggingHash.HashString(securityContext) + "::GetRemoteCertificate()");
+            }
+
             X509Certificate2 result = null;
             SafeFreeCertContext remoteContext = null;
             try
@@ -146,8 +151,10 @@ namespace System.Net
                 SecurityEventSource.Log.RemoteCertificate(result == null ? "null" : result.ToString(true));
             }
 
-            GlobalLog.Leave("CertificateValidationPal.Unix SecureChannel#" + LoggingHash.HashString(securityContext) + "::GetRemoteCertificate()", (result == null ? "null" : result.Subject));
-
+            if (globalLogEnabled)
+            {
+                GlobalLog.Leave("CertificateValidationPal.Unix SecureChannel#" + LoggingHash.HashString(securityContext) + "::GetRemoteCertificate()", (result == null ? "null" : result.Subject));
+            }
             return result;
         }      
 
@@ -211,6 +218,7 @@ namespace System.Net
 
                     if (store == null)
                     {
+                        bool globalLogEnabled = GlobalLog.IsEnabled;
                         try
                         {
                             store = new X509Store(StoreName.My, storeLocation);
@@ -218,16 +226,21 @@ namespace System.Net
 
                             Volatile.Write(ref storeField, store);
 
-                            GlobalLog.Print(
-                                "CertModule::EnsureStoreOpened() storeLocation:" + storeLocation +
-                                    " returned store:" + store.GetHashCode().ToString("x"));
+                            if (globalLogEnabled)
+                            {
+                                GlobalLog.Print(
+                                    "CertModule::EnsureStoreOpened() storeLocation:" + storeLocation +
+                                        " returned store:" + store.GetHashCode().ToString("x"));
+                            }
                         }
                         catch (CryptographicException e)
                         {
-                            GlobalLog.Assert(
-                                "CertModule::EnsureStoreOpened()",
-                                "Failed to open cert store, location:" + storeLocation + " exception:" + e);
-
+                            if (globalLogEnabled)
+                            {
+                                GlobalLog.Assert(
+                                    "CertModule::EnsureStoreOpened()",
+                                    "Failed to open cert store, location:" + storeLocation + " exception:" + e);
+                            }
                             throw;
                         }
                     }

--- a/src/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
@@ -149,7 +149,11 @@ namespace System.Net
                         for (int i = 0; i < count; ++i)
                         {
                             Interop.Secur32._CERT_CHAIN_ELEMENT* pIL2 = pIL + i;
-                            GlobalLog.Assert(pIL2->cbSize > 0, "SecureChannel::GetIssuers()", "Interop.Secur32._CERT_CHAIN_ELEMENT size is not positive: " + pIL2->cbSize.ToString());
+                            if (GlobalLog.IsEnabled && pIL2->cbSize <= 0)
+                            {
+                                GlobalLog.Assert("SecureChannel::GetIssuers()", "Interop.Secur32._CERT_CHAIN_ELEMENT size is not positive: " + pIL2->cbSize.ToString());
+                            }
+
                             if (pIL2->cbSize > 0)
                             {
                                 uint size = pIL2->cbSize;

--- a/src/System.Net.Security/src/System/Net/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/SecureChannel.cs
@@ -55,7 +55,11 @@ namespace System.Net.Security
         internal SecureChannel(string hostname, bool serverMode, SslProtocols sslProtocols, X509Certificate serverCertificate, X509CertificateCollection clientCertificates, bool remoteCertRequired, bool checkCertName,
                                                   bool checkCertRevocationStatus, EncryptionPolicy encryptionPolicy, LocalCertSelectionCallback certSelectionDelegate)
         {
-            GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::.ctor", "hostname:" + hostname + " #clientCertificates=" + ((clientCertificates == null) ? "0" : clientCertificates.Count.ToString(NumberFormatInfo.InvariantInfo)));
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+            if (globalLogEnabled)
+            {
+                GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::.ctor", "hostname:" + hostname + " #clientCertificates=" + ((clientCertificates == null) ? "0" : clientCertificates.Count.ToString(NumberFormatInfo.InvariantInfo)));
+            }
             if (SecurityEventSource.Log.IsEnabled())
             {
                 SecurityEventSource.SecureChannelCtor(this, hostname, clientCertificates, encryptionPolicy);
@@ -65,7 +69,10 @@ namespace System.Net.Security
 
             _destination = hostname;
 
-            GlobalLog.Assert(hostname != null, "SecureChannel#{0}::.ctor()|hostname == null", LoggingHash.HashString(this));
+            if (globalLogEnabled && hostname == null)
+            {
+                GlobalLog.AssertFormat("SecureChannel#{0}::.ctor()|hostname == null", LoggingHash.HashString(this));
+            }
             _hostName = hostname;
             _serverMode = serverMode;
 
@@ -80,7 +87,10 @@ namespace System.Net.Security
             _certSelectionDelegate = certSelectionDelegate;
             _refreshCredentialNeeded = true;
             _encryptionPolicy = encryptionPolicy;
-            GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::.ctor");
+            if (globalLogEnabled)
+            {
+                GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::.ctor");
+            }
         }
 
         //
@@ -118,7 +128,11 @@ namespace System.Net.Security
 
         internal ChannelBinding GetChannelBinding(ChannelBindingKind kind)
         {
-            GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::GetChannelBindingToken", kind.ToString());
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+            if (globalLogEnabled)
+            {
+                GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::GetChannelBindingToken", kind.ToString());
+            }
 
             ChannelBinding result = null;
             if (_securityContext != null)
@@ -126,7 +140,10 @@ namespace System.Net.Security
                 result = SslStreamPal.QueryContextChannelBinding(_securityContext, kind);
             }
 
-            GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::GetChannelBindingToken", LoggingHash.HashString(result));
+            if (globalLogEnabled)
+            {
+                GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::GetChannelBindingToken", LoggingHash.HashString(result));
+            }
             return result;
         }
 
@@ -378,7 +395,11 @@ namespace System.Net.Security
 
         private bool AcquireClientCredentials(ref byte[] thumbPrint)
         {
-            GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials");
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+            if (globalLogEnabled)
+            {
+                GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials");
+            }
 
             // Acquire possible Client Certificate information and set it on the handle.
             X509Certificate clientCertificate = null;   // This is a candidate that can come from the user callback or be guessed when targeting a session restart.
@@ -391,7 +412,10 @@ namespace System.Net.Security
             {
                 issuers = GetRequestCertificateAuthorities();
 
-                GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials() calling CertificateSelectionCallback");
+                if (globalLogEnabled)
+                {
+                    GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials() calling CertificateSelectionCallback");
+                }
 
                 X509Certificate2 remoteCert = null;
                 try
@@ -495,7 +519,11 @@ namespace System.Net.Security
                                 continue;
                             }
 
-                            GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials() root cert:" + certificateEx.Issuer);
+                            if (globalLogEnabled)
+                            {
+                                GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials() root cert:" + certificateEx.Issuer);
+                            }
+
                             chain = new X509Chain();
 
                             chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
@@ -514,10 +542,16 @@ namespace System.Net.Security
                                     found = Array.IndexOf(issuers, issuer) != -1;
                                     if (found)
                                     {
-                                        GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials() matched:" + issuer);
+                                        if (globalLogEnabled)
+                                        {
+                                            GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials() matched:" + issuer);
+                                        }
                                         break;
                                     }
-                                    GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials() no match:" + issuer);
+                                    if (globalLogEnabled)
+                                    {
+                                        GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials() no match:" + issuer);
+                                    }
                                 }
                             }
 
@@ -582,9 +616,16 @@ namespace System.Net.Security
                 selectedCert = null;
             }
 
-            GlobalLog.Assert(((object)clientCertificate == (object)selectedCert) || clientCertificate.Equals(selectedCert), "AcquireClientCredentials()|'selectedCert' does not match 'clientCertificate'.");
+            if (globalLogEnabled)
+            {
+                if ((object)clientCertificate != (object)selectedCert && !clientCertificate.Equals(selectedCert))
+                {
+                    GlobalLog.Assert("AcquireClientCredentials()|'selectedCert' does not match 'clientCertificate'.");
+                }
 
-            GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials() Selected Cert = " + (selectedCert == null ? "null" : selectedCert.Subject));
+                GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials() Selected Cert = " + (selectedCert == null ? "null" : selectedCert.Subject));
+            }
+
             try
             {
                 // Try to locate cached creds first.
@@ -599,7 +640,10 @@ namespace System.Net.Security
                 // (instead of going anonymous as we do here).
                 if (sessionRestartAttempt && cachedCredentialHandle == null && selectedCert != null)
                 {
-                    GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials() Reset to anonymous session.");
+                    if (globalLogEnabled)
+                    {
+                        GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials() Reset to anonymous session.");
+                    }
 
                     // IIS does not renegotiate a restarted session if client cert is needed.
                     // So we don't want to reuse **anonymous** cached credential for a new SSL connection if the client has passed some certificate.
@@ -643,7 +687,10 @@ namespace System.Net.Security
                 }
             }
 
-            GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials, cachedCreds = " + cachedCred.ToString(), LoggingHash.ObjectToString(_credentialsHandle));
+            if (globalLogEnabled)
+            {
+                GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials, cachedCreds = " + cachedCred.ToString(), LoggingHash.ObjectToString(_credentialsHandle));
+            }
             return cachedCred;
         }
 
@@ -653,7 +700,11 @@ namespace System.Net.Security
         //
         private bool AcquireServerCredentials(ref byte[] thumbPrint)
         {
-            GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireServerCredentials");
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+            if (globalLogEnabled)
+            {
+                GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireServerCredentials");
+            }
 
             X509Certificate localCertificate = null;
             bool cachedCred = false;
@@ -663,7 +714,10 @@ namespace System.Net.Security
                 X509CertificateCollection tempCollection = new X509CertificateCollection();
                 tempCollection.Add(_serverCertificate);
                 localCertificate = _certSelectionDelegate(string.Empty, tempCollection, null, Array.Empty<string>());
-                GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireServerCredentials() Use delegate selected Cert");
+                if (globalLogEnabled)
+                {
+                    GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireServerCredentials() Use delegate selected Cert");
+                }
             }
             else
             {
@@ -685,7 +739,10 @@ namespace System.Net.Security
                 throw new NotSupportedException(SR.net_ssl_io_no_server_cert);
             }
 
-            GlobalLog.Assert(localCertificate.Equals(selectedCert), "AcquireServerCredentials()|'selectedCert' does not match 'localCertificate'.");
+            if (globalLogEnabled && !localCertificate.Equals(selectedCert))
+            {
+                GlobalLog.Assert("AcquireServerCredentials()|'selectedCert' does not match 'localCertificate'.");
+            }
 
             //
             // Note selectedCert is a safe ref possibly cloned from the user passed Cert object
@@ -717,26 +774,41 @@ namespace System.Net.Security
                 }
             }
 
-            GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireServerCredentials, cachedCreds = " + cachedCred.ToString(), LoggingHash.ObjectToString(_credentialsHandle));
+            if (globalLogEnabled)
+            {
+                GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireServerCredentials, cachedCreds = " + cachedCred.ToString(), LoggingHash.ObjectToString(_credentialsHandle));
+            }
             return cachedCred;
         }
 
         //
         internal ProtocolToken NextMessage(byte[] incoming, int offset, int count)
         {
-            GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::NextMessage");
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+            if (globalLogEnabled)
+            {
+                GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::NextMessage");
+            }
+
             byte[] nextmsg = null;
             SecurityStatusPal errorCode = GenerateToken(incoming, offset, count, ref nextmsg);
 
             if (!_serverMode && errorCode == SecurityStatusPal.CredentialsNeeded)
             {
-                GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::NextMessage() returned SecurityStatusPal.CredentialsNeeded");
+                if (globalLogEnabled)
+                {
+                    GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::NextMessage() returned SecurityStatusPal.CredentialsNeeded");
+                }
+
                 SetRefreshCredentialNeeded();
                 errorCode = GenerateToken(incoming, offset, count, ref nextmsg);
             }
 
             ProtocolToken token = new ProtocolToken(nextmsg, errorCode);
-            GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::NextMessage", token.ToString());
+            if (globalLogEnabled)
+            {
+                GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::NextMessage", token.ToString());
+            }
             return token;
         }
 
@@ -758,18 +830,27 @@ namespace System.Net.Security
         private SecurityStatusPal GenerateToken(byte[] input, int offset, int count, ref byte[] output)
         {
 #if TRACE_VERBOSE
-            GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::GenerateToken, _refreshCredentialNeeded = " + _refreshCredentialNeeded);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::GenerateToken, _refreshCredentialNeeded = " + _refreshCredentialNeeded);
+            }
 #endif
 
             if (offset < 0 || offset > (input == null ? 0 : input.Length))
             {
-                GlobalLog.Assert(false, "SecureChannel#" + LoggingHash.HashString(this) + "::GenerateToken", "Argument 'offset' out of range.");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::GenerateToken", "Argument 'offset' out of range.");
+                }
                 throw new ArgumentOutOfRangeException("offset");
             }
 
             if (count < 0 || count > (input == null ? 0 : input.Length - offset))
             {
-                GlobalLog.Assert(false, "SecureChannel#" + LoggingHash.HashString(this) + "::GenerateToken", "Argument 'count' out of range.");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::GenerateToken", "Argument 'count' out of range.");
+                }
                 throw new ArgumentOutOfRangeException("count");
             }
 
@@ -870,7 +951,10 @@ namespace System.Net.Security
             output = outgoingSecurity.token;
 
 #if TRACE_VERBOSE
-            GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::GenerateToken()", Interop.MapSecurityStatus((uint)errorCode));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::GenerateToken()", Interop.MapSecurityStatus((uint)errorCode));
+            }
 #endif
             return (SecurityStatusPal)errorCode;
         }
@@ -884,7 +968,11 @@ namespace System.Net.Security
         --*/
         internal void ProcessHandshakeSuccess()
         {
-            GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::ProcessHandshakeSuccess");
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+            if (globalLogEnabled)
+            {
+                GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::ProcessHandshakeSuccess");
+            }
 
             StreamSizes streamSizes;
             SslStreamPal.QueryContextStreamSizes(_securityContext, out streamSizes);
@@ -899,9 +987,9 @@ namespace System.Net.Security
                 }
                 catch (Exception e)
                 {
-                    if (!ExceptionCheck.IsFatal(e))
+                    if (!ExceptionCheck.IsFatal(e) && GlobalLog.IsEnabled)
                     {
-                        GlobalLog.Assert(false, "SecureChannel#" + LoggingHash.HashString(this) + "::ProcessHandshakeSuccess", "StreamSizes out of range.");
+                        GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::ProcessHandshakeSuccess", "StreamSizes out of range.");
                     }
 
                     throw;
@@ -909,7 +997,11 @@ namespace System.Net.Security
             }
 
             SslStreamPal.QueryContextConnectionInfo(_securityContext, out _connectionInfo);
-            GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::ProcessHandshakeSuccess");
+
+            if (globalLogEnabled)
+            {
+                GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::ProcessHandshakeSuccess");
+            }
         }
 
         /*++
@@ -926,10 +1018,14 @@ namespace System.Net.Security
         --*/
         internal SecurityStatusPal Encrypt(byte[] buffer, int offset, int size, ref byte[] output, out int resultSize)
         {
-            GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt");
-            GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt() - offset: " + offset.ToString() + " size: " + size.ToString() + " buffersize: " + buffer.Length.ToString());
-            GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt() buffer:");
-            GlobalLog.Dump(buffer, Math.Min(buffer.Length, 128));
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+            if (globalLogEnabled)
+            {
+                GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt");
+                GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt() - offset: " + offset.ToString() + " size: " + size.ToString() + " buffersize: " + buffer.Length.ToString());
+                GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt() buffer:");
+                GlobalLog.Dump(buffer, Math.Min(buffer.Length, 128));
+            }
 
             byte[] writeBuffer;
             try
@@ -960,9 +1056,9 @@ namespace System.Net.Security
             }
             catch (Exception e)
             {
-                if (!ExceptionCheck.IsFatal(e))
+                if (!ExceptionCheck.IsFatal(e) && globalLogEnabled)
                 {
-                    GlobalLog.Assert(false, "SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Arguments out of range.");
+                    GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Arguments out of range.");
                 }
 
                 throw;
@@ -972,12 +1068,18 @@ namespace System.Net.Security
 
             if (secStatus != SecurityStatusPal.OK)
             {
-                GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt ERROR", secStatus.ToString());
+                if (globalLogEnabled)
+                {
+                    GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt ERROR", secStatus.ToString());
+                }
             }
             else
             {
                 output = writeBuffer;
-                GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt OK", "data size:" + resultSize.ToString());
+                if (globalLogEnabled)
+                {
+                    GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt OK", "data size:" + resultSize.ToString());
+                }
             }
 
             return secStatus;
@@ -985,17 +1087,28 @@ namespace System.Net.Security
 
         internal SecurityStatusPal Decrypt(byte[] payload, ref int offset, ref int count)
         {
-            GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::Decrypt() - offset: " + offset.ToString() + " size: " + count.ToString() + " buffersize: " + payload.Length.ToString());
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+
+            if (globalLogEnabled)
+            {
+                GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::Decrypt() - offset: " + offset.ToString() + " size: " + count.ToString() + " buffersize: " + payload.Length.ToString());
+            }
 
             if (offset < 0 || offset > (payload == null ? 0 : payload.Length))
             {
-                GlobalLog.Assert(false, "SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Argument 'offset' out of range.");
+                if (globalLogEnabled)
+                {
+                    GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Argument 'offset' out of range.");
+                }
                 throw new ArgumentOutOfRangeException("offset");
             }
 
             if (count < 0 || count > (payload == null ? 0 : payload.Length - offset))
             {
-                GlobalLog.Assert(false, "SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Argument 'count' out of range.");
+                if (globalLogEnabled)
+                {
+                    GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Argument 'count' out of range.");
+                }
                 throw new ArgumentOutOfRangeException("count");
             }
 
@@ -1017,7 +1130,12 @@ namespace System.Net.Security
         //
         internal bool VerifyRemoteCertificate(RemoteCertValidationCallback remoteCertValidationCallback)
         {
-            GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::VerifyRemoteCertificate");
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+            if (globalLogEnabled)
+            {
+                GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::VerifyRemoteCertificate");
+            }
+
             SslPolicyErrors sslPolicyErrors = SslPolicyErrors.None;
 
             // We don't catch exceptions in this method, so it's safe for "accepted" be initialized with true.
@@ -1033,7 +1151,10 @@ namespace System.Net.Security
 
                 if (remoteCertificateEx == null)
                 {
-                    GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::VerifyRemoteCertificate (no remote cert)", (!_remoteCertRequired).ToString());
+                    if (globalLogEnabled)
+                    {
+                        GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::VerifyRemoteCertificate (no remote cert)", (!_remoteCertRequired).ToString());
+                    }
                     sslPolicyErrors |= SslPolicyErrors.RemoteCertificateNotAvailable;
                 }
                 else
@@ -1045,7 +1166,7 @@ namespace System.Net.Security
                     {
                         chain.ChainPolicy.ExtraStore.AddRange(remoteCertificateStore);
                     }
-                    
+
                     sslPolicyErrors |= CertificateValidationPal.VerifyCertificateProperties(
                         chain,
                         remoteCertificateEx,
@@ -1114,7 +1235,11 @@ namespace System.Net.Security
                         }
                     }
                 }
-                GlobalLog.Print("Cert Validation, remote cert = " + (remoteCertificateEx == null ? "<null>" : remoteCertificateEx.ToString(true)));
+
+                if (globalLogEnabled)
+                {
+                    GlobalLog.Print("Cert Validation, remote cert = " + (remoteCertificateEx == null ? "<null>" : remoteCertificateEx.ToString(true)));
+                }
             }
             finally
             {
@@ -1130,7 +1255,11 @@ namespace System.Net.Security
                     remoteCertificateEx.Dispose();
                 }
             }
-            GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::VerifyRemoteCertificate", success.ToString());
+
+            if (globalLogEnabled)
+            {
+                GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::VerifyRemoteCertificate", success.ToString());
+            }
             return success;
         }
     }

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/FixedSizeReader.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/FixedSizeReader.cs
@@ -103,7 +103,10 @@ namespace System.Net
                 throw new IOException(SR.net_io_eof);
             }
 
-            GlobalLog.Assert(_totalRead + bytes <= _request.Count, "FixedSizeReader::CheckCompletion()|State got out of range. Total:{0} Count:{1}", _totalRead + bytes, _request.Count);
+            if (GlobalLog.IsEnabled && _totalRead + bytes > _request.Count)
+            {
+                GlobalLog.AssertFormat("FixedSizeReader::CheckCompletion()|State got out of range. Total:{0} Count:{1}", _totalRead + bytes, _request.Count);
+            }
 
             if ((_totalRead += bytes) == _request.Count)
             {
@@ -116,7 +119,11 @@ namespace System.Net
 
         private static void ReadCallback(IAsyncResult transportResult)
         {
-            GlobalLog.Assert(transportResult.AsyncState is FixedSizeReader, "ReadCallback|State type is wrong, expected FixedSizeReader.");
+            if (GlobalLog.IsEnabled && !(transportResult.AsyncState is FixedSizeReader))
+            {
+                GlobalLog.Assert("ReadCallback|State type is wrong, expected FixedSizeReader.");
+            }
+
             if (transportResult.CompletedSynchronously)
             {
                 return;

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/HelperAsyncResults.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/HelperAsyncResults.cs
@@ -40,8 +40,17 @@ namespace System.Net
 
         public AsyncProtocolRequest(LazyAsyncResult userAsyncResult)
         {
-            GlobalLog.Assert(userAsyncResult != null, "AsyncProtocolRequest()|userAsyncResult == null");
-            GlobalLog.Assert(!userAsyncResult.InternalPeekCompleted, "AsyncProtocolRequest()|userAsyncResult is already completed.");
+            if (GlobalLog.IsEnabled)
+            {
+                if (userAsyncResult == null)
+                {
+                    GlobalLog.Assert("AsyncProtocolRequest()|userAsyncResult == null");
+                }
+                if (userAsyncResult.InternalPeekCompleted)
+                {
+                    GlobalLog.Assert("AsyncProtocolRequest()|userAsyncResult is already completed.");
+                }
+            }
             UserAsyncResult = userAsyncResult;
         }
 

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslStreamContext.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslStreamContext.cs
@@ -10,7 +10,11 @@ namespace System.Net
     {
         internal SslStreamContext(SslStream sslStream)
         {
-            GlobalLog.Assert(sslStream != null, "SslStreamContext..ctor(): Not expecting a null sslStream!");
+            if (sslStream == null && GlobalLog.IsEnabled)
+            {
+                GlobalLog.Assert("SslStreamContext..ctor(): Not expecting a null sslStream!");
+            }
+
             _sslStream = sslStream;
         }
 

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslStreamInternal.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslStreamInternal.cs
@@ -353,7 +353,10 @@ namespace System.Net.Security
         {
             int result = 0;
 
-            GlobalLog.Assert(InternalBufferCount == 0, "SslStream::StartReading()|Previous frame was not consumed. InternalBufferCount:{0}", InternalBufferCount);
+            if (GlobalLog.IsEnabled && InternalBufferCount != 0)
+            {
+                GlobalLog.AssertFormat("SslStream::StartReading()|Previous frame was not consumed. InternalBufferCount:{0}", InternalBufferCount);
+            }
 
             do
             {
@@ -488,7 +491,10 @@ namespace System.Net.Security
             // ERROR - examine what kind
             ProtocolToken message = new ProtocolToken(null, errorCode);
 
-            GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::***Processing an error Status = " + message.Status.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::***Processing an error Status = " + message.Status.ToString());
+            }
 
             if (message.Renegotiate)
             {

--- a/src/System.Net.Security/src/System/Net/SecurityBuffer.cs
+++ b/src/System.Net.Security/src/System/Net/SecurityBuffer.cs
@@ -16,8 +16,17 @@ namespace System.Net.Security
 
         public SecurityBuffer(byte[] data, int offset, int size, SecurityBufferType tokentype)
         {
-            GlobalLog.Assert(offset >= 0 && offset <= (data == null ? 0 : data.Length), "SecurityBuffer::.ctor", "'offset' out of range.  [" + offset + "]");
-            GlobalLog.Assert(size >= 0 && size <= (data == null ? 0 : data.Length - offset), "SecurityBuffer::.ctor", "'size' out of range.  [" + size + "]");
+            if (GlobalLog.IsEnabled)
+            {
+                if (offset == 0 || offset > (data == null ? 0 : data.Length))
+                {
+                    GlobalLog.Assert("SecurityBuffer::.ctor", "'offset' out of range.  [" + offset + "]");
+                }
+                if (size == 0 || size > (data == null ? 0 : data.Length - offset))
+                {
+                    GlobalLog.Assert("SecurityBuffer::.ctor", "'size' out of range.  [" + size + "]");
+                }
+            }
 
             this.offset = data == null || offset < 0 ? 0 : Math.Min(offset, data.Length);
             this.size = data == null || size < 0 ? 0 : Math.Min(size, data.Length - this.offset);
@@ -34,7 +43,10 @@ namespace System.Net.Security
 
         public SecurityBuffer(int size, SecurityBufferType tokentype)
         {
-            GlobalLog.Assert(size >= 0, "SecurityBuffer::.ctor", "'size' out of range.  [" + size + "]");
+            if (size < 0 && GlobalLog.IsEnabled)
+            {
+                GlobalLog.Assert("SecurityBuffer::.ctor", "'size' out of range.  [" + size + "]");
+            }
 
             this.size = size;
             this.type = tokentype;

--- a/src/System.Net.Security/src/System/Net/SslSessionsCache.cs
+++ b/src/System.Net.Security/src/System/Net/SslSessionsCache.cs
@@ -125,9 +125,14 @@ namespace System.Net.Security
         //
         internal static SafeFreeCredentials TryCachedCredential(byte[] thumbPrint, SslProtocols sslProtocols, bool isServer, EncryptionPolicy encryptionPolicy)
         {
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+
             if (s_CachedCreds.Count == 0)
             {
-                GlobalLog.Print("TryCachedCredential() Not found, Current Cache Count = " + s_CachedCreds.Count);
+                if (globalLogEnabled)
+                {
+                    GlobalLog.Print("TryCachedCredential() Not found, Current Cache Count = " + s_CachedCreds.Count);
+                }
                 return null;
             }
 
@@ -137,11 +142,17 @@ namespace System.Net.Security
 
             if (cached == null || cached.IsClosed || cached.Target.IsInvalid)
             {
-                GlobalLog.Print("TryCachedCredential() Not found or invalid, Current Cache Count = " + s_CachedCreds.Count);
+                if (globalLogEnabled)
+                {
+                    GlobalLog.Print("TryCachedCredential() Not found or invalid, Current Cache Count = " + s_CachedCreds.Count);
+                }
                 return null;
             }
 
-            GlobalLog.Print("TryCachedCredential() Found a cached Handle = " + cached.Target.ToString());
+            if (globalLogEnabled)
+            {
+                GlobalLog.Print("TryCachedCredential() Found a cached Handle = " + cached.Target.ToString());
+            }
 
             return cached.Target;
         }
@@ -153,10 +164,19 @@ namespace System.Net.Security
         //
         internal static void CacheCredential(SafeFreeCredentials creds, byte[] thumbPrint, SslProtocols sslProtocols, bool isServer, EncryptionPolicy encryptionPolicy)
         {
-            GlobalLog.Assert(creds != null, "CacheCredential|creds == null");
+            bool globalLogEnabled = GlobalLog.IsEnabled;
+
+            if (creds == null && globalLogEnabled)
+            {
+                GlobalLog.Assert("CacheCredential|creds == null");
+            }
+
             if (creds.IsInvalid)
             {
-                GlobalLog.Print("CacheCredential() Refused to cache an Invalid Handle = " + creds.ToString() + ", Current Cache Count = " + s_CachedCreds.Count);
+                if (globalLogEnabled)
+                {
+                    GlobalLog.Print("CacheCredential() Refused to cache an Invalid Handle = " + creds.ToString() + ", Current Cache Count = " + s_CachedCreds.Count);
+                }
                 return;
             }
 
@@ -181,7 +201,10 @@ namespace System.Net.Security
                         }
 
                         s_CachedCreds[key] = cached;
-                        GlobalLog.Print("CacheCredential() Caching New Handle = " + creds.ToString() + ", Current Cache Count = " + s_CachedCreds.Count);
+                        if (globalLogEnabled)
+                        {
+                            GlobalLog.Print("CacheCredential() Caching New Handle = " + creds.ToString() + ", Current Cache Count = " + s_CachedCreds.Count);
+                        }
 
                         //
                         // A simplest way of preventing infinite cache grows.
@@ -217,16 +240,19 @@ namespace System.Net.Security
                                     }
                                 }
                             }
-                            GlobalLog.Print("Scavenged cache, New Cache Count = " + s_CachedCreds.Count);
+                            if (globalLogEnabled)
+                            {
+                                GlobalLog.Print("Scavenged cache, New Cache Count = " + s_CachedCreds.Count);
+                            }
                         }
                     }
-                    else
+                    else if (globalLogEnabled)
                     {
                         GlobalLog.Print("CacheCredential() (locked retry) Found already cached Handle = " + cached.Target.ToString());
                     }
                 }
             }
-            else
+            else if (globalLogEnabled)
             {
                 GlobalLog.Print("CacheCredential() Ignoring incoming handle = " + creds.ToString() + " since found already cached Handle = " + cached.Target.ToString());
             }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Unix.cs
@@ -19,9 +19,12 @@ namespace System.Net.Sockets
         public BaseOverlappedAsyncResult(Socket socket, Object asyncState, AsyncCallback asyncCallback)
             : base(socket, asyncState, asyncCallback)
         {
-            GlobalLog.Print(
-                "BaseOverlappedAsyncResult#" + LoggingHash.HashString(this) +
-                "(Socket#" + LoggingHash.HashString(socket) + ")");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print(
+                    "BaseOverlappedAsyncResult#" + LoggingHash.HashString(this) +
+                    "(Socket#" + LoggingHash.HashString(socket) + ")");
+            }
         }
 
         public void CompletionCallback(int numBytes, SocketError errorCode)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -1267,7 +1267,10 @@ namespace System.Net.Sockets
             int socketCount;
             Interop.Error err = Interop.Sys.Select(fdCount, readFds, writeFds, errorFds, microseconds, &socketCount);
 
-            GlobalLog.Print("Socket::Select() Interop.Sys.Select returns socketCount:" + socketCount);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Socket::Select() Interop.Sys.Select returns socketCount:" + socketCount);
+            }
 
             if (err != Interop.Error.SUCCESS)
             {


### PR DESCRIPTION
Same treatment as in #5238, but for the rest of System.Net.  I may have missed a call site here or there, but those can be fixed as one-offs.

Contributes to #5144 
cc: @ericeil, @pgavlin, @davidsh, @cipop, @josguil