### PR TITLE
MapType_OverridingSelectionOfConventionSelectedConstructor failed in CI

### DIFF
--- a/src/System.Composition.Convention/tests/ConventionBuilderTests.cs
+++ b/src/System.Composition.Convention/tests/ConventionBuilderTests.cs
@@ -87,14 +87,13 @@ namespace System.Composition.Convention.UnitTests
                 Export<IFoo>();
 
             builder.ForType<FooImplWithConstructors>()
-                .SelectConstructor(cis => cis.ElementAtOrDefault(1));
+                .SelectConstructor(cis => cis.Single(c => c.GetParameters().Length == 1));
 
             var fooImplWithConstructors = typeof(FooImplWithConstructors).GetTypeInfo();
 
             var constructor1 = fooImplWithConstructors.DeclaredConstructors.Where(c => c.GetParameters().Length == 0).Single();
             var constructor2 = fooImplWithConstructors.DeclaredConstructors.Where(c => c.GetParameters().Length == 1).Single();
             var constructor3 = fooImplWithConstructors.DeclaredConstructors.Where(c => c.GetParameters().Length == 2).Single();
-
 
             // necessary as BuildConventionConstructorAttributes is only called for type level query for attributes
             Assert.Equal(0, builder.GetCustomAttributes(typeof(FooImplWithConstructors), constructor1).Count());


### PR DESCRIPTION
This test was expecting constructors to be returned in a guaranteed order.  I changed it to no longer rely on the order that the constructors are enumerated.

Fix #4706

@stephentoub 

note - I'm not 100% certain this is the cause for the failure since I couldn't repro it locally, but this code looked suspect to me.  We will see if it fails again after this change.