### PR TITLE
Improve handling of TypeSpecs within signatures

### DIFF
--- a/src/System.Reflection.Metadata/src/Resources/Strings.resx
+++ b/src/System.Reflection.Metadata/src/Resources/Strings.resx
@@ -351,4 +351,7 @@
   <data name="SignatureTypeSequenceMustHaveAtLeastOneElement" xml:space="preserve">
     <value>Signature type sequence must have at least one element.</value>
   </data>
+  <data name="NotTypeDefOrRefOrSpecHandle" xml:space="preserve">
+    <value>Specified handle is not a TypeDefinitionHandle, TypeRefererenceHandle, or TypeSpecificationHandle.</value>
+  </data>
 </root>

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ISignatureTypeProvider.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ISignatureTypeProvider.cs
@@ -25,18 +25,9 @@ namespace System.Reflection.Metadata.Decoding
         /// </summary>
         /// <param name="reader">The metadata reader that was passed to the <see cref="SignatureDecoder{TType}"/>. It may be null.</param>
         /// <param name="isRequired">True if the modifier is required, false if it's optional.</param>
-        /// <param name="modifierTypeHandle">The modifier type applied. A <see cref="TypeDefinitionHandle"/>, <see cref="TypeReferenceHandle"/>, or <see cref="TypeSpecificationHandle"/>. </param>
+        /// <param name="modifier">The modifier type applied. </param>
         /// <param name="unmodifiedType">The type symbol of the underlying type without modifiers applied.</param>
-        /// <remarks>
-        /// The modifier type is passed as a handle rather than a decoded <typeparamref name="TType"/>.
-        ///
-        ///   1. It makes (not uncommon) scenarios that skip modifiers cheaper.
-        /// 
-        ///   2. It is the only valid place where a <see cref="TypeSpecificationHandle"/> can occur within a signature blob. 
-        ///      If we were to recurse into the type spec before calling GetModifiedType, it would eliminate scenarios such
-        ///      as caching by TypeSpec or deciphering the structure of a signature without resolving any handles.
-        /// </remarks>
-        TType GetModifiedType(MetadataReader reader, bool isRequired, EntityHandle modifierTypeHandle, TType unmodifiedType);
+        TType GetModifiedType(MetadataReader reader, bool isRequired, TType modifier, TType unmodifiedType);
 
         /// <summary>
         /// Gets the type symbol for a local variable type that is marked as pinned.

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ITypeProvider.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ITypeProvider.cs
@@ -36,5 +36,22 @@ namespace System.Reflection.Metadata.Decoding
         /// will be passed.
         /// </param>
         TType GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, SignatureTypeHandleCode code);
+
+
+        /// <summary>
+        /// Gets the type symbol for a type specification.
+        /// </summary>
+        /// <param name="reader">
+        /// The metadata reader that was passed to the <see cref= "SignatureDecoder{TType}" />. It may be null.
+        /// </param>
+        /// <param name="handle">
+        /// The type specification handle.
+        /// </param>
+        /// <param name="code">
+        /// When <see cref="SignatureDecoderOptions.DifferentiateClassAndValueTypes"/> is used indicates whether
+        /// the type reference is to class or value type. Otherwise <see cref="SignatureTypeHandleCode.Unresolved"/>
+        /// will be passed.
+        /// </param>
+        TType GetTypeFromSpecification(MetadataReader reader, TypeSpecificationHandle handle, SignatureTypeHandleCode code);
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/SignatureDecoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/SignatureDecoder.cs
@@ -46,14 +46,17 @@ namespace System.Reflection.Metadata.Decoding
         /// Decodes a type embedded in a signature and advances the reader past the type.
         /// </summary>
         /// <param name="blobReader">The blob reader positioned at the leading SignatureTypeCode</param>
+        /// <param name="allowTypeSpecifications">Allow a <see cref="TypeSpecificationHandle"/> to follow a (CLASS | VALUETYPE) in the signature.
+        /// At present, the only context where that would be valid is in a LocalConstantSig as defined by the Portable PDB specification.
+        /// </param>
         /// <returns>The decoded type.</returns>
         /// <exception cref="System.BadImageFormatException">The reader was not positioned at a valid signature type.</exception>
