### PR TITLE
Expose AppContext.TargetFrameworkName in the contracts

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -243,6 +243,8 @@
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('netcore50aot'))">netcore50aot</TargetGroup>
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('netcore50'))">netcore50</TargetGroup>
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('dnxcore50'))">dnxcore50</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('net462'))">net462</TargetGroup>
+    <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('net461'))">net461</TargetGroup>
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('net46'))">net46</TargetGroup>
     <TargetGroup Condition="'$(TargetGroup)'=='' and $(Configuration.Contains('net45'))">net45</TargetGroup>
   </PropertyGroup>
@@ -342,6 +344,20 @@
         <PackageTargetFramework>dnxcore50</PackageTargetFramework>
         <TargetingPackNugetPackageId>Microsoft.TargetingPack.Private.CoreCLR</TargetingPackNugetPackageId>
         <NuGetTargetMoniker>DNXCore,Version=v5.0</NuGetTargetMoniker>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(TargetGroup)'=='net462'">
+      <PropertyGroup>
+        <PackageTargetFramework>net462</PackageTargetFramework>
+        <TargetingPackNugetPackageId>Microsoft.TargetingPack.NETFramework.v4.6.2</TargetingPackNugetPackageId>
+        <NuGetTargetMoniker>.NETFramework,Version=v4.6.2</NuGetTargetMoniker>
+      </PropertyGroup>
+    </When>
+    <When Condition="'$(TargetGroup)'=='net461'">
+      <PropertyGroup>
+        <PackageTargetFramework>net461</PackageTargetFramework>
+        <TargetingPackNugetPackageId>Microsoft.TargetingPack.NETFramework.v4.6.1</TargetingPackNugetPackageId>
+        <NuGetTargetMoniker>.NETFramework,Version=v4.6.1</NuGetTargetMoniker>
       </PropertyGroup>
     </When>
     <When Condition="'$(TargetGroup)'=='net46'">

--- a/src/System.AppContext/pkg/System.AppContext.pkgproj
+++ b/src/System.AppContext/pkg/System.AppContext.pkgproj
@@ -3,8 +3,11 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
 
   <ItemGroup>
+    <ProjectReference Include="..\ref\4.0.0\System.AppContext.depproj">
+      <SupportedFramework>net46</SupportedFramework>
+    </ProjectReference>
     <ProjectReference Include="..\ref\System.AppContext.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.AppContext.builds" />
   </ItemGroup>

--- a/src/System.AppContext/ref/4.0.0/System.AppContext.depproj
+++ b/src/System.AppContext/ref/4.0.0/System.AppContext.depproj
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETPlatform,Version=v5.4</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.AppContext/ref/4.0.0/project.json
+++ b/src/System.AppContext/ref/4.0.0/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.AppContext": "4.0.0"
+  },
+  "frameworks": {
+    "dotnet5.4": {}
+  }
+}

--- a/src/System.AppContext/ref/System.AppContext.cs
+++ b/src/System.AppContext/ref/System.AppContext.cs
@@ -12,5 +12,6 @@ namespace System
         public static string BaseDirectory { get { return default(string); } }
         public static void SetSwitch(string switchName, bool isEnabled) { }
         public static bool TryGetSwitch(string switchName, out bool isEnabled) { isEnabled = default(bool); return default(bool); }
+        public static string TargetFrameworkName { get { return default(string); } }
     }
 }

--- a/src/System.AppContext/ref/System.AppContext.csproj
+++ b/src/System.AppContext/ref/System.AppContext.csproj
@@ -2,10 +2,10 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETPlatform,Version=v5.4</NuGetTargetMoniker>
+    <PackageTargetFramework>dotnet5.6</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETPlatform,Version=v5.6</NuGetTargetMoniker>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System.AppContext.cs" />

--- a/src/System.AppContext/src/System.AppContext.builds
+++ b/src/System.AppContext/src/System.AppContext.builds
@@ -4,6 +4,9 @@
   <ItemGroup>
     <Project Include="System.AppContext.csproj" />
     <Project Include="System.AppContext.csproj">
+      <TargetGroup>net462</TargetGroup>
+    </Project>
+    <Project Include="redist\System.AppContext.depproj">
       <TargetGroup>net46</TargetGroup>
     </Project>
     <Project Include="System.AppContext.csproj">

--- a/src/System.AppContext/src/System.AppContext.csproj
+++ b/src/System.AppContext/src/System.AppContext.csproj
@@ -5,9 +5,9 @@
     <AssemblyName>System.AppContext</AssemblyName>
     <ProjectGuid>{5522BAFC-E2FF-4896-993A-401DDEDFD85F}</ProjectGuid>
     <ClsCompliant>true</ClsCompliant>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)'!='netcore50'">true</IsPartialFacadeAssembly>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.6</PackageTargetFramework>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.AppContext/src/System.AppContext.csproj
+++ b/src/System.AppContext/src/System.AppContext.csproj
@@ -8,6 +8,8 @@
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)'!='netcore50'">true</IsPartialFacadeAssembly>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.6</PackageTargetFramework>
+    <!-- The following line needs to be removed once we have a targeting pack for 4.6.2 -->
+    <TargetingPackNugetPackageId Condition="'$(TargetGroup)'=='net462'">Microsoft.TargetingPack.NETFramework.v4.6</TargetingPackNugetPackageId>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.AppContext/src/project.json
+++ b/src/System.AppContext/src/project.json
@@ -14,7 +14,7 @@
         "System.Threading": "4.0.0"
       }
     },
-    "net46":{
+    "net462":{
       "dependencies": {
         "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0",
       }

--- a/src/System.AppContext/src/redist/System.AppContext.depproj
+++ b/src/System.AppContext/src/redist/System.AppContext.depproj
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">net46_Debug</Configuration>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>net46</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETFramework,Version=v4.6</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.AppContext/src/redist/project.json
+++ b/src/System.AppContext/src/redist/project.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
-    "System.Runtime": "4.0.0"
+    "System.AppContext": "4.0.0"
   },
   "frameworks": {
-    "dotnet5.6": {}
+    "net46": {}
   }
 }


### PR DESCRIPTION
The implementation was already checked in, this is exposing the API in the contracts and sets up packaging for it.

Fixes #3049
