### PR TITLE
Clean up Unix Domain Sockets example

### DIFF
--- a/src/Common/src/System/Net/Sockets/UnixDomainSocketEndPoint.cs
+++ b/src/Common/src/System/Net/Sockets/UnixDomainSocketEndPoint.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text;
+
+namespace System.Net.Sockets
+{
+    /// <summary>Represents a Unix Domain Socket endpoint as a path.</summary>
+    public sealed class UnixDomainSocketEndPoint : EndPoint
+    {
+        private const int MaxPathLength = 92;   // sockaddr_un.sun_path at http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_un.h.html
+        private const int PathOffset = 2;       // = offsetof(struct sockaddr_un, sun_path). It's the same on Linux and OSX
+        private const int MaxSocketAddressSize = PathOffset + MaxPathLength;
+        private const int MinSocketAddressSize = PathOffset + 2; // +1 for one character and +1 for \0 ending
+        private const AddressFamily EndPointAddressFamily = AddressFamily.Unix;
+
+        private static readonly Encoding s_pathEncoding = Encoding.UTF8;
+        private readonly string _path;
+        private readonly byte[] _encodedPath;
+
+        public UnixDomainSocketEndPoint(string path)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException("path");
+            }
+
+            if (path.Length == 0 || s_pathEncoding.GetByteCount(path) >= MaxPathLength)
+            {
+                throw new ArgumentOutOfRangeException("path");
+            }
+
+            _path = path;
+            _encodedPath = s_pathEncoding.GetBytes(_path);
+        }
+
+        internal UnixDomainSocketEndPoint(SocketAddress socketAddress)
+        {
+            if (socketAddress == null)
+            {
+                throw new ArgumentNullException("socketAddress");
+            }
+
+            if (socketAddress.Family != EndPointAddressFamily || 
+                socketAddress.Size > MaxSocketAddressSize)
+            {
+                throw new ArgumentOutOfRangeException("socketAddress");
+            }
+
+            if (socketAddress.Size >= MinSocketAddressSize)
+            {
+                _encodedPath = new byte[socketAddress.Size - PathOffset];
+                for (int index = 0; index < socketAddress.Size - PathOffset; index++)
+                {
+                    _encodedPath[index] = socketAddress[PathOffset + index];
+                }
+
+                _path = s_pathEncoding.GetString(_encodedPath, 0, _encodedPath.Length);
+            }
+            else
+            {
+                // Empty path may be used by System.Net.Socket logging.
+                _encodedPath = Array.Empty<byte>();
+                _path = string.Empty;
+            }
+        }
+
+        public string Path { get { return _path; } }
+
+        public override AddressFamily AddressFamily { get { return EndPointAddressFamily; } }
+
+        public override SocketAddress Serialize()
+        {
+            var result = new SocketAddress(AddressFamily.Unix, MaxSocketAddressSize);
+
+            // Ctor has already checked that PathOffset + _encodedPath.Length < MaxSocketAddressSize
+            for (int index = 0; index < _encodedPath.Length; index++)
+            {
+                result[PathOffset + index] = _encodedPath[index];
+            }
+            result[PathOffset + _encodedPath.Length] = 0; // The path must be ending with \0
+
+            return result;
+        }
+
+        public override EndPoint Create(SocketAddress socketAddress)
+        {
+            return new UnixDomainSocketEndPoint(socketAddress);
+        }
+
+        public override string ToString()
+        {
+            return Path;
+        }
+    }
+}

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -54,6 +54,9 @@
     <Compile Include="$(CommonTestPath)\System\Net\Sockets\SocketImplementationType.cs">
       <Link>SocketCommon\SocketImplementationType.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Sockets\UnixDomainSocketEndPoint.cs">
+      <Link>SocketCommon\System\Net\UnixDomainSocketEndPoint.cs</Link>
+    </Compile>
 
     <!-- Common test files -->
     <Compile Include="$(CommonTestPath)\System\Net\TestLogging.cs">


### PR DESCRIPTION
- Separate the type out into its own file, to make it easier for others to consume
- Fix a bug that prohbited it from being used with Accept (removed min length validation in ctor)
- Added a test that does Connect/Accept and Send/Receive
- A few other cleanups in the existing tests

As a follow-on to https://github.com/dotnet/corefx/pull/5051, fixes #4588.
cc: @IlyaBiryukov, @pgavlin, @ericeil 