### PR TITLE
System.IO.Compression: Modify path validation to be based on ZipArchive source OS

### DIFF
--- a/src/Common/src/System/IO/PathInternal.Unix.cs
+++ b/src/Common/src/System/IO/PathInternal.Unix.cs
@@ -9,7 +9,7 @@ namespace System.IO
     /// <summary>Contains internal path helpers that are shared between many projects.</summary>
     internal static partial class PathInternal
     {
-        // Therre is only one invalid path character in Unix
+        // There is only one invalid path character in Unix
         private const char InvalidPathChar = '\0';
         internal static readonly char[] InvalidPathChars = { InvalidPathChar };
 

--- a/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
+++ b/src/System.IO.Compression.ZipFile/tests/System.IO.Compression.ZipFile.Tests.csproj
@@ -42,7 +42,7 @@
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)System.IO.Compression.TestData\1.0.0-prerelease\content\**\*.*" />
+    <SupplementalTestData Include="$(PackagesDir)System.IO.Compression.TestData\1.0.1-prerelease\content\**\*.*" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileInvalidFileTests.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileInvalidFileTests.cs
@@ -197,5 +197,60 @@ namespace System.IO.Compression.Tests
             Assert.Throws<IOException>(() => ZipFile.ExtractToDirectory(archivePath, GetTmpDirPath()));
         }
 
+        /// <summary>
+        /// This test ensures that a zipfile with path names that are invalid to this OS will throw errors
+        /// when an attempt is made to extract them.
+        /// </summary>
+        [Theory]
+        [InlineData("NullCharFileName_FromWindows")]
+        [InlineData("NullCharFileName_FromUnix")]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public void Unix_ZipWithInvalidFileNames_ThrowsArgumentException(string zipName)
+        {
+            Assert.Throws<ArgumentException>(() => ZipFile.ExtractToDirectory(compat(zipName) + ".zip", GetTmpDirPath()));
+        }
+
+        [Theory]
+        [InlineData("backslashes_FromUnix", "aa\\bb\\cc\\dd")]
+        [InlineData("backslashes_FromWindows", "aa\\bb\\cc\\dd")]
+        [InlineData("WindowsInvalid_FromUnix", "aa<b>d")]
+        [InlineData("WindowsInvalid_FromWindows", "aa<b>d")]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public void Unix_ZipWithOSSpecificFileNames(string zipName, string fileName)
+        {
+            string tempDir = GetTmpDirPath();
+            ZipFile.ExtractToDirectory(compat(zipName) + ".zip", tempDir);
+            string[] results = Directory.GetFiles(tempDir, "*", SearchOption.AllDirectories);
+            Assert.Equal(1, results.Length);
+            Assert.Equal(fileName, Path.GetFileName(results[0]));
+        }
+
+        /// <summary>
+        /// This test ensures that a zipfile with path names that are invalid to this OS will throw errors
+        /// when an attempt is made to extract them.
+        /// </summary>
+        [Theory]
+        [InlineData("WindowsInvalid_FromUnix")]
+        [InlineData("WindowsInvalid_FromWindows")]
+        [InlineData("NullCharFileName_FromWindows")]
+        [InlineData("NullCharFileName_FromUnix")]
+        [PlatformSpecific(PlatformID.Windows)]
+        public void Windows_ZipWithInvalidFileNames_ThrowsArgumentException(string zipName)
+        {
+            Assert.Throws<ArgumentException>(() => ZipFile.ExtractToDirectory(compat(zipName) + ".zip", GetTmpDirPath()));
+        }
+
+        [Theory]
+        [InlineData("backslashes_FromUnix", "dd")]
+        [InlineData("backslashes_FromWindows", "dd")]
+        [PlatformSpecific(PlatformID.Windows)]
+        public void Windows_ZipWithOSSpecificFileNames(string zipName, string fileName)
+        {
+            string tempDir = GetTmpDirPath();
+            ZipFile.ExtractToDirectory(compat(zipName) + ".zip", tempDir);
+            string[] results = Directory.GetFiles(tempDir, "*", SearchOption.AllDirectories);
+            Assert.Equal(1, results.Length);
+            Assert.Equal(fileName, Path.GetFileName(results[0]));
+        }
     }
 }

--- a/src/System.IO.Compression.ZipFile/tests/project.json
+++ b/src/System.IO.Compression.ZipFile/tests/project.json
@@ -5,7 +5,7 @@
     "System.Diagnostics.Debug": "4.0.10",
     "System.IO": "4.0.10",
     "System.IO.Compression": "4.0.0",
-    "System.IO.Compression.TestData": "1.0.0-prerelease",
+    "System.IO.Compression.TestData": "1.0.1-prerelease",
     "System.IO.FileSystem": "4.0.0",
     "System.IO.FileSystem.Primitives": "4.0.0",
     "System.Linq": "4.0.0",

--- a/src/System.IO.Compression/src/Resources/Strings.resx
+++ b/src/System.IO.Compression/src/Resources/Strings.resx
@@ -318,4 +318,7 @@
   <data name="Argument_InvalidPathChars" xml:space="preserve">
     <value>Illegal characters in path.</value>
   </data>
