### PR TITLE
Combine Linq optimisations [WIP]

### DIFF
--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -530,7 +530,7 @@ namespace System.Linq
         }
 
 
-        internal sealed class SelectArrayIterator<TSource, TResult> : Iterator<TResult>, IArrayProvider<TResult>, IListProvider<TResult>
+        internal sealed class SelectArrayIterator<TSource, TResult> : Iterator<TResult>, IIListProvider<TResult>
         {
             private readonly TSource[] _source;
             private readonly Func<TSource, TResult> _selector;
@@ -587,7 +587,7 @@ namespace System.Linq
             }
         }
 
-        internal sealed class SelectListIterator<TSource, TResult> : Iterator<TResult>, IArrayProvider<TResult>, IListProvider<TResult>
+        internal sealed class SelectListIterator<TSource, TResult> : Iterator<TResult>, IIListProvider<TResult>
         {
             private readonly List<TSource> _source;
             private readonly Func<TSource, TResult> _selector;
@@ -653,7 +653,7 @@ namespace System.Linq
             }
         }
 
-        internal sealed class SelectIListIterator<TSource, TResult> : Iterator<TResult>, IArrayProvider<TResult>, IListProvider<TResult>
+        internal sealed class SelectIListIterator<TSource, TResult> : Iterator<TResult>, IIListProvider<TResult>
         {
             private readonly IList<TSource> _source;
             private readonly Func<TSource, TResult> _selector;
@@ -1270,14 +1270,14 @@ namespace System.Linq
         public static TSource[] ToArray<TSource>(this IEnumerable<TSource> source)
         {
             if (source == null) throw Error.ArgumentNull("source");
-            IArrayProvider<TSource> arrayProvider = source as IArrayProvider<TSource>;
+            IIListProvider<TSource> arrayProvider = source as IIListProvider<TSource>;
             return arrayProvider != null ? arrayProvider.ToArray() : new Buffer<TSource>(source).ToArray();
         }
 
         public static List<TSource> ToList<TSource>(this IEnumerable<TSource> source)
         {
             if (source == null) throw Error.ArgumentNull("source");
-            IListProvider<TSource> listProvider = source as IListProvider<TSource>;
+            IIListProvider<TSource> listProvider = source as IIListProvider<TSource>;
             return listProvider != null ? listProvider.ToList() : new List<TSource>(source);
         }
 
@@ -1787,7 +1787,7 @@ namespace System.Linq
             return new RangeIterator(start, count);
         }
 
-        private sealed class RangeIterator : Iterator<int>, IArrayProvider<int>, IListProvider<int>, IPartition<int>
+        private sealed class RangeIterator : Iterator<int>, IPartition<int>
         {
             private readonly int _start;
             private readonly int _end;
@@ -1901,7 +1901,7 @@ namespace System.Linq
             return new RepeatIterator<TResult>(element, count);
         }
 
-        private sealed class RepeatIterator<TResult> : Iterator<TResult>, IArrayProvider<TResult>, IListProvider<TResult>, IPartition<TResult>
+        private sealed class RepeatIterator<TResult> : Iterator<TResult>, IPartition<TResult>
         {
             private readonly int _count;
             private int _sent;
@@ -3310,22 +3310,16 @@ namespace System.Linq
     }
 
     /// <summary>
-    /// An iterator that can produce an array through an optimized path.
+    /// An iterator that can produce an array or an <see cref="List{TElement}"/> through an optimized path.
     /// </summary>
-    internal interface IArrayProvider<TElement>
+    internal interface IIListProvider<TElement>
     {
         /// <summary>
         /// Produce an array of the sequence through an optimized path.
         /// </summary>
         /// <returns>The array.</returns>
         TElement[] ToArray();
-    }
 
-    /// <summary>
-    /// An iterator that can produce a <see cref="List{TElement}"/> through an optimized path.
-    /// </summary>
-    internal interface IListProvider<TElement>
-    {
         /// <summary>
         /// Produce a <see cref="List{TElement}"/> of the sequence through an optimized path.
         /// </summary>
@@ -3358,7 +3352,7 @@ namespace System.Linq
         bool Contains(TKey key);
     }
 
-    public class Lookup<TKey, TElement> : IEnumerable<IGrouping<TKey, TElement>>, ILookup<TKey, TElement>, IArrayProvider<IGrouping<TKey, TElement>>, IListProvider<IGrouping<TKey, TElement>>
+    public class Lookup<TKey, TElement> : IEnumerable<IGrouping<TKey, TElement>>, ILookup<TKey, TElement>, IIListProvider<IGrouping<TKey, TElement>>
     {
         private IEqualityComparer<TKey> _comparer;
         private Grouping<TKey, TElement>[] _groupings;
@@ -3429,7 +3423,7 @@ namespace System.Linq
             }
         }
 
-        IGrouping<TKey, TElement>[] IArrayProvider<IGrouping<TKey, TElement>>.ToArray()
+        IGrouping<TKey, TElement>[] IIListProvider<IGrouping<TKey, TElement>>.ToArray()
         {
             IGrouping<TKey, TElement>[] array = new IGrouping<TKey, TElement>[_count];
             int index = 0;
@@ -3446,7 +3440,7 @@ namespace System.Linq
             return array;
         }
 
-        List<IGrouping<TKey, TElement>> IListProvider<IGrouping<TKey, TElement>>.ToList()
+        List<IGrouping<TKey, TElement>> IIListProvider<IGrouping<TKey, TElement>>.ToList()
         {
             List<IGrouping<TKey, TElement>> list = new List<IGrouping<TKey, TElement>>(_count);
             Grouping<TKey, TElement> g = _lastGrouping;
@@ -3786,7 +3780,7 @@ namespace System.Linq
         }
     }
 
-    internal class GroupedEnumerable<TSource, TKey, TElement> : IEnumerable<IGrouping<TKey, TElement>>, IArrayProvider<IGrouping<TKey, TElement>>, IListProvider<IGrouping<TKey, TElement>>
+    internal class GroupedEnumerable<TSource, TKey, TElement> : IEnumerable<IGrouping<TKey, TElement>>, IIListProvider<IGrouping<TKey, TElement>>
     {
         private IEnumerable<TSource> _source;
         private Func<TSource, TKey> _keySelector;
@@ -3816,18 +3810,18 @@ namespace System.Linq
 
         public IGrouping<TKey, TElement>[] ToArray()
         {
-            IArrayProvider<IGrouping<TKey, TElement>> lookup = Lookup<TKey, TElement>.Create<TSource>(_source, _keySelector, _elementSelector, _comparer);
+            IIListProvider<IGrouping<TKey, TElement>> lookup = Lookup<TKey, TElement>.Create<TSource>(_source, _keySelector, _elementSelector, _comparer);
             return lookup.ToArray();
         }
 
         public List<IGrouping<TKey, TElement>> ToList()
         {
-            IListProvider<IGrouping<TKey, TElement>> lookup = Lookup<TKey, TElement>.Create<TSource>(_source, _keySelector, _elementSelector, _comparer);
+            IIListProvider<IGrouping<TKey, TElement>> lookup = Lookup<TKey, TElement>.Create<TSource>(_source, _keySelector, _elementSelector, _comparer);
             return lookup.ToList();
         }
     }
 
