### PR TITLE
Add netcore50 configuration for X509Certificates

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.builds
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.builds
@@ -11,6 +11,10 @@
     <Project Include="System.Security.Cryptography.X509Certificates.csproj">
       <OSGroup>Windows_NT</OSGroup>
     </Project>
+    <Project Include="System.Security.Cryptography.X509Certificates.csproj">
+      <TargetGroup>netcore50</TargetGroup>
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
+++ b/src/System.Security.Cryptography.X509Certificates/src/System.Security.Cryptography.X509Certificates.csproj
@@ -16,6 +16,10 @@
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
     <UsePackageTargetRuntimeDefaults>true</UsePackageTargetRuntimeDefaults>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetGroup)' == 'netcore50' and '$(ProjectJson)' == '' ">
+    <ProjectJson>netcore50\project.json</ProjectJson>
+    <ProjectLockJson>netcore50\project.lock.json</ProjectLockJson>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetsWindows)' == 'true' and '$(ProjectJson)' == '' ">
     <ProjectJson>win\project.json</ProjectJson>
     <ProjectLockJson>win\project.lock.json</ProjectLockJson>
@@ -30,6 +34,11 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'OSX_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50'">
+    <DefineConstants>$(DefineConstants);NETNATIVE</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="Internal\Cryptography\ICertificatePal.cs" />
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHandleCache.cs">

--- a/src/System.Security.Cryptography.X509Certificates/src/netcore50/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/src/netcore50/project.json
@@ -1,0 +1,21 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.10",
+    "System.Diagnostics.Contracts": "4.0.0",
+    "System.Diagnostics.Debug": "4.0.10",
+    "System.Globalization.Calendars": "4.0.0",
+    "System.IO.FileSystem": "4.0.0",
+    "System.IO.FileSystem.Watcher": "4.0.0-rc2-23616",
+    "System.Resources.ResourceManager": "4.0.0",
+    "System.Runtime": "4.0.20",
+    "System.Runtime.InteropServices": "4.0.20",
+    "System.Runtime.Numerics": "4.0.0",
+    "System.Security.Cryptography.Cng": "4.0.0-rc2-23616",
+    "System.Security.Cryptography.Encoding": "4.0.0-rc2-23616",
+    "System.Text.Encoding": "4.0.10",
+    "System.Threading": "4.0.10"
+  },
+  "frameworks": {
+    "netcore50": {}
+  }
+}


### PR DESCRIPTION
This was very simple to port because the source code is already out here. Lots of the .NET Native-specific code are just behind a "NETNATIVE" #if-def, which I am now defining in this new project configuration.

I've included the .NET Native-specific project.json file because it is slightly different from the CoreCLR one. It doesn't include the Csp contract. Right now it doesn't matter, because the compiled output doesn't actually contain any references to that assembly (they are all #if'd out it seems). But it seems safer to just exclude it from the project.json file so that we don't accidentally slip a reference into the code in the future and silently compile it in.

@bartonjs , @weshaggard 