### PR TITLE
Mop up more System.Net logging guards

### DIFF
--- a/src/Common/src/Interop/Windows/SChannel/UnmanagedCertificateContext.cs
+++ b/src/Common/src/Interop/Windows/SChannel/UnmanagedCertificateContext.cs
@@ -37,9 +37,12 @@ namespace System.Net
                     }
 
                     var cert = new X509Certificate2(new IntPtr(next));
-                    GlobalLog.Print(
-                        "UnmanagedCertificateContext::GetRemoteCertificatesFromStoreContext " +
-                        "adding remote certificate:" + cert.Subject + cert.Thumbprint);
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Print(
+                            "UnmanagedCertificateContext::GetRemoteCertificatesFromStoreContext " +
+                            "adding remote certificate:" + cert.Subject + cert.Thumbprint);
+                    }
 
                     result.Add(cert);
                     last = next;

--- a/src/Common/src/Interop/Windows/sspicli/NegotiationInfoClass.cs
+++ b/src/Common/src/Interop/Windows/sspicli/NegotiationInfoClass.cs
@@ -19,12 +19,18 @@ namespace System.Net
         {
             if (safeHandle.IsInvalid)
             {
-                GlobalLog.Print("NegotiationInfoClass::.ctor() the handle is invalid:" + (safeHandle.DangerousGetHandle()).ToString("x"));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("NegotiationInfoClass::.ctor() the handle is invalid:" + (safeHandle.DangerousGetHandle()).ToString("x"));
+                }
                 return;
             }
 
             IntPtr packageInfo = safeHandle.DangerousGetHandle();
-            GlobalLog.Print("NegotiationInfoClass::.ctor() packageInfo:" + packageInfo.ToString("x8") + " negotiationState:" + negotiationState.ToString("x8"));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("NegotiationInfoClass::.ctor() packageInfo:" + packageInfo.ToString("x8") + " negotiationState:" + negotiationState.ToString("x8"));
+            }
 
             if (negotiationState == Interop.SspiCli.SECPKG_NEGOTIATION_COMPLETE
                 || negotiationState == Interop.SspiCli.SECPKG_NEGOTIATION_OPTIMISTIC)
@@ -36,7 +42,10 @@ namespace System.Net
                     name = Marshal.PtrToStringUni(unmanagedString);
                 }
 
-                GlobalLog.Print("NegotiationInfoClass::.ctor() packageInfo:" + packageInfo.ToString("x8") + " negotiationState:" + negotiationState.ToString("x8") + " name:" + LoggingHash.ObjectToString(name));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("NegotiationInfoClass::.ctor() packageInfo:" + packageInfo.ToString("x8") + " negotiationState:" + negotiationState.ToString("x8") + " name:" + LoggingHash.ObjectToString(name));
+                }
 
                 // An optimization for future string comparisons.
                 if (string.Compare(name, Kerberos, StringComparison.OrdinalIgnoreCase) == 0)

--- a/src/Common/src/Interop/Windows/sspicli/SSPIAuthType.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SSPIAuthType.cs
@@ -26,7 +26,10 @@ namespace System.Net
 
         public int EnumerateSecurityPackages(out int pkgnum, out SafeFreeContextBuffer pkgArray)
         {
-            GlobalLog.Print("SSPIAuthType::EnumerateSecurityPackages()");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("SSPIAuthType::EnumerateSecurityPackages()");
+            }
             return SafeFreeContextBuffer.EnumeratePackages(out pkgnum, out pkgArray);
         }
 
@@ -104,7 +107,10 @@ namespace System.Net
 
             if (status == 0 && qop == Interop.SspiCli.SECQOP_WRAP_NO_ENCRYPT)
             {
-                GlobalLog.Assert("SspiCli.DecryptMessage", "Expected qop = 0, returned value = " + qop.ToString("x", CultureInfo.InvariantCulture));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("SspiCli.DecryptMessage", "Expected qop = 0, returned value = " + qop.ToString("x", CultureInfo.InvariantCulture));
+                }
                 throw new InvalidOperationException(SR.net_auth_message_not_encrypted);
             }
 

--- a/src/Common/src/Interop/Windows/sspicli/SSPISecureChannelType.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SSPISecureChannelType.cs
@@ -25,7 +25,10 @@ namespace System.Net
 
         public int EnumerateSecurityPackages(out int pkgnum, out SafeFreeContextBuffer pkgArray)
         {
-            GlobalLog.Print("SSPISecureChannelType::EnumerateSecurityPackages()");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("SSPISecureChannelType::EnumerateSecurityPackages()");
+            }
             return SafeFreeContextBuffer.EnumeratePackages(out pkgnum, out pkgArray);
         }
 

--- a/src/Common/src/Interop/Windows/sspicli/SSPIWrapper.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SSPIWrapper.cs
@@ -12,7 +12,11 @@ namespace System.Net
     {
         internal static SecurityPackageInfoClass[] EnumerateSecurityPackages(SSPIInterface secModule)
         {
-            GlobalLog.Enter("EnumerateSecurityPackages");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Enter("EnumerateSecurityPackages");
+            }
+
             if (secModule.SecurityPackages == null)
             {
                 lock (secModule)
@@ -24,7 +28,10 @@ namespace System.Net
                         try
                         {
                             int errorCode = secModule.EnumerateSecurityPackages(out moduleCount, out arrayBaseHandle);
-                            GlobalLog.Print("SSPIWrapper::arrayBase: " + (arrayBaseHandle.DangerousGetHandle().ToString("x")));
+                            if (GlobalLog.IsEnabled)
+                            {
+                                GlobalLog.Print("SSPIWrapper::arrayBase: " + (arrayBaseHandle.DangerousGetHandle().ToString("x")));
+                            }
                             if (errorCode != 0)
                             {
                                 throw new Win32Exception(errorCode);
@@ -55,7 +62,10 @@ namespace System.Net
                 }
             }
 
-            GlobalLog.Leave("EnumerateSecurityPackages");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Leave("EnumerateSecurityPackages");
+            }
             return secModule.SecurityPackages;
         }
 
