### PR TITLE
Eliminate redundant code in Queue<T>.Contains

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -284,12 +284,7 @@ namespace System.Collections.Generic
             EqualityComparer<T> c = EqualityComparer<T>.Default;
             while (count-- > 0)
             {
-                if (((Object)item) == null)
-                {
-                    if (((Object)_array[index]) == null)
-                        return true;
-                }
-                else if (_array[index] != null && c.Equals(_array[index], item))
+                if (c.Equals(_array[index], item))
                 {
                     return true;
                 }


### PR DESCRIPTION
Null checks are not needed as the comparer handles this, and (combined with the casts to Object) can create unnecessary overhead for value types if we're unable to generate code. This PR removes the redundant code from `Queue.Contains`.