### PR TITLE
Fix serialization in NetNative to throw exception for get-only IEnumerable collection

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/CollectionDataContract.cs
@@ -1410,6 +1410,12 @@ namespace System.Runtime.Serialization
             {
                 // IsGetOnlyCollection value has already been used to create current collectiondatacontract, value can now be reset. 
                 context.IsGetOnlyCollection = false;
+#if NET_NATIVE
+                if (XmlFormatGetOnlyCollectionReaderDelegate == null)
+                {
+                    throw new InvalidDataContractException(SR.Format(SR.SerializationCodeIsMissingForType, UnderlyingType.ToString()));
+                }
+#endif
                 XmlFormatGetOnlyCollectionReaderDelegate(xmlReader, context, CollectionItemName, Namespace, this);
             }
             else


### PR DESCRIPTION
For IEnumerable get-only collection deserialization is not supported because there is no Add method to populate the collection. In this scenario, the NetNative sgen will not initialize the delegate to read them so we should throw meaningful exception when that happens.
This change only affects NetNative. The fix for NetCore has been merged in https://github.com/dotnet/corefx/pull/5404

@shmao @SGuyGe @zhenlan 