### PR TITLE
Adding the fields to get the Data Column Schema

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -3941,6 +3941,8 @@ namespace System.Data.SqlClient
                     return false;
                 }
 
+                col.isDifferentName = (TdsEnums.SQLDifferentName == (status & TdsEnums.SQLDifferentName));
+                col.isExpression = (TdsEnums.SQLExpression == (status & TdsEnums.SQLExpression));
                 col.isKey = (TdsEnums.SQLKey == (status & TdsEnums.SQLKey));
                 col.isHidden = (TdsEnums.SQLHidden == (status & TdsEnums.SQLHidden));
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserHelperClasses.cs
@@ -269,13 +269,38 @@ namespace System.Data.SqlClient
         internal MultiPartTableName multiPartTableName;
         internal readonly int ordinal;
         internal byte updatability;     // two bit field (0 is read only, 1 is updatable, 2 is updatability unknown)
+        internal bool isDifferentName;
         internal bool isKey;
         internal bool isHidden;
+        internal bool isExpression;
         internal bool isIdentity;
         internal _SqlMetaData(int ordinal) : base()
         {
             this.ordinal = ordinal;
         }
+
+        internal string serverName
+        {
+            get
+            {
+                return multiPartTableName.ServerName;
+            }
+        }
+        internal string catalogName
+        {
+            get
+            {
+                return multiPartTableName.CatalogName;
+            }
+        }
+        internal string schemaName
+        {
+            get
+            {
+                return multiPartTableName.SchemaName;
+            }
+        }
+
         internal string tableName
         {
             get


### PR DESCRIPTION
In this code change I have added a few fields to populate the Database column schema as needed by the DbColumn to provide the Columns Schema for the Data Reader

A sample of how this would be used is provided below. 

The below sample is applicable to a possible implementation of DbColumn

                _SqlMetaDataSet md = this.MetaData;
               DbColumn _dbColumn = new DbColumn();
                _SqlMetaData col = md[i];

                _dbColumn.AllowDBNull = col.isNullable;

                if (!ADP.IsEmpty(col.catalogName))
                {
                    _dbColumn.BaseCatalogName = col.catalogName;
                }

                if (!ADP.IsEmpty(col.column))
                {
                    _dbColumn.BaseColumnName = col.column;
                }

                if (!ADP.IsEmpty(col.schemaName))
                {
                    _dbColumn.BaseSchemaName = col.schemaName;
                }

                if (!ADP.IsEmpty(col.serverName))
                {
                    _dbColumn.BaseServerName = col.serverName;
                }

                if (!ADP.IsEmpty(col.tableName))
                {
                    _dbColumn.BaseTableName = col.tableName;
                }

                _dbColumn.DataType = GetFieldTypeInternal(col);

                _dbColumn.DataTypeName = GetDataTypeNameInternal(col);

                _dbColumn.BaseTableName = col.tableName;

                _dbColumn.ColumnName = col.column;

                _dbColumn.ColumnOrdinal = col.ordinal;

                _dbColumn.ColumnSize = (col.metaType.IsSizeInCharacters && (col.length != 0x7fffffff)) ? (col.length / 2) : col.length;

                if (_browseModeInfoConsumed)
                {
                    _dbColumn.IsAliased = col.isDifferentName;
                    _dbColumn.IsKey = col.isKey;
                    _dbColumn.IsHidden = col.isHidden;
                    _dbColumn.IsExpression = col.isExpression;
                }

                _dbColumn.IsAutoIncrement = col.isIdentity;

                _dbColumn.IsIdentity = col.isIdentity;

                _dbColumn.IsLong = col.metaType.IsLong;

                _dbColumn.IsReadOnly = (0 == col.updatability);

                _dbColumn.IsUnique = SqlDbType.Timestamp == col.type;

                if (TdsEnums.UNKNOWN_PRECISION_SCALE != col.precision)
                {
                    _dbColumn.NumericPrecision = col.precision;
                }
                else
                {
                    _dbColumn.NumericPrecision = col.metaType.Precision;
                }

                if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && col.IsNewKatmaiDateTimeType)
                {
                    _dbColumn.NumericScale = MetaType.MetaNVarChar.Scale;
                }
                else if (TdsEnums.UNKNOWN_PRECISION_SCALE != col.scale)
                {
                    _dbColumn.NumericScale = col.scale;
                }
                else
                {
                    _dbColumn.NumericScale = col.metaType.Scale;
                }