### PR TITLE
Adding the Datatype for DbColumn

### DIFF
--- a/src/System.Data.Common/src/System.Data.Common.csproj
+++ b/src/System.Data.Common/src/System.Data.Common.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <ProjectGuid>{29ef8d53-8e84-4e49-b90f-5950a2fe7d54}</ProjectGuid>
+    <ProjectGuid>{29EF8D53-8E84-4E49-B90F-5950A2FE7D54}</ProjectGuid>
     <AssemblyName>System.Data.Common</AssemblyName>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -13,6 +13,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="System\Data\Common\DbColumn.cs" />
     <Compile Include="System\DBNull.cs" />
     <Compile Include="System\Data\CommandBehavior.cs" />
     <Compile Include="System\Data\CommandType.cs" />

--- a/src/System.Data.Common/src/System/Data/Common/DbColumn.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbColumn.cs
@@ -7,7 +7,7 @@ namespace System.Data.Common
 {
     public class DbColumn
     {
-        private Dictionary<string, object> s_customValues = new Dictionary<string, object>();
+        private readonly Dictionary<string, object> _customValues = new Dictionary<string, object>();
         public virtual bool AllowDBNull { get; set; }
         public virtual string BaseCatalogName { get; set; }
         public virtual string BaseColumnName { get; set; }
@@ -36,12 +36,12 @@ namespace System.Data.Common
             get
             {
                 object value;
-                s_customValues.TryGetValue(property, out value);
+                _customValues.TryGetValue(property, out value);
                 return value;
             }
             set
             {
-                s_customValues.Add(property, value);
+                _customValues.Add(property, value);
             }
         }
 

--- a/src/System.Data.Common/src/System/Data/Common/DbColumn.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbColumn.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace System.Data.Common
+{
+    public class DbColumn
+    {
+        private Dictionary<string, object> s_customValues = new Dictionary<string, object>();
+        public virtual bool AllowDBNull { get; set; }
+        public virtual string BaseCatalogName { get; set; }
+        public virtual string BaseColumnName { get; set; }
+        public virtual string BaseSchemaName { get; set; }
+        public virtual string BaseServerName { get; set; }
+        public virtual string BaseTableName { get; set; }
+        public virtual string ColumnName { get; set; }
+        public virtual int ColumnOrdinal { get; set; }
+        public virtual int ColumnSize { get; set; }
+        public virtual bool IsAliased { get; set; }
+        public virtual bool IsAutoIncrement { get; set; }
+        public virtual bool IsExpression { get; set; }
+        public virtual bool IsHidden { get; set; }
+        public virtual bool IsIdentity { get; set; }
+        public virtual bool IsKey { get; set; }
+        public virtual bool IsLong { get; set; }
+        public virtual bool IsReadOnly { get; set; }
+        public virtual bool IsUnique { get; set; }
+        public virtual int NumericPrecision { get; set; }
+        public virtual int NumericScale { get; set; }
+        public virtual string UdtAssemblyQualifiedName { get; set; }
+        public virtual Type DataType { get; set; }
+        public virtual string DataTypeName { get; set; }
+        public virtual object this[string property]
+        {
+            get
+            {
+                object value;
+                s_customValues.TryGetValue(property, out value);
+                return value;
+            }
+            set
+            {
+                s_customValues.Add(property, value);
+            }
+        }
+
+    }
+}

--- a/src/System.Data.Common/src/System/Data/Common/DbColumn.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbColumn.cs
@@ -41,7 +41,7 @@ namespace System.Data.Common
             }
             set
             {
-                _customValues.Add(property, value);
+                _customValues[property] = value;
             }
         }
 


### PR DESCRIPTION
Adding new Type for DbColumn to support the Schema retrieval for DbDataReader

https://github.com/dotnet/corefx/issues/3423

After this is available, the API on the DbDataReader along with Sql Client implementation will be exposed as well.