### PR TITLE
 Merge the .Net Native and CoreCLR implementations of EventSource. Th…

### DIFF
--- a/src/Common/src/Interop/Windows/mincore/Interop.EventSetInformation.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.EventSetInformation.cs
@@ -9,13 +9,6 @@ internal static partial class Interop
     internal static partial class mincore
     {
         [DllImport(Interop.Libraries.Eventing)]
-        internal extern static uint EventSetInformation(ulong registrationHandle, EVENT_INFO_CLASS informationClass, IntPtr eventInformation, uint informationLength);
-
-        internal enum EVENT_INFO_CLASS
-        {
-            BinaryTrackInfo,
-            SetEnableAllKeywords, // obsolete
-            SetTraits,
-        }
+        internal extern static int EventSetInformation(ulong registrationHandle, int informationClass, IntPtr eventInformation, int informationLength);
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.EventWriteTransfer.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.EventWriteTransfer.cs
@@ -8,16 +8,6 @@ internal static partial class Interop
 {
     internal static partial class mincore
     {
-        /// <summary>
-        /// Make sure to keep in sync with EventProvider.EventData.
-        /// </summary>
-        public struct EventData
-        {
-            internal unsafe ulong Ptr;
-            internal uint Size;
-            internal uint Reserved;
-        }
-
         [DllImport(Interop.Libraries.Eventing)]
         internal unsafe static extern int EventWriteTransfer(
                 ulong registrationHandle,
@@ -25,7 +15,7 @@ internal static partial class Interop
                 Guid* activityId,
                 Guid* relatedActivityId,
                 int userDataCount,
-                EventData* userData
+                void* userData
                 );
     }
 }

--- a/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
+++ b/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
@@ -34,8 +34,10 @@
     <Compile Include="System\Diagnostics\Tracing\EventDescriptor.cs" />
     <Compile Include="System\Diagnostics\Tracing\EventProvider.cs" />
     <Compile Include="System\Diagnostics\Tracing\EventSource.cs" />
+    <Compile Include="System\Diagnostics\Tracing\EventSource_ProjectN.cs" />
     <Compile Include="System\Diagnostics\Tracing\EventSourceException.cs" />
     <Compile Include="System\Diagnostics\Tracing\StubEnvironment.cs" />
+    <Compile Include="System\Diagnostics\Tracing\UnsafeNativeMethods.cs" />
     <Compile Include="System\Diagnostics\Tracing\TraceLogging\PropertyValue.cs" />
     <Compile Include="System\Diagnostics\Tracing\Winmeta.cs" />
     <Compile Include="System\Diagnostics\Tracing\TraceLogging\ArrayTypeInfo.cs" />

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/ActivityTracker.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/ActivityTracker.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Diagnostics;
 using System.Threading;
@@ -10,14 +13,15 @@ using Contract = Microsoft.Diagnostics.Contracts.Internal.Contract;
 #if ES_BUILD_STANDALONE
 namespace Microsoft.Diagnostics.Tracing
 #else
+using System.Threading.Tasks;
 namespace System.Diagnostics.Tracing
 #endif
 {
     /// <summary>
-    /// Tracks activities.  This is meant to be a singledon (accessed by the ActivityTracer.Instance static property)
+    /// Tracks activities.  This is meant to be a singleton (accessed by the ActivityTracer.Instance static property)
     ///  
     /// Logically this is simply holds the m_current variable that holds the async local that holds the current ActivityInfo
-    /// An ActivityInfo is represents a actvity (which knows its creator and thus knows its path). 
+    /// An ActivityInfo is represents a activity (which knows its creator and thus knows its path). 
     ///
     /// Most of the magic is in the async local (it gets copied to new tasks)
     /// 
@@ -43,7 +47,7 @@ namespace System.Diagnostics.Tracing
         /// Called on work item begins.  The activity name = providerName + activityName without 'Start' suffix.
         /// It updates CurrentActivityId to track.   
         /// 
-        /// It returns true if the Start should be logged, otherwise (if it is illegal recurision) it return false. 
+        /// It returns true if the Start should be logged, otherwise (if it is illegal recursion) it return false. 
         /// 
         /// The start event should use as its activity ID the CurrentActivityId AFTER calling this routine and its
         /// RelatedActivityID the CurrentActivityId BEFORE calling this routine (the creator).  
@@ -53,21 +57,31 @@ namespace System.Diagnostics.Tracing
         public void OnStart(string providerName, string activityName, int task, ref Guid activityId, ref Guid relatedActivityId, EventActivityOptions options)
         {
             if (m_current == null)        // We are not enabled
-                return;
+            {
+                // We  used to rely on the TPL provider turning us on, but that has the disadvantage that you don't get Start-Stop tracking
+                // until you use Tasks for the first time (which you may never do).   Thus we change it to pull rather tan push for whether
+                // we are enabled.   
+                if (m_checkedForEnable)
+                    return;
+                m_checkedForEnable = true;
+                if (TplEtwProvider.Log.IsEnabled(EventLevel.Informational, TplEtwProvider.Keywords.TasksFlowActivityIds))
+                    Enable();
+                if (m_current == null)
+                    return;
+            }
+
 
             Contract.Assert((options & EventActivityOptions.Disable) == 0);
 
             var currentActivity = m_current.Value;
             var fullActivityName = NormalizeActivityName(providerName, activityName, task);
 
-#if ES_BUILD_STANDALONE
             var etwLog = TplEtwProvider.Log;
             if (etwLog.Debug)
             {
                 etwLog.DebugFacilityMessage("OnStartEnter", fullActivityName);
                 etwLog.DebugFacilityMessage("OnStartEnterActivityState", ActivityInfo.LiveActivities(currentActivity));
             }
-#endif
 
             if (currentActivity != null)
             {
@@ -76,11 +90,8 @@ namespace System.Diagnostics.Tracing
                 {
                     activityId = Guid.Empty;
                     relatedActivityId = Guid.Empty;
-                    
-#if ES_BUILD_STANDALONE
                     if (etwLog.Debug)
                         etwLog.DebugFacilityMessage("OnStartRET", "Fail");
-#endif
                     return;
                 }
                 // Check for recursion, and force-stop any activities if the activity already started.
@@ -89,7 +100,6 @@ namespace System.Diagnostics.Tracing
                     ActivityInfo existingActivity = FindActiveActivity(fullActivityName, currentActivity);
                     if (existingActivity != null)
                     {
-                        // TODO ERROR add some logging about this 
                         OnStop(providerName, activityName, task, ref activityId);
                         currentActivity = m_current.Value;
                     }
@@ -103,28 +113,26 @@ namespace System.Diagnostics.Tracing
             else
                 id = Interlocked.Increment(ref currentActivity.m_lastChildID);
 
-            // Remember the previous ID so we can log it
-            relatedActivityId = currentActivity != null ? currentActivity.ActivityId : Guid.Empty;
+            // The previous ID is my 'causer' and becomes my related activity ID
+            relatedActivityId = EventSource.CurrentThreadActivityId;
 
             // Add to the list of started but not stopped activities. 
-            ActivityInfo newActivity = new ActivityInfo(fullActivityName, id, currentActivity, options);
+            ActivityInfo newActivity = new ActivityInfo(fullActivityName, id, currentActivity, relatedActivityId, options);
             m_current.Value = newActivity;
 
             // Remember the current ID so we can log it 
             activityId = newActivity.ActivityId;
             
-#if ES_BUILD_STANDALONE
             if (etwLog.Debug)
             {
                 etwLog.DebugFacilityMessage("OnStartRetActivityState", ActivityInfo.LiveActivities(newActivity));
-                etwLog.DebugFacilityMessage("OnStartRet", activityId.ToString(), relatedActivityId.ToString());
+                etwLog.DebugFacilityMessage1("OnStartRet", activityId.ToString(), relatedActivityId.ToString());
             }
-#endif
         }
 
         /// <summary>
         /// Called when a work item stops.  The activity name = providerName + activityName without 'Stop' suffix.
-        /// It updates CurrentActivityId to track this fact.   The Stop event associated with stop should log the ActivityID associated with the event.
+        /// It updates m_current variable to track this fact.   The Stop event associated with stop should log the ActivityID associated with the event.
         ///
         /// If activity tracing is not on, then activityId and relatedActivityId are not set
         /// </summary>
@@ -135,14 +143,12 @@ namespace System.Diagnostics.Tracing
 
             var fullActivityName = NormalizeActivityName(providerName, activityName, task);
             
-#if ES_BUILD_STANDALONE
             var etwLog = TplEtwProvider.Log;
             if (etwLog.Debug)
             {
                 etwLog.DebugFacilityMessage("OnStopEnter", fullActivityName);
                 etwLog.DebugFacilityMessage("OnStopEnterActivityState", ActivityInfo.LiveActivities(m_current.Value));
             }
-#endif
 
             for (; ; ) // This is a retry loop.
             {
@@ -158,11 +164,9 @@ namespace System.Diagnostics.Tracing
                 if (activityToStop == null)
                 {
                     activityId = Guid.Empty;
-#if ES_BUILD_STANDALONE
                     // TODO add some logging about this. Basically could not find matching start.
                     if (etwLog.Debug)
                         etwLog.DebugFacilityMessage("OnStopRET", "Fail");
-#endif
                     return;
                 }
 
@@ -202,13 +206,11 @@ namespace System.Diagnostics.Tracing
 
                     m_current.Value = newCurrentActivity;
 
-#if ES_BUILD_STANDALONE
                     if (etwLog.Debug)
                     {
                         etwLog.DebugFacilityMessage("OnStopRetActivityState", ActivityInfo.LiveActivities(newCurrentActivity));
                         etwLog.DebugFacilityMessage("OnStopRet", activityId.ToString());
                     }
-#endif
                     return;
                 }
                 // We failed to stop it.  We must have hit a race to stop it.  Just start over and try again.  
@@ -223,7 +225,17 @@ namespace System.Diagnostics.Tracing
         {
             if (m_current == null)
             {
-                m_current = new AsyncLocal<ActivityInfo>(ActivityChanging);
+                // Catch the not Implemented 
+                try
+                {
+                    m_current = new AsyncLocal<ActivityInfo>(ActivityChanging);
+                }
+                catch (NotImplementedException) {
+#if (!ES_BUILD_PCL && ! PROJECTN)
+                    // send message to debugger without delay
+                    System.Diagnostics.Debugger.Log(0, null, "Activity Enabled() called but AsyncLocals Not Supported (pre V4.6).  Ignoring Enable");
+#endif
+                } 
             }
         }
 
@@ -274,24 +286,25 @@ namespace System.Diagnostics.Tracing
 
         // *******************************************************************************
         /// <summary>
-        /// An ActivityInfo repesents a particular activity.   It is almost read-only the only
+        /// An ActivityInfo represents a particular activity.   It is almost read-only.   The only
         /// fields that change after creation are
         ///    m_lastChildID - used to generate unique IDs for the children activities and for the most part can be ignored.
         ///    m_stopped - indicates that this activity is dead 
-        /// This read-only ness is important because an activity's  m_creator chain forms the 
+        /// This read-only-ness is important because an activity's  m_creator chain forms the 
         /// 'Path of creation' for the activity (which is also its unique ID) but is also used as
         /// the 'list of live parents' which indicate of those ancestors, which are alive (if they
         /// are not marked dead they are alive).   
         /// </summary>
         private class ActivityInfo
         {
-            public ActivityInfo(string name, long uniqueId, ActivityInfo creator, EventActivityOptions options)
+            public ActivityInfo(string name, long uniqueId, ActivityInfo creator, Guid activityIDToRestore, EventActivityOptions options)
             {
                 m_name = name;
                 m_eventOptions = options;
                 m_creator = creator;
                 m_uniqueId = uniqueId;
                 m_level = creator != null ? creator.m_level + 1 : 0;
+                m_activityIdToRestore = activityIDToRestore;
 
                 // Create a nice GUID that encodes the chain of activities that started this one.
                 CreateActivityPathGuid(out m_guid, out m_activityPathGuidOffset);
@@ -342,10 +355,10 @@ namespace System.Diagnostics.Tracing
             /// (rooted in an activity that predates activity tracking.  
             ///
             /// We wish to encode this path in the Guid to the extent that we can.  Many of the paths have
-            /// many small numbers in them and we take advatage of this in the encoding to output as long
+            /// many small numbers in them and we take advantage of this in the encoding to output as long
             /// a path in the GUID as possible.   
             /// 
-            /// Because of the possiblility of GUID collistion, we only use 96 of the 128 bits of the GUID
+            /// Because of the possibility of GUID collision, we only use 96 of the 128 bits of the GUID
             /// for encoding the path.  The last 32 bits are a simple checksum (and random number) that 
             /// identifies this as using the convention defined here.   
             ///
@@ -388,19 +401,19 @@ namespace System.Diagnostics.Tracing
 
             /// <summary>
             /// If we can't fit the activity Path into the GUID we come here.   What we do is simply
-            /// generate a 4 byte number (s_nextOverflowId).  Then look for an anscesor that has  
+            /// generate a 4 byte number (s_nextOverflowId).  Then look for an ancestor that has  
             /// sufficient space for this ID.   By doing this, we preserve the fact that this activity
             /// is a child (of unknown depth) from that ancestor.
             /// </summary>
             [System.Security.SecurityCritical]
             private unsafe void CreateOverflowGuid(Guid* outPtr)
             {
-                // Seach backwards for an ancestor that has sufficient space to put the ID.  
+                // Search backwards for an ancestor that has sufficient space to put the ID.  
                 for (ActivityInfo ancestor = m_creator; ancestor != null; ancestor = ancestor.m_creator)
                 {
                     if (ancestor.m_activityPathGuidOffset <= 10)  // we need at least 2 bytes.  
                     {
-                        uint id = (uint)Interlocked.Increment(ref ancestor.m_lastChildID);        // Get a unique ID 
+                        uint id = unchecked((uint)Interlocked.Increment(ref ancestor.m_lastChildID));        // Get a unique ID 
                         // Try to put the ID into the GUID
                         *outPtr = ancestor.m_guid;
                         int endId = AddIdToGuid(outPtr, ancestor.m_activityPathGuidOffset, id, true);
@@ -413,8 +426,8 @@ namespace System.Diagnostics.Tracing
             }
 
             /// <summary>
-            /// The encoding for a list of numbers used to make Activity  Guids.   Basically
-            /// we operate on nibbles (which are nice becase they show up as hex digits).  The
+            /// The encoding for a list of numbers used to make Activity  GUIDs.   Basically
+            /// we operate on nibbles (which are nice because they show up as hex digits).  The
             /// list is ended with a end nibble (0) and depending on the nibble value (Below)
             /// the value is either encoded into nibble itself or it can spill over into the
             /// bytes that follow.   
@@ -425,18 +438,18 @@ namespace System.Diagnostics.Tracing
                 LastImmediateValue = 0xA,
 
                 PrefixCode = 0xB,      // all the 'long' encodings go here.  If the next nibble is MultiByte1-4
-                // than this is a 'overflow' id.   Unlike the hierarchitcal IDs these are 
-                // allocated densly but don't tell you anything about nesting. we use 
-                // these when we run out of space in the GUID to store the path.
+                                       // than this is a 'overflow' id.   Unlike the hierarchical IDs these are 
+                                       // allocated densely but don't tell you anything about nesting. we use 
+                                       // these when we run out of space in the GUID to store the path.
 
                 MultiByte1 = 0xC,   // 1 byte follows.  If this Nibble is in the high bits, it the high bits of the number are stored in the low nibble.   
                 // commented out because the code does not explicitly reference the names (but they are logically defined).  
-                // MultiByte2 = 0xD,   // 2 bytes follow (we don't bother with the nibble optimzation)
-                // MultiByte3 = 0xE,   // 3 bytes follow (we don't bother with the nibble optimzation)
-                // MultiByte4 = 0xF,   // 4 bytes follow (we don't bother with the nibble optimzation)
+                // MultiByte2 = 0xD,   // 2 bytes follow (we don't bother with the nibble optimization)
+                // MultiByte3 = 0xE,   // 3 bytes follow (we don't bother with the nibble optimization)
+                // MultiByte4 = 0xF,   // 4 bytes follow (we don't bother with the nibble optimization)
             }
 
-            /// Add the acivity id 'id' to the output Guid 'outPtr' starting at the offset 'whereToAddId'
+            /// Add the activity id 'id' to the output Guid 'outPtr' starting at the offset 'whereToAddId'
             /// Thus if this number is 6 that is where 'id' will be added.    This will return 13 (12
             /// is the maximum number of bytes that fit in a GUID) if the path did not fit.  
             /// If 'overflow' is true, then the number is encoded as an 'overflow number (which has a
@@ -476,7 +489,7 @@ namespace System.Diagnostics.Tracing
                     // Do we have an odd nibble?   If so flush it or use it for the 12 byte case.   
                     if (ptr < endPtr && *ptr != 0)
                     {
-                        // If the value < 4096 we can use the nibble we are otherwise just outputing as padding. 
+                        // If the value < 4096 we can use the nibble we are otherwise just outputting as padding. 
                         if (id < 4096)
                         {
                             // Indicate this is a 1 byte multicode with 4 high order bits in the lower nibble.  
@@ -530,14 +543,15 @@ namespace System.Diagnostics.Tracing
             #endregion // CreateGuidForActivityPath
 
             readonly internal string m_name;                        // The name used in the 'start' and 'stop' APIs to help match up
-            readonly long m_uniqueId;                                    // a small number that makes this activity unique among its siblings
-            internal readonly Guid m_guid;                          // Activity Guid, it is bascially an encoding of the Path() (see CreateActivityPathGuid)
+            readonly long m_uniqueId;                               // a small number that makes this activity unique among its siblings
+            internal readonly Guid m_guid;                          // Activity Guid, it is basically an encoding of the Path() (see CreateActivityPathGuid)
             internal readonly int m_activityPathGuidOffset;         // Keeps track of where in m_guid the causality path stops (used to generated child GUIDs)
             internal readonly int m_level;                          // current depth of the Path() of the activity (used to keep recursion under control)
             readonly internal EventActivityOptions m_eventOptions;  // Options passed to start. 
             internal long m_lastChildID;                            // used to create a unique ID for my children activities
             internal int m_stopped;                                 // This work item has stopped
             readonly internal ActivityInfo m_creator;               // My parent (creator).  Forms the Path() for the activity.
+            readonly internal Guid m_activityIdToRestore;           // The Guid to restore after a stop.
             #endregion
         }
 
@@ -546,26 +560,50 @@ namespace System.Diagnostics.Tracing
         // with m_current.ActivityID
         void ActivityChanging(AsyncLocalValueChangedArgs<ActivityInfo> args)
         {
-            if (args.PreviousValue == args.CurrentValue)
-                return;
+            ActivityInfo cur = args.CurrentValue;
+            ActivityInfo prev = args.PreviousValue;
 
-            if (args.CurrentValue != null)
+            // Are we popping off a value?   (we have a prev, and it creator is cur) 
+            // Then check if we should use the GUID at the time of the start event
+            if (prev != null && prev.m_creator == cur)
             {
-                // Allow subsequent activities inside this thread to automatically get the current activity ID.
-                EventSource.SetCurrentThreadActivityId(args.CurrentValue.ActivityId);
+                // If the saved activity ID is not the same as the creator activity
+                // that takes precedence (it means someone explicitly did a SetActivityID)
+                // Set it to that and get out
+                if (cur == null || prev.m_activityIdToRestore != cur.ActivityId)
+                {
+                    EventSource.SetCurrentThreadActivityId(prev.m_activityIdToRestore);
+                    return;
+                }
             }
-            else
-                EventSource.SetCurrentThreadActivityId(Guid.Empty);
+
+            // OK we did not have an explicit SetActivityID set.   Then we should be 
+            // setting the activity to current ActivityInfo.  However that activity 
+            // might be dead, in which case we should skip it, so we never set 
+            // the ID to dead things.   
+            while (cur != null)
+            {
+                // We found a live activity (typically the first time), set it to that.  
+                if (cur.m_stopped == 0)
+                {
+                    EventSource.SetCurrentThreadActivityId(cur.ActivityId);
+                    return;
+                }
+                cur = cur.m_creator;
+            }
+            // we can get here if there is no information on our activity stack (everything is dead)
+            // currently we do nothing, as that seems better than setting to Guid.Emtpy.  
         }
 
         /// <summary>
-        /// Async local variables have the propery that the are automatically copied whenever a task is created and used
+        /// Async local variables have the property that the are automatically copied whenever a task is created and used
         /// while that task is running.   Thus m_current 'flows' to any task that is caused by the current thread that
         /// last set it.   
         /// 
         /// This variable points a a linked list that represents all Activities that have started but have not stopped.  
         /// </summary>
         AsyncLocal<ActivityInfo> m_current;
+        bool m_checkedForEnable;
 
         // Singleton
         private static ActivityTracker s_activityTrackerInstance = new ActivityTracker();
@@ -573,42 +611,46 @@ namespace System.Diagnostics.Tracing
         // Used to create unique IDs at the top level.  Not used for nested Ids (each activity has its own id generator)
         static long m_nextId = 0;
         private const ushort MAX_ACTIVITY_DEPTH = 100;            // Limit maximum depth of activities to be tracked at 100. 
-        // This will avoid leaking memory in case of activities that are never stopped.
+                                                                  // This will avoid leaking memory in case of activities that are never stopped.
 
         #endregion
     }
 
-#if ES_BUILD_STANDALONE
+#if ES_BUILD_STANDALONE || PROJECTN
     /******************************** SUPPORT *****************************/
     /// <summary>
-    /// This is suplied by the framework.   It is has the semantics that the value is copied to any new Tasks that is created
+    /// This is supplied by the framework.   It is has the semantics that the value is copied to any new Tasks that is created
     /// by the current task.   Thus all causally related code gets this value.    Note that reads and writes to this VARIABLE 
-    /// (not what it points it) to this does not need to be proteced by locks because it is inherenty thread local (you alwasy
+    /// (not what it points it) to this does not need to be protected by locks because it is inherently thread local (you always
     /// only get your thread local copy which means that you never have races.  
     /// </summary>
     /// 
-    internal static class TplEtwProvider
+#if ES_BUILD_STANDALONE
+    [EventSource(Name = "Microsoft.Tasks.Nuget")]
+#else
+    [EventSource(Name = "System.Diagnostics.Tracing.TplEtwProvider")]
+#endif
+    internal class TplEtwProvider : EventSource
     {
-        public static Logger Log { get { return null; } }
-
-        private static Logger m_logger = new Logger();
-        public class Logger
+        public class Keywords
         {
-            public bool Debug { get { return false; } }
-            public void DebugFacilityMessage(params object[] args)
-            { }
-
-            public void SetActivityId(Guid guid)
-            { }
+            public const EventKeywords TasksFlowActivityIds = (EventKeywords)0x80;
+            public const EventKeywords Debug = (EventKeywords)0x20000;
         }
-    }
 
+        public static TplEtwProvider Log = new TplEtwProvider();
+        public bool Debug { get { return IsEnabled(EventLevel.Verbose, Keywords.Debug); } }
+
+        public void DebugFacilityMessage(string Facility, string Message) { WriteEvent(1, Facility, Message); }
+        public void DebugFacilityMessage1(string Facility, string Message, string Arg) { WriteEvent(2, Facility, Message, Arg); }
+        public void SetActivityId(Guid Id) { WriteEvent(3, Id); }
+    }
+#endif
+
+#if ES_BUILD_AGAINST_DOTNET_V35 || ES_BUILD_PCL || NO_ASYNC_LOCAL
+    // In these cases we don't have any Async local support.   Do nothing.   
     internal sealed class AsyncLocalValueChangedArgs<T>
     {
-        public AsyncLocalValueChangedArgs()
-        {
-        }
-
         public T PreviousValue { get { return default(T); } }
         public T CurrentValue { get { return default(T); } }
 
@@ -616,26 +658,13 @@ namespace System.Diagnostics.Tracing
 
     internal sealed class AsyncLocal<T>
     {
-        public AsyncLocal()
-        {
+        public AsyncLocal(Action<AsyncLocalValueChangedArgs<T>> valueChangedHandler) { 
+            throw new NotImplementedException("AsyncLocal only available on V4.6 and above");
         }
-
-        public AsyncLocal(Action<AsyncLocalValueChangedArgs<T>> valueChangedHandler)
-        {
-
-        }
-
         public T Value
         {
-            get
-            {
-                object obj = null;  // TODO FIX 
-                return (obj == null) ? default(T) : (T)obj;
-            }
-            set
-            {
-                // TODO FIX 
-            }
+            get { return default(T); }
+            set { }
         }
     }
 #endif

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventActivityOptions.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventActivityOptions.cs
@@ -1,8 +1,6 @@
-//------------------------------------------------------------------------------
-// <copyright file="etwprovider.cs" company="Microsoft">
-//     Copyright (c) Microsoft Corporation.  All rights reserved.
-// </copyright>
-//------------------------------------------------------------------------------
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 #if ES_BUILD_STANDALONE

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventDescriptor.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventDescriptor.cs
@@ -1,9 +1,6 @@
-//------------------------------------------------------------------------------
-// <copyright file="etwprovider.cs" company="Microsoft">
-//     Copyright (c) Microsoft Corporation.  All rights reserved.
-// </copyright>
-// <OWNER>matell</OWNER>
-//------------------------------------------------------------------------------
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Runtime.InteropServices;
 
@@ -24,10 +21,8 @@ namespace System.Diagnostics.Tracing
 #endif
 {
     [StructLayout(LayoutKind.Explicit, Size = 16)]
-#if !PROJECTN
     [System.Security.Permissions.HostProtection(MayLeakOnAbort = true)]
-#endif
-    public struct EventDescriptor
+    internal struct EventDescriptor
     {
         # region private
         [FieldOffset(0)]
@@ -77,20 +72,12 @@ namespace System.Diagnostics.Tracing
         {
             if (id < 0)
             {
-#if PROJECTN
-                throw new ArgumentOutOfRangeException("id", SR.GetResourceString("ArgumentOutOfRange_NeedNonNegNum", "ArgumentOutOfRange_NeedNonNegNum"));
-#else
-                throw new ArgumentOutOfRangeException("id", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-#endif
+                throw new ArgumentOutOfRangeException("id", Resources.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             }
 
             if (id > ushort.MaxValue)
             {
-#if PROJECTN
-                throw new ArgumentOutOfRangeException("id", SR.Format("ArgumentOutOfRange_NeedValidId", 1, ushort.MaxValue));
-#else
-                throw new ArgumentOutOfRangeException("id", Environment.GetResourceString("ArgumentOutOfRange_NeedValidId", 1, ushort.MaxValue));
-#endif
+                throw new ArgumentOutOfRangeException("id", Resources.GetResourceString("ArgumentOutOfRange_NeedValidId", 1, ushort.MaxValue));
             }
 
             m_traceloggingId = 0;
@@ -103,20 +90,12 @@ namespace System.Diagnostics.Tracing
 
             if (task < 0)
             {
-#if PROJECTN
-                throw new ArgumentOutOfRangeException("task", SR.GetResourceString("ArgumentOutOfRange_NeedNonNegNum", "ArgumentOutOfRange_NeedNonNegNum"));
-#else
-                throw new ArgumentOutOfRangeException("task", Environment.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
-#endif
+                throw new ArgumentOutOfRangeException("task", Resources.GetResourceString("ArgumentOutOfRange_NeedNonNegNum"));
             }
 
             if (task > ushort.MaxValue)
             {
-#if PROJECTN
-                throw new ArgumentOutOfRangeException("task", SR.Format(SR.GetResourceString("ArgumentOutOfRange_NeedValidId", "ArgumentOutOfRange_NeedValidId"), 1, ushort.MaxValue));
-#else
-                throw new ArgumentOutOfRangeException("task", Environment.GetResourceString("ArgumentOutOfRange_NeedValidId", 1, ushort.MaxValue));
-#endif
+                throw new ArgumentOutOfRangeException("task", Resources.GetResourceString("ArgumentOutOfRange_NeedValidId", 1, ushort.MaxValue));
             }
 
             m_task = (ushort)task;
@@ -177,7 +156,7 @@ namespace System.Diagnostics.Tracing
             if (!(obj is EventDescriptor))
                 return false;
 
-            return Equals((EventDescriptor)obj);
+            return Equals((EventDescriptor) obj);
         }
 
         public override int GetHashCode()

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventProvider.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventProvider.cs
@@ -1,20 +1,15 @@
-//------------------------------------------------------------------------------
-// <copyright file="etwprovider.cs" company="Microsoft">
-//     Copyright (c) Microsoft Corporation.  All rights reserved.
-// </copyright>
-//------------------------------------------------------------------------------
-#if !PROJECTN
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using Microsoft.Win32;
-#endif
+
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Security;
-#if !PROJECTN
 using System.Security.Permissions;
-#endif
 using System.Threading;
 using System;
 
@@ -27,19 +22,6 @@ using Contract = Microsoft.Diagnostics.Contracts.Internal.Contract;
 #if ES_BUILD_STANDALONE
 using Environment = Microsoft.Diagnostics.Tracing.Internal.Environment;
 using EventDescriptor = Microsoft.Diagnostics.Tracing.EventDescriptor;
-#else
-#if PROJECTN
-using NativeInterop = Interop.mincore;
-using ManifestEtw = Interop.mincore;
-using Win32Interop = Interop.mincore;
-using EventData = Interop.mincore.EventData;
-#else
-using NativeInterop = UnsafeNativeMethods;
-using ManifestEtw = UnsafeNativeMethods.ManifestEtw;
-using EventWriteTransferWrapper = UnsafeNativeMethods.EventWriteTransferWrapper;
-using Win32Interop = Win32Native;
-using EventData = System.Diagnostics.Tracing.EventProvider.EventData;
-#endif
 #endif
 
 
@@ -68,12 +50,9 @@ namespace System.Diagnostics.Tracing
     /// Only here because System.Diagnostics.EventProvider needs one more extensibility hook (when it gets a 
     /// controller callback)
     /// </summary>
-#if !PROJECTN
     [System.Security.Permissions.HostProtection(MayLeakOnAbort = true)]
-#endif
-    internal class EventProvider : IDisposable
+    internal partial class EventProvider : IDisposable
     {
-#if !PROJECTN
         // This is the windows EVENT_DATA_DESCRIPTOR structure.  We expose it because this is what
         // subclasses of EventProvider use when creating efficient (but unsafe) version of
         // EventWrite.   We do make it a nested type because we really don't expect anyone to use 
@@ -84,7 +63,6 @@ namespace System.Diagnostics.Tracing
             internal uint Size;
             internal uint Reserved;
         }
-#endif
 
         /// <summary>
         /// A struct characterizing ETW sessions (identified by the etwSessionId) as
@@ -104,11 +82,11 @@ namespace System.Diagnostics.Tracing
         private static bool m_setInformationMissing;
 
         [SecurityCritical]
-        ManifestEtw.EtwEnableCallback m_etwCallback;     // Trace Callback function
-        private ulong m_regHandle;                        // Trace Registration Handle
+        UnsafeNativeMethods.ManifestEtw.EtwEnableCallback m_etwCallback;     // Trace Callback function
+        private long m_regHandle;                        // Trace Registration Handle
         private byte m_level;                            // Tracing Level
-        private ulong m_anyKeywordMask;                   // Trace Enable Flags
-        private ulong m_allKeywordMask;                   // Match all keyword
+        private long m_anyKeywordMask;                   // Trace Enable Flags
+        private long m_allKeywordMask;                   // Match all keyword
 #if ES_SESSION_INFO || FEATURE_ACTIVITYSAMPLING
         private List<SessionInfo> m_liveSessions;        // current live sessions (Tuple<sessionIdBit, etwSessionId>)
 #endif
@@ -164,40 +142,13 @@ namespace System.Diagnostics.Tracing
         {
             m_providerId = providerGuid;
             uint status;
-            m_etwCallback = new ManifestEtw.EtwEnableCallback(EtwEnableCallBack);
+            m_etwCallback = new UnsafeNativeMethods.ManifestEtw.EtwEnableCallback(EtwEnableCallBack);
 
             status = EventRegister(ref m_providerId, m_etwCallback);
             if (status != 0)
             {
-                throw new ArgumentException(Win32Interop.GetMessage(unchecked((int)status)));
+                throw new ArgumentException(Win32Native.GetMessage(unchecked((int)status)));
             }
-        }
-
-        [System.Security.SecurityCritical]
-        internal unsafe int SetInformation(
-            ManifestEtw.EVENT_INFO_CLASS eventInfoClass,
-            IntPtr data,
-            uint dataSize)
-        {
-            int status = ManifestEtw.ERROR_NOT_SUPPORTED;
-
-            if (!m_setInformationMissing)
-            {
-                try
-                {
-                    ManifestEtw.EventSetInformation(
-                        m_regHandle,
-                        eventInfoClass,
-                        data,
-                        dataSize);
-                }
-                catch (TypeLoadException)
-                {
-                    m_setInformationMissing = true;
-                }
-            }
-
-            return status;
         }
 
         //
@@ -280,44 +231,28 @@ namespace System.Diagnostics.Tracing
                 m_regHandle = 0;
             }
         }
-#if PROJECTN
+        
         [System.Security.SecurityCritical]
         unsafe void EtwEnableCallBack(
                         ref System.Guid sourceId,
                         int controlCode,
                         byte setLevel,
-                        ulong anyKeyword,
-                        ulong allKeyword,
-                        ManifestEtw.EVENT_FILTER_DESCRIPTOR* filterData,
-                        IntPtr callbackContext
+                        long anyKeyword,
+                        long allKeyword,
+                        UnsafeNativeMethods.ManifestEtw.EVENT_FILTER_DESCRIPTOR* filterData,
+                        void* callbackContext
                         )
-#else
-        // <SecurityKernel Critical="True" Ring="0">
-        // <UsesUnsafeCode Name="Parameter filterData of type: Void*" />
-        // <UsesUnsafeCode Name="Parameter callbackContext of type: Void*" />
-        // </SecurityKernel>
-        [System.Security.SecurityCritical]
-        unsafe void EtwEnableCallBack(
-                        [In] ref System.Guid sourceId,
-                        [In] int controlCode,
-                        [In] byte setLevel,
-                        [In] long anyKeyword,
-                        [In] long allKeyword,
-                        [In] ManifestEtw.EVENT_FILTER_DESCRIPTOR* filterData,
-                        [In] void* callbackContext
-                        )
-#endif
         {
             // This is an optional callback API. We will therefore ignore any failures that happen as a 
             // result of turning on this provider as to not crash the app.
-            // EventSource has code to validate whther initialization it expected to occur actually occurred
+            // EventSource has code to validate whether initialization it expected to occur actually occurred
             try
             {
                 ControllerCommand command = ControllerCommand.Update;
                 IDictionary<string, string> args = null;
                 bool skipFinalOnControllerCommand = false;
 
-                if (controlCode == ManifestEtw.EVENT_CONTROL_CODE_ENABLE_PROVIDER)
+                if (controlCode == UnsafeNativeMethods.ManifestEtw.EVENT_CONTROL_CODE_ENABLE_PROVIDER)
                 {
                     m_enabled = true;
                     m_level = setLevel;
@@ -368,11 +303,11 @@ namespace System.Diagnostics.Tracing
                         }
 
                         // execute OnControllerCommand once for every session that has changed.
-                        OnControllerCommand(command, args, (bEnabling ? sessionChanged : -sessionChanged));
+                        OnControllerCommand(command, args, (bEnabling ? sessionChanged : -sessionChanged), etwSessionId);
                     }
 #endif
                 }
-                else if (controlCode == ManifestEtw.EVENT_CONTROL_CODE_DISABLE_PROVIDER)
+                else if (controlCode == UnsafeNativeMethods.ManifestEtw.EVENT_CONTROL_CODE_DISABLE_PROVIDER)
                 {
                     m_enabled = false;
                     m_level = 0;
@@ -382,7 +317,7 @@ namespace System.Diagnostics.Tracing
                     m_liveSessions = null;
 #endif
                 }
-                else if (controlCode == ManifestEtw.EVENT_CONTROL_CODE_CAPTURE_STATE)
+                else if (controlCode == UnsafeNativeMethods.ManifestEtw.EVENT_CONTROL_CODE_CAPTURE_STATE)
                 {
                     command = ControllerCommand.SendManifest;
                 }
@@ -402,8 +337,8 @@ namespace System.Diagnostics.Tracing
         // New in CLR4.0
         protected virtual void OnControllerCommand(ControllerCommand command, IDictionary<string, string> arguments, int sessionId, int etwSessionId) { }
         protected EventLevel Level { get { return (EventLevel)m_level; } set { m_level = (byte)value; } }
-        protected EventKeywords MatchAnyKeyword { get { return (EventKeywords)m_anyKeywordMask; } set { m_anyKeywordMask = unchecked((ulong)value); } }
-        protected EventKeywords MatchAllKeyword { get { return (EventKeywords)m_allKeywordMask; } set { m_allKeywordMask = unchecked((ulong)value); } }
+        protected EventKeywords MatchAnyKeyword { get { return (EventKeywords)m_anyKeywordMask; } set { m_anyKeywordMask = unchecked((long)value); } }
+        protected EventKeywords MatchAllKeyword { get { return (EventKeywords)m_allKeywordMask; } set { m_allKeywordMask = unchecked((long)value); } }
 
         static private int FindNull(byte[] buffer, int idx)
         {
@@ -438,7 +373,7 @@ namespace System.Diagnostics.Tracing
             // (present in the m_liveSessions but not in the new liveSessionList)
             if (m_liveSessions != null)
             {
-                foreach(SessionInfo s in m_liveSessions)
+                foreach (SessionInfo s in m_liveSessions)
                 {
                     int idx;
                     if ((idx = IndexOfSessionInList(liveSessionList, s.etwSessionId)) < 0 ||
@@ -486,12 +421,12 @@ namespace System.Diagnostics.Tracing
             if (bitcount(sessionIdBitMask) == 1)
             {
                 // activity-tracing-aware etw session
-                sessionList.Add(new SessionInfo(bitindex(sessionIdBitMask)+1, etwSessionId));
+                sessionList.Add(new SessionInfo(bitindex(sessionIdBitMask) + 1, etwSessionId));
             }
             else
             {
                 // legacy etw session
-                sessionList.Add(new SessionInfo(bitcount((uint)SessionMask.All)+1, etwSessionId));
+                sessionList.Add(new SessionInfo(bitcount((uint)SessionMask.All) + 1, etwSessionId));
             }
         }
 
@@ -503,6 +438,15 @@ namespace System.Diagnostics.Tracing
         [System.Security.SecurityCritical]
         private unsafe void GetSessionInfo(Action<int, long> action)
         {
+            // We wish the EventSource package to be legal for Windows Store applications.   
+            // Currently EnumerateTraceGuidsEx is not an allowed API, so we avoid its use here
+            // and use the information in the registry instead.  This means that ETW controllers
+            // that do not publish their intent to the registry (basically all controllers EXCEPT 
+            // TraceEventSesion) will not work properly 
+
+            // However the framework version of EventSource DOES have ES_SESSION_INFO defined and thus
+            // does not have this issue.  
+#if ES_SESSION_INFO
             int buffSize = 256;     // An initial guess that probably works most of the time.  
             byte* buffer;
             for (; ; )
@@ -513,7 +457,7 @@ namespace System.Diagnostics.Tracing
 
                 fixed (Guid* provider = &m_providerId)
                 {
-                    hr = ManifestEtw.EnumerateTraceGuidsEx(UnsafeNativeMethods.ManifestEtw.TRACE_QUERY_INFO_CLASS.TraceGuidQueryInfo,
+                    hr = UnsafeNativeMethods.ManifestEtw.EnumerateTraceGuidsEx(UnsafeNativeMethods.ManifestEtw.TRACE_QUERY_INFO_CLASS.TraceGuidQueryInfo,
                         provider, sizeof(Guid), buffer, buffSize, ref buffSize);
                 }
                 if (hr == 0)
@@ -522,15 +466,15 @@ namespace System.Diagnostics.Tracing
                     return;
             }
 
-            var providerInfos = (ManifestEtw.TRACE_GUID_INFO*)buffer;
-            var providerInstance = (ManifestEtw.TRACE_PROVIDER_INSTANCE_INFO*)&providerInfos[1];
-            int processId = unchecked((int)Win32Interop.GetCurrentProcessId());
+            var providerInfos = (UnsafeNativeMethods.ManifestEtw.TRACE_GUID_INFO*)buffer;
+            var providerInstance = (UnsafeNativeMethods.ManifestEtw.TRACE_PROVIDER_INSTANCE_INFO*)&providerInfos[1];
+            int processId = unchecked((int)Win32Native.GetCurrentProcessId());
             // iterate over the instances of the EventProvider in all processes
             for (int i = 0; i < providerInfos->InstanceCount; i++)
             {
                 if (providerInstance->Pid == processId)
                 {
-                    var enabledInfos = (ManifestEtw.TRACE_ENABLE_INFO*)&providerInstance[1];
+                    var enabledInfos = (UnsafeNativeMethods.ManifestEtw.TRACE_ENABLE_INFO*)&providerInstance[1];
                     // iterate over the list of active ETW sessions "listening" to the current provider
                     for (int j = 0; j < providerInstance->EnableCount; j++)
                         action(enabledInfos[j].LoggerId, enabledInfos[j].MatchAllKeyword);
@@ -539,8 +483,51 @@ namespace System.Diagnostics.Tracing
                     break;
                 Contract.Assert(0 <= providerInstance->NextOffset && providerInstance->NextOffset < buffSize);
                 var structBase = (byte*)providerInstance;
-                providerInstance = (ManifestEtw.TRACE_PROVIDER_INSTANCE_INFO*)&structBase[providerInstance->NextOffset];
+                providerInstance = (UnsafeNativeMethods.ManifestEtw.TRACE_PROVIDER_INSTANCE_INFO*)&structBase[providerInstance->NextOffset];
             }
+#else 
+#if !ES_BUILD_PCL && !FEATURE_PAL   // TODO command arguments don't work on PCL builds...
+            // Determine our session from what is in the registry.  
+            string regKey = @"\Microsoft\Windows\CurrentVersion\Winevt\Publishers\{" + m_providerId + "}";
+            if (System.Runtime.InteropServices.Marshal.SizeOf(typeof(IntPtr)) == 8)
+                regKey = @"Software" + @"\Wow6432Node" + regKey;
+            else
+                regKey = @"Software" + regKey;
+
+            var key = Microsoft.Win32.Registry.LocalMachine.OpenSubKey(regKey);
+            if (key != null)
+            {
+                foreach (string valueName in key.GetValueNames())
+                {
+                    if (valueName.StartsWith("ControllerData_Session_"))
+                    {
+                        string strId = valueName.Substring(23);      // strip of the ControllerData_Session_
+                        int etwSessionId;
+                        if (int.TryParse(strId, out etwSessionId))
+                        {
+                            // we need to assert this permission for partial trust scenarios
+                            (new RegistryPermission(RegistryPermissionAccess.Read, regKey)).Assert();
+                            var data = key.GetValue(valueName) as byte[];
+                            if (data != null)
+                            {
+                                var dataAsString = System.Text.Encoding.UTF8.GetString(data);
+                                int keywordIdx = dataAsString.IndexOf("EtwSessionKeyword");
+                                if (0 <= keywordIdx)
+                                {
+                                    int startIdx = keywordIdx + 18;
+                                    int endIdx = dataAsString.IndexOf('\0', startIdx);
+                                    string keywordBitString = dataAsString.Substring(startIdx, endIdx-startIdx);
+                                    int keywordBit;
+                                    if (0 < endIdx && int.TryParse(keywordBitString, out keywordBit))
+                                        action(etwSessionId, 1L << keywordBit);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+#endif
+#endif
         }
 
         /// <summary>
@@ -571,14 +558,14 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         [System.Security.SecurityCritical]
         private unsafe bool GetDataFromController(int etwSessionId,
-                ManifestEtw.EVENT_FILTER_DESCRIPTOR* filterData,
+                UnsafeNativeMethods.ManifestEtw.EVENT_FILTER_DESCRIPTOR* filterData,
                 out ControllerCommand command, out byte[] data, out int dataStart)
         {
             data = null;
             dataStart = 0;
             if (filterData == null)
             {
-#if (!ES_BUILD_PCL && !PROJECTN)
+#if (!ES_BUILD_PCL && !PROJECTN && !FEATURE_PAL)
                 string regKey = @"\Microsoft\Windows\CurrentVersion\Winevt\Publishers\{" + m_providerId + "}";
                 if (System.Runtime.InteropServices.Marshal.SizeOf(typeof(IntPtr)) == 8)
                     regKey = @"HKEY_LOCAL_MACHINE\Software" + @"\Wow6432Node" + regKey;
@@ -630,7 +617,7 @@ namespace System.Diagnostics.Tracing
         /// <param name="keywords">
         /// Keyword  to test
         /// </param>
-        public bool IsEnabled(byte level, ulong keywords)
+        public bool IsEnabled(byte level, long keywords)
         {
             //
             // If not enabled at all, return false.
@@ -673,11 +660,11 @@ namespace System.Diagnostics.Tracing
         {
             switch (error)
             {
-                case ManifestEtw.ERROR_ARITHMETIC_OVERFLOW:
-                case ManifestEtw.ERROR_MORE_DATA:
+                case UnsafeNativeMethods.ManifestEtw.ERROR_ARITHMETIC_OVERFLOW:
+                case UnsafeNativeMethods.ManifestEtw.ERROR_MORE_DATA:
                     s_returnCode = WriteEventErrorCode.EventTooBig;
                     break;
-                case ManifestEtw.ERROR_NOT_ENOUGH_MEMORY:
+                case UnsafeNativeMethods.ManifestEtw.ERROR_NOT_ENOUGH_MEMORY:
                     s_returnCode = WriteEventErrorCode.NoFreeBuffers;
                     break;
             }
@@ -957,7 +944,7 @@ namespace System.Diagnostics.Tracing
         {
             int status = 0;
 
-            if (IsEnabled(eventDescriptor.Level, (ulong)eventDescriptor.Keywords))
+            if (IsEnabled(eventDescriptor.Level, eventDescriptor.Keywords))
             {
                 int argCount = 0;
                 unsafe
@@ -1081,7 +1068,7 @@ namespace System.Diagnostics.Tracing
                                 userDataPtr[refObjPosition[7]].Ptr = (ulong)v7;
                             }
 
-                            status = EventSource.EventWriteTransferWrapper(m_regHandle, ref eventDescriptor, activityID, childActivityID, argCount, userData);
+                            status = UnsafeNativeMethods.ManifestEtw.EventWriteTransferWrapper(m_regHandle, ref eventDescriptor, activityID, childActivityID, argCount, userData);
                         }
                     }
                     else
@@ -1107,7 +1094,7 @@ namespace System.Diagnostics.Tracing
                             }
                         }
 
-                        status = EventSource.EventWriteTransferWrapper(m_regHandle, ref eventDescriptor, activityID, childActivityID, argCount, userData);
+                        status = UnsafeNativeMethods.ManifestEtw.EventWriteTransferWrapper(m_regHandle, ref eventDescriptor, activityID, childActivityID, argCount, userData);
 
                         for (int i = 0; i < refObjIndex; ++i)
                         {
@@ -1160,8 +1147,8 @@ namespace System.Diagnostics.Tracing
                                 (EventOpcode)eventDescriptor.Opcode == EventOpcode.Start ||
                                 (EventOpcode)eventDescriptor.Opcode == EventOpcode.Stop);
             }
-
-            int status = EventSource.EventWriteTransferWrapper(m_regHandle, ref eventDescriptor, activityID, childActivityID, dataCount, (EventData*)data);
+            
+            int status = UnsafeNativeMethods.ManifestEtw.EventWriteTransferWrapper(m_regHandle, ref eventDescriptor, activityID, childActivityID, dataCount, (EventData*)data);
 
             if (status != 0)
             {
@@ -1180,9 +1167,7 @@ namespace System.Diagnostics.Tracing
             int dataCount,
             IntPtr data)
         {
-            int status;
-
-            status = EventSource.EventWriteTransferWrapper(
+            int status = UnsafeNativeMethods.ManifestEtw.EventWriteTransferWrapper(
                 m_regHandle,
                 ref eventDescriptor,
                 activityID,
@@ -1198,28 +1183,20 @@ namespace System.Diagnostics.Tracing
             return true;
         }
 
-
         // These are look-alikes to the Manifest based ETW OS APIs that have been shimmed to work
         // either with Manifest ETW or Classic ETW (if Manifest based ETW is not available).  
         [SecurityCritical]
-        private unsafe uint EventRegister(ref Guid providerId, ManifestEtw.EtwEnableCallback enableCallback)
+        private unsafe uint EventRegister(ref Guid providerId, UnsafeNativeMethods.ManifestEtw.EtwEnableCallback enableCallback)
         {
             m_providerId = providerId;
             m_etwCallback = enableCallback;
-            return ManifestEtw.EventRegister(ref providerId, enableCallback,
-#if PROJECTN
-                IntPtr.Zero,
-                out m_regHandle);
-#else
-                null, 
-                ref m_regHandle);
-#endif
+            return UnsafeNativeMethods.ManifestEtw.EventRegister(ref providerId, enableCallback, null, ref m_regHandle);
         }
-
+        
         [SecurityCritical]
         private uint EventUnregister()
         {
-            uint status = ManifestEtw.EventUnregister(m_regHandle);
+            uint status = UnsafeNativeMethods.ManifestEtw.EventUnregister(m_regHandle);
             m_regHandle = 0;
             return status;
         }

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventSource.cs
@@ -1,18 +1,24 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved 
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 // This program uses code hyperlinks available as part of the HyperAddin Visual Studio plug-in.
 // It is available from http://www.codeplex.com/hyperAddin 
+#if !PLATFORM_UNIX
+
 #define FEATURE_MANAGED_ETW
 
 #if !ES_BUILD_STANDALONE && !CORECLR && !PROJECTN
 #define FEATURE_ACTIVITYSAMPLING
 #endif // !ES_BUILD_STANDALONE
 
+#endif // !PLATFORM_UNIX
+
 #if ES_BUILD_STANDALONE
 #define FEATURE_MANAGED_ETW_CHANNELS
 // #define FEATURE_ADVANCED_MANAGED_ETW_CHANNELS
 #endif
 
-/*  DESIGN NOTES DESIGN NOTES DESIGN NOTES DESIGN NOTES  */
+/* DESIGN NOTES DESIGN NOTES DESIGN NOTES DESIGN NOTES */
 // DESIGN NOTES
 // Over the years EventSource has become more complex and so it is important to understand
 // the basic structure of the code to insure that it does not grow more complex.
@@ -180,30 +186,16 @@ using System.Globalization;
 using System.Reflection;
 using System.Resources;
 using System.Security;
-#if !PROJECTN
 using System.Security.Permissions;
-#endif
+
 using System.Text;
 using System.Threading;
-#if !PROJECTN
 using Microsoft.Win32;
-#endif
 
 #if ES_BUILD_STANDALONE
-using Environment = Microsoft.Diagnostics.Tracing.Internal.Environment;
 using EventDescriptor = Microsoft.Diagnostics.Tracing.EventDescriptor;
 #else
-#if PROJECTN
-using NativeInterop = Interop.mincore;
-using ManifestEtw = Interop.mincore;
-using Win32Interop = Interop.mincore;
-using ProviderEventData = Interop.mincore.EventData;
-#else
-using NativeInterop = UnsafeNativeMethods;
-using ManifestEtw = UnsafeNativeMethods.ManifestEtw;
-using Win32Interop = Win32Native;
-using ProviderEventData = EventProvider.EventData;
-#endif
+using System.Threading.Tasks;
 #endif
 
 using Microsoft.Reflection;
@@ -257,6 +249,11 @@ namespace System.Diagnostics.Tracing
     /// </remarks>
     public partial class EventSource : IDisposable
     {
+
+#if FEATURE_EVENTSOURCE_XPLAT
+        private static readonly EventListener persistent_Xplat_Listener = XplatEventLogger.InitializePersistentListener();
+#endif //FEATURE_EVENTSOURCE_XPLAT
+
         /// <summary>
         /// The human-friendly name of the eventSource.  It defaults to the simple name of the class
         /// </summary>
@@ -431,11 +428,7 @@ namespace System.Diagnostics.Tracing
 
             if (name == null)
             {
-#if PROJECTN
-                throw new ArgumentException(SR.GetResourceString("Argument_InvalidTypeName", null), "eventSourceType");
-#else
-                throw new ArgumentException(Environment.GetResourceString("Argument_InvalidTypeName"), "eventSourceType");
-#endif
+                throw new ArgumentException(Resources.GetResourceString("Argument_InvalidTypeName"), "eventSourceType");
             }
             return GenerateGuidFromName(name.ToUpperInvariant());       // Make it case insensitive.  
         }
@@ -522,134 +515,10 @@ namespace System.Diagnostics.Tracing
             // User-defined EventCommands should not conflict with the reserved commands.
             if ((int)command <= (int)EventCommand.Update && (int)command != (int)EventCommand.SendManifest)
             {
-#if PROJECTN
-                throw new ArgumentException(SR.GetResourceString("EventSource_InvalidCommand", null), "command");
-#else
-                throw new ArgumentException(Environment.GetResourceString("EventSource_InvalidCommand"), "command");
-#endif
+                throw new ArgumentException(Resources.GetResourceString("EventSource_InvalidCommand"), "command");
             }
 
             eventSource.SendCommand(null, 0, 0, command, true, EventLevel.LogAlways, EventKeywords.None, commandArguments);
-        }
-
-        // ActivityID support (see also WriteEventWithRelatedActivityIdCore)
-        /// <summary>
-        /// When a thread starts work that is on behalf of 'something else' (typically another 
-        /// thread or network request) it should mark the thread as working on that other work.
-        /// This API marks the current thread as working on activity 'activityID'. This API
-        /// should be used when the caller knows the thread's current activity (the one being
-        /// overwritten) has completed. Otherwise, callers should prefer the overload that
-        /// return the oldActivityThatWillContinue (below).
-        /// 
-        /// All events created with the EventSource on this thread are also tagged with the 
-        /// activity ID of the thread. 
-        /// 
-        /// It is common, and good practice after setting the thread to an activity to log an event
-        /// with a 'start' opcode to indicate that precise time/thread where the new activity 
-        /// started.
-        /// </summary>
-        /// <param name="activityId">A Guid that represents the new activity with which to mark 
-        /// the current thread</param>
-        [System.Security.SecuritySafeCritical]
-        public static void SetCurrentThreadActivityId(Guid activityId)
-        {
-#if FEATURE_THREAD_BASED_ACTIVITIES
-#if FEATURE_ACTIVITYSAMPLING
-            Guid newId = activityId;
-#endif // FEATURE_ACTIVITYSAMPLING
-
-            // We ignore errors to keep with the convention that EventSources do not throw errors.
-            // Note we can't access m_throwOnWrites because this is a static method.  
-
-            if (ManifestEtw.EventActivityIdControl(
-                ManifestEtw.ActivityControl.EVENT_ACTIVITY_CTRL_GET_SET_ID, ref activityId) == 0)
-            {
-#if FEATURE_ACTIVITYSAMPLING
-                var activityDying = s_activityDying;
-                if (activityDying != null && newId != activityId)
-                {
-                    if (activityId == Guid.Empty)
-                    {
-                        activityId = FallbackActivityId;
-                    }
-                    // OutputDebugString(string.Format("Activity dying: {0} -> {1}", activityId, newId));
-                    activityDying(activityId);     // This is actually the OLD activity ID.  
-                }
-#endif // FEATURE_ACTIVITYSAMPLING
-            }
-            
-#if ES_BUILD_STANDALONE
-            if (TplEtwProvider.Log != null)
-                TplEtwProvider.Log.SetActivityId(activityId);
-#endif
-#else // FEATURE_THREAD_BASED_ACTIVITIES
-            throw new NotSupportedException("Old style activities are not supported!");
-#endif // FEATURE_THREAD_BASED_ACTIVITIES
-        }
-
-        /// <summary>
-        /// When a thread starts work that is on behalf of 'something else' (typically another 
-        /// thread or network request) it should mark the thread as working on that other work.
-        /// This API marks the current thread as working on activity 'activityID'. It returns 
-        /// whatever activity the thread was previously marked with. There is a convention that
-        /// callers can assume that callees restore this activity mark before the callee returns. 
-        /// To encourage this this API returns the old activity, so that it can be restored later.
-        /// 
-        /// All events created with the EventSource on this thread are also tagged with the 
-        /// activity ID of the thread. 
-        /// 
-        /// It is common, and good practice after setting the thread to an activity to log an event
-        /// with a 'start' opcode to indicate that precise time/thread where the new activity 
-        /// started.
-        /// </summary>
-        /// <param name="activityId">A Guid that represents the new activity with which to mark 
-        /// the current thread</param>
-        /// <param name="oldActivityThatWillContinue">The Guid that represents the current activity  
-        /// which will continue at some point in the future, on the current thread</param>
-        [System.Security.SecuritySafeCritical]
-        public static void SetCurrentThreadActivityId(Guid activityId, out Guid oldActivityThatWillContinue)
-        {
-#if FEATURE_THREAD_BASED_ACTIVITIES
-            oldActivityThatWillContinue = activityId;
-            // We ignore errors to keep with the convention that EventSources do not throw errors.
-            // Note we can't access m_throwOnWrites because this is a static method.  
-
-            ManifestEtw.EventActivityIdControl(
-                ManifestEtw.ActivityControl.EVENT_ACTIVITY_CTRL_GET_SET_ID,
-                    ref oldActivityThatWillContinue);
-
-#if ES_BUILD_STANDALONE
-            // We don't call the activityDying callback here because the caller has declared that
-            // it is not dying.  
-            if (TplEtwProvider.Log != null)
-                TplEtwProvider.Log.SetActivityId(activityId);
-#endif
-#else
-            throw new NotSupportedException("Old style activities are not supported!");
-#endif
-        }
-
-        /// <summary>
-        /// Retrieves the ETW activity ID associated with the current thread.
-        /// </summary>
-        public static Guid CurrentThreadActivityId
-        {
-            [System.Security.SecurityCritical]
-            get
-            {
-#if FEATURE_THREAD_BASED_ACTIVITIES
-                // We ignore errors to keep with the convention that EventSources do not throw 
-                // errors. Note we can't access m_throwOnWrites because this is a static method.
-                Guid retVal = new Guid();
-
-                ManifestEtw.EventActivityIdControl(
-                    ManifestEtw.ActivityControl.EVENT_ACTIVITY_CTRL_GET_ID,
-                    ref retVal);
-                return retVal;
-#else
-            throw new NotSupportedException("Old style activities are not supported!");
-#endif
-            }
         }
 
 #if !ES_BUILD_STANDALONE
@@ -677,15 +546,12 @@ namespace System.Diagnostics.Tracing
             get
             {
 #pragma warning disable 612, 618
-#if PROJECTN
-                int threadID = (int)Win32Interop.GetCurrentThreadId();
-#else
                 int threadID = AppDomain.GetCurrentThreadId();
-#endif
+                
                 // Managed thread IDs are more aggressively re-used than native thread IDs,
                 // so we'll use the latter...
-                return new Guid(threadID,
-                                unchecked((short)s_currentPid), unchecked((short)(s_currentPid >> 16)),
+                return new Guid(unchecked((uint)threadID),
+                                unchecked((ushort)s_currentPid), unchecked((ushort)(s_currentPid >> 16)),
                                 0x94, 0x1b, 0x87, 0xd5, 0xa6, 0x5c, 0x36, 0x64);
 #pragma warning restore 612, 618
             }
@@ -730,11 +596,31 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         public override string ToString()
         {
-#if PROJECTN
-            return SR.Format("EventSource_ToString", Name, Guid); 
-#else
-            return Environment.GetResourceString("EventSource_ToString", Name, Guid); 
-#endif
+            return Resources.GetResourceString("EventSource_ToString", Name, Guid);
+        }
+
+        /// <summary>
+        /// Fires when a Command (e.g. Enable) comes from a an EventListener.  
+        /// </summary>
+        public event EventHandler<EventCommandEventArgs> EventCommandExecuted
+        {
+            add
+            {
+                m_eventCommandExecuted += value;
+             
+                // If we have an EventHandler<EventCommandEventArgs> attached to the EventSource before the first command arrives
+                // It should get a chance to handle the deferred commands.
+                EventCommandEventArgs deferredCommands = m_deferredCommands;
+                while (deferredCommands != null)
+                {
+                    value(this, deferredCommands);
+                    deferredCommands = deferredCommands.nextCommand;
+                }
+            }
+            remove
+            {
+                m_eventCommandExecuted -= value;
+            }
         }
 
         #region protected
@@ -786,27 +672,26 @@ namespace System.Diagnostics.Tracing
 
             Guid eventSourceGuid;
             string eventSourceName;
-#if PROJECTN
+
             EventMetadata[] eventDescriptors;
             byte[] manifest;
             GetMetadata(out eventSourceGuid, out eventSourceName, out eventDescriptors, out manifest);
 
             if (eventSourceGuid.Equals(Guid.Empty) || eventSourceName == null)
             {
-#endif
                 var myType = this.GetType();
                 eventSourceGuid = GetGuid(myType);
                 eventSourceName = GetName(myType);
-#if PROJECTN
             }
-#endif
+
             Initialize(eventSourceGuid, eventSourceName, traits);
         }
 
-        protected virtual void GetMetadata(out Guid eventSourceGuid, out string eventSourceName, out EventMetadata[] eventData, out byte[] manifestBytes)
+        internal virtual void GetMetadata(out Guid eventSourceGuid, out string eventSourceName, out EventMetadata[] eventData, out byte[] manifestBytes)
         {
             //
-            // Subclasses need to override this method, and return the data from their EventSourceAttribute and EventAttribute annotations.
+            // In ProjectN subclasses need to override this method, and return the data from their EventSourceAttribute and EventAttribute annotations.
+            // On other architectures it is a no-op.
             //
             // eventDescriptors needs to contain one EventDescriptor for each event; the event's ID should be the same as its index in this array.
             // manifestBytes is a UTF-8 encoding of the ETW manifest for the type.
@@ -820,7 +705,7 @@ namespace System.Diagnostics.Tracing
 
             return;
         }
-
+        
         /// <summary>
         /// This method is called when the eventSource is updated by the controller.  
         /// </summary>
@@ -1091,48 +976,70 @@ namespace System.Diagnostics.Tracing
                 }
             }
         }
+ 
+         [SecuritySafeCritical] 
+         [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")] 
+         protected unsafe void WriteEvent(int eventId, byte[] arg1) 
+         { 
+             if (m_eventSourceEnabled) 
+             { 
+                 EventSource.EventData* descrs = stackalloc EventSource.EventData[2]; 
+                 if (arg1 == null || arg1.Length == 0) 
+                 { 
+                     int blobSize = 0; 
+                     descrs[0].DataPointer = (IntPtr)(&blobSize); 
+                     descrs[0].Size = 4; 
+                     descrs[1].DataPointer = (IntPtr)(&blobSize); // valid address instead of empty content 
+                     descrs[1].Size = 0; 
+                     WriteEventCore(eventId, 2, descrs); 
+                 } 
+                 else 
+                 { 
+                     int blobSize = arg1.Length; 
+                     fixed (byte* blob = &arg1[0]) 
+                     { 
+                         descrs[0].DataPointer = (IntPtr)(&blobSize); 
+                         descrs[0].Size = 4; 
+                         descrs[1].DataPointer = (IntPtr)blob; 
+                         descrs[1].Size = blobSize; 
+                         WriteEventCore(eventId, 2, descrs); 
+                     } 
+                 } 
+             } 
+         } 
 
-        [SecuritySafeCritical]
-        [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")]
-        protected unsafe void WriteEvent(int eventId, byte[] arg1)
-        {
-            if (m_eventSourceEnabled)
-            {
-                if (arg1 == null) arg1 = new byte[0];
-                int blobSize = arg1.Length;
-                fixed (byte* blob = &arg1[0])
-                {
-                    EventSource.EventData* descrs = stackalloc EventSource.EventData[2];
-                    descrs[0].DataPointer = (IntPtr)(&blobSize);
-                    descrs[0].Size = 4;
-                    descrs[1].DataPointer = (IntPtr)blob;
-                    descrs[1].Size = blobSize;
-                    WriteEventCore(eventId, 2, descrs);
-                }
-            }
-        }
-
-        [SecuritySafeCritical]
-        [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")]
-        protected unsafe void WriteEvent(int eventId, long arg1, byte[] arg2)
-        {
-            if (m_eventSourceEnabled)
-            {
-                if (arg2 == null) arg2 = new byte[0];
-                int blobSize = arg2.Length;
-                fixed (byte* blob = &arg2[0])
-                {
-                    EventSource.EventData* descrs = stackalloc EventSource.EventData[3];
-                    descrs[0].DataPointer = (IntPtr)(&arg1);
-                    descrs[0].Size = 8;
-                    descrs[1].DataPointer = (IntPtr)(&blobSize);
-                    descrs[1].Size = 4;
-                    descrs[2].DataPointer = (IntPtr)blob;
-                    descrs[2].Size = blobSize;
-                    WriteEventCore(eventId, 3, descrs);
-                }
-            }
-        }
+         [SecuritySafeCritical] 
+         [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")] 
+         protected unsafe void WriteEvent(int eventId, long arg1, byte[] arg2) 
+         { 
+             if (m_eventSourceEnabled) 
+             { 
+                 EventSource.EventData* descrs = stackalloc EventSource.EventData[3]; 
+                 descrs[0].DataPointer = (IntPtr)(&arg1); 
+                 descrs[0].Size = 8; 
+                 if (arg2 == null || arg2.Length == 0) 
+                 { 
+                     int blobSize = 0; 
+                     descrs[1].DataPointer = (IntPtr)(&blobSize); 
+                     descrs[1].Size = 4; 
+                     descrs[2].DataPointer = (IntPtr)(&blobSize); // valid address instead of empty contents 
+                     descrs[2].Size = 0; 
+                     WriteEventCore(eventId, 3, descrs); 
+                 } 
+                 else 
+                 { 
+                     int blobSize = arg2.Length; 
+                     fixed (byte* blob = &arg2[0]) 
+                     { 
+                         descrs[1].DataPointer = (IntPtr)(&blobSize); 
+                         descrs[1].Size = 4; 
+                         descrs[2].DataPointer = (IntPtr)blob; 
+                         descrs[2].Size = blobSize; 
+                         WriteEventCore(eventId, 3, descrs); 
+                     } 
+                 } 
+             } 
+         } 
 
 #pragma warning restore 1591
 
@@ -1243,7 +1150,7 @@ namespace System.Diagnostics.Tracing
                 {
                     Contract.Assert(m_eventData != null);  // You must have initialized this if you enabled the source.
                     if (relatedActivityId != null)
-                        ValidateEventOpcodeForTransfer(ref m_eventData[eventId]);
+                        ValidateEventOpcodeForTransfer(ref m_eventData[eventId], m_eventData[eventId].Name);
 
 #if FEATURE_MANAGED_ETW
                     if (m_eventData[eventId].EnabledForETW)
@@ -1293,11 +1200,11 @@ namespace System.Diagnostics.Tracing
                                     // mask set to 0x0f so, when all ETW sessions want the event we don't need to 
                                     // synthesize a new one
                                     if (!m_provider.WriteEvent(ref m_eventData[eventId].Descriptor, pActivityId, relatedActivityId, eventDataCount, (IntPtr)data))
-                                        ThrowEventSourceException();
+                                        ThrowEventSourceException(m_eventData[eventId].Name);
                                 }
                                 else
                                 {
-                                    long origKwd = unchecked((long)(m_eventData[eventId].Descriptor.Keywords & ~(SessionMask.All.ToEventKeywords())));
+                                    long origKwd = unchecked((long)((ulong)m_eventData[eventId].Descriptor.Keywords & ~(SessionMask.All.ToEventKeywords())));
                                     // OutputDebugString(string.Format("  (2) id {0}, kwd {1:x}", 
                                     //                   m_eventData[eventId].Name, etwSessions.ToEventKeywords() | (ulong) origKwd));
                                     // only some of the ETW sessions will receive this event. Synthesize a new
@@ -1310,10 +1217,10 @@ namespace System.Diagnostics.Tracing
                                         m_eventData[eventId].Descriptor.Level,
                                         m_eventData[eventId].Descriptor.Opcode,
                                         m_eventData[eventId].Descriptor.Task,
-                                        unchecked(etwSessions.ToEventKeywords() | origKwd));
+                                        unchecked((long)etwSessions.ToEventKeywords() | origKwd));
 
                                     if (!m_provider.WriteEvent(ref desc, pActivityId, relatedActivityId, eventDataCount, (IntPtr)data))
-                                        ThrowEventSourceException();
+                                        ThrowEventSourceException(m_eventData[eventId].Name);
                                 }
                             }
                             else
@@ -1327,7 +1234,7 @@ namespace System.Diagnostics.Tracing
                                     Interlocked.CompareExchange(ref m_eventData[eventId].TraceLoggingEventTypes, tlet, null);
 
                                 }
-                                long origKwd = unchecked((long)(m_eventData[eventId].Descriptor.Keywords & ~(SessionMask.All.ToEventKeywords())));
+                                long origKwd = unchecked((long)((ulong)m_eventData[eventId].Descriptor.Keywords & ~(SessionMask.All.ToEventKeywords())));
                                 // TODO: activity ID support
                                 EventSourceOptions opt = new EventSourceOptions
                                 {
@@ -1343,7 +1250,7 @@ namespace System.Diagnostics.Tracing
                         if (!SelfDescribingEvents)
                         {
                             if (!m_provider.WriteEvent(ref m_eventData[eventId].Descriptor, pActivityId, relatedActivityId, eventDataCount, (IntPtr)data))
-                                ThrowEventSourceException();
+                                ThrowEventSourceException(m_eventData[eventId].Name);
                         }
                         else
                         {
@@ -1377,7 +1284,7 @@ namespace System.Diagnostics.Tracing
                     if (ex is EventSourceException)
                         throw;
                     else
-                        ThrowEventSourceException(ex);
+                        ThrowEventSourceException(m_eventData[eventId].Name, ex);
                 }
             }
         }
@@ -1457,6 +1364,7 @@ namespace System.Diagnostics.Tracing
 #endif
             }
             m_eventSourceEnabled = false;
+            m_eventSourceDisposed = true;
         }
         /// <summary>
         /// Finalizer for EventSource
@@ -1477,7 +1385,7 @@ namespace System.Diagnostics.Tracing
             {
                 if (listener == null)
                 {
-                    WriteEventString(0, unchecked(m.ToEventKeywords()), msg);
+                    WriteEventString(0, unchecked((long)m.ToEventKeywords()), msg);
                 }
                 else
                 {
@@ -1492,49 +1400,26 @@ namespace System.Diagnostics.Tracing
         }
 #endif
 
-#if PROJECTN
-        /// <summary>
-        ///  Call the ETW native API EventWriteTransfer and checks for invalid argument error. 
-        ///  The implementation of EventWriteTransfer on some older OSes (Windows 2008) does not accept null relatedActivityId.
-        ///  So, for these cases we will retry the call with an empty Guid.
-        /// </summary>
-        internal unsafe static int EventWriteTransferWrapper(ulong registrationHandle,
-                                                     ref EventDescriptor eventDescriptor,
-                                                     Guid* activityId,
-                                                     Guid* relatedActivityId,
-                                                     int userDataCount,
-                                                     Interop.mincore.EventData* userData)
-        {
-            fixed (void* eventDescriptorPtr = &eventDescriptor)
-            {
-                int HResult = Interop.mincore.EventWriteTransfer(registrationHandle, eventDescriptorPtr, activityId, relatedActivityId, userDataCount, userData);
-                if (HResult == Interop.mincore.ERROR_INVALID_PARAMETER && relatedActivityId == null)
-                {
-                    Guid emptyGuid = Guid.Empty;
-                    HResult = Interop.mincore.EventWriteTransfer(registrationHandle, eventDescriptorPtr, activityId, &emptyGuid, userDataCount, userData);
-                }
-                return HResult;
-            }
-        }
-
-#endif
         [SecurityCritical]
         private unsafe void WriteEventRaw(
+            string eventName,
             ref EventDescriptor eventDescriptor,
             Guid* activityID,
             Guid* relatedActivityID,
             int dataCount,
             IntPtr data)
         {
+#if FEATURE_MANAGED_ETW
             if (m_provider == null)
             {
-                ThrowEventSourceException();
+                ThrowEventSourceException(eventName);
             }
             else
             {
                 if (!m_provider.WriteEventRaw(ref eventDescriptor, activityID, relatedActivityID, dataCount, data))
-                    ThrowEventSourceException();
+                    ThrowEventSourceException(eventName);
             }
+#endif // FEATURE_MANAGED_ETW
         }
 
         // FrameworkEventSource is on the startup path for the framework, so we have this internal overload that it can use
@@ -1565,29 +1450,17 @@ namespace System.Diagnostics.Tracing
                 m_traits = traits;
                 if (m_traits != null && m_traits.Length % 2 != 0)
                 {
-#if PROJECTN
-                    throw new ArgumentException(SR.GetResourceString("TraitEven", null), "traits");
-#else
-                    throw new ArgumentException(Environment.GetResourceString("TraitEven"), "traits");
-#endif
+                    throw new ArgumentException(Resources.GetResourceString("TraitEven"), "traits");
                 }
 
                 if (eventSourceGuid == Guid.Empty)
                 {
-#if PROJECTN
-                    throw new ArgumentException(SR.GetResourceString("EventSource_NeedGuid", null));
-#else
-                    throw new ArgumentException(Environment.GetResourceString("EventSource_NeedGuid"));
-#endif
+                    throw new ArgumentException(Resources.GetResourceString("EventSource_NeedGuid"));
                 }
 
                 if (eventSourceName == null)
                 {
-#if PROJECTN
-                    throw new ArgumentException(SR.GetResourceString("EventSource_NeedName", null));
-#else
-                    throw new ArgumentException(Environment.GetResourceString("EventSource_NeedName"));
-#endif
+                    throw new ArgumentException(Resources.GetResourceString("EventSource_NeedName"));
                 }
 
                 m_name = eventSourceName;
@@ -1617,7 +1490,6 @@ namespace System.Diagnostics.Tracing
                 // OK if we get this far without an exception, then we can at least write out error messages. 
                 // Set m_provider, which allows this.  
                 m_provider = provider;
-#endif
 
 #if (!ES_BUILD_STANDALONE && !PROJECTN)
                 // API available on OS >= Win 8 and patched Win 7.
@@ -1632,12 +1504,13 @@ namespace System.Diagnostics.Tracing
                     IntPtr providerMetadata = metadataHandle.AddrOfPinnedObject();
 
                     setInformationResult = m_provider.SetInformation(
-                        ManifestEtw.EVENT_INFO_CLASS.SetTraits,
+                        UnsafeNativeMethods.ManifestEtw.EVENT_INFO_CLASS.SetTraits,
                         providerMetadata,
                         (uint)this.providerMetadata.Length);
 
                     metadataHandle.Free();
                 }
+#endif // FEATURE_MANAGED_ETW
 
                 Contract.Assert(!m_eventSourceEnabled);     // We can't be enabled until we are completely initted.  
                 // We are logically completely initialized at this point.  
@@ -1655,10 +1528,13 @@ namespace System.Diagnostics.Tracing
             {
                 // If there are any deferred commands, we can do them now.   
                 // This is the most likely place for exceptions to happen.  
-                while (m_deferredCommands != null)
+                // Note that we are NOT resetting m_deferredCommands to NULL here, 
+                // We are giving for EventHandler<EventCommandEventArgs> that will be attached later
+                EventCommandEventArgs deferredCommands = m_deferredCommands;
+                while (deferredCommands != null)
                 {
-                    DoCommand(m_deferredCommands);      // This can never throw, it catches them and reports the errors.   
-                    m_deferredCommands = m_deferredCommands.nextCommand;
+                    DoCommand(deferredCommands);      // This can never throw, it catches them and reports the errors.   
+                    deferredCommands = deferredCommands.nextCommand;
                 }
             }
         }
@@ -1865,90 +1741,17 @@ namespace System.Diagnostics.Tracing
             return new Guid(bytes);
         }
 
-#if PROJECTN
-        public enum EventParameterType
-        {
-            Boolean,
-            Byte,
-            SByte,
-            Char,
-            Int16,
-            UInt16,
-            Int32,
-            UInt32,
-            Int64,
-            UInt64,
-            IntPtr,
-            Single,
-            Double,
-            Decimal,
-            Guid,
-            String
-        }
-
-        private Type EventTypeToType(EventParameterType type)
-        {
-            switch (type)
-            {
-                case EventParameterType.Boolean:
-                    return typeof(bool);
-                case EventParameterType.Byte:
-                    return typeof(byte);
-                case EventParameterType.SByte:
-                    return typeof(sbyte);
-                case EventParameterType.Char:
-                    return typeof(char);
-                case EventParameterType.Int16:
-                    return typeof(short);
-                case EventParameterType.UInt16:
-                    return typeof(ushort);
-                case EventParameterType.Int32:
-                    return typeof(int);
-                case EventParameterType.UInt32:
-                    return typeof(uint);
-                case EventParameterType.Int64:
-                    return typeof(long);
-                case EventParameterType.UInt64:
-                    return typeof(ulong);
-                case EventParameterType.IntPtr:
-                    return typeof(IntPtr);
-                case EventParameterType.Single:
-                    return typeof(float);
-                case EventParameterType.Double:
-                    return typeof(double);
-                case EventParameterType.Decimal:
-                    return typeof(decimal);
-                case EventParameterType.Guid:
-                    return typeof(Guid);
-                case EventParameterType.String:
-                    return typeof(string);
-                default:
-                    // TODO: should I throw an exception here?
-                    return null;
-            }
-        }
-#endif
-
         [SecurityCritical]
         private unsafe object DecodeObject(int eventId, int parameterId, ref EventSource.EventData* data)
         {
+            // TODO FIX : We use reflection which in turn uses EventSource, right now we carefully avoid
+            // the recursion, but can we do this in a robust way?  
+
             IntPtr dataPointer = data->DataPointer;
             // advance to next EventData in array
             ++data;
 
-#if PROJECTN
-            Type dataType;
-            if(m_eventData[eventId].Parameters == null)
-            {
-                dataType = EventTypeToType(m_eventData[eventId].ParameterTypes[parameterId]);
-            }
-            else
-            {
-                dataType = m_eventData[eventId].Parameters[parameterId].ParameterType;
-            }
-#else
-            Type dataType = m_eventData[eventId].Parameters[parameterId].ParameterType;
-#endif
+            Type dataType = GetDataType(m_eventData[eventId], parameterId);
 
         Again:
             if (dataType == typeof(IntPtr))
@@ -2042,16 +1845,15 @@ namespace System.Diagnostics.Tracing
             }
             else
             {
-#if PROJECTN
-                if (m_EventSourcePreventRecursion)
+                if (m_EventSourcePreventRecursion && m_EventSourceInDecodeObject)
                 {
                     return null;
                 }
 
                 try
                 {
-                    m_EventSourcePreventRecursion = true;
-#endif
+                    m_EventSourceInDecodeObject = true;
+
                     if (dataType.IsEnum())
                     {
                         dataType = Enum.GetUnderlyingType(dataType);
@@ -2064,13 +1866,11 @@ namespace System.Diagnostics.Tracing
                     // null in the string.
                     return System.Runtime.InteropServices.Marshal.PtrToStringUni(dataPointer);
 
-#if PROJECTN
                 }
                 finally
                 {
-                    m_EventSourcePreventRecursion = false;
+                    m_EventSourceInDecodeObject = false;
                 }
-#endif
             }
         }
 
@@ -2097,8 +1897,24 @@ namespace System.Diagnostics.Tracing
                 {
                     Contract.Assert(m_eventData != null);  // You must have initialized this if you enabled the source.  
                     if (childActivityID != null)
-                        ValidateEventOpcodeForTransfer(ref m_eventData[eventId]);
+                    {
+                        ValidateEventOpcodeForTransfer(ref m_eventData[eventId], m_eventData[eventId].Name);
 
+                        // If you use WriteEventWithRelatedActivityID you MUST declare the first argument to be a GUID 
+                        // with the name 'relatedActivityID, and NOT pass this argument to the WriteEvent method.  
+                        // During manifest creation we modify the ParameterInfo[] that we store to strip out any
+                        // first parameter that is of type Guid and named "relatedActivityId." Thus, if you call
+                        // WriteEventWithRelatedActivityID from a method that doesn't name its first parameter correctly
+                        // we can end up in a state where the ParameterInfo[] doesn't have its first parameter stripped,
+                        // and this leads to a mismatch between the number of arguments and the number of ParameterInfos,
+                        // which would cause a cryptic IndexOutOfRangeException later if we don't catch it here.
+                        if (!m_eventData[eventId].HasRelatedActivityID)
+                        {
+                            throw new ArgumentException(Resources.GetResourceString("EventSource_NoRelatedActivityId"));
+                        }
+                    }
+
+                    LogEventArgsMismatches(m_eventData[eventId].Parameters, args);
 #if FEATURE_MANAGED_ETW
                     if (m_eventData[eventId].EnabledForETW)
                     {
@@ -2143,11 +1959,11 @@ namespace System.Diagnostics.Tracing
                                     // mask set to 0x0f so, when all ETW sessions want the event we don't need to 
                                     // synthesize a new one
                                     if (!m_provider.WriteEvent(ref m_eventData[eventId].Descriptor, pActivityId, childActivityID, args))
-                                        ThrowEventSourceException();
+                                        ThrowEventSourceException(m_eventData[eventId].Name);
                                 }
                                 else
                                 {
-                                    long origKwd = unchecked((long)(m_eventData[eventId].Descriptor.Keywords & ~(SessionMask.All.ToEventKeywords())));
+                                    long origKwd = unchecked((long)((ulong)m_eventData[eventId].Descriptor.Keywords & ~(SessionMask.All.ToEventKeywords())));
                                     // only some of the ETW sessions will receive this event. Synthesize a new
                                     // Descriptor whose Keywords field will have the appropriate bits set.
                                     var desc = new EventDescriptor(
@@ -2157,10 +1973,10 @@ namespace System.Diagnostics.Tracing
                                         m_eventData[eventId].Descriptor.Level,
                                         m_eventData[eventId].Descriptor.Opcode,
                                         m_eventData[eventId].Descriptor.Task,
-                                        unchecked((long)etwSessions | origKwd));
+                                        unchecked((long)(ulong)etwSessions | origKwd));
 
                                     if (!m_provider.WriteEvent(ref desc, pActivityId, childActivityID, args))
-                                        ThrowEventSourceException();
+                                        ThrowEventSourceException(m_eventData[eventId].Name);
                                 }
                             }
                             else
@@ -2174,7 +1990,7 @@ namespace System.Diagnostics.Tracing
                                     Interlocked.CompareExchange(ref m_eventData[eventId].TraceLoggingEventTypes, tlet, null);
 
                                 }
-                                long origKwd = unchecked((long)(m_eventData[eventId].Descriptor.Keywords & ~(SessionMask.All.ToEventKeywords())));
+                                long origKwd = unchecked((long)((ulong)m_eventData[eventId].Descriptor.Keywords & ~(SessionMask.All.ToEventKeywords())));
                                 // TODO: activity ID support
                                 EventSourceOptions opt = new EventSourceOptions
                                 {
@@ -2190,7 +2006,7 @@ namespace System.Diagnostics.Tracing
                         if (!SelfDescribingEvents)
                         {
                             if (!m_provider.WriteEvent(ref m_eventData[eventId].Descriptor, pActivityId, childActivityID, args))
-                                ThrowEventSourceException();
+                                ThrowEventSourceException(m_eventData[eventId].Name);
                         }
                         else
                         {
@@ -2237,7 +2053,7 @@ namespace System.Diagnostics.Tracing
                     if (ex is EventSourceException)
                         throw;
                     else
-                        ThrowEventSourceException(ex);
+                        ThrowEventSourceException(m_eventData[eventId].Name, ex);
                 }
             }
         }
@@ -2249,8 +2065,8 @@ namespace System.Diagnostics.Tracing
             if (eventTypes == null)
             {
                 eventTypes = new TraceLoggingEventTypes(m_eventData[eventId].Name,
-                                                    EventTags.None,
-                                                    m_eventData[eventId].Parameters);
+                                                        EventTags.None,
+                                                        m_eventData[eventId].Parameters);
                 Interlocked.CompareExchange(ref m_eventData[eventId].TraceLoggingEventTypes, eventTypes, null);
             }
             var eventData = new object[eventTypes.typeInfos.Length];
@@ -2261,29 +2077,53 @@ namespace System.Diagnostics.Tracing
             return eventData;
         }
 
+        /// <summary>
+        /// We expect that the arguments to the Event method and the arguments to WriteEvent match. This function 
+        /// checks that they in fact match and logs a warning to the debugger if they don't.
+        /// </summary>
+        /// <param name="infos"></param>
+        /// <param name="args"></param>
+        private void LogEventArgsMismatches(ParameterInfo[] infos, object[] args)
+        {
+#if (!ES_BUILD_PCL && !PROJECTN)
+            // It would be nice to have this on PCL builds, but it would be pointless since there isn't support for 
+            // writing to the debugger log on PCL.
+            bool typesMatch = args.Length == infos.Length;
+
+            int i = 0;
+            while (typesMatch && i < args.Length)
+            {
+                Type pType = infos[i].ParameterType;
+
+                // Checking to see if the Parameter types (from the Event method) match the supplied argument types.
+                // Fail if one of two things hold : either the argument type is not equal to the parameter type, or the 
+                // argument is null and the parameter type is non-nullable.
+                if ((args[i] != null && (args[i].GetType() != pType))
+                    || (args[i] == null && (!(pType.IsGenericType && pType.GetGenericTypeDefinition() == typeof(Nullable<>))))
+                    )
+                {
+                    typesMatch = false;
+                    break;
+                }
+
+                ++i;
+            }
+
+            if (!typesMatch)
+            {
+                System.Diagnostics.Debugger.Log(0, null, Resources.GetResourceString("EventSource_VarArgsParameterMismatch") + "\r\n");
+            }
+#endif //!ES_BUILD_PCL
+        }
+
         [SecurityCritical]
         unsafe private void WriteToAllListeners(int eventId, Guid* childActivityID, int eventDataCount, EventSource.EventData* data)
         {
-#if PROJECTN
-            int paramCount;
-            if(m_eventData[eventId].Parameters == null)
-            {
-                paramCount = m_eventData[eventId].ParameterTypes.Length;
-            }
-            else
-            {
-                paramCount = m_eventData[eventId].Parameters.Length;
-            }
-#else
-            int paramCount = m_eventData[eventId].Parameters.Length;
-#endif
+            int paramCount = GetParameterCount(m_eventData[eventId]);
+            
             if (eventDataCount != paramCount)
             {
-#if PROJECTN
-                ReportOutOfBandMessage(SR.Format("EventSource_EventParametersMismatch", eventId, eventDataCount, paramCount), true);
-#else
-                ReportOutOfBandMessage(Environment.GetResourceString("EventSource_EventParametersMismatch", eventId, eventDataCount, paramCount), true);
-#endif
+                ReportOutOfBandMessage(Resources.GetResourceString("EventSource_EventParametersMismatch", eventId, eventDataCount, paramCount), true);
                 paramCount = Math.Min(paramCount, eventDataCount);
             }
 
@@ -2307,11 +2147,11 @@ namespace System.Diagnostics.Tracing
             eventCallbackArgs.Message = m_eventData[eventId].Message;
             eventCallbackArgs.Payload = new ReadOnlyCollection<object>(args);
 
-            DisptachToAllListeners(eventId, childActivityID, eventCallbackArgs);
+            DispatchToAllListeners(eventId, childActivityID, eventCallbackArgs);
         }
 
         [SecurityCritical]
-        private unsafe void DisptachToAllListeners(int eventId, Guid* childActivityID, EventWrittenEventArgs eventCallbackArgs)
+        private unsafe void DispatchToAllListeners(int eventId, Guid* childActivityID, EventWrittenEventArgs eventCallbackArgs)
         {
             Exception lastThrownException = null;
             for (EventDispatcher dispatcher = m_Dispatchers; dispatcher != null; dispatcher = dispatcher.m_Next)
@@ -2352,15 +2192,11 @@ namespace System.Diagnostics.Tracing
             }
         }
         
-        public struct EventMessage
-        {
-            public string message;
-        }
-
         [SecuritySafeCritical]
         [SuppressMessage("Microsoft.Concurrency", "CA8001", Justification = "This does not need to be correct when racing with other threads")]
         private unsafe void WriteEventString(EventLevel level, long keywords, string msgString)
         {
+#if FEATURE_MANAGED_ETW
             if (m_provider != null)
             {
                 string eventName = "EventSourceMessage";
@@ -2371,7 +2207,7 @@ namespace System.Diagnostics.Tracing
                         Keywords = (EventKeywords)unchecked(keywords),
                         Level = level
                     };
-                    var msg = new EventMessage { message = msgString };
+                    var msg = new { message = msgString };
                     var tlet = new TraceLoggingEventTypes(eventName, EventTags.None, new Type[] { msg.GetType() });
                     WriteMultiMergeInner(eventName, ref opt, tlet, null, null, msg);
                 }
@@ -2392,7 +2228,7 @@ namespace System.Diagnostics.Tracing
                     fixed (char* msgStringPtr = msgString)
                     {
                         EventDescriptor descr = new EventDescriptor(0, 0, 0, (byte)level, 0, 0, keywords);
-                        ProviderEventData data = new ProviderEventData();
+                        EventProvider.EventData data = new EventProvider.EventData();
                         data.Ptr = (ulong)msgStringPtr;
                         data.Size = (uint)(2 * (msgString.Length + 1));
                         data.Reserved = 0;
@@ -2400,6 +2236,7 @@ namespace System.Diagnostics.Tracing
                     }
                 }
             }
+#endif // FEATURE_MANAGED_ETW
         }
 
         /// <summary>
@@ -2516,7 +2353,7 @@ namespace System.Diagnostics.Tracing
                 return false;
 
             EventLevel eventLevel = (EventLevel)m_eventData[eventNum].Descriptor.Level;
-            EventKeywords eventKeywords = unchecked((EventKeywords)(m_eventData[eventNum].Descriptor.Keywords & (~(SessionMask.All.ToEventKeywords()))));
+            EventKeywords eventKeywords = unchecked((EventKeywords)((ulong)m_eventData[eventNum].Descriptor.Keywords & (~(SessionMask.All.ToEventKeywords()))));
 
 #if FEATURE_MANAGED_ETW_CHANNELS
             EventChannel channel = unchecked((EventChannel)m_eventData[eventNum].Descriptor.Channel);
@@ -2559,9 +2396,9 @@ namespace System.Diagnostics.Tracing
 
         }
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.NoInlining)]
-        private void ThrowEventSourceException(Exception innerEx = null)
+        private void ThrowEventSourceException(string eventName, Exception innerEx = null)
         {
-            // If we fail during ouf of band logging we may end up trying 
+            // If we fail during out of band logging we may end up trying 
             // to throw another EventSourceException, thus hitting a StackOverflowException. 
             // Avoid StackOverflow by making sure we do not recursively call this method.
             if (m_EventSourceExceptionRecurenceCount > 0)
@@ -2569,51 +2406,37 @@ namespace System.Diagnostics.Tracing
             try
             {
                 m_EventSourceExceptionRecurenceCount++;
+                
+                string errorPrefix = "EventSourceException";
+                if(eventName != null)
+                {
+                    errorPrefix += " while processing event \"" + eventName + "\"";
+                }
 
                 // TODO Create variations of EventSourceException that indicate more information using the error code.
                 switch (EventProvider.GetLastWriteEventError())
                 {
                     case EventProvider.WriteEventErrorCode.EventTooBig:
-#if PROJECTN
-                        string eventTooBigResource = SR.GetResourceString("EventSource_EventTooBig", null);
-#else
-                        string eventTooBigResource = Environment.GetResourceString("EventSource_EventTooBig");
-#endif
-                        ReportOutOfBandMessage("EventSourceException: " + eventTooBigResource, true);
-                        if (ThrowOnEventWriteErrors) throw new EventSourceException(eventTooBigResource, innerEx);
+                        ReportOutOfBandMessage(errorPrefix + ": " + Resources.GetResourceString("EventSource_EventTooBig"), true);
+                        if (ThrowOnEventWriteErrors) throw new EventSourceException(Resources.GetResourceString("EventSource_EventTooBig"), innerEx);
                         break;
                     case EventProvider.WriteEventErrorCode.NoFreeBuffers:
-#if PROJECTN
-                        string noFreeBuffersResource = SR.GetResourceString("EventSource_NoFreeBuffers", null);
-#else
-                        string noFreeBuffersResource = Environment.GetResourceString("EventSource_NoFreeBuffers");
-#endif
-                        ReportOutOfBandMessage("EventSourceException: " + noFreeBuffersResource, true);
-                        if (ThrowOnEventWriteErrors) throw new EventSourceException(noFreeBuffersResource, innerEx);
+                        ReportOutOfBandMessage(errorPrefix + ": " + Resources.GetResourceString("EventSource_NoFreeBuffers"), true);
+                        if (ThrowOnEventWriteErrors) throw new EventSourceException(Resources.GetResourceString("EventSource_NoFreeBuffers"), innerEx);
                         break;
                     case EventProvider.WriteEventErrorCode.NullInput:
-#if PROJECTN
-                        string nullInputResource = SR.GetResourceString("EventSource_NullInput", null);
-#else
-                        string nullInputResource = Environtment.GetResourceString("EventSource_NullInput");
-#endif
-                        ReportOutOfBandMessage("EventSourceException: " + nullInputResource, true);
-                        if (ThrowOnEventWriteErrors) throw new EventSourceException(nullInputResource, innerEx);
+                        ReportOutOfBandMessage(errorPrefix + ": " + Resources.GetResourceString("EventSource_NullInput"), true);
+                        if (ThrowOnEventWriteErrors) throw new EventSourceException(Resources.GetResourceString("EventSource_NullInput"), innerEx);
                         break;
                     case EventProvider.WriteEventErrorCode.TooManyArgs:
-#if PROJECTN
-                        string tooManyArgsResource = SR.GetResourceString("EventSource_TooManyArgs", null);
-#else
-                        string tooManyArgsResource =  Environment.GetResourceString("EventSource_TooManyArgs");
-#endif
-                        ReportOutOfBandMessage("EventSourceException: " + tooManyArgsResource, true);
-                        if (ThrowOnEventWriteErrors) throw new EventSourceException(tooManyArgsResource, innerEx);
+                        ReportOutOfBandMessage(errorPrefix + ": " + Resources.GetResourceString("EventSource_TooManyArgs"), true);
+                        if (ThrowOnEventWriteErrors) throw new EventSourceException(Resources.GetResourceString("EventSource_TooManyArgs"), innerEx);
                         break;
                     default:
                         if (innerEx != null)
-                            ReportOutOfBandMessage("EventSourceException: " + innerEx.GetType() + ":" + innerEx.Message, true);
+                            ReportOutOfBandMessage(errorPrefix + ": " + innerEx.GetType() + ":" + innerEx.Message, true);
                         else
-                            ReportOutOfBandMessage("EventSourceException", true);
+                            ReportOutOfBandMessage(errorPrefix, true);
                         if (ThrowOnEventWriteErrors) throw new EventSourceException(innerEx);
                         break;
                 }
@@ -2624,12 +2447,13 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        private void ValidateEventOpcodeForTransfer(ref EventMetadata eventData)
+        private void ValidateEventOpcodeForTransfer(ref EventMetadata eventData, string eventName)
         {
             if ((EventOpcode)eventData.Descriptor.Opcode != EventOpcode.Send &&
-                (EventOpcode)eventData.Descriptor.Opcode != EventOpcode.Receive)
+                (EventOpcode)eventData.Descriptor.Opcode != EventOpcode.Receive && 
+                (EventOpcode)eventData.Descriptor.Opcode != EventOpcode.Start)
             {
-                ThrowEventSourceException();
+                ThrowEventSourceException(eventName);
             }
         }
 
@@ -2677,35 +2501,14 @@ namespace System.Diagnostics.Tracing
         /// descriptor as well as some stuff we added specifically for EventSource. see the
         /// code:m_eventData for where we use this.  
         /// </summary>
-        public struct EventMetadata
+        internal partial struct EventMetadata
         {
-#if PROJECTN
-            public EventMetadata(EventDescriptor descriptor,
-                EventTags tags,
-                bool enabledForAnyListener,
-                bool enabledForETW,
-                string name,
-                string message,
-                EventParameterType[] parameterTypes)
-            {
-                this.Descriptor = descriptor;
-                this.Tags = tags;
-                this.EnabledForAnyListener = enabledForAnyListener;
-                this.EnabledForETW = enabledForETW;
-                this.TriggersActivityTracking = 0;
-                this.Name = name;
-                this.Message = message;
-                this.Parameters = null;
-                this.TraceLoggingEventTypes = null;
-                this.ActivityOptions = EventActivityOptions.None;
-                this.ParameterTypes = parameterTypes;
-            }
-#endif
-
             public EventDescriptor Descriptor;
             public EventTags Tags;
             public bool EnabledForAnyListener;      // true if any dispatcher has this event turned on
             public bool EnabledForETW;              // is this event on for the OS ETW data dispatcher?
+
+            public bool HasRelatedActivityID;       // Set if the event method's first parameter is a Guid named 'relatedActivityId'
 #if !FEATURE_ACTIVITYSAMPLING
 #pragma warning disable 0649
 #endif
@@ -2719,7 +2522,7 @@ namespace System.Diagnostics.Tracing
 
             public TraceLoggingEventTypes TraceLoggingEventTypes;
             public EventActivityOptions ActivityOptions;
-
+            
 #if PROJECTN
             public EventParameterType[] ParameterTypes;
 #endif
@@ -2759,8 +2562,13 @@ namespace System.Diagnostics.Tracing
             var commandArgs = new EventCommandEventArgs(command, commandArguments, this, listener, perEventSourceSessionId, etwSessionId, enable, level, matchAnyKeyword);
             lock (EventListener.EventListenersLock)
             {
-                if (m_completelyInited)     // We are fully initialized, do the command 
+                if (m_completelyInited)
+                {
+                    // After the first command arrive after construction, we are ready to get rid of the deferred commands
+                    this.m_deferredCommands = null;
+                    // We are fully initialized, do the command 
                     DoCommand(commandArgs);
+                }
                 else
                 {
                     // We can't do the command, simply remember it and we do it when we are fully constructed.  
@@ -2782,8 +2590,10 @@ namespace System.Diagnostics.Tracing
             // We defer commands until we are completely inited.  This allows error messages to be sent.  
             Contract.Assert(m_completelyInited);
 
+#if FEATURE_MANAGED_ETW
             if (m_provider == null)     // If we failed to construct
                 return;
+#endif // FEATURE_MANAGED_ETW
 
             m_outOfBandMessageCount = 0;
             bool shouldReport = (commandArgs.perEventSourceSessionId > 0) && (commandArgs.perEventSourceSessionId <= SessionMask.MAX);
@@ -2796,11 +2606,7 @@ namespace System.Diagnostics.Tracing
                 commandArgs.dispatcher = GetDispatcher(commandArgs.listener);
                 if (commandArgs.dispatcher == null && commandArgs.listener != null)     // dispatcher == null means ETW dispatcher
                 {
-#if PROJECTN
-                    throw new ArgumentException(SR.GetResourceString("EventSource_ListenerNotFound", null));
-#else
-                    throw new ArgumentException(Environment.GetResourceString("EventSource_ListenerNotFound"));
-#endif
+                    throw new ArgumentException(Resources.GetResourceString("EventSource_ListenerNotFound"));
                 }
 
                 if (commandArgs.Arguments == null)
@@ -2879,15 +2685,9 @@ namespace System.Diagnostics.Tracing
 
                         if (commandArgs.listener == null && commandArgs.Arguments.Count > 0 && commandArgs.perEventSourceSessionId != sessionIdBit)
                         {
-#if PROJECTN
-                            throw new ArgumentException(SR.Format("EventSource_SessionIdError",
+                            throw new ArgumentException(Resources.GetResourceString("EventSource_SessionIdError",
                                                     commandArgs.perEventSourceSessionId + SessionMask.SHIFT_SESSION_TO_KEYWORD,
                                                         sessionIdBit + SessionMask.SHIFT_SESSION_TO_KEYWORD));
-#else
-                            throw new ArgumentException(Environment.GetResourceString("EventSource_SessionIdError",
-                                                    commandArgs.perEventSourceSessionId + SessionMask.SHIFT_SESSION_TO_KEYWORD,
-                                                        sessionIdBit + SessionMask.SHIFT_SESSION_TO_KEYWORD));
-#endif
                         }
 
                         if (commandArgs.listener == null)
@@ -2919,6 +2719,9 @@ namespace System.Diagnostics.Tracing
                     }
 
                     this.OnEventCommand(commandArgs);
+                    var eventCommandCallback = this.m_eventCommandExecuted;
+                    if (eventCommandCallback != null)
+                        eventCommandCallback(this, commandArgs);
 
 #if FEATURE_ACTIVITYSAMPLING
                     if (commandArgs.listener == null && !bSessionEnable && commandArgs.perEventSourceSessionId != -1)
@@ -3004,6 +2807,9 @@ namespace System.Diagnostics.Tracing
                     // Contract.Assert(matchAnyKeyword == EventKeywords.None);
 
                     this.OnEventCommand(commandArgs);
+                    var eventCommandCallback = m_eventCommandExecuted;
+                    if (eventCommandCallback != null)
+                        eventCommandCallback(this, commandArgs);
                 }
 
 #if FEATURE_ACTIVITYSAMPLING
@@ -3188,7 +2994,10 @@ namespace System.Diagnostics.Tracing
             return false;
         }
 
-        private bool IsDisposed { get { return m_provider == null || m_provider.m_disposed; } }
+        private bool IsDisposed 
+        {
+            get { return m_eventSourceDisposed; }
+        }
 
         [SecuritySafeCritical]
         private void EnsureDescriptorsInitialized()
@@ -3198,11 +3007,12 @@ namespace System.Diagnostics.Tracing
 #endif
             if (m_eventData == null)
             {
-                Guid eventSourceGuid;
-                string eventSourceName;
-                EventMetadata[] eventData;
-                byte[] manifest;
-                // Try the GetMetadata provided by the ILTransform. The default sets all to null, and in that case we fall back
+                Guid eventSourceGuid = Guid.Empty;
+                string eventSourceName = null;
+                EventMetadata[] eventData = null;
+                byte[] manifest = null;
+
+                // Try the GetMetadata provided by the ILTransform in ProjectN. The default sets all to null, and in that case we fall back
                 // to the reflection approach.
                 GetMetadata(out eventSourceGuid, out eventSourceName, out eventData, out manifest);
 
@@ -3230,11 +3040,7 @@ namespace System.Diagnostics.Tracing
                     {
                         if (eventSource != this)
                         {
-#if PROJECTN
-                            throw new ArgumentException(SR.Format("EventSource_EventSourceGuidInUse", m_guid));
-#else
-                            throw new ArgumentException(Environment.GetResourceString("EventSource_EventSourceGuidInUse", m_guid));
-#endif
+                            throw new ArgumentException(Resources.GetResourceString("EventSource_EventSourceGuidInUse", m_guid));
                         }
                     }
                 }
@@ -3254,7 +3060,7 @@ namespace System.Diagnostics.Tracing
                 // for non-BCL EventSource we must assert SecurityPermission
                 new SecurityPermission(PermissionState.Unrestricted).Assert();
 #endif
-                s_currentPid = Win32Interop.GetCurrentProcessId();
+                s_currentPid = Win32Native.GetCurrentProcessId();
             }
         }
 
@@ -3285,7 +3091,8 @@ namespace System.Diagnostics.Tracing
                 int dataLeft = rawManifest.Length;
                 envelope.ChunkNumber = 0;
 
-                ProviderEventData* dataDescrs = stackalloc ProviderEventData[2];
+                EventProvider.EventData* dataDescrs = stackalloc EventProvider.EventData[2];
+
                 dataDescrs[0].Ptr = (ulong)&envelope;
                 dataDescrs[0].Size = (uint)sizeof(ManifestEnvelope);
                 dataDescrs[0].Reserved = 0;
@@ -3316,7 +3123,7 @@ namespace System.Diagnostics.Tracing
                             }
                             success = false;
                             if (ThrowOnEventWriteErrors)
