### PR TITLE
Fix OuterLoop Console test failing on Windows

### DIFF
--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -148,14 +148,17 @@ public class WindowAndCursorProps
     [OuterLoop] // clears the screen, not very inner-loop friendly
     public static void Clear()
     {
-        // Nothing to verify; just run the code.
-        Console.Clear();
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || (!Console.IsInputRedirected && !Console.IsOutputRedirected))
+        {
+            // Nothing to verify; just run the code.
+            Console.Clear();
+        }
     }
 
     [Fact]
     public static void SetCursorPosition()
     {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || (!Console.IsInputRedirected && !Console.IsOutputRedirected))
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || (!Console.IsInputRedirected && !Console.IsOutputRedirected))
         {
             int origLeft = Console.CursorLeft;
             int origTop = Console.CursorTop;
@@ -186,7 +189,7 @@ public class WindowAndCursorProps
             Assert.Equal(origLeft, Console.CursorLeft);
             Assert.Equal(origTop, Console.CursorTop);
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        else if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             Assert.Equal(0, Console.CursorLeft);
             Assert.Equal(0, Console.CursorTop);


### PR DESCRIPTION
Console.Clear can't be called when input/output is redirected.

Also fix some tests to run on OS X as well.