### PR TITLE
Update init-tools.cmd and build.cmd scripts

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -23,16 +23,17 @@ if not defined VisualStudioVersion (
 )
 
 :CheckNative
+
+call init-tools.cmd
+
 :: Run the Native Windows build
-echo Building Native Libraries...
+echo [%time%] Building Native Libraries...
 call %~dp0src\native\Windows\build-native.cmd %* >nativebuild.log
 IF ERRORLEVEL 1 (
     echo Native component build failed see nativebuild.log for more details.
 )
 
 :EnvSet
-
-call init-tools.cmd
 
 :: Clear the 'Platform' env variable for this session,
 :: as it's a per-project setting within the build, and
@@ -50,12 +51,13 @@ call :build %*
 :: Build
 set _buildprefix=
 set _buildpostfix=
+echo [%time%] Building Managed Libraries...
 call :build %*
 
 goto :AfterBuild
 
 :build
-%_buildprefix% msbuild "%_buildproj%" /nologo /maxcpucount /verbosity:minimal /nodeReuse:false /fileloggerparameters:Verbosity=normal;LogFile="%_buildlog%";Append %* %_buildpostfix%
+%_buildprefix% msbuild "%_buildproj%" /nologo /maxcpucount /v:minimal /clp:Summary /nodeReuse:false /flp:v=normal;LogFile="%_buildlog%";Append %* %_buildpostfix%
 set BUILDERRORLEVEL=%ERRORLEVEL%
 goto :eof
 
@@ -64,6 +66,6 @@ goto :eof
 echo.
 :: Pull the build summary from the log file
 findstr /ir /c:".*Warning(s)" /c:".*Error(s)" /c:"Time Elapsed.*" "%_buildlog%"
-echo Build Exit Code = %BUILDERRORLEVEL%
+echo [%time%] Build Exit Code = %BUILDERRORLEVEL%
 
 exit /b %BUILDERRORLEVEL%

--- a/build.proj
+++ b/build.proj
@@ -34,15 +34,12 @@
   </PropertyGroup>
 
   <Target Name="BatchRestorePackages">
-    <Message Importance="High" Text="Restoring all packages..." />
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Restoring all packages..." />
     <!-- restore all project.jsons in one pass for perf & to avoid concurrency problems with dnu -->
     <!-- include ToolsDir to restore test-runtime\project.json as well -->
     <Exec Command="$(DnuRestoreCommand) &quot;%(DnuRestoreDir.Identity)&quot;" StandardOutputImportance="Low" CustomErrorRegularExpression="(^Unable to locate .*)|(^Updating the invalid lock file with .*)" ContinueOnError="WarnAndContinue" />
 
-    <ItemGroup>
-      <_allPackagesConfigs Include="$(MSBuildProjectDirectory)\src\**\packages.config"/>
-    </ItemGroup>
-    <Exec Condition="'@(_allPackagesConfigs)' != ''" Command="$(NugetRestoreCommand) &quot;%(_allPackagesConfigs.FullPath)&quot;" StandardOutputImportance="Low" />
+    <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Restoring all packages...Done." />
   </Target>
 
   <!-- Task from buildtools that validates dependencies contained in project.json files. -->


### PR DESCRIPTION
Move init-tools to the top of build.cmd

Clean-up init-tools.cmd script and put most stuff out into a log file

Update build.cmd to add timestamp during logging also add timestamps
around the batch restore target so we can see how log it takes.

Adds the Summary option which will dump all the warnings and errors
at the end of the console output so the are more noticable.

Also cleans out the unnecessary restoring of packages.config files as we
no longer have any of those.

cc @joperezr 