### PR TITLE
Augment GlobalLog.Assert* call sites in System.Net

### DIFF
--- a/src/Common/src/Interop/Windows/SChannel/SslConnectionInfo.cs
+++ b/src/Common/src/Interop/Windows/SChannel/SslConnectionInfo.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace System.Net
@@ -41,6 +42,7 @@ namespace System.Net
                     {
                         GlobalLog.Assert("SslConnectionInfo::.ctor", "Negative size.");
                     }
+                    Debug.Fail("SslConnectionInfo::.ctor", "Negative size.");
                     throw;
                 }
             }

--- a/src/Common/src/Interop/Windows/sspicli/SSPIAuthType.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SSPIAuthType.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.Globalization;
 using System.Net.Security;
 using System.Runtime.InteropServices;
@@ -111,6 +112,7 @@ namespace System.Net
                 {
                     GlobalLog.Assert("SspiCli.DecryptMessage", "Expected qop = 0, returned value = " + qop.ToString("x", CultureInfo.InvariantCulture));
                 }
+                Debug.Fail("SspiCli.DecryptMessage", "Expected qop = 0, returned value = " + qop.ToString("x", CultureInfo.InvariantCulture));
                 throw new InvalidOperationException(SR.net_auth_message_not_encrypted);
             }
 

--- a/src/Common/src/Interop/Windows/sspicli/SSPIWrapper.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SSPIWrapper.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Globalization;
 using System.Net.Security;
 using System.Runtime.InteropServices;
@@ -412,6 +413,7 @@ namespace System.Net
                             {
                                 GlobalLog.Assert("SSPIWrapper::EncryptDecryptHelper", "Unknown OP: " + op);
                             }
+                            Debug.Fail("SSPIWrapper::EncryptDecryptHelper", "Unknown OP: " + op);
                             throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
                     }
 
@@ -456,6 +458,7 @@ namespace System.Net
                                     {
                                         GlobalLog.Assert("SSPIWrapper::EncryptDecryptHelper", "Output buffer out of range.");
                                     }
+                                    Debug.Fail("SSPIWrapper::EncryptDecryptHelper", "Output buffer out of range.");
                                     iBuffer.size = 0;
                                     iBuffer.offset = 0;
                                     iBuffer.token = null;
@@ -464,16 +467,21 @@ namespace System.Net
                         }
 
                         // Backup validate the new sizes.
-                        if (GlobalLog.IsEnabled)
+                        if (iBuffer.offset < 0 || iBuffer.offset > (iBuffer.token == null ? 0 : iBuffer.token.Length))
                         {
-                            if (iBuffer.offset == 0 || iBuffer.offset > (iBuffer.token == null ? 0 : iBuffer.token.Length))
+                            if (GlobalLog.IsEnabled)
                             {
                                 GlobalLog.AssertFormat("SSPIWrapper::EncryptDecryptHelper|'offset' out of range.  [{0}]", iBuffer.offset);
                             }
-                            if (iBuffer.size == 0 || iBuffer.size > (iBuffer.token == null ? 0 : iBuffer.token.Length - iBuffer.offset))
+                            Debug.Fail("SSPIWrapper::EncryptDecryptHelper|'offset' out of range.  [" + iBuffer.offset + "]");
+                        }
+                        if (iBuffer.size < 0 || iBuffer.size > (iBuffer.token == null ? 0 : iBuffer.token.Length - iBuffer.offset))
+                        {
+                            if (GlobalLog.IsEnabled)
                             {
                                 GlobalLog.AssertFormat("SSPIWrapper::EncryptDecryptHelper|'size' out of range.  [{0}]", iBuffer.size);
                             }
+                            Debug.Fail("SSPIWrapper::EncryptDecryptHelper|'size' out of range.  [" + iBuffer.size + "]");
                         }
                     }
 

--- a/src/Common/src/Interop/Windows/sspicli/SecSizes.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SecSizes.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace System.Net
@@ -33,6 +34,7 @@ namespace System.Net
                     {
                         GlobalLog.Assert("SecSizes::.ctor", "Negative size.");
                     }
+                    Debug.Fail("SecSizes::.ctor", "Negative size.");
                     throw;
                 }
             }

--- a/src/Common/src/Interop/Windows/sspicli/SecuritySafeHandles.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SecuritySafeHandles.cs
@@ -543,16 +543,21 @@ namespace System.Net.Security
                 }
             }
 #endif
-            if (GlobalLog.IsEnabled)
+            if (outSecBuffer == null)
             {
-                if (outSecBuffer == null)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("SafeDeleteContext::InitializeSecurityContext()|outSecBuffer != null");
                 }
-                if (inSecBuffer != null && inSecBuffers != null)
+                Debug.Fail("SafeDeleteContext::InitializeSecurityContext()|outSecBuffer != null");
+            }
+            if (inSecBuffer != null && inSecBuffers != null)
+            {
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("SafeDeleteContext::InitializeSecurityContext()|inSecBuffer == null || inSecBuffers == null");
                 }
+                Debug.Fail("SafeDeleteContext::InitializeSecurityContext()|inSecBuffer == null || inSecBuffers == null");
             }
 
             if (inCredentials == null)
@@ -848,16 +853,21 @@ namespace System.Net.Security
                 }
             }
 #endif
-            if (GlobalLog.IsEnabled)
+            if (outSecBuffer == null)
             {
-                if (outSecBuffer == null)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("SafeDeleteContext::AcceptSecurityContext()|outSecBuffer != null");
                 }
-                if (inSecBuffer != null && inSecBuffers != null)
+                Debug.Fail("SafeDeleteContext::AcceptSecurityContext()|outSecBuffer != null");
+            }
+            if (inSecBuffer != null && inSecBuffers != null)
+            {
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("SafeDeleteContext::AcceptSecurityContext()|inSecBuffer == null || inSecBuffers == null");
                 }
+                Debug.Fail("SafeDeleteContext::AcceptSecurityContext()|outSecBuffer != null");
             }
 
             if (inCredentials == null)
@@ -1125,10 +1135,14 @@ namespace System.Net.Security
 #if TRACE_VERBOSE
                 GlobalLog.Print("    inSecBuffers[]   = length:" + inSecBuffers.Length);
 #endif
-                if (inSecBuffers == null)
+            }
+            if (inSecBuffers == null)
+            {
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("SafeDeleteContext::CompleteAuthToken()|inSecBuffers == null");
                 }
+                Debug.Fail("SafeDeleteContext::CompleteAuthToken()|inSecBuffers == null");
             }
 
             var inSecurityBufferDescriptor = new Interop.SspiCli.SecurityBufferDescriptor(inSecBuffers.Length);

--- a/src/Common/src/Interop/Windows/sspicli/SecuritySafeHandles.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SecuritySafeHandles.cs
@@ -225,8 +225,7 @@ namespace System.Net.Security
             ref Interop.SspiCli.AuthIdentity authdata,
             out SafeFreeCredentials outCredential)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Print("SafeFreeCredentials::AcquireCredentialsHandle#1("
                                 + package + ", "
@@ -250,7 +249,7 @@ namespace System.Net.Security
                             ref outCredential._handle,
                             out timeStamp);
 #if TRACE_VERBOSE
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Print("Unmanaged::AcquireCredentialsHandle() returns 0x"
                                 + String.Format("{0:x}", errorCode)
@@ -271,8 +270,7 @@ namespace System.Net.Security
             Interop.SspiCli.CredentialUse intent,
             out SafeFreeCredentials outCredential)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Print("SafeFreeCredentials::AcquireDefaultCredential("
                                 + package + ", "
@@ -296,7 +294,7 @@ namespace System.Net.Security
                             out timeStamp);
 
 #if TRACE_VERBOSE
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Print("Unmanaged::AcquireCredentialsHandle() returns 0x"
                                 + errorCode.ToString("x")
@@ -347,8 +345,7 @@ namespace System.Net.Security
             ref Interop.SspiCli.SecureCredential authdata,
             out SafeFreeCredentials outCredential)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Print("SafeFreeCredentials::AcquireCredentialsHandle#2("
                                 + package + ", "
@@ -390,7 +387,7 @@ namespace System.Net.Security
             }
 
 #if TRACE_VERBOSE
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Print("Unmanaged::AcquireCredentialsHandle() returns 0x"
                                 + errorCode.ToString("x")
@@ -525,9 +522,8 @@ namespace System.Net.Security
             SecurityBuffer outSecBuffer,
             ref Interop.SspiCli.ContextFlags outFlags)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
 #if TRACE_VERBOSE
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Enter("SafeDeleteContext::InitializeSecurityContext");
                 GlobalLog.Print("    credential       = " + inCredentials.ToString());
@@ -547,7 +543,7 @@ namespace System.Net.Security
                 }
             }
 #endif
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 if (outSecBuffer == null)
                 {
@@ -629,7 +625,7 @@ namespace System.Net.Security
                                     inUnmanagedBuffer[index].token = Marshal.UnsafeAddrOfPinnedArrayElement(securityBuffer.token, securityBuffer.offset);
                                 }
 #if TRACE_VERBOSE
-                                if (globalLogEnabled)
+                                if (GlobalLog.IsEnabled)
                                 {
                                     GlobalLog.Print("SecBuffer: cbBuffer:" + securityBuffer.size + " BufferType:" + securityBuffer.type);
                                 }
@@ -684,7 +680,7 @@ namespace System.Net.Security
                                             outFreeContextBuffer);
                         }
 
-                        if (globalLogEnabled)
+                        if (GlobalLog.IsEnabled)
                         {
                             GlobalLog.Print("SafeDeleteContext:InitializeSecurityContext  Marshalling OUT buffer");
                         }
@@ -727,7 +723,7 @@ namespace System.Net.Security
                 }
             }
 
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Leave("SafeDeleteContext::InitializeSecurityContext() unmanaged InitializeSecurityContext()", "errorCode:0x" + errorCode.ToString("x8") + " refContext:" + LoggingHash.ObjectToString(refContext));
             }
@@ -833,9 +829,8 @@ namespace System.Net.Security
             SecurityBuffer outSecBuffer,
             ref Interop.SspiCli.ContextFlags outFlags)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
 #if TRACE_VERBOSE
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Enter("SafeDeleteContext::AcceptSecurityContex");
                 GlobalLog.Print("    credential       = " + inCredentials.ToString());
@@ -853,7 +848,7 @@ namespace System.Net.Security
                 }
             }
 #endif
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 if (outSecBuffer == null)
                 {
@@ -935,7 +930,7 @@ namespace System.Net.Security
                                     inUnmanagedBuffer[index].token = Marshal.UnsafeAddrOfPinnedArrayElement(securityBuffer.token, securityBuffer.offset);
                                 }
 #if TRACE_VERBOSE
-                                if (globalLogEnabled)
+                                if (GlobalLog.IsEnabled)
                                 {
                                     GlobalLog.Print("SecBuffer: cbBuffer:" + securityBuffer.size + " BufferType:" + securityBuffer.type);
                                 }
@@ -983,7 +978,7 @@ namespace System.Net.Security
                                         ref outFlags,
                                         outFreeContextBuffer);
 
-                        if (globalLogEnabled)
+                        if (GlobalLog.IsEnabled)
                         {
                             GlobalLog.Print("SafeDeleteContext:AcceptSecurityContext  Marshalling OUT buffer");
                         }
@@ -1027,7 +1022,7 @@ namespace System.Net.Security
                 }
             }
 
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Leave("SafeDeleteContext::AcceptSecurityContex() unmanaged AcceptSecurityContex()", "errorCode:0x" + errorCode.ToString("x8") + " refContext:" + LoggingHash.ObjectToString(refContext));
             }
@@ -1123,8 +1118,7 @@ namespace System.Net.Security
             ref SafeDeleteContext refContext,
             SecurityBuffer[] inSecBuffers)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Enter("SafeDeleteContext::CompleteAuthToken");
                 GlobalLog.Print("    refContext       = " + LoggingHash.ObjectToString(refContext));
@@ -1174,7 +1168,7 @@ namespace System.Net.Security
                             inUnmanagedBuffer[index].token = Marshal.UnsafeAddrOfPinnedArrayElement(securityBuffer.token, securityBuffer.offset);
                         }
 #if TRACE_VERBOSE
-                        if (globalLogEnabled)
+                        if (GlobalLog.IsEnabled)
                         {
                             GlobalLog.Print("SecBuffer: cbBuffer:" + securityBuffer.size + " BufferType:" + securityBuffer.type);
                         }
@@ -1220,7 +1214,7 @@ namespace System.Net.Security
                 }
             }
 
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Leave("SafeDeleteContext::CompleteAuthToken() unmanaged CompleteAuthToken()", "errorCode:0x" + errorCode.ToString("x8") + " refContext:" + LoggingHash.ObjectToString(refContext));
             }

--- a/src/Common/src/Interop/Windows/sspicli/StreamSizes.cs
+++ b/src/Common/src/Interop/Windows/sspicli/StreamSizes.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace System.Net
@@ -35,6 +36,7 @@ namespace System.Net
                     {
                         GlobalLog.Assert("StreamSizes::.ctor", "Negative size.");
                     }
