### PR TITLE
Change namespace used in System.Linq.Expressions.Tests

### DIFF
--- a/src/System.Linq.Expressions/tests/Array/ArrayAccessTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayAccessTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Array
+namespace System.Linq.Expressions.Tests
 {
     public static class ArrayAccessTests
     {

--- a/src/System.Linq.Expressions/tests/Array/ArrayArrayIndexTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayArrayIndexTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Array
+namespace System.Linq.Expressions.Tests
 {
     public static class ArrayArrayIndexTests
     {

--- a/src/System.Linq.Expressions/tests/Array/ArrayArrayLengthTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayArrayLengthTests.cs
@@ -3,12 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Text;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Array
+namespace System.Linq.Expressions.Tests
 {
     public static class ArrayArrayLengthTests
     {

--- a/src/System.Linq.Expressions/tests/Array/ArrayBoundsOneOffTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayBoundsOneOffTests.cs
@@ -2,10 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Array
+namespace System.Linq.Expressions.Tests
 {
     public static class ArrayBoundsOneOffTests
     {

--- a/src/System.Linq.Expressions/tests/Array/ArrayBoundsTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayBoundsTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Array
+namespace System.Linq.Expressions.Tests
 {
     public static class ArrayBoundsTests
     {

--- a/src/System.Linq.Expressions/tests/Array/ArrayIndexTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayIndexTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Array
+namespace System.Linq.Expressions.Tests
 {
     public static class ArrayIndexTests
     {

--- a/src/System.Linq.Expressions/tests/Array/ArrayLengthTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayLengthTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Array
+namespace System.Linq.Expressions.Tests
 {
     public static class ArrayLengthTests
     {

--- a/src/System.Linq.Expressions/tests/Array/NewArrayListTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NewArrayListTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Array
+namespace System.Linq.Expressions.Tests
 {
     public static class NewArrayListTests
     {

--- a/src/System.Linq.Expressions/tests/Array/NullableArrayBoundsTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NullableArrayBoundsTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Array
+namespace System.Linq.Expressions.Tests
 {
     public static class NullableArrayBoundsTests
     {

--- a/src/System.Linq.Expressions/tests/Array/NullableArrayIndexTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NullableArrayIndexTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Array
+namespace System.Linq.Expressions.Tests
 {
     public static class NullableArrayIndexTests
     {

--- a/src/System.Linq.Expressions/tests/Array/NullableArrayLengthTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NullableArrayLengthTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Array
+namespace System.Linq.Expressions.Tests
 {
     public static class NullableArrayLengthTests
     {

--- a/src/System.Linq.Expressions/tests/Array/NullableNewArrayListTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NullableNewArrayListTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Array
+namespace System.Linq.Expressions.Tests
 {
     public static class NullableNewArrayListTests
     {

--- a/src/System.Linq.Expressions/tests/Array/ObjectArrayBoundsTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ObjectArrayBoundsTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Array
+namespace System.Linq.Expressions.Tests
 {
     public static class ObjectArrayBoundsTests
     {

--- a/src/System.Linq.Expressions/tests/Array/ObjectNullableArrayBoundsTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ObjectNullableArrayBoundsTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Array
+namespace System.Linq.Expressions.Tests
 {
     public class ObjectNullableArrayBoundsTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryAddTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryAddTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryDivideTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryDivideTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryDivideTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryModuloTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryModuloTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryModuloTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryMultiplyTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryMultiplyTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableAddTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableAddTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryNullableAddTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableDivideTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableDivideTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryNullableDivideTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableModuloTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableModuloTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryNullableModuloTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableMultiplyTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryNullableMultiplyTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullablePowerTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullablePowerTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryNullablePowerTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableSubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryNullableSubtractTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryNullableSubtractTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryShiftTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinaryShiftTests.cs
@@ -2,10 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryShiftTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Arithmetic/BinarySubtractTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinarySubtractTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryAndTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryAndTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryAndTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryExclusiveOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryExclusiveOrTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryExclusiveOrTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableAndTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableAndTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryNullableAndTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableExclusiveOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableExclusiveOrTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryNullableExclusiveOrTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryNullableOrTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryNullableOrTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryOrTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Bitwise/BinaryOrTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryOrTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryCoalesceTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryCoalesceTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryNullableCoalesceTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Coalesce/BinaryNullableCoalesceTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryNullableCoalesceTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryEqualTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryEqualTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryGreaterThanOrEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryGreaterThanOrEqualTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryGreaterThanOrEqualTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryGreaterThanTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryGreaterThanTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryGreaterThanTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryLessThanOrEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryLessThanOrEqualTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryLessThanOrEqualTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryLessThanTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryLessThanTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryLessThanTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNotEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNotEqualTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryNotEqualTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableEqualTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryNullableEqualTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableGreaterThanOrEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableGreaterThanOrEqualTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryNullableGreaterThanOrEqualTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableGreaterThanTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableGreaterThanTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryNullableGreaterThanTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableLessThanOrEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableLessThanOrEqualTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryNullableLessThanOrEqualTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableLessThanTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableLessThanTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryNullableLessThanTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableNotEqualTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Comparison/BinaryNullableNotEqualTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryNullableNotEqualTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryLogicalTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryLogicalTests
     {

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryNullableLogicalTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Logical/BinaryNullableLogicalTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Binary
+namespace System.Linq.Expressions.Tests
 {
     public static class BinaryNullableLogicalTests
     {

--- a/src/System.Linq.Expressions/tests/Block/BlockFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/BlockFactoryTests.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests
+namespace System.Linq.Expressions.Tests
 {
     public static class BlockFactoryTests
     {

--- a/src/System.Linq.Expressions/tests/Block/BlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/BlockTests.cs
@@ -3,12 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Block
+namespace System.Linq.Expressions.Tests
 {
     public static class BlockTests
     {

--- a/src/System.Linq.Expressions/tests/Block/NoParameterBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/NoParameterBlockTests.cs
@@ -6,7 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Xunit;
 
-namespace System.Linq.Expressions.Test
+namespace System.Linq.Expressions.Tests
 {
     public class NoParameterBlockTests : SharedBlockTests
     {

--- a/src/System.Linq.Expressions/tests/Block/ParameterBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/ParameterBlockTests.cs
@@ -6,7 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using Xunit;
 
-namespace System.Linq.Expressions.Test
+namespace System.Linq.Expressions.Tests
 {
     public class ParameterBlockTests : SharedBlockTests
     {

--- a/src/System.Linq.Expressions/tests/Block/SharedBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/SharedBlockTests.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using Xunit;
 
-namespace System.Linq.Expressions.Test
+namespace System.Linq.Expressions.Tests
 {
     public abstract class SharedBlockTests
     {

--- a/src/System.Linq.Expressions/tests/Call/CallFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Call/CallFactoryTests.cs
@@ -3,12 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests
+namespace System.Linq.Expressions.Tests
 {
     public static class CallFactoryTests
     {

--- a/src/System.Linq.Expressions/tests/Cast/AsNullable.cs
+++ b/src/System.Linq.Expressions/tests/Cast/AsNullable.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Cast
+namespace System.Linq.Expressions.Tests
 {
     public static class AsNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Cast/AsTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/AsTests.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Cast
+namespace System.Linq.Expressions.Tests
 {
     public static class AsTests
     {

--- a/src/System.Linq.Expressions/tests/Cast/CastNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/CastNullableTests.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Cast
+namespace System.Linq.Expressions.Tests
 {
     public static class CastNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Cast/CastTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/CastTests.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Cast
+namespace System.Linq.Expressions.Tests
 {
     public static class CastTests
     {

--- a/src/System.Linq.Expressions/tests/Cast/IsNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/IsNullableTests.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Cast
+namespace System.Linq.Expressions.Tests
 {
     public static class IsNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Cast/IsTests.cs
+++ b/src/System.Linq.Expressions/tests/Cast/IsTests.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Cast
+namespace System.Linq.Expressions.Tests
 {
     public static class IsTests
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Array.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Array.cs
@@ -3,10 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Binary.Assign.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Binary.Assign.cs
@@ -3,10 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 using System.Reflection;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Binary.Generated.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Binary.Generated.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Binary.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Binary.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Block.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Block.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Call.Generated.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Call.Generated.cs
@@ -3,10 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 using System.Reflection;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Call.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Call.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Conditional.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Conditional.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Constant.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Constant.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.DebugInfo.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.DebugInfo.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Linq.Expressions;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Default.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Default.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Extension.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Extension.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Goto.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Goto.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Invoke.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Invoke.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Lambda.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Lambda.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.ListInit.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.ListInit.cs
@@ -4,10 +4,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Logging.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Logging.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     public static partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Loop.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Loop.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.MemberAccess.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.MemberAccess.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.MemberInit.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.MemberInit.cs
@@ -3,10 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.New.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.New.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Parameter.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Parameter.cs
@@ -2,9 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
-using System.Linq.Expressions;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.RuntimeVariables.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.RuntimeVariables.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Switch.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Switch.cs
@@ -3,10 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.TypeBinary.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.TypeBinary.cs
@@ -4,9 +4,8 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Types.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Types.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     public struct S1
     {
@@ -193,13 +193,6 @@ namespace Tests.Expressions
         {
             return _b.GetHashCode();
         }
-    }
-
-    public enum E
-    {
-        Red,
-        Green,
-        Blue
     }
 
     public class Holder<T>

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Unary.Assign.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Unary.Assign.cs
@@ -3,10 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 using System.Reflection;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Unary.Generated.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Unary.Generated.cs
@@ -3,9 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Unary.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.Unary.cs
@@ -4,10 +4,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 using System.Reflection;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ExpressionCatalog.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     public static partial class ExpressionCatalog
     {

--- a/src/System.Linq.Expressions/tests/Catalog/ReflectionExtensions.cs
+++ b/src/System.Linq.Expressions/tests/Catalog/ReflectionExtensions.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Linq;
+using System.Reflection;
 
-namespace System.Reflection
+namespace System.Linq.Expressions.Tests
 {
     static class ReflectionExtensions
     {

--- a/src/System.Linq.Expressions/tests/Conditional/ConditionalOneOffTests.cs
+++ b/src/System.Linq.Expressions/tests/Conditional/ConditionalOneOffTests.cs
@@ -2,10 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.Expressions.Conditional
+namespace System.Linq.Expressions.Tests
 {
     public static class ConditionalOneOffTests
     {

--- a/src/System.Linq.Expressions/tests/Constant/ConstantArrayTests.cs
+++ b/src/System.Linq.Expressions/tests/Constant/ConstantArrayTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Constant
+namespace System.Linq.Expressions.Tests
 {
     public static class ConstantArrayTests
     {

--- a/src/System.Linq.Expressions/tests/Constant/ConstantNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Constant/ConstantNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Constant
+namespace System.Linq.Expressions.Tests
 {
     public static class ConstantNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
+++ b/src/System.Linq.Expressions/tests/Constant/ConstantTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Constant
+namespace System.Linq.Expressions.Tests
 {
     public static class ConstantTests
     {

--- a/src/System.Linq.Expressions/tests/Convert/ConvertCheckedTests.cs
+++ b/src/System.Linq.Expressions/tests/Convert/ConvertCheckedTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Convert
+namespace System.Linq.Expressions.Tests
 {
     public static class ConvertCheckedTests
     {

--- a/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
+++ b/src/System.Linq.Expressions/tests/Convert/ConvertTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Convert
+namespace System.Linq.Expressions.Tests
 {
     public static class ConvertTests
     {

--- a/src/System.Linq.Expressions/tests/HelperTypes.cs
+++ b/src/System.Linq.Expressions/tests/HelperTypes.cs
@@ -2,13 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Runtime.CompilerServices;
-using Tests.ExpressionCompiler;
 
-namespace Tests.ExpressionCompiler
+namespace System.Linq.Expressions.Tests
 {
     public interface I
     {
@@ -75,7 +70,10 @@ namespace Tests.ExpressionCompiler
     public enum E
     {
         A = 1,
-        B = 2
+        B = 2,
+        Red = 0,
+        Green,
+        Blue
     }
 
     public enum El : long

--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Address.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Address.cs
@@ -3,11 +3,10 @@
 
 #if FEATURE_INTERPRET
 using System;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     public static partial class InterpreterTests
     {

--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Generated.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Generated.cs
@@ -3,10 +3,9 @@
 
 #if FEATURE_INTERPRET
 using System.Collections.Generic;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class InterpreterTests
     {

--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.cs
@@ -3,12 +3,10 @@
 
 #if FEATURE_INTERPRET
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     public static partial class InterpreterTests
     {

--- a/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests
+namespace System.Linq.Expressions.Tests
 {
     public static class InvocationTests
     {

--- a/src/System.Linq.Expressions/tests/Invoke/InvokeFactoryTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvokeFactoryTests.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests
+namespace System.Linq.Expressions.Tests
 {
     public static class InvokeFactoryTests
     {

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaAddNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaAddNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lambda
+namespace System.Linq.Expressions.Tests
 {
     public static class LambdaAddNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaAddTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaAddTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lambda
+namespace System.Linq.Expressions.Tests
 {
     public static class LambdaAddTests
     {

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaDivideNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaDivideNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lambda
+namespace System.Linq.Expressions.Tests
 {
     public static class LambdaDivideNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaDivideTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaDivideTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lambda
+namespace System.Linq.Expressions.Tests
 {
     public static class LambdaDivideTests
     {

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaIdentityNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaIdentityNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lambda
+namespace System.Linq.Expressions.Tests
 {
     public static class LambdaIdentityNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaIdentityTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaIdentityTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lambda
+namespace System.Linq.Expressions.Tests
 {
     public static class LambdaIdentityTests
     {

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaModuloNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaModuloNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lambda
+namespace System.Linq.Expressions.Tests
 {
     public static class LambdaModuloNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaModuloTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaModuloTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lambda
+namespace System.Linq.Expressions.Tests
 {
     public static class LambdaModuloTests
     {

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaMultiplyNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaMultiplyNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lambda
+namespace System.Linq.Expressions.Tests
 {
     public static class LambdaMultiplyNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaMultiplyTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaMultiplyTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lambda
+namespace System.Linq.Expressions.Tests
 {
     public static class LambdaMultiplyTests
     {

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaSubtractNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaSubtractNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lambda
+namespace System.Linq.Expressions.Tests
 {
     public static class LambdaSubtractNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaSubtractTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaSubtractTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lambda
+namespace System.Linq.Expressions.Tests
 {
     public static class LambdaSubtractTests
     {

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaUnaryNotNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaUnaryNotNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lambda
+namespace System.Linq.Expressions.Tests
 {
     public static class LambdaUnaryNotNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lambda/LambdaUnaryNotTests.cs
+++ b/src/System.Linq.Expressions/tests/Lambda/LambdaUnaryNotTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lambda
+namespace System.Linq.Expressions.Tests
 {
     public static class LambdaUnaryNotTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedAddCheckedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedAddCheckedNullableTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class LiftedAddCheckedNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedAddNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedAddNullableTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class LiftedAddNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseAndNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseAndNullableTests.cs
@@ -2,11 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class LiftedBitwiseAndNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseExclusiveOrNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseExclusiveOrNullableTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class LiftedBitwiseExclusiveOrNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseOrNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedBitwiseOrNullableTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class LiftedBitwiseOrNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonEqualNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class LiftedComparisonEqualNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonGreaterThanNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonGreaterThanNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class LiftedComparisonGreaterThanNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonGreaterThanOrEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonGreaterThanOrEqualNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class LiftedComparisonGreaterThanOrEqualNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonLessThanNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonLessThanNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class LiftedComparisonLessThanNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonLessThanOrEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonLessThanOrEqualNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class LiftedComparisonLessThanOrEqualNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonNotEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedComparisonNotEqualNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class LiftedComparisonNotEqualNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedDivideNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedDivideNullableTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class LiftedDivideNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedModuloNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedModuloNullableTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class LiftedModuloNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyCheckedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyCheckedNullableTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class LiftedMultiplyCheckedNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedMultiplyNullableTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class LiftedMultiplyNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class LiftedNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractCheckedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractCheckedNullableTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class LiftedSubtractCheckedNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/LiftedSubtractNullableTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class LiftedSubtractNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonEqualNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class NonLiftedComparisonEqualNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonGreaterThanNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonGreaterThanNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class NonLiftedComparisonGreaterThanNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonGreaterThanOrEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonGreaterThanOrEqualNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class NonLiftedComparisonGreaterThanOrEqualNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonLessThanNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonLessThanNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class NonLiftedComparisonLessThanNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonLessThanOrEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonLessThanOrEqualNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class NonLiftedComparisonLessThanOrEqualNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonNotEqualNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Lifted/NonLiftedComparisonNotEqualNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Lifted
+namespace System.Linq.Expressions.Tests
 {
     public static class NonLiftedComparisonNotEqualNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
+++ b/src/System.Linq.Expressions/tests/Member/MemberAccessTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.MemberAccess
+namespace System.Linq.Expressions.Tests
 {
     public static class MemberAccessTests
     {

--- a/src/System.Linq.Expressions/tests/MemberInit/MemberInitTests.cs
+++ b/src/System.Linq.Expressions/tests/MemberInit/MemberInitTests.cs
@@ -3,11 +3,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.MemberInit
+namespace System.Linq.Expressions.Tests
 {
     public static class MemberInitTests
     {

--- a/src/System.Linq.Expressions/tests/New/NewTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.New
+namespace System.Linq.Expressions.Tests
 {
     public static class NewTests
     {

--- a/src/System.Linq.Expressions/tests/New/NewWithParameterTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewWithParameterTests.cs
@@ -2,13 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
-using Tests.ExpressionCompiler;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.New
+namespace System.Linq.Expressions.Tests
 {
     public static class NewWithParameterTests
     {

--- a/src/System.Linq.Expressions/tests/New/NewWithTwoParametersTests.cs
+++ b/src/System.Linq.Expressions/tests/New/NewWithTwoParametersTests.cs
@@ -2,15 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
-using System.Text;
-using Tests.ExpressionCompiler;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.New
+namespace System.Linq.Expressions.Tests
 {
     public static class NewWithTwoParametersTests
     {

--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -5,12 +5,10 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests
+namespace System.Linq.Expressions.Tests
 {
     public class Sequence_Tests
     {
@@ -4442,102 +4440,6 @@ namespace Tests
         }
     }
 
-    // Extensions on System.Type and friends
-    internal static class TypeExtensions
-    {
-        internal static Type GetReturnType(this MethodBase mi)
-        {
-            return (mi.IsConstructor) ? mi.DeclaringType : ((MethodInfo)mi).ReturnType;
-        }
-
-        // Expression trees/compiler just use IsByRef, why do we need this?
-        // (see LambdaCompiler.EmitArguments for usage in the compiler)
-        internal static bool IsByRefParameter(this ParameterInfo pi)
-        {
-            // not using IsIn/IsOut properties as they are not available in Silverlight:
-            if (pi.ParameterType.IsByRef) return true;
-
-            return (pi.Attributes & (ParameterAttributes.Out)) == ParameterAttributes.Out;
-        }
-
-        // Returns the matching method if the parameter types are reference
-        // assignable from the provided type arguments, otherwise null. 
-        internal static MethodInfo GetAnyStaticMethodValidated(
-            this Type type,
-            string name,
-            Type[] types)
-        {
-            var method = type.GetAnyStaticMethod(name);
-
-            return method.MatchesArgumentTypes(types) ? method : null;
-        }
-
-        /// <summary>
-        /// Returns true if the method's parameter types are reference assignable from
-        /// the argument types, otherwise false.
-        /// 
-        /// An example that can make the method return false is that 
-        /// typeof(double).GetMethod("op_Equality", ..., new[] { typeof(double), typeof(int) })
-        /// returns a method with two double parameters, which doesn't match the provided
-        /// argument types.
-        /// </summary>
-        /// <returns></returns>
-        private static bool MatchesArgumentTypes(this MethodInfo mi, Type[] argTypes)
-        {
-            if (mi == null || argTypes == null)
-            {
-                return false;
-            }
-            var ps = mi.GetParameters();
-
-            if (ps.Length != argTypes.Length)
-            {
-                return false;
-            }
-
-            for (int i = 0; i < ps.Length; i++)
-            {
-                if (!AreReferenceAssignable(ps[i].ParameterType, argTypes[i]))
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        internal static bool AreEquivalent(Type t1, Type t2)
-        {
-            return t1 == t2;
-            //            return t1 == t2 || t1.IsEquivalentTo(t2);
-        }
-
-        internal static bool AreReferenceAssignable(Type dest, Type src)
-        {
-            // WARNING: This actually implements "Is this identity assignable and/or reference assignable?"
-            if (AreEquivalent(dest, src))
-            {
-                return true;
-            }
-            if (!dest.GetTypeInfo().IsValueType && !src.GetTypeInfo().IsValueType && dest.GetTypeInfo().IsAssignableFrom(src.GetTypeInfo()))
-            {
-                return true;
-            }
-            return false;
-        }
-
-        internal static MethodInfo GetAnyStaticMethod(this Type type, string name)
-        {
-            foreach (var method in type.GetTypeInfo().DeclaredMethods)
-            {
-                if (method.IsStatic && method.Name == name)
-                {
-                    return method;
-                }
-            }
-            return null;
-        }
-    }
-
     public struct U
     {
         public static U operator +(U x, U y) { throw new NotImplementedException(); }
@@ -4605,10 +4507,6 @@ namespace Tests
         public static N operator -(N n) { throw new NotImplementedException(); }
         public static implicit operator N(M m) { throw new NotImplementedException(); }
         public static M Bar(N n) { throw new NotImplementedException(); }
-    }
-
-    public class BaseClass
-    {
     }
 
     public class DerivedClass : BaseClass

--- a/src/System.Linq.Expressions/tests/Ternary/TernaryArrayNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Ternary/TernaryArrayNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Ternary
+namespace System.Linq.Expressions.Tests
 {
     public static class TernaryArrayNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Ternary/TernaryArrayTests.cs
+++ b/src/System.Linq.Expressions/tests/Ternary/TernaryArrayTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Ternary
+namespace System.Linq.Expressions.Tests
 {
     public static class TernaryArrayTests
     {

--- a/src/System.Linq.Expressions/tests/Ternary/TernaryNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Ternary/TernaryNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Ternary
+namespace System.Linq.Expressions.Tests
 {
     public static class TernaryNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Ternary/TernaryTests.cs
+++ b/src/System.Linq.Expressions/tests/Ternary/TernaryTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Ternary
+namespace System.Linq.Expressions.Tests
 {
     public static class TernaryTests
     {

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Unary
+namespace System.Linq.Expressions.Tests
 {
     public static class UnaryArithmeticNegateCheckedNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateCheckedTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Unary
+namespace System.Linq.Expressions.Tests
 {
     public static class UnaryArithmeticNegateCheckedTests
     {

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableOneOffTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableOneOffTests.cs
@@ -2,10 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Unary
+namespace System.Linq.Expressions.Tests
 {
     public static class UnaryArithmeticNegateNullableOneOffTests
     {

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Unary
+namespace System.Linq.Expressions.Tests
 {
     public static class UnaryArithmeticNegateNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryArithmeticNegateTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Unary
+namespace System.Linq.Expressions.Tests
 {
     public static class UnaryArithmeticNegateTests
     {

--- a/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Unary
+namespace System.Linq.Expressions.Tests
 {
     public static class UnaryBitwiseNotNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryBitwiseNotTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Unary
+namespace System.Linq.Expressions.Tests
 {
     public static class UnaryBitwiseNotTests
     {

--- a/src/System.Linq.Expressions/tests/Unary/UnaryDecrementNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryDecrementNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Unary
+namespace System.Linq.Expressions.Tests
 {
     public static class UnaryDecrementNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Unary/UnaryDecrementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryDecrementTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Unary
+namespace System.Linq.Expressions.Tests
 {
     public static class UnaryDecrementTests
     {

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIncrementNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIncrementNullableTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Unary
+namespace System.Linq.Expressions.Tests
 {
     public static class UnaryIncrementNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIncrementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIncrementTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Unary
+namespace System.Linq.Expressions.Tests
 {
     public static class UnaryIncrementTests
     {

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseNullableTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Unary
+namespace System.Linq.Expressions.Tests
 {
     public static class UnaryIsFalseNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsFalseTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Unary
+namespace System.Linq.Expressions.Tests
 {
     public static class UnaryIsFalseTests
     {

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueNullableTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Unary
+namespace System.Linq.Expressions.Tests
 {
     public static class UnaryIsTrueNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryIsTrueTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Unary
+namespace System.Linq.Expressions.Tests
 {
     public static class UnaryIsTrueTests
     {

--- a/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementNullableTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Unary
+namespace System.Linq.Expressions.Tests
 {
     public static class OnesComplementNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryOnesComplementTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Unary
+namespace System.Linq.Expressions.Tests
 {
     public static class OnesComplementTests
     {

--- a/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusNullableTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusNullableTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Unary
+namespace System.Linq.Expressions.Tests
 {
     public static class UnaryPlusNullableTests
     {

--- a/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryUnaryPlusTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Unary
+namespace System.Linq.Expressions.Tests
 {
     public static class UnaryPlusTests
     {

--- a/src/System.Linq.Expressions/tests/Unary/UnaryUnboxTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnaryUnboxTests.cs
@@ -2,12 +2,10 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.ExpressionCompiler.Unary
+namespace System.Linq.Expressions.Tests
 {
     public static class UnaryUnboxTests
     {

--- a/src/System.Linq.Expressions/tests/Visitor/ExpressionVisitorTests.cs
+++ b/src/System.Linq.Expressions/tests/Visitor/ExpressionVisitorTests.cs
@@ -2,11 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
-using System.Linq.Expressions;
 using Xunit;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     public static partial class ExpressionVisitorTests
     {


### PR DESCRIPTION
To be consistently System.Linq.Expressions.Tests as per #2898

CC: @bartdesmet since you're adding tests here