### PR TITLE
SslStream override stream's async methods

### DIFF
--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslStream.cs
@@ -445,9 +445,9 @@ namespace System.Net.Security
             _sslState.SecureStream.Write(buffer, offset, count);
         }
 
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken token)
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            return _sslState.SecureStream.WriteAsync(buffer, offset, count, token);
+            return _sslState.SecureStream.WriteAsync(buffer, offset, count, cancellationToken);
         }
     }
 }

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslStream.cs
@@ -429,6 +429,11 @@ namespace System.Net.Security
         {
             return _sslState.SecureStream.Read(buffer, offset, count);
         }
+        
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return _sslState.SecureStream.ReadAsync(buffer, offset, count, cancellationToken);
+        }
 
         public void Write(byte[] buffer)
         {
@@ -438,6 +443,11 @@ namespace System.Net.Security
         public override void Write(byte[] buffer, int offset, int count)
         {
             _sslState.SecureStream.Write(buffer, offset, count);
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken token)
+        {
+            return _sslState.SecureStream.WriteAsync(buffer, offset, count, token);
         }
     }
 }


### PR DESCRIPTION
Rather than using Streams default implementation which end up calling the sync methods.

Resolves #5488