-    internal interface IPartition<TElement> : IEnumerable<TElement>, IArrayProvider<TElement>
+    internal interface IPartition<TElement> : IEnumerable<TElement>, IIListProvider<TElement>
     {
         IPartition<TElement> Skip(int count);
 
@@ -3846,7 +3840,7 @@ namespace System.Linq
         TElement LastOrDefault();
     }
 
-    internal sealed class EmptyPartition<TElement> : IPartition<TElement>, IListProvider<TElement>, IEnumerator<TElement>
+    internal sealed class EmptyPartition<TElement> : IPartition<TElement>, IEnumerator<TElement>
     {
         public EmptyPartition()
         {
@@ -4015,9 +4009,14 @@ namespace System.Linq
         {
             return _source.ToArray(_minIndex, _maxIndex);
         }
+
+        public List<TElement> ToList()
+        {
+            return _source.ToList(_minIndex, _maxIndex);
+        }
     }
 
-    internal abstract class OrderedEnumerable<TElement> : IOrderedEnumerable<TElement>, IArrayProvider<TElement>, IListProvider<TElement>, IPartition<TElement>
+    internal abstract class OrderedEnumerable<TElement> : IOrderedEnumerable<TElement>, IPartition<TElement>
     {
         internal IEnumerable<TElement> source;
 
@@ -4106,6 +4105,23 @@ namespace System.Linq
                 ++minIdx;
             }
             return array;
+        }
+
+        internal List<TElement> ToList(int minIdx, int maxIdx)
+        {
+            Buffer<TElement> buffer = new Buffer<TElement>(source);
+            int count = buffer.count;
+            if (count <= minIdx) return new List<TElement>(0);
+            if (count <= maxIdx) maxIdx = count - 1;
+            if (minIdx == maxIdx) return new List<TElement>(1) { GetEnumerableSorter().ElementAt(buffer.items, count, minIdx) };
+            int[] map = SortedMap(buffer, minIdx, maxIdx);
+            List<TElement> list = new List<TElement>(maxIdx - minIdx + 1);
+            while (minIdx <= maxIdx)
+            {
+                list.Add(buffer.items[map[minIdx]]);
+                ++minIdx;
+            }
+            return list;
         }
 
         private EnumerableSorter<TElement> GetEnumerableSorter()
@@ -4656,7 +4672,7 @@ namespace System.Linq
 
         internal Buffer(IEnumerable<TElement> source)
         {
-            IArrayProvider<TElement> iterator = source as IArrayProvider<TElement>;
+            IIListProvider<TElement> iterator = source as IIListProvider<TElement>;
             if (iterator != null)
             {
                 TElement[] array = iterator.ToArray();

--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -1234,7 +1234,7 @@ namespace System.Linq
             public List<TSource> ToList()
             {
                 int lastIndex = _source.Count - 1;
-                if (lastIndex < _minIndex) return new List<TSource>(0);
+                if (lastIndex < _minIndex) return new List<TSource>();
                 if (lastIndex > _maxIndex) lastIndex = _maxIndex;
                 List<TSource> list = new List<TSource>(lastIndex - _minIndex + 1);
                 for (int i = _minIndex; i <= lastIndex; ++i)
@@ -4493,7 +4493,7 @@ namespace System.Linq
 
         public List<TElement> ToList()
         {
-            return new List<TElement>(0);
+            return new List<TElement>();
         }
     }
 
@@ -4662,7 +4662,7 @@ namespace System.Linq
         {
             Buffer<TElement> buffer = new Buffer<TElement>(source);
             int count = buffer.count;
-            if (count <= minIdx) return new List<TElement>(0);
+            if (count <= minIdx) return new List<TElement>();
             if (count <= maxIdx) maxIdx = count - 1;
             if (minIdx == maxIdx) return new List<TElement>(1) { GetEnumerableSorter().ElementAt(buffer.items, count, minIdx) };
             int[] map = SortedMap(buffer, minIdx, maxIdx);

--- a/src/System.Linq/tests/DistinctTests.cs
+++ b/src/System.Linq/tests/DistinctTests.cs
@@ -198,5 +198,33 @@ namespace System.Linq.Tests
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }
+
+        [Fact]
+        public void ToArray()
+        {
+            int?[] source = { 1, 1, 1, 2, 2, 2, null, null };
+            int?[] expected = { 1, 2, null };
+
+            Assert.Equal(expected, source.Distinct().ToArray());
+        }
+
+        [Fact]
+        public void ToList()
+        {
+            int?[] source = { 1, 1, 1, 2, 2, 2, null, null };
+            int?[] expected = { 1, 2, null };
+
+            Assert.Equal(expected, source.Distinct().ToList());
+        }
+
+        [Fact]
+        public void RepeatEnumerating()
+        {
+            int?[] source = { 1, 1, 1, 2, 2, 2, null, null };
+
+            var result = source.Distinct();
+
+            Assert.Equal(result, result);
+        }
     }
 }

--- a/src/System.Linq/tests/ElementAtOrDefaultTests.cs
+++ b/src/System.Linq/tests/ElementAtOrDefaultTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Xunit;
 
 namespace System.Linq.Tests
@@ -130,6 +131,36 @@ namespace System.Linq.Tests
         public void NullSource()
         {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<int>)null).ElementAtOrDefault(2));
