### PR TITLE
Fix System.Runtime.Extensions package due to duplicate netcore50aot assets

### DIFF
--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.builds
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.builds
@@ -18,6 +18,7 @@
       <TargetGroup>net46</TargetGroup>
     </Project>
     <Project Include="System.Runtime.Extensions.csproj">
+      <OSGroup>Windows_NT</OSGroup>
       <TargetGroup>netcore50aot</TargetGroup>
     </Project>
   </ItemGroup>

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -30,8 +30,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windoww_netcore50aot_Release|AnyCPU'" />
 
   <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
     <SkipCommonResourcesIncludes>true</SkipCommonResourcesIncludes>


### PR DESCRIPTION
Package broken by https://github.com/dotnet/corefx/pull/5506. For this
case we need to explicitly make the netcore50aot version Windows_NT
specific.

@ericstj your ValidatePackage task doesn't correctly show up as a build failure as the exit code of msbuild was 0, so this issue slipped in. I'm going to file another issue for the ValidatePackage errors. 