@@ -93,7 +103,11 @@ namespace System.Net
 
         public static SafeFreeCredentials AcquireDefaultCredential(SSPIInterface secModule, string package, Interop.SspiCli.CredentialUse intent)
         {
-            GlobalLog.Print("SSPIWrapper::AcquireDefaultCredential(): using " + package);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("SSPIWrapper::AcquireDefaultCredential(): using " + package);
+            }
+
             if (SecurityEventSource.Log.IsEnabled())
             {
                 SecurityEventSource.Log.AcquireDefaultCredential(package, intent);
@@ -105,7 +119,10 @@ namespace System.Net
             if (errorCode != 0)
             {
 #if TRACE_VERBOSE
-                GlobalLog.Print("SSPIWrapper::AcquireDefaultCredential(): error " + Interop.MapSecurityStatus((uint)errorCode));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("SSPIWrapper::AcquireDefaultCredential(): error " + Interop.MapSecurityStatus((uint)errorCode));
+                }
 #endif
 
                 if (NetEventSource.Log.IsEnabled())
@@ -120,7 +137,10 @@ namespace System.Net
 
         public static SafeFreeCredentials AcquireCredentialsHandle(SSPIInterface secModule, string package, Interop.SspiCli.CredentialUse intent, ref Interop.SspiCli.AuthIdentity authdata)
         {
-            GlobalLog.Print("SSPIWrapper::AcquireCredentialsHandle#2(): using " + package);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("SSPIWrapper::AcquireCredentialsHandle#2(): using " + package);
+            }
 
             if (SecurityEventSource.Log.IsEnabled())
             {
@@ -136,7 +156,10 @@ namespace System.Net
             if (errorCode != 0)
             {
 #if TRACE_VERBOSE
-                GlobalLog.Print("SSPIWrapper::AcquireCredentialsHandle#2(): error " + Interop.MapSecurityStatus((uint)errorCode));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("SSPIWrapper::AcquireCredentialsHandle#2(): error " + Interop.MapSecurityStatus((uint)errorCode));
+                }
 #endif
                 if (NetEventSource.Log.IsEnabled())
                 {
@@ -173,7 +196,10 @@ namespace System.Net
 
         public static SafeFreeCredentials AcquireCredentialsHandle(SSPIInterface secModule, string package, Interop.SspiCli.CredentialUse intent, Interop.SspiCli.SecureCredential scc)
         {
-            GlobalLog.Print("SSPIWrapper::AcquireCredentialsHandle#3(): using " + package);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("SSPIWrapper::AcquireCredentialsHandle#3(): using " + package);
+            }
 
             if (SecurityEventSource.Log.IsEnabled())
             {
@@ -190,7 +216,10 @@ namespace System.Net
             if (errorCode != 0)
             {
 #if TRACE_VERBOSE
-                GlobalLog.Print("SSPIWrapper::AcquireCredentialsHandle#3(): error " + Interop.MapSecurityStatus((uint)errorCode));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("SSPIWrapper::AcquireCredentialsHandle#3(): error " + Interop.MapSecurityStatus((uint)errorCode));
+                }
 #endif
 
                 if (NetEventSource.Log.IsEnabled())
@@ -202,7 +231,10 @@ namespace System.Net
             }
 
 #if TRACE_VERBOSE
-            GlobalLog.Print("SSPIWrapper::AcquireCredentialsHandle#3(): cred handle = " + outCredential.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("SSPIWrapper::AcquireCredentialsHandle#3(): cred handle = " + outCredential.ToString());
+            }
 #endif
             return outCredential;
         }
@@ -376,7 +408,10 @@ namespace System.Net
                             break;
 
                         default:
-                            GlobalLog.Assert("SSPIWrapper::EncryptDecryptHelper", "Unknown OP: " + op);
+                            if (GlobalLog.IsEnabled)
+                            {
+                                GlobalLog.Assert("SSPIWrapper::EncryptDecryptHelper", "Unknown OP: " + op);
+                            }
                             throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
                     }
 
@@ -417,7 +452,10 @@ namespace System.Net
 
                                 if (j >= input.Length)
                                 {
-                                    GlobalLog.Assert("SSPIWrapper::EncryptDecryptHelper", "Output buffer out of range.");
+                                    if (GlobalLog.IsEnabled)
+                                    {
+                                        GlobalLog.Assert("SSPIWrapper::EncryptDecryptHelper", "Output buffer out of range.");
+                                    }
                                     iBuffer.size = 0;
                                     iBuffer.offset = 0;
                                     iBuffer.token = null;
@@ -468,17 +506,26 @@ namespace System.Net
 
         public static SafeFreeContextBufferChannelBinding QueryContextChannelBinding(SSPIInterface secModule, SafeDeleteContext securityContext, Interop.SspiCli.ContextAttribute contextAttribute)
         {
-            GlobalLog.Enter("QueryContextChannelBinding", contextAttribute.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Enter("QueryContextChannelBinding", contextAttribute.ToString());
+            }
 
             SafeFreeContextBufferChannelBinding result;
             int errorCode = secModule.QueryContextChannelBinding(securityContext, contextAttribute, out result);
             if (errorCode != 0)
             {
-                GlobalLog.Leave("QueryContextChannelBinding", "ERROR = " + ErrorDescription(errorCode));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Leave("QueryContextChannelBinding", "ERROR = " + ErrorDescription(errorCode));
+                }
                 return null;
             }
 
-            GlobalLog.Leave("QueryContextChannelBinding", LoggingHash.HashString(result));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Leave("QueryContextChannelBinding", LoggingHash.HashString(result));
+            }
             return result;
         }
 
