### PR TITLE
Add support for XmlElement for data contract serializers

### DIFF
--- a/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
+++ b/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
@@ -1098,4 +1098,7 @@
   <data name="FactoryObjectContainsSelfReference" xml:space="preserve">
     <value>Object graph of type '{0}' with Id '{2}' contains a reference to itself. The object has been replaced with a new object of type '{1}' either because it implements IObjectReference or because it is surrogated. The serializer does not support fixing up the nested reference to the new object and cannot deserialize this object. Consider changing the object to remove the nested self-reference.</value>
   </data>
+  <data name="UnknownXmlType" xml:space="preserve">
+    <value>Type '{0}' is not a valid XML type.</value>
+  </data>
 </root>

--- a/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
+++ b/src/System.Private.DataContractSerialization/src/System.Private.DataContractSerialization.csproj
@@ -76,6 +76,7 @@
     <Compile Include="$(RuntimeSerializationSources)\BitFlagsGenerator.cs" Condition="!$(NetNative)" />
     <Compile Include="$(RuntimeSerializationSources)\DataContractSurrogateCaller.cs" />
     <Compile Include="$(RuntimeSerializationSources)\DataContractSerializerExtensions.cs" />
+    <Compile Include="$(RuntimeSerializationSources)\XmlSerializableServices.cs" />
     <Compile Include="$(XmlSources)\ArrayHelper.cs" />
     <Compile Include="$(XmlSources)\BytesWithOffset.cs" />
     <Compile Include="$(XmlSources)\XmlDictionaryAsyncCheckWriter.cs" />

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -712,7 +712,7 @@ namespace System.Runtime.Serialization
             }
 
             [MethodImpl(MethodImplOptions.NoInlining)]
-            static void AssignDataContractToId(DataContract dataContract, int id)
+            private static void AssignDataContractToId(DataContract dataContract, int id)
             {
                 lock (s_cacheLock)
                 {
@@ -903,6 +903,8 @@ namespace System.Runtime.Serialization
                         }
                         else if (type == typeof(Array))
                             dataContract = new CollectionDataContract(type);
+                        else if (type == typeof(XmlElement) || type == typeof(XmlNode[]))
+                            dataContract = new XmlDataContract(type);
                         break;
                 }
 #endif
@@ -963,6 +965,13 @@ namespace System.Runtime.Serialization
                         dataContract = new CharDataContract();
                     else if ("ArrayOfanyType" == name)
                         dataContract = new CollectionDataContract(typeof(Array));
+                }
+                else if (ns == Globals.DataContractXmlNamespace)
+                {
+                    if (name == "XmlElement")
+                        dataContract = new XmlDataContract(typeof(XmlElement));
+                    else if (name == "ArrayOfXmlNode")
+                        dataContract = new XmlDataContract(typeof(XmlNode[]));
                 }
                 return dataContract != null;
             }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializerExtensions.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContractSerializerExtensions.cs
@@ -5,7 +5,7 @@ namespace System.Runtime.Serialization
 {
     public static class DataContractSerializerExtensions
     {
-        public static ISerializationSurrogateProvider GetSerializationSurrogateProvider(this DataContractSerializer serializer) 
+        public static ISerializationSurrogateProvider GetSerializationSurrogateProvider(this DataContractSerializer serializer)
         {
             return serializer.SerializationSurrogateProvider;
         }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
@@ -851,6 +851,32 @@ namespace System.Runtime.Serialization
             }
         }
 
+        [SecurityCritical]
+        private static Type s_typeOfXmlElement;
+        internal static Type TypeOfXmlElement
+        {
+            [SecuritySafeCritical]
+            get
+            {
+                if (s_typeOfXmlElement == null)
+                    s_typeOfXmlElement = typeof(XmlElement);
+                return s_typeOfXmlElement;
+            }
+        }
+
+        [SecurityCritical]
+        private static Type s_typeOfXmlNodeArray;
+        internal static Type TypeOfXmlNodeArray
+        {
+            [SecuritySafeCritical]
+            get
+            {
+                if (s_typeOfXmlNodeArray == null)
+                    s_typeOfXmlNodeArray = typeof(XmlNode[]);
+                return s_typeOfXmlNodeArray;
+            }
+        }
+
         private static bool s_shouldGetDBNullType = true;
 
         [SecurityCritical]

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerWriteContextComplexJson.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/XmlObjectSerializerWriteContextComplexJson.cs
@@ -125,7 +125,7 @@ namespace System.Runtime.Serialization.Json
                    object.ReferenceEquals(contract.Namespace, declaredContract.Namespace)) ||
                  (contract.Name.Value == declaredContract.Name.Value &&
                  contract.Namespace.Value == declaredContract.Namespace.Value)) &&
