### PR TITLE
Add netcore50aot and net46 configurations for System.Reflection.TypeExtensions

### DIFF
--- a/src/Common/src/Internal/Reflection/Execution/Binder/DefaultBinder.cs
+++ b/src/Common/src/Internal/Reflection/Execution/Binder/DefaultBinder.cs
@@ -1,0 +1,939 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+//
+// Ported from desktop (BCL\System\DefaultBinder.cs)
+//
+//
+
+using global::System;
+using global::System.Reflection;
+using global::System.Runtime.CompilerServices;
+using global::System.Runtime.Versioning;
+using global::System.Diagnostics.Contracts;
+
+using global::Internal.Reflection.Core.Execution;
+
+namespace Internal.Reflection.Core.Execution.Binder
+{
+    internal static class DefaultBinder
+    {
+        // This method is passed a set of methods and must choose the best
+        // fit.  The methods all have the same number of arguments and the object
+        // array args.  On exit, this method will choice the best fit method
+        // and coerce the args to match that method.  By match, we mean all primitive
+        // arguments are exact matchs and all object arguments are exact or subclasses
+        // of the target.  If the target OR is an interface, the object must implement
+        // that interface.  There are a couple of exceptions
+        // thrown when a method cannot be returned.  If no method matchs the args and
+        // ArgumentException is thrown.  If multiple methods match the args then 
+        // an AmbiguousMatchException is thrown.
+        // 
+        // The most specific match will be selected.  
+        // 
+        public static MethodBase BindToMethod(MethodBase[] match, ref Object[] args)
+        {
+            if (match == null || match.Length == 0)
+                throw new ArgumentException(SR.Arg_EmptyArray, "match");
+            Contract.EndContractBlock();
+
+            MethodBase[] candidates = (MethodBase[])match.Clone();
+
+            int i;
+            int j;
+
+            #region Map named parameters to candidate parameter postions
+            // We are creating an paramOrder array to act as a mapping
+            //  between the order of the args and the actual order of the
+            //  parameters in the method.  This order may differ because
+            //  named parameters (names) may change the order.  If names
+            //  is not provided, then we assume the default mapping (0,1,...)
+            int[][] paramOrder = new int[candidates.Length][];
+
+            for (i = 0; i < candidates.Length; i++)
+            {
+                ParameterInfo[] par = candidates[i].GetParameters();
+
+                // args.Length + 1 takes into account the possibility of a last paramArray that can be omitted
+                paramOrder[i] = new int[(par.Length > args.Length) ? par.Length : args.Length];
+
+                // Default mapping
+                for (j = 0; j < args.Length; j++)
+                    paramOrder[i][j] = j;
+            }
+            #endregion
+
+            Type[] paramArrayTypes = new Type[candidates.Length];
+
+            Type[] argTypes = new Type[args.Length];
+
+            #region Cache the type of the provided arguments
+            // object that contain a null are treated as if they were typeless (but match either object 
+            // references or value classes).  We mark this condition by placing a null in the argTypes array.
+            for (i = 0; i < args.Length; i++)
+            {
+                if (args[i] != null)
+                {
+                    argTypes[i] = args[i].GetType();
+                }
+            }
+            #endregion
+
+
+            // Find the method that matches...
+            int CurIdx = 0;
+
+            Type paramArrayType = null;
+
+            #region Filter methods by parameter count and type
+            for (i = 0; i < candidates.Length; i++)
+            {
+                paramArrayType = null;
+
+                // If we have named parameters then we may have a hole in the candidates array.
+                if (candidates[i] == null)
+                    continue;
+
+                // Validate the parameters.
+                ParameterInfo[] par = candidates[i].GetParameters();
+
+                #region Match method by parameter count
+                if (par.Length == 0)
+                {
+                    #region No formal parameters
+                    if (args.Length != 0)
+                    {
+                        if ((candidates[i].CallingConvention & CallingConventions.VarArgs) == 0)
+                            continue;
+                    }
+
+                    // This is a valid routine so we move it up the candidates list.
+                    paramOrder[CurIdx] = paramOrder[i];
+                    candidates[CurIdx++] = candidates[i];
+
+                    continue;
+                    #endregion
+                }
+                else if (par.Length > args.Length)
+                {
+                    #region Shortage of provided parameters
+                    // If the number of parameters is greater than the number of args then 
+                    // we are in the situation were we may be using default values.
+                    for (j = args.Length; j < par.Length - 1; j++)
+                    {
+                        if (!par[j].HasDefaultValue)
+                            break;
+                    }
+
+                    if (j != par.Length - 1)
+                        continue;
+
+                    if (!par[j].HasDefaultValue)
+                    {
+                        if (!par[j].ParameterType.IsArray)
+                            continue;
+
+                        if (!HasParamArrayAttribute(par[j]))
+                            continue;
+
+                        paramArrayType = par[j].ParameterType.GetElementType();
+                    }
+                    #endregion
+                }
+                else if (par.Length < args.Length)
+                {
+                    #region Excess provided parameters
+                    // test for the ParamArray case
+                    int lastArgPos = par.Length - 1;
+
+                    if (!par[lastArgPos].ParameterType.IsArray)
+                        continue;
+
+                    if (!HasParamArrayAttribute(par[lastArgPos]))
+                        continue;
+
+                    if (paramOrder[i][lastArgPos] != lastArgPos)
+                        continue;
+
+                    paramArrayType = par[lastArgPos].ParameterType.GetElementType();
+                    #endregion
+                }
+                else
+                {
+                    #region Test for paramArray, save paramArray type
+                    int lastArgPos = par.Length - 1;
+
+                    if (par[lastArgPos].ParameterType.IsArray
+                        && HasParamArrayAttribute(par[lastArgPos])
+                        && paramOrder[i][lastArgPos] == lastArgPos)
+                    {
+                        if (!par[lastArgPos].ParameterType.GetTypeInfo().IsAssignableFrom(argTypes[lastArgPos].GetTypeInfo()))
+                            paramArrayType = par[lastArgPos].ParameterType.GetElementType();
+                    }
+                    #endregion
+                }
+                #endregion
+
+                Type pCls = null;
+                int argsToCheck = (paramArrayType != null) ? par.Length - 1 : args.Length;
+
+                #region Match method by parameter type
+                for (j = 0; j < argsToCheck; j++)
+                {
+                    #region Classic argument coersion checks
+                    // get the formal type
+                    pCls = par[j].ParameterType;
+
+                    if (pCls.IsByRef)
+                        pCls = pCls.GetElementType();
+
+                    // the type is the same
+                    if (pCls == argTypes[paramOrder[i][j]])
+                        continue;
+
+                    // the argument was null, so it matches with everything
+                    if (args[paramOrder[i][j]] == null)
+                        continue;
+
+                    // the type is Object, so it will match everything
+                    if (pCls == typeof(Object))
+                        continue;
+
+                    // now do a "classic" type check
+                    if (pCls.GetTypeInfo().IsPrimitive)
+                    {
+                        if (argTypes[paramOrder[i][j]] == null || !CanConvertPrimitiveObjectToType(args[paramOrder[i][j]], pCls))
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        if (argTypes[paramOrder[i][j]] == null)
+                            continue;
+
+                        if (!pCls.GetTypeInfo().IsAssignableFrom(argTypes[paramOrder[i][j]].GetTypeInfo()))
+                        {
+                            break;
+                        }
+                    }
+                    #endregion
+                }
+
+                if (paramArrayType != null && j == par.Length - 1)
+                {
+                    #region Check that excess arguments can be placed in the param array
+
+                    // Legacy: It's so pathetic that we go to all this trouble let "widening-compatible" params arguments through this screen 
+                    // only to end up blowing up with an InvalidCastException anyway because we use Array.Copy() to do the actual copy down below.
+                    // Ah, the joys of backward compatibility...
+                    for (; j < args.Length; j++)
+                    {
+                        if (paramArrayType.GetTypeInfo().IsPrimitive)
+                        {
+                            if (argTypes[j] == null || !CanConvertPrimitiveObjectToType(args[j], paramArrayType))
+                                break;
+                        }
+                        else
+                        {
+                            if (argTypes[j] == null)
+                                continue;
+
+                            if (!paramArrayType.GetTypeInfo().IsAssignableFrom(argTypes[j].GetTypeInfo()))
+                            {
+                                break;
+                            }
+                        }
+                    }
+                    #endregion
+                }
+                #endregion
+
+                if (j == args.Length)
+                {
+                    #region This is a valid routine so we move it up the candidates list
+                    paramOrder[CurIdx] = paramOrder[i];
+                    paramArrayTypes[CurIdx] = paramArrayType;
+                    candidates[CurIdx++] = candidates[i];
+                    #endregion
+                }
+            }
+            #endregion
+
+            // If we didn't find a method 
+            if (CurIdx == 0)
+                throw new MissingMethodException(SR.MissingMember);
+
+            if (CurIdx == 1)
+            {
+                #region Found only one method
+                // If the parameters and the args are not the same length or there is a paramArray
+                //  then we need to create a argument array.
+                ParameterInfo[] parms = candidates[0].GetParameters();
+
+                if (parms.Length == args.Length)
+                {
+                    if (paramArrayTypes[0] != null)
+                    {
+                        Object[] objs = new Object[parms.Length];
+                        int lastPos = parms.Length - 1;
+                        Array.Copy(args, 0, objs, 0, lastPos);
+                        objs[lastPos] = Array.CreateInstance(paramArrayTypes[0], 1);
+                        ((Array)objs[lastPos]).SetValue(args[lastPos], 0);
+                        args = objs;
+                    }
+                }
+                else if (parms.Length > args.Length)
+                {
+                    Object[] objs = new Object[parms.Length];
+
+                    for (i = 0; i < args.Length; i++)
+                        objs[i] = args[i];
+
+                    for (; i < parms.Length - 1; i++)
+                        objs[i] = parms[i].DefaultValue;
+
+                    if (paramArrayTypes[0] != null)
+                        objs[i] = Array.CreateInstance(paramArrayTypes[0], 0); // create an empty array for the 
+
+                    else
+                        objs[i] = parms[i].DefaultValue;
+
+                    args = objs;
+                }
+                else
+                {
+                    if ((candidates[0].CallingConvention & CallingConventions.VarArgs) == 0)
+                    {
+                        Object[] objs = new Object[parms.Length];
+                        int paramArrayPos = parms.Length - 1;
+                        Array.Copy(args, 0, objs, 0, paramArrayPos);
+                        objs[paramArrayPos] = Array.CreateInstance(paramArrayTypes[0], args.Length - paramArrayPos);
+                        Array.Copy(args, paramArrayPos, (System.Array)objs[paramArrayPos], 0, args.Length - paramArrayPos);
+                        args = objs;
+                    }
+                }
+                #endregion
+
+                return candidates[0];
+            }
+
+            int currentMin = 0;
+            bool ambig = false;
+            for (i = 1; i < CurIdx; i++)
+            {
+                #region Walk all of the methods looking the most specific method to invoke
+                int newMin = FindMostSpecificMethod(candidates[currentMin], paramOrder[currentMin], paramArrayTypes[currentMin],
+                                                    candidates[i], paramOrder[i], paramArrayTypes[i], argTypes, args);
+
+                if (newMin == 0)
+                {
+                    ambig = true;
+                }
+                else if (newMin == 2)
+                {
+                    currentMin = i;
+                    ambig = false;
+                }
+                #endregion
+            }
+
+            if (ambig)
+                throw new AmbiguousMatchException(SR.Arg_AmbiguousMatchException);
+
+            // If the parameters and the args are not the same length or there is a paramArray
+            //  then we need to create a argument array.
+            ParameterInfo[] parameters = candidates[currentMin].GetParameters();
+            if (parameters.Length == args.Length)
+            {
+                if (paramArrayTypes[currentMin] != null)
+                {
+                    Object[] objs = new Object[parameters.Length];
+                    int lastPos = parameters.Length - 1;
+                    Array.Copy(args, 0, objs, 0, lastPos);
+                    objs[lastPos] = Array.CreateInstance(paramArrayTypes[currentMin], 1);
+                    ((Array)objs[lastPos]).SetValue(args[lastPos], 0);
+                    args = objs;
+                }
+            }
+            else if (parameters.Length > args.Length)
+            {
+                Object[] objs = new Object[parameters.Length];
+
+                for (i = 0; i < args.Length; i++)
+                    objs[i] = args[i];
+
+                for (; i < parameters.Length - 1; i++)
+                    objs[i] = parameters[i].DefaultValue;
+
+                if (paramArrayTypes[currentMin] != null)
+                {
+                    objs[i] = Array.CreateInstance(paramArrayTypes[currentMin], 0);
+                }
+                else
+                {
+                    objs[i] = parameters[i].DefaultValue;
+                }
+
+                args = objs;
+            }
+            else
+            {
+                if ((candidates[currentMin].CallingConvention & CallingConventions.VarArgs) == 0)
+                {
+                    Object[] objs = new Object[parameters.Length];
+                    int paramArrayPos = parameters.Length - 1;
+                    Array.Copy(args, 0, objs, 0, paramArrayPos);
+                    objs[paramArrayPos] = Array.CreateInstance(paramArrayTypes[currentMin], args.Length - paramArrayPos);
+                    Array.Copy(args, paramArrayPos, (System.Array)objs[paramArrayPos], 0, args.Length - paramArrayPos);
+                    args = objs;
+                }
+            }
+
+            return candidates[currentMin];
+        }
+
+
+        // Given a set of methods that match the base criteria, select a method based
+        // upon an array of types.  This method should return null if no method matchs
+        // the criteria.
+        public static MethodBase SelectMethod(MethodBase[] match, Type[] types)
+        {
+            int i;
+            int j;
+
+            MethodBase[] candidates = (MethodBase[])match.Clone();
+
+            // Find all the methods that can be described by the types parameter. 
+            //  Remove all of them that cannot.
+            int CurIdx = 0;
+            for (i = 0; i < candidates.Length; i++)
+            {
+                ParameterInfo[] par = candidates[i].GetParameters();
+                if (par.Length != types.Length)
+                    continue;
+                for (j = 0; j < types.Length; j++)
+                {
+                    Type pCls = par[j].ParameterType;
+                    if (pCls == types[j])
+                        continue;
+                    if (pCls == typeof(Object))
+                        continue;
+                    if (pCls.GetTypeInfo().IsPrimitive)
+                    {
+                        if (!CanConvertPrimitive(types[j], pCls))
+                            break;
+                    }
+                    else
+                    {
+                        if (!pCls.GetTypeInfo().IsAssignableFrom(types[j].GetTypeInfo()))
+                            break;
+                    }
+                }
+                if (j == types.Length)
+                    candidates[CurIdx++] = candidates[i];
+            }
+            if (CurIdx == 0)
+                return null;
+            if (CurIdx == 1)
+                return candidates[0];
+
+            // Walk all of the methods looking the most specific method to invoke
+            int currentMin = 0;
+            bool ambig = false;
+            int[] paramOrder = new int[types.Length];
+            for (i = 0; i < types.Length; i++)
+                paramOrder[i] = i;
+            for (i = 1; i < CurIdx; i++)
+            {
+                int newMin = FindMostSpecificMethod(candidates[currentMin], paramOrder, null, candidates[i], paramOrder, null, types, null);
+                if (newMin == 0)
+                    ambig = true;
+                else
+                {
+                    if (newMin == 2)
+                    {
+                        currentMin = i;
+                        ambig = false;
+                        currentMin = i;
+                    }
+                }
+            }
+            if (ambig)
+                throw new AmbiguousMatchException(SR.Arg_AmbiguousMatchException);
+            return candidates[currentMin];
+        }
+
+        private static bool HasParamArrayAttribute(ParameterInfo parameterInfo)
+        {
+            foreach (CustomAttributeData cad in parameterInfo.CustomAttributes)
+            {
+                if (cad.AttributeType.Equals(typeof(ParamArrayAttribute)))
+                    return true;
+            }
+            return false;
+        }
+
+        private static int FindMostSpecific(ParameterInfo[] p1, int[] paramOrder1, Type paramArrayType1,
+                                            ParameterInfo[] p2, int[] paramOrder2, Type paramArrayType2,
+                                            Type[] types, Object[] args)
+        {
+            // A method using params is always less specific than one not using params
+            if (paramArrayType1 != null && paramArrayType2 == null) return 2;
+            if (paramArrayType2 != null && paramArrayType1 == null) return 1;
+
+            // now either p1 and p2 both use params or neither does.
+
+            bool p1Less = false;
+            bool p2Less = false;
+
+            for (int i = 0; i < types.Length; i++)
+            {
+                if (args != null && args[i] == Type.Missing)
+                    continue;
+
+                Type c1, c2;
+
+                //  If a param array is present, then either
+                //      the user re-ordered the parameters in which case
+                //          the argument to the param array is either an array
+                //              in which case the params is conceptually ignored and so paramArrayType1 == null
+                //          or the argument to the param array is a single element
+                //              in which case paramOrder[i] == p1.Length - 1 for that element
+                //      or the user did not re-order the parameters in which case
+                //          the paramOrder array could contain indexes larger than p.Length - 1 (see VSW 577286)
+                //          so any index >= p.Length - 1 is being put in the param array
+
+                if (paramArrayType1 != null && paramOrder1[i] >= p1.Length - 1)
+                    c1 = paramArrayType1;
+                else
+                    c1 = p1[paramOrder1[i]].ParameterType;
+
+                if (paramArrayType2 != null && paramOrder2[i] >= p2.Length - 1)
+                    c2 = paramArrayType2;
+                else
+                    c2 = p2[paramOrder2[i]].ParameterType;
+
+                if (c1 == c2) continue;
+
+                switch (FindMostSpecificType(c1, c2, types[i]))
+                {
+                    case 0: return 0;
+                    case 1: p1Less = true; break;
+                    case 2: p2Less = true; break;
+                }
+            }
+
+            // Two way p1Less and p2Less can be equal.  All the arguments are the
+            //  same they both equal false, otherwise there were things that both
+            //  were the most specific type on....
+            if (p1Less == p2Less)
+            {
+                // if we cannot tell which is a better match based on parameter types (p1Less == p2Less),
+                // let's see which one has the most matches without using the params array (the longer one wins).
+                if (!p1Less && args != null)
+                {
+                    if (p1.Length > p2.Length)
+                    {
+                        return 1;
+                    }
+                    else if (p2.Length > p1.Length)
+                    {
+                        return 2;
+                    }
+                }
+
+                return 0;
+            }
+            else
+            {
+                return (p1Less == true) ? 1 : 2;
+            }
+        }
+
+        private static int FindMostSpecificType(Type c1, Type c2, Type t)
+        {
+            // If the two types are exact move on...
+            if (c1 == c2)
+                return 0;
+
+            if (c1 == t)
+                return 1;
+
+            if (c2 == t)
+                return 2;
+
+            bool c1FromC2;
+            bool c2FromC1;
+
+            if (c1.IsByRef || c2.IsByRef)
+            {
+                if (c1.IsByRef && c2.IsByRef)
+                {
+                    c1 = c1.GetElementType();
+                    c2 = c2.GetElementType();
+                }
+                else if (c1.IsByRef)
+                {
+                    if (c1.GetElementType() == c2)
+                        return 2;
+
+                    c1 = c1.GetElementType();
+                }
+                else
+                {
+                    if (c2.GetElementType() == c1)
+                        return 1;
+
+                    c2 = c2.GetElementType();
+                }
+            }
+
+
+            if (c1.GetTypeInfo().IsPrimitive && c2.GetTypeInfo().IsPrimitive)
+            {
+                c1FromC2 = CanConvertPrimitive(c2, c1);
+                c2FromC1 = CanConvertPrimitive(c1, c2);
+            }
+            else
+            {
+                c1FromC2 = c1.GetTypeInfo().IsAssignableFrom(c2.GetTypeInfo());
+                c2FromC1 = c2.GetTypeInfo().IsAssignableFrom(c1.GetTypeInfo());
+            }
+
+            if (c1FromC2 == c2FromC1)
+                return 0;
+
+            if (c1FromC2)
+            {
+                return 2;
+            }
+            else
+            {
+                return 1;
+            }
+        }
+
+        public static PropertyInfo SelectProperty(PropertyInfo[] match, Type returnType,
+                    Type[] indexes)
+        {
+            // Allow a null indexes array. But if it is not null, every element must be non-null as well.
+            if (indexes != null && !Contract.ForAll(indexes, delegate (Type t) { return t != null; }))
+            {
+                Exception e;  // Written this way to pass the Code Contracts style requirements.
+                e = new ArgumentNullException("indexes");
+                throw e;
+            }
+            if (match == null || match.Length == 0)
+                throw new ArgumentException(SR.Arg_EmptyArray, "match");
+            Contract.EndContractBlock();
+
+            PropertyInfo[] candidates = (PropertyInfo[])match.Clone();
+
+            int i, j = 0;
+
+            // Find all the properties that can be described by type indexes parameter
+            int CurIdx = 0;
+            int indexesLength = (indexes != null) ? indexes.Length : 0;
+            for (i = 0; i < candidates.Length; i++)
+            {
+                if (indexes != null)
+                {
+                    ParameterInfo[] par = candidates[i].GetIndexParameters();
+                    if (par.Length != indexesLength)
+                        continue;
+
+                    for (j = 0; j < indexesLength; j++)
+                    {
+                        Type pCls = par[j].ParameterType;
+
+                        // If the classes  exactly match continue
+                        if (pCls == indexes[j])
+                            continue;
+                        if (pCls == typeof(Object))
+                            continue;
+
+                        if (pCls.GetTypeInfo().IsPrimitive)
+                        {
+                            if (!CanConvertPrimitive(indexes[j], pCls))
+                                break;
+                        }
+                        else
+                        {
+                            if (!pCls.GetTypeInfo().IsAssignableFrom(indexes[j].GetTypeInfo()))
+                                break;
+                        }
+                    }
+                }
+
+                if (j == indexesLength)
+                {
+                    if (returnType != null)
+                    {
+                        if (candidates[i].PropertyType.GetTypeInfo().IsPrimitive)
+                        {
+                            if (!CanConvertPrimitive(returnType, candidates[i].PropertyType))
+                                continue;
+                        }
+                        else
+                        {
+                            if (!candidates[i].PropertyType.GetTypeInfo().IsAssignableFrom(returnType.GetTypeInfo()))
+                                continue;
+                        }
+                    }
+                    candidates[CurIdx++] = candidates[i];
+                }
+            }
+            if (CurIdx == 0)
+                return null;
+            if (CurIdx == 1)
+                return candidates[0];
+
+            // Walk all of the properties looking the most specific method to invoke
+            int currentMin = 0;
+            bool ambig = false;
+            int[] paramOrder = new int[indexesLength];
+            for (i = 0; i < indexesLength; i++)
+                paramOrder[i] = i;
+            for (i = 1; i < CurIdx; i++)
+            {
+                int newMin = FindMostSpecificType(candidates[currentMin].PropertyType, candidates[i].PropertyType, returnType);
+                if (newMin == 0 && indexes != null)
+                    newMin = FindMostSpecific(candidates[currentMin].GetIndexParameters(),
+                                              paramOrder,
+                                              null,
+                                              candidates[i].GetIndexParameters(),
+                                              paramOrder,
+                                              null,
+                                              indexes,
+                                              null);
+                if (newMin == 0)
+                {
+                    newMin = FindMostSpecificProperty(candidates[currentMin], candidates[i]);
+                    if (newMin == 0)
+                        ambig = true;
+                }
+                if (newMin == 2)
+                {
+                    ambig = false;
+                    currentMin = i;
+                }
+            }
+
+            if (ambig)
+                throw new AmbiguousMatchException(SR.Arg_AmbiguousMatchException);
+            return candidates[currentMin];
+        }
+
+        private static int FindMostSpecificMethod(MethodBase m1, int[] paramOrder1, Type paramArrayType1,
+                                                  MethodBase m2, int[] paramOrder2, Type paramArrayType2,
+                                                  Type[] types, Object[] args)
+        {
+            // Find the most specific method based on the parameters.
+            int res = FindMostSpecific(m1.GetParameters(), paramOrder1, paramArrayType1,
+                                       m2.GetParameters(), paramOrder2, paramArrayType2, types, args);
+
+            // If the match was not ambigous then return the result.
+            if (res != 0)
+                return res;
+
+            // Check to see if the methods have the exact same name and signature.
+            if (CompareMethodSigAndName(m1, m2))
+            {
+                // Determine the depth of the declaring types for both methods.
+                int hierarchyDepth1 = GetHierarchyDepth(m1.DeclaringType);
+                int hierarchyDepth2 = GetHierarchyDepth(m2.DeclaringType);
+
+                // The most derived method is the most specific one.
+                if (hierarchyDepth1 == hierarchyDepth2)
+                {
+                    return 0;
+                }
+                else if (hierarchyDepth1 < hierarchyDepth2)
+                {
+                    return 2;
+                }
+                else
+                {
+                    return 1;
+                }
+            }
+
+            // The match is ambigous.
+            return 0;
+        }
+
+        private static int FindMostSpecificProperty(PropertyInfo cur1, PropertyInfo cur2)
+        {
+            // Check to see if the fields have the same name.
+            if (cur1.Name == cur2.Name)
+            {
+                int hierarchyDepth1 = GetHierarchyDepth(cur1.DeclaringType);
+                int hierarchyDepth2 = GetHierarchyDepth(cur2.DeclaringType);
+
+                if (hierarchyDepth1 == hierarchyDepth2)
+                {
+                    return 0;
+                }
+                else if (hierarchyDepth1 < hierarchyDepth2)
+                    return 2;
+                else
+                    return 1;
+            }
+
+            // The match is ambigous.
+            return 0;
+        }
+
+        private static bool CompareMethodSigAndName(MethodBase m1, MethodBase m2)
+        {
+            ParameterInfo[] params1 = m1.GetParameters();
+            ParameterInfo[] params2 = m2.GetParameters();
+
+            if (params1.Length != params2.Length)
+                return false;
+
+            int numParams = params1.Length;
+            for (int i = 0; i < numParams; i++)
+            {
+                if (params1[i].ParameterType != params2[i].ParameterType)
+                    return false;
+            }
+
+            return true;
+        }
+
+        private static int GetHierarchyDepth(Type t)
+        {
+            int depth = 0;
+
+            Type currentType = t;
+            do
+            {
+                depth++;
+                currentType = currentType.GetTypeInfo().BaseType;
+            } while (currentType != null);
+
+            return depth;
+        }
+
+        // CanConvertPrimitive
+        // This will determine if the source can be converted to the target type
+        private static bool CanConvertPrimitive(Type source, Type target)
+        {
+            return CanPrimitiveWiden(source, target);
+        }
+
+        // CanConvertPrimitiveObjectToType
+        private static bool CanConvertPrimitiveObjectToType(Object source, Type type)
+        {
+            return CanConvertPrimitive(source.GetType(), type);
+        }
+
+        #region Portable Runtime Augments Methods
+        private static bool CanPrimitiveWiden(Type source, Type target)
+        {
+            Primitives widerCodes = _primitiveConversions[(int)GetTypeCode(source)];
+            Primitives targetCode = (Primitives)(1 << (int)GetTypeCode(target));
+
+            return 0 != (widerCodes & targetCode);
+        }
+
+        [Flags]
+        private enum Primitives
+        {
+            Boolean = 1 << (int)TypeCode.Boolean,
+            Char = 1 << (int)TypeCode.Char,
+            SByte = 1 << (int)TypeCode.SByte,
+            Byte = 1 << (int)TypeCode.Byte,
+            Int16 = 1 << (int)TypeCode.Int16,
+            UInt16 = 1 << (int)TypeCode.UInt16,
+            Int32 = 1 << (int)TypeCode.Int32,
+            UInt32 = 1 << (int)TypeCode.UInt32,
+            Int64 = 1 << (int)TypeCode.Int64,
+            UInt64 = 1 << (int)TypeCode.UInt64,
+            Single = 1 << (int)TypeCode.Single,
+            Double = 1 << (int)TypeCode.Double,
+            Decimal = 1 << (int)TypeCode.Decimal,
+            DateTime = 1 << (int)TypeCode.DateTime,
+            String = 1 << (int)TypeCode.String,
+        }
+
+
+        private static Primitives[] _primitiveConversions = new Primitives[]
+        {
+            /* Empty    */  0, // not primitive
+            /* Object   */  0, // not primitive
+            /* DBNull   */  0, // not exposed.
+            /* Boolean  */  Primitives.Boolean,
+            /* Char     */  Primitives.Char    | Primitives.UInt16 | Primitives.UInt32 | Primitives.Int32  | Primitives.UInt64 | Primitives.Int64  | Primitives.Single |  Primitives.Double,
+            /* SByte    */  Primitives.SByte   | Primitives.Int16  | Primitives.Int32  | Primitives.Int64  | Primitives.Single | Primitives.Double,
+            /* Byte     */  Primitives.Byte    | Primitives.Char   | Primitives.UInt16 | Primitives.Int16  | Primitives.UInt32 | Primitives.Int32  | Primitives.UInt64 |  Primitives.Int64 |  Primitives.Single |  Primitives.Double,
+            /* Int16    */  Primitives.Int16   | Primitives.Int32  | Primitives.Int64  | Primitives.Single | Primitives.Double,
+            /* UInt16   */  Primitives.UInt16  | Primitives.UInt32 | Primitives.Int32  | Primitives.UInt64 | Primitives.Int64  | Primitives.Single | Primitives.Double,
+            /* Int32    */  Primitives.Int32   | Primitives.Int64  | Primitives.Single | Primitives.Double |
+            /* UInt32   */  Primitives.UInt32  | Primitives.UInt64 | Primitives.Int64  | Primitives.Single | Primitives.Double,
+            /* Int64    */  Primitives.Int64   | Primitives.Single | Primitives.Double,
+            /* UInt64   */  Primitives.UInt64  | Primitives.Single | Primitives.Double,
+            /* Single   */  Primitives.Single  | Primitives.Double,
+            /* Double   */  Primitives.Double,
+            /* Decimal  */  Primitives.Decimal,
+            /* DateTime */  Primitives.DateTime,
+            /* [Unused] */  0,
+            /* String   */  Primitives.String,
+        };
+
+        private static TypeCode GetTypeCode(Type type)
+        {
+            if (type == typeof(Boolean))
+                return TypeCode.Boolean;
+
+            if (type == typeof(Char))
+                return TypeCode.Char;
+
+            if (type == typeof(SByte))
+                return TypeCode.SByte;
+
+            if (type == typeof(Byte))
+                return TypeCode.Byte;
+
+            if (type == typeof(Int16))
+                return TypeCode.Int16;
+
+            if (type == typeof(UInt16))
+                return TypeCode.UInt16;
+
+            if (type == typeof(Int32))
+                return TypeCode.Int32;
+
+            if (type == typeof(UInt32))
+                return TypeCode.UInt32;
+
+            if (type == typeof(Int64))
+                return TypeCode.Int64;
+
+            if (type == typeof(UInt64))
+                return TypeCode.UInt64;
+
+            if (type == typeof(Single))
+                return TypeCode.Single;
+
+            if (type == typeof(Double))
+                return TypeCode.Double;
+
+            if (type == typeof(Decimal))
+                return TypeCode.Decimal;
+
+            if (type == typeof(DateTime))
+                return TypeCode.DateTime;
+
+            if (type.GetTypeInfo().IsEnum)
+                return GetTypeCode(Enum.GetUnderlyingType(type));
+
+            return TypeCode.Object;
+        }
+        #endregion Portable Runtime Augments Methods
+    }
+}

