### PR TITLE
Remove unnecessary access checks in data contract serializers

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ClassDataContract.cs
@@ -540,10 +540,10 @@ namespace System.Runtime.Serialization
         ///          since this information is used to determine whether to give the generated code access
         ///          permissions to private members, any changes to the logic should be reviewed.
         /// </SecurityNote>
-        internal bool RequiresMemberAccessForRead(SecurityException securityException, string[] serializationAssemblyPatterns)
+        internal bool RequiresMemberAccessForRead(SecurityException securityException)
         {
             EnsureMethodsImported();
-            if (!IsTypeVisible(UnderlyingType, serializationAssemblyPatterns))
+            if (!IsTypeVisible(UnderlyingType))
             {
                 if (securityException != null)
                 {
@@ -555,10 +555,10 @@ namespace System.Runtime.Serialization
                 }
                 return true;
             }
-            if (this.BaseContract != null && this.BaseContract.RequiresMemberAccessForRead(securityException, serializationAssemblyPatterns))
+            if (this.BaseContract != null && this.BaseContract.RequiresMemberAccessForRead(securityException))
                 return true;
 
-            if (ConstructorRequiresMemberAccess(GetNonAttributedTypeConstructor(), serializationAssemblyPatterns))
+            if (ConstructorRequiresMemberAccess(GetNonAttributedTypeConstructor()))
             {
                 if (Globals.TypeOfScriptObject_IsAssignableFrom(UnderlyingType))
                 {
@@ -575,7 +575,7 @@ namespace System.Runtime.Serialization
                 return true;
             }
 
-            if (MethodRequiresMemberAccess(this.OnDeserializing, serializationAssemblyPatterns))
+            if (MethodRequiresMemberAccess(this.OnDeserializing))
             {
                 if (securityException != null)
                 {
@@ -589,7 +589,7 @@ namespace System.Runtime.Serialization
                 return true;
             }
 
-            if (MethodRequiresMemberAccess(this.OnDeserialized, serializationAssemblyPatterns))
+            if (MethodRequiresMemberAccess(this.OnDeserialized))
             {
                 if (securityException != null)
                 {
@@ -607,7 +607,7 @@ namespace System.Runtime.Serialization
             {
                 for (int i = 0; i < this.Members.Count; i++)
                 {
-                    if (this.Members[i].RequiresMemberAccessForSet(serializationAssemblyPatterns))
+                    if (this.Members[i].RequiresMemberAccessForSet())
                     {
                         if (securityException != null)
                         {
@@ -643,11 +643,11 @@ namespace System.Runtime.Serialization
         ///          since this information is used to determine whether to give the generated code access
         ///          permissions to private members, any changes to the logic should be reviewed.
         /// </SecurityNote>
-        internal bool RequiresMemberAccessForWrite(SecurityException securityException, string[] serializationAssemblyPatterns)
+        internal bool RequiresMemberAccessForWrite(SecurityException securityException)
         {
             EnsureMethodsImported();
 
-            if (!IsTypeVisible(UnderlyingType, serializationAssemblyPatterns))
+            if (!IsTypeVisible(UnderlyingType))
             {
                 if (securityException != null)
                 {
@@ -660,10 +660,10 @@ namespace System.Runtime.Serialization
                 return true;
             }
 
-            if (this.BaseContract != null && this.BaseContract.RequiresMemberAccessForWrite(securityException, serializationAssemblyPatterns))
+            if (this.BaseContract != null && this.BaseContract.RequiresMemberAccessForWrite(securityException))
                 return true;
 
-            if (MethodRequiresMemberAccess(this.OnSerializing, serializationAssemblyPatterns))
+            if (MethodRequiresMemberAccess(this.OnSerializing))
             {
                 if (securityException != null)
                 {
@@ -677,7 +677,7 @@ namespace System.Runtime.Serialization
                 return true;
             }
 
-            if (MethodRequiresMemberAccess(this.OnSerialized, serializationAssemblyPatterns))
+            if (MethodRequiresMemberAccess(this.OnSerialized))
             {
                 if (securityException != null)
                 {
@@ -695,7 +695,7 @@ namespace System.Runtime.Serialization
             {
                 for (int i = 0; i < this.Members.Count; i++)
                 {
-                    if (this.Members[i].RequiresMemberAccessForGet(serializationAssemblyPatterns))
+                    if (this.Members[i].RequiresMemberAccessForGet())
                     {
                         if (securityException != null)
                         {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
@@ -1298,9 +1298,9 @@ namespace System.Runtime.Serialization
         ///          since this information is used to determine whether to give the generated code access
         ///          permissions to private members, any changes to the logic should be reviewed.
         /// </SecurityNote>
-        internal bool RequiresMemberAccessForRead(SecurityException securityException, string[] serializationAssemblyPatterns)
+        internal bool RequiresMemberAccessForRead(SecurityException securityException)
         {
-            if (!IsTypeVisible(UnderlyingType, serializationAssemblyPatterns))
+            if (!IsTypeVisible(UnderlyingType))
             {
                 if (securityException != null)
                 {
@@ -1312,7 +1312,7 @@ namespace System.Runtime.Serialization
                 }
                 return true;
             }
-            if (ItemType != null && !IsTypeVisible(ItemType, serializationAssemblyPatterns))
+            if (ItemType != null && !IsTypeVisible(ItemType))
             {
                 if (securityException != null)
                 {
@@ -1324,7 +1324,7 @@ namespace System.Runtime.Serialization
                 }
                 return true;
             }
-            if (ConstructorRequiresMemberAccess(Constructor, serializationAssemblyPatterns))
+            if (ConstructorRequiresMemberAccess(Constructor))
             {
                 if (securityException != null)
                 {
@@ -1336,7 +1336,7 @@ namespace System.Runtime.Serialization
                 }
                 return true;
             }
-            if (MethodRequiresMemberAccess(this.AddMethod, serializationAssemblyPatterns))
+            if (MethodRequiresMemberAccess(this.AddMethod))
             {
                 if (securityException != null)
                 {
@@ -1358,9 +1358,9 @@ namespace System.Runtime.Serialization
         ///          since this information is used to determine whether to give the generated code access
         ///          permissions to private members, any changes to the logic should be reviewed.
         /// </SecurityNote>
-        internal bool RequiresMemberAccessForWrite(SecurityException securityException, string[] serializationAssemblyPatterns)
+        internal bool RequiresMemberAccessForWrite(SecurityException securityException)
         {
-            if (!IsTypeVisible(UnderlyingType, serializationAssemblyPatterns))
+            if (!IsTypeVisible(UnderlyingType))
             {
                 if (securityException != null)
                 {
@@ -1372,7 +1372,7 @@ namespace System.Runtime.Serialization
                 }
                 return true;
             }
-            if (ItemType != null && !IsTypeVisible(ItemType, serializationAssemblyPatterns))
+            if (ItemType != null && !IsTypeVisible(ItemType))
             {
                 if (securityException != null)
                 {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataMember.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataMember.cs
@@ -291,13 +291,13 @@ namespace System.Runtime.Serialization
         ///          since this information is used to determine whether to give the generated code access
         ///          permissions to private members, any changes to the logic should be reviewed.
         /// </SecurityNote>
-        internal bool RequiresMemberAccessForGet(string[] serializationAssemblyPatterns)
+        internal bool RequiresMemberAccessForGet()
         {
             MemberInfo memberInfo = MemberInfo;
             FieldInfo field = memberInfo as FieldInfo;
             if (field != null)
             {
-                return DataContract.FieldRequiresMemberAccess(field, serializationAssemblyPatterns);
+                return DataContract.FieldRequiresMemberAccess(field);
             }
             else
             {
@@ -305,7 +305,7 @@ namespace System.Runtime.Serialization
                 MethodInfo getMethod = property.GetMethod;
                 if (getMethod != null)
                 {
-                    return DataContract.MethodRequiresMemberAccess(getMethod, serializationAssemblyPatterns) || !DataContract.IsTypeVisible(property.PropertyType, serializationAssemblyPatterns);
+                    return DataContract.MethodRequiresMemberAccess(getMethod) || !DataContract.IsTypeVisible(property.PropertyType);
                 }
             }
             return false;
@@ -316,13 +316,13 @@ namespace System.Runtime.Serialization
         ///          since this information is used to determine whether to give the generated code access
         ///          permissions to private members, any changes to the logic should be reviewed.
         /// </SecurityNote>
-        internal bool RequiresMemberAccessForSet(string[] serializationAssemblyPatterns)
+        internal bool RequiresMemberAccessForSet()
         {
             MemberInfo memberInfo = MemberInfo;
             FieldInfo field = memberInfo as FieldInfo;
             if (field != null)
             {
-                return DataContract.FieldRequiresMemberAccess(field, serializationAssemblyPatterns);
+                return DataContract.FieldRequiresMemberAccess(field);
             }
             else
             {
@@ -330,7 +330,7 @@ namespace System.Runtime.Serialization
                 MethodInfo setMethod = property.SetMethod;
                 if (setMethod != null)
                 {
-                    return DataContract.MethodRequiresMemberAccess(setMethod, serializationAssemblyPatterns) || !DataContract.IsTypeVisible(property.PropertyType, serializationAssemblyPatterns);
+                    return DataContract.MethodRequiresMemberAccess(setMethod) || !DataContract.IsTypeVisible(property.PropertyType);
                 }
             }
             return false;

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Globals.cs
@@ -900,19 +900,6 @@ namespace System.Runtime.Serialization
             }
         }
 
-        [SecurityCritical]
-        private static string[] s_dataContractSerializationPatterns;
-        internal static string[] DataContractSerializationPatterns
-        {
-            [SecuritySafeCritical]
-            get
-            {
-                if (s_dataContractSerializationPatterns == null)
-                    s_dataContractSerializationPatterns = new string[] { SimpleSRSInternalsVisiblePattern, FullSRSInternalsVisiblePattern };
-                return s_dataContractSerializationPatterns;
-            }
-        }
-
         #region Contract compliance for System.Type
 
         private static bool TypeSequenceEqual(Type[] seq1, Type[] seq2)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractJsonSerializer.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/DataContractJsonSerializer.cs
@@ -424,7 +424,7 @@ namespace System.Runtime.Serialization.Json
                     InvokeOnSerializing(value, classContract.BaseContract, context);
                 if (classContract.OnSerializing != null)
                 {
-                    bool memberAccessFlag = classContract.RequiresMemberAccessForWrite(null, JsonGlobals.JsonSerializationPatterns);
+                    bool memberAccessFlag = classContract.RequiresMemberAccessForWrite(null);
                     try
                     {
                         classContract.OnSerializing.Invoke(value, new object[] { context.GetStreamingContext() });
@@ -433,7 +433,7 @@ namespace System.Runtime.Serialization.Json
                     {
                         if (memberAccessFlag)
                         {
-                            classContract.RequiresMemberAccessForWrite(securityException, JsonGlobals.JsonSerializationPatterns);
+                            classContract.RequiresMemberAccessForWrite(securityException);
                         }
                         else
                         {
@@ -462,7 +462,7 @@ namespace System.Runtime.Serialization.Json
                     InvokeOnSerialized(value, classContract.BaseContract, context);
                 if (classContract.OnSerialized != null)
                 {
-                    bool memberAccessFlag = classContract.RequiresMemberAccessForWrite(null, JsonGlobals.JsonSerializationPatterns);
+                    bool memberAccessFlag = classContract.RequiresMemberAccessForWrite(null);
                     try
                     {
                         classContract.OnSerialized.Invoke(value, new object[] { context.GetStreamingContext() });
@@ -471,7 +471,7 @@ namespace System.Runtime.Serialization.Json
                     {
                         if (memberAccessFlag)
                         {
-                            classContract.RequiresMemberAccessForWrite(securityException, JsonGlobals.JsonSerializationPatterns);
+                            classContract.RequiresMemberAccessForWrite(securityException);
                         }
                         else
                         {
@@ -500,7 +500,7 @@ namespace System.Runtime.Serialization.Json
                     InvokeOnDeserializing(value, classContract.BaseContract, context);
                 if (classContract.OnDeserializing != null)
                 {
-                    bool memberAccessFlag = classContract.RequiresMemberAccessForRead(null, JsonGlobals.JsonSerializationPatterns);
+                    bool memberAccessFlag = classContract.RequiresMemberAccessForRead(null);
                     try
                     {
                         classContract.OnDeserializing.Invoke(value, new object[] { context.GetStreamingContext() });
@@ -509,7 +509,7 @@ namespace System.Runtime.Serialization.Json
                     {
                         if (memberAccessFlag)
                         {
-                            classContract.RequiresMemberAccessForRead(securityException, JsonGlobals.JsonSerializationPatterns);
+                            classContract.RequiresMemberAccessForRead(securityException);
                         }
                         else
                         {
@@ -538,7 +538,7 @@ namespace System.Runtime.Serialization.Json
                     InvokeOnDeserialized(value, classContract.BaseContract, context);
                 if (classContract.OnDeserialized != null)
                 {
-                    bool memberAccessFlag = classContract.RequiresMemberAccessForRead(null, JsonGlobals.JsonSerializationPatterns);
+                    bool memberAccessFlag = classContract.RequiresMemberAccessForRead(null);
                     try
                     {
                         classContract.OnDeserialized.Invoke(value, new object[] { context.GetStreamingContext() });
@@ -547,7 +547,7 @@ namespace System.Runtime.Serialization.Json
                     {
                         if (memberAccessFlag)
                         {
-                            classContract.RequiresMemberAccessForRead(securityException, JsonGlobals.JsonSerializationPatterns);
+                            classContract.RequiresMemberAccessForRead(securityException);
                         }
                         else
                         {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatReaderGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatReaderGenerator.cs
@@ -69,7 +69,7 @@ namespace System.Runtime.Serialization.Json
             public JsonFormatClassReaderDelegate GenerateClassReader(ClassDataContract classContract)
             {
                 _ilg = new CodeGenerator();
-                bool memberAccessFlag = classContract.RequiresMemberAccessForRead(null, JsonGlobals.JsonSerializationPatterns);
+                bool memberAccessFlag = classContract.RequiresMemberAccessForRead(null);
                 try
                 {
                     BeginMethod(_ilg, "Read" + DataContract.SanitizeTypeName(classContract.StableName.Name) + "FromJson", typeof(JsonFormatClassReaderDelegate), memberAccessFlag);
@@ -78,7 +78,7 @@ namespace System.Runtime.Serialization.Json
                 {
                     if (memberAccessFlag)
                     {
-                        classContract.RequiresMemberAccessForRead(securityException, JsonGlobals.JsonSerializationPatterns);
+                        classContract.RequiresMemberAccessForRead(securityException);
                     }
                     else
                     {
@@ -140,7 +140,7 @@ namespace System.Runtime.Serialization.Json
             private CodeGenerator GenerateCollectionReaderHelper(CollectionDataContract collectionContract, bool isGetOnlyCollection)
             {
                 _ilg = new CodeGenerator();
-                bool memberAccessFlag = collectionContract.RequiresMemberAccessForRead(null, JsonGlobals.JsonSerializationPatterns);
+                bool memberAccessFlag = collectionContract.RequiresMemberAccessForRead(null);
                 try
                 {
                     if (isGetOnlyCollection)
@@ -156,7 +156,7 @@ namespace System.Runtime.Serialization.Json
                 {
                     if (memberAccessFlag)
                     {
-                        collectionContract.RequiresMemberAccessForRead(securityException, JsonGlobals.JsonSerializationPatterns);
+                        collectionContract.RequiresMemberAccessForRead(securityException);
                     }
                     else
                     {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatWriterGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonFormatWriterGenerator.cs
@@ -62,7 +62,7 @@ namespace System.Runtime.Serialization.Json
             internal JsonFormatClassWriterDelegate GenerateClassWriter(ClassDataContract classContract)
             {
                 _ilg = new CodeGenerator();
-                bool memberAccessFlag = classContract.RequiresMemberAccessForWrite(null, JsonGlobals.JsonSerializationPatterns);
+                bool memberAccessFlag = classContract.RequiresMemberAccessForWrite(null);
                 try
                 {
                     BeginMethod(_ilg, "Write" + DataContract.SanitizeTypeName(classContract.StableName.Name) + "ToJson", typeof(JsonFormatClassWriterDelegate), memberAccessFlag);
@@ -71,7 +71,7 @@ namespace System.Runtime.Serialization.Json
                 {
                     if (memberAccessFlag)
                     {
-                        classContract.RequiresMemberAccessForWrite(securityException, JsonGlobals.JsonSerializationPatterns);
+                        classContract.RequiresMemberAccessForWrite(securityException);
                     }
                     else
                     {
@@ -87,7 +87,7 @@ namespace System.Runtime.Serialization.Json
             internal JsonFormatCollectionWriterDelegate GenerateCollectionWriter(CollectionDataContract collectionContract)
             {
                 _ilg = new CodeGenerator();
-                bool memberAccessFlag = collectionContract.RequiresMemberAccessForWrite(null, JsonGlobals.JsonSerializationPatterns);
+                bool memberAccessFlag = collectionContract.RequiresMemberAccessForWrite(null);
                 try
                 {
                     BeginMethod(_ilg, "Write" + DataContract.SanitizeTypeName(collectionContract.StableName.Name) + "ToJson", typeof(JsonFormatCollectionWriterDelegate), memberAccessFlag);
@@ -96,7 +96,7 @@ namespace System.Runtime.Serialization.Json
                 {
                     if (memberAccessFlag)
                     {
-                        collectionContract.RequiresMemberAccessForWrite(securityException, JsonGlobals.JsonSerializationPatterns);
+                        collectionContract.RequiresMemberAccessForWrite(securityException);
                     }
                     else
                     {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonGlobals.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/Json/JsonGlobals.cs
@@ -59,24 +59,5 @@ namespace System.Runtime.Serialization.Json
         public const int maxScopeSize = 25;
         public static readonly XmlDictionaryString itemDictionaryString = new XmlDictionary().Add("item");
         public static readonly XmlDictionaryString rootDictionaryString = new XmlDictionary().Add("root");
-
-        public const string SimpleSMWInternalsVisiblePattern = @"^[\s]*System\.ServiceModel\.Web[\s]*$";
-        public const string FullSMWInternalsVisiblePattern = @"^[\s]*System\.ServiceModel\.Web[\s]*,[\s]*PublicKey[\s]*=[\s]*(?i:00240000048000009400000006020000002400005253413100040000010001008d56c76f9e8649383049f383c44be0ec204181822a6c31cf5eb7ef486944d032188ea1d3920763712ccb12d75fb77e9811149e6148e5d32fbaab37611c1878ddc19e20ef135d0cb2cff2bfec3d115810c3d9069638fe4be215dbf795861920e5ab6f7db2e2ceef136ac23d5dd2bf031700aec232f6c6b1c785b4305c123b37ab)[\s]*$";
-
-        [SecurityCritical]
-        private static string[] s_jsonSerializationPatterns;
-        internal static string[] JsonSerializationPatterns
-        {
-            [SecuritySafeCritical]
-            get
-            {
-                if (s_jsonSerializationPatterns == null)
-                {
-                    s_jsonSerializationPatterns = new string[] { Globals.SimpleSRSInternalsVisiblePattern, Globals.FullSRSInternalsVisiblePattern,
-                                                               SimpleSMWInternalsVisiblePattern, FullSMWInternalsVisiblePattern };
-                }
-                return s_jsonSerializationPatterns;
-            }
-        }
     }
 }

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlDataContract.cs
@@ -321,7 +321,7 @@ namespace System.Runtime.Serialization
         {
             Type type = this.UnderlyingType;
             CodeGenerator ilg = new CodeGenerator();
-            bool memberAccessFlag = RequiresMemberAccessForCreate(null, Globals.DataContractSerializationPatterns) && !(type.FullName == "System.Xml.Linq.XElement");
+            bool memberAccessFlag = RequiresMemberAccessForCreate(null) && !(type.FullName == "System.Xml.Linq.XElement");
             try
             {
                 ilg.BeginMethod("Create" + DataContract.GetClrTypeFullName(type), typeof(CreateXmlSerializableDelegate), memberAccessFlag);
@@ -330,7 +330,7 @@ namespace System.Runtime.Serialization
             {
                 if (memberAccessFlag)
                 {
-                    RequiresMemberAccessForCreate(securityException, Globals.DataContractSerializationPatterns);
+                    RequiresMemberAccessForCreate(securityException);
                 }
                 else
                 {
@@ -383,9 +383,9 @@ namespace System.Runtime.Serialization
         ///          since this information is used to determine whether to give the generated code access
         ///          permissions to private members, any changes to the logic should be reviewed.
         /// </SecurityNote>
-        private bool RequiresMemberAccessForCreate(SecurityException securityException, string[] serializationAssemblyPatterns)
+        private bool RequiresMemberAccessForCreate(SecurityException securityException)
         {
-            if (!IsTypeVisible(UnderlyingType, serializationAssemblyPatterns))
+            if (!IsTypeVisible(UnderlyingType))
             {
                 if (securityException != null)
                 {
@@ -396,7 +396,7 @@ namespace System.Runtime.Serialization
                 return true;
             }
 
-            if (ConstructorRequiresMemberAccess(GetConstructor(), serializationAssemblyPatterns))
+            if (ConstructorRequiresMemberAccess(GetConstructor()))
             {
                 if (securityException != null)
                 {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatReaderGenerator.cs
@@ -91,7 +91,7 @@ namespace System.Runtime.Serialization
             public XmlFormatClassReaderDelegate GenerateClassReader(ClassDataContract classContract)
             {
                 _ilg = new CodeGenerator();
-                bool memberAccessFlag = classContract.RequiresMemberAccessForRead(null, Globals.DataContractSerializationPatterns);
+                bool memberAccessFlag = classContract.RequiresMemberAccessForRead(null);
                 try
                 {
                     _ilg.BeginMethod("Read" + classContract.StableName.Name + "FromXml", Globals.TypeOfXmlFormatClassReaderDelegate, memberAccessFlag);
@@ -100,7 +100,7 @@ namespace System.Runtime.Serialization
                 {
                     if (memberAccessFlag)
                     {
-                        classContract.RequiresMemberAccessForRead(securityException, Globals.DataContractSerializationPatterns);
+                        classContract.RequiresMemberAccessForRead(securityException);
                     }
                     else
                     {
@@ -163,7 +163,7 @@ namespace System.Runtime.Serialization
             private CodeGenerator GenerateCollectionReaderHelper(CollectionDataContract collectionContract, bool isGetOnlyCollection)
             {
                 _ilg = new CodeGenerator();
-                bool memberAccessFlag = collectionContract.RequiresMemberAccessForRead(null, Globals.DataContractSerializationPatterns);
+                bool memberAccessFlag = collectionContract.RequiresMemberAccessForRead(null);
                 try
                 {
                     if (isGetOnlyCollection)
@@ -179,7 +179,7 @@ namespace System.Runtime.Serialization
                 {
                     if (memberAccessFlag)
                     {
-                        collectionContract.RequiresMemberAccessForRead(securityException, Globals.DataContractSerializationPatterns);
+                        collectionContract.RequiresMemberAccessForRead(securityException);
                     }
                     else
                     {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatWriterGenerator.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/XmlFormatWriterGenerator.cs
@@ -79,7 +79,7 @@ namespace System.Runtime.Serialization
             internal XmlFormatClassWriterDelegate GenerateClassWriter(ClassDataContract classContract)
             {
                 _ilg = new CodeGenerator();
-                bool memberAccessFlag = classContract.RequiresMemberAccessForWrite(null, Globals.DataContractSerializationPatterns);
+                bool memberAccessFlag = classContract.RequiresMemberAccessForWrite(null);
                 try
                 {
                     _ilg.BeginMethod("Write" + classContract.StableName.Name + "ToXml", Globals.TypeOfXmlFormatClassWriterDelegate, memberAccessFlag);
@@ -88,7 +88,7 @@ namespace System.Runtime.Serialization
                 {
                     if (memberAccessFlag)
                     {
-                        classContract.RequiresMemberAccessForWrite(securityException, Globals.DataContractSerializationPatterns);
+                        classContract.RequiresMemberAccessForWrite(securityException);
                     }
                     else
                     {
@@ -103,7 +103,7 @@ namespace System.Runtime.Serialization
             internal XmlFormatCollectionWriterDelegate GenerateCollectionWriter(CollectionDataContract collectionContract)
             {
                 _ilg = new CodeGenerator();
-                bool memberAccessFlag = collectionContract.RequiresMemberAccessForWrite(null, Globals.DataContractSerializationPatterns);
+                bool memberAccessFlag = collectionContract.RequiresMemberAccessForWrite(null);
                 try
                 {
                     _ilg.BeginMethod("Write" + collectionContract.StableName.Name + "ToXml", Globals.TypeOfXmlFormatCollectionWriterDelegate, memberAccessFlag);
@@ -112,7 +112,7 @@ namespace System.Runtime.Serialization
                 {
                     if (memberAccessFlag)
                     {
-                        collectionContract.RequiresMemberAccessForWrite(securityException, Globals.DataContractSerializationPatterns);
+                        collectionContract.RequiresMemberAccessForWrite(securityException);
                     }
                     else
                     {


### PR DESCRIPTION
Internal private member access doesn't require InternalsVisibleTo attribute anymore. In addition to that, implementation of DataConractSerializer and DataContractJsonSerializer have been consolidated into one assembly so there is no need to check for access visibility to System.ServiceModel.Web which no longer exists. 
This is porting a change from full Desktop to clean up the unnecessary checks for assembly by name patterns.

@shmao @SGuyGe @zhenlan 