-                 (contract.UnderlyingType != Globals.TypeOfObjectArray) && 
+                 (contract.UnderlyingType != Globals.TypeOfObjectArray) &&
                  (_emitXsiType != EmitTypeInformation.Never))
             {
                 // We always deserialize collections assigned to System.Object as object[]

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/SchemaExporter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/SchemaExporter.cs
@@ -87,10 +87,33 @@ namespace System.Runtime.Serialization
             return new Object();
         }
 
+        private static XmlSchemaComplexType CreateAnyType()
+        {
+            return new Object();
+        }
+
         internal static bool IsSpecialXmlType(Type type, out XmlQualifiedName typeName, out XmlSchemaType xsdType, out bool hasRoot)
         {
             xsdType = null;
             hasRoot = true;
+            if (type == Globals.TypeOfXmlElement || type == Globals.TypeOfXmlNodeArray)
+            {
+                string name = null;
+                if (type == Globals.TypeOfXmlElement)
+                {
+                    xsdType = CreateAnyElementType();
+                    name = "XmlElement";
+                    hasRoot = false;
+                }
+                else
+                {
+                    xsdType = CreateAnyType();
+                    name = "ArrayOfXmlNode";
+                    hasRoot = true;
+                }
+                typeName = new XmlQualifiedName(name, DataContract.GetDefaultStableNamespace(type));
+                return true;
+            }
             typeName = null;
             return false;
         }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlDataContract.cs
@@ -168,7 +168,7 @@ namespace System.Runtime.Serialization
         {
             get
             {
-                return false;
+                return UnderlyingType == Globals.TypeOfXmlElement || UnderlyingType == Globals.TypeOfXmlNodeArray;
             }
         }
         [SecurityCritical]

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerReadContext.cs
@@ -539,6 +539,18 @@ namespace System.Runtime.Serialization
                 xmlReader.Read();
                 xmlReader.MoveToContent();
             }
+            if (xmlDataContract.UnderlyingType == Globals.TypeOfXmlElement)
+            {
+                if (!xmlReader.IsStartElement())
+                    throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(CreateUnexpectedStateException(XmlNodeType.Element, xmlReader));
+                XmlDocument xmlDoc = new XmlDocument();
+                obj = (XmlElement)xmlDoc.ReadNode(xmlSerializableReader);
+            }
+            else if (xmlDataContract.UnderlyingType == Globals.TypeOfXmlNodeArray)
+            {
+                obj = XmlSerializableServices.ReadNodes(xmlSerializableReader);
+            }
+            else
             {
                 IXmlSerializable xmlSerializable = xmlDataContract.CreateXmlSerializableDelegate();
                 xmlSerializable.ReadXml(xmlSerializableReader);

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerWriteContext.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlObjectSerializerWriteContext.cs
@@ -555,6 +555,21 @@ namespace System.Runtime.Serialization
             IXmlSerializable xmlSerializable = obj as IXmlSerializable;
             if (xmlSerializable != null)
                 xmlSerializable.WriteXml(xmlSerializableWriter);
+            else
+            {
+                XmlElement xmlElement = obj as XmlElement;
+                if (xmlElement != null)
+                    xmlElement.WriteTo(xmlSerializableWriter);
+                else
+                {
+                    XmlNode[] xmlNodes = obj as XmlNode[];
+                    if (xmlNodes != null)
+                        foreach (XmlNode xmlNode in xmlNodes)
+                            xmlNode.WriteTo(xmlSerializableWriter);
+                    else
+                        throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.UnknownXmlType, DataContract.GetClrTypeFullName(obj.GetType()))));
+                }
+            }
             xmlSerializableWriter.EndWrite();
         }
 

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlSerializableServices.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlSerializableServices.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Runtime.Serialization
+{
+    using System.Collections.Generic;
+    using System.Xml;
+    using System.Xml.Schema;
+
+    public static class XmlSerializableServices
+    {
+        internal static readonly string ReadNodesMethodName = "ReadNodes";
+        public static XmlNode[] ReadNodes(XmlReader xmlReader)
+        {
+            if (xmlReader == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("xmlReader");
+            XmlDocument doc = new XmlDocument();
+            List<XmlNode> nodeList = new List<XmlNode>();
+            if (xmlReader.MoveToFirstAttribute())
+            {
+                do
+                {
+                    if (IsValidAttribute(xmlReader))
+                    {
+                        XmlNode node = doc.ReadNode(xmlReader);
+                        if (node == null)
+                            throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.UnexpectedEndOfFile));
+                        nodeList.Add(node);
+                    }
+                } while (xmlReader.MoveToNextAttribute());
+            }
+            xmlReader.MoveToElement();
+            if (!xmlReader.IsEmptyElement)
+            {
+                int startDepth = xmlReader.Depth;
+                xmlReader.Read();
+                while (xmlReader.Depth > startDepth && xmlReader.NodeType != XmlNodeType.EndElement)
+                {
+                    XmlNode node = doc.ReadNode(xmlReader);
+                    if (node == null)
+                        throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.UnexpectedEndOfFile));
+                    nodeList.Add(node);
+                }
+            }
+            return nodeList.ToArray();
+        }
+
+        private static bool IsValidAttribute(XmlReader xmlReader)
+        {
+            return xmlReader.NamespaceURI != Globals.SerializationNamespace &&
+                                   xmlReader.NamespaceURI != Globals.SchemaInstanceNamespace &&
+                                   xmlReader.Prefix != "xmlns" &&
+                                   xmlReader.LocalName != "xmlns";
+        }
+
+        internal static string WriteNodesMethodName = "WriteNodes";
+        public static void WriteNodes(XmlWriter xmlWriter, XmlNode[] nodes)
+        {
+            if (xmlWriter == null)
+                throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperArgumentNull("xmlWriter");
+            if (nodes != null)
+                for (int i = 0; i < nodes.Length; i++)
+                    if (nodes[i] != null)
+                        nodes[i].WriteTo(xmlWriter);
+        }
+    }
+}

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -1722,6 +1722,36 @@ public static partial class DataContractJsonSerializerTests
         });
     }
 
