### PR TITLE
Fix native-build command parsing and push it to log file in build.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -24,9 +24,10 @@ if not defined VisualStudioVersion (
 
 :CheckNative
 :: Run the Native Windows build
-call %~dp0src\native\Windows\build-native.cmd %*
+echo Building Native Libraries...
+call %~dp0src\native\Windows\build-native.cmd %* >nativebuild.log
 IF ERRORLEVEL 1 (
-    echo Native component build failed.
+    echo Native component build failed see nativebuild.log for more details.
 )
 
 :EnvSet

--- a/src/Native/Windows/build-native.cmd
+++ b/src/Native/Windows/build-native.cmd
@@ -14,25 +14,25 @@ set CMAKE_BUILD_TYPE=Debug
 :Arg_Loop
 :: Since the native build requires some configuration information before msbuild is called, we have to do some manual args parsing
 :: For consistency with building the managed components, args are taken in the msbuild style i.e. /p:
-if "%1" == "" goto :ToolsVersion
-if /i "%1" == "/p:Configuration"    (
-    if /i "%2" == "Release" (set CMAKE_BUILD_TYPE=Release&&shift&&shift&goto Arg_Loop)
-    if /i "%2" == "Debug"   (set CMAKE_BUILD_TYPE=Debug&&shift&&shift&goto Arg_Loop)
+if [%1] == [] goto :ToolsVersion
+if /i [%1] == [/p:ConfigurationGroup]    (
+    if /i [%2] == [Release] (set CMAKE_BUILD_TYPE=Release&&shift&&shift&goto Arg_Loop)
+    if /i [%2] == [Debug]   (set CMAKE_BUILD_TYPE=Debug&&shift&&shift&goto Arg_Loop)
     echo Error: Invalid configuration args "%1 and %2"
     exit /b 1
 )
-if /i "%1" == "/p:Platform"    (
-    if /i "%2" == "AnyCPU"  (set __BuildArch=AnyCPU&&set __VCBuildArch=x86_amd64&&shift&&shift&goto Arg_Loop)
-    if /i "%2" == "x86"     (set __BuildArch=x86&&set __VCBuildArch=x86&&shift&&shift&goto Arg_Loop)
-    if /i "%2" == "arm"     (set __BuildArch=arm&&set __VCBuildArch=x86_arm&&shift&&shift&goto Arg_Loop)
-    if /i "%2" == "x64"     (set __BuildArch=x64&&set __VCBuildArch=x86_amd64&&shift&&shift&goto Arg_Loop)
+if /i [%1] == [/p:Platform]    (
+    if /i [%2] == [AnyCPU]  (set __BuildArch=AnyCPU&&set __VCBuildArch=x86_amd64&&shift&&shift&goto Arg_Loop)
+    if /i [%2] == [x86]     (set __BuildArch=x86&&set __VCBuildArch=x86&&shift&&shift&goto Arg_Loop)
+    if /i [%2] == [arm]     (set __BuildArch=arm&&set __VCBuildArch=x86_arm&&shift&&shift&goto Arg_Loop)
+    if /i [%2] == [x64]     (set __BuildArch=x64&&set __VCBuildArch=x86_amd64&&shift&&shift&goto Arg_Loop)
     echo Error: Invalid platform args "%1 and %2"
     exit /b 1
 )
-if /i "%1" == "-intermediateDir"    (
+if /i [%1] == [-intermediateDir]    (
     set __IntermediatesDir=%2
 )
-if /i "%1" == "-binDir"    (
+if /i [%1] == [-binDir]    (
     set __CMakeBinDir=%2
 )
 shift


### PR DESCRIPTION
@stephentoub @ianhays 

This should fix the outerloop build errors see:
http://dotnet-ci.cloudapp.net/job/dotnet_corefx/job/outerloop_win10_debug/52/console