+                    Debug.Fail("StreamSizes::.ctor", "Negative size.");
                     throw;
                 }
             }

--- a/src/Common/src/System/Net/ContextAwareResult.cs
+++ b/src/Common/src/System/Net/ContextAwareResult.cs
@@ -361,9 +361,7 @@ namespace System.Net
         // Returns whether the operation completed sync or not.
         private bool CaptureOrComplete(ref ExecutionContext cachedContext, bool returnContext)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-
-            if ((_flags & StateFlags.PostBlockStarted) == 0 && globalLogEnabled)
+            if ((_flags & StateFlags.PostBlockStarted) == 0 && GlobalLog.IsEnabled)
             {
                 GlobalLog.AssertFormat("ContextAwareResult#{0}::CaptureOrComplete|Called without calling StartPostingAsyncOp.", LoggingHash.HashString(this));
             }
@@ -376,7 +374,7 @@ namespace System.Net
             // capturing the context won't be sufficient.
             if ((_flags & StateFlags.CaptureIdentity) != 0 && !InternalPeekCompleted && (!capturingContext))
             {
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Print("ContextAwareResult#" + LoggingHash.HashString(this) + "::CaptureOrComplete() starting identity capture");
                 }
@@ -388,7 +386,7 @@ namespace System.Net
             // Note that Capture() can return null, for example if SuppressFlow() is in effect.
             if (capturingContext && !InternalPeekCompleted)
             {
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Print("ContextAwareResult#" + LoggingHash.HashString(this) + "::CaptureOrComplete() starting capture");
                 }
@@ -411,7 +409,7 @@ namespace System.Net
                     }
                 }
 
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Print("ContextAwareResult#" + LoggingHash.HashString(this) + "::CaptureOrComplete() _Context:" + LoggingHash.HashString(_context));
                 }
@@ -419,13 +417,13 @@ namespace System.Net
             else
             {
                 // Otherwise we have to have completed synchronously, or not needed the context.
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Print("ContextAwareResult#" + LoggingHash.HashString(this) + "::CaptureOrComplete() skipping capture");
                 }
 
                 cachedContext = null;
-                if (AsyncCallback != null && !CompletedSynchronously && globalLogEnabled)
+                if (AsyncCallback != null && !CompletedSynchronously && GlobalLog.IsEnabled)
                 {
                     GlobalLog.AssertFormat("ContextAwareResult#{0}::CaptureOrComplete|Didn't capture context, but didn't complete synchronously!", LoggingHash.HashString(this));
                 }

--- a/src/Common/src/System/Net/ContextAwareResult.cs
+++ b/src/Common/src/System/Net/ContextAwareResult.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.Security;
 using System.Security.Principal;
 using System.Threading;
@@ -142,9 +143,13 @@ namespace System.Net
             {
                 if (InternalPeekCompleted)
                 {
-                    if ((_flags & StateFlags.ThreadSafeContextCopy) == 0 && GlobalLog.IsEnabled)
+                    if ((_flags & StateFlags.ThreadSafeContextCopy) == 0)
                     {
-                        GlobalLog.AssertFormat("ContextAwareResult#{0}::ContextCopy|Called on completed result.", LoggingHash.HashString(this));
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.AssertFormat("ContextAwareResult#{0}::ContextCopy|Called on completed result.", LoggingHash.HashString(this));
+                        }
+                        Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::ContextCopy |Called on completed result.");
                     }
 
                     throw new InvalidOperationException(SR.net_completed_result);
@@ -157,27 +162,39 @@ namespace System.Net
                 }
 
                 // Make sure the context was requested.
-                if (AsyncCallback == null && (_flags & StateFlags.CaptureContext) == 0 && GlobalLog.IsEnabled)
+                if (AsyncCallback == null && (_flags & StateFlags.CaptureContext) == 0)
                 {
-                    GlobalLog.AssertFormat("ContextAwareResult#{0}::ContextCopy|No context captured - specify a callback or forceCaptureContext.", LoggingHash.HashString(this));
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.AssertFormat("ContextAwareResult#{0}::ContextCopy|No context captured - specify a callback or forceCaptureContext.", LoggingHash.HashString(this));
+                    }
+                    Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::ContextCopy |No context captured - specify a callback or forceCaptureContext.");
                 }
 
                 // Just use the lock to block.  We might be on the thread that owns the lock which is great, it means we
                 // don't need a context anyway.
                 if ((_flags & StateFlags.PostBlockFinished) == 0)
                 {
-                    if (_lock == null && GlobalLog.IsEnabled)
+                    if (_lock == null)
                     {
-                        GlobalLog.AssertFormat("ContextAwareResult#{0}::ContextCopy|Must lock (StartPostingAsyncOp()) { ... FinishPostingAsyncOp(); } when calling ContextCopy (unless it's only called after FinishPostingAsyncOp).", LoggingHash.HashString(this));
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.AssertFormat("ContextAwareResult#{0}::ContextCopy|Must lock (StartPostingAsyncOp()) { ... FinishPostingAsyncOp(); } when calling ContextCopy (unless it's only called after FinishPostingAsyncOp).", LoggingHash.HashString(this));
+                        }
+                        Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) +"::ContextCopy |Must lock (StartPostingAsyncOp()) { ... FinishPostingAsyncOp(); } when calling ContextCopy (unless it's only called after FinishPostingAsyncOp).");
                     }
                     lock (_lock) { }
                 }
 
                 if (InternalPeekCompleted)
                 {
-                    if ((_flags & StateFlags.ThreadSafeContextCopy) == 0 && GlobalLog.IsEnabled)
+                    if ((_flags & StateFlags.ThreadSafeContextCopy) == 0)
                     {
-                        GlobalLog.AssertFormat("ContextAwareResult#{0}::ContextCopy|Result became completed during call.", LoggingHash.HashString(this));
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.AssertFormat("ContextAwareResult#{0}::ContextCopy|Result became completed during call.", LoggingHash.HashString(this));
+                        }
+                        Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::ContextCopy |Result became completed during call.");
                     }
 
                     throw new InvalidOperationException(SR.net_completed_result);
@@ -195,9 +212,13 @@ namespace System.Net
             {
                 if (InternalPeekCompleted)
                 {
-                    if ((_flags & StateFlags.ThreadSafeContextCopy) == 0 && GlobalLog.IsEnabled)
+                    if ((_flags & StateFlags.ThreadSafeContextCopy) == 0)
                     {
-                        GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|Called on completed result.", LoggingHash.HashString(this));
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|Called on completed result.", LoggingHash.HashString(this));
+                        }
+                        Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::Identity |Called on completed result.");
                     }
 
                     throw new InvalidOperationException(SR.net_completed_result);
@@ -209,27 +230,39 @@ namespace System.Net
                 }
 
                 // Make sure the identity was requested.
-                if ((_flags & StateFlags.CaptureIdentity) == 0 && GlobalLog.IsEnabled)
+                if ((_flags & StateFlags.CaptureIdentity) == 0)
                 {
-                    GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|No identity captured - specify captureIdentity.", LoggingHash.HashString(this));
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|No identity captured - specify captureIdentity.", LoggingHash.HashString(this));
+                    }
+                    Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::Identity |No identity captured - specify captureIdentity.");
                 }
 
                 // Just use the lock to block.  We might be on the thread that owns the lock which is great, it means we
                 // don't need an identity anyway.
                 if ((_flags & StateFlags.PostBlockFinished) == 0)
                 {
-                    if (_lock == null && GlobalLog.IsEnabled)
+                    if (_lock == null)
                     {
-                        GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|Must lock (StartPostingAsyncOp()) { ... FinishPostingAsyncOp(); } when calling Identity (unless it's only called after FinishPostingAsyncOp).", LoggingHash.HashString(this));
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|Must lock (StartPostingAsyncOp()) { ... FinishPostingAsyncOp(); } when calling Identity (unless it's only called after FinishPostingAsyncOp).", LoggingHash.HashString(this));
+                        }
+                        Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::Identity |Must lock (StartPostingAsyncOp()) { ... FinishPostingAsyncOp(); } when calling Identity (unless it's only called after FinishPostingAsyncOp).");
                     }
                     lock (_lock) { }
                 }
 
                 if (InternalPeekCompleted)
                 {
-                    if ((_flags & StateFlags.ThreadSafeContextCopy) == 0 && GlobalLog.IsEnabled)
+                    if ((_flags & StateFlags.ThreadSafeContextCopy) == 0)
                     {
-                        GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|Result became completed during call.", LoggingHash.HashString(this));
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|Result became completed during call.", LoggingHash.HashString(this));
+                        }
+                        Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::Identity |Result became completed during call.");
                     }
 
                     throw new InvalidOperationException(SR.net_completed_result);
@@ -262,9 +295,13 @@ namespace System.Net
         // object from being created.
         internal object StartPostingAsyncOp(bool lockCapture)
         {
-            if (InternalPeekCompleted && GlobalLog.IsEnabled)
+            if (InternalPeekCompleted)
             {
-                GlobalLog.AssertFormat("ContextAwareResult#{0}::StartPostingAsyncOp|Called on completed result.", LoggingHash.HashString(this));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.AssertFormat("ContextAwareResult#{0}::StartPostingAsyncOp|Called on completed result.", LoggingHash.HashString(this));
+                }
+                Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::StartPostingAsyncOp |Called on completed result.");
             }
 
             DebugProtectState(true);
@@ -361,9 +398,13 @@ namespace System.Net
         // Returns whether the operation completed sync or not.
         private bool CaptureOrComplete(ref ExecutionContext cachedContext, bool returnContext)
         {
-            if ((_flags & StateFlags.PostBlockStarted) == 0 && GlobalLog.IsEnabled)
+            if ((_flags & StateFlags.PostBlockStarted) == 0)
             {
-                GlobalLog.AssertFormat("ContextAwareResult#{0}::CaptureOrComplete|Called without calling StartPostingAsyncOp.", LoggingHash.HashString(this));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.AssertFormat("ContextAwareResult#{0}::CaptureOrComplete|Called without calling StartPostingAsyncOp.", LoggingHash.HashString(this));
+                }
+                Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::CaptureOrComplete |Called without calling StartPostingAsyncOp.");
             }
 
             // See if we're going to need to capture the context.
@@ -423,9 +464,13 @@ namespace System.Net
                 }
 
                 cachedContext = null;
-                if (AsyncCallback != null && !CompletedSynchronously && GlobalLog.IsEnabled)
+                if (AsyncCallback != null && !CompletedSynchronously)
                 {
-                    GlobalLog.AssertFormat("ContextAwareResult#{0}::CaptureOrComplete|Didn't capture context, but didn't complete synchronously!", LoggingHash.HashString(this));
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.AssertFormat("ContextAwareResult#{0}::CaptureOrComplete|Didn't capture context, but didn't complete synchronously!", LoggingHash.HashString(this));
+                    }
+                    Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::CaptureOrComplete |Didn't capture context, but didn't complete synchronously!");
                 }
             }
 

--- a/src/Common/src/System/Net/InternalException.cs
+++ b/src/Common/src/System/Net/InternalException.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
+
 namespace System.Net
 {
     internal class InternalException : Exception
@@ -11,6 +13,7 @@ namespace System.Net
             {
                 GlobalLog.Assert("InternalException thrown.");
             }
+            Debug.Fail("InternalException thrown.");
         }
     }
 }

--- a/src/Common/src/System/Net/LazyAsyncResult.cs
+++ b/src/Common/src/System/Net/LazyAsyncResult.cs
@@ -73,9 +73,7 @@ namespace System.Net
         // If a derived class ever uses this and overloads Cleanup, this may need to change.
         internal LazyAsyncResult(object myObject, object myState, AsyncCallback myCallBack, object result)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-
-            if (result == DBNull.Value && globalLogEnabled)
+            if (result == DBNull.Value && GlobalLog.IsEnabled)
             {
                 GlobalLog.AssertFormat("LazyAsyncResult#{0}::.ctor()|Result can't be set to DBNull - it's a special internal value.", LoggingHash.HashString(this));
             }
@@ -88,18 +86,18 @@ namespace System.Net
 
             if (_asyncCallback != null)
             {
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::Complete() invoking callback");
                 }
                 _asyncCallback(this);
             }
-            else if (globalLogEnabled)
+            else if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::Complete() no callback to invoke");
             }
 
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::.ctor() (pre-completed)");
             }
@@ -440,19 +438,17 @@ namespace System.Net
             ThreadContext threadContext = CurrentThreadContext;
             try
             {
-                bool globalLogEnabled = GlobalLog.IsEnabled;
-
                 ++threadContext._nestedIOCount;
                 if (_asyncCallback != null)
                 {
-                    if (globalLogEnabled)
+                    if (GlobalLog.IsEnabled)
                     {
                         GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::Complete() invoking callback");
                     }
 
                     if (threadContext._nestedIOCount >= ForceAsyncCount)
                     {
-                        if (globalLogEnabled)
+                        if (GlobalLog.IsEnabled)
                         {
                             GlobalLog.Print("LazyAsyncResult::Complete *** OFFLOADED the user callback ***");
                         }
@@ -471,7 +467,7 @@ namespace System.Net
                         _asyncCallback(this);
                     }
                 }
-                else if (globalLogEnabled)
+                else if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Print("LazyAsyncResult#" + LoggingHash.HashString(this) + "::Complete() no callback to invoke");
                 }