@@ -490,7 +537,10 @@ namespace System.Net
 
         public static object QueryContextAttributes(SSPIInterface secModule, SafeDeleteContext securityContext, Interop.SspiCli.ContextAttribute contextAttribute, out int errorCode)
         {
-            GlobalLog.Enter("QueryContextAttributes", contextAttribute.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Enter("QueryContextAttributes", contextAttribute.ToString());
+            }
 
             int nativeBlockSize = IntPtr.Size;
             Type handleType = null;
@@ -551,7 +601,10 @@ namespace System.Net
                 errorCode = secModule.QueryContextAttributes(securityContext, contextAttribute, nativeBuffer, handleType, out sspiHandle);
                 if (errorCode != 0)
                 {
-                    GlobalLog.Leave("Win32:QueryContextAttributes", "ERROR = " + ErrorDescription(errorCode));
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Leave("Win32:QueryContextAttributes", "ERROR = " + ErrorDescription(errorCode));
+                    }
                     return null;
                 }
 
@@ -614,7 +667,12 @@ namespace System.Net
                     sspiHandle.Dispose();
                 }
             }
-            GlobalLog.Leave("QueryContextAttributes", LoggingHash.ObjectToString(attribute));
+
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Leave("QueryContextAttributes", LoggingHash.ObjectToString(attribute));
+            }
+
             return attribute;
         }
 

--- a/src/Common/src/Interop/Windows/sspicli/SecurityPackageInfoClass.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SecurityPackageInfoClass.cs
@@ -26,12 +26,18 @@ namespace System.Net
         {
             if (safeHandle.IsInvalid)
             {
-                GlobalLog.Print("SecurityPackageInfoClass::.ctor() the pointer is invalid: " + (safeHandle.DangerousGetHandle()).ToString("x"));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("SecurityPackageInfoClass::.ctor() the pointer is invalid: " + (safeHandle.DangerousGetHandle()).ToString("x"));
+                }
                 return;
             }
 
             IntPtr unmanagedAddress = IntPtrHelper.Add(safeHandle.DangerousGetHandle(), SecurityPackageInfo.Size * index);
-            GlobalLog.Print("SecurityPackageInfoClass::.ctor() unmanagedPointer: " + ((long)unmanagedAddress).ToString("x"));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("SecurityPackageInfoClass::.ctor() unmanagedPointer: " + ((long)unmanagedAddress).ToString("x"));
+            }
 
             // TODO (Issue #3114): replace with Marshal.PtrToStructure.
             Capabilities = Marshal.ReadInt32(unmanagedAddress, (int)Marshal.OffsetOf<SecurityPackageInfo>("Capabilities"));
@@ -45,17 +51,26 @@ namespace System.Net
             if (unmanagedString != IntPtr.Zero)
             {
                 Name = Marshal.PtrToStringUni(unmanagedString);
-                GlobalLog.Print("Name: " + Name);
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("Name: " + Name);
+                }
             }
 
             unmanagedString = Marshal.ReadIntPtr(unmanagedAddress, (int)Marshal.OffsetOf<SecurityPackageInfo>("Comment"));
             if (unmanagedString != IntPtr.Zero)
             {
                 Comment = Marshal.PtrToStringUni(unmanagedString);
-                GlobalLog.Print("Comment: " + Comment);
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("Comment: " + Comment);
+                }
             }
 
-            GlobalLog.Print("SecurityPackageInfoClass::.ctor(): " + ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("SecurityPackageInfoClass::.ctor(): " + ToString());
+            }
         }
 
         public override string ToString()

--- a/src/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
@@ -93,7 +93,11 @@ namespace System.Net
                 return null;
             }
 
-            GlobalLog.Enter("CertificateValidationPal.Windows SecureChannel#" + LoggingHash.HashString(securityContext) + "::GetRemoteCertificate()");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Enter("CertificateValidationPal.Windows SecureChannel#" + LoggingHash.HashString(securityContext) + "::GetRemoteCertificate()");
+            }
+
             X509Certificate2 result = null;
             SafeFreeCertContext remoteContext = null;
             try
@@ -119,7 +123,10 @@ namespace System.Net
                 SecurityEventSource.Log.RemoteCertificate(result == null ? "null" : result.ToString(true));
             }
 
-            GlobalLog.Leave("CertificateValidationPal.Windows SecureChannel#" + LoggingHash.HashString(securityContext) + "::GetRemoteCertificate()", (result == null ? "null" : result.Subject));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Leave("CertificateValidationPal.Windows SecureChannel#" + LoggingHash.HashString(securityContext) + "::GetRemoteCertificate()", (result == null ? "null" : result.Subject));
+            }
 
             return result;
         }
@@ -166,7 +173,10 @@ namespace System.Net
 
                                 X500DistinguishedName x500DistinguishedName = new X500DistinguishedName(x);
                                 issuers[i] = x500DistinguishedName.Name;
-                                GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(securityContext) + "::GetIssuers() IssuerListEx[" + i + "]:" + issuers[i]);
+                                if (GlobalLog.IsEnabled)
+                                {
+                                    GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(securityContext) + "::GetIssuers() IssuerListEx[" + i + "]:" + issuers[i]);
+                                }
                             }
                         }
                     }
@@ -209,7 +219,10 @@ namespace System.Net
                                 WindowsIdentity.RunImpersonated(SafeAccessTokenHandle.InvalidHandle, () =>
                                 {
                                     store.Open(OpenFlags.ReadOnly | OpenFlags.OpenExistingOnly);
-                                    GlobalLog.Print("SecureChannel::EnsureStoreOpened() storeLocation:" + storeLocation + " returned store:" + store.GetHashCode().ToString("x"));
+                                    if (GlobalLog.IsEnabled)
+                                    {
+                                        GlobalLog.Print("SecureChannel::EnsureStoreOpened() storeLocation:" + storeLocation + " returned store:" + store.GetHashCode().ToString("x"));
+                                    }
                                 });
                             }
                             catch
