### PR TITLE
Fix AppContext .builds file and project.json

### DIFF
--- a/src/System.AppContext/src/System.AppContext.builds
+++ b/src/System.AppContext/src/System.AppContext.builds
@@ -7,7 +7,6 @@
       <TargetGroup>net46</TargetGroup>
     </Project>
     <Project Include="System.AppContext.csproj">
-      <OSGroup>Windows_NT</OSGroup>
       <TargetGroup>netcore50</TargetGroup>
     </Project>
   </ItemGroup>

--- a/src/System.AppContext/src/project.json
+++ b/src/System.AppContext/src/project.json
@@ -7,7 +7,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23530",
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.0",
         "System.Collections": "4.0.0",
         "System.Resources.ResourceManager": "4.0.0",
         "System.Runtime": "4.0.20",
@@ -16,7 +16,7 @@
     },
     "net46":{
       "dependencies": {
-        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0-rc2-23530",
+        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0",
       }
     }
   }


### PR DESCRIPTION
Switched to WinRT package for Windows.winmd.

Remove OSGroup=Windows_NT from netcore50 target as it isn't necessary and it will allow for the building of the package for this library on other OSGroups.

cc @stephentoub @ericstj @AlexGhiondea 


