### PR TITLE
Enable some IDNA tests on Unix

### DIFF
--- a/src/Common/src/System/Globalization/IdnMapping.Unix.cs
+++ b/src/Common/src/System/Globalization/IdnMapping.Unix.cs
@@ -7,11 +7,14 @@ namespace System.Globalization
     {
         private string GetAsciiCore(string unicode)
         {
+            uint flags = Flags;
+            CheckInvalidIdnCharacters(unicode, flags, "unicode");
+
             char[] buf = new char[unicode.Length];
 
             for (int attempts = 2; attempts > 0; attempts--)
             {
-                int realLen = Interop.GlobalizationNative.ToAscii(Flags, unicode, unicode.Length, buf, buf.Length);
+                int realLen = Interop.GlobalizationNative.ToAscii(flags, unicode, unicode.Length, buf, buf.Length);
 
                 if (realLen == 0)
                 {
@@ -31,11 +34,14 @@ namespace System.Globalization
 
         private string GetUnicodeCore(string ascii)
         {
+            uint flags = Flags;
+            CheckInvalidIdnCharacters(ascii, flags, "ascii");
+
             char[] buf = new char[ascii.Length];
 
             for (int attempts = 2; attempts > 0; attempts--)
             {
-                int realLen = Interop.GlobalizationNative.ToUnicode(Flags, ascii, ascii.Length, buf, buf.Length);
+                int realLen = Interop.GlobalizationNative.ToUnicode(flags, ascii, ascii.Length, buf, buf.Length);
 
                 if (realLen == 0)
                 {
@@ -65,6 +71,31 @@ namespace System.Globalization
                     (AllowUnassigned ? Interop.GlobalizationNative.AllowUnassigned : 0) |
                     (UseStd3AsciiRules ? Interop.GlobalizationNative.UseStd3AsciiRules : 0);
                 return (uint)flags;
+            }
+        }
+
+        /// <summary>
+        /// ICU doesn't check for invalid characters unless the STD3 rules option
+        /// is enabled.
+        ///
+        /// To match Windows behavior, we walk the string ourselves looking for these
+        /// bad characters so we can continue to throw ArgumentException in these cases. 
+        /// </summary>
+        private static void CheckInvalidIdnCharacters(string s, uint flags, string paramName)
+        {
+            if ((flags & Interop.GlobalizationNative.UseStd3AsciiRules) == 0)
+            {
+                for (int i = 0; i < s.Length; i++)
+                {
+                    char c = s[i];
+
+                    // These characters are prohibited regardless of the UseStd3AsciiRules property.
+                    // See https://msdn.microsoft.com/en-us/library/system.globalization.idnmapping.usestd3asciirules(v=vs.110).aspx
+                    if (c <= 0x1F || c == 0x7F)
+                    {
+                        throw new ArgumentException(SR.Argument_IdnIllegalName, paramName);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
1. Some IdnMapping tests were still disabled against #810.  Enabling these tests.

2. Fixing a small error on IdnMapping on Unix which was not failing with embedded null characters and other illegal characters.

Partial fix for #3406.

@ellismg @tarekgh @stephentoub 