### PR TITLE
Port additional WebSocket tests

### DIFF
--- a/src/Common/tests/System/Net/HttpTestServers.cs
+++ b/src/Common/tests/System/Net/HttpTestServers.cs
@@ -7,7 +7,7 @@ namespace System.Net.Tests
 {
     internal class HttpTestServers
     {
-        public const string Host = "corefx-net.azurewebsites.net";
+        public const string Host = "corefx-net.cloudapp.net";
         public const string Http2Host = "http2.akamai.com";
 
         private const string HttpScheme = "http";

--- a/src/Common/tests/System/Net/WebSocketTestServers.cs
+++ b/src/Common/tests/System/Net/WebSocketTestServers.cs
@@ -5,7 +5,7 @@ namespace System.Net.Tests
 {
     internal class WebSocketTestServers
     {
-        public const string Host = "corefx-net.azurewebsites.net";
+        public const string Host = "corefx-net.cloudapp.net";
 
         private const string EchoHandler = "WebSocket/EchoWebSocket.ashx";
         private const string EchoHeadersHandler = "WebSocket/EchoWebSocketHeaders.ashx";


### PR DESCRIPTION
Port remaining websocket client tests dealing with close handshake semantics including "server initiated" close handshakes.

Switch networking test servers to the newer Azure Cloud Service servers which work better with websocket close handshakes.