--- a/src/Common/src/Internal/Reflection/Execution/Binder/DefaultBinder.cs
+++ b/src/Common/src/Internal/Reflection/Execution/Binder/DefaultBinder.cs
@@ -1,20 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////
-//
 // Ported from desktop (BCL\System\DefaultBinder.cs)
-//
-//
 
-using global::System;
-using global::System.Reflection;
-using global::System.Runtime.CompilerServices;
-using global::System.Runtime.Versioning;
-using global::System.Diagnostics.Contracts;
-
-using global::Internal.Reflection.Core.Execution;
+using System;
+using System.Reflection;
+using System.Diagnostics.Contracts;
 
 namespace Internal.Reflection.Core.Execution.Binder
 {
@@ -33,11 +24,12 @@ namespace Internal.Reflection.Core.Execution.Binder
         // 
         // The most specific match will be selected.  
         // 
-        public static MethodBase BindToMethod(MethodBase[] match, ref Object[] args)
+        public static MethodBase BindToMethod(MethodBase[] match, ref object[] args)
         {
             if (match == null || match.Length == 0)
+            {
                 throw new ArgumentException(SR.Arg_EmptyArray, "match");
-            Contract.EndContractBlock();
+            }
 
             MethodBase[] candidates = (MethodBase[])match.Clone();
 
@@ -61,7 +53,9 @@ namespace Internal.Reflection.Core.Execution.Binder
 
                 // Default mapping
                 for (j = 0; j < args.Length; j++)
+                {
                     paramOrder[i][j] = j;
+                }
             }
             #endregion
 
@@ -94,7 +88,9 @@ namespace Internal.Reflection.Core.Execution.Binder
 
                 // If we have named parameters then we may have a hole in the candidates array.
                 if (candidates[i] == null)
+                {
                     continue;
+                }
 
                 // Validate the parameters.
                 ParameterInfo[] par = candidates[i].GetParameters();
@@ -106,7 +102,9 @@ namespace Internal.Reflection.Core.Execution.Binder
                     if (args.Length != 0)
                     {
                         if ((candidates[i].CallingConvention & CallingConventions.VarArgs) == 0)
+                        {
                             continue;
+                        }
                     }
 
                     // This is a valid routine so we move it up the candidates list.
@@ -124,19 +122,27 @@ namespace Internal.Reflection.Core.Execution.Binder
                     for (j = args.Length; j < par.Length - 1; j++)
                     {
                         if (!par[j].HasDefaultValue)
+                        {
                             break;
+                        }
                     }
 
                     if (j != par.Length - 1)
+                    {
                         continue;
+                    }
 
                     if (!par[j].HasDefaultValue)
                     {
                         if (!par[j].ParameterType.IsArray)
+                        {
                             continue;
+                        }
 
                         if (!HasParamArrayAttribute(par[j]))
+                        {
                             continue;
+                        }
 
                         paramArrayType = par[j].ParameterType.GetElementType();
                     }
@@ -149,13 +155,19 @@ namespace Internal.Reflection.Core.Execution.Binder
                     int lastArgPos = par.Length - 1;
 
                     if (!par[lastArgPos].ParameterType.IsArray)
+                    {
                         continue;
+                    }
 
                     if (!HasParamArrayAttribute(par[lastArgPos]))
+                    {
                         continue;
+                    }
 
                     if (paramOrder[i][lastArgPos] != lastArgPos)
+                    {
                         continue;
+                    }
 
                     paramArrayType = par[lastArgPos].ParameterType.GetElementType();
                     #endregion
@@ -170,7 +182,9 @@ namespace Internal.Reflection.Core.Execution.Binder
                         && paramOrder[i][lastArgPos] == lastArgPos)
                     {
                         if (!par[lastArgPos].ParameterType.GetTypeInfo().IsAssignableFrom(argTypes[lastArgPos].GetTypeInfo()))
+                        {
                             paramArrayType = par[lastArgPos].ParameterType.GetElementType();
+                        }
                     }
                     #endregion
                 }