-                                ThrowEventSourceException();
+                                ThrowEventSourceException("SendManifest");
                             break;
                         }
                     }
@@ -3325,7 +3132,7 @@ namespace System.Diagnostics.Tracing
                     envelope.ChunkNumber++;
                 }
             }
-#endif
+#endif // FEATURE_MANAGED_ETW
             return success;
         }
 
@@ -3401,11 +3208,7 @@ namespace System.Diagnostics.Tracing
 
             return null;
 #else // ES_BUILD_PCL && PROJECTN
-#if PROJECTN
-            throw new ArgumentException(SR.GetResourceString("EventSource", "EventSource_PCLPlatformNotSupportedReflection"));
-#else
-            throw new ArgumentException(Environment.GetResourceString("EventSource", "EventSource_PCLPlatformNotSupportedReflection"));
-#endif
+            throw new ArgumentException(Resources.GetResourceString("EventSource", "EventSource_PCLPlatformNotSupportedReflection"));
 #endif
         }
 
@@ -3522,19 +3325,11 @@ namespace System.Diagnostics.Tracing
 
                     if (!typeMatch)
                     {
-#if PROJECTN
-                        manifest.ManifestError(SR.GetResourceString("EventSource_TypeMustDeriveFromEventSource", null));
-#else
-                        manifest.ManifestError(Environment.GetResourceString("EventSource_TypeMustDeriveFromEventSource"));
-#endif
+                        manifest.ManifestError(Resources.GetResourceString("EventSource_TypeMustDeriveFromEventSource"));
                     }
                     if (!eventSourceType.IsAbstract() && !eventSourceType.IsSealed())
                     {
-#if PROJECTN
-                        manifest.ManifestError(SR.GetResourceString("EventSource_TypeMustBeSealedOrAbstract", null));
-#else
-                        manifest.ManifestError(Environment.GetResourceString("EventSource_TypeMustBeSealedOrAbstract"));
-#endif
+                        manifest.ManifestError(Resources.GetResourceString("EventSource_TypeMustBeSealedOrAbstract"));
                     }
                 }
 
