### PR TITLE
Add serialization negative tests for different collections of same type as KnownTypes

### DIFF
--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -1718,7 +1718,6 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
-<<<<<<< 9eab472a93bce7169e3b10f33eebf3a3771b210d
     public static void DCJS_XmlElementAsRoot()
     {
         XmlDocument xDoc = new XmlDocument();

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -1761,7 +1761,7 @@ public static partial class DataContractJsonSerializerTests
     public static void DCJS_DifferentCollectionsOfSameTypeAsKnownTypes()
     {
         Assert.Throws<InvalidOperationException>(() => {
-            (new DataContractSerializer(typeof(DifferentCollectionsOfSameTypeAsKnownTypes))).WriteObject(new MemoryStream(), new DifferentCollectionsOfSameTypeAsKnownTypes());
+            (new DataContractSerializer(typeof(TypeWithKnownTypesOfCollectionsWithConflictingXmlName))).WriteObject(new MemoryStream(), new TypeWithKnownTypesOfCollectionsWithConflictingXmlName());
         });
     }
 

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -1718,6 +1718,7 @@ public static partial class DataContractJsonSerializerTests
     }
 
     [Fact]
+<<<<<<< 9eab472a93bce7169e3b10f33eebf3a3771b210d
     public static void DCJS_XmlElementAsRoot()
     {
         XmlDocument xDoc = new XmlDocument();
@@ -1753,6 +1754,14 @@ public static partial class DataContractJsonSerializerTests
         Assert.Throws<InvalidDataContractException>(() =>
         {
             (new DataContractSerializer(typeof(RecursiveCollection))).WriteObject(new MemoryStream(), new RecursiveCollection());
+        });
+    }
+
+    [Fact]
+    public static void DCJS_DifferentCollectionsOfSameTypeAsKnownTypes()
+    {
+        Assert.Throws<InvalidOperationException>(() => {
+            (new DataContractSerializer(typeof(DifferentCollectionsOfSameTypeAsKnownTypes))).WriteObject(new MemoryStream(), new DifferentCollectionsOfSameTypeAsKnownTypes());
         });
     }
 

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -2012,7 +2012,7 @@ public static partial class DataContractSerializerTests
     public static void DCS_DifferentCollectionsOfSameTypeAsKnownTypes()
     {
         Assert.Throws<InvalidOperationException>(() => { 
-            (new DataContractSerializer(typeof(DifferentCollectionsOfSameTypeAsKnownTypes))).WriteObject(new MemoryStream(), new DifferentCollectionsOfSameTypeAsKnownTypes());
+            (new DataContractSerializer(typeof(TypeWithKnownTypesOfCollectionsWithConflictingXmlName))).WriteObject(new MemoryStream(), new TypeWithKnownTypesOfCollectionsWithConflictingXmlName());
         });
     }
 

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -2008,6 +2008,14 @@ public static partial class DataContractSerializerTests
         }
     }
 
+    [Fact]
+    public static void DCS_DifferentCollectionsOfSameTypeAsKnownTypes()
+    {
+        Assert.Throws<InvalidOperationException>(() => { 
+            (new DataContractSerializer(typeof(DifferentCollectionsOfSameTypeAsKnownTypes))).WriteObject(new MemoryStream(), new DifferentCollectionsOfSameTypeAsKnownTypes());
+        });
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractSerializerSettings settings = null, Func<DataContractSerializer> serializerFactory = null, bool skipStringCompare = false)
     {
         DataContractSerializer dcs;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -2368,6 +2368,19 @@ namespace SerializationTypes
     {
         public string Name { get; set; }
     }
+
+    [KnownType(typeof(List<SimpleType>))]
+    [KnownType(typeof(SimpleType[]))]
+    [DataContract]
+    public class DifferentCollectionsOfSameTypeAsKnownTypes
+    {
+        [DataMember]
+        public object Value1 = new List<SimpleType>();
+
+        [DataMember]
+        public object Value2 = new SimpleType[1];
+
+    }
 }
 
 namespace DuplicateTypeNamesTest.ns1

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -2372,7 +2372,7 @@ namespace SerializationTypes
     [KnownType(typeof(List<SimpleType>))]
     [KnownType(typeof(SimpleType[]))]
     [DataContract]
-    public class DifferentCollectionsOfSameTypeAsKnownTypes
+    public class TypeWithKnownTypesOfCollectionsWithConflictingXmlName
     {
         [DataMember]
         public object Value1 = new List<SimpleType>();


### PR DESCRIPTION
Add serialization negative tests for scenario when different collection types are provided through KnowType attribute but they're seen as the same type within serialization.

@shmao @SGuyGe @zhenlan 