### PR TITLE
Revert the removed lines to fix build break in NetNative

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -468,6 +468,12 @@ namespace System.Runtime.Serialization
             get { return false; }
         }
 
+#if NET_NATIVE
+        public bool TypeIsInterface;
+        public bool TypeIsCollectionInterface;
+        public Type GenericTypeDefinition;
+#endif
+
         internal virtual void WriteRootElement(XmlWriterDelegator writer, XmlDictionaryString name, XmlDictionaryString ns)
         {
             if (object.ReferenceEquals(ns, DictionaryGlobals.SerializationNamespace) && !IsPrimitive)


### PR DESCRIPTION
These were removed as part of https://github.com/dotnet/corefx/pull/5404. However they are needed for NetNative. So revert this change to fix NetNative build break.

@shmao @SGuyGe 