@@ -3550,11 +3345,7 @@ namespace System.Diagnostics.Tracing
                     {
                         if (eventSourceType.IsAbstract())
                         {
-#if PROJECTN
-                            manifest.ManifestError(SR.Format("EventSource_AbstractMustNotDeclareKTOC", nestedType.Name));
-#else
-                            manifest.ManifestError(Environment.GetResourceString("EventSource_AbstractMustNotDeclareKTOC", nestedType.Name));
-#endif
+                            manifest.ManifestError(Resources.GetResourceString("EventSource_AbstractMustNotDeclareKTOC", nestedType.Name));
                         }
                         else
                         {
@@ -3573,7 +3364,7 @@ namespace System.Diagnostics.Tracing
                     manifest.AddKeyword("Session0", (long)0x8000 << 32);
                 }
 
-                if (eventSourceType.Name != "EventSource")
+                if (eventSourceType != typeof(EventSource))
                 {
                     for (int i = 0; i < methods.Length; i++)
                     {
@@ -3597,11 +3388,7 @@ namespace System.Diagnostics.Tracing
                         {
                             if (eventAttribute != null)
                             {
-#if PROJECTN
-                                manifest.ManifestError(SR.Format("EventSource_AbstractMustNotDeclareEventMethods", method.Name, eventAttribute.EventId));
-#else
-                                manifest.ManifestError(Environment.GetResourceString("EventSource_AbstractMustNotDeclareEventMethods", method.Name, eventAttribute.EventId));
-#endif
+                                manifest.ManifestError(Resources.GetResourceString("EventSource_AbstractMustNotDeclareEventMethods", method.Name, eventAttribute.EventId));
                             }
                             continue;
                         }
@@ -3630,20 +3417,12 @@ namespace System.Diagnostics.Tracing
                         }
                         else if (eventAttribute.EventId <= 0)
                         {
-#if PROJECTN
-                            manifest.ManifestError(SR.Format("EventSource_NeedPositiveId", method.Name), true);
-#else
-                            manifest.ManifestError(Environment.GetResourceString("EventSource_NeedPositiveId", method.Name), true);
-#endif
+                            manifest.ManifestError(Resources.GetResourceString("EventSource_NeedPositiveId", method.Name), true);
                             continue;   // don't validate anything else for this event
                         }
                         if (method.Name.LastIndexOf('.') >= 0)
                         {
-#if PROJECTN
-                            manifest.ManifestError(SR.Format("EventSource_EventMustNotBeExplicitImplementation", method.Name, eventAttribute.EventId));
-#else
-                            manifest.ManifestError(Environment.GetResourceString("EventSource_EventMustNotBeExplicitImplementation", method.Name, eventAttribute.EventId));
-#endif
+                            manifest.ManifestError(Resources.GetResourceString("EventSource_EventMustNotBeExplicitImplementation", method.Name, eventAttribute.EventId));
                         }
 
                         eventId++;
@@ -3670,16 +3449,16 @@ namespace System.Diagnostics.Tracing
                                     if (string.Compare(eventName, 0, taskName, 0, taskName.Length) == 0 &&
                                         string.Compare(eventName, taskName.Length, s_ActivityStartSuffix, 0, Math.Max(eventName.Length - taskName.Length, s_ActivityStartSuffix.Length)) == 0)
                                     {
-                                        // Add a task that is just the task name for the start event.   This supress the auto-task generation
+                                        // Add a task that is just the task name for the start event.   This suppress the auto-task generation
                                         // That would otherwise happen (and create 'TaskName'Start as task name rather than just 'TaskName'
                                         manifest.AddTask(taskName, (int)eventAttribute.Task);
                                     }
                                 }
                                 else if (eventAttribute.Opcode == EventOpcode.Stop)
                                 {
-                                    // Find the start associated with this stop event.  We requre start to be immediately before the stop
+                                    // Find the start associated with this stop event.  We require start to be immediately before the stop
                                     int startEventId = eventAttribute.EventId - 1;
-                                    if (startEventId < eventData.Length)
+                                    if (eventData != null && startEventId < eventData.Length)
                                     {
                                         Contract.Assert(0 <= startEventId);                // Since we reserve id 0, we know that id-1 is <= 0
                                         EventMetadata startEventMetadata = eventData[startEventId];
@@ -3699,17 +3478,13 @@ namespace System.Diagnostics.Tracing
                                     }
                                     if (noTask && (flags & EventManifestOptions.Strict) != 0)        // Throw an error if we can compatibly.   
                                     {
-#if PROJECTN
-                                        throw new ArgumentException(SR.GetResourceString("EventSource_StopsFollowStarts", null));
-#else
-                                        throw new ArgumentException(Environment.GetResourceString("EventSource_StopsFollowStarts"));
-#endif
+                                        throw new ArgumentException(Resources.GetResourceString("EventSource_StopsFollowStarts"));
                                     }
                                 }
                             }
                         }
 
