### PR TITLE
Workaround [ThreadStatic] limitation in ImmutableList<T>

### DIFF
--- a/src/System.Collections.Immutable/tests/project.json
+++ b/src/System.Collections.Immutable/tests/project.json
@@ -1,6 +1,9 @@
 {
   "dependencies": {
     "System.Diagnostics.Contracts": "4.0.0",
+    "System.Reflection.Emit": "4.0.0",
+    "System.Reflection.Emit.Lightweight": "4.0.0",
+    "System.Reflection.TypeExtensions": "4.0.0",
     "System.Runtime": "4.0.20",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"


### PR DESCRIPTION
As a perf improvement awhile back, ImmutableList<T> took a dependency on [ThreadStatic].  This unfortunately breaks cases where ImmutableList<T> is used with a T from a collectible assembly, due to https://github.com/dotnet/coreclr/issues/2191.

Until that limitation is removed, this provides a workaround to restore the ability to use ImmutableList<T> with such types.  Some microbenchmarks around enumeration (which this was originally introduced to help with) show potential throughput regressions up to 10-15%.

cc: @ellismg, @AArnott 
Fixes https://github.com/dotnet/corefx/issues/4726