### PR TITLE
Performance improvements of Equals overrides.

### DIFF
--- a/src/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -772,14 +772,10 @@ namespace System.Net
 
         public override bool Equals(object comparand)
         {
-            if (!(comparand is Cookie))
-            {
-                return false;
-            }
+            Cookie other = comparand as Cookie;
 
-            Cookie other = (Cookie)comparand;
-
-            return string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase)
+            return other != null
+                    && string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase)
                     && string.Equals(Value, other.Value, StringComparison.Ordinal)
                     && string.Equals(Path, other.Path, StringComparison.Ordinal)
                     && string.Equals(Domain, other.Domain, StringComparison.OrdinalIgnoreCase)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/IPPacketInformation.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/IPPacketInformation.cs
@@ -45,12 +45,7 @@ namespace System.Net.Sockets
 
         public override bool Equals(object comparand)
         {
-            if ((object)comparand == null || !(comparand is IPPacketInformation))
-            {
-                return false;
-            }
-
-            return this == (IPPacketInformation)comparand;
+            return comparand is IPPacketInformation && this == (IPPacketInformation)comparand;
         }
 
         public override int GetHashCode()

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/StreamingContext.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/StreamingContext.cs
@@ -40,12 +40,8 @@ namespace System.Runtime.Serialization
             {
                 return false;
             }
-            if (((StreamingContext)obj).m_additionalContext == m_additionalContext &&
-                ((StreamingContext)obj).m_state == m_state)
-            {
-                return true;
-            }
-            return false;
+            StreamingContext ctx = (StreamingContext)obj;
+            return ctx.m_additionalContext == m_additionalContext && ctx.m_state == m_state;
         }
 
         public override int GetHashCode()

--- a/src/System.Private.DataContractSerialization/src/System/Xml/PrefixHandle.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/PrefixHandle.cs
@@ -3,6 +3,7 @@
 //------------------------------------------------------------
 //------------------------------------------------------------
 
+using System;
 using System.Runtime.Serialization;
 using System.Diagnostics;
 
@@ -17,7 +18,7 @@ namespace System.Xml
         Max,
     }
 
-    internal class PrefixHandle
+    internal class PrefixHandle : IEquatable<PrefixHandle>
     {
         private XmlBufferReader _bufferReader;
         private PrefixHandleType _type;
@@ -178,8 +179,10 @@ namespace System.Xml
             return GetString().CompareTo(that.GetString());
         }
 
-        private bool Equals2(PrefixHandle prefix2)
+        public bool Equals(PrefixHandle prefix2)
         {
+            if (ReferenceEquals(prefix2, null))
+                return false;
             PrefixHandleType type1 = _type;
             PrefixHandleType type2 = prefix2._type;
             if (type1 != type2)
@@ -226,19 +229,16 @@ namespace System.Xml
 
         static public bool operator ==(PrefixHandle prefix1, PrefixHandle prefix2)
         {
-            return prefix1.Equals2(prefix2);
+            return prefix1.Equals(prefix2);
         }
 
         static public bool operator !=(PrefixHandle prefix1, PrefixHandle prefix2)
         {
-            return !prefix1.Equals2(prefix2);
+            return !prefix1.Equals(prefix2);
         }
         public override bool Equals(object obj)
         {
-            PrefixHandle that = obj as PrefixHandle;
-            if (object.ReferenceEquals(that, null))
-                return false;
-            return this == that;
+            return Equals(obj as PrefixHandle);
         }
 
         public override string ToString()

--- a/src/System.Private.DataContractSerialization/src/System/Xml/StringHandle.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/StringHandle.cs
@@ -3,6 +3,7 @@
 //------------------------------------------------------------
 //------------------------------------------------------------
 
+using System;
 using System.Runtime.Serialization;
 using System.Diagnostics;
 
@@ -16,7 +17,7 @@ namespace System.Xml
         Item = 2
     }
 
-    internal class StringHandle
+    internal class StringHandle : IEquatable<StringHandle>
     {
         private XmlBufferReader _bufferReader;
         private StringHandleType _type;
@@ -227,15 +228,17 @@ namespace System.Xml
             return GetString() == _bufferReader.GetString(offset2, length2);
         }
 