-                        RemoveFirstArgIfRelatedActivityId(ref args);
+                        bool hasRelatedActivityID = RemoveFirstArgIfRelatedActivityId(ref args);
                         if (!(source != null && source.SelfDescribingEvents))
                         {
                             manifest.StartEvent(eventName, eventAttribute);
@@ -3723,7 +3498,7 @@ namespace System.Diagnostics.Tracing
                         if (source != null || (flags & EventManifestOptions.Strict) != 0)
                         {
                             // Do checking for user errors (optional, but not a big deal so we do it).  
-                            DebugCheckEvent(ref eventsByName, eventData, method, eventAttribute, manifest);
+                            DebugCheckEvent(ref eventsByName, eventData, method, eventAttribute, manifest, flags);
 
 #if FEATURE_MANAGED_ETW_CHANNELS
                             // add the channel keyword for Event Viewer channel based filters. This is added for creating the EventDescriptors only
@@ -3741,7 +3516,7 @@ namespace System.Diagnostics.Tracing
                             // overwrite inline message with the localized message
                             if (msg != null) eventAttribute.Message = msg;
 
-                            AddEventDescriptor(ref eventData, eventName, eventAttribute, args);
+                            AddEventDescriptor(ref eventData, eventName, eventAttribute, args, hasRelatedActivityID);
                         }
                     }
                 }
