### PR TITLE
SortedSet: Avoid redundant List allocation

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -1421,8 +1421,7 @@ namespace System.Collections.Generic
             }
             else
             {
-                //need perf improvement on this
-                T[] elements = (new List<T>(other)).ToArray();
+                T[] elements = EnumerableHelpers.ToArray(other);
                 Array.Sort(elements, this.Comparer);
                 SymmetricExceptWithSameEC(elements);
             }


### PR DESCRIPTION
Small change that avoids newing an intermediary `List<T>` to get an array.