--- a/src/Common/src/System/Net/LazyAsyncResult.cs
+++ b/src/Common/src/System/Net/LazyAsyncResult.cs
@@ -73,9 +73,13 @@ namespace System.Net
         // If a derived class ever uses this and overloads Cleanup, this may need to change.
         internal LazyAsyncResult(object myObject, object myState, AsyncCallback myCallBack, object result)
         {
-            if (result == DBNull.Value && GlobalLog.IsEnabled)
+            if (result == DBNull.Value)
             {
-                GlobalLog.AssertFormat("LazyAsyncResult#{0}::.ctor()|Result can't be set to DBNull - it's a special internal value.", LoggingHash.HashString(this));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.AssertFormat("LazyAsyncResult#{0}::.ctor()|Result can't be set to DBNull - it's a special internal value.", LoggingHash.HashString(this));
+                }
+                Debug.Fail("LazyAsyncResult#" + LoggingHash.HashString(this) + "::.ctor()|Result can't be set to DBNull - it's a special internal value.");
             }
 
             _asyncObject = myObject;
@@ -325,16 +329,21 @@ namespace System.Net
                 // then the "result" parameter passed to InvokeCallback() will be ignored.
 
                 // It's an error to call after the result has been completed or with DBNull.
-                if (GlobalLog.IsEnabled)
+                if (value == DBNull.Value)
                 {
-                    if (value == DBNull.Value)
+                    if (GlobalLog.IsEnabled)
                     {
                         GlobalLog.AssertFormat("LazyAsyncResult#{0}::set_Result()|Result can't be set to DBNull - it's a special internal value.", LoggingHash.HashString(this));
                     }
-                    if (InternalPeekCompleted)
+                    Debug.Fail("LazyAsyncResult#" + LoggingHash.HashString(this) + "::set_Result()|Result can't be set to DBNull - it's a special internal value.");
+                }
+                if (InternalPeekCompleted)
+                {
+                    if (GlobalLog.IsEnabled)
                     {
                         GlobalLog.AssertFormat("LazyAsyncResult#{0}::set_Result()|Called on completed result.", LoggingHash.HashString(this));
                     }
+                    Debug.Fail("LazyAsyncResult#" + LoggingHash.HashString(this) + "::set_Result()|Called on completed result.");
                 }
                 _result = value;
             }

--- a/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
@@ -114,14 +114,12 @@ namespace System.Net.Sockets
                     _asyncContext.Close();
                 }
 
-                bool globalLogEnabled = GlobalLog.IsEnabled;
-
                 // If _blockable was set in BlockingRelease, it's safe to block here, which means
                 // we can honor the linger options set on the socket.  It also means closesocket() might return WSAEWOULDBLOCK, in which
                 // case we need to do some recovery.
                 if (_blockable)
                 {
-                    if (globalLogEnabled)
+                    if (GlobalLog.IsEnabled)
                     {
                         GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") Following 'blockable' branch.");
                     }
@@ -132,7 +130,7 @@ namespace System.Net.Sockets
                         errorCode = (int)Interop.Sys.GetLastError();
                     }
 
-                    if (globalLogEnabled)
+                    if (GlobalLog.IsEnabled)
                     {
                         GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") close()#1:" + errorCode.ToString());
                     }
@@ -159,7 +157,7 @@ namespace System.Net.Sockets
                         // The socket successfully made blocking; retry the close().
                         errorCode = Interop.Sys.Close(handle);
 
-                        if (globalLogEnabled)
+                        if (GlobalLog.IsEnabled)
                         {
                             GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") close()#2:" + errorCode.ToString());
                         }
@@ -187,7 +185,7 @@ namespace System.Net.Sockets
 #if DEBUG
                 _closeSocketLinger = SocketPal.GetSocketErrorForErrorCode((Interop.Error)errorCode);
 #endif
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") setsockopt():" + errorCode.ToString());
                 }
@@ -203,7 +201,7 @@ namespace System.Net.Sockets
                 _closeSocketHandle = handle;
                 _closeSocketResult = SocketPal.GetSocketErrorForErrorCode((Interop.Error)errorCode);
 #endif
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") close#3():" + (errorCode == -1 ? (int)Interop.Sys.GetLastError() : errorCode).ToString());
                 }

--- a/src/Common/src/System/Net/SafeCloseSocket.Windows.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Windows.cs
@@ -104,14 +104,13 @@ namespace System.Net.Sockets
             private SocketError InnerReleaseHandle()
             {
                 SocketError errorCode;
-                bool globalLogEnabled = GlobalLog.IsEnabled;
 
                 // If _blockable was set in BlockingRelease, it's safe to block here, which means
                 // we can honor the linger options set on the socket.  It also means closesocket() might return WSAEWOULDBLOCK, in which
                 // case we need to do some recovery.
                 if (_blockable)
                 {
-                    if (globalLogEnabled)
+                    if (GlobalLog.IsEnabled)
                     {
                         GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") Following 'blockable' branch.");
                     }
@@ -122,7 +121,7 @@ namespace System.Net.Sockets
                     _closeSocketResult = errorCode;
 #endif
                     if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastWin32Error();
-                    if (globalLogEnabled)
+                    if (GlobalLog.IsEnabled)
                     {
                         GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") closesocket()#1:" + errorCode.ToString());
                     }
@@ -142,7 +141,7 @@ namespace System.Net.Sockets
                         ref nonBlockCmd);
                     if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastWin32Error();
 
-                    if (globalLogEnabled)
+                    if (GlobalLog.IsEnabled)
                     {
                         GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") ioctlsocket()#1:" + errorCode.ToString());
                     }
@@ -155,7 +154,7 @@ namespace System.Net.Sockets
                             IntPtr.Zero,
                             Interop.Winsock.AsyncEventBits.FdNone);
 
-                        if (globalLogEnabled)
+                        if (GlobalLog.IsEnabled)
                         {
                             GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") WSAEventSelect():" + (errorCode == SocketError.SocketError ? (SocketError)Marshal.GetLastWin32Error() : errorCode).ToString());
                         }
@@ -166,7 +165,7 @@ namespace System.Net.Sockets
                             Interop.Winsock.IoctlSocketConstants.FIONBIO,
                             ref nonBlockCmd);
 
-                        if (globalLogEnabled)
+                        if (GlobalLog.IsEnabled)
                         {
                             GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") ioctlsocket#2():" + (errorCode == SocketError.SocketError ? (SocketError)Marshal.GetLastWin32Error() : errorCode).ToString());
                         }
@@ -181,7 +180,7 @@ namespace System.Net.Sockets
                         _closeSocketResult = errorCode;
 #endif
                         if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastWin32Error();
-                        if (globalLogEnabled)
+                        if (GlobalLog.IsEnabled)
                         {
                             GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") closesocket#2():" + errorCode.ToString());
                         }
@@ -211,7 +210,7 @@ namespace System.Net.Sockets
                 _closeSocketLinger = errorCode;
 #endif
                 if (errorCode == SocketError.SocketError) errorCode = (SocketError)Marshal.GetLastWin32Error();
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") setsockopt():" + errorCode.ToString());
                 }
@@ -227,7 +226,7 @@ namespace System.Net.Sockets
                 _closeSocketHandle = handle;
                 _closeSocketResult = errorCode;
 #endif
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Print("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ") closesocket#3():" + (errorCode == SocketError.SocketError ? (SocketError)Marshal.GetLastWin32Error() : errorCode).ToString());
                 }

--- a/src/Common/src/System/Net/SafeCloseSocket.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.cs
@@ -201,9 +201,13 @@ namespace System.Net.Sockets
             }
             catch (Exception exception)
             {
-                if (!ExceptionCheck.IsFatal(exception) && GlobalLog.IsEnabled)
+                if (!ExceptionCheck.IsFatal(exception))
                 {
-                    GlobalLog.Assert("SafeCloseSocket::CloseAsIs(handle:" + handle.ToString("x") + ")", exception.Message);
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Assert("SafeCloseSocket::CloseAsIs(handle:" + handle.ToString("x") + ")", exception.Message);
+                    }
+                    Debug.Fail("SafeCloseSocket::CloseAsIs(handle:" + handle.ToString("x") + ")", exception.Message);
                 }
                 throw;
             }
@@ -244,9 +248,13 @@ namespace System.Net.Sockets
                 }
                 catch (Exception exception)
                 {
-                    if (!ExceptionCheck.IsFatal(exception) && GlobalLog.IsEnabled)
+                    if (!ExceptionCheck.IsFatal(exception))
                     {
-                        GlobalLog.Assert("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ")", exception.Message);
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.Assert("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ")", exception.Message);
+                        }
+                        Debug.Fail("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ")", exception.Message);
                     }
                     ret = true;  // Avoid a second assert.
                     throw;
@@ -255,9 +263,13 @@ namespace System.Net.Sockets
                 {
                     _closeSocketThread = Environment.CurrentManagedThreadId;
                     _closeSocketTick = Environment.TickCount;
-                    if (!ret && GlobalLog.IsEnabled)
+                    if (!ret)
                     {
-                        GlobalLog.AssertFormat("SafeCloseSocket::ReleaseHandle(handle:{0:x})|ReleaseHandle failed.", handle);
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.AssertFormat("SafeCloseSocket::ReleaseHandle(handle:{0:x})|ReleaseHandle failed.", handle);
+                        }
+                        Debug.Fail("SafeCloseSocket::ReleaseHandle(handle:" + handle.ToString("x") + ")|ReleaseHandle failed.");
                     }
                 }
 #endif

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/TeredoHelper.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/TeredoHelper.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Net.Sockets;
 using System.Threading;
 
@@ -53,9 +54,13 @@ namespace System.Net.NetworkInformation
         // 'Unsafe' because it does not flow ExecutionContext to the callback.
         public static bool UnsafeNotifyStableUnicastIpAddressTable(Action<object> callback, object state)
         {
-            if (GlobalLog.IsEnabled && callback == null)
+            if (callback == null)
             {
-                GlobalLog.Assert("UnsafeNotifyStableUnicastIpAddressTable called without specifying callback!");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("UnsafeNotifyStableUnicastIpAddressTable called without specifying callback!");
+                }
+                Debug.Fail("UnsafeNotifyStableUnicastIpAddressTable called without specifying callback!");
             }
 
             TeredoHelper helper = new TeredoHelper(callback, state);
@@ -83,9 +88,13 @@ namespace System.Net.NetworkInformation
 
                 if (err == Interop.IpHlpApi.ERROR_IO_PENDING)
                 {
-                    if (GlobalLog.IsEnabled && helper._cancelHandle.IsInvalid)
+                    if (helper._cancelHandle.IsInvalid)
                     {
-                        GlobalLog.Assert("CancelHandle invalid despite returning ERROR_IO_PENDING");
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.Assert("CancelHandle invalid despite returning ERROR_IO_PENDING");
+                        }
+                        Debug.Fail("CancelHandle invalid despite returning ERROR_IO_PENDING");
                     }
 
                     // Async completion: add us to the s_pendingNotifications list so we'll be canceled in the
@@ -105,9 +114,13 @@ namespace System.Net.NetworkInformation
 
         private void RunCallback(object o)
         {
-            if (GlobalLog.IsEnabled && !_runCallbackCalled)
+            if (!_runCallbackCalled)
             {
-                GlobalLog.Assert("RunCallback called without setting runCallbackCalled!");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("RunCallback called without setting runCallbackCalled!");
+                }
+                Debug.Fail("RunCallback called without setting runCallbackCalled!");
             }
 
             // If OnAppDomainUnload beats us to the lock, do nothing: the AppDomain is going down soon anyways.
@@ -121,17 +134,25 @@ namespace System.Net.NetworkInformation
 
 #if DEBUG
                 bool successfullyRemoved = s_pendingNotifications.Remove(this);
-                if (GlobalLog.IsEnabled && !successfullyRemoved)
+                if (!successfullyRemoved)
                 {
-                    GlobalLog.Assert("RunCallback for a TeredoHelper which is not in s_pendingNotifications!");
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Assert("RunCallback for a TeredoHelper which is not in s_pendingNotifications!");
+                    }
+                    Debug.Fail("RunCallback for a TeredoHelper which is not in s_pendingNotifications!");
                 }
 #else
                 s_pendingNotifications.Remove(this);
 #endif
 
-                if (GlobalLog.IsEnabled && (_cancelHandle == null || _cancelHandle.IsInvalid))
+                if ((_cancelHandle == null || _cancelHandle.IsInvalid))
                 {
-                    GlobalLog.Assert("Invalid cancelHandle in RunCallback");
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Assert("Invalid cancelHandle in RunCallback");
+                    }
+                    Debug.Fail("Invalid cancelHandle in RunCallback");
                 }
 
                 _cancelHandle.Dispose();

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/TeredoHelper.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/TeredoHelper.cs
@@ -53,8 +53,7 @@ namespace System.Net.NetworkInformation
         // 'Unsafe' because it does not flow ExecutionContext to the callback.
         public static bool UnsafeNotifyStableUnicastIpAddressTable(Action<object> callback, object state)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-            if (globalLogEnabled && callback == null)