@@ -3763,7 +3538,7 @@ namespace System.Diagnostics.Tracing
                 {
                     bNeedsManifest = (flags & EventManifestOptions.OnlyIfNeededForRegistration) == 0
 #if FEATURE_MANAGED_ETW_CHANNELS
- || manifest.GetChannelData().Length > 0
+                                            || manifest.GetChannelData().Length > 0
 #endif
 ;
 
@@ -3806,7 +3581,7 @@ namespace System.Diagnostics.Tracing
             return bNeedsManifest ? res : null;
         }
 
-        private static void RemoveFirstArgIfRelatedActivityId(ref ParameterInfo[] args)
+        private static bool RemoveFirstArgIfRelatedActivityId(ref ParameterInfo[] args)
         {
             // If the first parameter is (case insensitive) 'relatedActivityId' then skip it.  
             if (args.Length > 0 && args[0].ParameterType == typeof(Guid) &&
@@ -3815,7 +3590,11 @@ namespace System.Diagnostics.Tracing
                 var newargs = new ParameterInfo[args.Length - 1];
                 Array.Copy(args, 1, newargs, 0, args.Length - 1);
                 args = newargs;
+
+                return true;
             }
+
+            return false;
         }
 
         // adds a enumeration (keyword, opcode, task or channel) represented by 'staticField'
@@ -3852,18 +3631,15 @@ namespace System.Diagnostics.Tracing
 #endif
             return;
         Error:
-#if PROJECTN
-            manifest.ManifestError(SR.Format("EventSource_EnumKindMismatch", staticField.Name, staticField.FieldType.Name, providerEnumKind));
-#else
-            manifest.ManifestError(Environment.GetResourceString("EventSource_EnumKindMismatch", staticField.Name, staticField.FieldType.Name, providerEnumKind));
-#endif
+            manifest.ManifestError(Resources.GetResourceString("EventSource_EnumKindMismatch", staticField.Name, staticField.FieldType.Name, providerEnumKind));
         }
 
         // Helper used by code:CreateManifestAndDescriptors to add a code:EventData descriptor for a method
         // with the code:EventAttribute 'eventAttribute'.  resourceManger may be null in which case we populate it
         // it is populated if we need to look up message resources
         private static void AddEventDescriptor(ref EventMetadata[] eventData, string eventName,
-                                EventAttribute eventAttribute, ParameterInfo[] eventParameters)
+                                EventAttribute eventAttribute, ParameterInfo[] eventParameters,
+                                bool hasRelatedActivityID)
         {
             if (eventData == null || eventData.Length <= eventAttribute.EventId)
             {
@@ -3883,13 +3659,14 @@ namespace System.Diagnostics.Tracing
                     (byte)eventAttribute.Level,
                     (byte)eventAttribute.Opcode,
                     (int)eventAttribute.Task,
-                    unchecked(((long)eventAttribute.Keywords | SessionMask.All.ToEventKeywords())));
+                    unchecked((long)((ulong)eventAttribute.Keywords | SessionMask.All.ToEventKeywords())));
 
             eventData[eventAttribute.EventId].Tags = eventAttribute.Tags;
             eventData[eventAttribute.EventId].Name = eventName;
             eventData[eventAttribute.EventId].Parameters = eventParameters;
             eventData[eventAttribute.EventId].Message = eventAttribute.Message;
             eventData[eventAttribute.EventId].ActivityOptions = eventAttribute.ActivityOptions;
+            eventData[eventAttribute.EventId].HasRelatedActivityID = hasRelatedActivityID;
         }
 
         // Helper used by code:CreateManifestAndDescriptors that trims the m_eventData array to the correct
@@ -3929,40 +3706,37 @@ namespace System.Diagnostics.Tracing
         // index for two distinct events etc.  Throws exceptions when it finds something wrong. 
         private static void DebugCheckEvent(ref Dictionary<string, string> eventsByName,
             EventMetadata[] eventData, MethodInfo method, EventAttribute eventAttribute,
-            ManifestBuilder manifest)
+            ManifestBuilder manifest, EventManifestOptions options)
         {
             int evtId = eventAttribute.EventId;
             string evtName = method.Name;
             int eventArg = GetHelperCallFirstArg(method);
             if (eventArg >= 0 && evtId != eventArg)
             {
-#if PROJECTN
-                manifest.ManifestError(SR.Format("EventSource_MismatchIdToWriteEvent", evtName, evtId, eventArg), true);
-#else
-                manifest.ManifestError(Environment.GetResourceString("EventSource_MismatchIdToWriteEvent", evtName, evtId, eventArg), true);
-#endif
+                manifest.ManifestError(Resources.GetResourceString("EventSource_MismatchIdToWriteEvent", evtName, evtId, eventArg), true);
             }
 
             if (evtId < eventData.Length && eventData[evtId].Descriptor.EventId != 0)
             {
-#if PROJECTN
-                manifest.ManifestError(SR.Format("EventSource_EventIdReused", evtName, evtId, eventData[evtId].Name), true);
-#else
-                manifest.ManifestError(Environment.GetResourceString("EventSource_EventIdReused", evtName, evtId, eventData[evtId].Name), true);
-#endif
+                manifest.ManifestError(Resources.GetResourceString("EventSource_EventIdReused", evtName, evtId, eventData[evtId].Name), true);
             }
 
+            // We give a task to things if they don't have one.  
+            // TODO this is moderately expensive (N*N).   We probably should not even bother....   
+            Contract.Assert(eventAttribute.Task != EventTask.None || eventAttribute.Opcode != EventOpcode.Info);        
             for (int idx = 0; idx < eventData.Length; ++idx)
             {
+                // skip unused Event IDs. 
+                if (eventData[idx].Name == null)
+                    continue;
+
                 if (eventData[idx].Descriptor.Task == (int)eventAttribute.Task && eventData[idx].Descriptor.Opcode == (int)eventAttribute.Opcode)
                 {
-#if PROJECTN
-                    manifest.ManifestError(SR.Format("EventSource_TaskOpcodePairReused",
+                    manifest.ManifestError(Resources.GetResourceString("EventSource_TaskOpcodePairReused",
                                             evtName, evtId, eventData[idx].Name, idx));
-#else
-                    manifest.ManifestError(Environment.GetResourceString("EventSource_TaskOpcodePairReused",
-                                            evtName, evtId, eventData[idx].Name, idx));
-#endif
+                    // If we are not strict stop on first error.   We have had problems with really large providers taking forever.  because of many errors.  
+                    if ((options & EventManifestOptions.Strict) == 0)
+                        break;
                 }
             }
 
@@ -3983,11 +3757,7 @@ namespace System.Diagnostics.Tracing
                 }
                 if (failure)
                 {
-#if PROJECTN
-                    manifest.ManifestError(SR.Format("EventSource_EventMustHaveTaskIfNonDefaultOpcode", evtName, evtId));
-#else
-                    manifest.ManifestError(Environment.GetResourceString("EventSource_EventMustHaveTaskIfNonDefaultOpcode", evtName, evtId));
-#endif
+                    manifest.ManifestError(Resources.GetResourceString("EventSource_EventMustHaveTaskIfNonDefaultOpcode", evtName, evtId));
                 }
             }
 
@@ -3997,7 +3767,7 @@ namespace System.Diagnostics.Tracing
             // taskName & opcodeName could be passed in by the caller which has opTab & taskTab handy
             // if (!(((int)eventAttribute.Opcode == 0 && evtName == taskName) || (evtName == taskName+opcodeName)))
             // {
-            //     throw new WarningException(Environment.GetResourceString("EventSource_EventNameDoesNotEqualTaskPlusOpcode"));
+            //     throw new WarningException(Resources.GetResourceString("EventSource_EventNameDoesNotEqualTaskPlusOpcode"));
             // }
 
             if (eventsByName == null)
@@ -4005,11 +3775,7 @@ namespace System.Diagnostics.Tracing
 
             if (eventsByName.ContainsKey(evtName))
             {
-#if PROJECTN
-                manifest.ManifestError(SR.Format("EventSource_EventNameReused", evtName));
-#else
-                manifest.ManifestError(Environment.GetResourceString("EventSource_EventNameReused", evtName));
-#endif
+                manifest.ManifestError(Resources.GetResourceString("EventSource_EventNameReused", evtName), true);
             }
 
             eventsByName[evtName] = evtName;
@@ -4174,21 +3940,21 @@ namespace System.Diagnostics.Tracing
             {
 #if (!ES_BUILD_PCL && !PROJECTN)
                 // send message to debugger without delay
-                System.Diagnostics.Debugger.Log(0, null, msg + "\r\n");
+                System.Diagnostics.Debugger.Log(0, null, String.Format("EventSource Error: {0}{1}", msg , Environment.NewLine));
 #endif
 
                 // Send it to all listeners.
-                if (m_outOfBandMessageCount < 254)     // Note this is only if size byte
+                if (m_outOfBandMessageCount < 16 - 1)     // Note this is only if size byte
                     m_outOfBandMessageCount++;
                 else
                 {
-                    if (m_outOfBandMessageCount == 255)
+                    if (m_outOfBandMessageCount == 16)
                         return;
-                    m_outOfBandMessageCount = 255;    // Mark that we hit the limit.  Notify them that this is the case. 
+                    m_outOfBandMessageCount = 16;    // Mark that we hit the limit.  Notify them that this is the case. 
                     msg = "Reached message limit.   End of EventSource error messages.";
                 }
 
-                WriteEventString(EventLevel.LogAlways, (long)-1, msg);
+                WriteEventString(EventLevel.LogAlways, -1, msg);
                 WriteStringToAllListeners("EventSourceMessage", msg);
             }
             catch (Exception) { }      // If we fail during last chance logging, well, we have to give up....
@@ -4200,11 +3966,7 @@ namespace System.Diagnostics.Tracing
                                 EventSourceSettings.EtwSelfDescribingEventFormat;
             if ((settings & evtFormatMask) == evtFormatMask)
             {
-#if PROJECTN
-                throw new ArgumentException(SR.GetResourceString("EventSource_InvalidEventFormat", null), "settings");
-#else
-                throw new ArgumentException(Environment.GetResourceString("EventSource_InvalidEventFormat"), "settings");
-#endif
+                throw new ArgumentException(Resources.GetResourceString("EventSource_InvalidEventFormat"), "settings");
             }
 
             // If you did not explicitly ask for manifest, you get self-describing.  
@@ -4295,8 +4057,12 @@ namespace System.Diagnostics.Tracing
         internal volatile EventMetadata[] m_eventData;  // None per-event data
         private volatile byte[] m_rawManifest;          // Bytes to send out representing the event schema
 
+        private EventHandler<EventCommandEventArgs> m_eventCommandExecuted;
+
         private EventSourceSettings m_config;      // configuration information
 
+        private bool m_eventSourceDisposed;              // has Dispose been called.
+        
         // Enabling bits
         private bool m_eventSourceEnabled;              // am I enabled (any of my events are enabled for any dispatcher)
         internal EventLevel m_level;                    // highest level enabled by any output dispatcher
@@ -4317,10 +4083,9 @@ namespace System.Diagnostics.Tracing
         internal static uint s_currentPid;              // current process id, used in synthesizing quasi-GUIDs
         [ThreadStatic]
         private static byte m_EventSourceExceptionRecurenceCount = 0; // current recursion count inside ThrowEventSourceException
-#if PROJECTN
+
         [ThreadStatic]
-        private static bool m_EventSourcePreventRecursion = false; 
-#endif
+        private static bool m_EventSourceInDecodeObject = false;
 
 #if FEATURE_MANAGED_ETW_CHANNELS
         internal volatile ulong[] m_channelData;
@@ -4330,7 +4095,7 @@ namespace System.Diagnostics.Tracing
         private SessionMask m_curLiveSessions;          // the activity-tracing aware sessions' bits
         private EtwSession[] m_etwSessionIdMap;         // the activity-tracing aware sessions
         private List<EtwSession> m_legacySessions;      // the legacy ETW sessions listening to this source
-        internal ulong m_keywordTriggers;                // a bit is set if it corresponds to a keyword that's part of an enabled triggering event
+        internal long m_keywordTriggers;                // a bit is set if it corresponds to a keyword that's part of an enabled triggering event
         internal SessionMask m_activityFilteringForETWEnabled; // does THIS EventSource have activity filtering turned on for each ETW session
         static internal Action<Guid> s_activityDying;   // Fires when something calls SetCurrentThreadToActivity()
         // Also used to mark that activity tracing is on for some case
@@ -4419,57 +4184,52 @@ namespace System.Diagnostics.Tracing
     /// created.
     /// </para>
     /// </summary>
-    public abstract class EventListener : IDisposable
+    public class EventListener : IDisposable
     {
+        private event EventHandler<EventSourceCreatedEventArgs> _EventSourceCreated;
+
+        /// <summary>
+        /// This event is raised whenever a new eventSource is 'attached' to the dispatcher.
+        /// This can happen for all existing EventSources when the EventListener is created
+        /// as well as for any EventSources that come into existence after the EventListener
+        /// has been created.
+        /// 
+        /// These 'catch up' events are called during the construction of the EventListener.
+        /// Subclasses need to be prepared for that.
+        /// 
+        /// In a multi-threaded environment, it is possible that 'EventSourceEventWrittenCallback' 
+        /// events for a particular eventSource to occur BEFORE the EventSourceCreatedCallback is issued.
+        /// </summary>
+        public event EventHandler<EventSourceCreatedEventArgs> EventSourceCreated
+        { 
+            add
+            {
+                CallBackForExistingEventSources(false, value);
+
+                this._EventSourceCreated = (EventHandler<EventSourceCreatedEventArgs>)Delegate.Combine(_EventSourceCreated, value);
+            }
+            remove
+            {
+                this._EventSourceCreated = (EventHandler<EventSourceCreatedEventArgs>)Delegate.Remove(_EventSourceCreated, value);
+            }
+        }
+
+        /// <summary>
+        /// This event is raised whenever an event has been written by a EventSource for which 
+        /// the EventListener has enabled events.  
+        /// </summary>
+        public event EventHandler<EventWrittenEventArgs> EventWritten;
+
         /// <summary>
         /// Create a new EventListener in which all events start off turned off (use EnableEvents to turn
         /// them on).  
         /// </summary>
-        protected EventListener()
+        public EventListener()
         {
-            lock (EventListenersLock)
-            {
-                // Disallow creating EventListener reentrancy. 
-                if (s_CreatingListener)
-                {
-#if PROJECTN
-                    throw new InvalidOperationException(SR.GetResourceString("EventSource_ListenerCreatedInsideCallback", null));
-#else
-                    throw new InvalidOperationException(Environment.GetResourceString("EventSource_ListenerCreatedInsideCallback"));
-#endif
-                }
-                try
-                {
-                    s_CreatingListener = true;
-
-                    // Add to list of listeners in the system, do this BEFORE firing the 'OnEventSourceCreated' so that 
-                    // Those added sources see this listener.
-                    this.m_Next = s_Listeners;
-                    s_Listeners = this;
-
-                    // Find all existing eventSources call OnEventSourceCreated to 'catchup'
-                    // Note that we DO have reentrancy here because 'AddListener' calls out to user code (via OnEventSourceCreated callback) 
-                    // We tolerate this by iterating over a copy of the list here. New event sources will take care of adding listeners themselves
-                    // EventSources are not guaranteed to be added at the end of the s_EventSource list -- We re-use slots when a new source
-                    // is created.
-                    WeakReference[] eventSourcesSnapshot = s_EventSources.ToArray();
-
-                    for (int i = 0; i < eventSourcesSnapshot.Length; i++)
-                    {
-                        WeakReference eventSourceRef = eventSourcesSnapshot[i];
-                        EventSource eventSource = eventSourceRef.Target as EventSource;
-                        if (eventSource != null)
-                            eventSource.AddListener(this); // This will cause the OnEventSourceCreated callback to fire. 
-                    }
-
-                    Validate();
-                }
-                finally
-                {
-                    s_CreatingListener = false;
-                }
-            }
+            // This will cause the OnEventSourceCreated callback to fire. 
+            CallBackForExistingEventSources(true, (obj, args) => args.EventSource.AddListener(this) ); 
         }
+
         /// <summary>
         /// Dispose should be called when the EventListener no longer desires 'OnEvent*' callbacks. Because
         /// there is an internal list of strong references to all EventListeners, calling 'Dispose' directly
@@ -4586,6 +4346,15 @@ namespace System.Diagnostics.Tracing
         }
 
         /// <summary>
+        /// EventSourceIndex is small non-negative integer (suitable for indexing in an array)
+        /// identifying EventSource. It is unique per-appdomain. Some EventListeners might find
+        /// it useful to store additional information about each eventSource connected to it,
+        /// and EventSourceIndex allows this extra information to be efficiently stored in a
+        /// (growable) array (eg List(T)).
+        /// </summary>
+        public static int EventSourceIndex(EventSource eventSource) { return eventSource.m_id; }
+
+        /// <summary>
         /// This method is called whenever a new eventSource is 'attached' to the dispatcher.
         /// This can happen for all existing EventSources when the EventListener is created
         /// as well as for any EventSources that come into existence after the EventListener
@@ -4598,20 +4367,31 @@ namespace System.Diagnostics.Tracing
         /// for a particular eventSource to occur BEFORE the OnEventSourceCreated is issued.
         /// </summary>
         /// <param name="eventSource"></param>
-        internal protected virtual void OnEventSourceCreated(EventSource eventSource) { }
+        internal protected virtual void OnEventSourceCreated(EventSource eventSource)
+        {
+            EventHandler<EventSourceCreatedEventArgs> callBack = this._EventSourceCreated;
+            if(callBack != null)
+            {
+                EventSourceCreatedEventArgs args = new EventSourceCreatedEventArgs();
+                args.EventSource = eventSource;
+                callBack(this, args);
+            }
+        }
+
         /// <summary>
         /// This method is called whenever an event has been written by a EventSource for which 
         /// the EventListener has enabled events.  
         /// </summary>
-        internal protected abstract void OnEventWritten(EventWrittenEventArgs eventData);
-        /// <summary>
-        /// EventSourceIndex is small non-negative integer (suitable for indexing in an array)
-        /// identifying EventSource. It is unique per-appdomain. Some EventListeners might find
-        /// it useful to store additional information about each eventSource connected to it,
-        /// and EventSourceIndex allows this extra information to be efficiently stored in a
-        /// (growable) array (eg List(T)).
-        /// </summary>
-        static protected int EventSourceIndex(EventSource eventSource) { return eventSource.m_id; }
+        /// <param name="eventData"></param>
+        internal protected virtual void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            EventHandler<EventWrittenEventArgs> callBack = this.EventWritten;
+            if (callBack != null)
+            {
+                callBack(this, eventData);
+            }
+        }
+
 
         #region private
         /// <summary>
