### PR TITLE
Fix EventSource fuzzing test TimeZone failures

### DIFF
--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/FuzzyTests.cs
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/FuzzyTests.cs
@@ -2671,7 +2671,7 @@ namespace BasicEventSourceTests
                               logger.Write("FWKFKXHDFY",
                   new
                   {
-                      typeToCheck = new DateTimeOffset(30147, TimeZoneInfo.Local.GetUtcOffset(new DateTime(6875))),
+                      typeToCheck = new DateTimeOffset(30147, TimeSpan.FromHours(-8)),
                       A = new Char[] { 'X', 'T' },
                       D = new UInt16[] { 23656 },
                       P = new UIntPtr[] { new UIntPtr(162), new UIntPtr(224) },


### PR DESCRIPTION
The test fails in any time zones with a positive UTC offset as it attempts to create a DateTimeOffset before 0.

Fixes https://github.com/dotnet/corefx/issues/5299, #5154
cc: @davmason 