-        public TType DecodeType(ref BlobReader blobReader)
+        public TType DecodeType(ref BlobReader blobReader, bool allowTypeSpecifications = false)
         {
-            return DecodeType(ref blobReader, blobReader.ReadCompressedInteger());
+            return DecodeType(ref blobReader, allowTypeSpecifications, blobReader.ReadCompressedInteger());
         }
 
-        private TType DecodeType(ref BlobReader blobReader, int typeCode)
+        private TType DecodeType(ref BlobReader blobReader, bool allowTypeSpecifications, int typeCode)
         {
             TType elementType;
             int index;
@@ -192,7 +195,7 @@ namespace System.Reflection.Metadata.Decoding
                     {
                         break;
                     }
-                    parameterBuilder.Add(DecodeType(ref blobReader, typeCode));
+                    parameterBuilder.Add(DecodeType(ref blobReader, allowTypeSpecifications: false, typeCode: typeCode));
                 }
 
                 requiredParameterCount = parameterIndex;
@@ -287,12 +290,23 @@ namespace System.Reflection.Metadata.Decoding
 
         private TType DecodeModifiedType(ref BlobReader blobReader, bool isRequired)
         {
-            EntityHandle modifier = blobReader.ReadTypeHandle();
+            TType modifier = DecodeTypeDefOrRefOrSpec(ref blobReader, SignatureTypeHandleCode.Unresolved);
             TType unmodifiedType = DecodeType(ref blobReader);
+
             return _provider.GetModifiedType(_metadataReaderOpt, isRequired, modifier, unmodifiedType);
         }
 
         private TType DecodeTypeDefOrRef(ref BlobReader blobReader, SignatureTypeHandleCode code)
+        {
+            return DecodeTypeHandle(ref blobReader, code, alllowTypeSpecifications: false);
+        }
+
+        private TType DecodeTypeDefOrRefOrSpec(ref BlobReader blobReader, SignatureTypeHandleCode code)
+        {
+            return DecodeTypeHandle(ref blobReader, code, alllowTypeSpecifications: true);
+        }
+
+        private TType DecodeTypeHandle(ref BlobReader blobReader, SignatureTypeHandleCode code, bool alllowTypeSpecifications)
         {
             // Force no differentiation of class vs. value type unless the option is enabled.
             // Avoids cost of WinRT projection.
@@ -302,25 +316,50 @@ namespace System.Reflection.Metadata.Decoding
             }
  
             EntityHandle handle = blobReader.ReadTypeHandle();
