### PR TITLE
Switch System.Net.Security test to use shared HttpTestServers

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Net.Sockets;
+using System.Net.Tests;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 
@@ -16,11 +17,11 @@ namespace System.Net.Security.Tests
         {
             using (var client = new TcpClient(AddressFamily.InterNetwork))
             {
-                await client.ConnectAsync(TestConfiguration.HttpsTestServer, 443);
+                await client.ConnectAsync(HttpTestServers.Host, 443);
 
                 using (SslStream sslStream = new SslStream(client.GetStream(), false, RemoteHttpsCertValidation, null))
                 {
-                    await sslStream.AuthenticateAsClientAsync(TestConfiguration.HttpsTestServer);
+                    await sslStream.AuthenticateAsClientAsync(HttpTestServers.Host);
                 }
             }
         }

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -49,6 +49,9 @@
     <Compile Include="NegotiateStreamStreamToStreamTest.cs" />
 
     <!-- Common test files -->
+    <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers.cs">
+      <Link>Common\System\Net\HttpTestServers.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\Capability.Security.cs">
       <Link>Common\System\Net\Capability.Security.cs</Link>
     </Compile>

--- a/src/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/TestConfiguration.cs
@@ -14,8 +14,6 @@ namespace System.Net.Security.Tests
         public const int PassingTestTimeoutMilliseconds = 15 * 1000;
         public const int FailingTestTimeoutMiliseconds = 250;
 
-        public const string HttpsTestServer = "corefx-net.azurewebsites.net";
-
         private const string CertificatePassword = "testcertificate";
         private const string TestDataFolder = "TestData";
 


### PR DESCRIPTION
cc: @davidsh