+            if (GlobalLog.IsEnabled && callback == null)
             {
                 GlobalLog.Assert("UnsafeNotifyStableUnicastIpAddressTable called without specifying callback!");
             }
@@ -84,7 +83,7 @@ namespace System.Net.NetworkInformation
 
                 if (err == Interop.IpHlpApi.ERROR_IO_PENDING)
                 {
-                    if (globalLogEnabled && helper._cancelHandle.IsInvalid)
+                    if (GlobalLog.IsEnabled && helper._cancelHandle.IsInvalid)
                     {
                         GlobalLog.Assert("CancelHandle invalid despite returning ERROR_IO_PENDING");
                     }
@@ -106,8 +105,7 @@ namespace System.Net.NetworkInformation
 
         private void RunCallback(object o)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-            if (globalLogEnabled && !_runCallbackCalled)
+            if (GlobalLog.IsEnabled && !_runCallbackCalled)
             {
                 GlobalLog.Assert("RunCallback called without setting runCallbackCalled!");
             }
@@ -123,7 +121,7 @@ namespace System.Net.NetworkInformation
 
 #if DEBUG
                 bool successfullyRemoved = s_pendingNotifications.Remove(this);
-                if (globalLogEnabled && !successfullyRemoved)
+                if (GlobalLog.IsEnabled && !successfullyRemoved)
                 {
                     GlobalLog.Assert("RunCallback for a TeredoHelper which is not in s_pendingNotifications!");
                 }
@@ -131,7 +129,7 @@ namespace System.Net.NetworkInformation
                 s_pendingNotifications.Remove(this);
 #endif
 
-                if (globalLogEnabled && (_cancelHandle == null || _cancelHandle.IsInvalid))
+                if (GlobalLog.IsEnabled && (_cancelHandle == null || _cancelHandle.IsInvalid))
                 {
                     GlobalLog.Assert("Invalid cancelHandle in RunCallback");
                 }

--- a/src/System.Net.Primitives/src/System/Net/Cookie.cs
+++ b/src/System.Net.Primitives/src/System/Net/Cookie.cs
@@ -718,9 +718,13 @@ namespace System.Net
             {
                 // Only set by HttpListenerRequest::Cookies_get()
 #if !NETNative_SystemNetHttp
-                if (GlobalLog.IsEnabled && value != CookieVariant.Rfc2965)
+                if (value != CookieVariant.Rfc2965)
                 {
-                    GlobalLog.AssertFormat("Cookie#{0}::set_Variant()|value:{1}", LoggingHash.HashString(this), value);
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.AssertFormat("Cookie#{0}::set_Variant()|value:{1}", LoggingHash.HashString(this), value);
+                    }
+                    Debug.Fail("Cookie#" + LoggingHash.HashString(this) + "::set_Variant()|value:" + value);
                 }
 #endif
                 _cookieVariant = value;

--- a/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieContainer.cs
@@ -658,8 +658,7 @@ namespace System.Net
 
         internal CookieCollection CookieCutter(Uri uri, string headerName, string setCookieHeader, bool isThrow)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Print("CookieContainer#" + LoggingHash.HashString(this) + "::CookieCutter() uri:" + uri + " headerName:" + headerName + " setCookieHeader:" + setCookieHeader + " isThrow:" + isThrow);
             }
@@ -688,7 +687,7 @@ namespace System.Net
                 do
                 {
                     Cookie cookie = parser.Get();
-                    if (globalLogEnabled)
+                    if (GlobalLog.IsEnabled)
                     {
                         GlobalLog.Print("CookieContainer#" + LoggingHash.HashString(this) + "::CookieCutter() CookieParser returned cookie:" + LoggingHash.ObjectToString(cookie));
                     }

--- a/src/System.Net.Primitives/src/System/Net/CredentialCache.cs
+++ b/src/System.Net.Primitives/src/System/Net/CredentialCache.cs
@@ -188,8 +188,7 @@ namespace System.Net
                 throw new ArgumentNullException("authenticationType");
             }
 
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Print("CredentialCache::GetCredential(uriPrefix=\"" + uriPrefix + "\", authType=\"" + authenticationType + "\")");
             }
@@ -218,7 +217,7 @@ namespace System.Net
                 }
             }
 
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Print("CredentialCache::GetCredential returning " + ((mostSpecificMatch == null) ? "null" : "(" + mostSpecificMatch.UserName + ":" + mostSpecificMatch.Domain + ")"));
             }
@@ -245,8 +244,7 @@ namespace System.Net
                 throw new ArgumentOutOfRangeException("port");
             }
 
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Print("CredentialCache::GetCredential(host=\"" + host + ":" + port.ToString() + "\", authenticationType=\"" + authenticationType + "\")");
             }
@@ -267,7 +265,7 @@ namespace System.Net
                 }
             }
 
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Print("CredentialCache::GetCredential returning " + ((match == null) ? "null" : "(" + match.UserName + ":" + match.Domain + ")"));
             }

--- a/src/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
@@ -92,8 +92,7 @@ namespace System.Net
                 return null;
             }
 
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Enter("CertificateValidationPal.Unix SecureChannel#" + LoggingHash.HashString(securityContext) + "::GetRemoteCertificate()");
             }
@@ -151,7 +150,7 @@ namespace System.Net
                 SecurityEventSource.Log.RemoteCertificate(result == null ? "null" : result.ToString(true));
             }
 
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Leave("CertificateValidationPal.Unix SecureChannel#" + LoggingHash.HashString(securityContext) + "::GetRemoteCertificate()", (result == null ? "null" : result.Subject));
             }
@@ -218,7 +217,6 @@ namespace System.Net
 
                     if (store == null)
                     {
-                        bool globalLogEnabled = GlobalLog.IsEnabled;
                         try
                         {
                             store = new X509Store(StoreName.My, storeLocation);
@@ -226,7 +224,7 @@ namespace System.Net
 
                             Volatile.Write(ref storeField, store);
 
-                            if (globalLogEnabled)
+                            if (GlobalLog.IsEnabled)
                             {
                                 GlobalLog.Print(
                                     "CertModule::EnsureStoreOpened() storeLocation:" + storeLocation +
@@ -235,7 +233,7 @@ namespace System.Net
                         }
                         catch (CryptographicException e)
                         {
-                            if (globalLogEnabled)
+                            if (GlobalLog.IsEnabled)
                             {
                                 GlobalLog.Assert(
                                     "CertModule::EnsureStoreOpened()",

--- a/src/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/CertificateValidationPal.Unix.cs
@@ -239,6 +239,9 @@ namespace System.Net
                                     "CertModule::EnsureStoreOpened()",
                                     "Failed to open cert store, location:" + storeLocation + " exception:" + e);
                             }
+                            Debug.Fail(
+                                "CertModule::EnsureStoreOpened()",
+                                "Failed to open cert store, location:" + storeLocation + " exception:" + e);
                             throw;
                         }
                     }

--- a/src/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
@@ -2,12 +2,13 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Microsoft.Win32.SafeHandles;
+using System.Diagnostics;
+using System.Net.Security;
+using System.Runtime.InteropServices;
 using System.Security;
 using System.Security.Cryptography;
-using System.Net.Security;
-using System.Security.Principal;
-using System.Runtime.InteropServices;
 using System.Security.Cryptography.X509Certificates;
+using System.Security.Principal;
 using System.Threading;
 
 namespace System.Net
@@ -156,9 +157,13 @@ namespace System.Net
                         for (int i = 0; i < count; ++i)
                         {
                             Interop.SspiCli._CERT_CHAIN_ELEMENT* pIL2 = pIL + i;
-                            if (GlobalLog.IsEnabled && pIL2->cbSize <= 0)
+                            if (pIL2->cbSize <= 0)
                             {
-                                GlobalLog.Assert("SecureChannel::GetIssuers()", "Interop.SspiCli._CERT_CHAIN_ELEMENT size is not positive: " + pIL2->cbSize.ToString());
+                                if (GlobalLog.IsEnabled)
+                                {
+                                    GlobalLog.Assert("SecureChannel::GetIssuers()", "Interop.SspiCli._CERT_CHAIN_ELEMENT size is not positive: " + pIL2->cbSize.ToString());
+                                }
+                                Debug.Fail("SecureChannel::GetIssuers()", "Interop.SspiCli._CERT_CHAIN_ELEMENT size is not positive: " + pIL2->cbSize.ToString());
                             }
 
                             if (pIL2->cbSize > 0)
@@ -249,6 +254,7 @@ namespace System.Net
                                 {
                                     GlobalLog.Assert("SecureChannel::EnsureStoreOpened()", "Failed to open cert store, location:" + storeLocation + " exception:" + exception);
                                 }
+                                Debug.Fail("SecureChannel::EnsureStoreOpened()", "Failed to open cert store, location:" + storeLocation + " exception:" + exception);
                                 return null;
                             }
 

--- a/src/System.Net.Security/src/System/Net/NTAuthentication.cs
+++ b/src/System.Net.Security/src/System/Net/NTAuthentication.cs
@@ -200,9 +200,13 @@ namespace System.Net
         {
             get
             {
-                if ((IsCompleted && IsValidContext) && GlobalLog.IsEnabled)
+                if ((IsCompleted && IsValidContext))
                 {
-                    GlobalLog.Assert("NTAuthentication#{0}::MaxDataSize|The context is not completed or invalid.", LoggingHash.HashString(this));
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Assert("NTAuthentication#{0}::MaxDataSize|The context is not completed or invalid.", LoggingHash.HashString(this));
+                    }
+                    Debug.Fail("NTAuthentication#" + LoggingHash.HashString(this) + "::MaxDataSize |The context is not completed or invalid.");
                 }
 
                 if (_sizes == null)
@@ -335,14 +339,22 @@ namespace System.Net
         // This token can be used for impersonation. We use it to create a WindowsIdentity and hand it out to the server app.
         internal SecurityContextTokenHandle GetContextToken(out Interop.SecurityStatus status)
         {
-            if ((IsCompleted && IsValidContext) && GlobalLog.IsEnabled)
+            if ((IsCompleted && IsValidContext))
             {
-                GlobalLog.AssertFormat("NTAuthentication#{0}::GetContextToken|Should be called only when completed with success, currently is not!", LoggingHash.HashString(this));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.AssertFormat("NTAuthentication#{0}::GetContextToken|Should be called only when completed with success, currently is not!", LoggingHash.HashString(this));
+                }
+                Debug.Fail("NTAuthentication#" + LoggingHash.HashString(this) + "::GetContextToken |Should be called only when completed with success, currently is not!");
             }
 
-            if (IsServer && GlobalLog.IsEnabled)
+            if (IsServer)
             {
-                GlobalLog.AssertFormat("NTAuthentication#{0}::GetContextToken|The method must not be called by the client side!", LoggingHash.HashString(this));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.AssertFormat("NTAuthentication#{0}::GetContextToken|The method must not be called by the client side!", LoggingHash.HashString(this));
+                }
+                Debug.Fail("NTAuthentication#" + LoggingHash.HashString(this) + "::GetContextToken |The method must not be called by the client side!");
             }
 
             if (!IsValidContext)
@@ -513,9 +525,13 @@ namespace System.Net
             if (statusCode == Interop.SecurityStatus.OK)
             {
                 // Success.
-                if ((statusCode == Interop.SecurityStatus.OK) && GlobalLog.IsEnabled)
+                if ((statusCode == Interop.SecurityStatus.OK))
                 {
-                    GlobalLog.AssertFormat("NTAuthentication#{0}::GetOutgoingBlob()|statusCode:[0x{1:x8}] ({2}) m_SecurityContext#{3}::Handle:[{4}] [STATUS != OK]", LoggingHash.HashString(this), (int)statusCode, statusCode, LoggingHash.HashString(_securityContext), LoggingHash.ObjectToString(_securityContext));
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.AssertFormat("NTAuthentication#{0}::GetOutgoingBlob()|statusCode:[0x{1:x8}] ({2}) m_SecurityContext#{3}::Handle:[{4}] [STATUS != OK]", LoggingHash.HashString(this), (int)statusCode, statusCode, LoggingHash.HashString(_securityContext), LoggingHash.ObjectToString(_securityContext));
+                    }
+                    Debug.Fail("NTAuthentication#" + LoggingHash.HashString(this) + "::GetOutgoingBlob()|statusCode:[0x" + ((int)statusCode).ToString("x8") + "] (" + statusCode + ") m_SecurityContext#" + LoggingHash.HashString(_securityContext) + "::Handle:[" + LoggingHash.ObjectToString(_securityContext) + "] [STATUS != OK]");
                 }
 
                 _isCompleted = true;
@@ -549,11 +565,15 @@ namespace System.Net
             }
             catch (Exception e)
             {
-                if (!ExceptionCheck.IsFatal(e) && GlobalLog.IsEnabled)
+                if (!ExceptionCheck.IsFatal(e))
                 {
-                    GlobalLog.Assert("NTAuthentication#" + LoggingHash.HashString(this) + "::Encrypt", "Arguments out of range.");
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Assert("NTAuthentication#" + LoggingHash.HashString(this) + "::Encrypt", "Arguments out of range.");
+                    }
+                    Debug.Fail("NTAuthentication#" + LoggingHash.HashString(this) + "::Encrypt", "Arguments out of range.");
                 }
-                
+
                 throw;
             }
 
