### PR TITLE
Unique names for System.IO.Compression.Native.* exports

### DIFF
--- a/src/Native/System.IO.Compression.Native/pal_zlib.cpp
+++ b/src/Native/System.IO.Compression.Native/pal_zlib.cpp
@@ -92,6 +92,14 @@ static z_stream* GetCurrentZStream(PAL_ZStream* stream)
     return zStream;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.  
+extern "C" int32_t DeflateInit2_(PAL_ZStream* stream, int32_t level, int32_t method, int32_t windowBits, int32_t memLevel, int32_t strategy)
+{
+    return CompressionNative_DeflateInit2_(stream, level, method, windowBits, memLevel, strategy);
+}
+
 extern "C" int32_t CompressionNative_DeflateInit2_(
     PAL_ZStream* stream, int32_t level, int32_t method, int32_t windowBits, int32_t memLevel, int32_t strategy)
 {
@@ -106,6 +114,14 @@ extern "C" int32_t CompressionNative_DeflateInit2_(
     return result;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.  
+extern "C" int32_t Deflate(PAL_ZStream* stream, int32_t flush)
+{
+    return CompressionNative_Deflate(stream, flush);
+}
+
 extern "C" int32_t CompressionNative_Deflate(PAL_ZStream* stream, int32_t flush)
 {
     assert(stream != nullptr);
@@ -117,6 +133,14 @@ extern "C" int32_t CompressionNative_Deflate(PAL_ZStream* stream, int32_t flush)
     return result;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.  
+extern "C" int32_t DeflateEnd(PAL_ZStream* stream)
+{
+    return CompressionNative_DeflateEnd(stream);
+}
+
 extern "C" int32_t CompressionNative_DeflateEnd(PAL_ZStream* stream)
 {
     assert(stream != nullptr);
@@ -126,6 +150,14 @@ extern "C" int32_t CompressionNative_DeflateEnd(PAL_ZStream* stream)
     End(stream);
 
     return result;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.  
+extern "C" int32_t InflateInit2_(PAL_ZStream* stream, int32_t windowBits)
+{
+    return CompressionNative_InflateInit2_(stream, windowBits);
 }
 
 extern "C" int32_t CompressionNative_InflateInit2_(PAL_ZStream* stream, int32_t windowBits)
@@ -141,6 +173,14 @@ extern "C" int32_t CompressionNative_InflateInit2_(PAL_ZStream* stream, int32_t 
     return result;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.  
+extern "C" int32_t Inflate(PAL_ZStream* stream, int32_t flush)
+{
+    return CompressionNative_Inflate(stream, flush);
+}
+
 extern "C" int32_t CompressionNative_Inflate(PAL_ZStream* stream, int32_t flush)
 {
     assert(stream != nullptr);
@@ -152,6 +192,14 @@ extern "C" int32_t CompressionNative_Inflate(PAL_ZStream* stream, int32_t flush)
     return result;
 }
 
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.  
+extern "C" int32_t InflateEnd(PAL_ZStream* stream)
+{
+    return CompressionNative_InflateEnd(stream);
+}
+
 extern "C" int32_t CompressionNative_InflateEnd(PAL_ZStream* stream)
 {
     assert(stream != nullptr);
@@ -161,6 +209,14 @@ extern "C" int32_t CompressionNative_InflateEnd(PAL_ZStream* stream)
     End(stream);
 
     return result;
+}
+
+// TODO: temporarily keeping the un-prefixed signature of this method  
+// to keep tests running in CI. This will be removed once the managed assemblies  
+// are synced up with the native assemblies.  
+extern "C" uint32_t Crc32(uint32_t crc, uint8_t* buffer, int32_t len)
+{
+    return CompressionNative_Crc32(crc, buffer, len);
 }
 
 extern "C" uint32_t CompressionNative_Crc32(uint32_t crc, uint8_t* buffer, int32_t len)

--- a/src/Native/System.IO.Compression.Native/pal_zlib.cpp
+++ b/src/Native/System.IO.Compression.Native/pal_zlib.cpp
@@ -92,7 +92,8 @@ static z_stream* GetCurrentZStream(PAL_ZStream* stream)
     return zStream;
 }
 
-extern "C" int32_t DeflateInit2_(PAL_ZStream* stream, int32_t level, int32_t method, int32_t windowBits, int32_t memLevel, int32_t strategy)
+extern "C" int32_t CompressionNative_DeflateInit2_(
+    PAL_ZStream* stream, int32_t level, int32_t method, int32_t windowBits, int32_t memLevel, int32_t strategy)
 {
     assert(stream != nullptr);
 
@@ -105,7 +106,7 @@ extern "C" int32_t DeflateInit2_(PAL_ZStream* stream, int32_t level, int32_t met
     return result;
 }
 
-extern "C" int32_t Deflate(PAL_ZStream* stream, int32_t flush)
+extern "C" int32_t CompressionNative_Deflate(PAL_ZStream* stream, int32_t flush)
 {
     assert(stream != nullptr);
 
@@ -116,7 +117,7 @@ extern "C" int32_t Deflate(PAL_ZStream* stream, int32_t flush)
     return result;
 }
 
-extern "C" int32_t DeflateEnd(PAL_ZStream* stream)
+extern "C" int32_t CompressionNative_DeflateEnd(PAL_ZStream* stream)
 {
     assert(stream != nullptr);
 
@@ -127,7 +128,7 @@ extern "C" int32_t DeflateEnd(PAL_ZStream* stream)
     return result;
 }
 
-extern "C" int32_t InflateInit2_(PAL_ZStream* stream, int32_t windowBits)
+extern "C" int32_t CompressionNative_InflateInit2_(PAL_ZStream* stream, int32_t windowBits)
 {
     assert(stream != nullptr);
 
@@ -140,7 +141,7 @@ extern "C" int32_t InflateInit2_(PAL_ZStream* stream, int32_t windowBits)
     return result;
 }
 
-extern "C" int32_t Inflate(PAL_ZStream* stream, int32_t flush)
+extern "C" int32_t CompressionNative_Inflate(PAL_ZStream* stream, int32_t flush)
 {
     assert(stream != nullptr);
 
@@ -151,7 +152,7 @@ extern "C" int32_t Inflate(PAL_ZStream* stream, int32_t flush)
     return result;
 }
 
-extern "C" int32_t InflateEnd(PAL_ZStream* stream)
+extern "C" int32_t CompressionNative_InflateEnd(PAL_ZStream* stream)
 {
     assert(stream != nullptr);
 
@@ -162,7 +163,7 @@ extern "C" int32_t InflateEnd(PAL_ZStream* stream)
     return result;
 }
 
-extern "C" uint32_t Crc32(uint32_t crc, uint8_t* buffer, int32_t len)
+extern "C" uint32_t CompressionNative_Crc32(uint32_t crc, uint8_t* buffer, int32_t len)
 {
     assert(buffer != nullptr);
 

--- a/src/Native/System.IO.Compression.Native/pal_zlib.h
+++ b/src/Native/System.IO.Compression.Native/pal_zlib.h
@@ -8,15 +8,15 @@ A structure that holds the input and output values for the zlib functions.
 */
 struct PAL_ZStream
 {
-    uint8_t* nextIn; // next input byte
+    uint8_t* nextIn;  // next input byte
     uint8_t* nextOut; // next output byte should be put there
 
     char* msg; // last error message, NULL if no error
 
     // the underlying z_stream object is held in internalState, but it should not be used by external callers
-    void* internalState; 
+    void* internalState;
 
-    uint32_t availIn; // number of bytes available at nextIn
+    uint32_t availIn;  // number of bytes available at nextIn
     uint32_t availOut; // remaining free space at nextOut
 };
 
@@ -74,7 +74,8 @@ Initializes the PAL_ZStream so the Deflate function can be invoked on it.
 
 Returns a PAL_ErrorCode indicating success or an error number on failure.
 */
-extern "C" int32_t DeflateInit2_(PAL_ZStream* stream, int32_t level, int32_t method, int32_t windowBits, int32_t memLevel, int32_t strategy);
+extern "C" int32_t CompressionNative_DeflateInit2_(
+    PAL_ZStream* stream, int32_t level, int32_t method, int32_t windowBits, int32_t memLevel, int32_t strategy);
 
 /*
 Deflates (compresses) the bytes in the PAL_ZStream's nextIn buffer and puts the
@@ -82,21 +83,21 @@ compressed bytes in nextOut.
 
 Returns a PAL_ErrorCode indicating success or an error number on failure.
 */
-extern "C" int32_t Deflate(PAL_ZStream* stream, int32_t flush);
+extern "C" int32_t CompressionNative_Deflate(PAL_ZStream* stream, int32_t flush);
 
 /*
 All dynamically allocated data structures for this stream are freed.
 
 Returns a PAL_ErrorCode indicating success or an error number on failure.
 */
-extern "C" int32_t DeflateEnd(PAL_ZStream* stream);
+extern "C" int32_t CompressionNative_DeflateEnd(PAL_ZStream* stream);
 
 /*
 Initializes the PAL_ZStream so the Inflate function can be invoked on it.
 
 Returns a PAL_ErrorCode indicating success or an error number on failure.
 */
-extern "C" int32_t InflateInit2_(PAL_ZStream* stream, int32_t windowBits);
+extern "C" int32_t CompressionNative_InflateInit2_(PAL_ZStream* stream, int32_t windowBits);
 
 /*
 Inflates (uncompresses) the bytes in the PAL_ZStream's nextIn buffer and puts the
@@ -104,14 +105,14 @@ uncompressed bytes in nextOut.
 
 Returns a PAL_ErrorCode indicating success or an error number on failure.
 */
-extern "C" int32_t Inflate(PAL_ZStream* stream, int32_t flush);
+extern "C" int32_t CompressionNative_Inflate(PAL_ZStream* stream, int32_t flush);
 
 /*
 All dynamically allocated data structures for this stream are freed.
 
 Returns a PAL_ErrorCode indicating success or an error number on failure.
 */
-extern "C" int32_t InflateEnd(PAL_ZStream* stream);
+extern "C" int32_t CompressionNative_InflateEnd(PAL_ZStream* stream);
 
 /*
 Update a running CRC-32 with the bytes buffer[0..len-1] and return the
@@ -119,4 +120,4 @@ updated CRC-32.
 
 Returns the updated CRC-32.
 */
-extern "C" uint32_t Crc32(uint32_t crc, uint8_t* buffer, int32_t len);
+extern "C" uint32_t CompressionNative_Crc32(uint32_t crc, uint8_t* buffer, int32_t len);

--- a/src/System.IO.Compression/src/Interop/Interop.zlib.Unix.cs
+++ b/src/System.IO.Compression/src/Interop/Interop.zlib.Unix.cs
@@ -8,7 +8,7 @@ internal static partial class Interop
 {
     internal static partial class zlib
     {
-        [DllImport(Libraries.CompressionNative)]
+        [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_DeflateInit2_")]
         internal static extern ZLibNative.ErrorCode DeflateInit2_(
             ref ZLibNative.ZStream stream,
             ZLibNative.CompressionLevel level,
@@ -17,19 +17,19 @@ internal static partial class Interop
             int memLevel,
             ZLibNative.CompressionStrategy strategy);
 
-        [DllImport(Libraries.CompressionNative)]
+        [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_Deflate")]
         internal static extern ZLibNative.ErrorCode Deflate(ref ZLibNative.ZStream stream, ZLibNative.FlushCode flush);
 
-        [DllImport(Libraries.CompressionNative)]
+        [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_DeflateEnd")]
         internal static extern ZLibNative.ErrorCode DeflateEnd(ref ZLibNative.ZStream stream);
 
-        [DllImport(Libraries.CompressionNative)]
+        [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_InflateInit2_")]
         internal static extern ZLibNative.ErrorCode InflateInit2_(ref ZLibNative.ZStream stream, int windowBits);
 
-        [DllImport(Libraries.CompressionNative)]
+        [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_Inflate")]
         internal static extern ZLibNative.ErrorCode Inflate(ref ZLibNative.ZStream stream, ZLibNative.FlushCode flush);
 
-        [DllImport(Libraries.CompressionNative)]
+        [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_InflateEnd")]
         internal static extern ZLibNative.ErrorCode InflateEnd(ref ZLibNative.ZStream stream);
 
         internal static unsafe uint crc32(uint crc, byte[] buffer, int offset, int len)
@@ -38,7 +38,7 @@ internal static partial class Interop
                 return Crc32(crc, buf, len);
         }
 
-        [DllImport(Libraries.CompressionNative)]
+        [DllImport(Libraries.CompressionNative, EntryPoint = "CompressionNative_Crc32")]
         private static unsafe extern uint Crc32(uint crc, byte* buffer, int len);
     }
 }


### PR DESCRIPTION
The methods exported from System.IO.Compression.Native.\* shims have short generic names. Making them more unique by adding "CompressionNative_" prefix to each method name.

Fix #4818 