+        }
+
+        [Fact]
+        public void ArraySelectSource()
+        {
+            var source = new[] { 1, 2, 3, 4 }.Select(i => i * 2);
+            for (int i = 0; i != 4; ++i)
+                Assert.Equal((i + 1) * 2, source.ElementAtOrDefault(i));
+            Assert.Equal(0, source.ElementAtOrDefault(-1));
+            Assert.Equal(0, source.ElementAtOrDefault(4));
+        }
+
+        [Fact]
+        public void ListSelectSource()
+        {
+            var source = new[] { 1, 2, 3, 4 }.ToList().Select(i => i * 2);
+            for (int i = 0; i != 4; ++i)
+                Assert.Equal((i + 1) * 2, source.ElementAt(i));
+            Assert.Equal(0, source.ElementAtOrDefault(-1));
+            Assert.Equal(0, source.ElementAtOrDefault(4));
+        }
+
+        [Fact]
+        public void IListSelectSource()
+        {
+            var source = new ReadOnlyCollection<int>(new[] { 1, 2, 3, 4 }).Select(i => i * 2);
+            for (int i = 0; i != 4; ++i)
+                Assert.Equal((i + 1) * 2, source.ElementAt(i));
+            Assert.Equal(0, source.ElementAtOrDefault(-1));
+            Assert.Equal(0, source.ElementAtOrDefault(4));
         }
     }
 }

--- a/src/System.Linq/tests/ElementAtTests.cs
+++ b/src/System.Linq/tests/ElementAtTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Xunit;
 
 namespace System.Linq.Tests
@@ -130,6 +131,36 @@ namespace System.Linq.Tests
         public void NullSource()
         {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<int>)null).ElementAt(2));
+        }
+
+        [Fact]
+        public void ArraySelectSource()
+        {
+            var source = new[] { 1, 2, 3, 4 }.Select(i => i * 2);
+            for (int i = 0; i != 4; ++i)
+                Assert.Equal((i + 1) * 2, source.ElementAt(i));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => source.ElementAt(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => source.ElementAt(4));
+        }
+
+        [Fact]
+        public void ListSelectSource()
+        {
+            var source = new[] { 1, 2, 3, 4 }.ToList().Select(i => i * 2);
+            for (int i = 0; i != 4; ++i)
+                Assert.Equal((i + 1) * 2, source.ElementAt(i));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => source.ElementAt(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => source.ElementAt(4));
+        }
+
+        [Fact]
+        public void IListSelectSource()
+        {
+            var source = new ReadOnlyCollection<int>(new[] { 1, 2, 3, 4 }).Select(i => i * 2);
+            for (int i = 0; i != 4; ++i)
+                Assert.Equal((i + 1) * 2, source.ElementAt(i));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => source.ElementAt(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => source.ElementAt(4));
         }
     }
 }

--- a/src/System.Linq/tests/FirstOrDefaultTests.cs
+++ b/src/System.Linq/tests/FirstOrDefaultTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Xunit;
 
 namespace System.Linq.Tests
@@ -193,6 +194,27 @@ namespace System.Linq.Tests
         {
             Func<int, bool> predicate = null;
             Assert.Throws<ArgumentNullException>("predicate", () => Enumerable.Range(0, 3).FirstOrDefault(predicate));
+        }
+
+        [Fact]
+        public void ArraySelectSource()
+        {
+            Assert.Equal(11, new[] { 5, 6, 7, 8 }.Select(i => i * 2 + 1).FirstOrDefault());
+            Assert.Equal(0, new int[0].Select(i => i * 2 + 1).FirstOrDefault());
+        }
+
+        [Fact]
+        public void ListSelectSource()
+        {
+            Assert.Equal(11, new[] { 5, 6, 7, 8 }.ToList().Select(i => i * 2 + 1).FirstOrDefault());
+            Assert.Equal(0, new List<int>(0).Select(i => i * 2 + 1).FirstOrDefault());
+        }
+
+        [Fact]
+        public void IListSelectSource()
+        {
+            Assert.Equal(11, new ReadOnlyCollection<int>(new[] { 5, 6, 7, 8 }).Select(i => i * 2 + 1).FirstOrDefault());
+            Assert.Equal(0, new ReadOnlyCollection<int>(new int[0]).Select(i => i * 2 + 1).FirstOrDefault());
         }
     }
 }

--- a/src/System.Linq/tests/FirstTests.cs
+++ b/src/System.Linq/tests/FirstTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Xunit;
 
 namespace System.Linq.Tests
@@ -190,6 +191,30 @@ namespace System.Linq.Tests
         {
             Func<int, bool> predicate = null;
             Assert.Throws<ArgumentNullException>("predicate", () => Enumerable.Range(0, 3).First(predicate));
+        }
+
+        [Fact]
+        public void ArraySelectSource()
+        {
+            Assert.Equal(11, new[] { 5, 6, 7, 8 }.Select(i => i * 2 + 1).First());
+            var emptySource = new int[0].Select(i => i * 2 + 1);
+            Assert.Throws<InvalidOperationException>(() => emptySource.First());
+        }
+
+        [Fact]
+        public void ListSelectSource()
+        {
+            Assert.Equal(11, new[] { 5, 6, 7, 8 }.ToList().Select(i => i * 2 + 1).First());
+            var emptySource = new List<int>(0).Select(i => i * 2 + 1);
+            Assert.Throws<InvalidOperationException>(() => emptySource.First());
+        }
+
+        [Fact]
+        public void IListSelectSource()
+        {
+            Assert.Equal(11, new ReadOnlyCollection<int>(new[] { 5, 6, 7, 8 }).Select(i => i * 2 + 1).First());
+            var emptySource = new ReadOnlyCollection<int>(new int[0]).Select(i => i * 2 + 1);
+            Assert.Throws<InvalidOperationException>(() => emptySource.First());
         }
     }
 }

--- a/src/System.Linq/tests/GroupByTests.cs
+++ b/src/System.Linq/tests/GroupByTests.cs
@@ -630,5 +630,17 @@ namespace System.Linq.Tests
             Assert.Equal(4, groupedList.Count);
             Assert.Equal(source.GroupBy(r => r.Name, (r, e) => e), groupedList);
         }
+
+        [Fact]
+        public void EmptyGroupingToArray()
+        {
+            Assert.Empty(Enumerable.Empty<int>().GroupBy(i => i).ToArray());
+        }
+
+        [Fact]
+        public void EmptyGroupingToList()
+        {
+            Assert.Empty(Enumerable.Empty<int>().GroupBy(i => i).ToList());
+        }
     }
 }

--- a/src/System.Linq/tests/LastOrDefaultTests.cs
+++ b/src/System.Linq/tests/LastOrDefaultTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Xunit;
 
 namespace System.Linq.Tests.LegacyTests
