### PR TITLE
Disable two more NegotiateStream tests

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
@@ -67,6 +67,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [ActiveIssue(5284, PlatformID.Windows)]
         [Fact]
         [PlatformSpecific(PlatformID.Windows)]
         public void NegotiateStream_StreamToStream_Authentication_TargetName_Success()
@@ -122,6 +123,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [ActiveIssue(5284, PlatformID.Windows)]
         [Fact]
         [PlatformSpecific(PlatformID.Windows)]
         public void NegotiateStream_StreamToStream_Authentication_EmptyCredentials_Fails()


### PR DESCRIPTION
These have also been taking out multiple builds.

I'm assuming it's the same cause as the other ones on this type and have as such associated it with the same issue.

cc: @cipop, @davidsh