### PR TITLE
Fix XmlDictionaryReaderQuotas so MaxDepth and MaxStringContentLength are honored

### DIFF
--- a/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
+++ b/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
@@ -795,6 +795,12 @@
   <data name="XmlMaxNameTableCharCountExceeded" xml:space="preserve">
     <value>The maximum nametable character count quota ({0}) has been exceeded while reading XML data. The nametable is a data structure used to store strings encountered during XML processing - long XML documents with non-repeating element names, attribute names and attribute values may trigger this quota. This quota may be increased by changing the MaxNameTableCharCount property on the XmlDictionaryReaderQuotas object used when creating the XML reader.</value>
   </data>
+  <data name="XmlMaxDepthExceeded" xml:space="preserve">
+    <value>The maximum read depth ({0}) has been exceeded because XML data being read has more levels of nesting than is allowed by the quota. This quota may be increased by changing the MaxDepth property on the XmlDictionaryReaderQuotas object used when creating the XML reader.</value>
+  </data>
+  <data name="XmlMaxStringContentLengthExceeded" xml:space="preserve">
+    <value>The maximum string content length quota ({0}) has been exceeded while reading XML data. This quota may be increased by changing the MaxStringContentLength property on the XmlDictionaryReaderQuotas object used when creating the XML reader.</value>
+  </data>
   <data name="XmlMethodNotSupported" xml:space="preserve">
     <value>This XmlWriter implementation does not support the '{0}' method.</value>
   </data>

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBinaryReader.cs
@@ -98,8 +98,8 @@ namespace System.Xml
                     value = base.ReadElementContentAsString();
                     break;
             }
-
-            DiagnosticUtility.DebugAssert(value.Length < Quotas.MaxStringContentLength, "");
+            if (value.Length > Quotas.MaxStringContentLength)
+                XmlExceptionHelper.ThrowMaxStringContentLengthExceeded(this, Quotas.MaxStringContentLength);
             return value;
         }
 

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlDictionaryReader.cs
@@ -76,8 +76,6 @@ namespace System.Xml
             return reader;
         }
 
-
-
         static public XmlDictionaryReader CreateTextReader(byte[] buffer, XmlDictionaryReaderQuotas quotas)
         {
             if (buffer == null)

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlExceptionHelper.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlExceptionHelper.cs
@@ -128,7 +128,6 @@ namespace System.Xml
             ThrowXmlException(reader, SR.XmlMaxArrayLengthExceeded, maxArrayLength.ToString(NumberFormatInfo.CurrentInfo));
         }
 
-
         static public void ThrowMaxBytesPerReadExceeded(XmlDictionaryReader reader, int maxBytesPerRead)
         {
             ThrowXmlException(reader, SR.XmlMaxBytesPerReadExceeded, maxBytesPerRead.ToString(NumberFormatInfo.CurrentInfo));
@@ -137,6 +136,16 @@ namespace System.Xml
         static public void ThrowMaxNameTableCharCountExceeded(XmlDictionaryReader reader, int maxNameTableCharCount)
         {
             ThrowXmlException(reader, SR.XmlMaxNameTableCharCountExceeded, maxNameTableCharCount.ToString(NumberFormatInfo.CurrentInfo));
+        }
+
+        static public void ThrowMaxDepthExceeded(XmlDictionaryReader reader, int maxDepth)
+        {
+            ThrowXmlException(reader, SR.XmlMaxDepthExceeded, maxDepth.ToString());
+        }
+
+        static public void ThrowMaxStringContentLengthExceeded(XmlDictionaryReader reader, int maxStringContentLength)
+        {
+            ThrowXmlException(reader, SR.XmlMaxStringContentLengthExceeded, maxStringContentLength.ToString(NumberFormatInfo.CurrentInfo));
         }
 
         static public void ThrowBase64DataExpected(XmlDictionaryReader reader)

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -1929,16 +1929,16 @@ public static partial class DataContractSerializerTests
     [MemberData("XmlDictionaryReaderQuotasData")]
     public static void DCS_XmlDictionaryQuotas(XmlDictionaryReaderQuotas quotas, bool shouldSucceed)
     {
-        var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><TestLevelTwo><TestOne><SampleInt>10</SampleInt><SampleString>Sample string</SampleString></TestOne></TestLevelTwo>";
+        var input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><TypeWithTypeWithIntAndStringPropertyProperty><ObjectProperty><SampleInt>10</SampleInt><SampleString>Sample string</SampleString></ObjectProperty></TypeWithTypeWithIntAndStringPropertyProperty>";
         var content = new MemoryStream(Encoding.UTF8.GetBytes(input));
         using (var reader = XmlDictionaryReader.CreateTextReader(content, Encoding.UTF8, quotas, onClose: null))
         {
-            var serializer = new DataContractSerializer(typeof(TestLevelTwo), new DataContractSerializerSettings());
+            var serializer = new DataContractSerializer(typeof(TypeWithTypeWithIntAndStringPropertyProperty), new DataContractSerializerSettings());
             if (shouldSucceed)
             {
-                var deserializedObject = (TestLevelTwo)serializer.ReadObject(reader);
-                Assert.StrictEqual(10, deserializedObject.TestOne.SampleInt);
-                Assert.StrictEqual("Sample string", deserializedObject.TestOne.SampleString);
+                var deserializedObject = (TypeWithTypeWithIntAndStringPropertyProperty)serializer.ReadObject(reader);
+                Assert.StrictEqual(10, deserializedObject.ObjectProperty.SampleInt);
+                Assert.StrictEqual("Sample string", deserializedObject.ObjectProperty.SampleString);
             }
             else
             {

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -2712,3 +2712,20 @@ public class TypeWithByteProperty
 {
     public byte ByteProperty;
 }
+
+[DataContract(Name = "TestLevelOne", Namespace = "")]
+public class TestLevelOne
+{
+    [DataMember]
+    public int SampleInt { get; set; }
+
+    [DataMember]
+    public string SampleString { get; set; }
+}
+
+[DataContract(Name = "TestLevelTwo", Namespace = "")]
+public class TestLevelTwo
+{
+    [DataMember]
+    public TestLevelOne TestOne { get; set; }
+}

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -2713,8 +2713,8 @@ public class TypeWithByteProperty
     public byte ByteProperty;
 }
 
-[DataContract(Name = "TestLevelOne", Namespace = "")]
-public class TestLevelOne
+[DataContract(Name = "TypeWithIntAndStringProperty", Namespace = "")]
+public class TypeWithIntAndStringProperty
 {
     [DataMember]
     public int SampleInt { get; set; }
@@ -2723,9 +2723,9 @@ public class TestLevelOne
     public string SampleString { get; set; }
 }
 
-[DataContract(Name = "TestLevelTwo", Namespace = "")]
-public class TestLevelTwo
+[DataContract(Name = "TypeWithTypeWithIntAndStringPropertyProperty", Namespace = "")]
+public class TypeWithTypeWithIntAndStringPropertyProperty
 {
     [DataMember]
-    public TestLevelOne TestOne { get; set; }
+    public TypeWithIntAndStringProperty ObjectProperty { get; set; }
 }


### PR DESCRIPTION
MaxDepth and MaxStringContentLength settings in XmlDictionaryReaderQuotas are not effective due to missing the right handling in the implementation. This change adds the checks and throws exception when these two limit are exceeded.

Fix #4651 

@shmao @SGuyGe 