@@ -232,7 +245,10 @@ namespace System.Net
                         {
                             if (exception is CryptographicException || exception is SecurityException)
                             {
-                                GlobalLog.Assert("SecureChannel::EnsureStoreOpened()", "Failed to open cert store, location:" + storeLocation + " exception:" + exception);
+                                if (GlobalLog.IsEnabled)
+                                {
+                                    GlobalLog.Assert("SecureChannel::EnsureStoreOpened()", "Failed to open cert store, location:" + storeLocation + " exception:" + exception);
+                                }
                                 return null;
                             }
 
@@ -252,7 +268,11 @@ namespace System.Net
 
         private static uint Verify(SafeX509ChainHandle chainContext, ref Interop.Crypt32.CERT_CHAIN_POLICY_PARA cpp)
         {
-            GlobalLog.Enter("SecureChannel::VerifyChainPolicy", "chainContext=" + chainContext + ", options=" + String.Format("0x{0:x}", cpp.dwFlags));
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Enter("SecureChannel::VerifyChainPolicy", "chainContext=" + chainContext + ", options=" + String.Format("0x{0:x}", cpp.dwFlags));
+            }
+
             var status = new Interop.Crypt32.CERT_CHAIN_POLICY_STATUS();
             status.cbSize = (uint)Marshal.SizeOf<Interop.Crypt32.CERT_CHAIN_POLICY_STATUS>();
 
@@ -263,11 +283,15 @@ namespace System.Net
                     ref cpp,
                     ref status);
 
-            GlobalLog.Print("SecureChannel::VerifyChainPolicy() CertVerifyCertificateChainPolicy returned: " + errorCode);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("SecureChannel::VerifyChainPolicy() CertVerifyCertificateChainPolicy returned: " + errorCode);
 #if TRACE_VERBOSE
-            GlobalLog.Print("SecureChannel::VerifyChainPolicy() error code: " + status.dwError + String.Format(" [0x{0:x8}", status.dwError) + " " + Interop.MapSecurityStatus(status.dwError) + "]");
+                GlobalLog.Print("SecureChannel::VerifyChainPolicy() error code: " + status.dwError + String.Format(" [0x{0:x8}", status.dwError) + " " + Interop.MapSecurityStatus(status.dwError) + "]");
 #endif
-            GlobalLog.Leave("SecureChannel::VerifyChainPolicy", status.dwError.ToString());
+                GlobalLog.Leave("SecureChannel::VerifyChainPolicy", status.dwError.ToString());
+            }
+
             return status.dwError;
         }
     }

--- a/src/System.Net.Security/src/System/Net/NTAuthentication.cs
+++ b/src/System.Net.Security/src/System/Net/NTAuthentication.cs
@@ -61,7 +61,10 @@ namespace System.Net
                 }
 
                 string name = SSPIWrapper.QueryContextAttributes(GlobalSSPI.SSPIAuth, _securityContext, Interop.SspiCli.ContextAttribute.Names) as string;
-                GlobalLog.Print("NTAuthentication: The context is associated with [" + name + "]");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("NTAuthentication: The context is associated with [" + name + "]");
+                }
                 return name;
             }
         }
@@ -253,7 +256,11 @@ namespace System.Net
 
         private void Initialize(bool isServer, string package, NetworkCredential credential, string spn, Interop.SspiCli.ContextFlags requestedContextFlags, ChannelBinding channelBinding)
         {
-            GlobalLog.Print("NTAuthentication#" + LoggingHash.HashString(this) + "::.ctor() package:" + LoggingHash.ObjectToString(package) + " spn:" + LoggingHash.ObjectToString(spn) + " flags :" + requestedContextFlags.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("NTAuthentication#" + LoggingHash.HashString(this) + "::.ctor() package:" + LoggingHash.ObjectToString(package) + " spn:" + LoggingHash.ObjectToString(spn) + " flags :" + requestedContextFlags.ToString());
+            }
+
             _tokenSize = SSPIWrapper.GetVerifyPackageInfo(GlobalSSPI.SSPIAuth, package, true).MaxToken;
             _isServer = isServer;
             _spn = spn;
@@ -262,7 +269,10 @@ namespace System.Net
             _package = package;
             _channelBinding = channelBinding;
 
-            GlobalLog.Print("Peer SPN-> '" + _spn + "'");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("Peer SPN-> '" + _spn + "'");
+            }
 
             //
             // Check if we're using DefaultCredentials.
@@ -271,7 +281,11 @@ namespace System.Net
             Debug.Assert(CredentialCache.DefaultCredentials == CredentialCache.DefaultNetworkCredentials);
             if (credential == CredentialCache.DefaultCredentials)
             {
-                GlobalLog.Print("NTAuthentication#" + LoggingHash.HashString(this) + "::.ctor(): using DefaultCredentials");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("NTAuthentication#" + LoggingHash.HashString(this) + "::.ctor(): using DefaultCredentials");
+                }
+
                 _credentialsHandle = SSPIWrapper.AcquireDefaultCredential(
                     GlobalSSPI.SSPIAuth,
                     package,
@@ -368,7 +382,10 @@ namespace System.Net
         // Accepts an incoming binary security blob and returns an outgoing binary security blob.
         internal byte[] GetOutgoingBlob(byte[] incomingBlob, bool throwOnError, out Interop.SecurityStatus statusCode)
         {
-            GlobalLog.Enter("NTAuthentication#" + LoggingHash.HashString(this) + "::GetOutgoingBlob", ((incomingBlob == null) ? "0" : incomingBlob.Length.ToString(NumberFormatInfo.InvariantInfo)) + " bytes");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Enter("NTAuthentication#" + LoggingHash.HashString(this) + "::GetOutgoingBlob", ((incomingBlob == null) ? "0" : incomingBlob.Length.ToString(NumberFormatInfo.InvariantInfo)) + " bytes");
+            }
 
             var list = new List<SecurityBuffer>(2);
 
@@ -407,7 +424,10 @@ namespace System.Net
                         outSecurityBuffer,
                         ref _contextFlags);
 
