### PR TITLE
Improve Unix synchronous socket perf

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.SetReceiveTimeout.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SetReceiveTimeout.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetReceiveTimeout")]
+        internal static extern unsafe Error SetReceiveTimeout(int socket, int millisecondsTimeout);
+    }
+}

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SetSendTimeout.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SetSendTimeout.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Net.Sockets;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetSendTimeout")]
+        internal static extern unsafe Error SetSendTimeout(int socket, int millisecondsTimeout);
+    }
+}

--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -1341,6 +1341,33 @@ extern "C" Error SystemNative_SetLingerOption(int32_t socket, LingerOption* opti
     return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
 }
 
+Error SetTimeoutOption(int32_t socket, int32_t millisecondsTimeout, int optionName)
+{
+    if (millisecondsTimeout < 0)
+    {
+        return PAL_EINVAL;
+    }
+
+    timeval timeout =
+    {
+        timeout.tv_sec = millisecondsTimeout / 1000,
+        timeout.tv_usec = (millisecondsTimeout % 1000) * 1000
+    };
+
+    int err = setsockopt(socket, SOL_SOCKET, optionName, &timeout, sizeof(timeout));
+    return err == 0 ? PAL_SUCCESS : SystemNative_ConvertErrorPlatformToPal(errno);
+}
+
+extern "C" Error SystemNative_SetReceiveTimeout(int32_t socket, int32_t millisecondsTimeout)
+{
+    return SetTimeoutOption(socket, millisecondsTimeout, SO_RCVTIMEO);
+}
+
+extern "C" Error SystemNative_SetSendTimeout(int32_t socket, int32_t millisecondsTimeout)
+{
+    return SetTimeoutOption(socket, millisecondsTimeout, SO_SNDTIMEO);
+}
+
 static bool ConvertSocketFlagsPalToPlatform(int32_t palFlags, int& platformFlags)
 {
     const int32_t SupportedFlagsMask = PAL_MSG_OOB | PAL_MSG_PEEK | PAL_MSG_DONTROUTE | PAL_MSG_TRUNC | PAL_MSG_CTRUNC;

--- a/src/Native/System.Native/pal_networking.h
+++ b/src/Native/System.Native/pal_networking.h
@@ -364,6 +364,10 @@ extern "C" Error SystemNative_GetLingerOption(int32_t socket, LingerOption* opti
 
 extern "C" Error SystemNative_SetLingerOption(int32_t socket, LingerOption* option);
 
+extern "C" Error SystemNative_SetReceiveTimeout(int32_t socket, int32_t millisecondsTimeout);
+
+extern "C" Error SystemNative_SetSendTimeout(int32_t socket, int32_t millisecondsTimeout);
+
 extern "C" Error SystemNative_ReceiveMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* received);
 
 extern "C" Error SystemNative_SendMessage(int32_t socket, MessageHeader* messageHeader, int32_t flags, int64_t* sent);

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
@@ -979,6 +979,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(5832, PlatformID.AnyUnix)]
         public void AcceptV6BoundToSpecificV4_CantConnect()
         {
             Assert.Throws<SocketException>(() =>

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
@@ -2572,8 +2572,7 @@ namespace System.Net.Sockets.Tests
                 catch (SocketException ex)
                 {
                     Task.Delay(Configuration.FailingTestTimeout).Wait(); // Give the other end a chance to call Accept().
-                    _serverSocket.Shutdown(SocketShutdown.Both);  // Cancels the test
-                    _serverSocket.Dispose();
+                    _serverSocket.Dispose(); // Cancels the test
                     Error = ex.SocketErrorCode;
                 }
                 finally

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
@@ -999,6 +999,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(5832, PlatformID.AnyUnix)]
         public void AcceptV6BoundToAnyV4_CantConnect()
         {
             Assert.Throws<SocketException>(() =>

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
@@ -2572,7 +2572,8 @@ namespace System.Net.Sockets.Tests
                 catch (SocketException ex)
                 {
                     Task.Delay(Configuration.FailingTestTimeout).Wait(); // Give the other end a chance to call Accept().
-                    _serverSocket.Dispose(); // Cancels the test
+                    _serverSocket.Shutdown(SocketShutdown.Both);  // Cancels the test
+                    _serverSocket.Dispose();
                     Error = ex.SocketErrorCode;
                 }
                 finally

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
@@ -989,6 +989,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(5832, PlatformID.AnyUnix)]
         public void AcceptV4BoundToSpecificV6_CantConnect()
         {
             Assert.Throws<SocketException>(() =>

--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -416,6 +416,12 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.LingerOption.cs">
       <Link>Interop\Unix\System.Native\Interop.LingerOption.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SetSendTimeout.cs">
+      <Link>Interop\Unix\System.Native\Interop.SetSendTimeout.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SetReceiveTimeout.cs">
+      <Link>Interop\Unix\System.Native\Interop.SetReceiveTimeout.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Listen.cs">
       <Link>Interop\Unix\System.Native\Interop.Listen.cs</Link>
     </Compile>

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -411,6 +411,7 @@ namespace System.Net.Sockets
         private OperationQueue<AcceptOrConnectOperation> _acceptOrConnectQueue;
         private SocketAsyncEngine _engine;
         private Interop.Sys.SocketEvents _registeredEvents;
+        private volatile bool _nonBlockingSet;
 
         // These locks are hierarchical: _closeLock must be acquired before _queueLock in order
         // to prevent deadlock.
@@ -561,6 +562,28 @@ namespace System.Net.Sockets
             }
         }
 
+        public void SetNonBlocking()
+        {
+            //
+            // Our sockets may start as blocking, and later transition to non-blocking, either because the user
+            // explicitly requested non-blocking mode, or because we need non-blocking mode to support async
+            // operations.  We never transition back to blocking mode, to avoid problems synchronizing that
+            // transition with the async infrastructure.
+            //
+            // Note that there's no synchronization here, so we may set the non-blocking option multiple times
+            // in a race.  This should be fine.
+            //
+            if (!_nonBlockingSet)
+            {
+                if (Interop.Sys.Fcntl.SetIsNonBlocking((IntPtr)_fileDescriptor, 1) != 0)
+                {
+                    throw new SocketException((int)SocketPal.GetSocketErrorForErrorCode(Interop.Sys.GetLastError()));
+                }
+
+                _nonBlockingSet = true;
+            }
+        }
+
         private bool TryBeginOperation<TOperation>(ref OperationQueue<TOperation> queue, TOperation operation, Interop.Sys.SocketEvents events, out bool isStopped)
             where TOperation : AsyncOperation
         {
@@ -659,6 +682,8 @@ namespace System.Net.Sockets
             Debug.Assert(socketAddressLen > 0);
             Debug.Assert(callback != null);
 
+            SetNonBlocking();
+
             int acceptedFd;
             SocketError errorCode;
             if (SocketPal.TryCompleteAccept(_fileDescriptor, socketAddress, ref socketAddressLen, out acceptedFd, out errorCode))
@@ -742,6 +767,8 @@ namespace System.Net.Sockets
             Debug.Assert(socketAddress != null);
             Debug.Assert(socketAddressLen > 0);
             Debug.Assert(callback != null);
+
+            SetNonBlocking();
 
             SocketError errorCode;
             if (SocketPal.TryStartConnect(_fileDescriptor, socketAddress, socketAddressLen, out errorCode))
@@ -842,6 +869,8 @@ namespace System.Net.Sockets
 
         public SocketError ReceiveFromAsync(byte[] buffer, int offset, int count, SocketFlags flags, byte[] socketAddress, int socketAddressLen, Action<int, byte[], int, SocketFlags, SocketError> callback)
         {
+            SetNonBlocking();
+
             int bytesReceived;
             SocketFlags receivedFlags;
             SocketError errorCode;
@@ -950,6 +979,8 @@ namespace System.Net.Sockets
 
         public SocketError ReceiveFromAsync(IList<ArraySegment<byte>> buffers, SocketFlags flags, byte[] socketAddress, int socketAddressLen, Action<int, byte[], int, SocketFlags, SocketError> callback)
         {
+            SetNonBlocking();
+
             int bytesReceived;
             SocketFlags receivedFlags;
             SocketError errorCode;
@@ -1055,6 +1086,8 @@ namespace System.Net.Sockets
 
         public SocketError ReceiveMessageFromAsync(byte[] buffer, int offset, int count, SocketFlags flags, byte[] socketAddress, int socketAddressLen, bool isIPv4, bool isIPv6, Action<int, byte[], int, SocketFlags, IPPacketInformation, SocketError> callback)
         {
+            SetNonBlocking();
+
             int bytesReceived;
             SocketFlags receivedFlags;
             IPPacketInformation ipPacketInformation;
@@ -1162,6 +1195,8 @@ namespace System.Net.Sockets
 
         public SocketError SendToAsync(byte[] buffer, int offset, int count, SocketFlags flags, byte[] socketAddress, int socketAddressLen, Action<int, byte[], int, SocketFlags, SocketError> callback)
         {
+            SetNonBlocking();
+
             int bytesSent = 0;
             SocketError errorCode;
             if (SocketPal.TryCompleteSendTo(_fileDescriptor, buffer, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode))
@@ -1265,6 +1300,8 @@ namespace System.Net.Sockets
 
         public SocketError SendToAsync(IList<ArraySegment<byte>> buffers, SocketFlags flags, byte[] socketAddress, int socketAddressLen, Action<int, byte[], int, SocketFlags, SocketError> callback)
         {
+            SetNonBlocking();
+
             int bufferIndex = 0;
             int offset = 0;
             int bytesSent = 0;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -411,7 +411,7 @@ namespace System.Net.Sockets
         private OperationQueue<AcceptOrConnectOperation> _acceptOrConnectQueue;
         private SocketAsyncEngine _engine;
         private Interop.Sys.SocketEvents _registeredEvents;
-        private volatile bool _nonBlockingSet;
+        private bool _nonBlockingSet;
 
         // These locks are hierarchical: _closeLock must be acquired before _queueLock in order
         // to prevent deadlock.


### PR DESCRIPTION
Synchronous operations on sockets are currently always emulated in terms of async/non-blocking operations.  This has quite a lot of run-time overhead, due to extra system calls, context switches, etc.

With this change we keep the socket in "blocking" mode until the user requests non-blocking mode *or* initiates an asynchronous operation.  The result is that a socket that only ever experiences synchronous operations will not have the overhead of emulating sync over async.