@@ -243,6 +244,27 @@ namespace System.Linq.Tests.LegacyTests
         {
             Func<int, bool> predicate = null;
             Assert.Throws<ArgumentNullException>("predicate", () => Enumerable.Range(0, 3).LastOrDefault(predicate));
+        }
+
+        [Fact]
+        public void ArraySelectSource()
+        {
+            Assert.Equal(17, new[] { 5, 6, 7, 8 }.Select(i => i * 2 + 1).LastOrDefault());
+            Assert.Equal(0, new int[0].Select(i => i * 2 + 1).LastOrDefault());
+        }
+
+        [Fact]
+        public void ListSelectSource()
+        {
+            Assert.Equal(17, new[] { 5, 6, 7, 8 }.ToList().Select(i => i * 2 + 1).LastOrDefault());
+            Assert.Equal(0, new List<int>(0).Select(i => i * 2 + 1).LastOrDefault());
+        }
+
+        [Fact]
+        public void IListSelectSource()
+        {
+            Assert.Equal(17, new ReadOnlyCollection<int>(new[] { 5, 6, 7, 8 }).Select(i => i * 2 + 1).LastOrDefault());
+            Assert.Equal(0, new ReadOnlyCollection<int>(new int[0]).Select(i => i * 2 + 1).LastOrDefault());
         }
     }
 }

--- a/src/System.Linq/tests/LastTests.cs
+++ b/src/System.Linq/tests/LastTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Xunit;
 
 namespace System.Linq.Tests
@@ -238,6 +239,30 @@ namespace System.Linq.Tests
         {
             Func<int, bool> predicate = null;
             Assert.Throws<ArgumentNullException>("predicate", () => Enumerable.Range(0, 3).Last(predicate));
+        }
+
+        [Fact]
+        public void ArraySelectSource()
+        {
+            Assert.Equal(17, new[] { 5, 6, 7, 8 }.Select(i => i * 2 + 1).Last());
+            var emptySource = new int[0].Select(i => i * 2 + 1);
+            Assert.Throws<InvalidOperationException>(() => emptySource.Last());
+        }
+
+        [Fact]
+        public void ListSelectSource()
+        {
+            Assert.Equal(17, new[] { 5, 6, 7, 8 }.ToList().Select(i => i * 2 + 1).Last());
+            var emptySource = new List<int>(0).Select(i => i * 2 + 1);
+            Assert.Throws<InvalidOperationException>(() => emptySource.Last());
+        }
+
+        [Fact]
+        public void IListSelectSource()
+        {
+            Assert.Equal(17, new ReadOnlyCollection<int>(new[] { 5, 6, 7, 8 }).Select(i => i * 2 + 1).Last());
+            var emptySource = new ReadOnlyCollection<int>(new int[0]).Select(i => i * 2 + 1);
+            Assert.Throws<InvalidOperationException>(() => emptySource.Last());
         }
     }
 }

--- a/src/System.Linq/tests/OrderedSubsetting.cs
+++ b/src/System.Linq/tests/OrderedSubsetting.cs
@@ -303,9 +303,21 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void ToList()
+        {
+            Assert.Equal(Enumerable.Range(10, 20), Enumerable.Range(0, 100).Shuffle().OrderBy(i => i).Skip(10).Take(20).ToList());
+        }
+
+        [Fact]
         public void EmptyToArray()
         {
             Assert.Empty(Enumerable.Range(0, 100).Shuffle().OrderBy(i => i).Skip(100).ToArray());
+        }
+
+        [Fact]
+        public void EmptyToList()
+        {
+            Assert.Empty(Enumerable.Range(0, 100).Shuffle().OrderBy(i => i).Skip(100).ToList());
         }
 
         [Fact]
@@ -315,9 +327,21 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void AttemptedMoreToList()
+        {
+            Assert.Equal(Enumerable.Range(0, 20), Enumerable.Range(0, 20).Shuffle().OrderBy(i => i).Take(30).ToList());
+        }
+
+        [Fact]
         public void SingleElementToArray()
         {
             Assert.Equal(Enumerable.Repeat(10, 1), Enumerable.Range(0, 20).Shuffle().OrderBy(i => i).Skip(10).Take(1).ToArray());
+        }
+
+        [Fact]
+        public void SingleElementToList()
+        {
+            Assert.Equal(Enumerable.Repeat(10, 1), Enumerable.Range(0, 20).Shuffle().OrderBy(i => i).Skip(10).Take(1).ToList());
         }
 
         [Fact]

--- a/src/System.Linq/tests/OrderedSubsetting.cs
+++ b/src/System.Linq/tests/OrderedSubsetting.cs
@@ -351,5 +351,35 @@ namespace System.Linq.Tests
             while (enumerator.MoveNext()) { }
             Assert.False(enumerator.MoveNext());
         }
+
+        [Fact]
+        public void SubsetAfterSelect()
+        {
+            var page = Enumerable.Range(0, 50).Shuffle().OrderBy(i => i).Select(i => i * 2).Skip(20).Take(5);
+            Assert.Equal(new[] { 40, 42, 44, 46, 48 }, page);
+            Assert.Equal(new[] { 41, 43, 45, 47, 49 }, page.Select(i => i + 1));
+            Assert.Equal(40, page.First());
+            Assert.Equal(48, page.Last());
+            Assert.Equal(42, page.ElementAt(1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => page.ElementAt(20));
+            page = Enumerable.Range(0, 50).Shuffle().OrderBy(i => i).Select(i => i * 2).Skip(100).Take(5);
+            Assert.Throws<InvalidOperationException>(() => page.First());
+            Assert.Throws<InvalidOperationException>(() => page.Last());
+        }
+
+        [Fact]
+        public void SubsetAfterSelectEnumeratorDoesntContinue()
+        {
+            var enumerator = NumberRangeGuaranteedNotCollectionType(0, 3).Shuffle().OrderBy(i => i).Select(i => i * 2).Take(1).GetEnumerator();
+            while (enumerator.MoveNext()) { }
+            Assert.False(enumerator.MoveNext());
+        }
+
+        [Fact]
+        public void SubsetAfterSelectRepeatEnumerating()
+        {
+            var page = NumberRangeGuaranteedNotCollectionType(0, 3).Shuffle().OrderBy(i => i).Select(i => i * 2).Take(1);
+            Assert.Equal(page, page);
+        }
     }
 }

--- a/src/System.Linq/tests/ReverseTests.cs
+++ b/src/System.Linq/tests/ReverseTests.cs
@@ -77,5 +77,31 @@ namespace System.Linq.Tests
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }
+
+        [Fact]
+        public void ToArray()
+        {
+            int?[] source = new int?[] { -10, 0, 5, null, 0, 9, 100, null, 9 };
+            int?[] expected = new int?[] { 9, null, 100, 9, 0, null, 5, 0, -10 };
+
+            Assert.Equal(expected, source.Reverse().ToArray());
+        }
+
+        [Fact]
+        public void ToList()
+        {
+            int?[] source = new int?[] { -10, 0, 5, null, 0, 9, 100, null, 9 };
+            int?[] expected = new int?[] { 9, null, 100, 9, 0, null, 5, 0, -10 };
+
+            Assert.Equal(expected, source.Reverse().ToList());
+        }
+
+        [Fact]
+        public void RepeatEnumerating()
+        {
+            var reversed = new int?[] { -10, 0, 5, null, 0, 9, 100, null, 9 }.Reverse();
+
+            Assert.Equal(reversed, reversed);
+        }
     }
 }