@@ -187,19 +201,27 @@ namespace Internal.Reflection.Core.Execution.Binder
                     pCls = par[j].ParameterType;
 
                     if (pCls.IsByRef)
+                    {
                         pCls = pCls.GetElementType();
+                    }
 
                     // the type is the same
                     if (pCls == argTypes[paramOrder[i][j]])
+                    {
                         continue;
+                    }
 
                     // the argument was null, so it matches with everything
                     if (args[paramOrder[i][j]] == null)
+                    {
                         continue;
+                    }
 
                     // the type is Object, so it will match everything
                     if (pCls == typeof(Object))
+                    {
                         continue;
+                    }
 
                     // now do a "classic" type check
                     if (pCls.GetTypeInfo().IsPrimitive)
@@ -212,7 +234,9 @@ namespace Internal.Reflection.Core.Execution.Binder
                     else
                     {
                         if (argTypes[paramOrder[i][j]] == null)
+                        {
                             continue;
+                        }
 
                         if (!pCls.GetTypeInfo().IsAssignableFrom(argTypes[paramOrder[i][j]].GetTypeInfo()))
                         {
@@ -234,12 +258,16 @@ namespace Internal.Reflection.Core.Execution.Binder
                         if (paramArrayType.GetTypeInfo().IsPrimitive)
                         {
                             if (argTypes[j] == null || !CanConvertPrimitiveObjectToType(args[j], paramArrayType))
+                            {
                                 break;
+                            }
                         }
                         else
                         {
                             if (argTypes[j] == null)
+                            {
                                 continue;
+                            }
 
                             if (!paramArrayType.GetTypeInfo().IsAssignableFrom(argTypes[j].GetTypeInfo()))
                             {
@@ -264,7 +292,9 @@ namespace Internal.Reflection.Core.Execution.Binder
 
             // If we didn't find a method 
             if (CurIdx == 0)
+            {
                 throw new MissingMethodException(SR.MissingMember);
+            }
 
             if (CurIdx == 1)
             {
@@ -290,16 +320,24 @@ namespace Internal.Reflection.Core.Execution.Binder
                     Object[] objs = new Object[parms.Length];
 
                     for (i = 0; i < args.Length; i++)
+                    {
                         objs[i] = args[i];
+                    }
 
                     for (; i < parms.Length - 1; i++)
+                    {
                         objs[i] = parms[i].DefaultValue;
+                    }
 
                     if (paramArrayTypes[0] != null)
+                    {
                         objs[i] = Array.CreateInstance(paramArrayTypes[0], 0); // create an empty array for the 
+                    }
 
                     else
+                    {
                         objs[i] = parms[i].DefaultValue;
+                    }
 
                     args = objs;
                 }
@@ -341,7 +379,9 @@ namespace Internal.Reflection.Core.Execution.Binder
             }
 
             if (ambig)
+            {
                 throw new AmbiguousMatchException(SR.Arg_AmbiguousMatchException);
+            }
 
             // If the parameters and the args are not the same length or there is a paramArray
             //  then we need to create a argument array.
@@ -363,10 +403,14 @@ namespace Internal.Reflection.Core.Execution.Binder
                 Object[] objs = new Object[parameters.Length];
 
                 for (i = 0; i < args.Length; i++)
+                {
                     objs[i] = args[i];
+                }
 
                 for (; i < parameters.Length - 1; i++)
+                {
                     objs[i] = parameters[i].DefaultValue;
+                }
 
                 if (paramArrayTypes[currentMin] != null)
                 {
@@ -418,39 +462,57 @@ namespace Internal.Reflection.Core.Execution.Binder
                 {
                     Type pCls = par[j].ParameterType;
                     if (pCls == types[j])
+                    {
                         continue;
+                    }
                     if (pCls == typeof(Object))
+                    {
                         continue;
+                    }
                     if (pCls.GetTypeInfo().IsPrimitive)
                     {
                         if (!CanConvertPrimitive(types[j], pCls))
+                        {
                             break;
+                        }
                     }
                     else
                     {
                         if (!pCls.GetTypeInfo().IsAssignableFrom(types[j].GetTypeInfo()))
+                        {
                             break;
+                        }
                     }
                 }
                 if (j == types.Length)
+                {
                     candidates[CurIdx++] = candidates[i];
+                }
             }
             if (CurIdx == 0)
+            {
                 return null;
+            }
             if (CurIdx == 1)
+            {
                 return candidates[0];
+            }
 
             // Walk all of the methods looking the most specific method to invoke
             int currentMin = 0;
             bool ambig = false;
             int[] paramOrder = new int[types.Length];
             for (i = 0; i < types.Length; i++)
+            {
                 paramOrder[i] = i;
+            }
             for (i = 1; i < CurIdx; i++)
             {
                 int newMin = FindMostSpecificMethod(candidates[currentMin], paramOrder, null, candidates[i], paramOrder, null, types, null);
                 if (newMin == 0)
+                {
                     ambig = true;
+                }
                 else
                 {
                     if (newMin == 2)
@@ -462,7 +524,10 @@ namespace Internal.Reflection.Core.Execution.Binder
                 }
             }
             if (ambig)
+            {
                 throw new AmbiguousMatchException(SR.Arg_AmbiguousMatchException);
+            }
+
             return candidates[currentMin];
         }
 
@@ -471,8 +536,11 @@ namespace Internal.Reflection.Core.Execution.Binder
             foreach (CustomAttributeData cad in parameterInfo.CustomAttributes)
             {
                 if (cad.AttributeType.Equals(typeof(ParamArrayAttribute)))
+                {
                     return true;
+                }
             }
+
             return false;
         }
 
@@ -481,8 +549,14 @@ namespace Internal.Reflection.Core.Execution.Binder
                                             Type[] types, Object[] args)
         {
             // A method using params is always less specific than one not using params
-            if (paramArrayType1 != null && paramArrayType2 == null) return 2;
-            if (paramArrayType2 != null && paramArrayType1 == null) return 1;
+            if (paramArrayType1 != null && paramArrayType2 == null)
+            {
+                return 2;
+            }
+            if (paramArrayType2 != null && paramArrayType1 == null)
+            {
+                return 1;
+            }
 
             // now either p1 and p2 both use params or neither does.
 
@@ -492,7 +566,9 @@ namespace Internal.Reflection.Core.Execution.Binder
             for (int i = 0; i < types.Length; i++)
             {
                 if (args != null && args[i] == Type.Missing)
+                {
                     continue;
+                }
 
                 Type c1, c2;
 
@@ -507,16 +583,27 @@ namespace Internal.Reflection.Core.Execution.Binder
                 //          so any index >= p.Length - 1 is being put in the param array
 
                 if (paramArrayType1 != null && paramOrder1[i] >= p1.Length - 1)
+                {
                     c1 = paramArrayType1;
+                }
                 else
+                {
                     c1 = p1[paramOrder1[i]].ParameterType;
+                }
 
                 if (paramArrayType2 != null && paramOrder2[i] >= p2.Length - 1)
+                {
                     c2 = paramArrayType2;
+                }
                 else
+                {
                     c2 = p2[paramOrder2[i]].ParameterType;
+                }
 
-                if (c1 == c2) continue;
+                if (c1 == c2)
+                {
+                    continue;
+                }
 
                 switch (FindMostSpecificType(c1, c2, types[i]))
                 {
@@ -557,13 +644,19 @@ namespace Internal.Reflection.Core.Execution.Binder
         {
             // If the two types are exact move on...
             if (c1 == c2)
+            {
                 return 0;
+            }
 
             if (c1 == t)
+            {
                 return 1;
+            }
 
             if (c2 == t)
+            {
                 return 2;
+            }
 
             bool c1FromC2;
             bool c2FromC1;
@@ -578,14 +671,18 @@ namespace Internal.Reflection.Core.Execution.Binder
                 else if (c1.IsByRef)
                 {
                     if (c1.GetElementType() == c2)
+                    {
                         return 2;
+                    }
 
                     c1 = c1.GetElementType();
                 }
                 else
                 {
                     if (c2.GetElementType() == c1)
+                    {
                         return 1;
+                    }
 
                     c2 = c2.GetElementType();
                 }
@@ -616,8 +713,7 @@ namespace Internal.Reflection.Core.Execution.Binder
             }
         }
 
-        public static PropertyInfo SelectProperty(PropertyInfo[] match, Type returnType,
-                    Type[] indexes)
+        public static PropertyInfo SelectProperty(PropertyInfo[] match, Type returnType, Type[] indexes)
         {
             // Allow a null indexes array. But if it is not null, every element must be non-null as well.
             if (indexes != null && !Contract.ForAll(indexes, delegate (Type t) { return t != null; }))
@@ -627,8 +723,9 @@ namespace Internal.Reflection.Core.Execution.Binder
                 throw e;
             }
             if (match == null || match.Length == 0)
+            {
                 throw new ArgumentException(SR.Arg_EmptyArray, "match");
-            Contract.EndContractBlock();
+            }
 
             PropertyInfo[] candidates = (PropertyInfo[])match.Clone();
 
@@ -643,7 +740,9 @@ namespace Internal.Reflection.Core.Execution.Binder
                 {
                     ParameterInfo[] par = candidates[i].GetIndexParameters();
                     if (par.Length != indexesLength)
+                    {
                         continue;
+                    }
 
                     for (j = 0; j < indexesLength; j++)
                     {
@@ -651,19 +750,27 @@ namespace Internal.Reflection.Core.Execution.Binder
 
                         // If the classes  exactly match continue
                         if (pCls == indexes[j])
+                        {
                             continue;
+                        }
                         if (pCls == typeof(Object))
+                        {
                             continue;
+                        }
 
                         if (pCls.GetTypeInfo().IsPrimitive)
                         {
                             if (!CanConvertPrimitive(indexes[j], pCls))
+                            {
                                 break;
+                            }
                         }
                         else
                         {
                             if (!pCls.GetTypeInfo().IsAssignableFrom(indexes[j].GetTypeInfo()))
+                            {
                                 break;
+                            }
                         }
                     }
                 }
@@ -675,28 +782,38 @@ namespace Internal.Reflection.Core.Execution.Binder
                         if (candidates[i].PropertyType.GetTypeInfo().IsPrimitive)
                         {
                             if (!CanConvertPrimitive(returnType, candidates[i].PropertyType))
+                            {
                                 continue;
+                            }
                         }
                         else
                         {
                             if (!candidates[i].PropertyType.GetTypeInfo().IsAssignableFrom(returnType.GetTypeInfo()))
+                            {
                                 continue;
+                            }
                         }
                     }
                     candidates[CurIdx++] = candidates[i];
                 }
             }
             if (CurIdx == 0)
+            {
                 return null;
+            }
             if (CurIdx == 1)
+            {
                 return candidates[0];
+            }
 
             // Walk all of the properties looking the most specific method to invoke
             int currentMin = 0;
             bool ambig = false;
             int[] paramOrder = new int[indexesLength];
             for (i = 0; i < indexesLength; i++)
+            {
                 paramOrder[i] = i;
+            }
             for (i = 1; i < CurIdx; i++)
             {
                 int newMin = FindMostSpecificType(candidates[currentMin].PropertyType, candidates[i].PropertyType, returnType);
@@ -713,7 +830,9 @@ namespace Internal.Reflection.Core.Execution.Binder
                 {
                     newMin = FindMostSpecificProperty(candidates[currentMin], candidates[i]);
                     if (newMin == 0)
+                    {
                         ambig = true;
+                    }
                 }
                 if (newMin == 2)
                 {
@@ -723,7 +842,10 @@ namespace Internal.Reflection.Core.Execution.Binder
             }
 
             if (ambig)
+            {
                 throw new AmbiguousMatchException(SR.Arg_AmbiguousMatchException);
+            }
+
             return candidates[currentMin];
         }
 
@@ -737,7 +859,9 @@ namespace Internal.Reflection.Core.Execution.Binder
 
             // If the match was not ambigous then return the result.
             if (res != 0)
+            {
                 return res;
+            }
 
             // Check to see if the methods have the exact same name and signature.
             if (CompareMethodSigAndName(m1, m2))
@@ -778,9 +902,13 @@ namespace Internal.Reflection.Core.Execution.Binder
                     return 0;
                 }
                 else if (hierarchyDepth1 < hierarchyDepth2)
+                {
                     return 2;
+                }
                 else
+                {
                     return 1;
+                }
             }
 
             // The match is ambigous.
@@ -793,13 +921,17 @@ namespace Internal.Reflection.Core.Execution.Binder
             ParameterInfo[] params2 = m2.GetParameters();
 
             if (params1.Length != params2.Length)
+            {
                 return false;
+            }
 
             int numParams = params1.Length;
             for (int i = 0; i < numParams; i++)
             {
                 if (params1[i].ParameterType != params2[i].ParameterType)
+                {
                     return false;
+                }
             }
 
             return true;
@@ -888,49 +1020,79 @@ namespace Internal.Reflection.Core.Execution.Binder
         private static TypeCode GetTypeCode(Type type)
         {
             if (type == typeof(Boolean))
+            {
                 return TypeCode.Boolean;
+            }
 
             if (type == typeof(Char))
+            {
                 return TypeCode.Char;
+            }
 
             if (type == typeof(SByte))
+            {
                 return TypeCode.SByte;
+            }
 
             if (type == typeof(Byte))
+            {
                 return TypeCode.Byte;
+            }
 
             if (type == typeof(Int16))
+            {
                 return TypeCode.Int16;
+            }
 
             if (type == typeof(UInt16))
+            {
                 return TypeCode.UInt16;
+            }
 
             if (type == typeof(Int32))
+            {
                 return TypeCode.Int32;
+            }
 
             if (type == typeof(UInt32))
+            {
                 return TypeCode.UInt32;
+            }
 
             if (type == typeof(Int64))
+            {
                 return TypeCode.Int64;
+            }
 
             if (type == typeof(UInt64))
+            {
                 return TypeCode.UInt64;
+            }
 
             if (type == typeof(Single))
+            {
                 return TypeCode.Single;
+            }
 
             if (type == typeof(Double))
+            {
                 return TypeCode.Double;
+            }
 
             if (type == typeof(Decimal))
+            {
                 return TypeCode.Decimal;
+            }
 
             if (type == typeof(DateTime))
+            {
                 return TypeCode.DateTime;
+            }
 
             if (type.GetTypeInfo().IsEnum)
+            {
                 return GetTypeCode(Enum.GetUnderlyingType(type));
+            }
 
             return TypeCode.Object;
         }

--- a/src/System.Reflection.TypeExtensions/System.Reflection.TypeExtensions.sln
+++ b/src/System.Reflection.TypeExtensions/System.Reflection.TypeExtensions.sln
@@ -5,36 +5,69 @@ VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Reflection.TypeExtensions.CoreCLR", "src\System.Reflection.TypeExtensions.CoreCLR.csproj", "{1E689C1B-690C-4799-BDE9-6E7990585894}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{650D5B76-F9F7-4629-9237-3942E852F56E}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{330DBA8F-8363-4C47-AD9A-1203D264293D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{A13C6633-107D-4368-8648-0BA8ABC18F77}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Reflection.TypeExtensions", "ref\System.Reflection.TypeExtensions.csproj", "{5A7989CC-C142-40AC-821C-C4C9DD3193A2}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Reflection.TypeExtensions.Tests", "tests\System.Reflection.TypeExtensions.Tests.csproj", "{089444FE-8FF5-4D8F-A51B-32D026425F6B}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Reflection.TypeExtensions", "ref\System.Reflection.TypeExtensions.csproj", "{DA96367E-04D1-4057-997E-AED4A2773F0D}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Reflection.TypeExtensions.CoreCLR.Tests", "tests\CoreCLR\System.Reflection.TypeExtensions.CoreCLR.Tests.csproj", "{BED9F8D5-7420-404E-9EAD-D9148C16EAC1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		net46_Debug|Any CPU = net46_Debug|Any CPU
+		net46_Release|Any CPU = net46_Release|Any CPU
+		netcore50aot_Debug|Any CPU = netcore50aot_Debug|Any CPU
+		netcore50aot_Release|Any CPU = netcore50aot_Release|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1E689C1B-690C-4799-BDE9-6E7990585894}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1E689C1B-690C-4799-BDE9-6E7990585894}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E689C1B-690C-4799-BDE9-6E7990585894}.net46_Debug|Any CPU.ActiveCfg = net46_Debug|Any CPU
+		{1E689C1B-690C-4799-BDE9-6E7990585894}.net46_Debug|Any CPU.Build.0 = net46_Debug|Any CPU
+		{1E689C1B-690C-4799-BDE9-6E7990585894}.net46_Release|Any CPU.ActiveCfg = net46_Release|Any CPU
+		{1E689C1B-690C-4799-BDE9-6E7990585894}.net46_Release|Any CPU.Build.0 = net46_Release|Any CPU
+		{1E689C1B-690C-4799-BDE9-6E7990585894}.netcore50aot_Debug|Any CPU.ActiveCfg = netcore50aot_Debug|Any CPU
+		{1E689C1B-690C-4799-BDE9-6E7990585894}.netcore50aot_Debug|Any CPU.Build.0 = netcore50aot_Debug|Any CPU
+		{1E689C1B-690C-4799-BDE9-6E7990585894}.netcore50aot_Release|Any CPU.ActiveCfg = netcore50aot_Release|Any CPU
+		{1E689C1B-690C-4799-BDE9-6E7990585894}.netcore50aot_Release|Any CPU.Build.0 = netcore50aot_Release|Any CPU
 		{1E689C1B-690C-4799-BDE9-6E7990585894}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1E689C1B-690C-4799-BDE9-6E7990585894}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A7989CC-C142-40AC-821C-C4C9DD3193A2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A7989CC-C142-40AC-821C-C4C9DD3193A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A7989CC-C142-40AC-821C-C4C9DD3193A2}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A7989CC-C142-40AC-821C-C4C9DD3193A2}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A7989CC-C142-40AC-821C-C4C9DD3193A2}.net46_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A7989CC-C142-40AC-821C-C4C9DD3193A2}.net46_Release|Any CPU.Build.0 = Debug|Any CPU
