### PR TITLE
Add documentation for porting, triage, and issue bar

### DIFF
--- a/Documentation/project-docs/porting.md
+++ b/Documentation/project-docs/porting.md
@@ -1,10 +1,6 @@
 # Porting to .NET Core
 
----8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<
-
-The purpose of this document is to share the plans on how we're going to port more APIs to .NET Core. As the scissors indicate, this section is meant as the context for reviewers and contributors. We're aren't going to publish this part.
-
---->8--->8--->8--->8--->8--->8--->8--->8--->8--->8--->8--->8--->8--->8--->8--->8
+The purpose of this document is to share the plans on how we're going to port more APIs to .NET Core.
 
 ## Summary
 

--- a/Documentation/project-docs/porting.md
+++ b/Documentation/project-docs/porting.md
@@ -6,7 +6,7 @@ The purpose of this document is to share the plans on how we're going to port mo
 
 Compared to other .NET stacks, specifically the .NET Framework, Mono, Unity, and Xamarin the .NET Core platform doesn't expose enough APIs. This makes porting assets to .NET Core quite challenging, especially for areas which don't have replacements.
 
-So we want to bring more API to .NET Core. In order to keep our promise of being open and transparent, we want to:
+So we want to bring more APIs to .NET Core. In order to keep our promise of being open and transparent, we want to:
 
 * Clearly communicate what we plan on porting, how we prioritize, what we don't want to port, and how we're thinking of cross-platform and compatibility.
 * Avoid being the bottleneck by allowing community members to help with porting.
@@ -64,8 +64,8 @@ Here are the high level guidelines:
 	- **Do not** expose Windows-only technologies in otherwise fully portable assemblies.
 	- **Do** factor large chunks of functionality that cannot be supported everywhere into their own assemblies.
 	- **Do** consider using tester-doer patterns if only a very small number of APIs cannot be supported in all environments.
-* **Avoid** making changes that result in loss of binary and/or source compatibility between the .NET Framework and .NET Core.
 * **Consider** using extension methods and partial facades to accelerate bringing revised APIs to the .NET Framework.
+* **Avoid** making changes that result in loss of binary and/or source compatibility between the .NET Framework and .NET Core.
 * **Avoid** "franken-designs" with extension methods and partial facades purely for the sake of .NET Framework compatibility.
 
 ## Unsupported Technologies

