### PR TITLE
Remove SecurityTransparentAttribute from the Open Compression

### DIFF
--- a/src/System.IO.Compression/src/System.IO.Compression.csproj
+++ b/src/System.IO.Compression/src/System.IO.Compression.csproj
@@ -27,7 +27,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
   <!-- Files shared between net46 and core -->
   <ItemGroup>
-    <Compile Include="AssemblyInfo.cs" />
     <Compile Include="$(SharedOpenSourcePath)System\IO\Compression\Crc32Helper.cs" />
     <Compile Include="$(SharedOpenSourcePath)System\IO\Compression\ZipArchive.cs" />
     <Compile Include="$(SharedOpenSourcePath)System\IO\Compression\ZipArchiveEntry.cs" />
@@ -83,6 +82,7 @@
   </ItemGroup>
   <!-- Files exclusive to net46 -->
   <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
+    <Compile Include="AssemblyInfo.cs" />
     <TargetingPackReference Include="mscorlib" />
     <TargetingPackReference Include="System" />
   </ItemGroup>


### PR DESCRIPTION
[this TFS commit](https://github.com/dotnet/corefx/commit/15f47efe119b17032a661f752248ae1fcc172bf3) added an assembly tag to both the open and desktop builds that was previously only in the desktop build. The inclusion to the Open build is causing an upstream failure https://github.com/dotnet/corefx/issues/5380.

This PR moves the Security tag inclusion to only be used on the net46 build.

@weshaggard @stephentoub @troydai