--- a/src/System.Linq/tests/SkipTests.cs
+++ b/src/System.Linq/tests/SkipTests.cs
@@ -213,5 +213,225 @@ namespace System.Linq.Tests
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }
+
+        [Fact]
+        public void FollowWithTake()
+        {
+            var source = new[] { 5, 6, 7, 8 };
+            var expected = new[] { 6, 7 };
+            Assert.Equal(expected, source.Skip(1).Take(2));
+        }
+
+        [Fact]
+        public void FollowWithTakeNotIList()
+        {
+            var source = NumberRangeGuaranteedNotCollectionType(5, 4);
+            var expected = new[] { 6, 7 };
+            Assert.Equal(expected, source.Skip(1).Take(2));
+        }
+
+        [Fact]
+        public void FollowWithSkip()
+        {
+            var source = new[] { 1, 2, 3, 4, 5, 6 };
+            var expected = new[] { 4, 5, 6 };
+            Assert.Equal(expected, source.Skip(1).Skip(2).Skip(-4));
+        }
+
+        [Fact]
+        public void FollowWithSkipNotIList()
+        {
+            var source = NumberRangeGuaranteedNotCollectionType(1, 6);
+            var expected = new[] { 4, 5, 6 };
+            Assert.Equal(expected, source.Skip(1).Skip(2).Skip(-4));
+        }
+
+        [Fact]
+        public void ElementAt()
+        {
+            var source = new[] { 1, 2, 3, 4, 5, 6 };
+            var remaining = source.Skip(2);
+            Assert.Equal(3, remaining.ElementAt(0));
+            Assert.Equal(4, remaining.ElementAt(1));
+            Assert.Equal(6, remaining.ElementAt(3));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => remaining.ElementAt(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => remaining.ElementAt(4));
+        }
+
+        [Fact]
+        public void ElementAtNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5, 6 });
+            var remaining = source.Skip(2);
+            Assert.Equal(3, remaining.ElementAt(0));
+            Assert.Equal(4, remaining.ElementAt(1));
+            Assert.Equal(6, remaining.ElementAt(3));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => remaining.ElementAt(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => remaining.ElementAt(4));
+        }
+
+        [Fact]
+        public void ElementAtOrDefault()
+        {
+            var source = new[] { 1, 2, 3, 4, 5, 6 };
+            var remaining = source.Skip(2);
+            Assert.Equal(3, remaining.ElementAtOrDefault(0));
+            Assert.Equal(4, remaining.ElementAtOrDefault(1));
+            Assert.Equal(6, remaining.ElementAtOrDefault(3));
+            Assert.Equal(0, remaining.ElementAtOrDefault(-1));
+            Assert.Equal(0, remaining.ElementAtOrDefault(4));
+        }
+
+        [Fact]
+        public void ElementAtOrDefaultNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5, 6 });
+            var remaining = source.Skip(2);
+            Assert.Equal(3, remaining.ElementAtOrDefault(0));
+            Assert.Equal(4, remaining.ElementAtOrDefault(1));
+            Assert.Equal(6, remaining.ElementAtOrDefault(3));
+            Assert.Equal(0, remaining.ElementAtOrDefault(-1));
+            Assert.Equal(0, remaining.ElementAtOrDefault(4));
+        }
+
+        [Fact]
+        public void First()
+        {
+            var source = new []{ 1, 2, 3, 4, 5 };
+            Assert.Equal(1, source.Skip(0).First());
+            Assert.Equal(3, source.Skip(2).First());
+            Assert.Equal(5, source.Skip(4).First());
+            Assert.Throws<InvalidOperationException>(() => source.Skip(5).First());
+        }
+
+        [Fact]
+        public void FirstNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(1, source.Skip(0).First());
+            Assert.Equal(3, source.Skip(2).First());
+            Assert.Equal(5, source.Skip(4).First());
+            Assert.Throws<InvalidOperationException>(() => source.Skip(5).First());
+        }
+
+        [Fact]
+        public void FirstOrDefault()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(1, source.Skip(0).FirstOrDefault());
+            Assert.Equal(3, source.Skip(2).FirstOrDefault());
+            Assert.Equal(5, source.Skip(4).FirstOrDefault());
+            Assert.Equal(0, source.Skip(5).FirstOrDefault());
+        }
+
+        [Fact]
+        public void FirstOrDefaultNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(1, source.Skip(0).FirstOrDefault());
+            Assert.Equal(3, source.Skip(2).FirstOrDefault());
+            Assert.Equal(5, source.Skip(4).FirstOrDefault());
+            Assert.Equal(0, source.Skip(5).FirstOrDefault());
+        }
+
+        [Fact]
+        public void Last()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(5, source.Skip(0).Last());
+            Assert.Equal(5, source.Skip(1).Last());
+            Assert.Equal(5, source.Skip(4).Last());
+            Assert.Throws<InvalidOperationException>(() => source.Skip(5).Last());
+        }
+
+        [Fact]
+        public void LastNotList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(5, source.Skip(0).Last());
+            Assert.Equal(5, source.Skip(1).Last());
+            Assert.Equal(5, source.Skip(4).Last());
+            Assert.Throws<InvalidOperationException>(() => source.Skip(5).Last());
+        }
+
+        [Fact]
+        public void LastOrDefault()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(5, source.Skip(0).LastOrDefault());
+            Assert.Equal(5, source.Skip(1).LastOrDefault());
+            Assert.Equal(5, source.Skip(4).LastOrDefault());
+            Assert.Equal(0, source.Skip(5).LastOrDefault());
+        }
+
+        [Fact]
+        public void LastOrDefaultNotList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(5, source.Skip(0).LastOrDefault());
+            Assert.Equal(5, source.Skip(1).LastOrDefault());
+            Assert.Equal(5, source.Skip(4).LastOrDefault());
+            Assert.Equal(0, source.Skip(5).LastOrDefault());
+        }
+
+        [Fact]
+        public void ToArray()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Skip(0).ToArray());
+            Assert.Equal(new[] { 2, 3, 4, 5 }, source.Skip(1).ToArray());
+            Assert.Equal(5, source.Skip(4).ToArray().Single());
+            Assert.Empty(source.Skip(5).ToArray());
+            Assert.Empty(source.Skip(40).ToArray());
+        }
+
+        [Fact]
+        public void ToArrayNotList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Skip(0).ToArray());
+            Assert.Equal(new[] { 2, 3, 4, 5 }, source.Skip(1).ToArray());
+            Assert.Equal(5, source.Skip(4).ToArray().Single());
+            Assert.Empty(source.Skip(5).ToArray());
+            Assert.Empty(source.Skip(40).ToArray());
+        }
+
+        [Fact]
+        public void ToList()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Skip(0).ToList());
+            Assert.Equal(new[] { 2, 3, 4, 5 }, source.Skip(1).ToList());
+            Assert.Equal(5, source.Skip(4).ToList().Single());
+            Assert.Empty(source.Skip(5).ToList());
+            Assert.Empty(source.Skip(40).ToList());
+        }
+
+        [Fact]
+        public void ToListNotList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Skip(0).ToList());
+            Assert.Equal(new[] { 2, 3, 4, 5 }, source.Skip(1).ToList());
+            Assert.Equal(5, source.Skip(4).ToList().Single());
+            Assert.Empty(source.Skip(5).ToList());
+            Assert.Empty(source.Skip(40).ToList());
+        }
+
+        [Fact]
+        public void RepeatEnumerating()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            var remaining = source.Skip(1);
+            Assert.Equal(remaining, remaining);
+        }
+
+        [Fact]
+        public void RepeatEnumeratingNotList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            var remaining = source.Skip(1);
+            Assert.Equal(remaining, remaining);
+        }
     }
 }