+    [Fact]
+    public static void DCJS_XmlElementAsRoot()
+    {
+        XmlDocument xDoc = new XmlDocument();
+        xDoc.LoadXml(@"<html></html>");
+        XmlElement expected = xDoc.CreateElement("Element");
+        expected.InnerText = "Element innertext";
+        var actual = SerializeAndDeserialize(expected, @"""<Element>Element innertext<\/Element>""");
+        Assert.NotNull(actual);
+        Assert.StrictEqual(expected.InnerText, actual.InnerText);
+    }
+
+    [Fact]
+    public static void DCJS_TypeWithXmlElementProperty()
+    {
+        XmlDocument xDoc = new XmlDocument();
+        xDoc.LoadXml(@"<html></html>");
+        XmlElement productElement = xDoc.CreateElement("Product");
+        productElement.InnerText = "Product innertext";
+        XmlElement categoryElement = xDoc.CreateElement("Category");
+        categoryElement.InnerText = "Category innertext";
+        var expected = new TypeWithXmlElementProperty() { Elements = new[] { productElement, categoryElement } };
+        var actual = SerializeAndDeserialize(expected, @"{""Elements"":[""<Product>Product innertext<\/Product>"",""<Category>Category innertext<\/Category>""]}");
+        Assert.StrictEqual(expected.Elements.Length, actual.Elements.Length);
+        for (int i = 0; i < expected.Elements.Length; ++i)
+        {
+            Assert.StrictEqual(expected.Elements[i].InnerText, actual.Elements[i].InnerText);
+        }
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractJsonSerializerSettings settings = null, Func<DataContractJsonSerializer> serializerFactory = null, bool skipStringCompare = false)
     {
         DataContractJsonSerializer dcjs;

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -1972,6 +1972,38 @@ public static partial class DataContractSerializerTests
         });
     }
 
+    [Fact]
+    public static void DCS_XmlElementAsRoot()
+    {
+        XmlDocument xDoc = new XmlDocument();
+        xDoc.LoadXml(@"<html></html>");
+        XmlElement expected = xDoc.CreateElement("Element");
+        expected.InnerText = "Element innertext";
+        var actual = SerializeAndDeserialize(expected,
+@"<Element>Element innertext</Element>");
+        Assert.NotNull(actual);
+        Assert.StrictEqual(expected.InnerText, actual.InnerText);
+    }
+
+    [Fact]
+    public static void DCS_TypeWithXmlElementProperty()
+    {
+        XmlDocument xDoc = new XmlDocument();
+        xDoc.LoadXml(@"<html></html>");
+        XmlElement productElement = xDoc.CreateElement("Product");
+        productElement.InnerText = "Product innertext";
+        XmlElement categoryElement = xDoc.CreateElement("Category");
+        categoryElement.InnerText = "Category innertext";
+        var expected = new TypeWithXmlElementProperty() { Elements = new[] { productElement, categoryElement } };
+        var actual = SerializeAndDeserialize(expected,
+@"<TypeWithXmlElementProperty xmlns=""http://schemas.datacontract.org/2004/07/"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><Elements xmlns:a=""http://schemas.datacontract.org/2004/07/System.Xml""><a:XmlElement><Product xmlns="""">Product innertext</Product></a:XmlElement><a:XmlElement><Category xmlns="""">Category innertext</Category></a:XmlElement></Elements></TypeWithXmlElementProperty>");
+        Assert.StrictEqual(expected.Elements.Length, actual.Elements.Length);
+        for (int i = 0; i < expected.Elements.Length; ++i)
+        {
+            Assert.StrictEqual(expected.Elements[i].InnerText, actual.Elements[i].InnerText);
+        }
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractSerializerSettings settings = null, Func<DataContractSerializer> serializerFactory = null, bool skipStringCompare = false)
     {
         DataContractSerializer dcs;


### PR DESCRIPTION
This change is porting the support for XmlElement from Desktop implementation to data contract serializers.

@shmao @SGuyGe @zhenlan 