@@ -4685,11 +4465,14 @@ namespace System.Diagnostics.Tracing
         // See bug 724140 for more
         private static void DisposeOnShutdown(object sender, EventArgs e)
         {
-            foreach (var esRef in s_EventSources)
+            lock(EventListenersLock)
             {
-                EventSource es = esRef.Target as EventSource;
-                if (es != null)
-                    es.Dispose();
+                foreach (var esRef in s_EventSources)
+                {
+                    EventSource es = esRef.Target as EventSource;
+                    if (es != null)
+                        es.Dispose();
+                }
             }
         }
 
@@ -4701,6 +4484,9 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         private static void RemoveReferencesToListenerInEventSources(EventListener listenerToRemove)
         {
+#if !ES_BUILD_STANDALONE
+            Contract.Assert(Monitor.IsEntered(EventListener.EventListenersLock));
+#endif
             // Foreach existing EventSource in the appdomain
             foreach (WeakReference eventSourceRef in s_EventSources)
             {
@@ -4798,6 +4584,57 @@ namespace System.Diagnostics.Tracing
                     Interlocked.CompareExchange(ref s_EventSources, new List<WeakReference>(2), null);
                 return s_EventSources;
             }
+        }
+
+        private void CallBackForExistingEventSources(bool addToListenersList, EventHandler<EventSourceCreatedEventArgs> callback)
+        {
+            lock (EventListenersLock)
+            {
+                // Disallow creating EventListener reentrancy. 
+                if (s_CreatingListener)
+                {
+                    throw new InvalidOperationException(Resources.GetResourceString("EventSource_ListenerCreatedInsideCallback"));
+                }
+
+                try
+                {
+                    s_CreatingListener = true;
+
+                    if (addToListenersList)
+                    {
+                        // Add to list of listeners in the system, do this BEFORE firing the 'OnEventSourceCreated' so that 
+                        // Those added sources see this listener.
+                        this.m_Next = s_Listeners;
+                        s_Listeners = this;
+                    }
+
+                    // Find all existing eventSources call OnEventSourceCreated to 'catchup'
+                    // Note that we DO have reentrancy here because 'AddListener' calls out to user code (via OnEventSourceCreated callback) 
+                    // We tolerate this by iterating over a copy of the list here. New event sources will take care of adding listeners themselves
+                    // EventSources are not guaranteed to be added at the end of the s_EventSource list -- We re-use slots when a new source
+                    // is created.
+                    WeakReference[] eventSourcesSnapshot = s_EventSources.ToArray();
+
+                    for (int i = 0; i < eventSourcesSnapshot.Length; i++)
+                    {
+                        WeakReference eventSourceRef = eventSourcesSnapshot[i];
+                        EventSource eventSource = eventSourceRef.Target as EventSource;
+                        if (eventSource != null)
+                        {
+                            EventSourceCreatedEventArgs args = new EventSourceCreatedEventArgs();
+                            args.EventSource = eventSource;
+                            callback(this, args);
+                        }
+                    }
+
+                    Validate();
+                }
+                finally
+                {
+                    s_CreatingListener = false;
+                }
+            }
+
         }
 
         // Instance fields
@@ -4901,6 +4738,21 @@ namespace System.Diagnostics.Tracing
         internal EventCommandEventArgs nextCommand;     // We form a linked list of these deferred commands.      
 
         #endregion
+    }
+
+    /// <summary>
+    /// EventSourceCreatedEventArgs is passed to <see cref="EventListener.EventSourceCreated"/>
+    /// </summary>
+    public class EventSourceCreatedEventArgs : EventArgs
+    {
+        /// <summary>
+        /// The EventSource that is attaching to the listener.
+        /// </summary>
+        public EventSource EventSource
+        {
+            get;
+            internal set;
+        }
     }
 
     /// <summary>
@@ -5101,8 +4953,8 @@ namespace System.Diagnostics.Tracing
         {
             get
             {
-                if ((uint)EventId >= (uint)m_eventSource.m_eventData.Length)
-                    return EventLevel.LogAlways;
+                if (EventId < 0)      // TraceLogging convention EventID == -1
+                    return m_level;
                 return (EventLevel)m_eventSource.m_eventData[EventId].Descriptor.Level;
             }
         }
@@ -5118,6 +4970,7 @@ namespace System.Diagnostics.Tracing
         private ReadOnlyCollection<string> m_payloadNames;
         internal EventTags m_tags;
         internal EventOpcode m_opcode;
+        internal EventLevel m_level;
         internal EventKeywords m_keywords;
         #endregion
     }
@@ -5196,7 +5049,7 @@ namespace System.Diagnostics.Tracing
             }
         }
 
-        public bool IsOpcodeSet
+        internal bool IsOpcodeSet
         {
             get
             {
@@ -5686,7 +5539,7 @@ namespace System.Diagnostics.Tracing
                     // we could be more precise here, if we tracked 'anykeywords' per session
                     unchecked
                     {
-                        source.m_keywordTriggers |= ((ulong) source.m_eventData[af.m_eventId].Descriptor.Keywords & (ulong)sessKeywords);
+                        source.m_keywordTriggers |= (source.m_eventData[af.m_eventId].Descriptor.Keywords & (long)sessKeywords);
                     }
                 }
             }
@@ -5953,16 +5806,16 @@ namespace System.Diagnostics.Tracing
                 return;
 
             s_etwSessions.RemoveAll((wrEtwSession) =>
-            {
-                EtwSession session;
+                {
+                    EtwSession session;
 #if ES_BUILD_STANDALONE
                     return (session = (EtwSession) wrEtwSession.Target) != null &&
                            (session.m_etwSessionId == etwSession.m_etwSessionId);
 #else
-                return wrEtwSession.TryGetTarget(out session) &&
-                       (session.m_etwSessionId == etwSession.m_etwSessionId);
+                    return wrEtwSession.TryGetTarget(out session) &&
+                           (session.m_etwSessionId == etwSession.m_etwSessionId);
 #endif
-            });
+                });
 
             if (s_etwSessions.Count > s_thrSessionCount)
                 TrimGlobalList();
@@ -5974,14 +5827,14 @@ namespace System.Diagnostics.Tracing
                 return;
 
             s_etwSessions.RemoveAll((wrEtwSession) =>
-            {
+                {
 #if ES_BUILD_STANDALONE
                     return wrEtwSession.Target == null;
 #else
-                EtwSession session;
-                return !wrEtwSession.TryGetTarget(out session);
+                    EtwSession session;
+                    return !wrEtwSession.TryGetTarget(out session);
 #endif
-            });
+                });
         }
 
         private EtwSession(int etwSessionId)
@@ -6033,9 +5886,9 @@ namespace System.Diagnostics.Tracing
             return new SessionMask((uint)1 << perEventSourceSessionId);
         }
 
-        public long ToEventKeywords()
+        public ulong ToEventKeywords()
         {
-            return m_mask << SHIFT_SESSION_TO_KEYWORD;
+            return (ulong)m_mask << SHIFT_SESSION_TO_KEYWORD;
         }
 
         public static SessionMask FromEventKeywords(ulong m)
@@ -6087,8 +5940,8 @@ namespace System.Diagnostics.Tracing
         private uint m_mask;
 
         internal const int SHIFT_SESSION_TO_KEYWORD = 44;         // bits 44-47 inclusive are reserved
-        internal const uint MASK = 0x0fU;      // the mask of 4 reserved bits
-        internal const uint MAX = 4;          // maximum number of simultaneous ETW sessions supported
+        internal const uint MASK = 0x0fU;                         // the mask of 4 reserved bits
+        internal const uint MAX = 4;                              // maximum number of simultaneous ETW sessions supported
     }
 
     /// <summary>
@@ -6160,7 +6013,7 @@ namespace System.Diagnostics.Tracing
     /// ManifestBuilder is designed to isolate the details of the message of the event from the
     /// rest of EventSource.  This one happens to create XML. 
     /// </summary>
-    internal class ManifestBuilder
+    internal partial class ManifestBuilder
     {
         /// <summary>
         /// Build a manifest for 'providerName' with the given GUID, which will be packaged into 'dllName'.
@@ -6202,20 +6055,12 @@ namespace System.Diagnostics.Tracing
             {
                 if (value <= 10 || value >= 239)
                 {
-#if PROJECTN
-                    ManifestError(SR.Format("EventSource_IllegalOpcodeValue", name, value));
-#else
-                    ManifestError(Environment.GetResourceString("EventSource_IllegalOpcodeValue", name, value));
-#endif
+                    ManifestError(Resources.GetResourceString("EventSource_IllegalOpcodeValue", name, value));
                 }
                 string prevName;
                 if (opcodeTab.TryGetValue(value, out prevName) && !name.Equals(prevName, StringComparison.Ordinal))
                 {
-#if PROJECTN
-                    ManifestError(SR.Format("EventSource_OpcodeCollision", name, prevName, value));
-#else
-                    ManifestError(Environment.GetResourceString("EventSource_OpcodeCollision", name, prevName, value));
-#endif
+                    ManifestError(Resources.GetResourceString("EventSource_OpcodeCollision", name, prevName, value));
                 }
             }
             opcodeTab[value] = name;
@@ -6226,20 +6071,12 @@ namespace System.Diagnostics.Tracing
             {
                 if (value <= 0 || value >= 65535)
                 {
-#if PROJECTN
-                    ManifestError(SR.Format("EventSource_IllegalTaskValue", name, value));
-#else
-                    ManifestError(Environment.GetResourceString("EventSource_IllegalTaskValue", name, value));
-#endif
+                    ManifestError(Resources.GetResourceString("EventSource_IllegalTaskValue", name, value));
                 }
                 string prevName;
                 if (taskTab != null && taskTab.TryGetValue(value, out prevName) && !name.Equals(prevName, StringComparison.Ordinal))
                 {
-#if PROJECTN
-                    ManifestError(SR.Format("EventSource_TaskCollision", name, prevName, value));
-#else
-                    ManifestError(Environment.GetResourceString("EventSource_TaskCollision", name, prevName, value));
-#endif
+                    ManifestError(Resources.GetResourceString("EventSource_TaskCollision", name, prevName, value));
                 }
             }
             if (taskTab == null)
@@ -6250,30 +6087,18 @@ namespace System.Diagnostics.Tracing
         {
             if ((value & (value - 1)) != 0)   // Is it a power of 2?
             {
-#if PROJECTN
-                ManifestError(SR.Format("EventSource_KeywordNeedPowerOfTwo", "0x" + value.ToString("x", CultureInfo.CurrentCulture), name), true);
-#else
-                ManifestError(Environment.GetResourceString("EventSource_KeywordNeedPowerOfTwo", "0x" + value.ToString("x", CultureInfo.CurrentCulture), name), true);
-#endif
+                ManifestError(Resources.GetResourceString("EventSource_KeywordNeedPowerOfTwo", "0x" + value.ToString("x", CultureInfo.CurrentCulture), name), true);
             }
             if ((flags & EventManifestOptions.Strict) != 0)
             {
                 if (value >= 0x0000100000000000UL && !name.StartsWith("Session", StringComparison.Ordinal))
                 {
-#if PROJECTN
-                    ManifestError(SR.Format("EventSource_IllegalKeywordsValue", name, "0x" + value.ToString("x", CultureInfo.CurrentCulture)));
-#else
-                    ManifestError(Environment.GetResourceString("EventSource_IllegalKeywordsValue", name, "0x" + value.ToString("x", CultureInfo.CurrentCulture)));
-#endif
+                    ManifestError(Resources.GetResourceString("EventSource_IllegalKeywordsValue", name, "0x" + value.ToString("x", CultureInfo.CurrentCulture)));
                 }
                 string prevName;
                 if (keywordTab != null && keywordTab.TryGetValue(value, out prevName) && !name.Equals(prevName, StringComparison.Ordinal))
                 {
-#if PROJECTN
-                    ManifestError(SR.Format("EventSource_KeywordCollision", name, prevName, "0x" + value.ToString("x", CultureInfo.CurrentCulture)));
-#else
-                    ManifestError(Environment.GetResourceString("EventSource_KeywordCollision", name, prevName, "0x" + value.ToString("x", CultureInfo.CurrentCulture)));
-#endif
+                    ManifestError(Resources.GetResourceString("EventSource_KeywordCollision", name, prevName, "0x" + value.ToString("x", CultureInfo.CurrentCulture)));
                 }
             }
             if (keywordTab == null)
@@ -6289,13 +6114,13 @@ namespace System.Diagnostics.Tracing
         {
             EventChannel chValue = (EventChannel)value;
             if (value < (int)EventChannel.Admin || value > 255)
-                ManifestError(Environment.GetResourceString("EventSource_EventChannelOutOfRange", name, value));
+                ManifestError(Resources.GetResourceString("EventSource_EventChannelOutOfRange", name, value));
             else if (chValue >= EventChannel.Admin && chValue <= EventChannel.Debug &&
                      channelAttribute != null && EventChannelToChannelType(chValue) != channelAttribute.EventChannelType)
             {
                 // we want to ensure developers do not define EventChannels that conflict with the builtin ones,
                 // but we want to allow them to override the default ones...
-                ManifestError(Environment.GetResourceString("EventSource_ChannelTypeDoesNotMatchEventChannelValue",
+                ManifestError(Resources.GetResourceString("EventSource_ChannelTypeDoesNotMatchEventChannelValue",
                                                                             name, ((EventChannel)value).ToString()));
             }
 
@@ -6462,7 +6287,7 @@ namespace System.Diagnostics.Tracing
             }
 
             if (channelTab.Count == MaxCountChannels)
-                ManifestError(Environment.GetResourceString("EventSource_MaxChannelExceeded"));
+                ManifestError(Resources.GetResourceString("EventSource_MaxChannelExceeded"));
 
             ulong channelKeyword;
             ChannelInfo info;
@@ -6740,16 +6565,13 @@ namespace System.Diagnostics.Tracing
 
             stringBuilder.Append(" message=\"$(string.").Append(key).Append(")\"");
             string prevValue;
-            if (stringTab.TryGetValue(key, out prevValue))
+            if (stringTab.TryGetValue(key, out prevValue) && !prevValue.Equals(value))
             {
-#if PROJECTN
-                ManifestError(SR.GetResourceString("EventSource_DuplicateStringKey", key), true);
-#else
-                ManifestError(Environment.GetResourceString("EventSource_DuplicateStringKey", key), true);
-#endif
+                ManifestError(Resources.GetResourceString("EventSource_DuplicateStringKey", key), true);
+                return;
             }
-            else
-                stringTab.Add(key, value);
+
+            stringTab[key] = value;
         }
         internal string GetLocalizedMessage(string key, CultureInfo ci, bool etwFormat)
         {
@@ -6807,7 +6629,7 @@ namespace System.Diagnostics.Tracing
             if (channelTab == null || !channelTab.TryGetValue((int)channel, out info))
             {
                 if (channel < EventChannel.Admin) // || channel > EventChannel.Debug)
-                    ManifestError(Environment.GetResourceString("EventSource_UndefinedChannel", channel, eventName));
+                    ManifestError(Resources.GetResourceString("EventSource_UndefinedChannel", channel, eventName));
 
                 // allow channels to be auto-defined.  The well known ones get their well known names, and the
                 // rest get names Channel<N>.  This allows users to modify the Manifest if they want more advanced features. 
@@ -6820,13 +6642,13 @@ namespace System.Diagnostics.Tracing
 
                 AddChannel(channelName, (int)channel, GetDefaultChannelAttribute(channel));
                 if (!channelTab.TryGetValue((int)channel, out info))
-                    ManifestError(Environment.GetResourceString("EventSource_UndefinedChannel", channel, eventName));
+                    ManifestError(Resources.GetResourceString("EventSource_UndefinedChannel", channel, eventName));
             }
             // events that specify admin channels *must* have non-null "Message" attributes
             if (resources != null && eventMessage == null)
                 eventMessage = resources.GetString("event_" + eventName, CultureInfo.InvariantCulture);
             if (info.Attribs.EventChannelType == EventChannelType.Admin && eventMessage == null)
-                ManifestError(Environment.GetResourceString("EventSource_EventWithAdminChannelMustHaveMessage", eventName, info.Name));
+                ManifestError(Resources.GetResourceString("EventSource_EventWithAdminChannelMustHaveMessage", eventName, info.Name));
             return info.Name;
         }
 #endif
@@ -6842,6 +6664,7 @@ namespace System.Diagnostics.Tracing
                 ret = taskTab[(int)task] = eventName;
             return ret;
         }
+        
         private string GetOpcodeName(EventOpcode opcode, string eventName)
         {
             switch (opcode)
@@ -6873,15 +6696,12 @@ namespace System.Diagnostics.Tracing
             string ret;
             if (opcodeTab == null || !opcodeTab.TryGetValue((int)opcode, out ret))
             {
-#if PROJECTN
-                ManifestError(SR.Format("EventSource_UndefinedOpcode", opcode, eventName), true);
-#else
-                ManifestError(Environment.GetResourceString("EventSource_UndefinedOpcode", opcode, eventName), true);
-#endif
+                ManifestError(Resources.GetResourceString("EventSource_UndefinedOpcode", opcode, eventName), true);
                 ret = null;
             }
             return ret;
         }
+        
         private string GetKeywords(ulong keywords, string eventName)
         {
             string ret = "";
@@ -6899,11 +6719,7 @@ namespace System.Diagnostics.Tracing
                     }
                     if (keyword == null)
                     {
-#if PROJECTN
-                        ManifestError(SR.Format("EventSource_UndefinedKeyword", "0x" + bit.ToString("x", CultureInfo.CurrentCulture), eventName), true);
-#else
-                        ManifestError(Environment.GetResourceString("EventSource_UndefinedKeyword", "0x" + bit.ToString("x", CultureInfo.CurrentCulture), eventName), true);
-#endif
+                        ManifestError(Resources.GetResourceString("EventSource_UndefinedKeyword", "0x" + bit.ToString("x", CultureInfo.CurrentCulture), eventName), true);
                         keyword = string.Empty;
                     }
                     if (ret.Length != 0 && keyword.Length != 0)
@@ -6913,6 +6729,7 @@ namespace System.Diagnostics.Tracing
             }
             return ret;
         }
+        
         private string GetTypeName(Type type)
         {
             if (type.IsEnum())
@@ -6921,49 +6738,8 @@ namespace System.Diagnostics.Tracing
                 var typeName = GetTypeName(fields[0].FieldType);
                 return typeName.Replace("win:Int", "win:UInt"); // ETW requires enums to be unsigned.  
             }
-            switch (type.GetTypeCode())
-            {
-                case (Microsoft.Reflection.TypeCode)TypeCode.Boolean:
-                    return "win:Boolean";
-                case (Microsoft.Reflection.TypeCode)TypeCode.Byte:
-                    return "win:UInt8";
-                case (Microsoft.Reflection.TypeCode)TypeCode.Char:
-                case (Microsoft.Reflection.TypeCode)TypeCode.UInt16:
-                    return "win:UInt16";
-                case (Microsoft.Reflection.TypeCode)TypeCode.UInt32:
-                    return "win:UInt32";
-                case (Microsoft.Reflection.TypeCode)TypeCode.UInt64:
-                    return "win:UInt64";
-                case (Microsoft.Reflection.TypeCode)TypeCode.SByte:
-                    return "win:Int8";
-                case (Microsoft.Reflection.TypeCode)TypeCode.Int16:
-                    return "win:Int16";
-                case (Microsoft.Reflection.TypeCode)TypeCode.Int32:
-                    return "win:Int32";
-                case (Microsoft.Reflection.TypeCode)TypeCode.Int64:
-                    return "win:Int64";
-                case (Microsoft.Reflection.TypeCode)TypeCode.String:
-                    return "win:UnicodeString";
-                case (Microsoft.Reflection.TypeCode)TypeCode.Single:
-                    return "win:Float";
-                case (Microsoft.Reflection.TypeCode)TypeCode.Double:
-                    return "win:Double";
-                case (Microsoft.Reflection.TypeCode)TypeCode.DateTime:
-                    return "win:FILETIME";
-                default:
-                    if (type == typeof(Guid))
-                        return "win:GUID";
-                    else if (type == typeof(IntPtr))
-                        return "win:Pointer";
-                    else if ((type.IsArray || type.IsPointer) && type.GetElementType() == typeof(byte))
-                        return "win:Binary";
-#if PROJECTN
-                    ManifestError(SR.GetResourceString("EventSource_UnsupportedEventTypeInManifest", type.Name), true);
-#else
-                    ManifestError(Environment.GetResourceString("EventSource_UnsupportedEventTypeInManifest", type.Name), true);
-#endif
-                    return string.Empty;
-            }
+            
+            return GetTypeNameHelper(type);
         }
 
         private static void UpdateStringBuilder(ref StringBuilder stringBuilder, string eventMessage, int startIndex, int count)
@@ -7035,11 +6811,7 @@ namespace System.Diagnostics.Tracing
                     }
                     else
                     {
-#if PROJECTN
-                        ManifestError(SR.Format("EventSource_UnsupportedMessageProperty", evtName, eventMessage));
-#else
-                        ManifestError(Environment.GetResourceString("EventSource_UnsupportedMessageProperty", evtName, eventMessage));
-#endif
+                        ManifestError(Resources.GetResourceString("EventSource_UnsupportedMessageProperty", evtName, eventMessage));
                     }
                 }
                 else if ((chIdx = "&<>'\"\r\n\t".IndexOf(eventMessage[i])) >= 0)

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventSourceException.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventSourceException.cs
@@ -1,14 +1,8 @@
-// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
-/*============================================================
-**
-** File: EventSourceException.cs
-** 
-============================================================*/
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
+using System.Runtime.Serialization;
 
 #if ES_BUILD_STANDALONE
 using Environment = Microsoft.Diagnostics.Tracing.Internal.Environment;
@@ -32,11 +26,7 @@ namespace System.Diagnostics.Tracing
         /// Initializes a new instance of the EventSourceException class.
         /// </summary>
         public EventSourceException() :
-#if PROJECTN
-            base(SR.GetResourceString("EventSource_ListenerWriteFailure", "EventSource_ListenerWriteFailure")) { }
-#else
-            base(Environment.GetResourceString("EventSource_ListenerWriteFailure")) { }
-#endif
+            base(Resources.GetResourceString("EventSource_ListenerWriteFailure")) { }
 
         /// <summary>
         /// Initializes a new instance of the EventSourceException class with a specified error message.
@@ -57,10 +47,6 @@ namespace System.Diagnostics.Tracing
 #endif
 
         internal EventSourceException(Exception innerException) :
