### PR TITLE
Fixes the build warnings about conflicting references

### DIFF
--- a/src/System.Diagnostics.TraceSource/tests/project.json
+++ b/src/System.Diagnostics.TraceSource/tests/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "System.Diagnostics.Process": "4.1.0-rc2-23712",
+    "System.Globalization": "4.0.10",
     "System.IO": "4.0.10",
     "System.Runtime": "4.0.20",
     "System.Runtime.Extensions": "4.0.10",

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/project.json
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/project.json
@@ -5,7 +5,7 @@
     "System.IO": "4.0.10",
     "System.Net.Primitives": "4.0.10",
     "System.Runtime": "4.0.20",
-    "System.Threading": "4.0.0",
+    "System.Threading": "4.0.10",
     "System.Threading.Thread": "4.0.0-rc2-23712",
     "System.Threading.Tasks": "4.0.10",
     "System.Threading.Tasks.Parallel": "4.0.0",

--- a/src/System.Net.Sockets.Legacy/tests/PerformanceTests/project.json
+++ b/src/System.Net.Sockets.Legacy/tests/PerformanceTests/project.json
@@ -4,7 +4,7 @@
     "System.Diagnostics.Debug": "4.0.10",
     "System.Net.Primitives": "4.0.10",
     "System.Runtime": "4.0.20",
-    "System.Threading": "4.0.0",
+    "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "System.Threading.Tasks.Parallel": "4.0.0",
     "xunit": "2.1.0",

--- a/src/System.Net.Sockets/tests/FunctionalTests/project.json
+++ b/src/System.Net.Sockets/tests/FunctionalTests/project.json
@@ -4,7 +4,7 @@
     "System.Diagnostics.Debug": "4.0.10",
     "System.Net.Primitives": "4.0.10",
     "System.Runtime": "4.0.20",
-    "System.Threading": "4.0.0",
+    "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "System.Threading.Tasks.Parallel": "4.0.0",
     "xunit": "2.1.0",

--- a/src/System.Net.Sockets/tests/PerformanceTests/project.json
+++ b/src/System.Net.Sockets/tests/PerformanceTests/project.json
@@ -4,7 +4,7 @@
     "System.Diagnostics.Debug": "4.0.10",
     "System.Net.Primitives": "4.0.10",
     "System.Runtime": "4.0.20",
-    "System.Threading": "4.0.0",
+    "System.Threading": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "System.Threading.Tasks.Parallel": "4.0.0",
     "xunit": "2.1.0",

--- a/src/System.Runtime.InteropServices.RuntimeInformation/tests/project.json
+++ b/src/System.Runtime.InteropServices.RuntimeInformation/tests/project.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "System.Runtime": "4.0.20",
     "System.Threading.Tasks": "4.0.10",
-    "System.Reflection": "4.0.0",
+    "System.Reflection": "4.0.10",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },

--- a/src/System.Threading.Overlapped/tests/System.Threading.Overlapped.Tests.csproj
+++ b/src/System.Threading.Overlapped/tests/System.Threading.Overlapped.Tests.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
   <ItemGroup>
     <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
-    <ProjectReference Include="..\src\System.Threading.Overlapped.CoreCLR.csproj">
+    <ProjectReference Include="..\src\System.Threading.Overlapped.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Content</OutputItemType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/System.Xml.ReaderWriter/tests/XmlWriter/System.Xml.RW.XmlWriter.Tests.csproj
+++ b/src/System.Xml.ReaderWriter/tests/XmlWriter/System.Xml.RW.XmlWriter.Tests.csproj
@@ -24,10 +24,6 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\System.Text.Encoding.CodePages\src\System.Text.Encoding.CodePages.csproj">
-      <Project>{16ee6633-f557-5c9e-9ef3-b5334b044f47}</Project>
-      <Name>System.Text.Encoding.CodePages</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\src\System.Xml.ReaderWriter.csproj">
       <Project>{c559743a-762e-4d9d-b986-e77bdb97652e}</Project>
       <Name>System.Xml.ReaderWriter</Name>

--- a/src/System.Xml.ReaderWriter/tests/XmlWriter/project.json
+++ b/src/System.Xml.ReaderWriter/tests/XmlWriter/project.json
@@ -4,6 +4,7 @@
     "System.AppContext": "4.0.0",
     "System.IO": "4.0.10",
     "System.Text.Encoding": "4.0.10",
+    "System.Text.Encoding.CodePages": "4.0.0",
     "System.Text.Encoding.Extensions": "4.0.10",
     "System.Threading.Tasks": "4.0.10",
     "System.Xml.ReaderWriter": "4.0.10",


### PR DESCRIPTION
Fixes #5334

Majority of these warnings are just inconsistencies between different versions of the references coming from project.json, including the closure.

cc @stephentoub 