-                    GlobalLog.Print("NTAuthentication#" + LoggingHash.HashString(this) + "::GetOutgoingBlob() SSPIWrapper.InitializeSecurityContext() returns statusCode:0x" + ((int)statusCode).ToString("x8", NumberFormatInfo.InvariantInfo) + " (" + statusCode.ToString() + ")");
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Print("NTAuthentication#" + LoggingHash.HashString(this) + "::GetOutgoingBlob() SSPIWrapper.InitializeSecurityContext() returns statusCode:0x" + ((int)statusCode).ToString("x8", NumberFormatInfo.InvariantInfo) + " (" + statusCode.ToString() + ")");
+                    }
 
                     if (statusCode == Interop.SecurityStatus.CompleteNeeded)
                     {
@@ -419,7 +439,11 @@ namespace System.Net
                             ref _securityContext,
                             inSecurityBuffers);
 
-                        GlobalLog.Print("NTAuthentication#" + LoggingHash.HashString(this) + "::GetOutgoingDigestBlob() SSPIWrapper.CompleteAuthToken() returns statusCode:0x" + ((int)statusCode).ToString("x8", NumberFormatInfo.InvariantInfo) + " (" + statusCode.ToString() + ")");
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.Print("NTAuthentication#" + LoggingHash.HashString(this) + "::GetOutgoingDigestBlob() SSPIWrapper.CompleteAuthToken() returns statusCode:0x" + ((int)statusCode).ToString("x8", NumberFormatInfo.InvariantInfo) + " (" + statusCode.ToString() + ")");
+                        }
+
                         outSecurityBuffer.token = null;
                     }
                 }
@@ -436,7 +460,10 @@ namespace System.Net
                         outSecurityBuffer,
                         ref _contextFlags);
 
-                    GlobalLog.Print("NTAuthentication#" + LoggingHash.HashString(this) + "::GetOutgoingBlob() SSPIWrapper.AcceptSecurityContext() returns statusCode:0x" + ((int)statusCode).ToString("x8", NumberFormatInfo.InvariantInfo) + " (" + statusCode.ToString() + ")");
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Print("NTAuthentication#" + LoggingHash.HashString(this) + "::GetOutgoingBlob() SSPIWrapper.AcceptSecurityContext() returns statusCode:0x" + ((int)statusCode).ToString("x8", NumberFormatInfo.InvariantInfo) + " (" + statusCode.ToString() + ")");
+                    }
                 }
             }
             finally
@@ -461,11 +488,17 @@ namespace System.Net
                 if (throwOnError)
                 {
                     var exception = new Win32Exception((int)statusCode);
-                    GlobalLog.Leave("NTAuthentication#" + LoggingHash.HashString(this) + "::GetOutgoingBlob", "Win32Exception:" + exception);
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Leave("NTAuthentication#" + LoggingHash.HashString(this) + "::GetOutgoingBlob", "Win32Exception:" + exception);
+                    }
                     throw exception;
                 }
-                
-                GlobalLog.Leave("NTAuthentication#" + LoggingHash.HashString(this) + "::GetOutgoingBlob", "null statusCode:0x" + ((int)statusCode).ToString("x8", NumberFormatInfo.InvariantInfo) + " (" + statusCode.ToString() + ")");
+
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Leave("NTAuthentication#" + LoggingHash.HashString(this) + "::GetOutgoingBlob", "null statusCode:0x" + ((int)statusCode).ToString("x8", NumberFormatInfo.InvariantInfo) + " (" + statusCode.ToString() + ")");
+                }
                 return null;
             }
             else if (firstTime && _credentialsHandle != null)
@@ -487,13 +520,17 @@ namespace System.Net
 
                 _isCompleted = true;
             }
-            else
+            else if (GlobalLog.IsEnabled)
             {
                 // We need to continue.
                 GlobalLog.Print("NTAuthentication#" + LoggingHash.HashString(this) + "::GetOutgoingBlob() need continue statusCode:[0x" + ((int)statusCode).ToString("x8", NumberFormatInfo.InvariantInfo) + "] (" + statusCode.ToString() + ") m_SecurityContext#" + LoggingHash.HashString(_securityContext) + "::Handle:" + LoggingHash.ObjectToString(_securityContext) + "]");
             }
 
-            GlobalLog.Leave("NTAuthentication#" + LoggingHash.HashString(this) + "::GetOutgoingBlob", "IsCompleted:" + IsCompleted.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Leave("NTAuthentication#" + LoggingHash.HashString(this) + "::GetOutgoingBlob", "IsCompleted:" + IsCompleted.ToString());
+            }
+
             return outSecurityBuffer.token;
         }
 
@@ -552,7 +589,10 @@ namespace System.Net
 
             if (errorCode != 0)
             {
-                GlobalLog.Print("NTAuthentication#" + LoggingHash.HashString(this) + "::Encrypt() throw Error = " + errorCode.ToString("x", NumberFormatInfo.InvariantInfo));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("NTAuthentication#" + LoggingHash.HashString(this) + "::Encrypt() throw Error = " + errorCode.ToString("x", NumberFormatInfo.InvariantInfo));
+                }
                 throw new Win32Exception(errorCode);
             }
 
@@ -630,7 +670,10 @@ namespace System.Net
 
             if (errorCode != 0)
             {
-                GlobalLog.Print("NTAuthentication#" + LoggingHash.HashString(this) + "::Decrypt() throw Error = " + errorCode.ToString("x", NumberFormatInfo.InvariantInfo));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("NTAuthentication#" + LoggingHash.HashString(this) + "::Decrypt() throw Error = " + errorCode.ToString("x", NumberFormatInfo.InvariantInfo));
+                }
                 throw new Win32Exception(errorCode);
             }
 
@@ -645,7 +688,7 @@ namespace System.Net
 
         private string GetClientSpecifiedSpn()
         {
-            if ((IsValidContext && IsCompleted) && GlobalLog.IsEnabled)
+            if (GlobalLog.IsEnabled && (IsValidContext && IsCompleted))
             {
                 GlobalLog.Assert("NTAuthentication: Trying to get the client SPN before handshaking is done!");
             }
@@ -653,7 +696,10 @@ namespace System.Net
             string spn = SSPIWrapper.QueryContextAttributes(GlobalSSPI.SSPIAuth, _securityContext,
                 Interop.SspiCli.ContextAttribute.ClientSpecifiedSpn) as string;
 
-            GlobalLog.Print("NTAuthentication: The client specified SPN is [" + spn + "]");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("NTAuthentication: The client specified SPN is [" + spn + "]");
+            }
             return spn;
         }
 