-        private bool Equals2(StringHandle s2)
+        public bool Equals(StringHandle other)
         {
-            StringHandleType type = s2._type;
+            if (ReferenceEquals(other, null))
+                return false;
+            StringHandleType type = other._type;
             if (type == StringHandleType.Dictionary)
-                return Equals2(s2._key, s2._bufferReader);
+                return Equals2(other._key, other._bufferReader);
             if (type == StringHandleType.UTF8)
-                return Equals2(s2._offset, s2._length, s2._bufferReader);
+                return Equals2(other._offset, other._length, other._bufferReader);
             DiagnosticUtility.DebugAssert(type == StringHandleType.EscapedUTF8 || type == StringHandleType.ConstString, "");
-            return Equals2(s2.GetString());
+            return Equals2(other.GetString());
         }
 
         static public bool operator ==(StringHandle s1, XmlDictionaryString xmlString2)
@@ -259,12 +262,12 @@ namespace System.Xml
 
         static public bool operator ==(StringHandle s1, StringHandle s2)
         {
-            return s1.Equals2(s2);
+            return s1.Equals(s2);
         }
 
         static public bool operator !=(StringHandle s1, StringHandle s2)
         {
-            return !s1.Equals2(s2);
+            return !s1.Equals(s2);
         }
 
         public int CompareTo(StringHandle that)
@@ -276,10 +279,7 @@ namespace System.Xml
         }
         public override bool Equals(object obj)
         {
-            StringHandle that = obj as StringHandle;
-            if (object.ReferenceEquals(that, null))
-                return false;
-            return this == that;
+            return Equals(obj as StringHandle);
         }
 
         public override int GetHashCode()

--- a/src/System.Private.DataContractSerialization/src/System/Xml/UniqueId.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/UniqueId.cs
@@ -391,7 +391,7 @@ namespace System.Xml
 
         static public bool operator ==(UniqueId id1, UniqueId id2)
         {
-            if (object.ReferenceEquals(id1, null) && object.ReferenceEquals(id2, null))
+            if (object.ReferenceEquals(id1, id2))
                 return true;
 
             if (object.ReferenceEquals(id1, null) || object.ReferenceEquals(id2, null))

--- a/src/System.Runtime.Serialization.Primitives/src/System/Runtime/Serialization/StreamingContext.cs
+++ b/src/System.Runtime.Serialization.Primitives/src/System/Runtime/Serialization/StreamingContext.cs
@@ -42,12 +42,8 @@ namespace System.Runtime.Serialization
             {
                 return false;
             }
-            if (((StreamingContext)obj).m_additionalContext == m_additionalContext &&
-                ((StreamingContext)obj).m_state == m_state)
-            {
-                return true;
-            }
-            return false;
+            StreamingContext ctx = (StreamingContext)obj;
+            return ctx.m_additionalContext == m_additionalContext && ctx.m_state == m_state;
         }
 
         public override int GetHashCode()

--- a/src/System.Runtime.WindowsRuntime.UI.Xaml/src/System/Windows/Duration.cs
+++ b/src/System.Runtime.WindowsRuntime.UI.Xaml/src/System/Windows/Duration.cs
@@ -255,18 +255,7 @@ namespace Windows.UI.Xaml
 
         public override bool Equals(Object value)
         {
-            if (value == null)
-            {
-                return false;
-            }
-            else if (value is Duration)
-            {
-                return Equals((Duration)value);
-            }
-            else
-            {
-                return false;
-            }
+            return value is Duration && Equals((Duration)value);
         }
 
         public bool Equals(Duration duration)

--- a/src/System.Runtime.WindowsRuntime.UI.Xaml/src/System/Windows/Media/Animation/KeyTime.cs
+++ b/src/System.Runtime.WindowsRuntime.UI.Xaml/src/System/Windows/Media/Animation/KeyTime.cs
@@ -61,12 +61,7 @@ namespace Windows.UI.Xaml.Media.Animation
 
         public override bool Equals(object value)
         {
-            if (value == null || !(value is KeyTime))
-            {
-                return false;
-            }
-
-            return this == (KeyTime)value;
+            return value is KeyTime && this == (KeyTime)value;
         }
 
         public override int GetHashCode()

