### PR TITLE
Fix Process.Start's parsing of command-line args on Unix

### DIFF
--- a/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
+++ b/src/Common/tests/System/Diagnostics/RemoteExecutorTestBase.cs
@@ -77,6 +77,17 @@ namespace System.Diagnostics
         /// <param name="method">The method to invoke.</param>
         /// <param name="args">The arguments to pass to the method.</param>
         /// <param name="start">true if this function should Start the Process; false if that responsibility is left up to the caller.</param>
+        /// <param name="psi">The ProcessStartInfo to use, or null for a default.</param>
+        internal static RemoteInvokeHandle RemoteInvokeRaw(Delegate method, string unparsedArg, bool start, ProcessStartInfo psi)
+        {
+            return RemoteInvoke(method.GetMethodInfo(), new[] { unparsedArg }, start, psi);
+        }
+
+        /// <summary>Invokes the method from this assembly in another process using the specified arguments.</summary>
+        /// <param name="method">The method to invoke.</param>
+        /// <param name="args">The arguments to pass to the method.</param>
+        /// <param name="start">true if this function should Start the Process; false if that responsibility is left up to the caller.</param>
+        /// <param name="psi">The ProcessStartInfo to use, or null for a default.</param>
         private static RemoteInvokeHandle RemoteInvoke(MethodInfo method, string[] args, bool start, ProcessStartInfo psi)
         {
             // Verify the specified method is and that it returns an int (the exit code),

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -644,6 +644,7 @@ namespace System.Diagnostics.Tests
         [InlineData(@"a\\\\""b c"" d e", @"a\\b c,d,e")]
         [InlineData(@"a""b c""d e""f g""h i""j k""l", @"ab cd,ef gh,ij kl")]
         [InlineData(@"a b c""def", @"a,b,cdef")]
+        [InlineData(@"""\a\"" \\""\\\ b c", @"\a"" \\\\,b,c")]
         public void TestArgumentParsing(string inputArguments, string expectedArgv)
         {
             using (var handle = RemoteInvokeRaw((Func<string, string, string, int>)ConcatThreeArguments,

--- a/src/System.Diagnostics.Process/tests/ProcessTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessTests.cs
@@ -634,6 +634,32 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [Theory]
+        [InlineData(@"""abc"" d e", @"abc,d,e")]
+        [InlineData(@"""abc""      d e", @"abc,d,e")]
+        [InlineData("\"abc\"\t\td\te", @"abc,d,e")]
+        [InlineData(@"a\\b d""e f""g h", @"a\\b,de fg,h")]
+        [InlineData(@"\ \\ \\\", @"\,\\,\\\")]
+        [InlineData(@"a\\\""b c d", @"a\""b,c,d")]
+        [InlineData(@"a\\\\""b c"" d e", @"a\\b c,d,e")]
+        [InlineData(@"a""b c""d e""f g""h i""j k""l", @"ab cd,ef gh,ij kl")]
+        [InlineData(@"a b c""def", @"a,b,cdef")]
+        public void TestArgumentParsing(string inputArguments, string expectedArgv)
+        {
+            using (var handle = RemoteInvokeRaw((Func<string, string, string, int>)ConcatThreeArguments,
+                inputArguments,
+                start: true,
+                psi: new ProcessStartInfo { RedirectStandardOutput = true }))
+            {
+                Assert.Equal(expectedArgv, handle.Process.StandardOutput.ReadToEnd());
+            }
+        }
+
+        private static int ConcatThreeArguments(string one, string two, string three)
+        {
+            Console.Write(string.Join(",", one, two, three));
+            return SuccessExitCode;
+        }
 
         // [Fact] // uncomment for diagnostic purposes to list processes to console
         public void TestDiagnosticsWithConsoleWriteLine()


### PR DESCRIPTION
Backslashes were not being handled as intended when parsing the Arguments string used to create the argv for exec.  The Unix behavior now matches the Windows behavior.  

(Note that for the same rules as the shell on Unix, UseShellExecute can be used; as such, I've not attempted to emulate a particular shell's parsing logic and instead stuck with these simpler rules that are a small extension on what we already had.)

cc: @pallavit, @brthor
Fixes #5348