### PR TITLE
Fix URL used in System.Net.Security tests

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
@@ -14,7 +14,7 @@ namespace System.Net.Security.Tests
         public const int PassingTestTimeoutMilliseconds = 15 * 1000;
         public const int FailingTestTimeoutMiliseconds = 250;
 
-        public const string HttpsTestServer = "corefx-networking.azurewebsites.net";
+        public const string HttpsTestServer = "corefx-net.azurewebsites.net";
 
         private const string CertificatePassword = "testcertificate";
         private const string TestDataFolder = "TestData";


### PR DESCRIPTION
An incorrect URL was causing the CertificateValidationRemoteServer_EndToEnd_Ok test to fail.

Fixes #5297 
cc: @cipop, @davidsh, @ericeil, @weshaggard 