### PR TITLE
Remove ReturnObject from System.Linq.Expressions.rd.xml

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/System.Linq.Expressions.rd.xml
+++ b/src/System.Linq.Expressions/src/Resources/System.Linq.Expressions.rd.xml
@@ -87,9 +87,6 @@
           <Method Name="Return">
             <TypeParameter Name="type" Dynamic="Public"/>
           </Method>
-          <Method Name="ReturnObject&lt;T&gt;">
-            <GenericParameter Name="T" Dynamic="Public"/>
-          </Method>
           <Method Name="Switch">
             <TypeParameter Name="type" Dynamic="Public"/>
           </Method>


### PR DESCRIPTION
It is not used and is no longer public
 as of https://github.com/dotnet/corefx/commit/0824d9745687271503f7538d16f44f17f5ef5f18