### PR TITLE
CollectionExtensions: Avoid the List<T> allocation

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/CollectionExtensions.cs
+++ b/src/Common/src/System/Dynamic/Utils/CollectionExtensions.cs
@@ -37,22 +37,10 @@ namespace System.Dynamic.Utils
                 return builder.ToReadOnlyCollection();
             }
 
-            var collection = enumerable as ICollection<T>;
-            if (collection != null)
-            {
-                int count = collection.Count;
-                if (count == 0)
-                {
-                    return EmptyReadOnlyCollection<T>.Instance;
-                }
-
-                T[] clone = new T[count];
-                collection.CopyTo(clone, 0);
-                return new TrueReadOnlyCollection<T>(clone);
-            }
-
-            // ToArray trims the excess space and speeds up access
-            return new TrueReadOnlyCollection<T>(new List<T>(enumerable).ToArray());
+            T[] array = EnumerableHelpers.ToArray(enumerable);
+            return array.Length == 0 ?
+                EmptyReadOnlyCollection<T>.Instance :
+                new TrueReadOnlyCollection<T>(array);
         }
 
         // We could probably improve the hashing here

--- a/src/System.Dynamic.Runtime/src/System.Dynamic.Runtime.csproj
+++ b/src/System.Dynamic.Runtime/src/System.Dynamic.Runtime.csproj
@@ -28,6 +28,9 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)' != 'true'">
+    <Compile Include="$(CommonPath)\System\Collections\Generic\EnumerableHelpers.cs">
+      <Link>Common\System\Collections\Generic\EnumerableHelpers.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Dynamic\Utils\CacheDict.cs">
       <Link>Common\System\Dynamic\Utils\CacheDict.cs</Link>
     </Compile>

--- a/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
+++ b/src/System.Linq.Expressions/src/System.Linq.Expressions.csproj
@@ -34,6 +34,9 @@
     <TargetingPackReference Include="System.Private.CoreLib.DynamicDelegate" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="$(CommonPath)\System\Collections\Generic\EnumerableHelpers.cs">
+      <Link>Common\System\Collections\Generic\EnumerableHelpers.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
       <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
     </Compile>


### PR DESCRIPTION
Use `EnumerableHelpers` to avoid the unnecessary `List<T>` allocation and simplify the code.