+		{5A7989CC-C142-40AC-821C-C4C9DD3193A2}.netcore50aot_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A7989CC-C142-40AC-821C-C4C9DD3193A2}.netcore50aot_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A7989CC-C142-40AC-821C-C4C9DD3193A2}.netcore50aot_Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A7989CC-C142-40AC-821C-C4C9DD3193A2}.netcore50aot_Release|Any CPU.Build.0 = Debug|Any CPU
+		{5A7989CC-C142-40AC-821C-C4C9DD3193A2}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A7989CC-C142-40AC-821C-C4C9DD3193A2}.Release|Any CPU.Build.0 = Debug|Any CPU
 		{089444FE-8FF5-4D8F-A51B-32D026425F6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{089444FE-8FF5-4D8F-A51B-32D026425F6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{089444FE-8FF5-4D8F-A51B-32D026425F6B}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{089444FE-8FF5-4D8F-A51B-32D026425F6B}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{089444FE-8FF5-4D8F-A51B-32D026425F6B}.net46_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{089444FE-8FF5-4D8F-A51B-32D026425F6B}.net46_Release|Any CPU.Build.0 = Release|Any CPU
+		{089444FE-8FF5-4D8F-A51B-32D026425F6B}.netcore50aot_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{089444FE-8FF5-4D8F-A51B-32D026425F6B}.netcore50aot_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{089444FE-8FF5-4D8F-A51B-32D026425F6B}.netcore50aot_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{089444FE-8FF5-4D8F-A51B-32D026425F6B}.netcore50aot_Release|Any CPU.Build.0 = Release|Any CPU
 		{089444FE-8FF5-4D8F-A51B-32D026425F6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{089444FE-8FF5-4D8F-A51B-32D026425F6B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DA96367E-04D1-4057-997E-AED4A2773F0D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{DA96367E-04D1-4057-997E-AED4A2773F0D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DA96367E-04D1-4057-997E-AED4A2773F0D}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{DA96367E-04D1-4057-997E-AED4A2773F0D}.Release|Any CPU.Build.0 = Debug|Any CPU
-		{BED9F8D5-7420-404E-9EAD-D9148C16EAC1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BED9F8D5-7420-404E-9EAD-D9148C16EAC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BED9F8D5-7420-404E-9EAD-D9148C16EAC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BED9F8D5-7420-404E-9EAD-D9148C16EAC1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{1E689C1B-690C-4799-BDE9-6E7990585894} = {650D5B76-F9F7-4629-9237-3942E852F56E}
+		{5A7989CC-C142-40AC-821C-C4C9DD3193A2} = {330DBA8F-8363-4C47-AD9A-1203D264293D}
+		{089444FE-8FF5-4D8F-A51B-32D026425F6B} = {A13C6633-107D-4368-8648-0BA8ABC18F77}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Reflection.TypeExtensions/src/Internal/Reflection/Extensions/NonPortable/InheritedPropertyInfo.cs
+++ b/src/System.Reflection.TypeExtensions/src/Internal/Reflection/Extensions/NonPortable/InheritedPropertyInfo.cs
@@ -17,6 +17,9 @@ namespace Internal.Reflection.Extensions.NonPortable
     //
     internal sealed class InheritedPropertyInfo : ExtensiblePropertyInfo
     {
+        private readonly PropertyInfo _underlyingPropertyInfo;
+        private readonly Type _reflectedType;
+
         internal InheritedPropertyInfo(PropertyInfo underlyingPropertyInfo, Type reflectedType)
         {
             // If the reflectedType is the declaring type, the caller should have used the original PropertyInfo.
@@ -72,13 +75,19 @@ namespace Internal.Reflection.Extensions.NonPortable
         {
             InheritedPropertyInfo other = obj as InheritedPropertyInfo;
             if (other == null)
+            {
                 return false;
+            }
 
             if (!(_underlyingPropertyInfo.Equals(other._underlyingPropertyInfo)))
+            {
                 return false;
+            }
 
             if (!(_reflectedType.Equals(other._reflectedType)))
+            {
                 return false;
+            }
 
             return true;
         }
@@ -107,7 +116,10 @@ namespace Internal.Reflection.Extensions.NonPortable
         public sealed override Object GetValue(Object obj, Object[] index)
         {
             if (GetMethod == null)
+            {
                 throw new ArgumentException(SR.Arg_GetMethNotFnd);
+            }
+
             return _underlyingPropertyInfo.GetValue(obj, index);
         }
 
@@ -133,7 +145,10 @@ namespace Internal.Reflection.Extensions.NonPortable
         public sealed override void SetValue(Object obj, Object value, Object[] index)
         {
             if (SetMethod == null)
+            {
                 throw new ArgumentException(SR.Arg_SetMethNotFnd);
+            }
+
             _underlyingPropertyInfo.SetValue(obj, value, index);
         }
 
@@ -146,13 +161,12 @@ namespace Internal.Reflection.Extensions.NonPortable
             //   A: That inconsistency is also desktop-compatible.
             //
             if (accessor == null || accessor.IsPrivate)
+            {
                 return null;
+            }
 
             return accessor;
         }
-
-        private PropertyInfo _underlyingPropertyInfo;
-        private Type _reflectedType;
     }
 }
  

--- a/src/System.Reflection.TypeExtensions/src/Internal/Reflection/Extensions/NonPortable/InheritedPropertyInfo.cs
+++ b/src/System.Reflection.TypeExtensions/src/Internal/Reflection/Extensions/NonPortable/InheritedPropertyInfo.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
+
+using Internal.Reflection.Extensibility;
+
+namespace Internal.Reflection.Extensions.NonPortable
+{
+    //
+    // This class exists for desktop compatibility. If one uses an api such as Type.GetProperty(string) to retrieve a member
+    // from a base class, the desktop returns a special MemberInfo object that is blocked from seeing or invoking private
+    // set or get methods on that property. That is, the type used to find the member is part of that member's object identity.
+    //
+    internal sealed class InheritedPropertyInfo : ExtensiblePropertyInfo
+    {
+        internal InheritedPropertyInfo(PropertyInfo underlyingPropertyInfo, Type reflectedType)
+        {
+            // If the reflectedType is the declaring type, the caller should have used the original PropertyInfo.
+            // This assert saves us from having to check this throughout.
+            Debug.Assert(!(reflectedType.Equals(underlyingPropertyInfo.DeclaringType)), "reflectedType must be a proper base type of (and not equal to) underlyingPropertyInfo.DeclaringType.");
+
+            _underlyingPropertyInfo = underlyingPropertyInfo;
+            _reflectedType = reflectedType;
+            return;
+        }
+
+        public sealed override PropertyAttributes Attributes
+        {
+            get { return _underlyingPropertyInfo.Attributes; }
+        }
+
+        public sealed override bool CanRead
+        {
+            get { return GetMethod != null; }
+        }
+
+        public sealed override bool CanWrite
+        {
+            get { return SetMethod != null; }
+        }
+
+        public sealed override ParameterInfo[] GetIndexParameters()
+        {
+            return _underlyingPropertyInfo.GetIndexParameters();
+        }
+
+        public sealed override Type PropertyType
+        {
+            get { return _underlyingPropertyInfo.PropertyType; }
+        }
+
+        public sealed override Type DeclaringType
+        {
+            get { return _underlyingPropertyInfo.DeclaringType; }
+        }
+
+        public sealed override String Name
+        {
+            get { return _underlyingPropertyInfo.Name; }
+        }
+
+        public sealed override IEnumerable<CustomAttributeData> CustomAttributes
+        {
+            get { return _underlyingPropertyInfo.CustomAttributes; }
+        }
+
+        public sealed override bool Equals(Object obj)
+        {
+            InheritedPropertyInfo other = obj as InheritedPropertyInfo;
+            if (other == null)
+                return false;
+
+            if (!(_underlyingPropertyInfo.Equals(other._underlyingPropertyInfo)))
+                return false;
+
+            if (!(_reflectedType.Equals(other._reflectedType)))
+                return false;
+
+            return true;
+        }
+
+        public sealed override int GetHashCode()
+        {
+            int hashCode = _reflectedType.GetHashCode();
+            hashCode ^= _underlyingPropertyInfo.GetHashCode();
+            return hashCode;
+        }
+
+        public sealed override Object GetConstantValue()
+        {
+            return _underlyingPropertyInfo.GetConstantValue();
+        }
+
+        public sealed override MethodInfo GetMethod
+        {
+            get
+            {
+                MethodInfo accessor = _underlyingPropertyInfo.GetMethod;
+                return Filter(accessor);
+            }
+        }
+
+        public sealed override Object GetValue(Object obj, Object[] index)
+        {
+            if (GetMethod == null)
+                throw new ArgumentException(SR.Arg_GetMethNotFnd);
+            return _underlyingPropertyInfo.GetValue(obj, index);
+        }
+
+        public sealed override Module Module
+        {
+            get { return _underlyingPropertyInfo.Module; }
+        }
+
+        public sealed override String ToString()
+        {
+            return _underlyingPropertyInfo.ToString();
+        }
+
+        public sealed override MethodInfo SetMethod
+        {
+            get
+            {
+                MethodInfo accessor = _underlyingPropertyInfo.SetMethod;
+                return Filter(accessor);
+            }
+        }
+
+        public sealed override void SetValue(Object obj, Object value, Object[] index)
+        {
+            if (SetMethod == null)
+                throw new ArgumentException(SR.Arg_SetMethNotFnd);
+            _underlyingPropertyInfo.SetValue(obj, value, index);
+        }
+
+        private MethodInfo Filter(MethodInfo accessor)
+        {
+            //
+            // For desktop compat, hide inherited accessors that are marked private.
+            //  
+            //   Q: Why don't we also hide cross-assembly "internal" accessors?
+            //   A: That inconsistency is also desktop-compatible.
+            //
+            if (accessor == null || accessor.IsPrivate)
+                return null;
+
+            return accessor;
+        }
+
+        private PropertyInfo _underlyingPropertyInfo;
+        private Type _reflectedType;
+    }
+}
+ 

--- a/src/System.Reflection.TypeExtensions/src/Internal/Reflection/Extensions/NonPortable/MemberEnumerator.cs
+++ b/src/System.Reflection.TypeExtensions/src/Internal/Reflection/Extensions/NonPortable/MemberEnumerator.cs
@@ -1,0 +1,212 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using global::System;
+using global::System.IO;
+using global::System.Linq;
+using global::System.Reflection;
+using global::System.Diagnostics;
+using global::System.Collections.Generic;
+
+namespace Internal.Reflection.Extensions.NonPortable
+{
+    public static class MemberEnumerator
+    {
+        //
+        // Enumerates members, optionally filtered by a name, in the given class and its base classes (but not implemented interfaces.)
+        // Basically emulates the old Type.GetFoo(BindingFlags) api.
+        //
+        public static IEnumerable<M> GetMembers<M>(this Type type, Object nameFilterOrAnyName, BindingFlags bindingFlags) where M : MemberInfo
+        {
+            // Do all the up-front argument validation here so that the exception occurs on call rather than on the first move.
+            if (type == null)
+                throw new ArgumentNullException();
+            if (nameFilterOrAnyName == null)
+                throw new ArgumentNullException();
+            String optionalNameFilter;
+            if (nameFilterOrAnyName == AnyName)
+                optionalNameFilter = null;
+            else
+                optionalNameFilter = (String)nameFilterOrAnyName;
+            return GetMembersWorker<M>(type, optionalNameFilter, bindingFlags);
+        }
+
+        //
+        // The iterator worker for GetMember<M>()
+        //
+        private static IEnumerable<M> GetMembersWorker<M>(Type type, String optionalNameFilter, BindingFlags bindingFlags) where M : MemberInfo
+        {
+            Type reflectedType = type;
+            Type typeOfM = typeof(M);
+            Type typeOfEventInfo = typeof(EventInfo);
+
+            MemberPolicies<M> policies = MemberPolicies<M>.Default;
+            bindingFlags = policies.ModifyBindingFlags(bindingFlags);
+
+            LowLevelList<M> overridingMembers = new LowLevelList<M>();
+
+            StringComparison comparisonType = (0 != (bindingFlags & BindingFlags.IgnoreCase)) ? StringComparison.CurrentCultureIgnoreCase : StringComparison.CurrentCulture;
+            bool inBaseClass = false;
+
+            bool nameFilterIsPrefix = false;
+            if (optionalNameFilter != null && optionalNameFilter.EndsWith("*", StringComparison.Ordinal))
+            {
+                nameFilterIsPrefix = true;
+                optionalNameFilter = optionalNameFilter.Substring(0, optionalNameFilter.Length - 1);
+            }
+
+            while (type != null)
+            {
+                TypeInfo typeInfo = type.GetTypeInfo();
+
+                foreach (M member in policies.GetDeclaredMembers(typeInfo))
+                {
+                    if (optionalNameFilter != null)
+                    {
+                        if (nameFilterIsPrefix)
+                        {
+                            if (!member.Name.StartsWith(optionalNameFilter, comparisonType))
+                                continue;
+                        }
+                        else if (!member.Name.Equals(optionalNameFilter, comparisonType))
+                        {
+                            continue;
+                        }
+                    }
+
+                    MethodAttributes visibility;
+                    bool isStatic;
+                    bool isVirtual;
+                    bool isNewSlot;
+                    policies.GetMemberAttributes(member, out visibility, out isStatic, out isVirtual, out isNewSlot);
+
+                    BindingFlags memberBindingFlags = (BindingFlags)0;
+                    memberBindingFlags |= (isStatic ? BindingFlags.Static : BindingFlags.Instance);
+                    memberBindingFlags |= ((visibility == MethodAttributes.Public) ? BindingFlags.Public : BindingFlags.NonPublic);
+                    if ((bindingFlags & memberBindingFlags) != memberBindingFlags)
+                        continue;
+
+                    bool passesVisibilityScreen = true;
+                    if (inBaseClass && visibility == MethodAttributes.Private)
+                        passesVisibilityScreen = false;
+
+                    bool passesStaticScreen = true;
+                    if (inBaseClass && isStatic && (0 == (bindingFlags & BindingFlags.FlattenHierarchy)))
+                        passesStaticScreen = false;
+
+                    //
+                    // Desktop compat: The order in which we do checks is important.
+                    //
+                    if (!passesVisibilityScreen)
+                        continue;
+                    if ((!passesStaticScreen) && !(typeOfM.Equals(typeOfEventInfo)))
+                        continue;
+
+                    bool isImplicitlyOverridden = false;
+                    if (isVirtual)
+                    {
+                        if (isNewSlot)
+                        {
+                            // A new virtual member definition.
+                            for (int i = 0; i < overridingMembers.Count; i++)
+                            {
+                                if (policies.AreNamesAndSignatureEqual(member, overridingMembers[i]))
+                                {
+                                    // This member is overridden by a more derived class.
+                                    isImplicitlyOverridden = true;
+                                    overridingMembers.RemoveAt(i);
+                                    break;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            for (int i = 0; i < overridingMembers.Count; i++)
+                            {
+                                if (policies.AreNamesAndSignatureEqual(overridingMembers[i], member))
+                                {
+                                    // This member overrides another, *and* is overridden by yet another method.
+                                    isImplicitlyOverridden = true;
+                                    break;
+                                }
+                            }
+
+                            if (!isImplicitlyOverridden)
+                            {
+                                // This member overrides another and is the most derived instance of it we've fonud.
+                                overridingMembers.Add(member);
+                            }
+                        }
+                    }
+
+                    if (isImplicitlyOverridden)
+                        continue;
+
+                    if (!passesStaticScreen)
+                        continue;
+
+                    if (inBaseClass)
+                        yield return policies.GetInheritedMemberInfo(member, reflectedType);
+                    else
+                        yield return member;
+                }
+
+                if (0 != (bindingFlags & BindingFlags.DeclaredOnly))
+                    break;
+
+                inBaseClass = true;
+                type = typeInfo.BaseType;
+            }
+        }
+
+        //
+        // If member is a virtual member that implicitly overrides a member in a base class, return the overridden member.
+        // Otherwise, return null.
+        //
+        // - MethodImpls ignored. (I didn't say it made sense, this is just how the desktop api we're porting behaves.)
+        // - Implemented interfaces ignores. (I didn't say it made sense, this is just how the desktop api we're porting behaves.) 
+        //
+        public static M GetImplicitlyOverriddenBaseClassMember<M>(this M member) where M : MemberInfo
+        {
+            MemberPolicies<M> policies = MemberPolicies<M>.Default;
+            MethodAttributes visibility;
+            bool isStatic;
+            bool isVirtual;
+            bool isNewSlot;
+            policies.GetMemberAttributes(member, out visibility, out isStatic, out isVirtual, out isNewSlot);
+            if (isNewSlot || !isVirtual)
+                return null;
+            String name = member.Name;
+            TypeInfo typeInfo = member.DeclaringType.GetTypeInfo();
+            for (; ;)
+            {
+                Type baseType = typeInfo.BaseType;
+                if (baseType == null)
+                    return null;
+                typeInfo = baseType.GetTypeInfo();
+                foreach (M candidate in policies.GetDeclaredMembers(typeInfo))
+                {
+                    if (candidate.Name != name)
+                        continue;
+                    MethodAttributes candidateVisibility;
+                    bool isCandidateStatic;
+                    bool isCandidateVirtual;
+                    bool isCandidateNewSlot;
+                    policies.GetMemberAttributes(member, out candidateVisibility, out isCandidateStatic, out isCandidateVirtual, out isCandidateNewSlot);
+                    if (!isCandidateVirtual)
+                        continue;
+                    if (!policies.AreNamesAndSignatureEqual(member, candidate))
+                        continue;
+                    return candidate;
+                }
+            }
+        }
+
+        // Uniquely allocated sentinel "string"
+        //  - can't use null as that may be an app-supplied null, which we have to throw ArgumentNullException for.
+        //  - risky to use a proper String as the FX or toolchain can unexpectedly give you back a shared string
+        //    even when you'd swear you were allocating a new one.
+        public static readonly Object AnyName = new Object();
+    }
+}
+

--- a/src/System.Reflection.TypeExtensions/src/Internal/Reflection/Extensions/NonPortable/MemberEnumerator.cs
+++ b/src/System.Reflection.TypeExtensions/src/Internal/Reflection/Extensions/NonPortable/MemberEnumerator.cs
@@ -1,12 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using global::System;
-using global::System.IO;
-using global::System.Linq;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
+using System;
+using System.Reflection;
+using System.Collections.Generic;
 
 namespace Internal.Reflection.Extensions.NonPortable
 {
@@ -20,14 +17,24 @@ namespace Internal.Reflection.Extensions.NonPortable
         {
             // Do all the up-front argument validation here so that the exception occurs on call rather than on the first move.
             if (type == null)
+            {
                 throw new ArgumentNullException();
+            }
             if (nameFilterOrAnyName == null)
+            {
                 throw new ArgumentNullException();
+            }
+
             String optionalNameFilter;
             if (nameFilterOrAnyName == AnyName)
+            {
                 optionalNameFilter = null;
+            }
             else
+            {
                 optionalNameFilter = (String)nameFilterOrAnyName;
+            }
+
             return GetMembersWorker<M>(type, optionalNameFilter, bindingFlags);
         }
 
@@ -66,7 +73,9 @@ namespace Internal.Reflection.Extensions.NonPortable
                         if (nameFilterIsPrefix)
                         {
                             if (!member.Name.StartsWith(optionalNameFilter, comparisonType))
+                            {
                                 continue;
+                            }
                         }
                         else if (!member.Name.Equals(optionalNameFilter, comparisonType))
                         {
@@ -84,23 +93,33 @@ namespace Internal.Reflection.Extensions.NonPortable
                     memberBindingFlags |= (isStatic ? BindingFlags.Static : BindingFlags.Instance);
                     memberBindingFlags |= ((visibility == MethodAttributes.Public) ? BindingFlags.Public : BindingFlags.NonPublic);
                     if ((bindingFlags & memberBindingFlags) != memberBindingFlags)
+                    {
                         continue;
+                    }
 
                     bool passesVisibilityScreen = true;
                     if (inBaseClass && visibility == MethodAttributes.Private)
+                    {
                         passesVisibilityScreen = false;
+                    }
 
                     bool passesStaticScreen = true;
                     if (inBaseClass && isStatic && (0 == (bindingFlags & BindingFlags.FlattenHierarchy)))
+                    {
                         passesStaticScreen = false;
+                    }
 
                     //
                     // Desktop compat: The order in which we do checks is important.
                     //
                     if (!passesVisibilityScreen)
+                    {
                         continue;
+                    }
                     if ((!passesStaticScreen) && !(typeOfM.Equals(typeOfEventInfo)))
+                    {
                         continue;
+                    }
 
                     bool isImplicitlyOverridden = false;
                     if (isVirtual)
@@ -140,19 +159,29 @@ namespace Internal.Reflection.Extensions.NonPortable
                     }
 
                     if (isImplicitlyOverridden)
+                    {
                         continue;
+                    }
 
                     if (!passesStaticScreen)
+                    {
                         continue;
+                    }
 
                     if (inBaseClass)
+                    {
                         yield return policies.GetInheritedMemberInfo(member, reflectedType);
+                    }
                     else
+                    {
                         yield return member;
+                    }
                 }
 
                 if (0 != (bindingFlags & BindingFlags.DeclaredOnly))
+                {
                     break;
+                }
 
                 inBaseClass = true;
                 type = typeInfo.BaseType;
@@ -175,28 +204,38 @@ namespace Internal.Reflection.Extensions.NonPortable
             bool isNewSlot;
             policies.GetMemberAttributes(member, out visibility, out isStatic, out isVirtual, out isNewSlot);
             if (isNewSlot || !isVirtual)
+            {
                 return null;
+            }
             String name = member.Name;
             TypeInfo typeInfo = member.DeclaringType.GetTypeInfo();
             for (; ;)
             {
                 Type baseType = typeInfo.BaseType;
                 if (baseType == null)
+                {
                     return null;
+                }
                 typeInfo = baseType.GetTypeInfo();
                 foreach (M candidate in policies.GetDeclaredMembers(typeInfo))
                 {
                     if (candidate.Name != name)
+                    {
                         continue;
+                    }
                     MethodAttributes candidateVisibility;
                     bool isCandidateStatic;
                     bool isCandidateVirtual;
                     bool isCandidateNewSlot;
                     policies.GetMemberAttributes(member, out candidateVisibility, out isCandidateStatic, out isCandidateVirtual, out isCandidateNewSlot);
                     if (!isCandidateVirtual)
+                    {
                         continue;
+                    }
                     if (!policies.AreNamesAndSignatureEqual(member, candidate))
+                    {
                         continue;
+                    }
                     return candidate;
                 }
             }
@@ -209,4 +248,3 @@ namespace Internal.Reflection.Extensions.NonPortable
         public static readonly Object AnyName = new Object();
     }
 }
-

--- a/src/System.Reflection.TypeExtensions/src/Internal/Reflection/Extensions/NonPortable/MemberPolicies.cs
+++ b/src/System.Reflection.TypeExtensions/src/Internal/Reflection/Extensions/NonPortable/MemberPolicies.cs
@@ -1,0 +1,316 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using global::System;
+using global::System.IO;
+using global::System.Linq;
+using global::System.Reflection;
+using global::System.Diagnostics;
+using global::System.Collections.Generic;
+
+namespace Internal.Reflection.Extensions.NonPortable
+{
+    //=================================================================================================================
+    // This class encapsulates the minimum set of arcane desktop CLR policies needed to implement the System.Reflections.Extensions contract.
+    //
+    // In particular, it encapsulates behaviors such as what exactly determines the "visibility" of a property and event, and
+    // what determines whether and how they are overridden.
+    //=================================================================================================================
+    internal abstract class MemberPolicies<M> where M : MemberInfo
+    {
+        //=================================================================================================================
+        // Subclasses for specific MemberInfo types must override these:
+        //=================================================================================================================
+
+        //
+        // Returns all of the directly declared members on the given TypeInfo.
+        //
+        public abstract IEnumerable<M> GetDeclaredMembers(TypeInfo typeInfo);
+
+        //
+        // Policy to decide whether a member is considered "virtual", "virtual new" and what its member visibility is.
+        // (For "visbility", we reuse the MethodAttributes enum since Reflection lacks an element-agnostic enum for this.
+        //  Only the MemberAccessMask bits are set.)
+        //
+        public abstract void GetMemberAttributes(M member, out MethodAttributes visibility, out bool isStatic, out bool isVirtual, out bool isNewSlot);
+
+        //
+        // Policy to decide whether two virtual members are signature-compatible for the purpose of implicit overriding. 
+        //
+        public abstract bool AreNamesAndSignatureEqual(M member1, M member2);
+
+        //
+        // Policy to decide how BindingFlags should be reinterpreted for a given member type.
+        // This is overridden for nested types which all match on any combination Instance | Static and are never inherited.
+        // It is also overridden for constructors which are never inherited.
+        //
+        public virtual BindingFlags ModifyBindingFlags(BindingFlags bindingFlags)
+        {
+            return bindingFlags;
+        }
+
+        //
+        // Policy to create a wrapper MemberInfo (if appropriate). This is due to the fact that MemberInfo's actually have their identity
+        // tied to the type they were queried off of and this unfortunate fact shows up in certain api behaviors.
+        //
+        public virtual M GetInheritedMemberInfo(M underlyingMemberInfo, Type reflectedType)
+        {
+            return underlyingMemberInfo;
+        }
+
+        //
+        // Helper method for determining whether two methods are signature-compatible for the purpose of implicit overriding.
+        //
+        protected static bool AreNamesAndSignaturesEqual(MethodInfo method1, MethodInfo method2)
+        {
+            if (method1.Name != method2.Name)
+                return false;
+
+            ParameterInfo[] p1 = method1.GetParameters();
+            ParameterInfo[] p2 = method2.GetParameters();
+            if (p1.Length != p2.Length)
+                return false;
+
+            for (int i = 0; i < p1.Length; i++)
+            {
+                Type parameterType1 = p1[i].ParameterType;
+                Type parameterType2 = p2[i].ParameterType;
+                if (!(parameterType1.Equals(parameterType2)))
+                    return false;
+            }
+            return true;
+        }
+
+        //
+        // This is a singleton class one for each MemberInfo category: Return the appropriate one. 
+        //
+        public static MemberPolicies<M> Default
+        {
+            get
+            {
+                if (_default == null)
+                {
+                    Type t = typeof(M);
+                    if (t.Equals(typeof(FieldInfo)))
+                        _default = (MemberPolicies<M>)(Object)(new FieldPolicies());
+                    else if (t.Equals(typeof(MethodInfo)))
+                        _default = (MemberPolicies<M>)(Object)(new MethodPolicies());
+                    else if (t.Equals(typeof(ConstructorInfo)))
+                        _default = (MemberPolicies<M>)(Object)(new ConstructorPolicies());
+                    else if (t.Equals(typeof(PropertyInfo)))
+                        _default = (MemberPolicies<M>)(Object)(new PropertyPolicies());
+                    else if (t.Equals(typeof(EventInfo)))
+                        _default = (MemberPolicies<M>)(Object)(new EventPolicies());
+                    else if (t.Equals(typeof(TypeInfo)))
+                        _default = (MemberPolicies<M>)(Object)(new NestedTypePolicies());
+                    else
+                        Debug.Assert(false, "Unknown MemberInfo type.");
+                }
+                return _default;
+            }
+        }
+
+        private static volatile MemberPolicies<M> _default;
+    }
+
+    //==========================================================================================================================
+    // Policies for fields.
+    //==========================================================================================================================
+    internal sealed class FieldPolicies : MemberPolicies<FieldInfo>
+    {
+        public sealed override IEnumerable<FieldInfo> GetDeclaredMembers(TypeInfo typeInfo)
+        {
+            return typeInfo.DeclaredFields;
+        }
+
+        public sealed override void GetMemberAttributes(FieldInfo member, out MethodAttributes visibility, out bool isStatic, out bool isVirtual, out bool isNewSlot)
+        {
+            FieldAttributes fieldAttributes = member.Attributes;
+            visibility = (MethodAttributes)(fieldAttributes & FieldAttributes.FieldAccessMask);
+            isStatic = (0 != (fieldAttributes & FieldAttributes.Static));
+            isVirtual = false;
+            isNewSlot = false;
+        }
+
+        public sealed override bool AreNamesAndSignatureEqual(FieldInfo member1, FieldInfo member2)
+        {
+            Debug.Assert(false, "This code path should be unreachable as fields are never \"virtual\".");
+            throw new NotSupportedException();
+        }
+    }
+
+
+    //==========================================================================================================================
+    // Policies for constructors.
+    //==========================================================================================================================
+    internal sealed class ConstructorPolicies : MemberPolicies<ConstructorInfo>
+    {
+        public sealed override IEnumerable<ConstructorInfo> GetDeclaredMembers(TypeInfo typeInfo)
+        {
+            return typeInfo.DeclaredConstructors;
+        }
+
+        public sealed override BindingFlags ModifyBindingFlags(BindingFlags bindingFlags)
+        {
+            // Constructors are not inherited.
+            return bindingFlags | BindingFlags.DeclaredOnly;
+        }
+
+        public sealed override void GetMemberAttributes(ConstructorInfo member, out MethodAttributes visibility, out bool isStatic, out bool isVirtual, out bool isNewSlot)
+        {
+            MethodAttributes methodAttributes = member.Attributes;
+            visibility = methodAttributes & MethodAttributes.MemberAccessMask;
+            isStatic = (0 != (methodAttributes & MethodAttributes.Static));
+            isVirtual = false;
+            isNewSlot = false;
+        }
+
+        public sealed override bool AreNamesAndSignatureEqual(ConstructorInfo member1, ConstructorInfo member2)
+        {
+            Debug.Assert(false, "This code path should be unreachable as constructors are never \"virtual\".");
+            throw new NotSupportedException();
+        }
+    }
+
+
+    //==========================================================================================================================
+    // Policies for methods.
+    //==========================================================================================================================
+    internal sealed class MethodPolicies : MemberPolicies<MethodInfo>
+    {
+        public sealed override IEnumerable<MethodInfo> GetDeclaredMembers(TypeInfo typeInfo)
+        {
+            return typeInfo.DeclaredMethods;
+        }
+
+        public sealed override void GetMemberAttributes(MethodInfo member, out MethodAttributes visibility, out bool isStatic, out bool isVirtual, out bool isNewSlot)
+        {
+            MethodAttributes methodAttributes = member.Attributes;
+            visibility = methodAttributes & MethodAttributes.MemberAccessMask;
+            isStatic = (0 != (methodAttributes & MethodAttributes.Static));
+            isVirtual = (0 != (methodAttributes & MethodAttributes.Virtual));
+            isNewSlot = (0 != (methodAttributes & MethodAttributes.NewSlot));
+        }
+
+        public sealed override bool AreNamesAndSignatureEqual(MethodInfo member1, MethodInfo member2)
+        {
+            return AreNamesAndSignaturesEqual(member1, member2);
+        }
+    }
+
+    //==========================================================================================================================
+    // Policies for properties.
+    //==========================================================================================================================
+    internal sealed class PropertyPolicies : MemberPolicies<PropertyInfo>
+    {
+        public sealed override IEnumerable<PropertyInfo> GetDeclaredMembers(TypeInfo typeInfo)
+        {
+            return typeInfo.DeclaredProperties;
+        }
+
+        public sealed override void GetMemberAttributes(PropertyInfo member, out MethodAttributes visibility, out bool isStatic, out bool isVirtual, out bool isNewSlot)
+        {
+            MethodInfo accessorMethod = GetAccessorMethod(member);
+            MethodAttributes methodAttributes = accessorMethod.Attributes;
+            visibility = methodAttributes & MethodAttributes.MemberAccessMask;
+            isStatic = (0 != (methodAttributes & MethodAttributes.Static));
+            isVirtual = (0 != (methodAttributes & MethodAttributes.Virtual));
+            isNewSlot = (0 != (methodAttributes & MethodAttributes.NewSlot));
+        }
+
+        public sealed override bool AreNamesAndSignatureEqual(PropertyInfo member1, PropertyInfo member2)
+        {
+            return AreNamesAndSignaturesEqual(GetAccessorMethod(member1), GetAccessorMethod(member2));
+        }
+
+        public sealed override PropertyInfo GetInheritedMemberInfo(PropertyInfo underlyingMemberInfo, Type reflectedType)
+        {
+            return new InheritedPropertyInfo(underlyingMemberInfo, reflectedType);
+        }
+
+        private MethodInfo GetAccessorMethod(PropertyInfo property)
+        {
+            MethodInfo accessor = property.GetMethod;
+            if (accessor == null)
+                accessor = property.SetMethod;
+            return accessor;
+        }
+    }
+
+    //==========================================================================================================================
+    // Policies for events.
+    //==========================================================================================================================
+    internal sealed class EventPolicies : MemberPolicies<EventInfo>
+    {
+        public sealed override IEnumerable<EventInfo> GetDeclaredMembers(TypeInfo typeInfo)
+        {
+            return typeInfo.DeclaredEvents;
+        }
+
+        public sealed override void GetMemberAttributes(EventInfo member, out MethodAttributes visibility, out bool isStatic, out bool isVirtual, out bool isNewSlot)
+        {
+            MethodInfo accessorMethod = GetAccessorMethod(member);
+            MethodAttributes methodAttributes = accessorMethod.Attributes;
+            visibility = methodAttributes & MethodAttributes.MemberAccessMask;
+            isStatic = (0 != (methodAttributes & MethodAttributes.Static));
+            isVirtual = (0 != (methodAttributes & MethodAttributes.Virtual));
+            isNewSlot = (0 != (methodAttributes & MethodAttributes.NewSlot));
+        }
+
+        public sealed override bool AreNamesAndSignatureEqual(EventInfo member1, EventInfo member2)
+        {
+            return AreNamesAndSignaturesEqual(GetAccessorMethod(member1), GetAccessorMethod(member2));
+        }
+
+        private MethodInfo GetAccessorMethod(EventInfo e)
+        {
+            MethodInfo accessor = e.AddMethod;
+            return accessor;
+        }
+    }
+
+    //==========================================================================================================================
+    // Policies for nested types.
+    //
+    // Nested types enumerate a little differently than other members:
+    //
+    //    Base classes are never searched, regardless of BindingFlags.DeclaredOnly value.
+    //
+    //    Public|NonPublic|IgnoreCase are the only relevant BindingFlags. The apis ignore any other bits.
+    //
+    //    There is no such thing as a "static" or "instanced" nested type. For enumeration purposes,
+    //    we'll arbitrarily denote all nested types as "static."
+    //
+    //==========================================================================================================================
+    internal sealed class NestedTypePolicies : MemberPolicies<TypeInfo>
+    {
+        public sealed override IEnumerable<TypeInfo> GetDeclaredMembers(TypeInfo typeInfo)
+        {
+            return typeInfo.DeclaredNestedTypes;
+        }
+
+        public sealed override void GetMemberAttributes(TypeInfo member, out MethodAttributes visibility, out bool isStatic, out bool isVirtual, out bool isNewSlot)
+        {
+            isStatic = true;
+            isVirtual = false;
+            isNewSlot = false;
+
+            // Since we never search base types for nested types, we don't need to map every visibility value one to one.
+            // We just need to distinguish between "public" and "everything else."
+            visibility = member.IsNestedPublic ? MethodAttributes.Public : MethodAttributes.Private;
+        }
+
+        public sealed override bool AreNamesAndSignatureEqual(TypeInfo member1, TypeInfo member2)
+        {
+            Debug.Assert(false, "This code path should be unreachable as nested types are never \"virtual\".");
+            throw new NotSupportedException();
+        }
+
+        public sealed override BindingFlags ModifyBindingFlags(BindingFlags bindingFlags)
+        {
+            bindingFlags &= BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.IgnoreCase;
+            bindingFlags |= BindingFlags.Static | BindingFlags.DeclaredOnly;
+            return bindingFlags;
+        }
+    }
+}

--- a/src/System.Reflection.TypeExtensions/src/Internal/Reflection/Extensions/NonPortable/MemberPolicies.cs
+++ b/src/System.Reflection.TypeExtensions/src/Internal/Reflection/Extensions/NonPortable/MemberPolicies.cs
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using global::System;
-using global::System.IO;
-using global::System.Linq;
-using global::System.Reflection;
-using global::System.Diagnostics;
-using global::System.Collections.Generic;
+using System;
+using System.Reflection;
+using System.Diagnostics;
+using System.Collections.Generic;
 
 namespace Internal.Reflection.Extensions.NonPortable
 {
@@ -64,19 +62,25 @@ namespace Internal.Reflection.Extensions.NonPortable
         protected static bool AreNamesAndSignaturesEqual(MethodInfo method1, MethodInfo method2)
         {
             if (method1.Name != method2.Name)
+            {
                 return false;
+            }
 
             ParameterInfo[] p1 = method1.GetParameters();
             ParameterInfo[] p2 = method2.GetParameters();
             if (p1.Length != p2.Length)
+            {
                 return false;
+            }
 
             for (int i = 0; i < p1.Length; i++)
             {
                 Type parameterType1 = p1[i].ParameterType;
                 Type parameterType2 = p2[i].ParameterType;
                 if (!(parameterType1.Equals(parameterType2)))
+                {
                     return false;
+                }
             }
             return true;
         }
@@ -92,19 +96,33 @@ namespace Internal.Reflection.Extensions.NonPortable
                 {
                     Type t = typeof(M);
                     if (t.Equals(typeof(FieldInfo)))
+                    {
                         _default = (MemberPolicies<M>)(Object)(new FieldPolicies());
+                    }
                     else if (t.Equals(typeof(MethodInfo)))
+                    {
                         _default = (MemberPolicies<M>)(Object)(new MethodPolicies());
+                    }
                     else if (t.Equals(typeof(ConstructorInfo)))
+                    {
                         _default = (MemberPolicies<M>)(Object)(new ConstructorPolicies());
+                    }
                     else if (t.Equals(typeof(PropertyInfo)))
+                    {
                         _default = (MemberPolicies<M>)(Object)(new PropertyPolicies());
+                    }
                     else if (t.Equals(typeof(EventInfo)))
+                    {
                         _default = (MemberPolicies<M>)(Object)(new EventPolicies());
+                    }
                     else if (t.Equals(typeof(TypeInfo)))
+                    {
                         _default = (MemberPolicies<M>)(Object)(new NestedTypePolicies());
+                    }
                     else
+                    {
                         Debug.Assert(false, "Unknown MemberInfo type.");
+                    }
                 }
                 return _default;
             }
@@ -232,7 +250,10 @@ namespace Internal.Reflection.Extensions.NonPortable
         {
             MethodInfo accessor = property.GetMethod;
             if (accessor == null)
+            {
                 accessor = property.SetMethod;
+            }
+
             return accessor;
         }
     }

--- a/src/System.Reflection.TypeExtensions/src/Resources/Strings.netcore50aot.resx
+++ b/src/System.Reflection.TypeExtensions/src/Resources/Strings.netcore50aot.resx
@@ -1,0 +1,144 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Arg_AmbiguousMatchException" xml:space="preserve">
+    <value>Ambiguous match found.</value>
+  </data>
+  <data name="Arg_EmptyArray" xml:space="preserve">
+    <value>Array may not be empty.</value>
+  </data>
+  <data name="Arg_GetMethNotFnd" xml:space="preserve">
+    <value>Property get method not found.</value>
+  </data>
+  <data name="Arg_SetMethNotFnd" xml:space="preserve">
+    <value>Property set method not found.</value>
+  </data>
+  <data name="MissingMember" xml:space="preserve">
+    <value>Member not found.</value>
+  </data>
+  <data name="MetadataTokenNotSupported" xml:space="preserve">
+    <value>Metadata tokens cannot be retrieved on this platform.</value>
+  </data>
+  <data name="ModuleVersionIdNotSupported" xml:space="preserve">
+    <value>Module version IDs (MVIDs) cannot be retrieved on this platform.</value>
+  </data>
+  <data name="TypeIsNotReflectable" xml:space="preserve">
+    <value>Type instance is not IReflectable.</value>
+  </data>
+</root>

--- a/src/System.Reflection.TypeExtensions/src/System.Reflection.TypeExtensions.CoreCLR.csproj
+++ b/src/System.Reflection.TypeExtensions/src/System.Reflection.TypeExtensions.CoreCLR.csproj
@@ -4,16 +4,45 @@
   <PropertyGroup>
     <AssemblyName>System.Reflection.TypeExtensions</AssemblyName>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
-    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' != 'netcore50aot'">true</IsPartialFacadeAssembly>
     <NuGetTargetFrameworkMoniker>DNXCore,Version=v5.0</NuGetTargetFrameworkMoniker>
     <ProjectGuid>{1E689C1B-690C-4799-BDE9-6E7990585894}</ProjectGuid>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
+    <StringResourcesPath>Resources\Strings.netcore50aot.resx</StringResourcesPath>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Reflection\Requires.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' != 'netcore50aot'">
     <Compile Include="System\Reflection\TypeExtensions.CoreCLR.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
+    <Compile Include="System\Reflection\AssemblyExtensions.cs" />
+    <Compile Include="System\Reflection\BindingFlags.cs" />
+    <Compile Include="System\Reflection\EventInfoExtensions.cs" />
+    <Compile Include="System\Reflection\Helpers.cs" />
+    <Compile Include="System\Reflection\MemberInfoExtensions.cs" />
+    <Compile Include="System\Reflection\ModuleExtensions.cs" />
+    <Compile Include="System\Reflection\MethodInfoExtensions.cs" />
+    <Compile Include="System\Reflection\PropertyInfoExtensions.cs" />
+    <Compile Include="System\Reflection\TypeExtensions.cs" />
+    <Compile Include="Internal\Reflection\Extensions\NonPortable\InheritedPropertyInfo.cs" />
+    <Compile Include="Internal\Reflection\Extensions\NonPortable\MemberEnumerator.cs" />
+    <Compile Include="Internal\Reflection\Extensions\NonPortable\MemberPolicies.cs" />
+    <Compile Include="$(CommonPath)\Internal\Reflection\Execution\Binder\DefaultBinder.cs" />
+    <Compile Include="$(CommonPath)\System\Collections\Generic\LowLevelList.cs" />
+    <TargetingPackReference Include="System.Private.Reflection.Extensibility" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
+    <TargetingPackReference Include="mscorlib" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Reflection.TypeExtensions/src/System.Reflection.TypeExtensions.CoreCLR.csproj
+++ b/src/System.Reflection.TypeExtensions/src/System.Reflection.TypeExtensions.CoreCLR.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -33,12 +33,16 @@
     <Compile Include="System\Reflection\ModuleExtensions.cs" />
     <Compile Include="System\Reflection\MethodInfoExtensions.cs" />
     <Compile Include="System\Reflection\PropertyInfoExtensions.cs" />
-    <Compile Include="System\Reflection\TypeExtensions.cs" />
+    <Compile Include="System\Reflection\TypeExtensions.netcore50aot.cs" />
     <Compile Include="Internal\Reflection\Extensions\NonPortable\InheritedPropertyInfo.cs" />
     <Compile Include="Internal\Reflection\Extensions\NonPortable\MemberEnumerator.cs" />
     <Compile Include="Internal\Reflection\Extensions\NonPortable\MemberPolicies.cs" />
-    <Compile Include="$(CommonPath)\Internal\Reflection\Execution\Binder\DefaultBinder.cs" />
-    <Compile Include="$(CommonPath)\System\Collections\Generic\LowLevelList.cs" />
+    <Compile Include="$(CommonPath)\Internal\Reflection\Execution\Binder\DefaultBinder.cs">
+      <Link>Common\Internal\Reflection\Execution\Binder\DefaultBinder.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Collections\Generic\LowLevelList.cs">
+      <Link>Common\System\Collections\Generic\LowLevelList.cs</Link>
+    </Compile>
     <TargetingPackReference Include="System.Private.Reflection.Extensibility" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net46'">

--- a/src/System.Reflection.TypeExtensions/src/System.Reflection.TypeExtensions.builds
+++ b/src/System.Reflection.TypeExtensions/src/System.Reflection.TypeExtensions.builds
@@ -3,6 +3,13 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Reflection.TypeExtensions.CoreCLR.csproj" />
+    <Project Include="System.Reflection.TypeExtensions.CoreCLR.csproj">
+      <TargetGroup>net46</TargetGroup>
+    </Project>
+    <Project Include="System.Reflection.TypeExtensions.CoreCLR.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>netcore50aot</TargetGroup>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/AssemblyExtensions.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/AssemblyExtensions.cs
@@ -1,8 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-// -----------------------------------------------------------------------
-
-// -----------------------------------------------------------------------
 
 using System.Linq;
 

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/AssemblyExtensions.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/AssemblyExtensions.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// -----------------------------------------------------------------------
+
+// -----------------------------------------------------------------------
+
+using System.Linq;
+
+namespace System.Reflection
+{
+    /// <summary>
+    /// Extension methods offering source-code compatibility with certain instance methods of <see cref="System.Reflection.Assembly"/> on other platforms.
+    /// </summary>
+    public static class AssemblyExtensions
+    {
+        /// <summary>
+        /// Gets the public types defined in this assembly that are visible outside the assembly.
+        /// </summary>
+        /// <param name="assembly">Assembly on which to perform lookup</param>
+        /// <returns>An array that represents the types defined in this assembly that are visible outside the assembly.</returns>
+        public static Type[] GetExportedTypes(this Assembly assembly)
+        {
+            Requires.NotNull(assembly, "assembly");
+            return assembly.ExportedTypes.ToArray();
+        }
+
+        /// <summary>
+        /// Gets all the modules that are part of this assembly.
+        /// </summary>
+        /// <param name="assembly">Assembly on which to perform lookup</param>
+        /// <returns>An array of modules.</returns>
+        public static Module[] GetModules(this Assembly assembly)
+        {
+            Requires.NotNull(assembly, "assembly");
+            return assembly.Modules.ToArray();
+        }
+
+        /// <summary>
+        /// Gets the types defined in this assembly.
+        /// </summary>
+        /// <param name="assembly">Assembly on which to perform lookup</param>
+        /// <returns>An array that contains all the types that are defined in this assembly.</returns>
+        public static Type[] GetTypes(this Assembly assembly)
+        {
+            Requires.NotNull(assembly, "assembly");
+            return assembly.DefinedTypes.Select(t => t.AsType()).ToArray();
+        }
+    }
+}

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/BindingFlags.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/BindingFlags.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// -----------------------------------------------------------------------
+
+// -----------------------------------------------------------------------
+
+namespace System.Reflection
+{
+    [Flags]
+    public enum BindingFlags
+    {
+        // These flags indicate what to search for when binding
+        IgnoreCase = 0x01,        // Ignore the case of Names while searching
+        DeclaredOnly = 0x02,        // Only look at the members declared on the Type
+        Instance = 0x04,        // Include Instance members in search
+        Static = 0x08,        // Include Static members in search
+        Public = 0x10,        // Include Public members in search
+        NonPublic = 0x20,        // Include Non-Public members in search
+        FlattenHierarchy = 0x40,        // Rollup the statics into the class.
+
+        ExactBinding = 0x010000,        // Bind with Exact Type matching, No Change type
+        OptionalParamBinding = 0x040000,
+    }
+}

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/BindingFlags.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/BindingFlags.cs
@@ -1,8 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-// -----------------------------------------------------------------------
-
-// -----------------------------------------------------------------------
 
 namespace System.Reflection
 {

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/EventInfoExtensions.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/EventInfoExtensions.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// -----------------------------------------------------------------------
+
+// -----------------------------------------------------------------------
+
+namespace System.Reflection
+{
+    /// <summary>
+    /// Extension methods offering source-code compatibility with certain instance methods of <see cref="System.Reflection.EventInfo"/> on other platforms.
+    /// </summary>
+    public static class EventInfoExtensions
+    {
+        /// <summary>
+        /// Returns the method used to add an event handler delegate to the event source.
+        /// </summary>
+        /// <param name="eventInfo">EventInfo object on which to perform lookup</param>
+        /// <returns>A MethodInfo object representing the method used to add an event handler delegate to the event source.</returns>
+        public static MethodInfo GetAddMethod(this EventInfo eventInfo)
+        {
+            return GetAddMethod(eventInfo, nonPublic: false);
+        }
+
+        /// <summary>
+        /// Retrieves the MethodInfo object for the AddEventHandler method of the event, specifying whether to return non-public methods.
+        /// </summary>
+        /// <param name="eventInfo">EventInfo object on which to perform lookup</param>
+        /// <param name="nonPublic">true if non-public methods can be returned; otherwise, false. </param>
+        /// <returns></returns>
+        public static MethodInfo GetAddMethod(this EventInfo eventInfo, bool nonPublic)
+        {
+            Requires.NotNull(eventInfo, "eventInfo");
+            return Helpers.FilterAccessor(eventInfo.AddMethod, nonPublic);
+        }
+
+        /// <summary>
+        /// Returns the method that is called when the event is raised.
+        /// </summary>
+        /// <param name="eventInfo">EventInfo object on which to perform lookup</param>
+        /// <returns>The method that is called when the event is raised.</returns>
+        public static MethodInfo GetRaiseMethod(this EventInfo eventInfo)
+        {
+            return GetRaiseMethod(eventInfo, nonPublic: false);
+        }
+
+        /// <summary>
+        /// Returns the method that is called when the event is raised, specifying whether to return non-public methods.
+        /// </summary>
+        /// <param name="eventInfo">EventInfo object on which to perform lookup</param>
+        /// <param name="nonPublic">true if non-public methods can be returned; otherwise, false. </param>
+        /// <returns>A MethodInfo object that was called when the event was raised.</returns>
+        public static MethodInfo GetRaiseMethod(this EventInfo eventInfo, bool nonPublic)
+        {
+            Requires.NotNull(eventInfo, "eventInfo");
+            return Helpers.FilterAccessor(eventInfo.RaiseMethod, nonPublic);
+        }
+
+        /// <summary>
+        /// Returns the method used to remove an event handler delegate from the event source.
+        /// </summary>
+        /// <param name="eventInfo">EventInfo object on which to perform lookup</param>
+        /// <returns>A MethodInfo object representing the method used to remove an event handler delegate from the event source.</returns>
+        public static MethodInfo GetRemoveMethod(this EventInfo eventInfo)
+        {
+            return GetRemoveMethod(eventInfo, nonPublic: false);
+        }
+
+        /// <summary>
+        /// Retrieves the MethodInfo object for removing a method of the event, specifying whether to return non-public methods.
+        /// </summary>
+        /// <param name="eventInfo">EventInfo object on which to perform lookup</param>
+        /// <param name="nonPublic">true if non-public methods can be returned; otherwise, false. </param>
+        /// <returns>A MethodInfo object representing the method used to remove an event handler delegate from the event source.</returns>
+        public static MethodInfo GetRemoveMethod(this EventInfo eventInfo, bool nonPublic)
+        {
+            Requires.NotNull(eventInfo, "eventInfo");
+            return Helpers.FilterAccessor(eventInfo.RemoveMethod, nonPublic);
+        }
+    }
+}

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/EventInfoExtensions.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/EventInfoExtensions.cs
@@ -1,8 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-// -----------------------------------------------------------------------
-
-// -----------------------------------------------------------------------
 
 namespace System.Reflection
 {

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/Helpers.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/Helpers.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// -----------------------------------------------------------------------
+
+// -----------------------------------------------------------------------
+
+namespace System.Reflection
+{
+    internal static class Helpers
+    {
+        internal const BindingFlags DefaultLookup = BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance;
+        internal static readonly MethodInfo[] EmptyMethodArray = new MethodInfo[0];
+        internal static readonly Type[] EmptyTypeArray = new Type[0];
+        internal static readonly MemberInfo[] EmptyMemberArray = new MemberInfo[0];
+
+        internal static MethodInfo FilterAccessor(MethodInfo accessor, bool nonPublic)
+        {
+            if (nonPublic || (accessor != null && accessor.IsPublic))
+            {
+                return accessor;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/Helpers.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/Helpers.cs
@@ -1,8 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-// -----------------------------------------------------------------------
-
-// -----------------------------------------------------------------------
 
 namespace System.Reflection
 {

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/MemberInfoExtensions.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/MemberInfoExtensions.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Reflection
+{
+    public static class MemberInfoExtensions
+    {
+        public static bool HasMetadataToken(this MemberInfo member)
+        {
+            Requires.NotNull(member, "member");
+            return false; // never available on .NET Native
+        }
+        
+        public static int GetMetadataToken(this MemberInfo member)
+        {
+            Requires.NotNull(member, "member");
+            throw new InvalidOperationException(SR.MetadataTokenNotSupported);
+        }
+    }
+}

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/MethodInfoExtensions.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/MethodInfoExtensions.cs
@@ -1,8 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-// -----------------------------------------------------------------------
-
-// -----------------------------------------------------------------------
 
 using Internal.Reflection.Extensions.NonPortable;
 

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/MethodInfoExtensions.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/MethodInfoExtensions.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// -----------------------------------------------------------------------
+
+// -----------------------------------------------------------------------
+
+using Internal.Reflection.Extensions.NonPortable;
+
+namespace System.Reflection
+{
+    /// <summary>
+    /// Extension methods offering source-code compatibility with certain instance methods of <see cref="System.Reflection.MethodInfo"/> on other platforms.
+    /// </summary>
+    public static class MethodInfoExtensions
+    {
+        /// <summary>
+        /// Returns the MethodInfo object for the method on the direct or indirect base class in which the method represented by this instance was first declared.
+        /// </summary>
+        /// <param name="method">MethodInfo object on which to perform lookup</param>
+        /// <returns>A MethodInfo object for the first implementation of this method.</returns>
+        public static MethodInfo GetBaseDefinition(this MethodInfo method)
+        {
+            Requires.NotNull(method, "method");
+
+            while (true)
+            {
+                MethodInfo next = method.GetImplicitlyOverriddenBaseClassMember();
+                if (next == null)
+                {
+                    return method;
+                }
+                method = next;
+            }
+        }
+    }
+}

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/ModuleExtensions.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/ModuleExtensions.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Reflection
+{
+    public static class ModuleExtensions
+    {
+        public static bool HasModuleVersionId(this Module module)
+        {
+            Requires.NotNull(module, "module");
+            return false; // never available on .NET Native
+        }
+        
+        public static Guid GetModuleVersionId(this Module module)
+        {
+            Requires.NotNull(module, "module");
+            throw new InvalidOperationException(SR.ModuleVersionIdNotSupported);
+        }
+    }
+}

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/PropertyInfoExtensions.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/PropertyInfoExtensions.cs
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// -----------------------------------------------------------------------
+
+// -----------------------------------------------------------------------
+
+namespace System.Reflection
+{
+    /// <summary>
+    /// Extension methods offering source-code compatibility with certain instance methods of <see cref="System.Reflection.PropertyInfo"/> on other platforms.
+    /// </summary>
+    public static class PropertyInfoExtensions
+    {
+        /// <summary>
+        /// Returns an array whose elements reflect the public get, set, and other accessors of the property reflected by the current instance
+        /// </summary>
+        /// <param name="property">PropertyInfo object on which to perform lookup</param>
+        /// <returns>An array of MethodInfo objects that reflect the public get, set, and other accessors of the property reflected by the current instance, if found; otherwise, this method returns an array with zero (0) elements.</returns>
+        public static MethodInfo[] GetAccessors(this PropertyInfo property)
+        {
+            return GetAccessors(property, nonPublic: false);
+        }
+
+        /// <summary>
+        /// Returns an array whose elements reflect the public and, if specified, non-public get, set, and other accessors of the property reflected by the current instance.
+        /// </summary>
+        /// <param name="property">PropertyInfo object on which to perform lookup</param>
+        /// <param name="nonPublic">Indicates whether non-public methods should be returned in the MethodInfo array. true if non-public methods are to be included; otherwise, false. </param>
+        /// <returns>An array of MethodInfo objects whose elements reflect the get, set, and other accessors of the property reflected by the current instance. If nonPublic is true, this array contains public and non-public get, set, and other accessors. If nonPublic is false, this array contains only public get, set, and other accessors. If no accessors with the specified visibility are found, this method returns an array with zero (0) elements. </returns>
+        public static MethodInfo[] GetAccessors(this PropertyInfo property, bool nonPublic)
+        {
+            // NOTE: Technically, this isn't strictly compatible with desktop as there can be
+            //       "other" accessors which are neither getters nor setters in metadata and
+            //       desktop can return them. However, they are extraordinarily rare and there
+            //       is no portable way to get them from the core reflection contract.
+
+            Requires.NotNull(property, "property");
+
+            MethodInfo getMethod = Helpers.FilterAccessor(property.GetMethod, nonPublic);
+            MethodInfo setMethod = Helpers.FilterAccessor(property.SetMethod, nonPublic);
+
+            if (getMethod == null && setMethod == null)
+            {
+                return Helpers.EmptyMethodArray;
+            }
+
+            if (getMethod == null)
+            {
+                return new MethodInfo[] { setMethod };
+            }
+
+            if (setMethod == null)
+            {
+                return new MethodInfo[] { getMethod };
+            }
+
+            return new MethodInfo[] { getMethod, setMethod };
+        }
+
+        /// <summary>
+        /// Returns the public get accessor for this property.
+        /// </summary>
+        /// <param name="property">PropertyInfo object on which to perform lookup</param>
+        /// <returns>A MethodInfo object representing the public get accessor for this property, or null if the get accessor is non-public or does not exist.</returns>
+        public static MethodInfo GetGetMethod(this PropertyInfo property)
+        {
+            return GetGetMethod(property, nonPublic: false);
+        }
+
+        /// <summary>
+        /// Returns the public or non-public get accessor for this property.
+        /// </summary>
+        /// <param name="property">PropertyInfo object on which to perform lookup</param>
+        /// <param name="nonPublic">Indicates whether a non-public get accessor should be returned. true if a non-public accessor is to be returned; otherwise, false. </param>
+        /// <returns>A MethodInfo object representing the get accessor for this property, if nonPublic is true. Returns null if nonPublic is false and the get accessor is non-public, or if nonPublic is true but no get accessors exist.</returns>
+        public static MethodInfo GetGetMethod(this PropertyInfo property, bool nonPublic)
+        {
+            Requires.NotNull(property, "property");
+            return Helpers.FilterAccessor(property.GetMethod, nonPublic);
+        }
+
+        /// <summary>
+        /// Returns the public set accessor for this property.
+        /// </summary>
+        /// <param name="property">PropertyInfo object on which to perform lookup</param>
+        /// <returns>The MethodInfo object representing the Set method for this property if the set accessor is public, or null if the set accessor is not public.</returns>
+        public static MethodInfo GetSetMethod(this PropertyInfo property)
+        {
+            return GetSetMethod(property, nonPublic: false);
+        }
+
+        /// <summary>
+        /// Returns the set accessor for this property.
+        /// </summary>
+        /// <param name="property">PropertyInfo object on which to perform lookup</param>
+        /// <param name="nonPublic">Indicates whether the accessor should be returned if it is non-public. true if a non-public accessor is to be returned; otherwise, false. </param>
+        /// <returns>A MethodInfo object representing the Set method for this property. 
+        /// - or -
+        /// null </returns>
+        public static MethodInfo GetSetMethod(this PropertyInfo property, bool nonPublic)
+        {
+            Requires.NotNull(property, "property");
+            return Helpers.FilterAccessor(property.SetMethod, nonPublic);
+        }
+    }
+}

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/PropertyInfoExtensions.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/PropertyInfoExtensions.cs
@@ -1,8 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-// -----------------------------------------------------------------------
-
-// -----------------------------------------------------------------------
 
 namespace System.Reflection
 {

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/TypeExtensions.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/TypeExtensions.cs
@@ -1,0 +1,629 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+// -----------------------------------------------------------------------
+
+// -----------------------------------------------------------------------
+
+using Internal.Reflection.Core.Execution.Binder;
+using Internal.Reflection.Extensions.NonPortable;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace System.Reflection
+{
+    /// <summary>
+    /// Extension methods offering source-code compatibility with certain instance methods of <see cref="System.Type"/> on other platforms.
+    /// </summary>
+    public static class TypeExtensions
+    {
+        /// <summary>
+        /// Searches for a public instance constructor whose parameters match the types in the specified array.
+        /// </summary>
+        /// <param name="type">Type from which to get constructor</param>
+        /// <param name="types">  An array of Type objects representing the number, order, and type of the parameters for the desired constructor.
+        /// -or- 
+        /// An empty array of Type objects, to get a constructor that takes no parameters. Such an empty array is provided by the Array.Empty method. </param>
+        /// <returns>Specific ConstructorInfo for type specified in "type" parameter</returns>
+        public static ConstructorInfo GetConstructor(this Type type, Type[] types)
+        {
+            if (types == null)
+            {
+                throw new ArgumentNullException("types");
+            }
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<ConstructorInfo> constructors = MemberEnumerator.GetMembers<ConstructorInfo>(type, MemberEnumerator.AnyName, Helpers.DefaultLookup);
+            return Disambiguate(constructors, types);
+        }
+
+        /// <summary>
+        /// Returns all the public constructors defined for the current Type.
+        /// </summary>
+        /// <param name="type">Type to retrieve constructors for</param>
+        /// <returns>An array of ConstructorInfo objects representing all the public instance constructors defined for the current Type, but not including the type initializer (static constructor). If no public instance constructors are defined for the current Type, or if the current Type represents a type parameter in the definition of a generic type or generic method, an empty array of type ConstructorInfo is returned.</returns>
+        public static ConstructorInfo[] GetConstructors(this Type type)
+        {
+            return GetConstructors(type, Helpers.DefaultLookup);
+        }
+
+        /// <summary>
+        /// Searches for the constructors defined for the current Type, using the specified BindingFlags.
+        /// </summary>
+        /// <param name="type">Type to retrieve constructors for</param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted.
+        /// -or- 
+        /// Zero, to return null. </param>
+        /// <returns>An array of ConstructorInfo objects representing all constructors defined for the current Type that match the specified binding constraints, including the type initializer if it is defined. Returns an empty array of type ConstructorInfo if no constructors are defined for the current Type, if none of the defined constructors match the binding constraints, or if the current Type represents a type parameter in the definition of a generic type or generic method.</returns>
+        public static ConstructorInfo[] GetConstructors(this Type type, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<ConstructorInfo> constructors = type.GetMembers<ConstructorInfo>(MemberEnumerator.AnyName, bindingAttr);
+            return constructors.ToArray();
+        }
+
+        /// <summary>
+        /// Searches for the members defined for the current Type whose DefaultMemberAttribute is set.
+        /// </summary>
+        /// <param name="type">Type to be queried</param>
+        /// <returns>An array of MemberInfo objects representing all default members of the current Type.
+        /// -or- 
+        /// An empty array of type MemberInfo, if the current Type does not have default members.</returns>
+        public static MemberInfo[] GetDefaultMembers(this Type type)
+        {
+            TypeInfo typeInfo = GetTypeInfoOrThrow(type);
+            string defaultMemberName = GetDefaultMemberName(typeInfo);
+
+            if (defaultMemberName == null)
+            {
+                return Helpers.EmptyMemberArray;
+            }
+
+            return GetMember(type, defaultMemberName);
+        }
+
+        /// <summary>
+        /// Returns the EventInfo object representing the specified public event.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="name">The string containing the name of an event that is declared or inherited by the current Type. </param>
+        /// <returns>The object representing the specified public event that is declared or inherited by the current Type, if found; otherwise, null.</returns>
+        public static EventInfo GetEvent(this Type type, string name)
+        {
+            return GetEvent(type, name, Helpers.DefaultLookup);
+        }
+
+        /// <summary>
+        /// Returns the EventInfo object representing the specified event, using the specified binding constraints.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="name">The string containing the name of an event which is declared or inherited by the current Type. </param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted.
+        /// -or- 
+        /// Zero, to return null. </param>
+        /// <returns>The object representing the specified event that is declared or inherited by the current Type, if found; otherwise, null.</returns>
+        public static EventInfo GetEvent(this Type type, string name, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<EventInfo> events = MemberEnumerator.GetMembers<EventInfo>(type, name, bindingAttr);
+            return Disambiguate(events);
+        }
+
+        /// <summary>
+        /// Returns all the public events that are declared or inherited by the current Type.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <returns>An array of EventInfo objects representing all the public events which are declared or inherited by the current Type.
+        /// -or- 
+        /// An empty array of type EventInfo, if the current Type does not have public events.</returns>
+        public static EventInfo[] GetEvents(this Type type)
+        {
+            return GetEvents(type, Helpers.DefaultLookup);
+        }
+
+        /// <summary>
+        /// Searches for events that are declared or inherited by the current Type, using the specified binding constraints.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted.
+        /// -or- 
+        /// Zero, to return null. </param>
+        /// <returns>An array of EventInfo objects representing all events that are declared or inherited by the current Type that match the specified binding constraints.
+        /// -or- 
+        /// An empty array of type EventInfo, if the current Type does not have events, or if none of the events match the binding constraints.</returns>
+        public static EventInfo[] GetEvents(this Type type, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<EventInfo> events = MemberEnumerator.GetMembers<EventInfo>(type, MemberEnumerator.AnyName, bindingAttr);
+            return events.ToArray();
+        }
+
+        /// <summary>
+        /// Searches for the public field with the specified name.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="name">The string containing the name of the data field to get. </param>
+        /// <returns>An object representing the public field with the specified name, if found; otherwise, null.</returns>
+        public static FieldInfo GetField(this Type type, string name)
+        {
+            return GetField(type, name, Helpers.DefaultLookup);
+        }
+
+        /// <summary>
+        /// Searches for the specified field, using the specified binding constraints.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="name">The string containing the name of the data field to get. </param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted.
+        /// -or- 
+        /// Zero, to return null.</param>
+        /// <returns>An object representing the field that matches the specified requirements, if found; otherwise, null.</returns>
+        public static FieldInfo GetField(this Type type, string name, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<FieldInfo> fields = MemberEnumerator.GetMembers<FieldInfo>(type, name, bindingAttr);
+            return Disambiguate(fields);
+        }
+
+        /// <summary>
+        /// Returns all the public fields of the current Type.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <returns>An array of FieldInfo objects representing all the public fields defined for the current Type.
+        /// -or- 
+        /// An empty array of type FieldInfo, if no public fields are defined for the current Type.</returns>
+        public static FieldInfo[] GetFields(this Type type)
+        {
+            return GetFields(type, Helpers.DefaultLookup);
+        }
+
+        /// <summary>
+        /// Searches for the fields defined for the current Type, using the specified binding constraints.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted
+        /// -or- 
+        /// Zero, to return an empty array. </param>
+        /// <returns>An array of FieldInfo objects representing all fields defined for the current Type that match the specified binding constraints.
+        /// -or- 
+        /// An empty array of type FieldInfo, if no fields are defined for the current Type, or if none of the defined fields match the binding constraints.</returns>
+        public static FieldInfo[] GetFields(this Type type, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            return MemberEnumerator.GetMembers<FieldInfo>(type, MemberEnumerator.AnyName, bindingAttr).ToArray();
+        }
+
+        /// <summary>
+        /// Returns an array of Type objects that represent the type arguments of a generic type or the type parameters of a generic type definition
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <returns>An array of Type objects that represent the type arguments of a generic type. Returns an empty array if the current type is not a generic type.</returns>
+        public static Type[] GetGenericArguments(this Type type)
+        {
+            TypeInfo typeInfo = GetTypeInfoOrThrow(type);
+
+            if (type.IsConstructedGenericType)
+            {
+                return type.GenericTypeArguments;
+            }
+
+            if (typeInfo.IsGenericTypeDefinition)
+            {
+                return typeInfo.GenericTypeParameters;
+            }
+
+            return Helpers.EmptyTypeArray;
+        }
+
+        /// <summary>
+        /// Gets all the interfaces implemented or inherited by the current Type.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <returns>An array of Type objects representing all the interfaces implemented or inherited by the current Type.
+        /// -or- 
+        /// An empty array of type Type, if no interfaces are implemented or inherited by the current Type.</returns>
+        public static Type[] GetInterfaces(this Type type)
+        {
+            TypeInfo typeInfo = GetTypeInfoOrThrow(type);
+            return typeInfo.ImplementedInterfaces.ToArray();
+        }
+
+        /// <summary>
+        /// Searches for the public members with the specified name.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="name">The string containing the name of the public members to get.</param>
+        /// <returns>An array of MemberInfo objects representing the public members with the specified name, if found; otherwise, an empty array.</returns>
+        public static MemberInfo[] GetMember(this Type type, string name)
+        {
+            return GetMember(type, name, Helpers.DefaultLookup);
+        }
+
+        /// <summary>
+        /// Searches for the public members with the specified name.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="name"> The string containing the name of the public members to get.  </param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted
+        /// -or- 
+        /// Zero, to return an empty array. </param>
+        /// <returns>An array of MemberInfo objects representing the public members with the specified name, if found; otherwise, an empty array.</returns>
+        public static MemberInfo[] GetMember(this Type type, string name, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            LowLevelList<MemberInfo> members = GetMembers(type, name, bindingAttr);
+            return members.ToArray();
+        }
+
+        /// <summary>
+        /// Returns all the public members of the current Type.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <returns>An array of MemberInfo objects representing all the public members of the current Type
+        /// -or- 
+        /// An empty array of type MemberInfo, if the current Type does not have public members.</returns>
+        public static MemberInfo[] GetMembers(this Type type)
+        {
+            return GetMembers(type, Helpers.DefaultLookup);
+        }
+
+        /// <summary>
+        /// Searches for the members defined for the current Type, using the specified binding constraints.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted
+        /// -or- 
+        /// Zero, to return an empty array. </param>
+        /// <returns>An array of MemberInfo objects representing all members defined for the current Type that match the specified binding constraints.
+        /// -or- 
+        /// An empty array of type MemberInfo, if no members are defined for the current Type, or if none of the defined members match the binding constraints.</returns>
+        public static MemberInfo[] GetMembers(this Type type, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            LowLevelList<MemberInfo> members = GetMembers(type, MemberEnumerator.AnyName, bindingAttr);
+            return members.ToArray();
+        }
+
+        /// <summary>
+        /// Searches for the public method with the specified name.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="name">The string containing the name of the public method to get. </param>
+        /// <returns>An object that represents the public method with the specified name, if found; otherwise, null</returns>
+        public static MethodInfo GetMethod(this Type type, string name)
+        {
+            return GetMethod(type, name, Helpers.DefaultLookup);
+        }
+
+        /// <summary>
+        /// Searches for the specified method, using the specified binding constraints.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="name">The string containing the name of the method to get.</param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted
+        /// -or- 
+        /// Zero, to return null. </param>
+        /// <returns>An object representing the method that matches the specified requirements, if found; otherwise, null.</returns>
+        public static MethodInfo GetMethod(this Type type, string name, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<MethodInfo> methods = MemberEnumerator.GetMembers<MethodInfo>(type, name, bindingAttr);
+            return Disambiguate(methods);
+        }
+
+        /// <summary>
+        /// Searches for the specified public method whose parameters match the specified argument types.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="name">The string containing the name of the public method to get. </param>
+        /// <param name="types">An array of Type objects representing the number, order, and type of the parameters for the method to get 
+        /// -or- An empty array of Type objects (as provided by the Array.Empty method) to get a method that takes no parameters. </param>
+        /// <returns>An object representing the public method whose parameters match the specified argument types, if found; otherwise, null.</returns>
+        public static MethodInfo GetMethod(this Type type, string name, Type[] types)
+        {
+            if (types == null)
+            {
+                throw new ArgumentNullException("types");
+            }
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<MethodInfo> methods = MemberEnumerator.GetMembers<MethodInfo>(type, name, Helpers.DefaultLookup);
+            return Disambiguate(methods, types);
+        }
+
+        /// <summary>
+        /// Returns all the public methods of the current Type.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <returns>An array of MethodInfo objects representing all the public methods defined for the current Type.
+        /// -or- 
+        /// An empty array of type MethodInfo, if no public methods are defined for the current Type.</returns>
+        public static MethodInfo[] GetMethods(this Type type)
+        {
+            return GetMethods(type, Helpers.DefaultLookup);
+        }
+
+        /// <summary>
+        /// Returns all the public methods of the current Type.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted
+        /// -or- 
+        /// Zero, to return an empty array. </param>
+        /// <returns>An array of MethodInfo objects representing all the public methods defined for the current Type
+        /// -or- 
+        /// An empty array of type MethodInfo, if no public methods are defined for the current Type.</returns>
+        public static MethodInfo[] GetMethods(this Type type, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<MethodInfo> methods = MemberEnumerator.GetMembers<MethodInfo>(type, MemberEnumerator.AnyName, bindingAttr);
+            return methods.ToArray();
+        }
+
+        /// <summary>
+        /// Searches for the specified nested type, using the specified binding constraints.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="name">The string containing the name of the nested type to get. </param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted
+        /// -or- 
+        /// Zero, to return null. </param>
+        /// <returns>An object representing the nested type that matches the specified requirements, if found; otherwise, null.</returns>
+        public static Type GetNestedType(this Type type, string name, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<TypeInfo> nestedTypes = MemberEnumerator.GetMembers<TypeInfo>(type, name, bindingAttr);
+            TypeInfo nestedType = Disambiguate(nestedTypes);
+            return nestedType == null ? null : nestedType.AsType();
+        }
+
+        /// <summary>
+        /// Searches for the types nested in the current Type, using the specified binding constraints.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted -or- Zero, to return null. </param>
+        /// <returns>An array of Type objects representing all the types nested in the current Type that match the specified binding constraints (the search is not recursive), or an empty array of type Type, if no nested types are found that match the binding constraints.</returns>
+        public static Type[] GetNestedTypes(this Type type, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<TypeInfo> types = MemberEnumerator.GetMembers<TypeInfo>(type, MemberEnumerator.AnyName, bindingAttr);
+            return types.Select(t => t.AsType()).ToArray();
+        }
+
+        /// <summary>
+        /// Returns all the public properties of the current Type.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <returns>An array of PropertyInfo objects representing all public properties of the current Type -or- An empty array of type PropertyInfo, if the current Type does not have public properties</returns>
+        public static PropertyInfo[] GetProperties(this Type type)
+        {
+            return GetProperties(type, Helpers.DefaultLookup);
+        }
+
+        /// <summary>
+        /// Searches for the properties of the current Type, using the specified binding constraints.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted -or- Zero, to return null. </param>
+        /// <returns>An array of PropertyInfo objects representing all properties of the current Type that match the specified binding constraints.
+        /// -or- 
+        /// An empty array of type PropertyInfo, if the current Type does not have properties, or if none of the properties match the binding constraints.</returns>
+        public static PropertyInfo[] GetProperties(this Type type, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<PropertyInfo> properties = MemberEnumerator.GetMembers<PropertyInfo>(type, MemberEnumerator.AnyName, bindingAttr);
+            return properties.ToArray();
+        }
+
+        /// <summary>
+        /// Searches for the public property with the specified name.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="name">The string containing the name of the public property to get. </param>
+        /// <returns>An object representing the public property with the specified name, if found; otherwise, null.</returns>
+        public static PropertyInfo GetProperty(this Type type, string name)
+        {
+            return GetProperty(type, name, Helpers.DefaultLookup);
+        }
+
+        /// <summary>
+        /// Searches for the specified property, using the specified binding constraints.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="name">The string containing the name of the property to get. </param>
+        /// <param name="bindingAttr">A bitmask comprised of one or more BindingFlags that specify how the search is conducted.
+        /// -or- 
+        /// Zero, to return null. </param>
+        /// <returns>A bitmask comprised of one or more BindingFlags that specify how the search is conducted.
+        /// -or- 
+        /// Zero, to return null. </returns>
+        public static PropertyInfo GetProperty(this Type type, string name, BindingFlags bindingAttr)
+        {
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<PropertyInfo> properties = MemberEnumerator.GetMembers<PropertyInfo>(type, name, bindingAttr);
+            return Disambiguate(properties);
+        }
+
+        /// <summary>
+        /// Searches for the public property with the specified name and return type.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="name">The string containing the name of the public property to get. </param>
+        /// <param name="returnType">The return type of the property. </param>
+        /// <returns>An object representing the public property with the specified name, if found; otherwise, null</returns>
+        public static PropertyInfo GetProperty(this Type type, string name, Type returnType)
+        {
+            return GetProperty(type, name, returnType, Array.Empty<Type>());
+        }
+
+        /// <summary>
+        /// Searches for the specified public property whose parameters match the specified argument types.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="name">The string containing the name of the public property to get. </param>
+        /// <param name="returnType">The return type of the property. </param>
+        /// <param name="types">
+        /// An array of Type objects representing the number, order, and type of the parameters for the indexed property to get.
+        /// -or- 
+        /// An empty array of the type Type (that is, Type[] types = new Type[0]) to get a property that is not indexed.
+        /// </param>
+        /// <returns>
+        /// An object representing the public property with the specified name, return type, and indexing types, if found; otherwise, null.
+        /// </returns>
+        public static PropertyInfo GetProperty(this Type type, string name, Type returnType, Type[] types)
+        {
+            if (types == null)
+            {
+                throw new ArgumentNullException("types");
+            }
+            GetTypeInfoOrThrow(type);
+
+            IEnumerable<PropertyInfo> properties = MemberEnumerator.GetMembers<PropertyInfo>(type, name, Helpers.DefaultLookup);
+            return Disambiguate(properties, returnType, types);
+        }
+
+        /// <summary>
+        /// Determines whether an instance of the current Type can be assigned from an instance of the specified Type.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="c">The type to compare with the current type. </param>
+        /// <returns>true if c and the current Type represent the same type, or if the current Type is in the inheritance hierarchy of c, or if the current Type is an interface that c implements, or if c is a generic type parameter and the current Type represents one of the constraints of c, or if c represents a value type and the current Type represents Nullable&lt;c&gt; (Nullable(Of c) in Visual Basic). false if none of these conditions are true, or if c is null.</returns>
+        public static bool IsAssignableFrom(this Type type, Type c)
+        {
+            TypeInfo typeInfo = GetTypeInfoOrThrow(type);
+            return c != null && typeInfo.IsAssignableFrom(GetTypeInfoOrThrow(c, "c"));
+        }
+
+        /// <summary>
+        /// Determines whether the specified object is an instance of the current Type.
+        /// </summary>
+        /// <param name="type">Type on which to perform lookup</param>
+        /// <param name="o">The object to compare with the current type</param>
+        /// <returns>true if the current Type is in the inheritance hierarchy of the object represented by o, or if the current Type is an interface that o supports. false if neither of these conditions is the case, or if o is null, or if the current Type is an open generic type (that is, ContainsGenericParameters returns true).</returns>
+        public static bool IsInstanceOfType(this Type type, object o)
+        {
+            Debug.Assert(o == null || o.GetType().GetTypeInfo() != null, "Type obtained from object instance should implement IReflectableType on all platforms that support reflection.");
+            return o != null && IsAssignableFrom(type, o.GetType());
+        }
+
+        private static LowLevelList<MemberInfo> GetMembers(Type type, object nameFilterOrAnyName, BindingFlags bindingAttr)
+        {
+            LowLevelList<MemberInfo> members = new LowLevelList<MemberInfo>();
+
+            members.AddRange(MemberEnumerator.GetMembers<MethodInfo>(type, nameFilterOrAnyName, bindingAttr));
+            members.AddRange(MemberEnumerator.GetMembers<ConstructorInfo>(type, nameFilterOrAnyName, bindingAttr));
+            members.AddRange(MemberEnumerator.GetMembers<PropertyInfo>(type, nameFilterOrAnyName, bindingAttr));
+            members.AddRange(MemberEnumerator.GetMembers<EventInfo>(type, nameFilterOrAnyName, bindingAttr));
+            members.AddRange(MemberEnumerator.GetMembers<FieldInfo>(type, nameFilterOrAnyName, bindingAttr));
+            members.AddRange(MemberEnumerator.GetMembers<TypeInfo>(type, nameFilterOrAnyName, bindingAttr));
+
+            return members;
+        }
+
+        private static string GetDefaultMemberName(TypeInfo typeInfo)
+        {
+            TypeInfo t = typeInfo;
+
+            while (t != null)
+            {
+                CustomAttributeData attribute = GetDefaultMemberAttribute(typeInfo);
+                if (attribute != null)
+                {
+                    // NOTE: Neither indexing nor cast can fail here. Any attempt to use fewer than 1 argument
+                    // or a non-string argument would correctly trigger MissingMethodException before
+                    // we reach here as that would be an attempt to reference a non-existent DefaultMemberAttribute
+                    // constructor.
+                    Debug.Assert(attribute.ConstructorArguments.Count == 1 && attribute.ConstructorArguments[0].Value is string);
+                    return (string)attribute.ConstructorArguments[0].Value;
+                }
+
+                Type baseType = t.BaseType;
+                if (baseType == null)
+                    break;
+
+                t = baseType.GetTypeInfo();
+            }
+
+            return null;
+        }
+
+        private static CustomAttributeData GetDefaultMemberAttribute(TypeInfo typeInfo)
+        {
+            foreach (CustomAttributeData attribute in typeInfo.CustomAttributes)
+            {
+                if (attribute.AttributeType == typeof(DefaultMemberAttribute))
+                {
+                    return attribute;
+                }
+            }
+
+            return null;
+        }
+
+        private static TypeInfo GetTypeInfoOrThrow(Type type, string parameterName = "type")
+        {
+            Requires.NotNull(type, parameterName);
+            TypeInfo typeInfo = type.GetTypeInfo();
+
+            if (typeInfo == null)
+            {
+                throw new ArgumentException(SR.TypeIsNotReflectable, parameterName);
+            }
+
+            return typeInfo;
+        }
+
+        private static T Disambiguate<T>(IEnumerable<T> members) where T : MemberInfo
+        {
+            IEnumerator<T> enumerator = members.GetEnumerator();
+            if (!enumerator.MoveNext())
+            {
+                return null;
+            }
+
+            T result = enumerator.Current;
+            if (!enumerator.MoveNext())
+            {
+                return result;
+            }
+
+            T anotherResult = enumerator.Current;
+            if (anotherResult.DeclaringType.Equals(result.DeclaringType))
+            {
+                throw new AmbiguousMatchException();
+            }
+
+            return result;
+        }
+
+        private static T Disambiguate<T>(IEnumerable<T> members, Type[] parameterTypes) where T : MethodBase
+        {
+            return (T)DefaultBinder.SelectMethod(members.ToArray(), parameterTypes);
+        }
+
+        private static PropertyInfo Disambiguate(IEnumerable<PropertyInfo> members, Type returnType, Type[] parameterTypes)
+        {
+            PropertyInfo[] memberArray = members.ToArray();
+
+            if(memberArray.Length == 0)
+            {
+                return null;
+            }
+
+            return DefaultBinder.SelectProperty(memberArray, returnType, parameterTypes);
+        }
+    }
+}

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/TypeExtensions.netcore50aot.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/TypeExtensions.netcore50aot.cs
@@ -1,8 +1,5 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
-// -----------------------------------------------------------------------
-
-// -----------------------------------------------------------------------
 
 using Internal.Reflection.Core.Execution.Binder;
 using Internal.Reflection.Extensions.NonPortable;
@@ -552,7 +549,9 @@ namespace System.Reflection
 
                 Type baseType = t.BaseType;
                 if (baseType == null)
+                {
                     break;
+                }
 
                 t = baseType.GetTypeInfo();
             }

--- a/src/System.Reflection.TypeExtensions/src/project.json
+++ b/src/System.Reflection.TypeExtensions/src/project.json
@@ -1,8 +1,24 @@
 {
-  "dependencies": {
-    "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23520"
-  },
   "frameworks": {
-    "dnxcore50": {}
+    "dnxcore50": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23714"
+      }
+    },
+    "net46": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0"
+      }
+    },
+    "netcore50": {
+      "dependencies": {
+        "System.Collections": "4.0.0",
+        "System.Diagnostics.Contracts": "4.0.0",
+        "System.Linq": "4.0.0",
+        "System.Reflection": "4.0.10",
+        "System.Runtime.Extensions": "4.0.10",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc2-23714"
+      }
+    }
   }
 }


### PR DESCRIPTION
There's quite a bit of ported code in this one, as TypeExtensions is not a partial facade on .NET Native. The second commit cleans up and formats the new code to bring it in line with our guidelines.

NOTE: We should rename the csproj file (System.Reflection.TypeExtensions.CoreCLR.csproj), but I will do that as a follow-up in our internal source control so that I can make sure nothing is broken by the rename.

@weshaggard @venkat-raman251 