@@ -632,6 +652,7 @@ namespace System.Net
                 {
                     GlobalLog.Assert("NTAuthentication#" + LoggingHash.HashString(this) + "::Decrypt", "Argument 'offset' out of range.");
                 }
+                Debug.Fail("NTAuthentication#" + LoggingHash.HashString(this) + "::Decrypt", "Argument 'offset' out of range.");
 
                 throw new ArgumentOutOfRangeException("offset");
             }
@@ -642,6 +663,7 @@ namespace System.Net
                 {
                     GlobalLog.Assert("NTAuthentication#" + LoggingHash.HashString(this) + "::Decrypt", "Argument 'count' out of range.");
                 }
+                Debug.Fail("NTAuthentication#" + LoggingHash.HashString(this) + "::Decrypt", "Argument 'count' out of range.");
 
                 throw new ArgumentOutOfRangeException("count");
             }
@@ -688,9 +710,13 @@ namespace System.Net
 
         private string GetClientSpecifiedSpn()
         {
-            if (GlobalLog.IsEnabled && (IsValidContext && IsCompleted))
+            if ((IsValidContext && IsCompleted))
             {
-                GlobalLog.Assert("NTAuthentication: Trying to get the client SPN before handshaking is done!");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("NTAuthentication: Trying to get the client SPN before handshaking is done!");
+                }
+                Debug.Fail("NTAuthentication: Trying to get the client SPN before handshaking is done!");
             }
 
             string spn = SSPIWrapper.QueryContextAttributes(GlobalSSPI.SSPIAuth, _securityContext,
@@ -712,6 +738,7 @@ namespace System.Net
                 {
                     GlobalLog.Assert("NTAuthentication#" + LoggingHash.HashString(this) + "::DecryptNtlm", "Argument 'count' out of range.");
                 }
+                Debug.Fail("NTAuthentication#" + LoggingHash.HashString(this) + "::DecryptNtlm", "Argument 'count' out of range.");
 
                 throw new ArgumentOutOfRangeException("count");
             }

--- a/src/System.Net.Security/src/System/Net/SSPIHandleCache.cs
+++ b/src/System.Net.Security/src/System/Net/SSPIHandleCache.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.Threading;
 
 namespace System.Net.Security
@@ -39,9 +40,13 @@ namespace System.Net.Security
             }
             catch (Exception e)
             {
-                if (!ExceptionCheck.IsFatal(e) && GlobalLog.IsEnabled)
+                if (!ExceptionCheck.IsFatal(e))
                 {
-                    GlobalLog.Assert("SSPIHandlCache", "Attempted to throw: " + e.ToString());
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Assert("SSPIHandlCache", "Attempted to throw: " + e.ToString());
+                    }
+                    Debug.Fail("SSPIHandlCache", "Attempted to throw: " + e.ToString());
                 }
             }
         }

--- a/src/System.Net.Security/src/System/Net/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/SecureChannel.cs
@@ -68,9 +68,13 @@ namespace System.Net.Security
 
             _destination = hostname;
 
-            if (GlobalLog.IsEnabled && hostname == null)
+            if (hostname == null)
             {
-                GlobalLog.AssertFormat("SecureChannel#{0}::.ctor()|hostname == null", LoggingHash.HashString(this));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.AssertFormat("SecureChannel#{0}::.ctor()|hostname == null", LoggingHash.HashString(this));
+                }
+                Debug.Fail("SecureChannel#" + LoggingHash.HashString(this) + "::.ctor()|hostname == null");
             }
             _hostName = hostname;
             _serverMode = serverMode;
@@ -613,13 +617,17 @@ namespace System.Net.Security
                 selectedCert = null;
             }
 
-            if (GlobalLog.IsEnabled)
+            if ((object)clientCertificate != (object)selectedCert && !clientCertificate.Equals(selectedCert))
             {
-                if ((object)clientCertificate != (object)selectedCert && !clientCertificate.Equals(selectedCert))
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("AcquireClientCredentials()|'selectedCert' does not match 'clientCertificate'.");
                 }
+                Debug.Fail("AcquireClientCredentials()|'selectedCert' does not match 'clientCertificate'.");
+            }
 
+            if (GlobalLog.IsEnabled)
+            {
                 GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials() Selected Cert = " + (selectedCert == null ? "null" : selectedCert.Subject));
             }
 
@@ -735,9 +743,13 @@ namespace System.Net.Security
                 throw new NotSupportedException(SR.net_ssl_io_no_server_cert);
             }
 
-            if (GlobalLog.IsEnabled && !localCertificate.Equals(selectedCert))
+            if (!localCertificate.Equals(selectedCert))
             {
-                GlobalLog.Assert("AcquireServerCredentials()|'selectedCert' does not match 'localCertificate'.");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("AcquireServerCredentials()|'selectedCert' does not match 'localCertificate'.");
+                }
+                Debug.Fail("AcquireServerCredentials()|'selectedCert' does not match 'localCertificate'.");
             }
 
             //
@@ -837,6 +849,7 @@ namespace System.Net.Security
                 {
                     GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::GenerateToken", "Argument 'offset' out of range.");
                 }
+                Debug.Fail("SecureChannel#" + LoggingHash.HashString(this) + "::GenerateToken", "Argument 'offset' out of range.");
                 throw new ArgumentOutOfRangeException("offset");
             }
 
@@ -846,6 +859,7 @@ namespace System.Net.Security
                 {
                     GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::GenerateToken", "Argument 'count' out of range.");
                 }
+                Debug.Fail("SecureChannel#" + LoggingHash.HashString(this) + "::GenerateToken", "Argument 'count' out of range.");
                 throw new ArgumentOutOfRangeException("count");
             }
 
@@ -981,9 +995,13 @@ namespace System.Net.Security
                 }
                 catch (Exception e)
                 {
-                    if (!ExceptionCheck.IsFatal(e) && GlobalLog.IsEnabled)
+                    if (!ExceptionCheck.IsFatal(e))
                     {
-                        GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::ProcessHandshakeSuccess", "StreamSizes out of range.");
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::ProcessHandshakeSuccess", "StreamSizes out of range.");
+                        }
+                        Debug.Fail("SecureChannel#" + LoggingHash.HashString(this) + "::ProcessHandshakeSuccess", "StreamSizes out of range.");
                     }
 
                     throw;
@@ -1049,9 +1067,13 @@ namespace System.Net.Security
             }
             catch (Exception e)
             {
-                if (!ExceptionCheck.IsFatal(e) && GlobalLog.IsEnabled)
+                if (!ExceptionCheck.IsFatal(e))
                 {
-                    GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Arguments out of range.");
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Arguments out of range.");
+                    }
+                    Debug.Fail("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Arguments out of range.");
                 }
 
                 throw;
@@ -1091,6 +1113,7 @@ namespace System.Net.Security
                 {
                     GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Argument 'offset' out of range.");
                 }
+                Debug.Fail("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Argument 'offset' out of range.");
                 throw new ArgumentOutOfRangeException("offset");
             }
 
@@ -1100,6 +1123,7 @@ namespace System.Net.Security
                 {
                     GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Argument 'count' out of range.");
                 }
+                Debug.Fail("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Argument 'count' out of range.");
                 throw new ArgumentOutOfRangeException("count");
             }
 

--- a/src/System.Net.Security/src/System/Net/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/SecureChannel.cs
@@ -55,8 +55,7 @@ namespace System.Net.Security
         internal SecureChannel(string hostname, bool serverMode, SslProtocols sslProtocols, X509Certificate serverCertificate, X509CertificateCollection clientCertificates, bool remoteCertRequired, bool checkCertName,
                                                   bool checkCertRevocationStatus, EncryptionPolicy encryptionPolicy, LocalCertSelectionCallback certSelectionDelegate)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::.ctor", "hostname:" + hostname + " #clientCertificates=" + ((clientCertificates == null) ? "0" : clientCertificates.Count.ToString(NumberFormatInfo.InvariantInfo)));
             }
@@ -69,7 +68,7 @@ namespace System.Net.Security
 
             _destination = hostname;
 
-            if (globalLogEnabled && hostname == null)
+            if (GlobalLog.IsEnabled && hostname == null)
             {
                 GlobalLog.AssertFormat("SecureChannel#{0}::.ctor()|hostname == null", LoggingHash.HashString(this));
             }
@@ -87,7 +86,7 @@ namespace System.Net.Security
             _certSelectionDelegate = certSelectionDelegate;
             _refreshCredentialNeeded = true;
             _encryptionPolicy = encryptionPolicy;
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::.ctor");
             }
@@ -128,8 +127,7 @@ namespace System.Net.Security
 
         internal ChannelBinding GetChannelBinding(ChannelBindingKind kind)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::GetChannelBindingToken", kind.ToString());
             }
@@ -140,7 +138,7 @@ namespace System.Net.Security
                 result = SslStreamPal.QueryContextChannelBinding(_securityContext, kind);
             }
 
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::GetChannelBindingToken", LoggingHash.HashString(result));
             }
@@ -395,8 +393,7 @@ namespace System.Net.Security
 
         private bool AcquireClientCredentials(ref byte[] thumbPrint)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials");
             }
@@ -412,7 +409,7 @@ namespace System.Net.Security
             {
                 issuers = GetRequestCertificateAuthorities();
 
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials() calling CertificateSelectionCallback");
                 }
@@ -519,7 +516,7 @@ namespace System.Net.Security
                                 continue;
                             }
 
-                            if (globalLogEnabled)
+                            if (GlobalLog.IsEnabled)
                             {
                                 GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials() root cert:" + certificateEx.Issuer);
                             }
@@ -542,13 +539,13 @@ namespace System.Net.Security
                                     found = Array.IndexOf(issuers, issuer) != -1;
                                     if (found)
                                     {
-                                        if (globalLogEnabled)
+                                        if (GlobalLog.IsEnabled)
                                         {
                                             GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials() matched:" + issuer);
                                         }
                                         break;
                                     }
-                                    if (globalLogEnabled)
+                                    if (GlobalLog.IsEnabled)
                                     {
                                         GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials() no match:" + issuer);
                                     }
@@ -616,7 +613,7 @@ namespace System.Net.Security
                 selectedCert = null;
             }
 
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 if ((object)clientCertificate != (object)selectedCert && !clientCertificate.Equals(selectedCert))
                 {
@@ -640,7 +637,7 @@ namespace System.Net.Security
                 // (instead of going anonymous as we do here).
                 if (sessionRestartAttempt && cachedCredentialHandle == null && selectedCert != null)
                 {
-                    if (globalLogEnabled)
+                    if (GlobalLog.IsEnabled)
                     {
                         GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials() Reset to anonymous session.");
                     }
@@ -687,7 +684,7 @@ namespace System.Net.Security
                 }
             }
 
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireClientCredentials, cachedCreds = " + cachedCred.ToString(), LoggingHash.ObjectToString(_credentialsHandle));
             }
@@ -700,8 +697,7 @@ namespace System.Net.Security
         //
         private bool AcquireServerCredentials(ref byte[] thumbPrint)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireServerCredentials");
             }
@@ -714,7 +710,7 @@ namespace System.Net.Security
                 X509CertificateCollection tempCollection = new X509CertificateCollection();
                 tempCollection.Add(_serverCertificate);
                 localCertificate = _certSelectionDelegate(string.Empty, tempCollection, null, Array.Empty<string>());
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireServerCredentials() Use delegate selected Cert");
                 }
@@ -739,7 +735,7 @@ namespace System.Net.Security
                 throw new NotSupportedException(SR.net_ssl_io_no_server_cert);
             }
 
-            if (globalLogEnabled && !localCertificate.Equals(selectedCert))
+            if (GlobalLog.IsEnabled && !localCertificate.Equals(selectedCert))
             {
                 GlobalLog.Assert("AcquireServerCredentials()|'selectedCert' does not match 'localCertificate'.");
             }
@@ -774,7 +770,7 @@ namespace System.Net.Security
                 }
             }
 
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::AcquireServerCredentials, cachedCreds = " + cachedCred.ToString(), LoggingHash.ObjectToString(_credentialsHandle));
             }
@@ -784,8 +780,7 @@ namespace System.Net.Security
         //
         internal ProtocolToken NextMessage(byte[] incoming, int offset, int count)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::NextMessage");
             }