--- a/Documentation/project-docs/porting.md
+++ b/Documentation/project-docs/porting.md
@@ -1,0 +1,117 @@
+# Porting to .NET Core
+
+---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<
+
+The purpose of this document is to share the plans on how we're going to port more APIs to .NET Core. As the scissors indicate, this section is meant as the context for reviewers and contributors. We're aren't going to publish this part.
+
+--->8--->8--->8--->8--->8--->8--->8--->8--->8--->8--->8--->8--->8--->8--->8--->8
+
+## Summary
+
+Compared to other .NET stacks, specifically the .NET Framework, Mono, Unity, and Xamarin the .NET Core platform doesn't expose enough APIs. This makes porting assets to .NET Core quite challenging, especially for areas which don't have replacements.
+
+So we want to bring more API to .NET Core. In order to keep our promise of being open and transparent, we want to:
+
+* Clearly communicate what we plan on porting, how we prioritize, what we don't want to port, and how we're thinking of cross-platform and compatibility.
+* Avoid being the bottleneck by allowing community members to help with porting.
+
+## Prioritization
+
+As of today, .NET Core supports three app models:
+
+* **ASP.NET apps and services**
+* **Console apps**
+* **Universal Windows Platform (UWP) apps**
+
+We'll prioritize APIs that affect the ability to write those kind of apps over app models that .NET Core currently doesn't support (such as building desktop applications). Please note that this doesn't mean that we'll never port the other APIs -- it just means those rank lower.
+
+The same is true for platforms: the implementation of .NET Framework only runs on Windows. Our goal for .NET Core is to support the following platforms:
+
+* Windows
+* OS X
+* Linux
+
+(Please note that that the specific version numbers, editions, and distros aren't fully finalized yet.)
+
+While we try to be mindful of other ports actively happening (such a BSD Unix), we prioritize those three platforms. It's also worth pointing out that we generally don't prioritize within these platforms; in other words we consider them all as equals. Of course, we start from a Windows implementation so the support is currently more complete there. Also, we're mindful of the ways developers are most likely to use the platforms as well. For instance, many web developers debug and test on OS X but deploy to Linux. This guides us when prioritizing work to address point-in-time issues.
+
+We determine which APIs are critical by leveraging various data sources:
+
+* **Community feedback** (such as GitHub, UserVoice)
+* **Partner feedback** (1st party and 3rd party applications)
+* **API usage of existing applications** (such as submissions from API Port, ASP.NET applications, and Silverlight based phone apps)
+
+We obviously aren't going to use a fixed formula to determine the stack rank of an API. We'll also leverage the experience from long term members on the team and combine it with the data and feedback to make intelligent decisions. For the sake of transparency we'll share all the data we have and the factors that lead to a specific decision. So if a decision we make is problematic for a part of the .NET ecosystem, such as not including the interfaces of ADO.NET for ORM providers, we can adjust as we go.
+
+## Mechanics
+
+For the most part, the source code for .NET Framework and .NET Core is disjoint. In other words, porting code to .NET Core isn't an exercise of checking a box -- it requires active work.
+
+Here is the summary of the activities involved:
+
+* Decide which APIs should go into .NET Core
+* Assess implications on componentization (see guidelines for more details)
+* Assess cross-platform impact. If necessary, find out how, and even if, the current design can be supported on all supported platforms
+* Get the code onto GitHub (this includes some minor clean up, such as running the code formatting tool)
+* Produce packages
+* Port corresponding tests
+
+## Porting Guidelines
+
+Here are the high level guidelines:
+
+* **Do not** port APIs of technologies we don't want to support moving forward (see list below).
+* **Do not** port APIs marked as obsolete.
+* **Consider** porting APIs even if considered legacy, problematic, or otherwise inadequate.
+* **Do** factor assemblies appropriately in order to preserve the componentization, specifically:
+	- **Do not** add dependencies from non-legacy to legacy components.
+	- **Do not** expose Windows-only technologies in otherwise fully portable assemblies.
+	- **Do** factor large chunks of functionality that cannot be supported everywhere into their own assemblies.
+	- **Do** consider using tester-doer patterns if only a very small number of APIs cannot be supported in all environments.
+* **Avoid** making changes that result in loss of binary and/or source compatibility between the .NET Framework and .NET Core.
+* **Consider** using extension methods and partial facades to accelerate bringing revised APIs to the .NET Framework.
+* **Avoid** "franken-designs" with extension methods and partial facades purely for the sake of .NET Framework compatibility.
+
+## Unsupported Technologies
+
+Feature owners reserve the right to call out what they don't want to support on .NET Core. Since .NET Core is a new platform, we don't want to penalize our ability to build a componentized and cross-platform stack by signing up for technologies that are expensive to bring into this world and we don't think are sensible for today's needs.
+
+This list, while not complete, is meant as a reference point. We'll add to it as we refine our porting plan.
+
+Technology                 | More information
+---------------------------|-----------------------------------
+AppDomains                 | [Details](#app_domains)
+Remoting                   | [Details](#remoting)
+Binary Serialization       | [Details](#binary-serialization)
+Code Access Security (CAS) | [Details](#code-access-security-cas)
+Security Transparency      | [Details](#security-transparency)
+
+### App Domains
+
+**Justification**. AppDomains require runtime support and are generally quite expensive. While still implemented by CoreCLR it's not available in .NET Native and we don't plan on adding this capability.
+
+**Replacement**. AppDomains were used for different features; for isolation we recommend processes and/or containers.
+
+### Remoting
+
+**Justification**. The idea of .NET remoting -- which is transparent remote procedure calls -- has been identified as a problematic architecture. Outside of that realm, it's also used for cross AppDomain communication which is no longer supported. On top of that, remoting requires runtime support and is quite heavyweight.
+
+**Replacement**. For communication across processes, inter-process communication (IPC) should be used, such as pipes or memory mapped files. Across machines, you should use a network based solution, preferably a low-overhead plain text protocol such as HTTP.
+
+### Binary Serialization
+
+**Justification**. After a decade of servicing we've learned that serialization is incredibly complicated and a huge compatibility burden for the types supporting it. Thus, we made the decision that serialization should be a protocol implemented on top of the available public APIs. However, binary serialization requires intimate knowledge of the types as it allows to serialize object graphs including private state.
+
+**Replacement**. Choose the serialization technology that fits your goals for formatting and footprint. Popular choices include data contract serialization, XML serialization, JSON.NET, and protobuf-net.
+
+### Code Access Security (CAS)
+
+**Justification**. Sand-boxing, i.e. relying on the runtime or the framework to constrain which resources a managed application can run, is considered a non-goal for .NET Core. We've already state previously that relying on sand-boxing for security reasons isn't an approach we're feeling comfortable with; there are simply too many pieces in object oriented framework that can result in elevation of privileges. Thus we don't treat CAS as security boundary anymore. On top of that, it makes the implementation more complicated and often has performance implications for the happy path.
+
+**Replacement**. Use operating system provided security boundaries, such as user accounts for running processes with the least set of privileges.
+
+### Security Transparency
+
+**Justification**. Similar to CAS, this feature allows separating sand-boxed code from security critical code in a declarative fashion. This feature was heavily used by Silverlight. 
+
+**Replacement**. Use operating system provided security boundaries, such as user accounts for running processes with the least set of privileges.

--- a/Documentation/project-docs/roadmap.md
+++ b/Documentation/project-docs/roadmap.md
@@ -1,0 +1,23 @@
+# Roadmap for CoreFx
+
+---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<
+
+We need a document that outlines our vision for .NET Core:
+
+* Startup space: highly scalable, efficient applications
+* When in conflict, favor this over pure productivity
+* Efficient data manipulation APIs
+    - Low allocation APIs
+    - Better blending of native code and managed code (Span, DllExport)
+
+As the scissors indicate, these are notes for Krzysztof to fill in more details here.
+
+Example:
+
+## Provide a better alternative for `System.Diagnostics.Process` 
+
+Our `Process` class was designed for a time where one would drag & drop a process component on a design surface, configure it in a visual designer, and then write a line or two to launch it. Also, it was designed around many concepts that are arguably specific to the Windows platform, such as `ShellExecute`.
+
+It seems we should take another look at this and see whether we can create a better API for dealing with processes.
+
+---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<---8<

--- a/Documentation/project-docs/rtm.md
+++ b/Documentation/project-docs/rtm.md
@@ -24,7 +24,7 @@ Unfortunately, when we introduced `TypeInfo` we also tried to clean up the surfa
 Based on extensive customer feedback we decided that we need to improve reflection so that porting code to .NET Core becomes easier. The current proposal is to:
 
 1. Keep the split, i.e. don't add those APIs to `System.Type`
-2. Add all the APIs that used to live on `System.Type` and add them to `System.Reflection.TypeInfo`
+2. Add all the APIs that used to live on `System.Type` to `System.Reflection.TypeInfo`
 
 While having any delta is unfortunate, we believe it is vital to be able to deliver a .NET stack that doesn't require reflection, especially for ahead-of-time (AOT) compilation scenarios, in order to reduce footprint.
 

--- a/Documentation/project-docs/rtm.md
+++ b/Documentation/project-docs/rtm.md
@@ -1,0 +1,53 @@
+# Road to RTM of .NET Core
+
+Our current focus is to get the bits in order for a high quality RTM release. This includes fixing bugs, finishing the cross-platform bring-up, as well as adding new APIs and features to create the end-to-end developer experience.
+
+This document calls out in more detail what we're focusing for the next couple of months. Of course, it doesn't list all issues; but it highlights the big areas and gives you an idea of the theme.
+
+## Finish porting `System.Console`
+
+Originally, we subset `System.Console` quite aggressively. The reason being that not all app models required all APIs and many of them were non-trivial to port cross platforms.
+
+Since then, we've learned quite a bit. Based on early adopter feedback, we've decided to extend the surface to almost full parity.
+
+## Expose old reflection APIs on `System.Reflection.TypeInfo`
+
+One of the key goals for .NET Core was ensuring that the framework is factored well, with sensible and sustainable dependencies. As a result we decided to remove the direct dependency from `System.Object` to `System.Reflection`, which comes from `Object.GetType()`. In order to do that, we created the new `System.Reflection.TypeInfo` class that represents the full type information, and made `System.Type` the representation for a type name. In order to reflect, code is expected to do something like:
+
+```C#
+object data = GetData();
+TypeInfo typeInfo = data.GetType().GetTypeInfo();
+```
+
+Unfortunately, when we introduced `TypeInfo` we also tried to clean up the surface area of reflection, and as a result didn't expose all the APIs and concepts reflection used to have. For instance, we didn't include APIs that use `BindingFlags` and provide certain semantics, such as flatting the type hierarchy.
+
+Based on extensive customer feedback we decided that we need to improve reflection so that porting code to .NET Core becomes easier. The current proposal is to:
+
+1. Keep the split, i.e. don't add those APIs to `System.Type`
+2. Add all the APIs that used to live on `System.Type` and add them to `System.Reflection.TypeInfo`
+
+While having any delta is unfortunate, we believe it is vital to be able to deliver a .NET stack that doesn't require reflection, especially for ahead-of-time (AOT) compilation scenarios, in order to reduce footprint.
+
+Also, this delta would be quite easy to reason about. Missing a reflection API? Insert a call to `GetTypeInfo()`.
+
+## Finish `System.Buffers`
+
+Most performance optimizations around managed code boil down to reducing the number of allocations. This could be by writing better code that requires fewer objects, avoiding excessive boxing, or pooling objects.
+
+Related to this is the handling of buffers, i.e. arrays. This is especially relevant in I/O heavy operations, such as web servers. Instead of creating buffers when needed, it can be beneficial to pool them. This can reduce GC pressure which improves overall throughput.
+
+We've started [building a prototype](https://github.com/dotnet/corefx/tree/master/src/System.Buffers) that we intend to finish before RTM so that ASP.NET can take a dependency on it. 
+
+## Finish `System.Runtime.Loader.AssemblyLoadContext`
+
+For CoreCLR, we've added a new API that allows loading assemblies into different load contexts. This allows hosts to be able to load different versions of assemblies without having to unify them.
+
+This API is heavily used by ASP.NET and thus needs to be finished before RTM.
+
+## Splitting the `System.Runtime.InteropServices`
+
+The .NET stack always had a comprehensive interop story for native code, especially on Windows. This includes support for calling C APIs via P/Invoke but also includes COM and, since Windows 8, WinRT.
+
+In the past, we've centralized the handling of all these technologies in APIs exposed from `System.Runtime.InteropServices.dll`. However, many applications don't need all of it. This is especially true in cross-platform scenarios, because COM and WinRT interop doesn't make any sense for non-Windows applications.
+
+We've decided to extract a smaller component that deals with P/Invoke only. This allows applications to call into C APIs without having to bring along the entire COM/WinRT interop infrastructure.

--- a/Documentation/project-docs/triage.md
+++ b/Documentation/project-docs/triage.md
@@ -1,0 +1,51 @@
+# Triaging process
+
+The nice thing about open source and GitHub in particular is that there is a very low barrier of entry for participation, which includes filing feature requests and bugs.
+
+## The challenge
+
+The tricky thing is that we need to strike a balance:
+
+* We don't want to close all issues that represent work we're currently not resourced to do. In the end, a healthy open source project requires a well maintained backlog so that we can plan the next version in a transparent fashion.
+
+* On the other hand, we don't want to have so many pending issues that we can't see the forest for the trees. Of course, what is *too many* is highly subjective. As a general rule, it's not so much the sheer number of issues, it's how diverse they are.
+
+At Microsoft, we've a lot of experience on how to run big, multi-year releases with thousands of engineers. I think it's fair to say that we're still learning on how to adjust our processes and tools to deal with short releases, especially around open source. It's interesting to note that the number of engineers and products have pretty stayed the same. What has changed is that we pushed the release management down to the individual teams so that decisions are more localized and thus can be made faster with fewer expensive round trips across large organizational boundaries. This is one of the reasons we introduced the .NET Core platform. Since its release cycle is decoupled from the .NET Framework (and thus Windows) we can iterate much faster.
+
+However, another key thing hasn't changed either: our customers continue to expect a well integrated set of products. For .NET Core, this means we need to align runtime work, language innovation, designer integration, and IDE investments in order to deliver the great development experience .NET is known for.
+
+So while we strive to move faster at each of these components, we still have to be mindful of the integration points and ensure we deliver a set of components that work well with each other.
+
+## Themes for alignment
+
+In the multi year release cycles we've learned that organizational alignment is much simpler when releases have a set of themes and key scenarios we want to enable. This ensures that components that need to integrate commit resources and prioritize issues in a similar fashion. This reduces confusion and avoids constant fire drills around integration points.
+
+Of course, teams aren't hostage to the set of themes and scenarios. But they provide the goal post to judge what is considered critical, important and merely nice to have. Depending on cost and complexity, certain features can be quickly discarded as out of scope while others can be grouped together in order to streamline planning and execution.
+
+## What this means for CoreFx
+
+Our goal is to become a bit more trigger happy when it comes to closing issues. We've currently over 700 open issues on the corefx repo alone. We've noticed that our design review process is a major bottleneck for adding new features, in particular when we're adding APIs to types that are shared with the .NET Framework: we need to think about how we can reconcile that difference in the future so that you can still author libraries that can run on both platforms.
+
+We owe our customers -- and this includes our open source community -- that we don't lose track of what's important. We do, however, want to make sure we can continuously improve small things as well. We strongly believe that one of the key reasons open source is so successful is because it encourages a mindset of small changes over time.
+
+## Triaging approach
+
+Our current approach to triage looks as follows (the higher the number the more likely we're going to close it):
+
+1. Is it relevant to unblock the developer experience for [.NET Core RTM](rtm.md)?
+2. Is it helping with [porting .NET Framework code to .NET Core](porting.md)?
+3. Is it aligned with the [roadmap of .NET Core vNext](roadmap.md)?
+3. Is it a separate type that we can deliver as a standalone library for both, .NET Framework and .NET Core?
+4. Is it going to require modifying the .NET Framework?
+
+Of course, this list isn't meant to be comprehensive, as this is generally impossible to write up. However, it should give you an idea of how we prioritize and what goes through our head when triaging.
+
+In particular, we strive to follow these guidelines:
+
+* **Do** favor issues that impact our ability to deliver the current release
+* **Do** prioritize expensive work items that is strongly aligned with the roadmap for the upcoming release
+* **Avoid** working on a large number of unrelated issues
+* **Do** close issues that represent work we don't think makes sense for the current or upcoming release
+* **Do** close issues that provide little or questionable value to APIs that are included with the .NET Framework
+* **Do** favor issues that do not require modifying types that are included with the .NET Framework.
+* **Avoid** franken design just to avoid adding APIs to types that are included with the .NET Framework


### PR DESCRIPTION
This also includes some boiler plate for the roadmap for post-RTM, but
it's not fully done yet. However, I believe it's better to get the parts
in we already have, then waiting for the complete set.

@weshaggard @KrzysztofCwalina @richlander @bleroy 