### PR TITLE
Fix project.json dependencies: xunit DNXCore incompatibility + invalid package dependencies

### DIFF
--- a/src/Common/test-runtime/project.json
+++ b/src/Common/test-runtime/project.json
@@ -14,7 +14,9 @@
     "xunit.runner.utility": "2.1.0"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   },
   "runtimes": {
     "win7-x64": {},

--- a/src/Common/tests/project.json
+++ b/src/Common/tests/project.json
@@ -16,6 +16,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/Microsoft.Win32.Primitives/tests/project.json
+++ b/src/Microsoft.Win32.Primitives/tests/project.json
@@ -6,6 +6,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/Microsoft.Win32.Registry/tests/project.json
+++ b/src/Microsoft.Win32.Registry/tests/project.json
@@ -10,6 +10,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/Scenarios/tests/InterProcessCommunication/project.json
+++ b/src/Scenarios/tests/InterProcessCommunication/project.json
@@ -14,6 +14,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Buffers/tests/project.json
+++ b/src/System.Buffers/tests/project.json
@@ -8,6 +8,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Collections.Concurrent/tests/project.json
+++ b/src/System.Collections.Concurrent/tests/project.json
@@ -15,6 +15,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Collections.Immutable/tests/project.json
+++ b/src/System.Collections.Immutable/tests/project.json
@@ -6,6 +6,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Collections.NonGeneric/tests/project.json
+++ b/src/System.Collections.NonGeneric/tests/project.json
@@ -16,6 +16,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Collections.Specialized/tests/project.json
+++ b/src/System.Collections.Specialized/tests/project.json
@@ -13,6 +13,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Collections/tests/project.json
+++ b/src/System.Collections/tests/project.json
@@ -14,6 +14,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.ComponentModel.Annotations/tests/project.json
+++ b/src/System.ComponentModel.Annotations/tests/project.json
@@ -11,6 +11,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.ComponentModel.EventBasedAsync/tests/project.json
+++ b/src/System.ComponentModel.EventBasedAsync/tests/project.json
@@ -7,6 +7,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.ComponentModel.Primitives/tests/project.json
+++ b/src/System.ComponentModel.Primitives/tests/project.json
@@ -6,6 +6,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.ComponentModel.TypeConverter/tests/project.json
+++ b/src/System.ComponentModel.TypeConverter/tests/project.json
@@ -9,6 +9,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.ComponentModel/tests/project.json
+++ b/src/System.ComponentModel/tests/project.json
@@ -5,6 +5,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Composition.Convention/tests/project.json
+++ b/src/System.Composition.Convention/tests/project.json
@@ -6,6 +6,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Composition.Convention/tests/project.json
+++ b/src/System.Composition.Convention/tests/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "System.Linq.Expressions": "4.0.10-rc2-23616",
-    "System.Runtime": "4.0.20-rc2-23616",
+    "System.Linq.Expressions": "4.0.10",
+    "System.Runtime": "4.0.20",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },

--- a/src/System.Composition/tests/project.json
+++ b/src/System.Composition/tests/project.json
@@ -6,6 +6,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Console/tests/project.json
+++ b/src/System.Console/tests/project.json
@@ -15,6 +15,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Console/tests/project.json
+++ b/src/System.Console/tests/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0025",
-    "System.Diagnostics.Process": "4.0.0-rc2-23616",
+    "System.Diagnostics.Process": "4.1.0-rc2-23616",
     "System.IO": "4.0.10",
     "System.IO.FileSystem": "4.0.0",
     "System.Runtime": "4.0.20",

