### PR TITLE
Avoid creating GroupJoin lookup when outer is empty

### DIFF
--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -1008,10 +1008,18 @@ namespace System.Linq
 
         private static IEnumerable<TResult> GroupJoinIterator<TOuter, TInner, TKey, TResult>(IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, IEnumerable<TInner>, TResult> resultSelector, IEqualityComparer<TKey> comparer)
         {
-            Lookup<TKey, TInner> lookup = Lookup<TKey, TInner>.CreateForJoin(inner, innerKeySelector, comparer);
-            foreach (TOuter item in outer)
+            using (IEnumerator<TOuter> e = outer.GetEnumerator())
             {
-                yield return resultSelector(item, lookup[outerKeySelector(item)]);
+                if (e.MoveNext())
+                {
+                    Lookup<TKey, TInner> lookup = Lookup<TKey, TInner>.CreateForJoin(inner, innerKeySelector, comparer);
+                    do
+                    {
+                        TOuter item = e.Current;
+                        yield return resultSelector(item, lookup[outerKeySelector(item)]);
+                    }
+                    while (e.MoveNext());
+                }
             }
         }
 


### PR DESCRIPTION
Optimization to avoid creating the ```Lookup<TKey, TInner>``` when the outer enumeration is empty.

Fixes #5370 
cc: @VSadov, @JonHanna 

There are already tests covering both the empty and non-empty cases.  Note that this will have the observable effect of not iterating the inner enumerable when outer is empty, but we've made other similar changes in corefx.