+  <data name="FileNameContainsInvalidCharacters" xml:space="preserve">
+    <value>An entry in the ZipArchive has a path that contains invalid characters.</value>
+  </data>
 </root>

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Unix.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Unix.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
+
 namespace System.IO.Compression
 {
     public partial class ZipArchiveEntry
@@ -13,26 +15,13 @@ namespace System.IO.Compression
         /// This method takes in a FullName and the platform of the ZipArchiveEntry and returns
         /// the platform-correct file name.
         /// </summary>
+        /// <remarks>This method ensures no validation on the paths. Invalid characters are allowed.</remarks>
         internal static string ParseFileName(string path, ZipVersionMadeByPlatform madeByPlatform)
         {
-            // Validation checking is done based on current OS, not source OS.
-            PathInternal.CheckInvalidPathChars(path);
-
             if (madeByPlatform == ZipVersionMadeByPlatform.Windows)
-            {
-                int length = path.Length;
-                for (int i = length; --i >= 0;)
-                {
-                    char ch = path[i];
-                    if (ch == '\\' || ch == '/' || ch == ':')
-                        return path.Substring(i + 1);
-                }
-                return path;
-            }
+                return GetFileName_Windows(path);
             else
-            {
-                return Path.GetFileName(path);
-            }
+                return GetFileName_Unix(path);
         }
     }
 }

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Windows.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.Windows.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
+
 namespace System.IO.Compression
 {
     public partial class ZipArchiveEntry
@@ -13,23 +15,13 @@ namespace System.IO.Compression
         /// This method takes in a FullName and the platform of the ZipArchiveEntry and returns
         /// the platform-correct file name.
         /// </summary>
+        /// <remarks>This method ensures no validation on the paths. Invalid characters are allowed.</remarks>
         internal static string ParseFileName(string path, ZipVersionMadeByPlatform madeByPlatform)
         {
-            // Validation checking is done based on current OS, not source OS.
-            PathInternal.CheckInvalidPathChars(path);
-
             if (madeByPlatform == ZipVersionMadeByPlatform.Unix)
-            {
-                int length = path.Length;
-                for (int i = length; --i >= 0;)
-                    if (path[i] == '/')
-                        return path.Substring(i + 1);
-                return path;
-            }
+                return GetFileName_Unix(path);
             else
-            {
-                return Path.GetFileName(path);
-            }
+                return GetFileName_Windows(path);
         }
     }
 }

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipArchiveEntry.cs
@@ -195,7 +195,7 @@ namespace System.IO.Compression
                 else
                     _generalPurposeBitFlag &= ~BitFlagValues.UnicodeFileName;
 
-                if (ZipHelper.EndsWithDirChar(value))
+                if (ParseFileName(value, _versionMadeByPlatform) == "")
                     VersionToExtractAtLeast(ZipVersionNeededValues.ExplicitDirectory);
             }
         }
@@ -1090,6 +1090,33 @@ namespace System.IO.Compression
             if (_archive == null)
                 throw new InvalidOperationException(SR.DeletedEntry);
             _archive.ThrowIfDisposed();
+        }
+
+        /// <summary>
+        /// Gets the file name of the path based on Windows path separator characters
+        /// </summary>
+        private static string GetFileName_Windows(string path)
+        {
+            int length = path.Length;
+            for (int i = length; --i >= 0;)
+            {
+                char ch = path[i];
+                if (ch == '\\' || ch == '/' || ch == ':')
+                    return path.Substring(i + 1);
+            }
+            return path;
+        }
+
+        /// <summary>
+        /// Gets the file name of the path based on Unix path separator characters
+        /// </summary>
+        private static string GetFileName_Unix(string path)
+        {
+            int length = path.Length;
+            for (int i = length; --i >= 0;)
+                if (path[i] == '/')
+                    return path.Substring(i + 1);
+            return path;
         }
 
         #endregion Privates

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipHelper.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipHelper.cs
@@ -18,12 +18,6 @@ namespace System.IO.Compression
 
         private static readonly DateTime s_invalidDateIndicator = new DateTime(ValidZipDate_YearMin, 1, 1, 0, 0, 0);
 
-
-        internal static Boolean EndsWithDirChar(String test)
-        {
-            return Path.GetFileName(test) == "";
-        }
-
         internal static Boolean RequiresUnicode(String test)
         {
             Debug.Assert(test != null);

--- a/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -57,7 +57,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)System.IO.Compression.TestData\1.0.0-prerelease\content\**\*.*" />
+    <SupplementalTestData Include="$(PackagesDir)System.IO.Compression.TestData\1.0.1-prerelease\content\**\*.*" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.Compression/tests/project.json
+++ b/src/System.IO.Compression/tests/project.json
@@ -6,7 +6,7 @@
     "System.Diagnostics.Debug": "4.0.10",
     "System.IO": "4.0.10",
     "System.IO.Compression": "4.0.0",
-    "System.IO.Compression.TestData": "1.0.0-prerelease",
+    "System.IO.Compression.TestData": "1.0.1-prerelease",
     "System.IO.FileSystem": "4.0.0",
     "System.Linq": "4.0.0",
     "System.Runtime": "4.0.20",


### PR DESCRIPTION
This commit resolves #4991 by adding explicit path validation based on the OS that a ZipArchive was written on instead of just using CheckInvalidPathChars for all cases.

This PR will fail until a new corefx-testdata package is published that contains the test assets for the new tests added.

@stephentoub 