--- a/src/System.Diagnostics.Contracts/tests/project.json
+++ b/src/System.Diagnostics.Contracts/tests/project.json
@@ -8,6 +8,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Diagnostics.Debug/tests/project.json
+++ b/src/System.Diagnostics.Debug/tests/project.json
@@ -5,6 +5,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Diagnostics.DiagnosticSource/tests/project.json
+++ b/src/System.Diagnostics.DiagnosticSource/tests/project.json
@@ -9,6 +9,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/project.json
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/project.json
@@ -10,6 +10,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Diagnostics.Process/tests/project.json
+++ b/src/System.Diagnostics.Process/tests/project.json
@@ -24,6 +24,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Diagnostics.TextWriterTraceListener/tests/project.json
+++ b/src/System.Diagnostics.TextWriterTraceListener/tests/project.json
@@ -12,7 +12,9 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   },
   "runtimes": {
     "win7-x86": {},

--- a/src/System.Diagnostics.Tools/tests/project.json
+++ b/src/System.Diagnostics.Tools/tests/project.json
@@ -5,6 +5,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Diagnostics.TraceSource/tests/project.json
+++ b/src/System.Diagnostics.TraceSource/tests/project.json
@@ -9,6 +9,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Diagnostics.TraceSource/tests/project.json
+++ b/src/System.Diagnostics.TraceSource/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "System.Diagnostics.Process": "4.0.0-rc2-23616",
+    "System.Diagnostics.Process": "4.1.0-rc2-23616",
     "System.IO": "4.0.10",
     "System.Runtime": "4.0.20",
     "System.Runtime.Extensions": "4.0.10",

--- a/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/project.json
+++ b/src/System.Diagnostics.Tracing/tests/BasicEventSourceTest/project.json
@@ -10,6 +10,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Dynamic.Runtime/tests/project.json
+++ b/src/System.Dynamic.Runtime/tests/project.json
@@ -20,6 +20,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Globalization.Calendars/tests/project.json
+++ b/src/System.Globalization.Calendars/tests/project.json
@@ -8,6 +8,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Globalization.Extensions/tests/project.json
+++ b/src/System.Globalization.Extensions/tests/project.json
@@ -11,6 +11,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Globalization/tests/project.json
+++ b/src/System.Globalization/tests/project.json
@@ -10,6 +10,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.IO.Compression.ZipFile/tests/project.json
+++ b/src/System.IO.Compression.ZipFile/tests/project.json
@@ -18,7 +18,9 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   },
   "runtimes": {
     "win7-x64": {}

--- a/src/System.IO.Compression/tests/project.json
+++ b/src/System.IO.Compression/tests/project.json
@@ -19,7 +19,9 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   },
   "runtimes": {
     "win7-x86": {},

--- a/src/System.IO.FileSystem.DriveInfo/tests/project.json
+++ b/src/System.IO.FileSystem.DriveInfo/tests/project.json
@@ -10,6 +10,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.IO.FileSystem.Primitives/tests/project.json
+++ b/src/System.IO.FileSystem.Primitives/tests/project.json
@@ -5,6 +5,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.IO.FileSystem.Watcher/tests/project.json
+++ b/src/System.IO.FileSystem.Watcher/tests/project.json
@@ -14,6 +14,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.IO.FileSystem/tests/project.json
+++ b/src/System.IO.FileSystem/tests/project.json
@@ -21,6 +21,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.IO.MemoryMappedFiles/tests/project.json
+++ b/src/System.IO.MemoryMappedFiles/tests/project.json
@@ -14,6 +14,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.IO.Packaging/tests/project.json
+++ b/src/System.IO.Packaging/tests/project.json
@@ -12,7 +12,9 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   },
   "runtimes": {
     "win7-x64": {}

--- a/src/System.IO.Pipes/tests/project.json
+++ b/src/System.IO.Pipes/tests/project.json
@@ -16,6 +16,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.IO.UnmanagedMemoryStream/tests/project.json
+++ b/src/System.IO.UnmanagedMemoryStream/tests/project.json
@@ -13,6 +13,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.IO/tests/project.json
+++ b/src/System.IO/tests/project.json
@@ -7,6 +7,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Linq.Expressions/tests/project.json
+++ b/src/System.Linq.Expressions/tests/project.json
@@ -17,6 +17,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Linq.Parallel/tests/project.json
+++ b/src/System.Linq.Parallel/tests/project.json
@@ -14,6 +14,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Linq.Queryable/tests/project.json
+++ b/src/System.Linq.Queryable/tests/project.json
@@ -10,6 +10,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Linq/tests/project.json
+++ b/src/System.Linq/tests/project.json
@@ -10,6 +10,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/project.json
@@ -9,6 +9,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
@@ -18,6 +18,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/project.json
@@ -12,6 +12,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.Http/tests/UnitTests/project.json
+++ b/src/System.Net.Http/tests/UnitTests/project.json
@@ -10,6 +10,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.NameResolution/src/project.json
+++ b/src/System.Net.NameResolution/src/project.json
@@ -1,19 +1,19 @@
 {
   "dependencies": {
-    "System.Collections": "4.0.0-rc2-23616",
-    "System.Diagnostics.Contracts": "4.0.0-rc2-23616",
-    "System.Diagnostics.Tracing": "4.0.0-rc2-23616",
-    "System.Runtime": "4.0.20-rc2-23616",
-    "System.Runtime.Extensions": "4.0.10-rc2-23616",
-    "System.Resources.ResourceManager": "4.0.0-rc2-23616",
-    "System.Threading": "4.0.10-rc2-23616",
-    "System.Threading.Tasks": "4.0.0-rc2-23616",
-    "System.Runtime.InteropServices": "4.0.20-rc2-23616",
-    "System.Runtime.Handles": "4.0.0-rc2-23616",
-    "System.Globalization": "4.0.0-rc2-23616",
-    "System.Diagnostics.Debug": "4.0.10-rc2-23616",
+    "System.Collections": "4.0.0",
+    "System.Diagnostics.Contracts": "4.0.0",
+    "System.Diagnostics.Tracing": "4.0.0",
+    "System.Runtime": "4.0.20",
+    "System.Runtime.Extensions": "4.0.10",
+    "System.Resources.ResourceManager": "4.0.0",
+    "System.Threading": "4.0.10",
+    "System.Threading.Tasks": "4.0.0",
+    "System.Runtime.InteropServices": "4.0.20",
+    "System.Runtime.Handles": "4.0.0",
+    "System.Globalization": "4.0.0",
+    "System.Diagnostics.Debug": "4.0.10",
     "System.Security.Principal.Windows": "4.0.0-rc2-23616",
-    "System.Net.Primitives": "4.0.10-rc2-23616"
+    "System.Net.Primitives": "4.0.10"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.Net.NameResolution/tests/FunctionalTests/project.json
+++ b/src/System.Net.NameResolution/tests/FunctionalTests/project.json
@@ -10,6 +10,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.NameResolution/tests/PalTests/project.json
+++ b/src/System.Net.NameResolution/tests/PalTests/project.json
@@ -25,6 +25,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/project.json
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "System.Net.Primitives": "4.0.10-rc2-23616",
+    "System.Net.Primitives": "4.0.10",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/project.json
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/project.json
@@ -5,6 +5,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.NetworkInformation/tests/UnitTests/project.json
+++ b/src/System.Net.NetworkInformation/tests/UnitTests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "System.Net.Primitives": "4.0.10-rc2-23616",
+    "System.Net.Primitives": "4.0.10",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },

--- a/src/System.Net.NetworkInformation/tests/UnitTests/project.json
+++ b/src/System.Net.NetworkInformation/tests/UnitTests/project.json
@@ -5,6 +5,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.Ping/src/project.json
+++ b/src/System.Net.Ping/src/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "System.Diagnostics.Process": "4.1.0-rc2-23616",
-    "System.Net.Primitives": "4.0.10-rc2-23616",
+    "System.Net.Primitives": "4.0.10",
     "System.Net.NameResolution": "4.0.0-rc2-23616",
     "System.Net.Sockets": "4.1.0-rc2-23616",
     "System.Threading.ThreadPool": "4.0.10-rc2-23616"

--- a/src/System.Net.Ping/tests/FunctionalTests/project.json
+++ b/src/System.Net.Ping/tests/FunctionalTests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "System.Net.Primitives": "4.0.10-rc2-23616",
+    "System.Net.Primitives": "4.0.10",
     "System.Diagnostics.Process": "4.1.0-rc2-23616",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"

--- a/src/System.Net.Ping/tests/FunctionalTests/project.json
+++ b/src/System.Net.Ping/tests/FunctionalTests/project.json
@@ -6,6 +6,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.Primitives/tests/FunctionalTests/project.json
+++ b/src/System.Net.Primitives/tests/FunctionalTests/project.json
@@ -7,6 +7,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.Primitives/tests/PalTests/project.json
+++ b/src/System.Net.Primitives/tests/PalTests/project.json
@@ -15,6 +15,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.Primitives/tests/UnitTests/project.json
+++ b/src/System.Net.Primitives/tests/UnitTests/project.json
@@ -17,6 +17,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.Requests/tests/project.json
+++ b/src/System.Net.Requests/tests/project.json
@@ -7,6 +7,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.Security/src/unix/project.json
+++ b/src/System.Net.Security/src/unix/project.json
@@ -1,10 +1,10 @@
 {
   "dependencies": {
-    "System.Diagnostics.Contracts": "4.0.0-rc2-23616",
+    "System.Diagnostics.Contracts": "4.0.0",
     "System.Globalization.Extensions": "4.0.0",
-    "System.Threading": "4.0.10-rc2-23616",
+    "System.Threading": "4.0.10",
     "System.Threading.ThreadPool": "4.0.10-rc2-23616",
-    "System.Net.Primitives": "4.0.10-rc2-23616",
+    "System.Net.Primitives": "4.0.10",
     "System.Security.Cryptography.OpenSsl": "4.0.0-rc2-23616",
     "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23616",
     "System.Security.Principal": "4.0.0",

--- a/src/System.Net.Security/src/win/project.json
+++ b/src/System.Net.Security/src/win/project.json
@@ -7,7 +7,7 @@
     "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23616",
     "System.Security.Principal": "4.0.0",
     "System.Security.Principal.Windows": "4.0.0-rc2-23616",
-    "System.Collections.Specialized": "4.0.0-rc2-23616"
+    "System.Collections.Specialized": "4.0.0"
   },
   "frameworks": {
     "dnxcore50": {}

--- a/src/System.Net.Security/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/unix/project.json
@@ -9,6 +9,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.Security/tests/FunctionalTests/unix/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/unix/project.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "System.Net.Primitives": "4.0.10-rc2-23616",
+    "System.Net.Primitives": "4.0.10",
     "System.Net.Sockets": "4.1.0-rc2-23616",
     "System.Net.TestData": "1.0.0-prerelease",
-    "System.Security.Principal": "4.0.0-rc2-23616",
+    "System.Security.Principal": "4.0.0",
     "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23616",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"

--- a/src/System.Net.Security/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/win/project.json
@@ -1,9 +1,9 @@
 {
   "dependencies": {
-    "System.Net.Primitives": "4.0.10-rc2-23616",
+    "System.Net.Primitives": "4.0.10",
     "System.Net.Sockets": "4.1.0-rc2-23616",
     "System.Net.TestData": "1.0.0-prerelease",
-    "System.Security.Principal": "4.0.0-rc2-23616",
+    "System.Security.Principal": "4.0.0",
     "System.Security.Principal.Windows": "4.0.0-rc2-23616",
     "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23616",
     "xunit": "2.1.0",

--- a/src/System.Net.Security/tests/FunctionalTests/win/project.json
+++ b/src/System.Net.Security/tests/FunctionalTests/win/project.json
@@ -10,6 +10,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.Security/tests/UnitTests/project.json
+++ b/src/System.Net.Security/tests/UnitTests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "System.Net.Primitives": "4.0.10-rc2-23616",
+    "System.Net.Primitives": "4.0.10",
     "System.Net.Sockets": "4.1.0-rc2-23616",
     "System.Net.TestData": "1.0.0-prerelease",
     "System.Security.Cryptography.X509Certificates": "4.0.0-rc2-23616",

--- a/src/System.Net.Security/tests/UnitTests/project.json
+++ b/src/System.Net.Security/tests/UnitTests/project.json
@@ -8,6 +8,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/project.json
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/project.json
@@ -14,6 +14,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.Sockets.Legacy/tests/PerformanceTests/project.json
+++ b/src/System.Net.Sockets.Legacy/tests/PerformanceTests/project.json
@@ -11,6 +11,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.Sockets/tests/FunctionalTests/project.json
+++ b/src/System.Net.Sockets/tests/FunctionalTests/project.json
@@ -11,6 +11,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.Sockets/tests/PerformanceTests/project.json
+++ b/src/System.Net.Sockets/tests/PerformanceTests/project.json
@@ -11,6 +11,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.WebHeaderCollection/tests/project.json
+++ b/src/System.Net.WebHeaderCollection/tests/project.json
@@ -6,6 +6,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.WebSockets.Client/tests/project.json
+++ b/src/System.Net.WebSockets.Client/tests/project.json
@@ -8,6 +8,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Net.WebSockets/tests/project.json
+++ b/src/System.Net.WebSockets/tests/project.json
@@ -6,6 +6,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Numerics.Vectors/tests/project.json
+++ b/src/System.Numerics.Vectors/tests/project.json
@@ -16,6 +16,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.ObjectModel/tests/project.json
+++ b/src/System.ObjectModel/tests/project.json
@@ -12,6 +12,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Reflection.DispatchProxy/tests/project.json
+++ b/src/System.Reflection.DispatchProxy/tests/project.json
@@ -9,6 +9,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Reflection.Emit.ILGeneration/tests/project.json
+++ b/src/System.Reflection.Emit.ILGeneration/tests/project.json
@@ -12,6 +12,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Reflection.Emit.Lightweight/tests/project.json
+++ b/src/System.Reflection.Emit.Lightweight/tests/project.json
@@ -8,6 +8,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Reflection.Emit/tests/project.json
+++ b/src/System.Reflection.Emit/tests/project.json
@@ -11,6 +11,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Reflection.Extensions/tests/project.json
+++ b/src/System.Reflection.Extensions/tests/project.json
@@ -9,6 +9,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Reflection.Metadata/tests/project.json
+++ b/src/System.Reflection.Metadata/tests/project.json
@@ -20,6 +20,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Reflection.TypeExtensions/tests/CoreCLR/project.json
+++ b/src/System.Reflection.TypeExtensions/tests/CoreCLR/project.json
@@ -14,6 +14,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Reflection.TypeExtensions/tests/project.json
+++ b/src/System.Reflection.TypeExtensions/tests/project.json
@@ -10,6 +10,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Reflection/tests/CoreCLR/project.json
+++ b/src/System.Reflection/tests/CoreCLR/project.json
@@ -11,6 +11,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Reflection/tests/project.json
+++ b/src/System.Reflection/tests/project.json
@@ -13,6 +13,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Resources.Reader/tests/project.json
+++ b/src/System.Resources.Reader/tests/project.json
@@ -9,6 +9,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Resources.ReaderWriter/tests/project.json
+++ b/src/System.Resources.ReaderWriter/tests/project.json
@@ -9,6 +9,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Resources.ResourceManager/tests/project.json
+++ b/src/System.Resources.ResourceManager/tests/project.json
@@ -7,6 +7,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Resources.Writer/tests/project.json
+++ b/src/System.Resources.Writer/tests/project.json
@@ -9,6 +9,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Runtime.Extensions/tests/project.json
+++ b/src/System.Runtime.Extensions/tests/project.json
@@ -13,6 +13,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Runtime.Handles/tests/project.json
+++ b/src/System.Runtime.Handles/tests/project.json
@@ -6,6 +6,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/project.json
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/project.json
@@ -7,6 +7,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Runtime.InteropServices/tests/project.json
+++ b/src/System.Runtime.InteropServices/tests/project.json
@@ -5,6 +5,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Runtime.Loader/tests/project.json
+++ b/src/System.Runtime.Loader/tests/project.json
@@ -14,6 +14,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Runtime.Numerics/tests/project.json
+++ b/src/System.Runtime.Numerics/tests/project.json
@@ -10,6 +10,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Runtime.Serialization.Json/tests/project.json
+++ b/src/System.Runtime.Serialization.Json/tests/project.json
@@ -17,6 +17,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Runtime.Serialization.Xml/tests/project.json
+++ b/src/System.Runtime.Serialization.Xml/tests/project.json
@@ -20,6 +20,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Runtime/tests/project.json
+++ b/src/System.Runtime/tests/project.json
@@ -14,6 +14,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Security.Cryptography.Algorithms/tests/project.json
+++ b/src/System.Security.Cryptography.Algorithms/tests/project.json
@@ -9,6 +9,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Security.Cryptography.Cng/tests/project.json
+++ b/src/System.Security.Cryptography.Cng/tests/project.json
@@ -11,6 +11,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Security.Cryptography.Csp/tests/project.json
+++ b/src/System.Security.Cryptography.Csp/tests/project.json
@@ -9,6 +9,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Security.Cryptography.Encoding/tests/project.json
+++ b/src/System.Security.Cryptography.Encoding/tests/project.json
@@ -7,6 +7,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Security.Cryptography.OpenSsl/tests/project.json
+++ b/src/System.Security.Cryptography.OpenSsl/tests/project.json
@@ -10,6 +10,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Security.Cryptography.Primitives/tests/project.json
+++ b/src/System.Security.Cryptography.Primitives/tests/project.json
@@ -6,6 +6,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Security.Cryptography.X509Certificates/tests/project.json
+++ b/src/System.Security.Cryptography.X509Certificates/tests/project.json
@@ -13,6 +13,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Security.Principal.Windows/tests/project.json
+++ b/src/System.Security.Principal.Windows/tests/project.json
@@ -7,6 +7,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Security.Principal/tests/project.json
+++ b/src/System.Security.Principal/tests/project.json
@@ -5,6 +5,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/project.json
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/project.json
@@ -9,6 +9,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/project.json
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.Win32.Registry": "4.0.0-rc2-23616",
-    "System.Diagnostics.Process": "4.0.0-rc2-23616",
+    "System.Diagnostics.Process": "4.1.0-rc2-23616",
     "System.Runtime": "4.0.20",
     "System.Security.Principal.Windows": "4.0.0-rc2-23616",
     "System.Threading.Tasks": "4.0.10",

--- a/src/System.Text.Encoding.CodePages/tests/project.json
+++ b/src/System.Text.Encoding.CodePages/tests/project.json
@@ -8,6 +8,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Text.Encoding.Extensions/tests/project.json
+++ b/src/System.Text.Encoding.Extensions/tests/project.json
@@ -7,6 +7,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Text.Encoding/tests/project.json
+++ b/src/System.Text.Encoding/tests/project.json
@@ -11,6 +11,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Text.Encodings.Web/tests/project.json
+++ b/src/System.Text.Encodings.Web/tests/project.json
@@ -10,6 +10,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Text.RegularExpressions/tests/project.json
+++ b/src/System.Text.RegularExpressions/tests/project.json
@@ -10,6 +10,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Threading.Overlapped/tests/project.json
+++ b/src/System.Threading.Overlapped/tests/project.json
@@ -5,6 +5,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Threading.Tasks.Dataflow/tests/project.json
+++ b/src/System.Threading.Tasks.Dataflow/tests/project.json
@@ -15,6 +15,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Threading.Tasks.Extensions/tests/project.json
+++ b/src/System.Threading.Tasks.Extensions/tests/project.json
@@ -6,6 +6,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Threading.Tasks.Parallel/tests/project.json
+++ b/src/System.Threading.Tasks.Parallel/tests/project.json
@@ -13,6 +13,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Threading.Tasks/tests/project.json
+++ b/src/System.Threading.Tasks/tests/project.json
@@ -13,6 +13,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Threading.Timer/tests/project.json
+++ b/src/System.Threading.Timer/tests/project.json
@@ -8,6 +8,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Threading/tests/project.json
+++ b/src/System.Threading/tests/project.json
@@ -11,6 +11,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.ReaderWriter/tests/Readers/CharCheckingReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CharCheckingReader/project.json
@@ -7,6 +7,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/CustomReader/project.json
@@ -7,6 +7,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/FactoryReader/project.json
@@ -7,6 +7,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.ReaderWriter/tests/Readers/NameTable/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/NameTable/project.json
@@ -9,6 +9,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/project.json
@@ -10,6 +10,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.ReaderWriter/tests/Readers/SubtreeReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/SubtreeReader/project.json
@@ -7,6 +7,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.ReaderWriter/tests/Readers/WrappedReader/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Readers/WrappedReader/project.json
@@ -7,6 +7,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/project.json
@@ -12,6 +12,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/project.json
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/project.json
@@ -12,6 +12,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/project.json
@@ -7,6 +7,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/ReadContentAs/project.json
@@ -8,6 +8,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/Tests/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/Tests/project.json
@@ -9,6 +9,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReader/XmlResolver/project.json
@@ -11,6 +11,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/project.json
@@ -10,6 +10,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.ReaderWriter/tests/XmlWriter/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlWriter/project.json
@@ -11,6 +11,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.XDocument/tests/Properties/project.json
+++ b/src/System.Xml.XDocument/tests/Properties/project.json
@@ -13,6 +13,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.XDocument/tests/SDMSample/project.json
+++ b/src/System.Xml.XDocument/tests/SDMSample/project.json
@@ -12,6 +12,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.XDocument/tests/Streaming/project.json
+++ b/src/System.Xml.XDocument/tests/Streaming/project.json
@@ -11,6 +11,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.XDocument/tests/TreeManipulation/project.json
+++ b/src/System.Xml.XDocument/tests/TreeManipulation/project.json
@@ -12,6 +12,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.XDocument/tests/XDocument.Common/project.json
+++ b/src/System.Xml.XDocument/tests/XDocument.Common/project.json
@@ -13,6 +13,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.XDocument/tests/XDocument.Test.ModuleCore/project.json
+++ b/src/System.Xml.XDocument/tests/XDocument.Test.ModuleCore/project.json
@@ -12,6 +12,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.XDocument/tests/axes/project.json
+++ b/src/System.Xml.XDocument/tests/axes/project.json
@@ -9,6 +9,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.XDocument/tests/events/project.json
+++ b/src/System.Xml.XDocument/tests/events/project.json
@@ -10,6 +10,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.XDocument/tests/misc/project.json
+++ b/src/System.Xml.XDocument/tests/misc/project.json
@@ -11,6 +11,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.XDocument/tests/xNodeBuilder/project.json
+++ b/src/System.Xml.XDocument/tests/xNodeBuilder/project.json
@@ -14,6 +14,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.XDocument/tests/xNodeReader/project.json
+++ b/src/System.Xml.XDocument/tests/xNodeReader/project.json
@@ -12,6 +12,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.XPath.XDocument/tests/project.json
+++ b/src/System.Xml.XPath.XDocument/tests/project.json
@@ -15,6 +15,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.XPath.XmlDocument/tests/project.json
+++ b/src/System.Xml.XPath.XmlDocument/tests/project.json
@@ -15,6 +15,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.XPath/tests/project.json
+++ b/src/System.Xml.XPath/tests/project.json
@@ -13,6 +13,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.XmlDocument/tests/project.json
+++ b/src/System.Xml.XmlDocument/tests/project.json
@@ -8,6 +8,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }

--- a/src/System.Xml.XmlSerializer/tests/project.json
+++ b/src/System.Xml.XmlSerializer/tests/project.json
@@ -18,6 +18,8 @@
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
   }
 }


### PR DESCRIPTION
I ran a script to fix two problems we've been having with the project.json files during package restore with NuGet. (DNU restore doesn't surface these issues.)

### xunit DNXCore incompatibility

`xunit.abstractions 2.0.0 is not compatible with DNXCore,Version=v5.0.` This is the main issue in https://github.com/dotnet/corefx/issues/4771

This fix for this is [to add an import:](https://github.com/dotnet/corefx/issues/4448#issuecomment-156255106)

	"frameworks": {
	  "dnxcore50": {
	    "imports": "portable-net45+win8"
	  }
	}

My tool looked at every project.json, and if it contained `xunit` it added the imports statement.

### Dependencies on packages that don't exist

An easy way to accidentally depend on a nonexistent package is to upgrade the repository-wide prerelease version, leaving the minor/patch version out of date for any packages that have had a release since the last prerelease upgrade.

A "best" match is found during restore, but will depend on what the sources contain. This also causes network requests during every restore, because (like floating dependencies) there's no way to tell if the already-restored version is the correct one.

The tool that fixes this looks at all project.lock.json files from a restore. When it sees that the restored package wasn't what was requested, it has two options:

1. If a prerelease was fulfilled by a stable package, change to the stable version.
2. If a prerelease was fulfilled by a different prerelease package, run `nuget list` to find a version with the requested prerelease.

[Here's a list](https://gist.github.com/dagood/05f074fe6eb2c756cc80) of all the changes the tool made to fix the invalid versions.

---

I'm submitting this now (rather than including it in the changes to allow nuget.exe restore) to fix https://github.com/dotnet/corefx/issues/4771 and segment out the changes a little.

cc: @ericstj