@@ -690,7 +736,10 @@ namespace System.Net
 
             if (errorCode != 0)
             {
-                GlobalLog.Print("NTAuthentication#" + LoggingHash.HashString(this) + "::Decrypt() throw Error = " + errorCode.ToString("x", NumberFormatInfo.InvariantInfo));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("NTAuthentication#" + LoggingHash.HashString(this) + "::Decrypt() throw Error = " + errorCode.ToString("x", NumberFormatInfo.InvariantInfo));
+                }
                 throw new Win32Exception(errorCode);
             }
 

--- a/src/System.Net.Security/src/System/Net/SSPIHandleCache.cs
+++ b/src/System.Net.Security/src/System/Net/SSPIHandleCache.cs
@@ -39,7 +39,7 @@ namespace System.Net.Security
             }
             catch (Exception e)
             {
-                if (!ExceptionCheck.IsFatal(e))
+                if (!ExceptionCheck.IsFatal(e) && GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("SSPIHandlCache", "Attempted to throw: " + e.ToString());
                 }

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslState.cs
@@ -996,8 +996,7 @@ namespace System.Net.Security
         //
         private bool CompleteHandshake()
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Enter("CompleteHandshake");
             }
@@ -1008,13 +1007,16 @@ namespace System.Net.Security
             {
                 _handshakeCompleted = false;
                 _certValidationFailed = true;
-                GlobalLog.Leave("CompleteHandshake", false);
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Leave("CompleteHandshake", false);
+                }
                 return false;
             }
 
             _certValidationFailed = false;
             _handshakeCompleted = true;
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Leave("CompleteHandshake", true);
             }
@@ -1579,7 +1581,10 @@ namespace System.Net.Security
 #if TRACE_VERBOSE
                 if (bytes[1] != 3) 
                 {
-                    GlobalLog.Print("WARNING: SslState::DetectFraming() SSL protocol is > 3, trying SSL3 framing in retail = " + bytes[1].ToString("x", NumberFormatInfo.InvariantInfo));
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Print("WARNING: SslState::DetectFraming() SSL protocol is > 3, trying SSL3 framing in retail = " + bytes[1].ToString("x", NumberFormatInfo.InvariantInfo));
+                    }
                 }
 #endif
 
@@ -1596,7 +1601,7 @@ namespace System.Net.Security
             }
 
 #if TRACE_VERBOSE
-            if ((bytes[0] & 0x80) == 0)
+            if ((bytes[0] & 0x80) == 0 && GlobalLog.IsEnabled)
             {
                 // We have a three-byte header format
                 GlobalLog.Print("WARNING: SslState::DetectFraming() SSL v <=2 HELLO has no high bit set for 3 bytes header, we are broken, received byte = " + bytes[0].ToString("x", NumberFormatInfo.InvariantInfo));
@@ -1662,8 +1667,7 @@ namespace System.Net.Security
         // This is called from SslStream class too.
         internal int GetRemainingFrameSize(byte[] buffer, int dataSize)
         {
-            bool globalLogRemaining = GlobalLog.IsEnabled;
-            if (globalLogRemaining)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Enter("GetRemainingFrameSize", "dataSize = " + dataSize);
             }
@@ -1706,7 +1710,7 @@ namespace System.Net.Security
                     break;
             }
 
-            if (globalLogRemaining)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Leave("GetRemainingFrameSize", payloadSize);
             }

--- a/src/System.Net.Security/src/System/Net/SslStreamPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/SslStreamPal.Windows.cs
@@ -137,7 +137,10 @@ namespace System.Net
 
             if (errorCode != 0)
             {
-                GlobalLog.Print("SslStreamPal.Windows: SecureChannel#" + LoggingHash.HashString(securityContext) + "::Encrypt ERROR" + errorCode.ToString("x"));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("SslStreamPal.Windows: SecureChannel#" + LoggingHash.HashString(securityContext) + "::Encrypt ERROR" + errorCode.ToString("x"));
+                }
                 resultSize = 0;
             }
             else

--- a/src/System.Net.Sockets/src/System/Net/Sockets/MultipleConnectAsync.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/MultipleConnectAsync.cs
@@ -350,7 +350,7 @@ namespace System.Net.Sockets
         {
             try
             {
-                if (attemptSocket == null)
+                if (attemptSocket == null && GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("MultipleConnectAsync.AttemptConnection: attemptSocket is null!");
                 }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -797,11 +797,14 @@ namespace System.Net.Sockets
                 socketAddress.Size);
 
 #if TRACE_VERBOSE
-            try
+            if (GlobalLog.IsEnabled)
             {
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Bind() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " Interop.Winsock.bind returns errorCode:" + errorCode);
+                try
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Bind() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " Interop.Winsock.bind returns errorCode:" + errorCode);
+                }
+                catch (ObjectDisposedException) { }
             }
-            catch (ObjectDisposedException) { }
 #endif
 
             // Throw an appropriate SocketException if the native call fails.
@@ -1097,11 +1100,14 @@ namespace System.Net.Sockets
                 backlog);
 
 #if TRACE_VERBOSE
-            try
+            if (GlobalLog.IsEnabled)
             {
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Listen() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " Interop.Winsock.listen returns errorCode:" + errorCode);
+                try
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Listen() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " Interop.Winsock.listen returns errorCode:" + errorCode);
+                }
+                catch (ObjectDisposedException) { }
             }
-            catch (ObjectDisposedException) { }
 #endif
 
             // Throw an appropriate SocketException if the native call fails.
