### PR TITLE
XmlSerializer: Avoid unnecessary allocations

### DIFF
--- a/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializer.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/Serialization/XmlSerializer.cs
@@ -639,13 +639,13 @@ namespace System.Xml.Serialization
                 return Array.Empty<XmlSerializer>();
 
 #if NET_NATIVE
-            var serializers = new List<XmlSerializer>();
-            foreach (var t in types)
+            var serializers = new XmlSerializer[types.Length];
+            for (int i = 0; i < types.Length; i++)
             {
-                serializers.Add(new XmlSerializer(t));
+                serializers[i] = new XmlSerializer(types[i]);
             }
 
-            return serializers.ToArray();
+            return serializers;
 #else
             XmlReflectionImporter importer = new XmlReflectionImporter();
             XmlTypeMapping[] mappings = new XmlTypeMapping[types.Length];


### PR DESCRIPTION
Avoid unnecessary `List<T>` and array allocations.

Fixes #5389

cc: @shmao