-#if PROJECTN
-            base(SR.GetResourceString("EventSource_ListenerWriteFailure", "EventSource_ListenerWriteFailure"), innerException) { }
-#else
-            base(Environment.GetResourceString("EventSource_ListenerWriteFailure"), innerException) { }
-#endif
+            base(Resources.GetResourceString("EventSource_ListenerWriteFailure"), innerException) { }
     }
 }

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventSource_ProjectN.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventSource_ProjectN.cs
@@ -1,0 +1,295 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+using System.Security;
+using Microsoft.Reflection;
+using Microsoft.Win32;
+
+namespace System.Diagnostics.Tracing
+{
+    public partial class EventSource : IDisposable
+    {
+        // ActivityID support (see also WriteEventWithRelatedActivityIdCore)
+        /// <summary>
+        /// When a thread starts work that is on behalf of 'something else' (typically another 
+        /// thread or network request) it should mark the thread as working on that other work.
+        /// This API marks the current thread as working on activity 'activityID'. This API
+        /// should be used when the caller knows the thread's current activity (the one being
+        /// overwritten) has completed. Otherwise, callers should prefer the overload that
+        /// return the oldActivityThatWillContinue (below).
+        /// 
+        /// All events created with the EventSource on this thread are also tagged with the 
+        /// activity ID of the thread. 
+        /// 
+        /// It is common, and good practice after setting the thread to an activity to log an event
+        /// with a 'start' opcode to indicate that precise time/thread where the new activity 
+        /// started.
+        /// </summary>
+        /// <param name="activityId">A Guid that represents the new activity with which to mark 
+        /// the current thread</param>
+        [System.Security.SecuritySafeCritical]
+        public static void SetCurrentThreadActivityId(Guid activityId)
+        {
+            throw new NotSupportedException("Old style activities are not supported!");
+        }
+
+        /// <summary>
+        /// When a thread starts work that is on behalf of 'something else' (typically another 
+        /// thread or network request) it should mark the thread as working on that other work.
+        /// This API marks the current thread as working on activity 'activityID'. It returns 
+        /// whatever activity the thread was previously marked with. There is a convention that
+        /// callers can assume that callees restore this activity mark before the callee returns. 
+        /// To encourage this this API returns the old activity, so that it can be restored later.
+        /// 
+        /// All events created with the EventSource on this thread are also tagged with the 
+        /// activity ID of the thread. 
+        /// 
+        /// It is common, and good practice after setting the thread to an activity to log an event
+        /// with a 'start' opcode to indicate that precise time/thread where the new activity 
+        /// started.
+        /// </summary>
+        /// <param name="activityId">A Guid that represents the new activity with which to mark 
+        /// the current thread</param>
+        /// <param name="oldActivityThatWillContinue">The Guid that represents the current activity  
+        /// which will continue at some point in the future, on the current thread</param>
+        [System.Security.SecuritySafeCritical]
+        public static void SetCurrentThreadActivityId(Guid activityId, out Guid oldActivityThatWillContinue)
+        {
+            throw new NotSupportedException("Old style activities are not supported!");
+        }
+
+        /// <summary>
+        /// Retrieves the ETW activity ID associated with the current thread.
+        /// </summary>
+        public static Guid CurrentThreadActivityId
+        {
+            [System.Security.SecuritySafeCritical]
+            get
+            {
+                throw new NotSupportedException("Old style activities are not supported!");
+            }
+        }
+
+        private int GetParameterCount(EventMetadata eventData)
+        {
+            int paramCount;
+            if(eventData.Parameters == null)
+            {
+                paramCount = eventData.ParameterTypes.Length;
+            }
+            else
+            {
+                paramCount = eventData.Parameters.Length;
+            }
+            
+            return paramCount;
+        }
+
+        private Type GetDataType(EventMetadata eventData, int parameterId)
+        {
+            Type dataType;
+            if(eventData.Parameters == null)
+            {
+                dataType = EventTypeToType(eventData.ParameterTypes[parameterId]);
+            }
+            else
+            {
+                dataType = eventData.Parameters[parameterId].ParameterType;
+            }
+            
+            return dataType;
+        }
+
+        private static readonly bool m_EventSourcePreventRecursion = true; 
+
+        internal partial struct EventMetadata
+        {
+            public EventMetadata(EventDescriptor descriptor,
+                EventTags tags,
+                bool enabledForAnyListener,
+                bool enabledForETW,
+                string name,
+                string message,
+                EventParameterType[] parameterTypes)
+            {
+                this.Descriptor = descriptor;
+                this.Tags = tags;
+                this.EnabledForAnyListener = enabledForAnyListener;
+                this.EnabledForETW = enabledForETW;
+                this.TriggersActivityTracking = 0;
+                this.Name = name;
+                this.Message = message;
+                this.Parameters = null;
+                this.TraceLoggingEventTypes = null;
+                this.ActivityOptions = EventActivityOptions.None;
+                this.ParameterTypes = parameterTypes;
+                this.HasRelatedActivityID = false;
+            }
+        }
+        
+        public enum EventParameterType
+        {
+            Boolean,
+            Byte,
+            SByte,
+            Char,
+            Int16,
+            UInt16,
+            Int32,
+            UInt32,
+            Int64,
+            UInt64,
+            IntPtr,
+            Single,
+            Double,
+            Decimal,
+            Guid,
+            String
+        }
+
+        private Type EventTypeToType(EventParameterType type)
+        {
+            switch (type)
+            {
+                case EventParameterType.Boolean:
+                    return typeof(bool);
+                case EventParameterType.Byte:
+                    return typeof(byte);
+                case EventParameterType.SByte:
+                    return typeof(sbyte);
+                case EventParameterType.Char:
+                    return typeof(char);
+                case EventParameterType.Int16:
+                    return typeof(short);
+                case EventParameterType.UInt16:
+                    return typeof(ushort);
+                case EventParameterType.Int32:
+                    return typeof(int);
+                case EventParameterType.UInt32:
+                    return typeof(uint);
+                case EventParameterType.Int64:
+                    return typeof(long);
+                case EventParameterType.UInt64:
+                    return typeof(ulong);
+                case EventParameterType.IntPtr:
+                    return typeof(IntPtr);
+                case EventParameterType.Single:
+                    return typeof(float);
+                case EventParameterType.Double:
+                    return typeof(double);
+                case EventParameterType.Decimal:
+                    return typeof(decimal);
+                case EventParameterType.Guid:
+                    return typeof(Guid);
+                case EventParameterType.String:
+                    return typeof(string);
+                default:
+                    // TODO: should I throw an exception here?
+                    return null;
+            }
+        }
+    }
+    
+    internal partial class ManifestBuilder
+    {
+        private string GetTypeNameHelper(Type type)
+        {
+            switch (type.GetTypeCode())
+            {
+                case (Microsoft.Reflection.TypeCode)TypeCode.Boolean:
+                    return "win:Boolean";
+                case (Microsoft.Reflection.TypeCode)TypeCode.Byte:
+                    return "win:UInt8";
+                case (Microsoft.Reflection.TypeCode)TypeCode.Char:
+                case (Microsoft.Reflection.TypeCode)TypeCode.UInt16:
+                    return "win:UInt16";
+                case (Microsoft.Reflection.TypeCode)TypeCode.UInt32:
+                    return "win:UInt32";
+                case (Microsoft.Reflection.TypeCode)TypeCode.UInt64:
+                    return "win:UInt64";
+                case (Microsoft.Reflection.TypeCode)TypeCode.SByte:
+                    return "win:Int8";
+                case (Microsoft.Reflection.TypeCode)TypeCode.Int16:
+                    return "win:Int16";
+                case (Microsoft.Reflection.TypeCode)TypeCode.Int32:
+                    return "win:Int32";
+                case (Microsoft.Reflection.TypeCode)TypeCode.Int64:
+                    return "win:Int64";
+                case (Microsoft.Reflection.TypeCode)TypeCode.String:
+                    return "win:UnicodeString";
+                case (Microsoft.Reflection.TypeCode)TypeCode.Single:
+                    return "win:Float";
+                case (Microsoft.Reflection.TypeCode)TypeCode.Double:
+                    return "win:Double";
+                case (Microsoft.Reflection.TypeCode)TypeCode.DateTime:
+                    return "win:FILETIME";
+                default:
+                    if (type == typeof(Guid))
+                        return "win:GUID";
+                    else if (type == typeof(IntPtr))
+                        return "win:Pointer";
+                    else if ((type.IsArray || type.IsPointer) && type.GetElementType() == typeof(byte))
+                        return "win:Binary";
+                        
+                    ManifestError(Resources.GetResourceString("EventSource_UnsupportedEventTypeInManifest", type.Name), true);
+                    return string.Empty;
+            }
+        }
+    }
+    
+    internal partial class EventProvider
+    {
+        [System.Security.SecurityCritical]
+        internal unsafe int SetInformation(
+            UnsafeNativeMethods.ManifestEtw.EVENT_INFO_CLASS eventInfoClass,
+            IntPtr data,
+            uint dataSize)
+        {
+            int status = UnsafeNativeMethods.ManifestEtw.ERROR_NOT_SUPPORTED;
+
+            if (!m_setInformationMissing)
+            {
+                try
+                {
+                    status = UnsafeNativeMethods.ManifestEtw.EventSetInformation(
+                        m_regHandle,
+                        eventInfoClass,
+                        (void*)data,
+                        (int)dataSize);
+                }
+                catch (TypeLoadException)
+                {
+                    m_setInformationMissing = true;
+                }
+            }
+
+            return status;
+        }
+    }
+    
+    internal static class Resources
+    {
+        internal static string GetResourceString(string key, params object[] args)
+        {
+            string fmt = SR.GetResourceString(key, null);
+            if (fmt != null)
+                return string.Format(fmt, args);
+
+            string sargs = String.Empty;
+            foreach(var arg in args)
+            {
+                if (sargs != String.Empty)
+                    sargs += ", ";
+                sargs += arg.ToString();
+            }
+
+            return key + " (" + sargs + ")";
+        }
+        
+        public static string GetRuntimeResourceString(string key, params object[] args)
+        {
+            return GetResourceString(key, args);
+        }
+    }
+}

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/StubEnvironment.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/StubEnvironment.cs
@@ -1,4 +1,6 @@
-﻿// Copyright (c) Microsoft Corporation.  All rights reserved
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 
@@ -28,7 +30,7 @@ namespace System.Diagnostics.Tracing.Internal
                 return string.Format(fmt, args);
 
             string sargs = String.Empty;
-            foreach (var arg in args)
+            foreach(var arg in args)
             {
                 if (sargs != String.Empty)
                     sargs += ", ";
@@ -203,6 +205,8 @@ namespace Microsoft.Reflection
         public static bool IsEnum(this Type type) { return type.IsEnum; }
         public static bool IsAbstract(this Type type) { return type.IsAbstract; }
         public static bool IsSealed(this Type type) { return type.IsSealed; }
+        public static bool IsValueType(this Type type) { return type.IsValueType; }
+        public static bool IsGenericType(this Type type) { return type.IsGenericType; }
         public static Type BaseType(this Type type) { return type.BaseType; }
         public static Assembly Assembly(this Type type) { return type.Assembly; }
         public static TypeCode GetTypeCode(this Type type) { return Type.GetTypeCode(type); }
@@ -217,9 +221,14 @@ namespace Microsoft.Reflection
         public static bool IsEnum(this Type type) { return type.GetTypeInfo().IsEnum; }
         public static bool IsAbstract(this Type type) { return type.GetTypeInfo().IsAbstract; }
         public static bool IsSealed(this Type type) { return type.GetTypeInfo().IsSealed; }
+        public static bool IsValueType(this Type type) { return type.GetTypeInfo().IsValueType; }
+        public static bool IsGenericType(this Type type) { return type.IsConstructedGenericType; }
         public static Type BaseType(this Type type) { return type.GetTypeInfo().BaseType; }
         public static Assembly Assembly(this Type type) { return type.GetTypeInfo().Assembly; }
-
+        public static IEnumerable<PropertyInfo> GetProperties(this Type type) { return type.GetTypeInfo().DeclaredProperties; }
+        public static MethodInfo GetGetMethod(this PropertyInfo propInfo) { return propInfo.GetMethod; }
+        public static Type[] GetGenericArguments(this Type type) { return type.GenericTypeArguments; }
+        
         public static MethodInfo[] GetMethods(this Type type, BindingFlags flags)
         {
             // Minimal implementation to cover only the cases we need
@@ -331,7 +340,7 @@ namespace Microsoft.Reflection
 }
 
 // Defining some no-ops in PCL builds
-#if ES_BUILD_PCL
+#if ES_BUILD_PCL || PROJECTN
 namespace System.Security
 {
     class SuppressUnmanagedCodeSecurityAttribute : Attribute { }
@@ -346,5 +355,18 @@ namespace System.Security.Permissions
         public PermissionSetAttribute(System.Security.SecurityAction action) { }
         public bool Unrestricted { get; set; }
     }
+}
+#endif
+
+#if PROJECTN
+namespace System
+{
+    public static class AppDomain
+    {
+        public static int GetCurrentThreadId()
+        {
+            return (int)Interop.mincore.GetCurrentThreadId();
+        }
+    }    
 }
 #endif

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/ArrayTypeInfo.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/ArrayTypeInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/ConcurrentSet.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/ConcurrentSet.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using Interlocked = System.Threading.Interlocked;
 
 #if ES_BUILD_STANDALONE

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/ConcurrentSetItem.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/ConcurrentSetItem.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 
 #if ES_BUILD_STANDALONE
 namespace Microsoft.Diagnostics.Tracing

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/DataCollector.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/DataCollector.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Runtime.InteropServices;
 using System.Security;
@@ -82,11 +85,7 @@ namespace System.Diagnostics.Tracing
                 var scratchNew = scratchOld + size;
                 if (this.scratchEnd < scratchNew)
                 {
-#if PROJECTN
-                    throw new IndexOutOfRangeException(SR.GetResourceString("EventSource_AddScalarOutOfRange", null));
-#else
-                    throw new IndexOutOfRangeException(Environment.GetResourceString("EventSource_AddScalarOutOfRange"));
-#endif
+                    throw new IndexOutOfRangeException(Resources.GetResourceString("EventSource_AddScalarOutOfRange"));
                 }
 
                 this.ScalarsBegin();
@@ -273,21 +272,13 @@ namespace System.Diagnostics.Tracing
             var pinsTemp = this.pins;
             if (this.pinsEnd <= pinsTemp)
             {
-#if PROJECTN
-                throw new IndexOutOfRangeException(SR.GetResourceString("EventSource_PinArrayOutOfRange", null));
-#else
-                throw new IndexOutOfRangeException(Environment.GetResourceString("EventSource_PinArrayOutOfRange"));
-#endif
+                throw new IndexOutOfRangeException(Resources.GetResourceString("EventSource_PinArrayOutOfRange"));
             }
 
             var datasTemp = this.datas;
             if (this.datasEnd <= datasTemp)
             {
-#if PROJECTN
-                throw new IndexOutOfRangeException(SR.GetResourceString("EventSource_DataDescriptorsOutOfRange", null));
-#else
-                throw new IndexOutOfRangeException(Environment.GetResourceString("EventSource_DataDescriptorsOutOfRange"));
-#endif
+                throw new IndexOutOfRangeException(Resources.GetResourceString("EventSource_DataDescriptorsOutOfRange"));
             }
 
             this.pins = pinsTemp + 1;
@@ -305,11 +296,7 @@ namespace System.Diagnostics.Tracing
                 var datasTemp = this.datas;
                 if (this.datasEnd <= datasTemp)
                 {
-#if PROJECTN
-                    throw new IndexOutOfRangeException(SR.GetResourceString("EventSource_DataDescriptorsOutOfRange", null));
-#else
-                    throw new IndexOutOfRangeException(Environment.GetResourceString("EventSource_DataDescriptorsOutOfRange"));
-#endif
+                    throw new IndexOutOfRangeException(Resources.GetResourceString("EventSource_DataDescriptorsOutOfRange"));
                 }
 
                 datasTemp->m_Ptr = (long)(ulong)(UIntPtr)this.scratch;

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/EmptyStruct.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/EmptyStruct.cs
@@ -1,4 +1,7 @@
-﻿#if ES_BUILD_STANDALONE
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if ES_BUILD_STANDALONE
 namespace Microsoft.Diagnostics.Tracing
 #else
 namespace System.Diagnostics.Tracing

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/EnumHelper.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/EnumHelper.cs
@@ -1,5 +1,7 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #if EVENTSOURCE_GENERICS
-﻿using System;
+?using System;
 using System.Reflection;
 
 #if ES_BUILD_STANDALONE

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/EnumerableTypeInfo.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/EnumerableTypeInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections;
 using System.Collections.Generic;

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/EventDataAttribute.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/EventDataAttribute.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 
 #if ES_BUILD_STANDALONE
 namespace Microsoft.Diagnostics.Tracing

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/EventFieldAttribute.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/EventFieldAttribute.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 
 #if ES_BUILD_STANDALONE
 namespace Microsoft.Diagnostics.Tracing

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/EventFieldFormat.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/EventFieldFormat.cs
@@ -1,4 +1,7 @@
-﻿#if ES_BUILD_STANDALONE
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if ES_BUILD_STANDALONE
 namespace Microsoft.Diagnostics.Tracing
 #else
 namespace System.Diagnostics.Tracing

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/EventIgnoreAttribute.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/EventIgnoreAttribute.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 
 #if ES_BUILD_STANDALONE
 namespace Microsoft.Diagnostics.Tracing

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/EventPayload.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/EventPayload.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System.Collections.Generic;
 using System.Collections;
 
@@ -95,7 +98,10 @@ namespace System.Diagnostics.Tracing
 
         public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
         {
-            throw new System.NotSupportedException();
+            for (int i = 0; i < Keys.Count; i++)
+            {
+                yield return new KeyValuePair<string, object>(this.m_names[i], this.m_values[i]);
+            }
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/EventSourceActivity.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/EventSourceActivity.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 
 #if !ES_BUILD_AGAINST_DOTNET_V35
 using Contract = System.Diagnostics.Contracts.Contract;

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/EventSourceOptions.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/EventSourceOptions.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 #if ES_BUILD_STANDALONE

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/FieldMetadata.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/FieldMetadata.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using Encoding = System.Text.Encoding;
 
@@ -124,29 +127,17 @@ namespace System.Diagnostics.Tracing
             {
                 if (coreType == (int)TraceLoggingDataType.Nil)
                 {
-#if PROJECTN
-                    throw new NotSupportedException(SR.GetResourceString("EventSource_NotSupportedArrayOfNil", null));
-#else
-                    throw new NotSupportedException(Environment.GetResourceString("EventSource_NotSupportedArrayOfNil"));
-#endif
+                    throw new NotSupportedException(Resources.GetResourceString("EventSource_NotSupportedArrayOfNil"));
                 }
                 if (coreType == (int)TraceLoggingDataType.Binary)
                 {
-#if PROJECTN
-                    throw new NotSupportedException(SR.GetResourceString("EventSource_NotSupportedArrayOfBinary", null));
-#else
-                    throw new NotSupportedException(Environment.GetResourceString("EventSource_NotSupportedArrayOfBinary"));
-#endif
+                    throw new NotSupportedException(Resources.GetResourceString("EventSource_NotSupportedArrayOfBinary"));
                 }
 #if !BROKEN_UNTIL_M3
                 if (coreType == (int)TraceLoggingDataType.Utf16String ||
                     coreType == (int)TraceLoggingDataType.MbcsString)
                 {
-#if PROJECTN
-                    throw new NotSupportedException(SR.GetResourceString("EventSource_NotSupportedArrayOfNullTerminatedString", null));
-#else
-                    throw new NotSupportedException(Environment.GetResourceString("EventSource_NotSupportedArrayOfNullTerminatedString"));
-#endif
+                    throw new NotSupportedException(Resources.GetResourceString("EventSource_NotSupportedArrayOfNullTerminatedString"));
                 }
 #endif
             }
@@ -168,11 +159,7 @@ namespace System.Diagnostics.Tracing
             this.outType++;
             if ((this.outType & Statics.OutTypeMask) == 0)
             {
-#if PROJECTN
-                throw new NotSupportedException(SR.GetResourceString("EventSource_TooManyFields", null));
-#else
-                throw new NotSupportedException(Environment.GetResourceString("EventSource_TooManyFields"));
-#endif
+                throw new NotSupportedException(Resources.GetResourceString("EventSource_TooManyFields"));
             }
         }
 

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/InvokeTypeInfo.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/InvokeTypeInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/NameInfo.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/NameInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 using Interlocked = System.Threading.Interlocked;
@@ -21,7 +24,7 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         internal static void ReserveEventIDsBelow(int eventId)
         {
-            for (; ; )
+            for(;;)
             {
                 int snapshot = lastIdentity;
                 int newIdentity = (lastIdentity & ~0xFFFFFF) + eventId;

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/PropertyAnalysis.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/PropertyAnalysis.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Reflection;
 
 #if ES_BUILD_STANDALONE

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/PropertyValue.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/PropertyValue.cs
@@ -1,6 +1,12 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
 
+#if !ES_BUILD_AGAINST_DOTNET_V35
+using Contract = System.Diagnostics.Contracts.Contract;
+#else
+using Contract = Microsoft.Diagnostics.Contracts.Internal.Contract;
+#endif
+
 namespace System.Diagnostics.Tracing
 {
     /// <summary>
@@ -126,7 +132,7 @@ namespace System.Diagnostics.Tracing
         {
             get
             {
-                Debug.Assert(_scalarLength == 0, "This ReflectedValue refers to an unboxed value type, not a reference type or boxed value type.");
+                Contract.Assert(_scalarLength == 0, "This ReflectedValue refers to an unboxed value type, not a reference type or boxed value type.");
                 return _reference;
             }
         }
@@ -135,7 +141,7 @@ namespace System.Diagnostics.Tracing
         {
             get
             {
-                Debug.Assert(_scalarLength > 0, "This ReflectedValue refers to a reference type or boxed value type, not an unboxed value type");
+                Contract.Assert(_scalarLength > 0, "This ReflectedValue refers to a reference type or boxed value type, not an unboxed value type");
                 return _scalar;
             }
         }
@@ -144,7 +150,7 @@ namespace System.Diagnostics.Tracing
         {
             get
             {
-                Debug.Assert(_scalarLength > 0, "This ReflectedValue refers to a reference type or boxed value type, not an unboxed value type");
+                Contract.Assert(_scalarLength > 0, "This ReflectedValue refers to a reference type or boxed value type, not an unboxed value type");
                 return _scalarLength;
             }
         }

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/SimpleEventTypes.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/SimpleEventTypes.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using Interlocked = System.Threading.Interlocked;
 
 #if ES_BUILD_STANDALONE

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/SimpleTypeInfos.cs
@@ -1,6 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+
+#if !ES_BUILD_AGAINST_DOTNET_V35
+using Contract = System.Diagnostics.Contracts.Contract;
+#else
+using Contract = Microsoft.Diagnostics.Contracts.Internal.Contract;
+#endif
 
 #if ES_BUILD_STANDALONE
 namespace Microsoft.Diagnostics.Tracing
@@ -147,6 +156,16 @@ namespace System.Diagnostics.Tracing
         {
             collector.AddBinary((string)value.ReferenceValue);
         }
+        
+        public override object GetData(object value)
+        {
+            if(value == null)
+            {
+                return "";
+            }
+            
+            return value;
+        }
     }
 
     /// <summary>
@@ -249,7 +268,7 @@ namespace System.Diagnostics.Tracing
             : base(type)
         {
             var typeArgs = type.GenericTypeArguments;
-            Debug.Assert(typeArgs.Length == 1);
+            Contract.Assert(typeArgs.Length == 1);
             this.valueInfo = TraceLoggingTypeInfo.GetInstance(typeArgs[0], recursionCheck);
             this.hasValueGetter = PropertyValue.GetPropertyGetter(type.GetTypeInfo().GetDeclaredProperty("HasValue"));
             this.valueGetter = PropertyValue.GetPropertyGetter(type.GetTypeInfo().GetDeclaredProperty("Value"));

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/Statics.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/Statics.cs
@@ -1,8 +1,13 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Encoding = System.Text.Encoding;
+
+using Microsoft.Reflection;
 
 #if ES_BUILD_STANDALONE
 using Environment = Microsoft.Diagnostics.Tracing.Internal.Environment;
@@ -363,45 +368,25 @@ namespace System.Diagnostics.Tracing
 
         public static bool IsValueType(Type type)
         {
-            bool result;
-#if (ES_BUILD_PCL || PROJECTN)
-            result = type.GetTypeInfo().IsValueType;
-#else
-            result = type.IsValueType;
-#endif
+            bool result = type.IsValueType();
             return result;
         }
 
         public static bool IsEnum(Type type)
         {
-            bool result;
-#if (ES_BUILD_PCL || PROJECTN)
-            result = type.GetTypeInfo().IsEnum;
-#else
-            result = type.IsEnum;
-#endif
+            bool result = type.IsEnum();
             return result;
         }
 
         public static IEnumerable<PropertyInfo> GetProperties(Type type)
         {
-            IEnumerable<PropertyInfo> result;
-#if (ES_BUILD_PCL || PROJECTN)
-            result = type.GetTypeInfo().DeclaredProperties;
-#else
-            result = type.GetProperties();
-#endif
+            IEnumerable<PropertyInfo> result = type.GetProperties();
             return result;
         }
 
         public static MethodInfo GetGetMethod(PropertyInfo propInfo)
         {
-            MethodInfo result;
-#if (ES_BUILD_PCL || PROJECTN)
-            result = propInfo.GetMethod;
-#else
-            result = propInfo.GetGetMethod();
-#endif
+            MethodInfo result = propInfo.GetGetMethod();
             return result;
         }
 
@@ -476,11 +461,7 @@ namespace System.Diagnostics.Tracing
 
         public static Type[] GetGenericArguments(Type type)
         {
-#if (ES_BUILD_PCL || PROJECTN)
-            return type.GenericTypeArguments;
-#else
             return type.GetGenericArguments();
-#endif
         }
 
         public static Type FindEnumerableElementType(Type type)
@@ -524,13 +505,7 @@ namespace System.Diagnostics.Tracing
 
         public static bool IsGenericMatch(Type type, object openType)
         {
-            bool isGeneric;
-#if (ES_BUILD_PCL || PROJECTN)
-            isGeneric = type.IsConstructedGenericType;
-#else
-            isGeneric = type.IsGenericType;
-#endif
-            return isGeneric && type.GetGenericTypeDefinition() == (Type)openType;
+            return type.IsGenericType() && type.GetGenericTypeDefinition() == (Type)openType;
         }
 
         public static Delegate CreateDelegate(Type delegateType, MethodInfo methodInfo)
@@ -555,11 +530,7 @@ namespace System.Diagnostics.Tracing
 
             if (recursionCheck.Contains(dataType))
             {
-#if PROJECTN
-                throw new NotSupportedException(SR.GetResourceString("EventSource_RecursiveTypeDefinition", null));
-#else
-                throw new NotSupportedException(Environment.GetResourceString("EventSource_RecursiveTypeDefinition"));
-#endif
+                throw new NotSupportedException(Resources.GetResourceString("EventSource_RecursiveTypeDefinition"));
             }
 
             recursionCheck.Add(dataType);
@@ -742,11 +713,7 @@ namespace System.Diagnostics.Tracing
                     }
                     else
                     {
-#if PROJECTN
-                        throw new ArgumentException(SR.Format("EventSource_NonCompliantTypeError", dataType.Name));
-#else
-                    throw new ArgumentException(Environment.GetResourceString("EventSource_NonCompliantTypeError", dataType.Name));
-#endif
+                        throw new ArgumentException(Resources.GetResourceString("EventSource_NonCompliantTypeError", dataType.Name));
                     }
                 }
             }

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingDataCollector.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingDataCollector.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
 using System.Security;
 
 #if ES_BUILD_STANDALONE

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingDataType.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingDataType.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 #if ES_BUILD_STANDALONE
@@ -33,7 +36,6 @@ namespace System.Diagnostics.Tracing
         /// Core type.
         /// Encoding assumes null-terminated Char16 string.
         /// Decoding treats as UTF-16LE string.