--- a/src/System.Linq/tests/SkipTests.cs
+++ b/src/System.Linq/tests/SkipTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -432,6 +433,39 @@ namespace System.Linq.Tests
             var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
             var remaining = source.Skip(1);
             Assert.Equal(remaining, remaining);
+        }
+
+        [Fact]
+        public void ArraySelectSource()
+        {
+            var source = new[] { 1, 2, 3, 4 }.Select(i => i * 2);
+            Assert.Equal(new[] { 6, 8 }, source.Skip(2));
+            Assert.Empty(source.Skip(4));
+            Assert.Empty(source.Skip(20));
+            Assert.Equal(source, source.Skip(0));
+            Assert.Equal(source, source.Skip(-1));
+        }
+
+        [Fact]
+        public void ListSelectSource()
+        {
+            var source = new[] { 1, 2, 3, 4 }.ToList().Select(i => i * 2);
+            Assert.Equal(new[] { 6, 8 }, source.Skip(2));
+            Assert.Empty(source.Skip(4));
+            Assert.Empty(source.Skip(20));
+            Assert.Equal(source, source.Skip(0));
+            Assert.Equal(source, source.Skip(-1));
+        }
+
+        [Fact]
+        public void IListSelectSource()
+        {
+            var source = new ReadOnlyCollection<int>(new[] { 1, 2, 3, 4 }).Select(i => i * 2);
+            Assert.Equal(new[] { 6, 8 }, source.Skip(2));
+            Assert.Empty(source.Skip(4));
+            Assert.Empty(source.Skip(20));
+            Assert.Equal(source, source.Skip(0));
+            Assert.Equal(source, source.Skip(-1));
         }
     }
 }

--- a/src/System.Linq/tests/TakeTests.cs
+++ b/src/System.Linq/tests/TakeTests.cs
@@ -9,12 +9,28 @@ namespace System.Linq.Tests
 {
     public class TakeTests : EnumerableTests
     {
+        private static IEnumerable<T> GuaranteeNotIList<T>(IEnumerable<T> source)
+        {
+            foreach (T element in source)
+                yield return element;
+        }
+
         [Fact]
         public void SameResultsRepeatCallsIntQuery()
         {
             var q = from x in new[] { 9999, 0, 888, -1, 66, -777, 1, 2, -12345 }
                     where x > Int32.MinValue
                     select x;
+
+            Assert.Equal(q.Take(9), q.Take(9));
+        }
+
+        [Fact]
+        public void SameResultsRepeatCallsIntQueryIList()
+        {
+            var q = (from x in new[] { 9999, 0, 888, -1, 66, -777, 1, 2, -12345 }
+                     where x > Int32.MinValue
+                     select x).ToList();
 
             Assert.Equal(q.Take(9), q.Take(9));
         }
@@ -30,9 +46,26 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void SameResultsRepeatCallsStringQueryIList()
+        {
+            var q = (from x in new[] { "!@#$%^", "C", "AAA", "", "Calling Twice", "SoS", String.Empty }
+                     where !String.IsNullOrEmpty(x)
+                     select x).ToList();
+
+            Assert.Equal(q.Take(7), q.Take(7));
+        }
+
+        [Fact]
         public void SourceEmptyCountPositive()
         {
             int[] source = { };
+            Assert.Empty(source.Take(5));
+        }
+
+        [Fact]
+        public void SourceEmptyCountPositiveNotIList()
+        {
+            var source = NumberRangeGuaranteedNotCollectionType(0, 0);
             Assert.Empty(source.Take(5));
         }
 
@@ -44,9 +77,23 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void SourceNonEmptyCountNegativeNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 2, 5, 9, 1 });
+            Assert.Empty(source.Take(-5));
+        }
+
+        [Fact]
         public void SourceNonEmptyCountZero()
         {
             int[] source = { 2, 5, 9, 1 };
+            Assert.Empty(source.Take(0));
+        }
+
+        [Fact]
+        public void SourceNonEmptyCountZeroNotIList()
+        {
+            var source = GuaranteeNotIList(new []{ 2, 5, 9, 1 });
             Assert.Empty(source.Take(0));
         }
 
@@ -60,11 +107,28 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void SourceNonEmptyCountOneNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 2, 5, 9, 1 });
+            int[] expected = { 2 };
+
+            Assert.Equal(expected, source.Take(1));
+        }
+
+        [Fact]
         public void SourceNonEmptyTakeAllExactly()
         {
             int[] source = { 2, 5, 9, 1 };
-            
+
             Assert.Equal(source, source.Take(source.Length));
+        }
+
+        [Fact]
+        public void SourceNonEmptyTakeAllExactlyNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 2, 5, 9, 1 });
+
+            Assert.Equal(source, source.Take(source.Count()));
         }
 
         [Fact]
@@ -77,13 +141,30 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void SourceNonEmptyTakeAllButOneNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 2, 5, 9, 1 });
+            int[] expected = { 2, 5, 9 };
+
+            Assert.Equal(expected, source.Take(3));
+        }
+
+        [Fact]
         public void SourceNonEmptyTakeExcessive()
         {
             int?[] source = { 2, 5, null, 9, 1 };
 
             Assert.Equal(source, source.Take(source.Length + 1));
         }
