### PR TITLE
Add Environment.MachineName to .NET Core.

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetNodeName.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetNodeName.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetNodeName", SetLastError = true)]
+        private static extern unsafe int GetNodeName(char* name, out int len);
+
+        internal static unsafe string GetNodeName()
+        {
+            // max value of _UTSNAME_LENGTH on known Unix platforms is 1024.
+            const int _UTSNAME_LENGTH = 1024;
+            int len = _UTSNAME_LENGTH;
+            char* name = stackalloc char[_UTSNAME_LENGTH];
+            int err = GetNodeName(name, out len);
+            if (err != 0)
+            {
+                // max domain name can be 255 chars. 
+                Debug.Fail("getnodename failed");
+                throw new InvalidOperationException(string.Format("getnodename returned {0}", err));
+            }
+
+            // Marshal.PtrToStringAnsi uses UTF8 on Unix.
+            return Marshal.PtrToStringAnsi((IntPtr)name);
+        }
+    }
+}

--- a/src/Native/System.Native/CMakeLists.txt
+++ b/src/Native/System.Native/CMakeLists.txt
@@ -12,6 +12,7 @@ set(NATIVE_SOURCES
     pal_networkstatistics.cpp
     pal_process.cpp
     pal_runtimeinformation.cpp
+    pal_runtimeextensions.cpp
     pal_string.cpp
     pal_tcpstate.cpp
     pal_time.cpp

--- a/src/Native/System.Native/pal_runtimeextensions.cpp
+++ b/src/Native/System.Native/pal_runtimeextensions.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include "pal_runtimeextensions.h"
+#include "pal_types.h"
+#include <stdio.h>
+#include <sys/utsname.h>
+
+extern "C" int32_t SystemNative_GetNodeName(char* version, int* capacity)
+{
+    struct utsname _utsname;
+    if (uname(&_utsname) != -1)
+    {
+        int r = snprintf(version, static_cast<size_t>(*capacity), "%s", _utsname.nodename);
+        if (r > *capacity)
+        {
+            *capacity = r + 1;
+            return -1;
+        }
+    }
+
+    return 0;
+}

--- a/src/Native/System.Native/pal_runtimeextensions.h
+++ b/src/Native/System.Native/pal_runtimeextensions.h
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include "pal_types.h"
+
+extern "C" int32_t SystemNative_GetNodeName(char* version, int* capacity);

--- a/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
+++ b/src/System.Runtime.Extensions/ref/System.Runtime.Extensions.cs
@@ -432,6 +432,7 @@ namespace System
     {
         public static int CurrentManagedThreadId { get { return default(int); } }
         public static bool HasShutdownStarted { get { return default(bool); } }
+        public static string MachineName { get { return default(string); } }
         public static string NewLine { get { return default(string); } }
         public static int ProcessorCount { get { return default(int); } }
         public static string StackTrace { get { return default(string); } }

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
@@ -21,6 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Diagnostics\Stopwatch.cs" />
+    <Compile Include="System\Environment.MachineName.cs" />
     <Compile Include="System\Runtime\Versioning\FrameworkName.cs" />
     <Compile Include="System\IO\PathTests.cs" />
     <Compile Include="System\IO\Path.Combine.cs" />
@@ -59,7 +60,12 @@
     <Compile Include="System\Progress.cs" />
     <Compile Include="System\Random.cs" />
     <Compile Include="System\StringComparer.cs" />
-	
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetNodeName.cs">
+      <Link>Common\Interop\Unix\System.Native\Interop.GetNodeName.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+      <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Diagnostics\AssertWithCallerAttributes.cs">
       <Link>Common\tests\System\Diagnostics\AssertWithCallerAttributes.cs</Link>
     </Compile>

--- a/src/System.Runtime.Extensions/tests/System/Environment.MachineName.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.MachineName.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace System.Runtime.Extensions.Tests
+{
+    public class Environment_MachineName
+    {
+        [Fact]
+        public void TestMachineNameProperty()
+        {
+            string computerName = GetComputerName();
+            Assert.Equal(computerName, Environment.MachineName);
+        }
+
+        internal static string GetComputerName()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return Environment.GetEnvironmentVariable("COMPUTERNAME");
+            }
+            else
+            {
+                return Interop.Sys.GetNodeName();
+            }
+        }
+    }
+}


### PR DESCRIPTION
In reference to #4306 

The implementation is not provided for .NET Native, and will be documented in ```AppCompatBaseLine.txt```. The win32 api ```GetComputerName``` is not available for Store profile, will be implementing this for .NET Native when there are relevant win32 apis that can be used.

cc @joshfree 