-        /// NOTE: arrays of Utf16String will not be supported until M3.
         /// </summary>
         Utf16String = 1,
 
@@ -41,7 +43,6 @@ namespace System.Diagnostics.Tracing
         /// Core type.
         /// Encoding assumes null-terminated Char8 string.
         /// Decoding treats as MBCS string.
-        /// NOTE: arrays of MbcsString will not be supported until M3.
         /// </summary>
         MbcsString = 2,
 
@@ -126,7 +127,6 @@ namespace System.Diagnostics.Tracing
         /// Core type.
         /// Encoding assumes 16-bit bytecount followed by binary data.
         /// Decoding treats as binary data.
-        /// NOTE: arrays of Binary will not be supported until M3.
         /// </summary>
         Binary = 14,
 
@@ -258,7 +258,6 @@ namespace System.Diagnostics.Tracing
         /// Formatted type.
         /// Encoding assumes 16-bit bytecount followed by binary data.
         /// Decoding treats as IPv6 address.
-        /// NOTE: arrays of Ipv6Address will not be supported until M3.
         /// </summary>
         Ipv6Address = Binary + (EventSourceFieldFormat.Ipv6Address << 8),
 
@@ -266,7 +265,6 @@ namespace System.Diagnostics.Tracing
         /// Formatted type.
         /// Encoding assumes 16-bit bytecount followed by binary data.
         /// Decoding treats as SOCKADDR.
-        /// NOTE: arrays of SocketAddress will not be supported until M3.
         /// </summary>
         SocketAddress = Binary + (EventSourceFieldFormat.SocketAddress << 8),
 #endif
@@ -274,7 +272,6 @@ namespace System.Diagnostics.Tracing
         /// Formatted type.
         /// Encoding assumes null-terminated Char16 string.
         /// Decoding treats as UTF-16LE XML string.
-        /// NOTE: arrays of Utf16Xml will not be supported until M3.
         /// </summary>
         Utf16Xml = Utf16String + (EventFieldFormat.Xml << 8),
 
@@ -282,7 +279,6 @@ namespace System.Diagnostics.Tracing
         /// Formatted type.
         /// Encoding assumes null-terminated Char8 string.
         /// Decoding treats as MBCS XML string.
-        /// NOTE: arrays of MbcsXml will not be supported until M3.
         /// </summary>
         MbcsXml = MbcsString + (EventFieldFormat.Xml << 8),
 
@@ -304,7 +300,6 @@ namespace System.Diagnostics.Tracing
         /// Formatted type.
         /// Encoding assumes null-terminated Char16 string.
         /// Decoding treats as UTF-16LE JSON string.
-        /// NOTE: arrays of Utf16Json will not be supported until M3.
         /// </summary>
         Utf16Json = Utf16String + (EventFieldFormat.Json << 8),
 
@@ -312,7 +307,6 @@ namespace System.Diagnostics.Tracing
         /// Formatted type.
         /// Encoding assumes null-terminated Char8 string.
         /// Decoding treats as MBCS JSON string.
-        /// NOTE: arrays of MbcsJson will not be supported until M3.
         /// </summary>
         MbcsJson = MbcsString + (EventFieldFormat.Json << 8),
 

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventSource.cs
@@ -1,6 +1,9 @@
-// Copyright (c) Microsoft Corporation.  All rights reserved
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 // This program uses code hyperlinks available as part of the HyperAddin Visual Studio plug-in.
 // It is available from http://www.codeplex.com/hyperAddin 
+
 #define FEATURE_MANAGED_ETW
 
 #if !ES_BUILD_STANDALONE
@@ -15,16 +18,6 @@
 #if ES_BUILD_STANDALONE
 using Environment = Microsoft.Diagnostics.Tracing.Internal.Environment;
 using EventDescriptor = Microsoft.Diagnostics.Tracing.EventDescriptor;
-#else
-#if PROJECTN
-using NativeInterop = Interop.mincore;
-using ManifestEtw = Interop.mincore;
-using Win32Interop = Interop.mincore;
-#else
-using NativeInterop = UnsafeNativeMethods;
-using ManifestEtw = UnsafeNativeMethods.ManifestEtw;
-using Win32Interop = Win32Native;
-#endif
 #endif
 
 using System;
@@ -482,6 +475,7 @@ namespace System.Diagnostics.Tracing
                     }
 
                     this.WriteEventRaw(
+                        eventName,
                         ref descriptor,
                         activityID,
                         childActivityID,
@@ -592,6 +586,7 @@ namespace System.Diagnostics.Tracing
                     }
 
                     this.WriteEventRaw(
+                        eventName,
                         ref descriptor,
                         activityID,
                         childActivityID,
@@ -674,6 +669,7 @@ namespace System.Diagnostics.Tracing
                             info.WriteData(TraceLoggingDataCollector.Instance, info.PropertyValueFactory(data));
 
                             this.WriteEventRaw(
+                                eventName,
                                 ref descriptor,
                                 pActivityId,
                                 pRelatedActivityId,
@@ -693,7 +689,7 @@ namespace System.Diagnostics.Tracing
                             if (ex is EventSourceException)
                                 throw;
                             else
-                                ThrowEventSourceException(ex);
+                                ThrowEventSourceException(eventName, ex);
                         }
                         finally
                         {
@@ -707,7 +703,7 @@ namespace System.Diagnostics.Tracing
                 if (ex is EventSourceException)
                     throw;
                 else
-                    ThrowEventSourceException(ex);
+                    ThrowEventSourceException(eventName, ex);
             }
         }
 
@@ -716,8 +712,9 @@ namespace System.Diagnostics.Tracing
         {
             EventWrittenEventArgs eventCallbackArgs = new EventWrittenEventArgs(this);
             eventCallbackArgs.EventName = eventName;
-            eventCallbackArgs.m_keywords = (EventKeywords)eventDescriptor.Keywords;
-            eventCallbackArgs.m_opcode = (EventOpcode)eventDescriptor.Opcode;
+            eventCallbackArgs.m_level = (EventLevel) eventDescriptor.Level;
+            eventCallbackArgs.m_keywords = (EventKeywords) eventDescriptor.Keywords;
+            eventCallbackArgs.m_opcode = (EventOpcode) eventDescriptor.Opcode;
             eventCallbackArgs.m_tags = tags;
 
             // Self described events do not have an id attached. We mark it internally with -1.
@@ -731,7 +728,7 @@ namespace System.Diagnostics.Tracing
                 eventCallbackArgs.PayloadNames = new ReadOnlyCollection<string>((IList<string>)payload.Keys);
             }
 
-            DisptachToAllListeners(-1, pActivityId, eventCallbackArgs);
+            DispatchToAllListeners(-1, pActivityId, eventCallbackArgs);
         }
 
 #if (!ES_BUILD_PCL && !PROJECTN)
@@ -773,11 +770,7 @@ namespace System.Diagnostics.Tracing
                             }
                             else
                             {
-#if PROJECTN
-                                throw new ArgumentException(SR.GetResourceString("UnknownEtwTrait", etwTrait), "traits");
-#else
-                                throw new ArgumentException(Environment.GetResourceString("UnknownEtwTrait", etwTrait), "traits");
-#endif
+                                throw new ArgumentException(Resources.GetResourceString("UnknownEtwTrait", etwTrait), "traits");
                             }
                         }
                         string value = m_traits[i + 1];
@@ -815,32 +808,24 @@ namespace System.Diagnostics.Tracing
             {
                 for (int i = 1; i < value.Length; i++)
                 {
-                    if (value[i] != ' ')        // Skp spaces between bytes.  
+                    if (value[i] != ' ')        // Skip spaces between bytes.  
                     {
                         if (!(i + 1 < value.Length))
                         {
-#if PROJECTN
-                            throw new ArgumentException(SR.GetResourceString("EvenHexDigits", null), "traits");
-#else
-                            throw new ArgumentException(Environment.GetResourceString("EvenHexDigits"), "traits");
-#endif
+                            throw new ArgumentException(Resources.GetResourceString("EvenHexDigits"), "traits");
                         }
                         metaData.Add((byte)(HexDigit(value[i]) * 16 + HexDigit(value[i + 1])));
                         i++;
                     }
                 }
             }
-            else if (' ' <= firstChar)      // Is it alphabetic (excludes digits and most punctuation. 
+            else if ('A' <= firstChar || ' ' == firstChar)  // Is it alphabetic or space (excludes digits and most punctuation). 
             {
                 metaData.AddRange(Encoding.UTF8.GetBytes(value));
             }
             else
             {
-#if PROJECTN
-                throw new ArgumentException(SR.GetResourceString("IllegalValue", value), "traits");
-#else
-                throw new ArgumentException(Environment.GetResourceString("IllegalValue", value), "traits");
-#endif
+                throw new ArgumentException(Resources.GetResourceString("IllegalValue", value), "traits");
             }
 
             return metaData.Count - startPos;
@@ -863,11 +848,8 @@ namespace System.Diagnostics.Tracing
             {
                 return (c - 'A' + 10);
             }
-#if PROJECTN
-            throw new ArgumentException(SR.Format("BadHexDigit", c), "traits");
-#else
-            throw new ArgumentException(Environment.GetResourceString("BadHexDigit", c), "traits");
-#endif
+            
+            throw new ArgumentException(Resources.GetResourceString("BadHexDigit", c), "traits");
         }
 
         private NameInfo UpdateDescriptor(

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventTraits.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventTraits.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 
 #if ES_BUILD_STANDALONE

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventTypes.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingEventTypes.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 using Interlocked = System.Threading.Interlocked;

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingMetadataCollector.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingMetadataCollector.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 
@@ -228,11 +231,7 @@ namespace System.Diagnostics.Tracing
 
             if (this.BeginningBufferedArray)
             {
-#if PROJECTN
-                throw new NotSupportedException(SR.GetResourceString("EventSource_NotSupportedNestedArraysEnums", null));
-#else
-                throw new NotSupportedException(Environment.GetResourceString("EventSource_NotSupportedNestedArraysEnums"));
-#endif
+                throw new NotSupportedException(Resources.GetResourceString("EventSource_NotSupportedNestedArraysEnums"));
             }
 
             this.impl.AddScalar(2);
@@ -244,11 +243,7 @@ namespace System.Diagnostics.Tracing
         {
             if (this.bufferedArrayFieldCount >= 0)
             {
-#if PROJECTN
-                throw new NotSupportedException(SR.GetResourceString("EventSource_NotSupportedNestedArraysEnums", null));
-#else
-                throw new NotSupportedException(Environment.GetResourceString("EventSource_NotSupportedNestedArraysEnums"));
-#endif
+                throw new NotSupportedException(Resources.GetResourceString("EventSource_NotSupportedNestedArraysEnums"));
             }
 
             this.bufferedArrayFieldCount = 0;
@@ -259,11 +254,7 @@ namespace System.Diagnostics.Tracing
         {
             if (this.bufferedArrayFieldCount != 1)
             {
-#if PROJECTN
-                throw new InvalidOperationException(SR.GetResourceString("EventSource_IncorrentlyAuthoredTypeInfo", null));
-#else
-                throw new InvalidOperationException(Environment.GetResourceString("EventSource_IncorrentlyAuthoredTypeInfo"));
-#endif
+                throw new InvalidOperationException(Resources.GetResourceString("EventSource_IncorrentlyAuthoredTypeInfo"));
             }
 
             this.bufferedArrayFieldCount = int.MinValue;
@@ -282,11 +273,7 @@ namespace System.Diagnostics.Tracing
         {
             if (this.BeginningBufferedArray)
             {
-#if PROJECTN
-                throw new NotSupportedException(SR.GetResourceString("EventSource_NotSupportedCustomSerializedData", null));
-#else
-                throw new NotSupportedException(Environment.GetResourceString("EventSource_NotSupportedCustomSerializedData"));
-#endif
+                throw new NotSupportedException(Resources.GetResourceString("EventSource_NotSupportedCustomSerializedData"));
             }
 
             this.impl.AddScalar(2);

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingTypeInfo.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/TraceLoggingTypeInfo.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/TypeAnalysis.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/TraceLogging/TypeAnalysis.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using System;
 using System.Collections.Generic;
 using System.Reflection;

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/UnsafeNativeMethods.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/UnsafeNativeMethods.cs
@@ -1,0 +1,273 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics.Tracing;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Text;
+
+namespace Microsoft.Win32
+{
+    [SuppressUnmanagedCodeSecurityAttribute()]
+    internal static class UnsafeNativeMethods
+    {
+        [SecurityCritical]
+        [SuppressUnmanagedCodeSecurityAttribute()]
+        internal static unsafe class ManifestEtw
+        {
+            //
+            // Constants error coded returned by ETW APIs
+            //
+
+            // The event size is larger than the allowed maximum (64k - header).
+            internal const int ERROR_ARITHMETIC_OVERFLOW = 534;
+
+            // Occurs when filled buffers are trying to flush to disk, 
+            // but disk IOs are not happening fast enough. 
+            // This happens when the disk is slow and event traffic is heavy. 
+            // Eventually, there are no more free (empty) buffers and the event is dropped.
+            internal const int ERROR_NOT_ENOUGH_MEMORY = 8;
+
+            internal const int ERROR_MORE_DATA = 0xEA;
+            internal const int ERROR_NOT_SUPPORTED = 50;
+            internal const int ERROR_INVALID_PARAMETER = 0x57;
+
+            //
+            // ETW Methods
+            //
+
+            internal const int EVENT_CONTROL_CODE_DISABLE_PROVIDER = 0;
+            internal const int EVENT_CONTROL_CODE_ENABLE_PROVIDER = 1;
+            internal const int EVENT_CONTROL_CODE_CAPTURE_STATE = 2;
+
+            //
+            // Callback
+            //
+            [SecurityCritical]
+            internal unsafe delegate void EtwEnableCallback(
+                [In] ref Guid sourceId,
+                [In] int isEnabled,
+                [In] byte level,
+                [In] long matchAnyKeywords,
+                [In] long matchAllKeywords,
+                [In] EVENT_FILTER_DESCRIPTOR* filterData,
+                [In] void* callbackContext
+                );
+
+            //
+            // Registration APIs
+            //
+            [SecurityCritical]
+            internal static unsafe uint EventRegister(
+                        [In] ref Guid providerId,
+                        [In]EtwEnableCallback enableCallback,
+                        [In]void* callbackContext,
+                        [In][Out]ref long registrationHandle
+                        )
+            {
+                Interop.mincore.EtwEnableCallback indirection = delegate(ref Guid sourceId,
+                                                                         int isEnabled,
+                                                                         byte level,
+                                                                         ulong matchAnyKeywords,
+                                                                         ulong matchAllKeywords,
+                                                                         Interop.mincore.EVENT_FILTER_DESCRIPTOR* filterData,
+                                                                         IntPtr cbContext)
+                {
+                    enableCallback(ref sourceId,
+                                   isEnabled,
+                                   level,
+                                   (long)matchAnyKeywords,
+                                   (long)matchAllKeywords,
+                                   (EVENT_FILTER_DESCRIPTOR*)filterData,
+                                   (void*)cbContext);
+                };
+                ulong temp;
+                uint status = Interop.mincore.EventRegister(ref providerId, indirection, (IntPtr)callbackContext, out temp);
+                registrationHandle = (long)temp;
+                
+                return status;
+            }
+
+
+            [SecurityCritical]
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
+            internal static uint EventUnregister([In] long registrationHandle)
+            {
+                return Interop.mincore.EventUnregister((ulong)registrationHandle);
+            }
+
+
+            [StructLayout(LayoutKind.Sequential)]
+            unsafe internal struct EVENT_FILTER_DESCRIPTOR
+            {
+                public long Ptr;
+                public int Size;
+                public int Type;
+            };
+
+            /// <summary>
+            ///  Call the ETW native API EventWriteTransfer and checks for invalid argument error. 
+            ///  The implementation of EventWriteTransfer on some older OSes (Windows 2008) does not accept null relatedActivityId.
+            ///  So, for these cases we will retry the call with an empty Guid.
+            /// </summary>
+            internal static int EventWriteTransferWrapper(long registrationHandle,
+                                                         ref EventDescriptor eventDescriptor,
+                                                         Guid* activityId,
+                                                         Guid* relatedActivityId,
+                                                         int userDataCount,
+                                                         EventProvider.EventData* userData)
+            {
+                int HResult = EventWriteTransfer(registrationHandle, ref eventDescriptor, activityId, relatedActivityId, userDataCount, userData);
+                if (HResult == ERROR_INVALID_PARAMETER && relatedActivityId == null)
+                {
+                    Guid emptyGuid = Guid.Empty;
+                    HResult = EventWriteTransfer(registrationHandle, ref eventDescriptor, activityId, &emptyGuid, userDataCount, userData);
+                }
+
+                return HResult;
+            }
+
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
+            [SuppressUnmanagedCodeSecurityAttribute]        // Don't do security checks 
+            private static unsafe int EventWriteTransfer(
+                    [In] long registrationHandle,
+                    [In] ref EventDescriptor eventDescriptor,
+                    [In] Guid* activityId,
+                    [In] Guid* relatedActivityId,
+                    [In] int userDataCount,
+                    [In] EventProvider.EventData* userData
+                    )
+            {
+                IntPtr descripPtr = Marshal.AllocHGlobal(Marshal.SizeOf(eventDescriptor));
+                Marshal.StructureToPtr(eventDescriptor, descripPtr, false);
+                int status = Interop.mincore.EventWriteTransfer((ulong)registrationHandle, 
+                                                        (void*)descripPtr, 
+                                                        activityId, 
+                                                        relatedActivityId, 
+                                                        userDataCount, 
+                                                        (void*)userData);
+                Marshal.FreeHGlobal(descripPtr);
+                return status;
+            }
+
+            internal enum ActivityControl : uint
+            {
+                EVENT_ACTIVITY_CTRL_GET_ID = 1,
+                EVENT_ACTIVITY_CTRL_SET_ID = 2,
+                EVENT_ACTIVITY_CTRL_CREATE_ID = 3,
+                EVENT_ACTIVITY_CTRL_GET_SET_ID = 4,
+                EVENT_ACTIVITY_CTRL_CREATE_SET_ID = 5
+            };
+
+            internal enum EVENT_INFO_CLASS
+            {
+                BinaryTrackInfo,
+                SetEnableAllKeywords, // obsolete
+                SetTraits,
+            }
+
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
+            [SuppressUnmanagedCodeSecurityAttribute]        // Don't do security checks 
+            internal static int EventSetInformation(
+                [In] long registrationHandle,
+                [In] EVENT_INFO_CLASS informationClass,
+                [In] void* eventInformation,
+                [In] int informationLength)
+            {
+                return Interop.mincore.EventSetInformation((ulong)registrationHandle, (int)informationClass, (IntPtr)eventInformation, informationLength);
+            }
+
+            // We want to not use this API for the Nuget package, as it is not an allowed API in the Store.  
+#if ES_SESSION_INFO || FEATURE_ACTIVITYSAMPLING
+
+            // Support for EnumerateTraceGuidsEx
+            internal enum TRACE_QUERY_INFO_CLASS
+            {
+                TraceGuidQueryList,
+                TraceGuidQueryInfo,
+                TraceGuidQueryProcess,
+                TraceStackTracingInfo,
+                MaxTraceSetInfoClass
+            };
+
+            internal struct TRACE_GUID_INFO
+            {
+                public int InstanceCount;
+                public int Reserved;
+            };
+
+            internal struct TRACE_PROVIDER_INSTANCE_INFO
+            {
+                public int NextOffset;
+                public int EnableCount;
+                public int Pid;
+                public int Flags;
+            };
+
+#pragma warning disable 0649
+            internal struct TRACE_ENABLE_INFO
+            {
+                public int IsEnabled;
+                public byte Level;
+                public byte Reserved1;
+                public ushort LoggerId;
+                public int EnableProperty;
+                public int Reserved2;
+                public long MatchAnyKeyword;
+                public long MatchAllKeyword;
+            };
+#pragma warning restore 0649
+
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2118:ReviewSuppressUnmanagedCodeSecurityUsage")]
+            [SuppressUnmanagedCodeSecurityAttribute]        // Don't do security checks 
+            internal static int EnumerateTraceGuidsEx(
+                TRACE_QUERY_INFO_CLASS TraceQueryInfoClass,
+                void* InBuffer,
+                int InBufferSize,
+                void* OutBuffer,
+                int OutBufferSize,
+                ref int ReturnLength)
+            {
+                return Interop.mincore.EnumerateTraceGuidsEx(TraceQueryInfoClass,
+                                                             InBuffer,
+                                                             InBufferSize,
+                                                             OutBuffer,
+                                                             OutBufferSize,
+                                                             ReturnLength);
+                )
+            }
+#endif
+        }
+    }
+
+    internal static class Win32Native
+    {
+#if ES_BUILD_PCL
+        private const string CoreProcessThreadsApiSet = "api-ms-win-core-processthreads-l1-1-0";
+        private const string CoreLocalizationApiSet = "api-ms-win-core-localization-l1-2-0";
+#else
+        private const string CoreProcessThreadsApiSet = "kernel32.dll";
+        private const string CoreLocalizationApiSet = "kernel32.dll";
+#endif
+
+        [System.Security.SecuritySafeCritical]
+        // Gets an error message for a Win32 error code.
+        internal static String GetMessage(int errorCode)
+        {
+            return Interop.mincore.GetMessage(errorCode);
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1060:MovePInvokesToNativeMethodsClass")]
+        [System.Security.SecurityCritical]
+        internal static uint GetCurrentProcessId()
+        {
+            return Interop.mincore.GetCurrentProcessId();
+        }
+
+
+        private const int FORMAT_MESSAGE_IGNORE_INSERTS = 0x00000200;
+        private const int FORMAT_MESSAGE_FROM_SYSTEM = 0x00001000;
+        private const int FORMAT_MESSAGE_ARGUMENT_ARRAY = 0x00002000;
+    }
+}

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/Winmeta.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/Winmeta.cs
@@ -1,11 +1,8 @@
-// ==++==
-// 
-//   Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
-// ==--==
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 /*============================================================
 **
-** File: winmeta.cs
 **
 ** Purpose: 
 ** Contains eventing constants defined by the Windows 
@@ -162,6 +159,10 @@ namespace System.Diagnostics.Tracing
         /// </summary>
         All = ~0,
         /// <summary>
+        /// Telemetry events
+        /// </summary>
+        MicrosoftTelemetry = 0x02000000000000,
+        /// <summary>
         /// WDI context events
         /// </summary>
         WdiContext = 0x02000000000000,
@@ -183,7 +184,7 @@ namespace System.Diagnostics.Tracing
         AuditSuccess = 0x20000000000000,
         /// <summary>
         /// Transfer events where the related Activity ID is a computed value and not a GUID
-        /// TODO: this is the same as AuditFailure, should it be 0x40000000000000?
+        /// N.B. The correct value for this field is 0x40000000000000.
         /// </summary>
         CorrelationHint = 0x10000000000000,
         /// <summary>

--- a/src/System.Diagnostics.Tracing/tests/project.json
+++ b/src/System.Diagnostics.Tracing/tests/project.json
@@ -17,6 +17,6 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dotnet5.4": {}
+    "dnxcore50": {}
   }
 }


### PR DESCRIPTION
…is replaces a lot of the previous ifdefs in the ProjectN impelmentation with a partial class that is cleaner and easier to understand.

 # This is a combination of 5 commits.
Merge the .Net Native and CoreCLR implementations of EventSource

Merge the CoreCLR refactoring in to the ProjectN folder. After this change the project should be much easier to merge and all bug fixes are up to date.

Refactor the interop in ProjectN so it can work without ifdefs.

Move methods that use EventActivityIDControl to EventSource_ProjectN.c

Add formatting to the debugger message that EventSource prints when an internal error happens.

Port remaining fixes to N from CoreCLR.