@@ -795,7 +790,7 @@ namespace System.Net.Security
 
             if (!_serverMode && errorCode == SecurityStatusPal.CredentialsNeeded)
             {
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::NextMessage() returned SecurityStatusPal.CredentialsNeeded");
                 }
@@ -805,7 +800,7 @@ namespace System.Net.Security
             }
 
             ProtocolToken token = new ProtocolToken(nextmsg, errorCode);
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::NextMessage", token.ToString());
             }
@@ -968,8 +963,7 @@ namespace System.Net.Security
         --*/
         internal void ProcessHandshakeSuccess()
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::ProcessHandshakeSuccess");
             }
@@ -998,7 +992,7 @@ namespace System.Net.Security
 
             SslStreamPal.QueryContextConnectionInfo(_securityContext, out _connectionInfo);
 
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::ProcessHandshakeSuccess");
             }
@@ -1018,8 +1012,7 @@ namespace System.Net.Security
         --*/
         internal SecurityStatusPal Encrypt(byte[] buffer, int offset, int size, ref byte[] output, out int resultSize)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt");
                 GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt() - offset: " + offset.ToString() + " size: " + size.ToString() + " buffersize: " + buffer.Length.ToString());
@@ -1056,7 +1049,7 @@ namespace System.Net.Security
             }
             catch (Exception e)
             {
-                if (!ExceptionCheck.IsFatal(e) && globalLogEnabled)
+                if (!ExceptionCheck.IsFatal(e) && GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Arguments out of range.");
                 }
@@ -1068,7 +1061,7 @@ namespace System.Net.Security
 
             if (secStatus != SecurityStatusPal.OK)
             {
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt ERROR", secStatus.ToString());
                 }
@@ -1076,7 +1069,7 @@ namespace System.Net.Security
             else
             {
                 output = writeBuffer;
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt OK", "data size:" + resultSize.ToString());
                 }
@@ -1087,16 +1080,14 @@ namespace System.Net.Security
 
         internal SecurityStatusPal Decrypt(byte[] payload, ref int offset, ref int count)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Print("SecureChannel#" + LoggingHash.HashString(this) + "::Decrypt() - offset: " + offset.ToString() + " size: " + count.ToString() + " buffersize: " + payload.Length.ToString());
             }
 
             if (offset < 0 || offset > (payload == null ? 0 : payload.Length))
             {
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Argument 'offset' out of range.");
                 }
@@ -1105,7 +1096,7 @@ namespace System.Net.Security
 
             if (count < 0 || count > (payload == null ? 0 : payload.Length - offset))
             {
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Argument 'count' out of range.");
                 }
@@ -1130,8 +1121,7 @@ namespace System.Net.Security
         //
         internal bool VerifyRemoteCertificate(RemoteCertValidationCallback remoteCertValidationCallback)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Enter("SecureChannel#" + LoggingHash.HashString(this) + "::VerifyRemoteCertificate");
             }
@@ -1151,7 +1141,7 @@ namespace System.Net.Security
 
                 if (remoteCertificateEx == null)
                 {
-                    if (globalLogEnabled)
+                    if (GlobalLog.IsEnabled)
                     {
                         GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::VerifyRemoteCertificate (no remote cert)", (!_remoteCertRequired).ToString());
                     }
@@ -1236,7 +1226,7 @@ namespace System.Net.Security
                     }
                 }
 
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Print("Cert Validation, remote cert = " + (remoteCertificateEx == null ? "<null>" : remoteCertificateEx.ToString(true)));
                 }
@@ -1256,7 +1246,7 @@ namespace System.Net.Security
                 }
             }
 
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Leave("SecureChannel#" + LoggingHash.HashString(this) + "::VerifyRemoteCertificate", success.ToString());
             }

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/FixedSizeReader.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/FixedSizeReader.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.IO;
 
 namespace System.Net
@@ -104,9 +105,13 @@ namespace System.Net
                 throw new IOException(SR.net_io_eof);
             }
 
-            if (GlobalLog.IsEnabled && _totalRead + bytes > _request.Count)
+            if (_totalRead + bytes > _request.Count)
             {
-                GlobalLog.AssertFormat("FixedSizeReader::CheckCompletion()|State got out of range. Total:{0} Count:{1}", _totalRead + bytes, _request.Count);
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.AssertFormat("FixedSizeReader::CheckCompletion()|State got out of range. Total:{0} Count:{1}", _totalRead + bytes, _request.Count);
+                }
+                Debug.Fail("FixedSizeReader::CheckCompletion()|State got out of range. Total:" + (_totalRead + bytes) + " Count:" + _request.Count);
             }
 
             if ((_totalRead += bytes) == _request.Count)
@@ -120,9 +125,13 @@ namespace System.Net
 
         private static void ReadCallback(IAsyncResult transportResult)
         {
-            if (GlobalLog.IsEnabled && !(transportResult.AsyncState is FixedSizeReader))
+            if (!(transportResult.AsyncState is FixedSizeReader))
             {
-                GlobalLog.Assert("ReadCallback|State type is wrong, expected FixedSizeReader.");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("ReadCallback|State type is wrong, expected FixedSizeReader.");
+                }
+                Debug.Fail("ReadCallback|State type is wrong, expected FixedSizeReader.");
             }
 
             if (transportResult.CompletedSynchronously)

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/HelperAsyncResults.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/HelperAsyncResults.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.Threading;
 
 namespace System.Net
@@ -40,16 +41,21 @@ namespace System.Net
 
         public AsyncProtocolRequest(LazyAsyncResult userAsyncResult)
         {
-            if (GlobalLog.IsEnabled)
+            if (userAsyncResult == null)
             {
-                if (userAsyncResult == null)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("AsyncProtocolRequest()|userAsyncResult == null");
                 }
-                if (userAsyncResult.InternalPeekCompleted)
+                Debug.Fail("AsyncProtocolRequest()|userAsyncResult == null");
+            }
+            if (userAsyncResult.InternalPeekCompleted)
+            {
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("AsyncProtocolRequest()|userAsyncResult is already completed.");
                 }
+                Debug.Fail("AsyncProtocolRequest()|userAsyncResult is already completed.");
             }
             UserAsyncResult = userAsyncResult;
         }

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/InternalNegotiateStream.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/InternalNegotiateStream.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 
@@ -300,9 +301,13 @@ namespace System.Net.Security
                 return 0;
             }
 
-            if ((readBytes == _ReadHeader.Length) && GlobalLog.IsEnabled)
+            if ((readBytes == _ReadHeader.Length))
             {
-                GlobalLog.AssertFormat("NegoStream::ProcessHeader()|Frame size must be 4 but received {0} bytes.", readBytes);
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.AssertFormat("NegoStream::ProcessHeader()|Frame size must be 4 but received {0} bytes.", readBytes);
+                }
+                Debug.Fail("NegoStream::ProcessHeader()|Frame size must be 4 but received " + readBytes + " bytes.");
             }
 
             // Replace readBytes with the body size recovered from the header content.
@@ -393,9 +398,13 @@ namespace System.Net.Security
                 return;
             }
 
-            if ((transportResult.AsyncState is AsyncProtocolRequest) && GlobalLog.IsEnabled)
+            if ((transportResult.AsyncState is AsyncProtocolRequest))
             {
-                GlobalLog.Assert("NegotiateSteam::WriteCallback|State type is wrong, expected AsyncProtocolRequest.");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("NegotiateSteam::WriteCallback|State type is wrong, expected AsyncProtocolRequest.");
+                }
+                Debug.Fail("NegotiateSteam::WriteCallback|State type is wrong, expected AsyncProtocolRequest.");
             }
 
             AsyncProtocolRequest asyncRequest = (AsyncProtocolRequest)transportResult.AsyncState;

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/NegoState.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/NegoState.Windows.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.IO;
 using System.Security;
 using System.Security.Principal;
@@ -754,9 +755,13 @@ namespace System.Net.Security
 
         private static void WriteCallback(IAsyncResult transportResult)
         {
-            if ((transportResult.AsyncState is LazyAsyncResult) && GlobalLog.IsEnabled)
+            if ((transportResult.AsyncState is LazyAsyncResult))
             {
-                GlobalLog.Assert("WriteCallback|State type is wrong, expected LazyAsyncResult.");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("WriteCallback|State type is wrong, expected LazyAsyncResult.");
+                }
+                Debug.Fail("WriteCallback|State type is wrong, expected LazyAsyncResult.");
             }
 
             if (transportResult.CompletedSynchronously)
@@ -795,9 +800,13 @@ namespace System.Net.Security
 
         private static void ReadCallback(IAsyncResult transportResult)
         {
-            if ((transportResult.AsyncState is LazyAsyncResult) && GlobalLog.IsEnabled)
+            if ((transportResult.AsyncState is LazyAsyncResult))
             {
-                GlobalLog.Assert("ReadCallback|State type is wrong, expected LazyAsyncResult.");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("ReadCallback|State type is wrong, expected LazyAsyncResult.");
+                }
+                Debug.Fail("ReadCallback|State type is wrong, expected LazyAsyncResult.");
             }
 
             if (transportResult.CompletedSynchronously)

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslState.cs
@@ -1043,9 +1043,13 @@ namespace System.Net.Security
             }
             catch (Exception exception)
             {
-                if (!ExceptionCheck.IsFatal(exception) && GlobalLog.IsEnabled)
+                if (!ExceptionCheck.IsFatal(exception))
                 {
-                    GlobalLog.Assert("SslState::WriteCallback", "Exception while decoding context. type:" + exception.GetType().ToString() + " message:" + exception.Message);
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Assert("SslState::WriteCallback", "Exception while decoding context. type:" + exception.GetType().ToString() + " message:" + exception.Message);
+                    }
+                    Debug.Fail("SslState::WriteCallback", "Exception while decoding context. type:" + exception.GetType().ToString() + " message:" + exception.Message);
                 }
 
                 throw;
@@ -1564,9 +1568,13 @@ namespace System.Net.Security
 
             int version = -1;
 
-            if (GlobalLog.IsEnabled && (bytes == null || bytes.Length == 0))
+            if ((bytes == null || bytes.Length == 0))
             {
-                GlobalLog.Assert("SslState::DetectFraming()|Header buffer is not allocated will boom shortly.");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("SslState::DetectFraming()|Header buffer is not allocated will boom shortly.");
+                }
+                Debug.Fail("SslState::DetectFraming()|Header buffer is not allocated will boom shortly.");
             }
 
             // If the first byte is SSL3 HandShake, then check if we have a SSLv3 Type3 client hello.
@@ -1785,16 +1793,21 @@ namespace System.Net.Security
         private void RehandshakeCompleteCallback(IAsyncResult result)
         {
             LazyAsyncResult lazyAsyncResult = (LazyAsyncResult)result;
-            if (GlobalLog.IsEnabled)
+            if (lazyAsyncResult == null)
             {
-                if (lazyAsyncResult == null)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("SslState::RehandshakeCompleteCallback()|result is null!");
                 }
-                if (!lazyAsyncResult.InternalPeekCompleted)
+                Debug.Fail("SslState::RehandshakeCompleteCallback()|result is null!");
+            }
+            if (!lazyAsyncResult.InternalPeekCompleted)
+            {
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("SslState::RehandshakeCompleteCallback()|result is not completed!");
                 }
+                Debug.Fail("SslState::RehandshakeCompleteCallback()|result is not completed!");
             }
 
             // If the rehandshake succeeded, FinishHandshake has already been called; if there was a SocketException

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslStreamContext.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslStreamContext.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.Net.Security;
 using System.Security.Authentication.ExtendedProtection;
 
@@ -10,9 +11,13 @@ namespace System.Net
     {
         internal SslStreamContext(SslStream sslStream)
         {
-            if (sslStream == null && GlobalLog.IsEnabled)
+            if (sslStream == null)
             {
-                GlobalLog.Assert("SslStreamContext..ctor(): Not expecting a null sslStream!");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("SslStreamContext..ctor(): Not expecting a null sslStream!");
+                }
+                Debug.Fail("SslStreamContext..ctor(): Not expecting a null sslStream!");
             }
 
             _sslStream = sslStream;

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslStreamInternal.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslStreamInternal.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 
@@ -353,9 +354,13 @@ namespace System.Net.Security
         {
             int result = 0;
 
-            if (GlobalLog.IsEnabled && InternalBufferCount != 0)
+            if (InternalBufferCount != 0)
             {
-                GlobalLog.AssertFormat("SslStream::StartReading()|Previous frame was not consumed. InternalBufferCount:{0}", InternalBufferCount);
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.AssertFormat("SslStream::StartReading()|Previous frame was not consumed. InternalBufferCount:{0}", InternalBufferCount);
+                }
+                Debug.Fail("SslStream::StartReading()|Previous frame was not consumed. InternalBufferCount:" + InternalBufferCount);
             }
 
             do

--- a/src/System.Net.Security/src/System/Net/SecurityBuffer.cs
+++ b/src/System.Net.Security/src/System/Net/SecurityBuffer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security.Authentication.ExtendedProtection;
 
@@ -16,16 +17,21 @@ namespace System.Net.Security
 
         public SecurityBuffer(byte[] data, int offset, int size, SecurityBufferType tokentype)
         {
-            if (GlobalLog.IsEnabled)
+            if (offset < 0 || offset > (data == null ? 0 : data.Length))
             {
-                if (offset == 0 || offset > (data == null ? 0 : data.Length))
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("SecurityBuffer::.ctor", "'offset' out of range.  [" + offset + "]");
                 }
-                if (size == 0 || size > (data == null ? 0 : data.Length - offset))
+                Debug.Fail("SecurityBuffer::.ctor", "'offset' out of range.  [" + offset + "]");
+            }
+            if (size < 0 || size > (data == null ? 0 : data.Length - offset))
+            {
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("SecurityBuffer::.ctor", "'size' out of range.  [" + size + "]");
                 }
+                Debug.Fail("SecurityBuffer::.ctor", "'size' out of range.  [" + size + "]");
             }
 
             this.offset = data == null || offset < 0 ? 0 : Math.Min(offset, data.Length);
