### PR TITLE
Update System.Runtime.Extensions pkg and assembly in corefx

### DIFF
--- a/src/System.Runtime.Extensions/pkg/System.Runtime.Extensions.builds
+++ b/src/System.Runtime.Extensions/pkg/System.Runtime.Extensions.builds
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Runtime.Extensions.pkgproj"/>
+    <Project Include="win\System.Runtime.Extensions.pkgproj">
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
+    <Project Include="unix\System.Runtime.Extensions.pkgproj">
+      <OSGroup>Linux</OSGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Runtime.Extensions/pkg/System.Runtime.Extensions.pkgproj
+++ b/src/System.Runtime.Extensions/pkg/System.Runtime.Extensions.pkgproj
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\ref\4.0.0\System.Runtime.Extensions.depproj">
+      <SupportedFramework>net45;netcore45;wp80;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\ref\System.Runtime.Extensions.csproj">
+      <SupportedFramework>netcore50;dnxcore50;net46;</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Runtime.Extensions.csproj" >
+      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+    </ProjectReference>
+    <ProjectReference Include="win\System.Runtime.Extensions.pkgproj" />
+    <ProjectReference Include="unix\System.Runtime.Extensions.pkgproj" />
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Extensions/pkg/unix/System.Runtime.Extensions.pkgproj
+++ b/src/System.Runtime.Extensions/pkg/unix/System.Runtime.Extensions.pkgproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>unix</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Runtime.Extensions.builds">
+      <AdditionalProperties>FilterToOSGroup=Linux</AdditionalProperties>
+    </ProjectReference>
+    <ProjectReference Include="$(NativePackagePath)\runtime.native.System\runtime.native.System.pkgproj" />
+    <ProjectReference Include="$(NativePackagePath)\runtime.native.System.Security.Cryptography\runtime.native.System.Security.Cryptography.pkgproj" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Extensions/pkg/win/System.Runtime.Extensions.pkgproj
+++ b/src/System.Runtime.Extensions/pkg/win/System.Runtime.Extensions.pkgproj
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>win7</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Runtime.Extensions.builds">
+      <AdditionalProperties>FilterToOSGroup=Windows_NT</AdditionalProperties>
+    </ProjectReference>
+
+    <!-- don't use the dotnet implementation for any version of desktop, it's implementation comes from the reference package -->
+    <ExternalOnTargetFramework Include="net" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
     <NuGetTargetMoniker>.NETPlatform,Version=v5.4</NuGetTargetMoniker>

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <ProjectGuid>{845D2B72-D8A4-42E5-9BE9-17639EC4FC1A}</ProjectGuid>
     <AssemblyName>System.Runtime.Extensions</AssemblyName>
-    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
@@ -15,7 +15,8 @@
     <!-- System.IO.Path conflicts between type in partial facade and in mscorlib -->
     <NoWarn>0436</NoWarn>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
-    <UsePackageTargetRuntimeDefaults>true</UsePackageTargetRuntimeDefaults>
+    <PackageTargetRuntime Condition="'$(TargetsWindows)' == 'true' And '$(TargetGroup)' != 'net46'">win7</PackageTargetRuntime >
+    <PackageTargetRuntime Condition="'$(TargetsUnix)' == 'true'">unix</PackageTargetRuntime >
   </PropertyGroup>
 
   <!-- Default configurations to help VS understand the configurations -->


### PR DESCRIPTION
This change does the following
1. Add System.Runtime.Extensions package to corefx repo.
2. Update the version to 4.1.0.0
Fixes #5050 