### PR TITLE
Fix serialization of get-only IEnumerable to throw exception

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
+
 namespace System.Runtime.Serialization
 {
     using System;
@@ -524,6 +526,11 @@ namespace System.Runtime.Serialization
                     {
                         if (_helper.XmlFormatGetOnlyCollectionReaderDelegate == null)
                         {
+                            if (TypeIsInterface && (Kind == CollectionKind.Enumerable || Kind == CollectionKind.Collection || Kind == CollectionKind.GenericEnumerable))
+                            {
+                                throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidDataContractException(SR.Format(SR.GetOnlyCollectionMustHaveAddMethod, GetClrTypeFullName(UnderlyingType))));
+                            }
+                            Debug.Assert(AddMethod != null || Kind == CollectionKind.Array, "Add method cannot be null if the collection is being used as a get-only property");
                             XmlFormatGetOnlyCollectionReaderDelegate tempDelegate = new XmlFormatReaderGenerator().GenerateGetOnlyCollectionReader(this);
                             Interlocked.MemoryBarrier();
                             _helper.XmlFormatGetOnlyCollectionReaderDelegate = tempDelegate;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
@@ -526,7 +526,7 @@ namespace System.Runtime.Serialization
                     {
                         if (_helper.XmlFormatGetOnlyCollectionReaderDelegate == null)
                         {
-                            if (TypeIsInterface && (Kind == CollectionKind.Enumerable || Kind == CollectionKind.Collection || Kind == CollectionKind.GenericEnumerable))
+                            if (UnderlyingType.GetTypeInfo().IsInterface && (Kind == CollectionKind.Enumerable || Kind == CollectionKind.Collection || Kind == CollectionKind.GenericEnumerable))
                             {
                                 throw DiagnosticUtility.ExceptionUtility.ThrowHelperError(new InvalidDataContractException(SR.Format(SR.GetOnlyCollectionMustHaveAddMethod, GetClrTypeFullName(UnderlyingType))));
                             }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -468,10 +468,6 @@ namespace System.Runtime.Serialization
             get { return false; }
         }
 
-        public bool TypeIsInterface;
-        public bool TypeIsCollectionInterface;
-        public Type GenericTypeDefinition;
-
         internal virtual void WriteRootElement(XmlWriterDelegator writer, XmlDictionaryString name, XmlDictionaryString ns)
         {
             if (object.ReferenceEquals(ns, DictionaryGlobals.SerializationNamespace) && !IsPrimitive)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonCollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonCollectionDataContract.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Reflection;
 using System.Threading;
 using System.Xml;
 using System.Security;
@@ -56,7 +57,7 @@ namespace System.Runtime.Serialization.Json
                         if (_helper.JsonFormatGetOnlyReaderDelegate == null)
                         {
                             CollectionKind kind = this.TraditionalCollectionDataContract.Kind;
-                            if (this.TraditionalDataContract.TypeIsInterface && (kind == CollectionKind.Enumerable || kind == CollectionKind.Collection || kind == CollectionKind.GenericEnumerable))
+                            if (this.TraditionalDataContract.UnderlyingType.GetTypeInfo().IsInterface && (kind == CollectionKind.Enumerable || kind == CollectionKind.Collection || kind == CollectionKind.GenericEnumerable))
                             {
                                 throw new InvalidDataContractException(SR.Format(SR.GetOnlyCollectionMustHaveAddMethod, DataContract.GetClrTypeFullName(this.TraditionalDataContract.UnderlyingType)));
                             }

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -1711,8 +1711,9 @@ public static partial class DataContractJsonSerializerTests
     [Fact]
     public static void DCJS_CollectionInterfaceGetOnlyCollection()
     {
-        var obj = new CollectionInterfaceGetOnlyCollectionTester(new List<string>() { "item1", "item2", "item3" });
-        SerializeAndDeserialize(obj, @"{""Items"":[""item1"",""item2"",""item3""]}");
+        var obj = new TypeWithCollectionInterfaceGetOnlyCollection(new List<string>() { "item1", "item2", "item3" });
+        var deserializedObj = SerializeAndDeserialize(obj, @"{""Items"":[""item1"",""item2"",""item3""]}");
+        Assert.Equal(obj.Items, deserializedObj.Items);
     }
 
     [Fact]
@@ -1720,7 +1721,7 @@ public static partial class DataContractJsonSerializerTests
     {
         // Expect exception in deserialization process
         Assert.Throws<InvalidDataContractException>(() => {
-            var obj = new EnumerableInterfaceGetOnlyCollectionTester(new List<string>() { "item1", "item2", "item3" });
+            var obj = new TypeWithEnumerableInterfaceGetOnlyCollection(new List<string>() { "item1", "item2", "item3" });
             SerializeAndDeserialize(obj, @"{""Items"":[""item1"",""item2"",""item3""]}");
         });
     }

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -1695,6 +1695,7 @@ public static partial class DataContractJsonSerializerTests
         Assert.StrictEqual(true, Enumerable.SequenceEqual(value.CollectionProperty, deserializedValue.CollectionProperty));
     }
 
+    [Fact]
     public static void DCJS_DataMemberNames()
     {
         var obj = new AppEnvironment()
@@ -1705,6 +1706,23 @@ public static partial class DataContractJsonSerializerTests
         var actual = SerializeAndDeserialize(obj, @"{""screen_dpi(x:y)"":440,""screen:orientation"":""horizontal""}");
         Assert.StrictEqual(obj.ScreenDpi, actual.ScreenDpi);
         Assert.StrictEqual(obj.ScreenOrientation, actual.ScreenOrientation);
+    }
+
+    [Fact]
+    public static void DCJS_CollectionInterfaceGetOnlyCollection()
+    {
+        var obj = new CollectionInterfaceGetOnlyCollectionTester(new List<string>() { "item1", "item2", "item3" });
+        SerializeAndDeserialize(obj, @"{""Items"":[""item1"",""item2"",""item3""]}");
+    }
+
+    [Fact]
+    public static void DCJS_EnumerableInterfaceGetOnlyCollection()
+    {
+        // Expect exception in deserialization process
+        Assert.Throws<InvalidDataContractException>(() => {
+            var obj = new EnumerableInterfaceGetOnlyCollectionTester(new List<string>() { "item1", "item2", "item3" });
+            SerializeAndDeserialize(obj, @"{""Items"":[""item1"",""item2"",""item3""]}");
+        });
     }
 
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractJsonSerializerSettings settings = null, Func<DataContractJsonSerializer> serializerFactory = null, bool skipStringCompare = false)

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -1963,8 +1963,9 @@ public static partial class DataContractSerializerTests
     [Fact]
     public static void DCS_CollectionInterfaceGetOnlyCollection()
     {
-        var obj = new CollectionInterfaceGetOnlyCollectionTester(new List<string>() { "item1", "item2", "item3" });
-        SerializeAndDeserialize(obj, @"<CollectionInterfaceGetOnlyCollectionTester xmlns=""http://schemas.datacontract.org/2004/07/"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><Items xmlns:a=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""><a:string>item1</a:string><a:string>item2</a:string><a:string>item3</a:string></Items></CollectionInterfaceGetOnlyCollectionTester>");
+        var obj = new TypeWithCollectionInterfaceGetOnlyCollection(new List<string>() { "item1", "item2", "item3" });
+        var deserializedObj = SerializeAndDeserialize(obj, @"<TypeWithCollectionInterfaceGetOnlyCollection xmlns=""http://schemas.datacontract.org/2004/07/"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><Items xmlns:a=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""><a:string>item1</a:string><a:string>item2</a:string><a:string>item3</a:string></Items></TypeWithCollectionInterfaceGetOnlyCollection>");
+        Assert.Equal(obj.Items, deserializedObj.Items);
     }
 
     [Fact]
@@ -1972,8 +1973,8 @@ public static partial class DataContractSerializerTests
     {
         // Expect exception in deserialization process
         Assert.Throws<InvalidDataContractException>(() => {
-            var obj = new EnumerableInterfaceGetOnlyCollectionTester(new List<string>() { "item1", "item2", "item3" });
-            SerializeAndDeserialize(obj, @"<EnumerableInterfaceGetOnlyCollectionTester xmlns=""http://schemas.datacontract.org/2004/07/"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><Items xmlns:a=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""><a:string>item1</a:string><a:string>item2</a:string><a:string>item3</a:string></Items></EnumerableInterfaceGetOnlyCollectionTester>");
+            var obj = new TypeWithEnumerableInterfaceGetOnlyCollection(new List<string>() { "item1", "item2", "item3" });
+            SerializeAndDeserialize(obj, @"<TypeWithEnumerableInterfaceGetOnlyCollection xmlns=""http://schemas.datacontract.org/2004/07/"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><Items xmlns:a=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""><a:string>item1</a:string><a:string>item2</a:string><a:string>item3</a:string></Items></TypeWithEnumerableInterfaceGetOnlyCollection>");
         });
     }
 

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -1970,6 +1970,7 @@ public static partial class DataContractSerializerTests
     [Fact]
     public static void DCS_EnumerableInterfaceGetOnlyCollection()
     {
+        // Expect exception in deserialization process
         Assert.Throws<InvalidDataContractException>(() => {
             var obj = new EnumerableInterfaceGetOnlyCollectionTester(new List<string>() { "item1", "item2", "item3" });
             SerializeAndDeserialize(obj, @"<EnumerableInterfaceGetOnlyCollectionTester xmlns=""http://schemas.datacontract.org/2004/07/"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><Items xmlns:a=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""><a:string>item1</a:string><a:string>item2</a:string><a:string>item3</a:string></Items></EnumerableInterfaceGetOnlyCollectionTester>");

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -1960,6 +1960,22 @@ public static partial class DataContractSerializerTests
         }
     }
 
+    [Fact]
+    public static void DCS_CollectionInterfaceGetOnlyCollection()
+    {
+        var obj = new CollectionInterfaceGetOnlyCollectionTester(new List<string>() { "item1", "item2", "item3" });
+        SerializeAndDeserialize(obj, @"<CollectionInterfaceGetOnlyCollectionTester xmlns=""http://schemas.datacontract.org/2004/07/"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><Items xmlns:a=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""><a:string>item1</a:string><a:string>item2</a:string><a:string>item3</a:string></Items></CollectionInterfaceGetOnlyCollectionTester>");
+    }
+
+    [Fact]
+    public static void DCS_EnumerableInterfaceGetOnlyCollection()
+    {
+        Assert.Throws<InvalidDataContractException>(() => {
+            var obj = new EnumerableInterfaceGetOnlyCollectionTester(new List<string>() { "item1", "item2", "item3" });
+            SerializeAndDeserialize(obj, @"<EnumerableInterfaceGetOnlyCollectionTester xmlns=""http://schemas.datacontract.org/2004/07/"" xmlns:i=""http://www.w3.org/2001/XMLSchema-instance""><Items xmlns:a=""http://schemas.microsoft.com/2003/10/Serialization/Arrays""><a:string>item1</a:string><a:string>item2</a:string><a:string>item3</a:string></Items></EnumerableInterfaceGetOnlyCollectionTester>");
+        });
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractSerializerSettings settings = null, Func<DataContractSerializer> serializerFactory = null, bool skipStringCompare = false)
     {
         DataContractSerializer dcs;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -2731,7 +2731,7 @@ public class TypeWithTypeWithIntAndStringPropertyProperty
 }
 
 [DataContract]
-public class CollectionInterfaceGetOnlyCollectionTester
+public class TypeWithCollectionInterfaceGetOnlyCollection
 {
     List<string> items;
 
@@ -2748,16 +2748,16 @@ public class CollectionInterfaceGetOnlyCollectionTester
         }
     }
 
-    public CollectionInterfaceGetOnlyCollectionTester() { }
+    public TypeWithCollectionInterfaceGetOnlyCollection() { }
 
-    public CollectionInterfaceGetOnlyCollectionTester(List<string> items)
+    public TypeWithCollectionInterfaceGetOnlyCollection(List<string> items)
     {
         this.items = items;
     }
 }
 
 [DataContract]
-public class EnumerableInterfaceGetOnlyCollectionTester
+public class TypeWithEnumerableInterfaceGetOnlyCollection
 {
     List<string> items;
 
@@ -2774,9 +2774,9 @@ public class EnumerableInterfaceGetOnlyCollectionTester
         }
     }
 
-    public EnumerableInterfaceGetOnlyCollectionTester() { }
+    public TypeWithEnumerableInterfaceGetOnlyCollection() { }
 
-    public EnumerableInterfaceGetOnlyCollectionTester(List<string> items)
+    public TypeWithEnumerableInterfaceGetOnlyCollection(List<string> items)
     {
         this.items = items;
     }

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -2729,3 +2729,55 @@ public class TypeWithTypeWithIntAndStringPropertyProperty
     [DataMember]
     public TypeWithIntAndStringProperty ObjectProperty { get; set; }
 }
+
+[DataContract]
+public class CollectionInterfaceGetOnlyCollectionTester
+{
+    List<string> items;
+
+    [DataMember]
+    public ICollection<string> Items
+    {
+        get
+        {
+            if (items == null)
+            {
+                items = new List<string>();
+            }
+            return this.items;
+        }
+    }
+
+    public CollectionInterfaceGetOnlyCollectionTester() { }
+
+    public CollectionInterfaceGetOnlyCollectionTester(List<string> items)
+    {
+        this.items = items;
+    }
+}
+
+[DataContract]
+public class EnumerableInterfaceGetOnlyCollectionTester
+{
+    List<string> items;
+
+    [DataMember]
+    public IEnumerable<string> Items
+    {
+        get
+        {
+            if (items == null)
+            {
+                items = new List<string>();
+            }
+            return this.items;
+        }
+    }
+
+    public EnumerableInterfaceGetOnlyCollectionTester() { }
+
+    public EnumerableInterfaceGetOnlyCollectionTester(List<string> items)
+    {
+        this.items = items;
+    }
+}


### PR DESCRIPTION
Porting a fix from Desktop.
Deserialization of get-only IEnumerable collection is not supported. This change fixes the NRE by throwing exception earlier in the deserialization process.

@shmao @SGuyGe @zhenlan 