### PR TITLE
Enable all passing tests that are marked with ActiveIssue for #846.

### DIFF
--- a/src/Common/tests/System/Xml/XPath/MiscellaneousCases/GlobalizationTests.cs
+++ b/src/Common/tests/System/Xml/XPath/MiscellaneousCases/GlobalizationTests.cs
@@ -19,7 +19,6 @@ namespace XPathTests.FunctionalTests
         /// </summary>
         [Fact]
         [OuterLoop]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GlobalizationTest566()
         {
             var xml = "Surrogates_1.xml";
@@ -148,7 +147,6 @@ namespace XPathTests.FunctionalTests
         /// Thai Risky : xpath testing, returns 4 nodes
         /// </summary>
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GlobalizationTest568()
         {
             var xml = "Thai_risky_chars.xml";
@@ -201,7 +199,6 @@ namespace XPathTests.FunctionalTests
         /// Japanese 1: xpath testing problem char, returns 19 nodes
         /// </summary>
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GlobalizationTest569()
         {
             var xml = "JPN_problem_chars_1.xml";
@@ -388,7 +385,6 @@ namespace XPathTests.FunctionalTests
         /// Japanese 2: xpath testing problem char, returns 7 nodes
         /// </summary>
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GlobalizationTest5610()
         {
             var xml = "JPN_problem_chars_2.xml";
@@ -467,7 +463,6 @@ namespace XPathTests.FunctionalTests
         /// Korean: xpath testing problem char, return 6 nodes
         /// </summary>
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void GlobalizationTest5613()
         {
             var xml = "KOR_problem_chars_b.xml";

--- a/src/System.Collections.NonGeneric/tests/CaseInsensitiveComparer/CaseInsensitiveComparer_CultureInfo.cs
+++ b/src/System.Collections.NonGeneric/tests/CaseInsensitiveComparer/CaseInsensitiveComparer_CultureInfo.cs
@@ -8,7 +8,6 @@ using Xunit;
 
 public class CaseInsensitiveComparer_CultureInfo
 {
-
     public bool runTest()
     {
         //////////// Global Variables used for all tests
@@ -137,10 +136,7 @@ public class CaseInsensitiveComparer_CultureInfo
         }
     }
 
-
-
     [Fact]
-    [ActiveIssue(2769, PlatformID.AnyUnix)]
     public static void ExecuteCaseInsensitiveComparer_CultureInfo()
     {
         bool bResult = false;
@@ -157,6 +153,5 @@ public class CaseInsensitiveComparer_CultureInfo
         }
 
         Assert.True(bResult);
-    }}
-
-
+    }
+}

--- a/src/System.Collections.NonGeneric/tests/Comparer/Comparer_CaseInsensitive.cs
+++ b/src/System.Collections.NonGeneric/tests/Comparer/Comparer_CaseInsensitive.cs
@@ -112,7 +112,7 @@ public class Comparer_CaseInsensitive
 
 
     [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
+    [ActiveIssue(5460, PlatformID.AnyUnix)]
     public static void ExecuteComparer_CaseInsensitive()
     {
         bool bResult = false;

--- a/src/System.Collections.NonGeneric/tests/Comparer/Comparer_DefaultInvariant.cs
+++ b/src/System.Collections.NonGeneric/tests/Comparer/Comparer_DefaultInvariant.cs
@@ -96,7 +96,6 @@ public class Comparer_DefaultInvariant
 
 
     [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
     public static void ExecuteComparer_DefaultInvariant()
     {
         bool bResult = false;

--- a/src/System.Collections.NonGeneric/tests/SortedList/GetObjectTests.cs
+++ b/src/System.Collections.NonGeneric/tests/SortedList/GetObjectTests.cs
@@ -16,7 +16,6 @@ namespace System.Collections.Tests
 
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void Test01()
         {
             StringBuilder sblMsg = new StringBuilder(99);

--- a/src/System.Collections/tests/Generic/SortedDictionary/SortedDictionary_CtorTests.cs
+++ b/src/System.Collections/tests/Generic/SortedDictionary/SortedDictionary_CtorTests.cs
@@ -124,7 +124,6 @@ namespace SortedDictionaryTests
             }
 
             [Fact]
-            [ActiveIssue(846, PlatformID.AnyUnix)]
             public static void SortedDictionary_IDictionaryIKeyComparerCtorTest()
             {
                 Driver<String, String> driver = new Driver<String, String>();
@@ -160,7 +159,6 @@ namespace SortedDictionaryTests
             }
 
             [Fact]
-            [ActiveIssue(846, PlatformID.AnyUnix)]
             public static void SortedDictionary_IKeyComparerCtorTest()
             {
                 Driver<String, String> driver1 = new Driver<String, String>();

--- a/src/System.Collections/tests/Generic/SortedList/Constructor_IDictionary_ComparisonType.cs
+++ b/src/System.Collections/tests/Generic/SortedList/Constructor_IDictionary_ComparisonType.cs
@@ -306,7 +306,7 @@ namespace SortedListCtorIDicComp
         static public String[] stringsNoCaseDaCulture = new String[s_count];
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5460, PlatformID.AnyUnix)]
         public static void RunTests()
         {
             //This mostly follows the format established by the original author of these tests

--- a/src/System.Collections/tests/Generic/SortedList/Constructor_IDictionary_IKeyComparer.cs
+++ b/src/System.Collections/tests/Generic/SortedList/Constructor_IDictionary_IKeyComparer.cs
@@ -201,7 +201,7 @@ namespace SortedListCtorIDicIKeyComp
     public class Constructor_IDictionary_IKeyComparer
     {
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5460, PlatformID.AnyUnix)]
         public static void RunTests()
         {
             //This mostly follows the format established by the original author of these tests

--- a/src/System.Collections/tests/Generic/SortedList/Constructor_IKeyComparer.cs
+++ b/src/System.Collections/tests/Generic/SortedList/Constructor_IKeyComparer.cs
@@ -175,7 +175,7 @@ namespace SortedListCtorIKeyComp
     public class Constructor_IKeyComparer
     {
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5460, PlatformID.AnyUnix)]
         public static void RunTests()
         {
             //This mostly follows the format established by the original author of these tests

--- a/src/System.Collections/tests/Generic/SortedList/Constructor_int_ComparisonType.cs
+++ b/src/System.Collections/tests/Generic/SortedList/Constructor_int_ComparisonType.cs
@@ -149,7 +149,7 @@ namespace SortedListCtorIntComp
     public class Constructor_int_StringComparer
     {
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5460, PlatformID.AnyUnix)]
         public static void RunTests()
         {
             //This mostly follows the format established by the original author of these tests

--- a/src/System.Collections/tests/Generic/SortedList/Constructor_int_IKeyComparer.cs
+++ b/src/System.Collections/tests/Generic/SortedList/Constructor_int_IKeyComparer.cs
@@ -193,7 +193,7 @@ namespace SortedListCtorIntIKeyComp
     public class Constructor_int_IKeyComparer
     {
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5460, PlatformID.AnyUnix)]
         public static void RunTests()
         {
             //This mostly follows the format established by the original author of these tests

--- a/src/System.ComponentModel.TypeConverter/tests/DateTimeConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/DateTimeConverterTests.cs
@@ -45,7 +45,6 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void ConvertTo_WithContext()
         {
             DateTimeFormatInfo formatInfo = (DateTimeFormatInfo)CultureInfo.CurrentCulture.GetFormat(typeof(DateTimeFormatInfo));

--- a/src/System.ComponentModel.TypeConverter/tests/DateTimeOffsetConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/DateTimeOffsetConverterTests.cs
@@ -45,7 +45,6 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void ConvertTo_WithContext()
         {
             DateTimeFormatInfo formatInfo = (DateTimeFormatInfo)CultureInfo.CurrentCulture.GetFormat(typeof(DateTimeFormatInfo));

--- a/src/System.ComponentModel.TypeConverter/tests/TypeConverterTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/TypeConverterTests.cs
@@ -79,7 +79,6 @@ namespace System.ComponentModel.Tests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void ConvertTo_WithContext()
         {
             Assert.Throws<ArgumentNullException>(

--- a/src/System.Globalization/tests/CompareInfo.cs
+++ b/src/System.Globalization/tests/CompareInfo.cs
@@ -26,7 +26,7 @@ public partial class CompareInfoTests
 
     [Theory]
     [MemberData("CompareToData")]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
+    [ActiveIssue(5463, PlatformID.AnyUnix)]
     public static void Compare(string localeName, string left, string right, int expected, CompareOptions options)
     {
         CompareInfo ci = CompareInfo.GetCompareInfo(localeName);        
@@ -90,7 +90,7 @@ public partial class CompareInfoTests
 
     [Theory]
     [MemberData("IndexOfData")]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
+    [ActiveIssue(5463, PlatformID.AnyUnix)]
     public static void IndexOf(string localeName, string source, string value, int expectedResult, CompareOptions options)
     {
         CompareInfo ci = CompareInfo.GetCompareInfo(localeName);
@@ -195,7 +195,7 @@ public partial class CompareInfoTests
 
     [Theory]
     [MemberData("LastIndexOfData")]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
+    [ActiveIssue(5463, PlatformID.AnyUnix)]
     public static void LastIndexOf(string localeName, string source, string value, int expectedResult, CompareOptions options)
     {
         CompareInfo ci = CompareInfo.GetCompareInfo(localeName);
@@ -288,7 +288,7 @@ public partial class CompareInfoTests
 
     [Theory]
     [MemberData("IsPrefixData")]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
+    [ActiveIssue(5463, PlatformID.AnyUnix)]
     public static void IsPrefix(string localeName, string source, string prefix, bool expectedResult, CompareOptions options)
     {
         CompareInfo ci = CompareInfo.GetCompareInfo(localeName);
@@ -324,7 +324,7 @@ public partial class CompareInfoTests
 
     [Theory]
     [MemberData("IsSuffixData")]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
+    [ActiveIssue(5463, PlatformID.AnyUnix)]
     public static void IsSuffix(string localeName, string source, string suffix, bool expectedResult, CompareOptions options)
     {
         CompareInfo ci = CompareInfo.GetCompareInfo(localeName);
@@ -373,7 +373,7 @@ public partial class CompareInfoTests
     }
 
     [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
+    [ActiveIssue(5463, PlatformID.AnyUnix)]
     public static void GetHashCodeOfString()
     {
         CompareInfo ci = CultureInfo.InvariantCulture.CompareInfo;

--- a/src/System.Globalization/tests/CompareInfo/CompareInfoCompare.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoCompare.cs
@@ -22,7 +22,7 @@ namespace System.Globalization.Tests
         private const string c_SoftHyphen = "\u00AD";
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void Test1() { TestOrd(CultureInfo.InvariantCulture, "\u3042", "\u30A1", 1, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
@@ -179,7 +179,7 @@ namespace System.Globalization.Tests
         public void Test52() { TestOrd(CultureInfo.InvariantCulture, "'\u3000'", "' '", 0, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void Test53() { TestOrd(CultureInfo.InvariantCulture, "'\u3000'", "''", 1, CompareOptions.IgnoreKanaType | CompareOptions.IgnoreWidth | CompareOptions.IgnoreCase); }
 
         [Fact]
@@ -312,27 +312,27 @@ namespace System.Globalization.Tests
         public void Test96() { Test(CultureInfo.InvariantCulture, "\u3060", "\u30C0", s_expectedHiraganaToKatakanaCompare, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void Test97() { Test(CultureInfo.InvariantCulture, "\u30C7\u30BF\u30D9\u30B9", "\uFF83\uFF9E\uFF80\uFF8D\uFF9E\uFF7D", 1, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void Test98() { Test(CultureInfo.InvariantCulture, "\u30C7", "\uFF83\uFF9E", 1, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void Test99() { Test(CultureInfo.InvariantCulture, "\u30C7\u30BF", "\uFF83\uFF9E\uFF80", 1, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void Test100() { Test(CultureInfo.InvariantCulture, "\u30C7\u30BF\u30D9", "\uFF83\uFF9E\uFF80\uFF8D\uFF9E", 1, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void Test101() { Test(CultureInfo.InvariantCulture, "\u30BF", "\uFF80", 1, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void Test102() { Test(CultureInfo.InvariantCulture, "\uFF83\uFF9E\uFF70\uFF80\uFF8D\uFF9E\uFF70\uFF7D", "\u3067\u30FC\u305F\u3079\u30FC\u3059", -1, CompareOptions.None); }
 
         [Fact]
@@ -375,7 +375,7 @@ namespace System.Globalization.Tests
         public void Test115() { Test(CultureInfo.InvariantCulture, "'\u3000'", "' '", 1, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void Test116() { Test(CultureInfo.InvariantCulture, "'\u3000'", "''", 1, CompareOptions.None); }
 
         [Fact]
@@ -385,7 +385,7 @@ namespace System.Globalization.Tests
         public void Test118() { Test(CultureInfo.InvariantCulture, "\uFF08", "(", 1, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void Test119() { Test(CultureInfo.InvariantCulture, "\u30FC", "\uFF70", 0, CompareOptions.None); }
 
         [Fact]
@@ -410,7 +410,7 @@ namespace System.Globalization.Tests
         public void Test126() { Test(CultureInfo.InvariantCulture, "\"", "\uFF02", -1, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void Test127() { Test(new CultureInfo("hu-HU"), "dzsdzs", "ddzs", 0, CompareOptions.None); }
 
         [Fact]
@@ -465,7 +465,7 @@ namespace System.Globalization.Tests
         public void Test144() { TestOrd(CultureInfo.InvariantCulture, "\u00C0", "a\u0300", 1, CompareOptions.Ordinal); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void Test145()
         {
             char unassignedUnicode = GetNextUnassignedUnicode();
@@ -476,7 +476,7 @@ namespace System.Globalization.Tests
         public void Test146() { TestOrd(CultureInfo.InvariantCulture, "FooBar", "Foo\u0400Bar", -1, CompareOptions.Ordinal); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void Test147()
         {
             char unassignedUnicode = GetNextUnassignedUnicode();
@@ -493,7 +493,7 @@ namespace System.Globalization.Tests
         public void Test149() { Test(CultureInfo.InvariantCulture, "Test's", "Tests", 0, CompareOptions.IgnoreSymbols); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void Test150() { Test(CultureInfo.InvariantCulture, "Test's", "Tests", 1, CompareOptions.None); }
 
         [Fact]

--- a/src/System.Globalization/tests/CompareInfo/CompareInfoIndexOf.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoIndexOf.cs
@@ -46,7 +46,7 @@ namespace System.Globalization.Tests
         public void Test11() { Test(CultureInfo.InvariantCulture, new string('a', 5555), new string('a', 5000) + "b", -1, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void Test12() { Test(s_hungarian, "foobardzsdzs", "rddzs", 5, CompareOptions.None); }
 
         [Fact]
@@ -101,7 +101,7 @@ namespace System.Globalization.Tests
         public void Test29() { Test(CultureInfo.InvariantCulture, "Exhibit \u00C0", "a\u0300", -1, CompareOptions.Ordinal); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void Test30()
         {
             char unassignedUnicode = GetNextUnassignedUnicode();
@@ -112,7 +112,7 @@ namespace System.Globalization.Tests
         public void Test31() { Test(CultureInfo.InvariantCulture, "FooBar", "Foo\u0400Bar", -1, CompareOptions.Ordinal); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void Test32()
         {
             char unassignedUnicode = GetNextUnassignedUnicode();

--- a/src/System.Globalization/tests/CompareInfo/CompareInfoIsPrefix.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoIsPrefix.cs
@@ -46,7 +46,7 @@ namespace System.Globalization.Tests
         public void Test11() { Test(CultureInfo.InvariantCulture, new string('a', 5555), new string('a', 5000) + "b", false, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
+        [ActiveIssue(5463, PlatformID.AnyUnix)] 
         public void Test12() { Test(s_hungarian, "dzsdzsfoobar", "ddzsf", true, CompareOptions.None); }
 
         [Fact]
@@ -101,7 +101,7 @@ namespace System.Globalization.Tests
         public void Test29() { Test(CultureInfo.InvariantCulture, "\u00C0nimal", "a\u0300", false, CompareOptions.Ordinal); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
+        [ActiveIssue(5463, PlatformID.AnyUnix)] 
         public void Test30()
         {
             char unassignedUnicode = GetNextUnassignedUnicode();
@@ -112,7 +112,7 @@ namespace System.Globalization.Tests
         public void Test31() { Test(CultureInfo.InvariantCulture, "FooBar", "Foo\u0400Bar", false, CompareOptions.Ordinal); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
+        [ActiveIssue(5463, PlatformID.AnyUnix)] 
         public void Test32()
         {
             char unassignedUnicode = GetNextUnassignedUnicode();

--- a/src/System.Globalization/tests/CompareInfo/CompareInfoIsSuffix.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoIsSuffix.cs
@@ -46,7 +46,7 @@ namespace System.Globalization.Tests
         public void Test11() { Test(CultureInfo.InvariantCulture, new string('a', 5555), new string('a', 5000) + "b", false, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
+        [ActiveIssue(5463, PlatformID.AnyUnix)] 
         public void Test12() { Test(s_hungarian, "foobardzsdzs", "rddzs", true, CompareOptions.None); }
 
         [Fact]
@@ -101,7 +101,7 @@ namespace System.Globalization.Tests
         public void Test29() { Test(CultureInfo.InvariantCulture, "Exhibit \u00C0", "a\u0300", false, CompareOptions.Ordinal); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
+        [ActiveIssue(5463, PlatformID.AnyUnix)] 
         public void Test30()
         {
             char unassignedUnicode = GetNextUnassignedUnicode();
@@ -112,7 +112,7 @@ namespace System.Globalization.Tests
         public void Test31() { Test(CultureInfo.InvariantCulture, "FooBar", "Foo\u0400Bar", false, CompareOptions.Ordinal); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)] 
+        [ActiveIssue(5463, PlatformID.AnyUnix)] 
         public void Test32()
         {
             char unassignedUnicode = GetNextUnassignedUnicode();

--- a/src/System.Globalization/tests/CompareInfo/CompareInfoLastIndexOf.cs
+++ b/src/System.Globalization/tests/CompareInfo/CompareInfoLastIndexOf.cs
@@ -46,7 +46,7 @@ namespace System.Globalization.Tests
         public void Test11() { Test(CultureInfo.InvariantCulture, new string('a', 5555), new string('a', 5000) + "b", -1, CompareOptions.None); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void Test12() { Test(s_hungarian, "foobardzsdzs", "rddzs", 5, CompareOptions.None); }
 
         [Fact]
@@ -101,7 +101,7 @@ namespace System.Globalization.Tests
         public void Test29() { Test(CultureInfo.InvariantCulture, "Exhibit \u00C0", "a\u0300", -1, CompareOptions.Ordinal); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void Test30()
         {
             char unassignedUnicode = GetNextUnassignedUnicode();
@@ -112,7 +112,7 @@ namespace System.Globalization.Tests
         public void Test31() { Test(CultureInfo.InvariantCulture, "FooBar", "Foo\u0400Bar", -1, CompareOptions.Ordinal); }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void Test32()
         {
             char unassignedUnicode = GetNextUnassignedUnicode();

--- a/src/System.Globalization/tests/CompareInfo/compareinfo.cs
+++ b/src/System.Globalization/tests/CompareInfo/compareinfo.cs
@@ -21,7 +21,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void CompareInfoIndexTest1()
         {
             // Creates CompareInfo for the InvariantCulture.
@@ -126,7 +126,7 @@ namespace System.Globalization.Tests
         [Theory]
         [InlineData("de-DE", "Ü", "UE", -1)]
         [InlineData("de-DE_phoneb", "Ü", "UE", 0)]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void TestLocaleAlternateSortOrder(string locale, string string1, string string2, int expected)
         {
             CultureInfo myTestCulture = new CultureInfo(locale);

--- a/src/System.Globalization/tests/CultureInfo/CultureInfoAll.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoAll.cs
@@ -16,7 +16,7 @@ namespace System.Globalization.Tests
     public class CultureInfoAll
     {
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void TestAllCultures()
         {
             Assert.True(EnumSystemLocalesEx(EnumLocales, LOCALE_WINDOWS, IntPtr.Zero, IntPtr.Zero), "EnumSystemLocalesEx has failed");

--- a/src/System.Globalization/tests/CultureInfo/CultureInfoCompareInfo.cs
+++ b/src/System.Globalization/tests/CultureInfo/CultureInfoCompareInfo.cs
@@ -19,7 +19,7 @@ namespace System.Globalization.Tests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5463, PlatformID.AnyUnix)]
         public void TestEsESTraditional()
         {
             CultureInfo myCItrad = new CultureInfo("es-ES_tradnl");

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
@@ -14,10 +14,7 @@ namespace System.IO.Compression.Tests
         public async Task CreateFromDirectoryNormal()
         {
             await TestCreateDirectory(zfolder("normal"), true);
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // [ActiveIssue(846, PlatformID.AnyUnix)]
-            {
-                await TestCreateDirectory(zfolder("unicode"), true);
-            }
+            await TestCreateDirectory(zfolder("unicode"), true);
         }
 
         private async Task TestCreateDirectory(string folderName, Boolean testWithBaseDir)
@@ -66,10 +63,7 @@ namespace System.IO.Compression.Tests
         public void ExtractToDirectoryNormal()
         {
             TestExtract(zfile("normal.zip"), zfolder("normal"));
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // [ActiveIssue(846, PlatformID.AnyUnix)]
-            {
-                TestExtract(zfile("unicode.zip"), zfolder("unicode"));
-            }
+            TestExtract(zfile("unicode.zip"), zfolder("unicode"));
             TestExtract(zfile("empty.zip"), zfolder("empty"));
             TestExtract(zfile("explicitdir1.zip"), zfolder("explicitdir"));
             TestExtract(zfile("explicitdir2.zip"), zfolder("explicitdir"));
@@ -162,15 +156,12 @@ namespace System.IO.Compression.Tests
                 DirsEqual(tempFolder, zfolder("normal"));
             }
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // [ActiveIssue(846, PlatformID.AnyUnix)]
+            using (ZipArchive archive = ZipFile.OpenRead(zfile("unicode.zip")))
             {
-                using (ZipArchive archive = ZipFile.OpenRead(zfile("unicode.zip")))
-                {
-                    string tempFolder = GetTmpDirPath(false);
-                    archive.ExtractToDirectory(tempFolder);
+                string tempFolder = GetTmpDirPath(false);
+                archive.ExtractToDirectory(tempFolder);
 
-                    DirsEqual(tempFolder, zfolder("unicode"));
-                }
+                DirsEqual(tempFolder, zfolder("unicode"));
             }
         }
 

--- a/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
+++ b/src/System.IO.Compression.ZipFile/tests/ZipFileConvenienceMethods.cs
@@ -14,7 +14,10 @@ namespace System.IO.Compression.Tests
         public async Task CreateFromDirectoryNormal()
         {
             await TestCreateDirectory(zfolder("normal"), true);
-            await TestCreateDirectory(zfolder("unicode"), true);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // [ActiveIssue(5459, PlatformID.AnyUnix)]
+            {
+                await TestCreateDirectory(zfolder("unicode"), true);
+            }
         }
 
         private async Task TestCreateDirectory(string folderName, Boolean testWithBaseDir)
@@ -63,7 +66,10 @@ namespace System.IO.Compression.Tests
         public void ExtractToDirectoryNormal()
         {
             TestExtract(zfile("normal.zip"), zfolder("normal"));
-            TestExtract(zfile("unicode.zip"), zfolder("unicode"));
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // [ActiveIssue(5459, PlatformID.AnyUnix)]
+            {
+                TestExtract(zfile("unicode.zip"), zfolder("unicode"));
+            }
             TestExtract(zfile("empty.zip"), zfolder("empty"));
             TestExtract(zfile("explicitdir1.zip"), zfolder("explicitdir"));
             TestExtract(zfile("explicitdir2.zip"), zfolder("explicitdir"));
@@ -156,12 +162,15 @@ namespace System.IO.Compression.Tests
                 DirsEqual(tempFolder, zfolder("normal"));
             }
 
-            using (ZipArchive archive = ZipFile.OpenRead(zfile("unicode.zip")))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) // [ActiveIssue(5459, PlatformID.AnyUnix)]
             {
-                string tempFolder = GetTmpDirPath(false);
-                archive.ExtractToDirectory(tempFolder);
+                using (ZipArchive archive = ZipFile.OpenRead(zfile("unicode.zip")))
+                {
+                    string tempFolder = GetTmpDirPath(false);
+                    archive.ExtractToDirectory(tempFolder);
 
-                DirsEqual(tempFolder, zfolder("unicode"));
+                    DirsEqual(tempFolder, zfolder("unicode"));
+                }
             }
         }
 

--- a/src/System.IO.FileSystem/tests/Directory/GetFiles.cs
+++ b/src/System.IO.FileSystem/tests/Directory/GetFiles.cs
@@ -93,7 +93,6 @@ namespace System.IO.Tests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public void CharacterTests()
         {
             //bug #417100 - not sure if this hard coded approach is safe in all 9x platforms!!!

--- a/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
+++ b/src/System.IO.FileSystem/tests/PortedCommon/IOInputs.cs
@@ -43,7 +43,7 @@ internal static class IOInputs
     {
         yield return Path.GetRandomFileName();
         yield return "!@#$%^&";
-        // yield return "\x65e5\x672c\x8a9e"; // TODO: Issue #846
+        yield return "\x65e5\x672c\x8a9e";
         yield return "A";
         yield return " A";
         yield return "  A";

--- a/src/System.Reflection/tests/AssemblyName/AssemblyName_ProcessorArchitectureTests.cs
+++ b/src/System.Reflection/tests/AssemblyName/AssemblyName_ProcessorArchitectureTests.cs
@@ -152,7 +152,7 @@ namespace System.Reflection.Tests
             }
         }
 
-        [Fact, ActiveIssue(846, PlatformID.AnyUnix)]
+        [Fact]
         public void GetFullNameAndToString_AreEquivalentAndDoNotPreserveArchitecture()
         {
             foreach (KeyValuePair<string, ProcessorArchitecture> pair in GetValidNameValuePairs())

--- a/src/System.Reflection/tests/AssemblyName/CultureName.cs
+++ b/src/System.Reflection/tests/AssemblyName/CultureName.cs
@@ -10,7 +10,7 @@ namespace System.Reflection.Tests
 {
     public class CultureNameTests
     {
-        [Fact, ActiveIssue(846, PlatformID.AnyUnix)]
+        [Fact]
         public void SettingNullCultureNameSucceeds()
         {
             var an = new AssemblyName("Test, Culture=en-US");
@@ -22,7 +22,7 @@ namespace System.Reflection.Tests
             AssertAssemblyNamesAreEqual(new AssemblyName("Test"), an);
         }
 
-        [Fact, ActiveIssue(846, PlatformID.AnyUnix)]
+        [Fact]
         public void SettingEmptyCultureNameSucceeds()
         {
             var an = new AssemblyName("Test, Culture=en-US");
@@ -34,7 +34,7 @@ namespace System.Reflection.Tests
             AssertAssemblyNamesAreEqual(new AssemblyName("Test, Culture=neutral"), an);
         }
 
-        [Fact, ActiveIssue(846, PlatformID.AnyUnix)]
+        [Fact]
         public void SettingValidCultureNameSucceeds()
         {
             var an = new AssemblyName("Test");
@@ -45,7 +45,7 @@ namespace System.Reflection.Tests
             AssertAssemblyNamesAreEqual(new AssemblyName("Test, Culture=en-US"), an);
         }
 
-        [Fact, ActiveIssue(846, PlatformID.AnyUnix)]
+        [Fact]
         public void SettingCultureNameIsCaseInsensitive()
         {
             var an = new AssemblyName("Test");
@@ -57,7 +57,7 @@ namespace System.Reflection.Tests
             AssertAssemblyNamesAreEqual(new AssemblyName("Test, Culture=en-US"), an);
         }
 
-        [Fact, ActiveIssue(846, PlatformID.AnyUnix)]
+        [Fact]
         public void SettingInvalidCultureNameThrowsCultureNotFound()
         {
             var an = new AssemblyName("Test");

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -957,7 +957,6 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
     public static void DCJS_XElementAsRoot()
     {
         var original = new XElement("ElementName1");
@@ -969,7 +968,6 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
     public static void DCJS_WithXElement()
     {
         var original = new WithXElement(true);
@@ -991,7 +989,6 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
     public static void DCJS_WithXElementWithNestedXElement()
     {
         var original = new WithXElementWithNestedXElement(true);
@@ -1002,7 +999,6 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
     public static void DCJS_WithArrayOfXElement()
     {
         var original = new WithArrayOfXElement(true);
@@ -1015,7 +1011,6 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
     public static void DCJS_WithListOfXElement()
     {
         var original = new WithListOfXElement(true);

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -945,7 +945,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
     public static void DCS_XElementAsRoot()
     {
         var original = new XElement("ElementName1");
@@ -957,7 +956,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
     public static void DCS_WithXElement()
     {
         var original = new WithXElement(true);
@@ -978,7 +976,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
     public static void DCS_WithXElementWithNestedXElement()
     {
         var original = new WithXElementWithNestedXElement(true);
@@ -989,7 +986,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
     public static void DCS_WithArrayOfXElement()
     {
         var original = new WithArrayOfXElement(true);
@@ -1002,7 +998,6 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
     public static void DCS_WithListOfXElement()
     {
         var original = new WithListOfXElement(true);

--- a/src/System.Text.Encoding.Extensions/tests/Fallback.cs
+++ b/src/System.Text.Encoding.Extensions/tests/Fallback.cs
@@ -13,7 +13,6 @@ namespace EncodingTests
         private static readonly string s_asciiInputStringWinNoFallback = "abc";
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void TestEncoderReplacementFallback()
         {
             Encoding asciiEncoding = Encoding.GetEncoding("us-ascii", new EncoderReplacementFallback("(unknown)"), new DecoderReplacementFallback(""));
@@ -37,7 +36,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void TestDecoderReplacementFallback()
         {
             Encoding asciiEncoding = Encoding.GetEncoding("us-ascii", new EncoderReplacementFallback("(unknown)"), new DecoderReplacementFallback("Error"));
@@ -45,7 +43,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void TestEncoderExceptionFallback()
         {
             Encoding asciiEncoding = Encoding.GetEncoding("us-ascii", new EncoderExceptionFallback(), new DecoderExceptionFallback());
@@ -53,7 +50,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void TestDecoderExceptionFallback()
         {
             Encoding asciiEncoding = Encoding.GetEncoding("us-ascii", new EncoderExceptionFallback(), new DecoderExceptionFallback());
@@ -61,7 +57,6 @@ namespace EncodingTests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void TestCustomFallback()
         {
             Encoding asciiEncoding = Encoding.GetEncoding("us-ascii", new EncoderCustomFallback(), new DecoderReplacementFallback(""));

--- a/src/System.Text.RegularExpressions/tests/RegexLangElementsCoverageTests.cs
+++ b/src/System.Text.RegularExpressions/tests/RegexLangElementsCoverageTests.cs
@@ -10,7 +10,6 @@ public class RegexLangElementsCoverageTests
 {
     // This class mainly exists to hit language elements that were missed in other test cases.
     [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
     public static void RegexLangElementsCoverage()
     {
         //////////// Global Variables used for all tests

--- a/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlConvertTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlConvert/XmlConvertTests.cs
@@ -52,7 +52,7 @@ namespace System.Xml.Tests
 
         [Fact]
         [OuterLoop]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
+        [ActiveIssue(5462, PlatformID.AnyUnix)]
         [ActiveIssue(1303, PlatformID.Windows)]
         public static void ToTypeTests()
         {

--- a/src/System.Xml.ReaderWriter/tests/XmlWriter/WriteWithEncodingWithFallback.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlWriter/WriteWithEncodingWithFallback.cs
@@ -24,7 +24,6 @@ namespace System.Xml.Tests
         private const string ExampleSurrogateEntity = "&#x10000;";
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void XmlWriterConvertsInvalidCharacterToEntity()
         {
             MemoryStream ms = new MemoryStream();
@@ -52,7 +51,6 @@ namespace System.Xml.Tests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void EncodingFallbackFailsWhenInvalidCharacterInTagName()
         {
             MemoryStream ms = new MemoryStream();
@@ -75,7 +73,6 @@ namespace System.Xml.Tests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void XmlWriterConvertsSurrogatePairToEntity()
         {
             MemoryStream ms = new MemoryStream();
@@ -103,7 +100,6 @@ namespace System.Xml.Tests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void AsyncXmlWriterConvertsInvalidCharacterToEntity()
         {
             MemoryStream ms = new MemoryStream();
@@ -132,7 +128,6 @@ namespace System.Xml.Tests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void AsyncEncodingFallbackFailsWhenInvalidCharacterInTagName()
         {
             MemoryStream ms = new MemoryStream();
@@ -158,7 +153,6 @@ namespace System.Xml.Tests
         }
 
         [Fact]
-        [ActiveIssue(846, PlatformID.AnyUnix)]
         public static void AsyncXmlWriterConvertsSurrogatePairToEntity()
         {
             MemoryStream ms = new MemoryStream();

--- a/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
+++ b/src/System.Xml.XmlSerializer/tests/XmlSerializerTests.cs
@@ -637,7 +637,6 @@ public static partial class XmlSerializerTests
     }
 
     [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
     public static void Xml_WithXElementWithNestedXElement()
     {
         var original = new WithXElementWithNestedXElement(true);
@@ -656,7 +655,6 @@ public static partial class XmlSerializerTests
     }
 
     [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
     public static void Xml_WithArrayOfXElement()
     {
         var original = new WithArrayOfXElement(true);
@@ -683,7 +681,6 @@ public static partial class XmlSerializerTests
     }
 
     [Fact]
-    [ActiveIssue(846, PlatformID.AnyUnix)]
     public static void Xml_WithListOfXElement()
     {
         var original = new WithListOfXElement(true);


### PR DESCRIPTION
@ellismg @stephentoub 

After this change, the bulk of tests left marked with #846 are in System.Globalization.Tests.  There are a handful that are still failing in System.Collections, one in System.Collections.NonGeneric, and one in System.Xml.ReaderWriter that is marked as OuterLoop and also has ActiveIssue #1303 on it.