-        
+
+        [Fact]
+        public void SourceNonEmptyTakeExcessiveNotIList()
+        {
+            var source = GuaranteeNotIList(new int?[] { 2, 5, null, 9, 1 });
+
+            Assert.Equal(source, source.Take(source.Count() + 1));
+        }
+
         [Fact]
         public void ThrowsOnNullSource()
         {
@@ -98,6 +179,243 @@ namespace System.Linq.Tests
             // Don't insist on this behaviour, but check its correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
+        }
+
+        [Fact]
+        public void ForcedToEnumeratorDoesntEnumerateIList()
+        {
+            var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).ToList().Take(2);
+            // Don't insist on this behaviour, but check its correct if it happens
+            var en = iterator as IEnumerator<int>;
+            Assert.False(en != null && en.MoveNext());
+        }
+
+        [Fact]
+        public void FollowWithTake()
+        {
+            var source = new[] { 5, 6, 7, 8 };
+            var expected = new[] { 5, 6 };
+            Assert.Equal(expected, source.Take(5).Take(3).Take(2).Take(40));
+        }
+
+        [Fact]
+        public void FollowWithTakeNotIList()
+        {
+            var source = NumberRangeGuaranteedNotCollectionType(5, 4);
+            var expected = new[] { 5, 6 };
+            Assert.Equal(expected, source.Take(5).Take(3).Take(2));
+        }
+
+        [Fact]
+        public void FollowWithSkip()
+        {
+            var source = new[] { 1, 2, 3, 4, 5, 6 };
+            var expected = new[] { 3, 4, 5 };
+            Assert.Equal(expected, source.Take(5).Skip(2).Skip(-4));
+        }
+
+        [Fact]
+        public void FollowWithSkipNotIList()
+        {
+            var source = NumberRangeGuaranteedNotCollectionType(1, 6);
+            var expected = new[] { 3, 4, 5 };
+            Assert.Equal(expected, source.Take(5).Skip(2).Skip(-4));
+        }
+
+        [Fact]
+        public void ElementAt()
+        {
+            var source = new[] { 1, 2, 3, 4, 5, 6 };
+            var taken = source.Take(3);
+            Assert.Equal(1, taken.ElementAt(0));
+            Assert.Equal(3, taken.ElementAt(2));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => taken.ElementAt(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => taken.ElementAt(3));
+        }
+
+        [Fact]
+        public void ElementAtNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5, 6 });
+            var taken = source.Take(3);
+            Assert.Equal(1, taken.ElementAt(0));
+            Assert.Equal(3, taken.ElementAt(2));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => taken.ElementAt(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => taken.ElementAt(3));
+        }
+
+        [Fact]
+        public void ElementAtOrDefault()
+        {
+            var source = new[] { 1, 2, 3, 4, 5, 6 };
+            var taken = source.Take(3);
+            Assert.Equal(1, taken.ElementAtOrDefault(0));
+            Assert.Equal(3, taken.ElementAtOrDefault(2));
+            Assert.Equal(0, taken.ElementAtOrDefault(-1));
+            Assert.Equal(0, taken.ElementAtOrDefault(3));
+        }
+
+        [Fact]
+        public void ElementAtOrDefaultNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5, 6 });
+            var taken = source.Take(3);
+            Assert.Equal(1, taken.ElementAtOrDefault(0));
+            Assert.Equal(3, taken.ElementAtOrDefault(2));
+            Assert.Equal(0, taken.ElementAtOrDefault(-1));
+            Assert.Equal(0, taken.ElementAtOrDefault(3));
+        }
+
+        [Fact]
+        public void First()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(1, source.Take(1).First());
+            Assert.Equal(1, source.Take(4).First());
+            Assert.Equal(1, source.Take(40).First());
+            Assert.Throws<InvalidOperationException>(() => source.Take(0).First());
+            Assert.Throws<InvalidOperationException>(() => source.Skip(5).Take(10).First());
+        }
+
+        [Fact]
+        public void FirstNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(1, source.Take(1).First());
+            Assert.Equal(1, source.Take(4).First());
+            Assert.Equal(1, source.Take(40).First());
+            Assert.Throws<InvalidOperationException>(() => source.Take(0).First());
+            Assert.Throws<InvalidOperationException>(() => source.Skip(5).Take(10).First());
+        }
+
+        [Fact]
+        public void FirstOrDefault()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(1, source.Take(1).FirstOrDefault());
+            Assert.Equal(1, source.Take(4).FirstOrDefault());
+            Assert.Equal(1, source.Take(40).FirstOrDefault());
+            Assert.Equal(0, source.Take(0).FirstOrDefault());
+            Assert.Equal(0, source.Skip(5).Take(10).FirstOrDefault());
+        }
+
+        [Fact]
+        public void FirstOrDefaultNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(1, source.Take(1).FirstOrDefault());
+            Assert.Equal(1, source.Take(4).FirstOrDefault());
+            Assert.Equal(1, source.Take(40).FirstOrDefault());
+            Assert.Equal(0, source.Take(0).FirstOrDefault());
+            Assert.Equal(0, source.Skip(5).Take(10).FirstOrDefault());
+        }
+
+        [Fact]
+        public void Last()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(1, source.Take(1).Last());
+            Assert.Equal(5, source.Take(5).Last());
+            Assert.Equal(5, source.Take(40).Last());
+            Assert.Throws<InvalidOperationException>(() => source.Take(0).Last());
+            Assert.Throws<InvalidOperationException>(() => Array.Empty<int>().Take(40).Last());
+        }
+
+        [Fact]
+        public void LastNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(1, source.Take(1).Last());
+            Assert.Equal(5, source.Take(5).Last());
+            Assert.Equal(5, source.Take(40).Last());
+            Assert.Throws<InvalidOperationException>(() => source.Take(0).Last());
+            Assert.Throws<InvalidOperationException>(() => GuaranteeNotIList(Array.Empty<int>()).Take(40).Last());
+        }
+
+        [Fact]
+        public void LastOrDefault()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(1, source.Take(1).LastOrDefault());
+            Assert.Equal(5, source.Take(5).LastOrDefault());
+            Assert.Equal(5, source.Take(40).LastOrDefault());
+            Assert.Equal(0, source.Take(0).LastOrDefault());
+            Assert.Equal(0, Array.Empty<int>().Take(40).LastOrDefault());
+        }
+
+        [Fact]
+        public void LastOrDefaultNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(1, source.Take(1).LastOrDefault());
+            Assert.Equal(5, source.Take(5).LastOrDefault());
+            Assert.Equal(5, source.Take(40).LastOrDefault());
+            Assert.Equal(0, source.Take(0).LastOrDefault());
+            Assert.Equal(0, GuaranteeNotIList(Array.Empty<int>()).Take(40).LastOrDefault());
+        }
+
+        [Fact]
+        public void ToArray()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Take(5).ToArray());
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Take(40).ToArray());
+            Assert.Equal(new[] { 1, 2, 3, 4 }, source.Take(4).ToArray());
+            Assert.Equal(1, source.Take(1).ToArray().Single());
+            Assert.Empty(source.Take(0).ToArray());
+            Assert.Empty(source.Take(-10).ToArray());
+        }
+
+        [Fact]
+        public void ToArrayNotList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Take(5).ToArray());
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Take(40).ToArray());
+            Assert.Equal(new[] { 1, 2, 3, 4 }, source.Take(4).ToArray());
+            Assert.Equal(1, source.Take(1).ToArray().Single());
+            Assert.Empty(source.Take(0).ToArray());
+            Assert.Empty(source.Take(-10).ToArray());
+        }
+
+        [Fact]
+        public void ToList()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Take(5).ToList());
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Take(40).ToList());
+            Assert.Equal(new[] { 1, 2, 3, 4 }, source.Take(4).ToList());
+            Assert.Equal(1, source.Take(1).ToList().Single());
+            Assert.Empty(source.Take(0).ToList());
+            Assert.Empty(source.Take(-10).ToList());
+        }
+
+        [Fact]
+        public void ToListNotList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Take(5).ToList());
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Take(40).ToList());
+            Assert.Equal(new[] { 1, 2, 3, 4 }, source.Take(4).ToList());
+            Assert.Equal(1, source.Take(1).ToList().Single());
+            Assert.Empty(source.Take(0).ToList());
+            Assert.Empty(source.Take(-10).ToList());
+        }
+
+        [Fact]
+        public void RepeatEnumerating()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            var taken = source.Take(3);
+            Assert.Equal(taken, taken);
+        }
+
+        [Fact]
+        public void RepeatEnumeratingNotList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            var taken = source.Take(3);
+            Assert.Equal(taken, taken);
         }
     }
 }

