### PR TITLE
Removed some CommonTypes from System.IO nuget description

### DIFF
--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -531,9 +531,7 @@
         "Description": "Provides base input and output (I/O) types, including System.IO.Stream, System.IO.StreamReader and System.IO.StreamWriter, that allow reading and writing to data streams",
         "CommonTypes": [
             "System.IO.Stream",
-            "System.IO.IOException",
             "System.IO.EndOfStreamException",
-            "System.IO.FileNotFoundException",
             "System.IO.MemoryStream",
             "System.IO.StreamReader",
             "System.IO.StreamWriter",


### PR DESCRIPTION
System.IO.IOException and System.IO.FileNotFoundException have moved to System.Runtime