### PR TITLE
Remove misleading comment.

### DIFF
--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -266,7 +266,6 @@ namespace System.Collections.Generic
         // Returns true if the queue contains at least one object equal to item.
         // Equality is determined using item.Equals().
         //
-        // Exceptions: ArgumentNullException if item == null.
         /// <include file='doc\Queue.uex' path='docs/doc[@for="Queue.Contains"]/*' />
         public bool Contains(T item)
         {


### PR DESCRIPTION
Comment says Queue<T>.Contains throws "ArgumentNullException if item == null."

This is untrue. Remove comment.