### PR TITLE
Adding System.Buffers support to the System.IO.Compression namespace

### DIFF
--- a/src/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.cs
+++ b/src/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
@@ -504,38 +505,45 @@ namespace System.IO.Compression
                 // to be greater than the length of typical entry names from the file system, even
                 // on non-Windows platforms. The capacity will be increased, if needed.
                 const int DefaultCapacity = 260;
-                char[] entryNameBuffer = new char[DefaultCapacity];
+                char[] entryNameBuffer = ArrayPool<char>.Shared.Rent(DefaultCapacity);
 
-                foreach (FileSystemInfo file in di.EnumerateFileSystemInfos("*", SearchOption.AllDirectories))
+                try
                 {
-                    directoryIsEmpty = false;
-
-                    Int32 entryNameLength = file.FullName.Length - basePath.Length;
-                    Debug.Assert(entryNameLength > 0);
-
-                    if (file is FileInfo)
+                    foreach (FileSystemInfo file in di.EnumerateFileSystemInfos("*", SearchOption.AllDirectories))
                     {
-                        // Create entry for file:
-                        String entryName = EntryFromPath(file.FullName, basePath.Length, entryNameLength, ref entryNameBuffer);
-                        ZipFileExtensions.DoCreateEntryFromFile(archive, file.FullName, entryName, compressionLevel);
-                    }
-                    else
-                    {
-                        // Entry marking an empty dir:
-                        DirectoryInfo possiblyEmpty = file as DirectoryInfo;
-                        if (possiblyEmpty != null && IsDirEmpty(possiblyEmpty))
+                        directoryIsEmpty = false;
+
+                        Int32 entryNameLength = file.FullName.Length - basePath.Length;
+                        Debug.Assert(entryNameLength > 0);
+
+                        if (file is FileInfo)
                         {
-                            // FullName never returns a directory separator character on the end,
-                            // but Zip archives require it to specify an explicit directory:
-                            String entryName = EntryFromPath(file.FullName, basePath.Length, entryNameLength, ref entryNameBuffer, appendPathSeparator: true);
-                            archive.CreateEntry(entryName);
+                            // Create entry for file:
+                            String entryName = EntryFromPath(file.FullName, basePath.Length, entryNameLength, ref entryNameBuffer);
+                            ZipFileExtensions.DoCreateEntryFromFile(archive, file.FullName, entryName, compressionLevel);
                         }
-                    }
-                }  // foreach
+                        else
+                        {
+                            // Entry marking an empty dir:
+                            DirectoryInfo possiblyEmpty = file as DirectoryInfo;
+                            if (possiblyEmpty != null && IsDirEmpty(possiblyEmpty))
+                            {
+                                // FullName never returns a directory separator character on the end,
+                                // but Zip archives require it to specify an explicit directory:
+                                String entryName = EntryFromPath(file.FullName, basePath.Length, entryNameLength, ref entryNameBuffer, appendPathSeparator: true);
+                                archive.CreateEntry(entryName);
+                            }
+                        }
+                    }  // foreach
 
-                // If no entries create an empty root directory entry:
-                if (includeBaseDirectory && directoryIsEmpty)
-                    archive.CreateEntry(EntryFromPath(di.Name, 0, di.Name.Length, ref entryNameBuffer, appendPathSeparator: true));
+                    // If no entries create an empty root directory entry:
+                    if (includeBaseDirectory && directoryIsEmpty)
+                        archive.CreateEntry(EntryFromPath(di.Name, 0, di.Name.Length, ref entryNameBuffer, appendPathSeparator: true));
+                }
+                finally
+                {
+                    ArrayPool<char>.Shared.Return(entryNameBuffer);
+                }
 
             } // using
         }  // DoCreateFromDirectory
@@ -588,7 +596,8 @@ namespace System.IO.Compression
             {
                 int newCapacity = buffer.Length * 2;
                 if (newCapacity < min) newCapacity = min;
-                buffer = new char[newCapacity];
+                ArrayPool<char>.Shared.Return(buffer);
+                buffer = ArrayPool<char>.Shared.Rent(newCapacity);
             }
         }
 

--- a/src/System.IO.Compression.ZipFile/src/project.json
+++ b/src/System.IO.Compression.ZipFile/src/project.json
@@ -2,6 +2,7 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
+        "System.Buffers" : "4.0.0-rc2-23712",
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",