@@ -1257,11 +1263,14 @@ namespace System.Net.Sockets
             errorCode = SocketPal.Send(_handle, buffers, socketFlags, out bytesTransferred);
 
 #if TRACE_VERBOSE
-            try
+            if (GlobalLog.IsEnabled)
             {
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Send() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " Interop.Winsock.send returns errorCode:" + errorCode + " bytesTransferred:" + bytesTransferred);
+                try
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Send() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " Interop.Winsock.send returns errorCode:" + errorCode + " bytesTransferred:" + bytesTransferred);
+                }
+                catch (ObjectDisposedException) { }
             }
-            catch (ObjectDisposedException) { }
 #endif
 
             if (errorCode != SocketError.Success)
@@ -1572,15 +1581,15 @@ namespace System.Net.Sockets
                 }
             }
 
-#if TRACE_VERBOSE
-            try
-            {
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Receive() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " bytesTransferred:" + bytesTransferred);
-            }
-            catch (ObjectDisposedException) { }
-#endif
             if (GlobalLog.IsEnabled)
             {
+#if TRACE_VERBOSE
+                try
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Receive() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " bytesTransferred:" + bytesTransferred);
+                }
+                catch (ObjectDisposedException) { }
+#endif
                 GlobalLog.Dump(buffer, offset, bytesTransferred);
             }
             if (s_loggingEnabled)
@@ -1643,11 +1652,14 @@ namespace System.Net.Sockets
             errorCode = SocketPal.Receive(_handle, buffers, ref socketFlags, out bytesTransferred);
 
 #if TRACE_VERBOSE
-            try
+            if (GlobalLog.IsEnabled)
             {
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Receive() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " Interop.Winsock.send returns errorCode:" + errorCode + " bytesTransferred:" + bytesTransferred);
+                try
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Receive() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " Interop.Winsock.send returns errorCode:" + errorCode + " bytesTransferred:" + bytesTransferred);
+                }
+                catch (ObjectDisposedException) { }
             }
-            catch (ObjectDisposedException) { }
 #endif
 
             if (errorCode != SocketError.Success)
@@ -1677,11 +1689,14 @@ namespace System.Net.Sockets
             }
 
 #if TRACE_VERBOSE
-            try
+            if (GlobalLog.IsEnabled)
             {
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Receive() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " bytesTransferred:" + bytesTransferred);
+                try
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::Receive() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " bytesTransferred:" + bytesTransferred);
+                }
+                catch (ObjectDisposedException) { }
             }
-            catch (ObjectDisposedException) { }
 #endif
 
             if (s_loggingEnabled)
@@ -2704,8 +2719,7 @@ namespace System.Net.Sockets
 
         private SocketError DoBeginSend(byte[] buffer, int offset, int size, SocketFlags socketFlags, OverlappedAsyncResult asyncResult)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginSend() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " size:" + size.ToString());
             }
@@ -2716,14 +2730,14 @@ namespace System.Net.Sockets
             try
             {
                 // Get the Send going.
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Print("BeginSend: asyncResult:" + LoggingHash.HashString(asyncResult) + " size:" + size.ToString());
                 }
 
                 errorCode = SocketPal.SendAsync(_handle, buffer, offset, size, socketFlags, asyncResult);
 
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginSend() Interop.Winsock.WSASend returns:" + errorCode.ToString() + " size:" + size.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
                 }
@@ -2804,8 +2818,7 @@ namespace System.Net.Sockets
 
         private SocketError DoBeginSend(IList<ArraySegment<byte>> buffers, SocketFlags socketFlags, OverlappedAsyncResult asyncResult)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginSend() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " buffers:" + buffers);
             }
@@ -2815,14 +2828,14 @@ namespace System.Net.Sockets
             SocketError errorCode = SocketError.SocketError;
             try
             {
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Print("BeginSend: asyncResult:" + LoggingHash.HashString(asyncResult));
                 }
 
                 errorCode = SocketPal.SendAsync(_handle, buffers, socketFlags, asyncResult);
 
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::BeginSend() Interop.Winsock.WSASend returns:" + errorCode.ToString() + " returning AsyncResult:" + LoggingHash.HashString(asyncResult));
                 }
@@ -3477,11 +3490,14 @@ namespace System.Net.Sockets
             }
 
 #if TRACE_VERBOSE
-            try
+            if (GlobalLog.IsEnabled)
             {
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::EndReceive() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " bytesTransferred:" + bytesTransferred.ToString());
+                try
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::EndReceive() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " bytesTransferred:" + bytesTransferred.ToString());
+                }
+                catch (ObjectDisposedException) { }
             }
-            catch (ObjectDisposedException) { }
 #endif
 
             // Throw an appropriate SocketException if the native call failed asynchronously.
@@ -3838,6 +3854,7 @@ namespace System.Net.Sockets
         private void DoBeginReceiveFrom(byte[] buffer, int offset, int size, SocketFlags socketFlags, EndPoint endPointSnapshot, Internals.SocketAddress socketAddress, OverlappedAsyncResult asyncResult)
         {
             EndPoint oldEndPoint = _rightEndPoint;
+
             if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::DoBeginReceiveFrom() size:" + size.ToString());
@@ -4198,11 +4215,14 @@ namespace System.Net.Sockets
             }
 
 #if TRACE_VERBOSE
-            try
+            if (GlobalLog.IsEnabled)
             {
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::EndAccept() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " acceptedSocket:" + LoggingHash.HashString(socket) + " acceptedSocket.SRC:" + LoggingHash.ObjectToString(socket.LocalEndPoint) + " acceptedSocket.DST:" + LoggingHash.ObjectToString(socket.RemoteEndPoint) + " bytesTransferred:" + bytesTransferred.ToString());
+                try
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::EndAccept() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " acceptedSocket:" + LoggingHash.HashString(socket) + " acceptedSocket.SRC:" + LoggingHash.ObjectToString(socket.LocalEndPoint) + " acceptedSocket.DST:" + LoggingHash.ObjectToString(socket.RemoteEndPoint) + " bytesTransferred:" + bytesTransferred.ToString());
+                }
+                catch (ObjectDisposedException) { }
             }