@@ -43,9 +49,13 @@ namespace System.Net.Security
 
         public SecurityBuffer(int size, SecurityBufferType tokentype)
         {
-            if (size < 0 && GlobalLog.IsEnabled)
+            if (size < 0)
             {
-                GlobalLog.Assert("SecurityBuffer::.ctor", "'size' out of range.  [" + size + "]");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("SecurityBuffer::.ctor", "'size' out of range.  [" + size + "]");
+                }
+                Debug.Fail("SecurityBuffer::.ctor", "'size' out of range.  [" + size + "]");
             }
 
             this.size = size;

--- a/src/System.Net.Security/src/System/Net/SslSessionsCache.cs
+++ b/src/System.Net.Security/src/System/Net/SslSessionsCache.cs
@@ -125,11 +125,9 @@ namespace System.Net.Security
         //
         internal static SafeFreeCredentials TryCachedCredential(byte[] thumbPrint, SslProtocols sslProtocols, bool isServer, EncryptionPolicy encryptionPolicy)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-
             if (s_CachedCreds.Count == 0)
             {
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Print("TryCachedCredential() Not found, Current Cache Count = " + s_CachedCreds.Count);
                 }
@@ -142,14 +140,14 @@ namespace System.Net.Security
 
             if (cached == null || cached.IsClosed || cached.Target.IsInvalid)
             {
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Print("TryCachedCredential() Not found or invalid, Current Cache Count = " + s_CachedCreds.Count);
                 }
                 return null;
             }
 
-            if (globalLogEnabled)
+            if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Print("TryCachedCredential() Found a cached Handle = " + cached.Target.ToString());
             }
@@ -164,16 +162,14 @@ namespace System.Net.Security
         //
         internal static void CacheCredential(SafeFreeCredentials creds, byte[] thumbPrint, SslProtocols sslProtocols, bool isServer, EncryptionPolicy encryptionPolicy)
         {
-            bool globalLogEnabled = GlobalLog.IsEnabled;
-
-            if (creds == null && globalLogEnabled)
+            if (creds == null && GlobalLog.IsEnabled)
             {
                 GlobalLog.Assert("CacheCredential|creds == null");
             }
 
             if (creds.IsInvalid)
             {
-                if (globalLogEnabled)
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Print("CacheCredential() Refused to cache an Invalid Handle = " + creds.ToString() + ", Current Cache Count = " + s_CachedCreds.Count);
                 }
@@ -201,7 +197,7 @@ namespace System.Net.Security
                         }
 
                         s_CachedCreds[key] = cached;
-                        if (globalLogEnabled)
+                        if (GlobalLog.IsEnabled)
                         {
                             GlobalLog.Print("CacheCredential() Caching New Handle = " + creds.ToString() + ", Current Cache Count = " + s_CachedCreds.Count);
                         }
@@ -240,19 +236,19 @@ namespace System.Net.Security
                                     }
                                 }
                             }
-                            if (globalLogEnabled)
+                            if (GlobalLog.IsEnabled)
                             {
                                 GlobalLog.Print("Scavenged cache, New Cache Count = " + s_CachedCreds.Count);
                             }
                         }
                     }
-                    else if (globalLogEnabled)
+                    else if (GlobalLog.IsEnabled)
                     {
                         GlobalLog.Print("CacheCredential() (locked retry) Found already cached Handle = " + cached.Target.ToString());
                     }
                 }
             }
-            else if (globalLogEnabled)
+            else if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Print("CacheCredential() Ignoring incoming handle = " + creds.ToString() + " since found already cached Handle = " + cached.Target.ToString());
             }

--- a/src/System.Net.Security/src/System/Net/SslSessionsCache.cs
+++ b/src/System.Net.Security/src/System/Net/SslSessionsCache.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections;
+using System.Diagnostics;
 using System.Security.Authentication;
 
 namespace System.Net.Security
@@ -162,9 +163,13 @@ namespace System.Net.Security
         //
         internal static void CacheCredential(SafeFreeCredentials creds, byte[] thumbPrint, SslProtocols sslProtocols, bool isServer, EncryptionPolicy encryptionPolicy)
         {
-            if (creds == null && GlobalLog.IsEnabled)
+            if (creds == null)
             {
-                GlobalLog.Assert("CacheCredential|creds == null");
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("CacheCredential|creds == null");
+                }
+                Debug.Fail("CacheCredential|creds == null");
             }
 
             if (creds.IsInvalid)

--- a/src/System.Net.Security/src/System/Net/StreamFramer.cs
+++ b/src/System.Net.Security/src/System/Net/StreamFramer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Diagnostics;
 using System.IO;
 using System.Globalization;
 
@@ -152,9 +153,13 @@ namespace System.Net
 
         private void ReadFrameCallback(IAsyncResult transportResult)
         {
-            if ((transportResult.AsyncState is WorkerAsyncResult) && GlobalLog.IsEnabled)
+            if ((transportResult.AsyncState is WorkerAsyncResult))
             {
-                GlobalLog.Assert("StreamFramer::ReadFrameCallback|The state expected to be WorkerAsyncResult, received:{0}.", transportResult.GetType().FullName);
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.Assert("StreamFramer::ReadFrameCallback|The state expected to be WorkerAsyncResult, received:{0}.", transportResult.GetType().FullName);
+                }
+                Debug.Fail("StreamFramer::ReadFrameCallback|The state expected to be WorkerAsyncResult, received:" + transportResult.GetType().FullName + ".");
             }
 
             if (transportResult.CompletedSynchronously)
@@ -195,9 +200,13 @@ namespace System.Net
         {
             do
             {
-                if ((transportResult.AsyncState is WorkerAsyncResult) && GlobalLog.IsEnabled)
+                if ((transportResult.AsyncState is WorkerAsyncResult))
                 {
-                    GlobalLog.AssertFormat("StreamFramer::ReadFrameComplete|The state expected to be WorkerAsyncResult, received:{0}.", transportResult.GetType().FullName);
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.AssertFormat("StreamFramer::ReadFrameComplete|The state expected to be WorkerAsyncResult, received:{0}.", transportResult.GetType().FullName);
+                    }
+                    Debug.Fail("StreamFramer::ReadFrameComplete|The state expected to be WorkerAsyncResult, received:" + transportResult.GetType().FullName + ".");
                 }
 
                 WorkerAsyncResult workerResult = (WorkerAsyncResult)transportResult.AsyncState;
@@ -205,9 +214,13 @@ namespace System.Net
                 int bytesRead = _transportAPM.EndRead(transportResult);
                 workerResult.Offset += bytesRead;
 
-                if ((workerResult.Offset <= workerResult.End) && GlobalLog.IsEnabled)
+                if ((workerResult.Offset <= workerResult.End))
                 {
-                    GlobalLog.AssertFormat("StreamFramer::ReadFrameCallback|WRONG: offset - end = {0}", workerResult.Offset - workerResult.End);
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.AssertFormat("StreamFramer::ReadFrameCallback|WRONG: offset - end = {0}", workerResult.Offset - workerResult.End);
+                    }
+                    Debug.Fail("StreamFramer::ReadFrameCallback|WRONG: offset - end = " + (workerResult.Offset - workerResult.End));
                 }
 
                 if (bytesRead <= 0)
@@ -377,9 +390,13 @@ namespace System.Net
 
         private void BeginWriteCallback(IAsyncResult transportResult)
         {
-            if ((transportResult.AsyncState is WorkerAsyncResult) && GlobalLog.IsEnabled)
+            if ((transportResult.AsyncState is WorkerAsyncResult))
             {
-                GlobalLog.AssertFormat("StreamFramer::BeginWriteCallback|The state expected to be WorkerAsyncResult, received:{0}.", transportResult.AsyncState.GetType().FullName);
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.AssertFormat("StreamFramer::BeginWriteCallback|The state expected to be WorkerAsyncResult, received:{0}.", transportResult.AsyncState.GetType().FullName);
+                }
+                Debug.Fail("StreamFramer::BeginWriteCallback|The state expected to be WorkerAsyncResult, received:" + transportResult.AsyncState.GetType().FullName + ".");
             }
 
             if (transportResult.CompletedSynchronously)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/AcceptOverlappedAsyncResult.Windows.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -105,9 +106,13 @@ namespace System.Net.Sockets
 
         private void LogBuffer(long size)
         {
-            if (!SocketsEventSource.Log.IsEnabled() && GlobalLog.IsEnabled)
+            if (!SocketsEventSource.Log.IsEnabled())
             {
-                GlobalLog.AssertFormat("AcceptOverlappedAsyncResult#{0}::LogBuffer()|Logging is off!", LoggingHash.HashString(this));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.AssertFormat("AcceptOverlappedAsyncResult#{0}::LogBuffer()|Logging is off!", LoggingHash.HashString(this));
+                }
+                Debug.Fail("AcceptOverlappedAsyncResult#" + LoggingHash.HashString(this) + "::LogBuffer()|Logging is off!");
             }
             IntPtr pinnedBuffer = Marshal.UnsafeAddrOfPinnedArrayElement(_buffer, 0);
             if (pinnedBuffer != IntPtr.Zero)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/BaseOverlappedAsyncResult.Windows.cs
@@ -91,13 +91,16 @@ namespace System.Net.Sockets
 
                 object returnObject = null;
 
-                if (GlobalLog.IsEnabled)
+                if (asyncResult.InternalPeekCompleted)
                 {
-                    if (asyncResult.InternalPeekCompleted)
+                    if (GlobalLog.IsEnabled)
                     {
                         GlobalLog.AssertFormat("BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|asyncResult.IsCompleted", LoggingHash.HashString(asyncResult));
-                    }
-
+                    }                
+                    Debug.Fail("BaseOverlappedAsyncResult#" + LoggingHash.HashString(asyncResult) + "::CompletionPortCallback()|asyncResult.IsCompleted");
+                }
+                if (GlobalLog.IsEnabled)
+                {
                     GlobalLog.Print(
                         "BaseOverlappedAsyncResult#" + LoggingHash.HashString(asyncResult) + "::CompletionPortCallback" +
                         " errorCode:" + errorCode.ToString() +
@@ -141,15 +144,23 @@ namespace System.Net.Sockets
                             if (!success)
                             {
                                 socketError = (SocketError)Marshal.GetLastWin32Error();
-                                if (socketError == 0 && GlobalLog.IsEnabled)
+                                if (socketError == 0)
                                 {
-                                    GlobalLog.AssertFormat("BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|socketError:0 numBytes:{1}", LoggingHash.HashString(asyncResult), numBytes);
+                                    if (GlobalLog.IsEnabled)
+                                    {
+                                        GlobalLog.AssertFormat("BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|socketError:0 numBytes:{1}", LoggingHash.HashString(asyncResult), numBytes);
+                                    }
+                                    Debug.Fail("BaseOverlappedAsyncResult#" + LoggingHash.HashString(asyncResult) + "::CompletionPortCallback()|socketError:0 numBytes:" + numBytes);
                                 }
                             }
 
-                            if (success && GlobalLog.IsEnabled)
+                            if (success)
                             {
-                                GlobalLog.AssertFormat("BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|Unexpectedly succeeded. errorCode:{1} numBytes:{2}", LoggingHash.HashString(asyncResult), errorCode, numBytes);
+                                if (GlobalLog.IsEnabled)
+                                {
+                                    GlobalLog.AssertFormat("BaseOverlappedAsyncResult#{0}::CompletionPortCallback()|Unexpectedly succeeded. errorCode:{1} numBytes:{2}", LoggingHash.HashString(asyncResult), errorCode, numBytes);
+                                }
+                                Debug.Fail("BaseOverlappedAsyncResult#" + LoggingHash.HashString(asyncResult) + "::CompletionPortCallback()|Unexpectedly succeeded. errorCode:" + errorCode + " numBytes: " + numBytes);
                             }
                         }
                         catch (ObjectDisposedException)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/MultipleConnectAsync.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/MultipleConnectAsync.cs
@@ -49,12 +49,15 @@ namespace System.Net.Sockets
         {
             lock (_lockObject)
             {
-                if (GlobalLog.IsEnabled &&
-                    endPoint.AddressFamily != AddressFamily.Unspecified &&
+                if (endPoint.AddressFamily != AddressFamily.Unspecified &&
                     endPoint.AddressFamily != AddressFamily.InterNetwork &&
                     endPoint.AddressFamily != AddressFamily.InterNetworkV6)
                 {
-                    GlobalLog.Assert("MultipleConnectAsync.StartConnectAsync(): Unexpected endpoint address family - " + endPoint.AddressFamily.ToString());
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Assert("MultipleConnectAsync.StartConnectAsync(): Unexpected endpoint address family - " + endPoint.AddressFamily.ToString());
+                    }
+                    Debug.Fail("MultipleConnectAsync.StartConnectAsync(): Unexpected endpoint address family - " + endPoint.AddressFamily.ToString());
                 }
 
                 _userArgs = args;
@@ -68,9 +71,13 @@ namespace System.Net.Sockets
                     return false;
                 }
 
-                if (_state != State.NotStarted && GlobalLog.IsEnabled)
+                if (_state != State.NotStarted)
                 {
-                    GlobalLog.Assert("MultipleConnectAsync.StartConnectAsync(): Unexpected object state");
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Assert("MultipleConnectAsync.StartConnectAsync(): Unexpected object state");
+                    }
+                    Debug.Fail("MultipleConnectAsync.StartConnectAsync(): Unexpected object state");
                 }
 
                 _state = State.DnsQuery;
@@ -112,17 +119,25 @@ namespace System.Net.Sockets
                     return true;
                 }
 