--- a/src/System.Runtime.WindowsRuntime.UI.Xaml/src/System/Windows/Media/Matrix.cs
+++ b/src/System.Runtime.WindowsRuntime.UI.Xaml/src/System/Windows/Media/Matrix.cs
@@ -189,13 +189,7 @@ namespace Windows.UI.Xaml.Media
 
         public override bool Equals(object o)
         {
-            if ((null == o) || !(o is Matrix))
-            {
-                return false;
-            }
-
-            Matrix value = (Matrix)o;
-            return Matrix.Equals(this, value);
+            return o is Matrix && Matrix.Equals(this, (Matrix)o);
         }
 
         public bool Equals(Matrix value)

--- a/src/System.Runtime.WindowsRuntime.UI.Xaml/src/System/Windows/Media/Media3D/Matrix3D.cs
+++ b/src/System.Runtime.WindowsRuntime.UI.Xaml/src/System/Windows/Media/Media3D/Matrix3D.cs
@@ -462,13 +462,7 @@ namespace Windows.UI.Xaml.Media.Media3D
 
         public override bool Equals(object o)
         {
-            if ((null == o) || !(o is Matrix3D))
-            {
-                return false;
-            }
-
-            Matrix3D value = (Matrix3D)o;
-            return Matrix3D.Equals(this, value);
+            return o is Matrix3D && Matrix3D.Equals(this, (Matrix3D)o);
         }
 
         public bool Equals(Matrix3D value)

--- a/src/System.Runtime.WindowsRuntime/src/System/Windows/Point.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Windows/Point.cs
@@ -95,13 +95,7 @@ namespace Windows.Foundation
 
         public override bool Equals(object o)
         {
-            if ((null == o) || !(o is Point))
-            {
-                return false;
-            }
-
-            Point value = (Point)o;
-            return (this == value);
+            return o is Point && this == (Point)o;
         }
 
         public bool Equals(Point value)

--- a/src/System.Runtime.WindowsRuntime/src/System/Windows/Rect.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Windows/Rect.cs
@@ -346,13 +346,7 @@ namespace Windows.Foundation
 
         public override bool Equals(object o)
         {
-            if ((null == o) || !(o is Rect))
-            {
-                return false;
-            }
-
-            Rect value = (Rect)o;
-            return (this == value);
+            return o is Rect && this == (Rect)o;
         }
 
         public override int GetHashCode()

--- a/src/System.Runtime.WindowsRuntime/src/System/Windows/Size.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Windows/Size.cs
@@ -105,13 +105,7 @@ namespace Windows.Foundation
 
         public override bool Equals(object o)
         {
-            if ((null == o) || !(o is Size))
-            {
-                return false;
-            }
-
-            Size value = (Size)o;
-            return Size.Equals(this, value);
+            return o is Size && Size.Equals(this, (Size)o);
         }
 
         public bool Equals(Size value)

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngProperty.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngProperty.cs
@@ -48,10 +48,7 @@ namespace System.Security.Cryptography
 
         public override bool Equals(object obj)
         {
-            if (obj == null || !(obj is CngProperty))
-                return false;
-
-            return Equals((CngProperty)obj);
+            return obj is CngProperty && Equals((CngProperty)obj);
         }
 
         public bool Equals(CngProperty other)

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/IdentityReference.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/IdentityReference.cs
@@ -27,7 +27,7 @@ namespace System.Security.Principal
             object l = left;
             object r = right;
 
-            if (l == null && r == null)
+            if (l == r)
             {
                 return true;
             }

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/NTAccount.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/NTAccount.cs
@@ -142,19 +142,7 @@ namespace System.Security.Principal
 
         public override bool Equals(object o)
         {
-            if (o == null)
-            {
-                return false;
-            }
-
-            NTAccount nta = o as NTAccount;
-
-            if (nta == null)
-            {
-                return false;
-            }
-
-            return (this == nta); // invokes operator==
+            return (this == o as NTAccount); // invokes operator==
         }
 
         public override int GetHashCode()