-            catch (ObjectDisposedException) { }
 #endif
 
             if (s_loggingEnabled)
@@ -5133,11 +5153,14 @@ namespace System.Net.Sockets
             // This can throw ObjectDisposedException.
             SocketError errorCode = SocketPal.Connect(_handle, socketAddress.Buffer, socketAddress.Size);
 #if TRACE_VERBOSE
-            try
+            if (GlobalLog.IsEnabled)
             {
-                GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::InternalConnect() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " Interop.Winsock.WSAConnect returns errorCode:" + errorCode);
+                try
+                {
+                    GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::InternalConnect() SRC:" + LoggingHash.ObjectToString(LocalEndPoint) + " DST:" + LoggingHash.ObjectToString(RemoteEndPoint) + " Interop.Winsock.WSAConnect returns errorCode:" + errorCode);
+                }
+                catch (ObjectDisposedException) { }
             }
-            catch (ObjectDisposedException) { }
 #endif
 
             // Throw an appropriate SocketException if the native call fails.
@@ -5631,11 +5654,18 @@ namespace System.Net.Sockets
         // error code, and will update internal state on success.
         private SocketError InternalSetBlocking(bool desired, out bool current)
         {
-            GlobalLog.Enter("Socket#" + LoggingHash.HashString(this) + "::InternalSetBlocking", "desired:" + desired.ToString() + " willBlock:" + _willBlock.ToString() + " willBlockInternal:" + _willBlockInternal.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Enter("Socket#" + LoggingHash.HashString(this) + "::InternalSetBlocking", "desired:" + desired.ToString() + " willBlock:" + _willBlock.ToString() + " willBlockInternal:" + _willBlockInternal.ToString());
+            }
 
             if (CleanedUp)
             {
-                GlobalLog.Leave("Socket#" + LoggingHash.HashString(this) + "::InternalSetBlocking", "ObjectDisposed");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Leave("Socket#" + LoggingHash.HashString(this) + "::InternalSetBlocking", "ObjectDisposed");
+                }
+
                 current = _willBlock;
                 return SocketError.Success;
             }
@@ -5664,7 +5694,11 @@ namespace System.Net.Sockets
                 _willBlockInternal = willBlock;
             }
 
-            GlobalLog.Leave("Socket#" + LoggingHash.HashString(this) + "::InternalSetBlocking", "errorCode:" + errorCode.ToString() + " willBlock:" + _willBlock.ToString() + " willBlockInternal:" + _willBlockInternal.ToString());
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Leave("Socket#" + LoggingHash.HashString(this) + "::InternalSetBlocking", "errorCode:" + errorCode.ToString() + " willBlock:" + _willBlock.ToString() + " willBlockInternal:" + _willBlockInternal.ToString());
+            }
+
             current = _willBlockInternal;
             return errorCode;
         }
@@ -6137,8 +6171,11 @@ namespace System.Net.Sockets
         [System.Diagnostics.Conditional("TRACE_VERBOSE")]
         internal void DebugMembers()
         {
-            GlobalLog.Print("_handle:" + _handle.DangerousGetHandle().ToString("x") );
-            GlobalLog.Print("_isConnected: " + _isConnected);
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("_handle:" + _handle.DangerousGetHandle().ToString("x"));
+                GlobalLog.Print("_isConnected: " + _isConnected);
+            }
         }
     }
 }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -1228,10 +1228,13 @@ namespace System.Net.Sockets
             GlobalLog.SetThreadSource(ThreadKinds.CompletionPort);
             using (GlobalLog.SetThreadKind(ThreadKinds.System))
             {
-                GlobalLog.Enter(
-                    "CompletionPortCallback",
-                    "errorCode: " + errorCode + ", numBytes: " + numBytes +
-                    ", overlapped#" + ((IntPtr)nativeOverlapped).ToString("x"));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Enter(
+                        "CompletionPortCallback",
+                        "errorCode: " + errorCode + ", numBytes: " + numBytes +
+                        ", overlapped#" + ((IntPtr)nativeOverlapped).ToString("x"));
+                }
 #endif
                 SocketFlags socketFlags = SocketFlags.None;
                 SocketError socketError = (SocketError)errorCode;
@@ -1276,7 +1279,10 @@ namespace System.Net.Sockets
                 }
 
 #if DEBUG
-                GlobalLog.Leave("CompletionPortCallback");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Leave("CompletionPortCallback");
+                }
             }
 #endif
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPListener.cs
@@ -127,7 +127,10 @@ namespace System.Net.Sockets
                 NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Start", null);
             }
 
-            GlobalLog.Print("TCPListener::Start()");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("TCPListener::Start()");
+            }
 
             if (_serverSocket == null)
             {
@@ -172,7 +175,10 @@ namespace System.Net.Sockets
                 NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "Stop", null);
             }
 
-            GlobalLog.Print("TCPListener::Stop()");
+            if (GlobalLog.IsEnabled)
+            {
+                GlobalLog.Print("TCPListener::Stop()");
+            }
 
             if (_serverSocket != null)
             {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
@@ -228,7 +228,11 @@ namespace System.Net.Sockets
         {
             if (disposing)
             {
-                GlobalLog.Print("UdpClient::Dispose()");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Print("UdpClient::Dispose()");
+                }
+
                 FreeResources();
                 GC.SuppressFinalize(this);
             }


### PR DESCRIPTION
Some more GlobalLog.IsEnabled guards.  I noticed a few while doing some other profiling, and so did another set of searches across the whole codebase.  Many of these came from the System.Net.Security PRs that were in-progress at the same time I was doing the previous logging changes.

cc: @davidsh, @cipop, @ericeil, @pgavlin, @josguil 

(@cipop, there's no rush on merging this... if it's going to cause conflicts elsewhere, we can delay merging this until those other PRs are in and then I can handle fixing up any conflicts... just let me know.)