--- a/src/System.Linq/tests/TakeTests.cs
+++ b/src/System.Linq/tests/TakeTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Xunit;
 
 namespace System.Linq.Tests
@@ -416,6 +417,39 @@ namespace System.Linq.Tests
             var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
             var taken = source.Take(3);
             Assert.Equal(taken, taken);
+        }
+
+        [Fact]
+        public void ArraySelectSource()
+        {
+            var source = new[] { 1, 2, 3, 4 }.Select(i => i * 2);
+            Assert.Equal(new[] { 2, 4 }, source.Take(2));
+            Assert.Empty(source.Take(0));
+            Assert.Empty(source.Take(-20));
+            Assert.Equal(source, source.Take(4));
+            Assert.Equal(source, source.Take(40));
+        }
+
+        [Fact]
+        public void ListSelectSource()
+        {
+            var source = new[] { 1, 2, 3, 4 }.ToList().Select(i => i * 2);
+            Assert.Equal(new[] { 2, 4 }, source.Take(2));
+            Assert.Empty(source.Take(0));
+            Assert.Empty(source.Take(-20));
+            Assert.Equal(source, source.Take(4));
+            Assert.Equal(source, source.Take(40));
+        }
+
+        [Fact]
+        public void IListSelectSource()
+        {
+            var source = new ReadOnlyCollection<int>(new[] { 1, 2, 3, 4 }).Select(i => i * 2);
+            Assert.Equal(new[] { 2, 4 }, source.Take(2));
+            Assert.Empty(source.Take(0));
+            Assert.Empty(source.Take(-20));
+            Assert.Equal(source, source.Take(4));
+            Assert.Equal(source, source.Take(40));
         }
     }
 }

--- a/src/System.Linq/tests/UnionTests.cs
+++ b/src/System.Linq/tests/UnionTests.cs
@@ -205,5 +205,36 @@ namespace System.Linq.Tests
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }
+
+        [Fact]
+        public void ToArray()
+        {
+            string[] first = { "Bob", "Robert", "Tim", "Matt", "miT" };
+            string[] second = { "ttaM", "Charlie", "Bbo" };
+            string[] expected = { "Bob", "Robert", "Tim", "Matt", "miT", "ttaM", "Charlie", "Bbo" };
+
+            Assert.Equal(expected, first.Union(second).ToArray());
+        }
+
+        [Fact]
+        public void ToList()
+        {
+            string[] first = { "Bob", "Robert", "Tim", "Matt", "miT" };
+            string[] second = { "ttaM", "Charlie", "Bbo" };
+            string[] expected = { "Bob", "Robert", "Tim", "Matt", "miT", "ttaM", "Charlie", "Bbo" };
+
+            Assert.Equal(expected, first.Union(second).ToList());
+        }
+
+        [Fact]
+        public void RepeatEnumerating()
+        {
+            string[] first = { "Bob", "Robert", "Tim", "Matt", "miT" };
+            string[] second = { "ttaM", "Charlie", "Bbo" };
+
+            var result = first.Union(second);
+
+            Assert.Equal(result, result);
+        }
     }
 }


### PR DESCRIPTION
A few different optimisations to Linq added recently can be usefully combined with each other.

## Combine `IArrayProvider` and `IListProvider`

Anything that can be one can be the other, so merge the two interfaces.

Add `ToList` support to `OrderedPartition`.

## Have IList optimised result of Skip() partitionable.

Optimisation of `Skip()` for `IList<T>` sources from #4551 fits with optimisations of `Skip()` and `Take()` for other sources from #2401.

Combine the approaches, extending how the result of `Skip()` on a list handles subsequent operations.

## Use partitioning on list-based select iterators.

The creation of `SelectListIterator` above allows for partitioning to be used with the list-based `Select()` iterators, improving some subsequent operations on them.

##  Remove unused paths in `Set`.

`Set` never has `Add` called after `Remove`. Remove paths and fields only necessary in that case.

Add debug-only check on this assumption, so any new uses that break this assumption are flagged to the developer.

##  Implement `IIListProvider` on `Distinct()` and `Union()`.

With those changes to `Set` it's now easy to give these methods an optimised `ToArray` and `ToList()`.

## Tests of `IIListProvider` on empty `GroupBy` results.

Noticed in the process of the above that this case isn't covered by tests though it does have very slightly different behaviour.