--- a/src/System.IO.Compression.ZipFile/tests/project.json
+++ b/src/System.IO.Compression.ZipFile/tests/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "System.Buffers" : "4.0.0-rc2-23712",
     "System.Collections": "4.0.10",
     "System.Console": "4.0.0-rc2-23712",
     "System.Diagnostics.Debug": "4.0.10",

--- a/src/System.IO.Compression/src/System.IO.Compression.csproj
+++ b/src/System.IO.Compression/src/System.IO.Compression.csproj
@@ -85,6 +85,7 @@
     <Compile Include="AssemblyInfo.cs" />
     <TargetingPackReference Include="mscorlib" />
     <TargetingPackReference Include="System" />
+    <TargetingPackReference Include="System.Runtime" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateStream.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -94,7 +95,7 @@ namespace System.IO.Compression
             _stream = stream;
             _mode = CompressionMode.Decompress;
             _leaveOpen = leaveOpen;
-            _buffer = new byte[DefaultBufferSize];
+            _buffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
         }
 
         /// <summary>
@@ -111,7 +112,7 @@ namespace System.IO.Compression
             _stream = stream;
             _mode = CompressionMode.Compress;
             _leaveOpen = leaveOpen;
-            _buffer = new byte[DefaultBufferSize];
+            _buffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
         }
 
         #endregion
@@ -531,6 +532,9 @@ namespace System.IO.Compression
                     }
                     finally
                     {
+                        if (_buffer != null)
+                            ArrayPool<byte>.Shared.Return(_buffer, clearArray: true);
+                        _buffer = null;
                         _deflater = null;
                         _inflater = null;
                         base.Dispose(disposing);

--- a/src/System.IO.Compression/src/System/IO/Compression/ZipHelper.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/ZipHelper.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Buffers;
 using System.Diagnostics;
 using System.Diagnostics.Contracts;
 
@@ -106,29 +107,36 @@ namespace System.IO.Compression
         {
             Int32 bufferPointer = 0;
             UInt32 currentSignature = 0;
-            Byte[] buffer = new Byte[BackwardsSeekingBufferSize];
+            Byte[] buffer = ArrayPool<byte>.Shared.Rent(BackwardsSeekingBufferSize);
 
             Boolean outOfBytes = false;
             Boolean signatureFound = false;
 
-            while (!signatureFound && !outOfBytes)
+            try
             {
-                outOfBytes = SeekBackwardsAndRead(stream, buffer, out bufferPointer);
-
-                Debug.Assert(bufferPointer < buffer.Length);
-
-                while (bufferPointer >= 0 && !signatureFound)
+                while (!signatureFound && !outOfBytes)
                 {
-                    currentSignature = (currentSignature << 8) | ((UInt32)buffer[bufferPointer]);
-                    if (currentSignature == signatureToFind)
+                    outOfBytes = SeekBackwardsAndRead(stream, buffer, out bufferPointer);
+
+                    Debug.Assert(bufferPointer < buffer.Length);
+
+                    while (bufferPointer >= 0 && !signatureFound)
                     {
-                        signatureFound = true;
-                    }
-                    else
-                    {
-                        bufferPointer--;
+                        currentSignature = (currentSignature << 8) | ((UInt32)buffer[bufferPointer]);
+                        if (currentSignature == signatureToFind)
+                        {
+                            signatureFound = true;
+                        }
+                        else
+                        {
+                            bufferPointer--;
+                        }
                     }
                 }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
             }
 
             if (!signatureFound)

--- a/src/System.IO.Compression/src/project.json
+++ b/src/System.IO.Compression/src/project.json
@@ -2,6 +2,7 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
+        "System.Buffers" : "4.0.0-rc2-23712",
         "System.Collections": "4.0.10",
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",
@@ -19,7 +20,8 @@
     },
     "net46": {
       "dependencies": {
-        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0"
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0",
+        "System.Buffers" : "4.0.0-rc2-23712"
       }
     }
   }

--- a/src/System.IO.Compression/tests/project.json
+++ b/src/System.IO.Compression/tests/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0025",
+    "System.Buffers" : "4.0.0-rc2-23712",
     "System.Collections": "4.0.10",
     "System.Console": "4.0.0-rc2-23712",
     "System.Diagnostics.Debug": "4.0.10",


### PR DESCRIPTION
Changing the System.IO.Compression namespace to utilize the System.Buffers implementation, which allows for pooling of byte[] and char[] buffers, which should reduce GC pressure and overhead since the buffers will reused instead of allocated on-demand each time. 

This should fix issues #4875 and #1991

/cc @stephentoub 
/fyi: @KrzysztofCwalina 