-                if (_state != State.DnsQuery && GlobalLog.IsEnabled)
+                if (_state != State.DnsQuery)
                 {
-                    GlobalLog.Assert("MultipleConnectAsync.DoDnsCallback(): Unexpected object state");
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Assert("MultipleConnectAsync.DoDnsCallback(): Unexpected object state");
+                    }
+                    Debug.Fail("MultipleConnectAsync.DoDnsCallback(): Unexpected object state");
                 }
 
                 try
                 {
                     _addressList = DnsAPMExtensions.EndGetHostAddresses(result);
-                    if (_addressList == null && GlobalLog.IsEnabled)
+                    if (_addressList == null)
                     {
-                        GlobalLog.Assert("MultipleConnectAsync.DoDnsCallback(): EndGetHostAddresses returned null!");
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.Assert("MultipleConnectAsync.DoDnsCallback(): EndGetHostAddresses returned null!");
+                        }
+                        Debug.Fail("MultipleConnectAsync.DoDnsCallback(): EndGetHostAddresses returned null!");
                     }
                 }
                 catch (Exception e)
@@ -248,16 +263,21 @@ namespace System.Net.Sockets
                 }
                 else
                 {
-                    if (GlobalLog.IsEnabled)
+                    if (_state != State.UserConnectAttempt)
                     {
-                        if (_state != State.UserConnectAttempt)
+                        if (GlobalLog.IsEnabled)
                         {
                             GlobalLog.Assert("MultipleConnectAsync.InternalConnectCallback(): Unexpected object state");
                         }
-                        if (!RequiresUserConnectAttempt)
+                        Debug.Fail("MultipleConnectAsync.InternalConnectCallback(): Unexpected object state");
+                    }
+                    if (!RequiresUserConnectAttempt)
+                    {
+                        if (GlobalLog.IsEnabled)
                         {
                             GlobalLog.Assert("MultipleConnectAsync.InternalConnectCallback(): State.UserConnectAttempt without RequiresUserConnectAttempt");
                         }
+                        Debug.Fail("MultipleConnectAsync.InternalConnectCallback(): State.UserConnectAttempt without RequiresUserConnectAttempt");
                     }
 
                     if (args.SocketError == SocketError.Success)
@@ -303,9 +323,13 @@ namespace System.Net.Sockets
                     return new SocketException((int)SocketError.NoData);
                 }
 
-                if (attemptAddress == null && GlobalLog.IsEnabled)
+                if (attemptAddress == null)
                 {
-                    GlobalLog.Assert("MultipleConnectAsync.AttemptConnection: attemptAddress is null!");
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Assert("MultipleConnectAsync.AttemptConnection: attemptAddress is null!");
+                    }
+                    Debug.Fail("MultipleConnectAsync.AttemptConnection: attemptAddress is null!");
                 }
 
                 _internalArgs.RemoteEndPoint = new IPEndPoint(attemptAddress, _endPoint.Port);
@@ -314,9 +338,13 @@ namespace System.Net.Sockets
             }
             catch (Exception e)
             {
-                if (e is ObjectDisposedException && GlobalLog.IsEnabled)
+                if (e is ObjectDisposedException)
                 {
-                    GlobalLog.Assert("MultipleConnectAsync.AttemptConnection: unexpected ObjectDisposedException");
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Assert("MultipleConnectAsync.AttemptConnection: unexpected ObjectDisposedException");
+                    }
+                    Debug.Fail("MultipleConnectAsync.AttemptConnection: unexpected ObjectDisposedException");
                 }
                 return e;
             }
@@ -338,9 +366,13 @@ namespace System.Net.Sockets
             }
             catch (Exception e)
             {
-                if (e is ObjectDisposedException && GlobalLog.IsEnabled)
+                if (e is ObjectDisposedException)
                 {
-                    GlobalLog.Assert("MultipleConnectAsync.AttemptConnection: unexpected ObjectDisposedException");
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Assert("MultipleConnectAsync.AttemptConnection: unexpected ObjectDisposedException");
+                    }
+                    Debug.Fail("MultipleConnectAsync.AttemptConnection: unexpected ObjectDisposedException");
                 }
                 return e;
             }
@@ -350,9 +382,13 @@ namespace System.Net.Sockets
         {
             try
             {
-                if (attemptSocket == null && GlobalLog.IsEnabled)
+                if (attemptSocket == null)
                 {
-                    GlobalLog.Assert("MultipleConnectAsync.AttemptConnection: attemptSocket is null!");
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.Assert("MultipleConnectAsync.AttemptConnection: attemptSocket is null!");
+                    }
+                    Debug.Fail("MultipleConnectAsync.AttemptConnection: attemptSocket is null!");
                 }
 
                 if (!attemptSocket.ConnectAsync(args))
@@ -490,6 +526,7 @@ namespace System.Net.Sockets
                         {
                             GlobalLog.Assert("MultipleConnectAsync.Cancel(): Unexpected object state");
                         }
+                        Debug.Fail("MultipleConnectAsync.Cancel(): Unexpected object state");
                         break;
                 }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/OverlappedAsyncResult.Windows.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -112,9 +113,13 @@ namespace System.Net.Sockets
 
         private void LogBuffer(int size)
         {
-            if (!SocketsEventSource.Log.IsEnabled() && GlobalLog.IsEnabled)
+            if (!SocketsEventSource.Log.IsEnabled())
             {
-                GlobalLog.AssertFormat("OverlappedAsyncResult#{0}::LogBuffer()|Logging is off!", LoggingHash.HashString(this));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.AssertFormat("OverlappedAsyncResult#{0}::LogBuffer()|Logging is off!", LoggingHash.HashString(this));
+                }
+                Debug.Fail("OverlappedAsyncResult#" + LoggingHash.HashString(this) + "::LogBuffer()|Logging is off!");
             }
 
             if (size > -1)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/ReceiveMessageOverlappedAsyncResult.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/ReceiveMessageOverlappedAsyncResult.Windows.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Diagnostics;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -160,9 +161,13 @@ namespace System.Net.Sockets
 
         private void LogBuffer(int size)
         {
-            if (!SocketsEventSource.Log.IsEnabled() && GlobalLog.IsEnabled)
+            if (!SocketsEventSource.Log.IsEnabled())
             {
-                GlobalLog.AssertFormat("ReceiveMessageOverlappedAsyncResult#{0}::LogBuffer()|Logging is off!", LoggingHash.HashString(this));
+                if (GlobalLog.IsEnabled)
+                {
+                    GlobalLog.AssertFormat("ReceiveMessageOverlappedAsyncResult#{0}::LogBuffer()|Logging is off!", LoggingHash.HashString(this));
+                }
+                Debug.Fail("ReceiveMessageOverlappedAsyncResult#" + LoggingHash.HashString(this) + "::LogBuffer()|Logging is off!");
             }
             SocketsEventSource.Dump(_wsaBuffer->Pointer, Math.Min(_wsaBuffer->Length, size));
         }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -758,10 +758,15 @@ namespace System.Net.Sockets
             if (GlobalLog.IsEnabled)
             {
                 GlobalLog.Print("Socket#" + LoggingHash.HashString(this) + "::InternalBind() localEP:" + localEP.ToString());
-                if (localEP is DnsEndPoint)
+            }
+
+            if (localEP is DnsEndPoint)
+            {
+                if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("Calling InternalBind with a DnsEndPoint, about to get NotImplementedException");
                 }
+                Debug.Fail("Calling InternalBind with a DnsEndPoint, about to get NotImplementedException");
             }
 
             // Ask the EndPoint to generate a SocketAddress that we can pass down to native code.
@@ -3289,10 +3294,11 @@ namespace System.Net.Sockets
             // Throw an appropriate SocketException if the native call fails synchronously.
             if (errorCode != SocketError.Success)
             {
-                if (GlobalLog.IsEnabled)
-                {
-                    GlobalLog.AssertFormat("Socket#{0}::DoBeginReceive()|GetLastWin32Error() returned zero.", LoggingHash.HashString(this));
-                }
+                // TODO: https://github.com/dotnet/corefx/issues/5426
+                //if (GlobalLog.IsEnabled)
+                //{
+                //    GlobalLog.AssertFormat("Socket#{0}::DoBeginReceive()|GetLastWin32Error() returned zero.", LoggingHash.HashString(this));
+                //}
 
                 // Update the internal state of this socket according to the error before throwing.
                 UpdateStatusAfterSocketError(errorCode);
@@ -3603,6 +3609,7 @@ namespace System.Net.Sockets
                         {
                             GlobalLog.Assert("Socket#" + LoggingHash.HashString(this) + "::BeginReceiveMessageFrom()|Returned WSAEMSGSIZE!");
                         }
+                        Debug.Fail("Socket#" + LoggingHash.HashString(this) + "::BeginReceiveMessageFrom()|Returned WSAEMSGSIZE!");
 
                         errorCode = SocketError.IOPending;
                     }
@@ -5363,6 +5370,7 @@ namespace System.Net.Sockets
                 {
                     GlobalLog.Assert("SafeCloseSocket::Dispose(handle:" + _handle.DangerousGetHandle().ToString("x") + ")", "Closing the handle threw ObjectDisposedException.");
                 }
+                Debug.Fail("SafeCloseSocket::Dispose(handle:" + _handle.DangerousGetHandle().ToString("x") + ")", "Closing the handle threw ObjectDisposedException.");
             }
         }
 
@@ -5728,9 +5736,13 @@ namespace System.Net.Sockets
             // called if _rightEndPoint is not null, of that the endpoint is an IPEndPoint.
             if (_rightEndPoint == null)
             {
-                if (endPointSnapshot.GetType() != typeof(IPEndPoint) && GlobalLog.IsEnabled)
+                if (endPointSnapshot.GetType() != typeof(IPEndPoint))
                 {
-                    GlobalLog.AssertFormat("Socket#{0}::BeginConnectEx()|Socket not bound and endpoint not IPEndPoint.", LoggingHash.HashString(this));
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.AssertFormat("Socket#{0}::BeginConnectEx()|Socket not bound and endpoint not IPEndPoint.", LoggingHash.HashString(this));
+                    }
+                    Debug.Fail("Socket#" + LoggingHash.HashString(this) + "::BeginConnectEx()|Socket not bound and endpoint not IPEndPoint.");
                 }
 
                 if (endPointSnapshot.AddressFamily == AddressFamily.InterNetwork)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.cs
@@ -488,9 +488,13 @@ namespace System.Net.Sockets
                 {
                     // Otherwise we're doing a normal ConnectAsync - cancel it by closing the socket.
                     // _currentSocket will only be null if _multipleConnect was set, so we don't have to check.
-                    if (_currentSocket == null && GlobalLog.IsEnabled)
+                    if (_currentSocket == null)
                     {
-                        GlobalLog.Assert("SocketAsyncEventArgs::CancelConnectAsync - CurrentSocket and MultipleConnect both null!");
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.Assert("SocketAsyncEventArgs::CancelConnectAsync - CurrentSocket and MultipleConnect both null!");
+                        }
+                        Debug.Fail("SocketAsyncEventArgs::CancelConnectAsync - CurrentSocket and MultipleConnect both null!");
                     }
                     _currentSocket.Dispose();
                 }


### PR DESCRIPTION
The "temporary" part 1 of https://github.com/dotnet/corefx/issues/5265 until a better logging solution can be put in place.

1. Removed the "bool globalLogEnabled = GlobalLog.IsEnabled" that had been used previously.
2. Added Debug.Fail calls at all GlobalLog.Assert* call sites.

cc: @cipop, @davidsh, @josguil 