@@ -217,7 +205,7 @@ namespace System.Security.Principal
             object l = left;
             object r = right;
 
-            if (l == null && r == null)
+            if (l == r)
             {
                 return true;
             }

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/SID.cs
@@ -638,28 +638,11 @@ namespace System.Security.Principal
 
         public override bool Equals(object o)
         {
-            if (o == null)
-            {
-                return false;
-            }
-
-            SecurityIdentifier sid = o as SecurityIdentifier;
-
-            if (sid == null)
-            {
-                return false;
-            }
-
-            return (this == sid); // invokes operator==
+            return (this == o as SecurityIdentifier); // invokes operator==
         }
 
         public bool Equals(SecurityIdentifier sid)
         {
-            if (sid == null)
-            {
-                return false;
-            }
-
             return (this == sid); // invokes operator==
         }
 
@@ -805,7 +788,7 @@ namespace System.Security.Principal
             object l = left;
             object r = right;
 
-            if (l == null && r == null)
+            if (l == r)
             {
                 return true;
             }

--- a/src/System.Xml.XPath/src/System/Xml/Cache/XPathNodeInfoAtom.cs
+++ b/src/System.Xml.XPath/src/System/Xml/Cache/XPathNodeInfoAtom.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System;
 using System.Diagnostics;
 using System.Text;
 using System.Xml.XPath;
@@ -74,7 +75,7 @@ namespace MS.Internal.Xml.Cache
     /// string.Intern() operation.  If a node's name, type, or parent/sibling pages are modified, then a new
     /// InfoAtom needs to be obtained, since other nodes may still be referencing the old InfoAtom.
     /// </summary>
-    sealed internal class XPathNodeInfoAtom
+    sealed internal class XPathNodeInfoAtom : IEquatable<XPathNodeInfoAtom>
     {
         private string _localName;
         private string _namespaceUri;
@@ -278,23 +279,27 @@ namespace MS.Internal.Xml.Cache
         /// </summary>
         public override bool Equals(object other)
         {
-            XPathNodeInfoAtom that = other as XPathNodeInfoAtom;
-            Debug.Assert(that != null);
-            Debug.Assert((object)_doc == (object)that._doc);
+            return Equals(other as XPathNodeInfoAtom);
+        }
+
+        public bool Equals(XPathNodeInfoAtom other)
+        {
+            Debug.Assert(other != null);
+            Debug.Assert((object)_doc == (object)other._doc);
             Debug.Assert(_pageInfo == null);
 
             // Assume that name parts are atomized
-            if (this.GetHashCode() == that.GetHashCode())
+            if (this.GetHashCode() == other.GetHashCode())
             {
-                if ((object)_localName == (object)that._localName &&
-                    (object)_pageSibling == (object)that._pageSibling &&
-                    (object)_namespaceUri == (object)that._namespaceUri &&
-                    (object)_pageParent == (object)that._pageParent &&
-                    (object)_pageSimilar == (object)that._pageSimilar &&
-                    (object)_prefix == (object)that._prefix &&
-                    (object)_baseUri == (object)that._baseUri &&
-                    _lineNumBase == that._lineNumBase &&
-                    _linePosBase == that._linePosBase)
+                if ((object)_localName == (object)other._localName &&
+                    (object)_pageSibling == (object)other._pageSibling &&
+                    (object)_namespaceUri == (object)other._namespaceUri &&
+                    (object)_pageParent == (object)other._pageParent &&
+                    (object)_pageSimilar == (object)other._pageSimilar &&
+                    (object)_prefix == (object)other._prefix &&
+                    (object)_baseUri == (object)other._baseUri &&
+                    _lineNumBase == other._lineNumBase &&
+                    _linePosBase == other._linePosBase)
                 {
                     return true;
                 }


### PR DESCRIPTION
Implement IEquatable<T> on some internal/private types used as keys.

Remove redundant null checks that are repeated in next method called.

Remove redundant null checks that are done before `is` checks that will likewise return false on `null`.

Reduce unboxing in two cases.

Use of `as` and null check rather than `is` and cast.

Do reference-equals test instead of both-null test (same cost, covers the both-null case and adds short-circuit true in other reference-equals cases).