### PR TITLE
Disabling System.Net intermittently failing tests

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -21,9 +21,14 @@
     <ProjectLockJson>unix\project.lock.json</ProjectLockJson>
   </PropertyGroup>
   
-  <!-- Help VS understand available configurations -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+<!-- Help VS understand available configurations -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Linux_Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Linux_Release|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'OSX_Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'OSX_Release|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU' " />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU' " />
+
   <ItemGroup>
     <Compile Include="DummyTcpServer.cs" />
     <Compile Include="FakeNetworkStream.cs" />

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/UdpClientTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/UdpClientTest.cs
@@ -54,6 +54,14 @@ namespace System.Net.Sockets.Tests
             Assert.True(_waitHandle.WaitOne(Configuration.PassingTestTimeout), "Timed out while waiting for connection");
         }
 
+        [ActiveIssue(4968)]
+        [Fact]
+        public void UdpClient_ConnectAsync_Success()
+        {
+            var c = new UdpClient();
+            c.Client.ConnectAsync("114.114.114.114", 53).Wait();
+        }
+
         private void AsyncCompleted(IAsyncResult ar)
         {
             UdpClient udpService = (UdpClient)ar.AsyncState;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEventArgs.Windows.cs
@@ -161,7 +161,7 @@ namespace System.Net.Sockets
 
         private void CompleteIOCPOperation()
         {
-            // TODO: Optimization to remove callbacks if the operations are completed synchronously:
+            // TODO #4900: Optimization to remove callbacks if the operations are completed synchronously:
             //       Use SetFileCompletionNotificationModes(FILE_SKIP_COMPLETION_PORT_ON_SUCCESS).
 
             // If SetFileCompletionNotificationModes(FILE_SKIP_COMPLETION_PORT_ON_SUCCESS) is not set on this handle

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -463,12 +463,14 @@ namespace System.Net.Sockets.Tests
             SendToRecvFromAsync_Datagram_UDP(IPAddress.Loopback, IPAddress.Loopback);
         }
 
+        [ActiveIssue(5411, PlatformID.Windows)]
         [Fact]
         public void SendToRecvFromAsync_UdpClient_Single_Datagram_UDP_IPv6()
         {
             SendToRecvFromAsync_UdpClient_Datagram_UDP(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
         }
 
+        [ActiveIssue(5411, PlatformID.Windows)]
         [Fact]
         public void SendToRecvFromAsync_UdpClient_Single_Datagram_UDP_IPv4()
         {
@@ -506,6 +508,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(5234, PlatformID.Windows)]
         public void SendRecvAsync_TcpListener_TcpClient_IPv4()
         {
             SendRecvAsync_TcpListener_TcpClient(IPAddress.Loopback);


### PR DESCRIPTION
* Disabling failing tests based on reported bugs.
* Adding new tests that repro reported issues.
* Fixing System.Net.Security.Tests.csproj.

@davidsh @stephentoub @ericeil PTAL