-            switch (handle.Kind)
+            if (!handle.IsNil)
             {
-                case HandleKind.TypeDefinition:
-                    var typeDef = (TypeDefinitionHandle)handle;
-                    return _provider.GetTypeFromDefinition(_metadataReaderOpt, typeDef, code);
+                switch (handle.Kind)
+                {
+                    case HandleKind.TypeDefinition:
+                        var typeDef = (TypeDefinitionHandle)handle;
+                        return _provider.GetTypeFromDefinition(_metadataReaderOpt, typeDef, code);
 
-                case HandleKind.TypeReference:
-                    var typeRef = (TypeReferenceHandle)handle;
-                    if (code != SignatureTypeHandleCode.Unresolved)
-                    {
-                        ProjectClassOrValueType(typeRef, ref code);
-                    }
-                    return _provider.GetTypeFromReference(_metadataReaderOpt, typeRef, code);
+                    case HandleKind.TypeReference:
+                        var typeRef = (TypeReferenceHandle)handle;
+                        if (code != SignatureTypeHandleCode.Unresolved)
+                        {
+                            ProjectClassOrValueType(typeRef, ref code);
+                        }
+                        return _provider.GetTypeFromReference(_metadataReaderOpt, typeRef, code);
 
-                default:
-                    // To prevent cycles, the token following (CLASS | VALUETYPE) must not be a type spec
-                    // https://github.com/dotnet/coreclr/blob/8ff2389204d7c41b17eff0e9536267aea8d6496f/src/md/compiler/mdvalidator.cpp#L6154-L6160
-                    throw new BadImageFormatException(SR.NotTypeDefOrRefHandle);
+                    case HandleKind.TypeSpecification:
+                        if (!alllowTypeSpecifications)
+                        {
+                            // To prevent cycles, the token following (CLASS | VALUETYPE) must not be a type spec.
+                            // https://github.com/dotnet/coreclr/blob/8ff2389204d7c41b17eff0e9536267aea8d6496f/src/md/compiler/mdvalidator.cpp#L6154-L6160
+                            throw new BadImageFormatException(SR.NotTypeDefOrRefHandle);
+                        }
+
+                        if (code != SignatureTypeHandleCode.Unresolved)
+                        {
+                            // TODO: We need more work here in differentiating case because instantiations can project class 
+                            // to value type as in IReference<T> -> Nullable<T>. Unblocking Roslyn work where the differentiation
+                            // feature is not used. Note that the use-case of custom-mods will not hit this because there is no
+                            // CLASS | VALUETYPE before the modifier token and so it always comes in unresolved.
+                            code = SignatureTypeHandleCode.Unresolved; // never lie in the meantime.
+                        }
+
+                        var typeSpec = (TypeSpecificationHandle)handle;
+                        return _provider.GetTypeFromSpecification(_metadataReaderOpt, typeSpec, SignatureTypeHandleCode.Unresolved);
+
+                    default:
+                        // indicates an error returned from ReadTypeHandle, otherwise unreachable.
+                        Debug.Assert(handle.IsNil); // will fall through to throw in release.
+                        break;
+                }
             }
+
+            throw new BadImageFormatException(SR.NotTypeDefOrRefOrSpecHandle);
         }
 
         private void ProjectClassOrValueType(TypeReferenceHandle handle, ref SignatureTypeHandleCode code)

--- a/src/System.Reflection.Metadata/tests/Metadata/Decoding/DisassemblingTypeProvider.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/Decoding/DisassemblingTypeProvider.cs
@@ -123,6 +123,11 @@ namespace System.Reflection.Metadata.Decoding.Tests
             }
         }
 
+        public virtual string GetTypeFromSpecification(MetadataReader reader, TypeSpecificationHandle handle, SignatureTypeHandleCode code = SignatureTypeHandleCode.Unresolved)
+        {
+            return reader.GetTypeSpecification(handle).DecodeSignature(this);
+        }
+
         public virtual string GetSZArrayType(string elementType)
         {
             return elementType + "[]";
@@ -203,16 +208,16 @@ namespace System.Reflection.Metadata.Decoding.Tests
                     return GetTypeFromReference(reader, (TypeReferenceHandle)handle);
 
                 case HandleKind.TypeSpecification:
-                    return reader.GetTypeSpecification((TypeSpecificationHandle)handle).DecodeSignature(this);
+                    return GetTypeFromSpecification(reader, (TypeSpecificationHandle)handle);
 
                 default:
                     throw new ArgumentOutOfRangeException("handle");
             }
         }
 
-        public virtual string GetModifiedType(MetadataReader reader, bool isRequired, EntityHandle modifierTypeHandle, string unmodifiedType)
+        public virtual string GetModifiedType(MetadataReader reader, bool isRequired, string modifierType, string unmodifiedType)
         {
-            return unmodifiedType + (isRequired ? " modreq(" : " modopt(") + GetTypeFromHandle(reader, modifierTypeHandle) + ")";
+            return unmodifiedType + (isRequired ? " modreq(" : " modopt(") + modifierType + ")";
         }
 
         public virtual string GetFunctionPointerType(MethodSignature<string> signature)


### PR DESCRIPTION
* Introduce ITypeProvider.GetTypeFromSpecification

* Replace EntityHandle with TType in GetModifiedType.

* Provide public entry point for allowing (CLASS | VALUETYPE) TypeSpec,
  which can appear in LocalConstantSig of portable PDB.