### PR TITLE
Fix Method call write-back on instance and byref parameters

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2181,21 +2181,24 @@ namespace System.Linq.Expressions.Interpreter
 
         private static bool ShouldWritebackNode(Expression node)
         {
-            if (!node.Type.GetTypeInfo().IsValueType)
-                return false;
-            switch (node.NodeType)
+            if (node.Type.GetTypeInfo().IsValueType)
             {
-                case ExpressionType.Parameter:
-                case ExpressionType.Call:
-                case ExpressionType.ArrayIndex:
-                    return true;
-                case ExpressionType.Index:
-                    return ((IndexExpression)node).Object.Type.IsArray;
-                case ExpressionType.MemberAccess:
-                    return ((MemberExpression)node).Member is FieldInfo;
-                default:
-                    return false;
+                switch (node.NodeType)
+                {
+                    case ExpressionType.Parameter:
+                    case ExpressionType.Call:
+                    case ExpressionType.ArrayIndex:
+                        return true;
+                    case ExpressionType.Index:
+                        return ((IndexExpression)node).Object.Type.IsArray;
+                    case ExpressionType.MemberAccess:
+                        return ((MemberExpression)node).Member is FieldInfo;
+                    // ExpressionType.Unbox does have the behaviour write-back is used to simulate, but
+                    // it doesn't need explicit write-back to produce it, so include it in the default
+                    // false cases.
+                }
             }
+            return false;
         }
 
         /// <summary>
@@ -2206,123 +2209,108 @@ namespace System.Linq.Expressions.Interpreter
         /// <returns></returns>
         private ByRefUpdater CompileAddress(Expression node, int index)
         {
-            if (index == -1)
+            if (index != -1 || ShouldWritebackNode(node))
             {
-                if (!ShouldWritebackNode(node))
+                switch (node.NodeType)
                 {
-                    Compile(node);
-                    return null;
-                }
-            }
-            switch (node.NodeType)
-            {
-                case ExpressionType.Parameter:
-                    LoadLocalNoValueTypeCopy((ParameterExpression)node);
+                    case ExpressionType.Parameter:
+                        LoadLocalNoValueTypeCopy((ParameterExpression)node);
 
-                    return new ParameterByRefUpdater(ResolveLocal((ParameterExpression)node), index);
-                case ExpressionType.ArrayIndex:
-                    BinaryExpression array = (BinaryExpression)node;
+                        return new ParameterByRefUpdater(ResolveLocal((ParameterExpression)node), index);
+                    case ExpressionType.ArrayIndex:
+                        BinaryExpression array = (BinaryExpression)node;
 
-                    return CompileArrayIndexAddress(array.Left, array.Right, index);
-                case ExpressionType.Index:
-                    var indexNode = (IndexExpression)node;
-                    if (/*!TypeUtils.AreEquivalent(type, node.Type) || */indexNode.Indexer != null)
-                    {
-                        LocalDefinition? objTmp = null;
-                        if (indexNode.Object != null)
+                        return CompileArrayIndexAddress(array.Left, array.Right, index);
+                    case ExpressionType.Index:
+                        var indexNode = (IndexExpression)node;
+                        if (/*!TypeUtils.AreEquivalent(type, node.Type) || */indexNode.Indexer != null)
                         {
-                            Compile(indexNode.Object);
-                            objTmp = _locals.DefineLocal(Expression.Parameter(indexNode.Object.Type), _instructions.Count);
+                            LocalDefinition? objTmp = null;
+                            if (indexNode.Object != null)
+                            {
+                                Compile(indexNode.Object);
+                                objTmp = _locals.DefineLocal(Expression.Parameter(indexNode.Object.Type), _instructions.Count);
+                                _instructions.EmitDup();
+                                _instructions.EmitStoreLocal(objTmp.Value.Index);
+                            }
+
+                            List<LocalDefinition> indexLocals = new List<LocalDefinition>();
+                            for (int i = 0; i < indexNode.Arguments.Count; i++)
+                            {
+                                Compile(indexNode.Arguments[i]);
+
+                                var argTmp = _locals.DefineLocal(Expression.Parameter(indexNode.Arguments[i].Type), _instructions.Count);
+                                _instructions.EmitDup();
+                                _instructions.EmitStoreLocal(argTmp.Index);
+
+                                indexLocals.Add(argTmp);
+                            }
+
+                            EmitIndexGet(indexNode);
+
+                            return new IndexMethodByRefUpdater(objTmp, indexLocals.ToArray(), indexNode.Indexer.GetSetMethod(), index);
+                        }
+                        else if (indexNode.Arguments.Count == 1)
+                        {
+                            return CompileArrayIndexAddress(indexNode.Object, indexNode.Arguments[0], index);
+                        }
+                        else
+                        {
+                            return CompileMultiDimArrayAccess(indexNode.Object, indexNode.Arguments, index);
+                        }
+                    case ExpressionType.MemberAccess:
+                        var member = (MemberExpression)node;
+
+                        LocalDefinition? memberTemp = null;
+                        if (member.Expression != null)
+                        {
+                            memberTemp = _locals.DefineLocal(Expression.Parameter(member.Expression.Type, "member"), _instructions.Count);
+                            EmitThisForMethodCall(member.Expression);
                             _instructions.EmitDup();
-                            _instructions.EmitStoreLocal(objTmp.Value.Index);
+                            _instructions.EmitStoreLocal(memberTemp.Value.Index);
                         }
 
-                        List<LocalDefinition> indexLocals = new List<LocalDefinition>();
-                        for (int i = 0; i < indexNode.Arguments.Count; i++)
+                        FieldInfo field = member.Member as FieldInfo;
+                        if (field != null)
                         {
-                            Compile(indexNode.Arguments[i]);
-
-                            var argTmp = _locals.DefineLocal(Expression.Parameter(indexNode.Arguments[i].Type), _instructions.Count);
-                            _instructions.EmitDup();
-                            _instructions.EmitStoreLocal(argTmp.Index);
-
-                            indexLocals.Add(argTmp);
+                            _instructions.EmitLoadField(field);
+                            if (!field.IsLiteral && !field.IsInitOnly)
+                            {
+                                return new FieldByRefUpdater(memberTemp, field, index);
+                            }
+                            return null;
                         }
-
-                        EmitIndexGet(indexNode);
-
-                        return new IndexMethodByRefUpdater(objTmp, indexLocals.ToArray(), indexNode.Indexer.GetSetMethod(), index);
-                    }
-                    else if (indexNode.Arguments.Count == 1)
-                    {
-                        return CompileArrayIndexAddress(indexNode.Object, indexNode.Arguments[0], index);
-                    }
-                    else
-                    {
-                        return CompileMultiDimArrayAccess(indexNode.Object, indexNode.Arguments, index);
-                    }
-                case ExpressionType.MemberAccess:
-                    var member = (MemberExpression)node;
-
-                    LocalDefinition? memberTemp = null;
-                    if (member.Expression != null)
-                    {
-                        memberTemp = _locals.DefineLocal(Expression.Parameter(member.Expression.Type, "member"), _instructions.Count);
-                        EmitThisForMethodCall(member.Expression);
-                        _instructions.EmitDup();
-                        _instructions.EmitStoreLocal(memberTemp.Value.Index);
-                    }
-
-                    FieldInfo field = member.Member as FieldInfo;
-                    if (field != null)
-                    {
-                        _instructions.EmitLoadField(field);
-                        if (!field.IsLiteral && !field.IsInitOnly)
-                        {
-                            return new FieldByRefUpdater(memberTemp, field, index);
-                        }
-                        return null;
-                    }
-                    PropertyInfo property = member.Member as PropertyInfo;
-                    if (property != null)
-                    {
+                        Debug.Assert(member.Member is PropertyInfo);
+                        PropertyInfo property = (PropertyInfo)member.Member;
                         _instructions.EmitCall(property.GetGetMethod(true));
                         if (property.CanWrite)
                         {
                             return new PropertyByRefUpdater(memberTemp, property, index);
                         }
                         return null;
-                    }
-                    throw new InvalidOperationException(String.Format("Address of {0}", node.NodeType));
-                case ExpressionType.Call:
-                    // An array index of a multi-dimensional array is represented by a call to Array.Get,
-                    // rather than having its own array-access node. This means that when we are trying to
-                    // get the address of a member of a multi-dimensional array, we'll be trying to
-                    // get the address of a Get method, and it will fail to do so. Instead, detect
-                    // this situation and replace it with a call to the Address method.
-                    MethodCallExpression call = (MethodCallExpression)node;
-                    if (!call.Method.IsStatic &&
-                        call.Object.Type.IsArray &&
-                        call.Method == call.Object.Type.GetMethod("Get", BindingFlags.Public | BindingFlags.Instance))
-                    {
-                        return CompileMultiDimArrayAccess(
-                            call.Object,
-                            call.Arguments,
-                            index
-                        );
-                    }
-                    else
-                    {
-                        goto default;
-                    }
-
-                case ExpressionType.Unbox:
-                    Compile(node);
-                    return null;
-                default:
-                    Compile(node);
-                    return null;
+                    case ExpressionType.Call:
+                        // An array index of a multi-dimensional array is represented by a call to Array.Get,
+                        // rather than having its own array-access node. This means that when we are trying to
+                        // get the address of a member of a multi-dimensional array, we'll be trying to
+                        // get the address of a Get method, and it will fail to do so. Instead, detect
+                        // this situation and replace it with a call to the Address method.
+                        MethodCallExpression call = (MethodCallExpression)node;
+                        if (!call.Method.IsStatic &&
+                            call.Object.Type.IsArray &&
+                            call.Method == call.Object.Type.GetMethod("Get", BindingFlags.Public | BindingFlags.Instance))
+                        {
+                            return CompileMultiDimArrayAccess(
+                                call.Object,
+                                call.Arguments,
+                                index
+                            );
+                        }
+                        break;
+                }
             }
+            // Includes Unbox case as it doesn't need explicit write-back.
+            Compile(node);
+            return null;
         }
 
         private ByRefUpdater CompileMultiDimArrayAccess(Expression array, IList<Expression> arguments, int index)

--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Call.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Call.cs
@@ -3,12 +3,10 @@
 
 #if FEATURE_INTERPRET
 using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
 using System.Reflection;
 using Xunit;
 
-namespace Tests.Expressions
+namespace System.Linq.Expressions.Tests
 {
     partial class InterpreterTests
     {

--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Call.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Call.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if FEATURE_INTERPRET
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Xunit;
+
+namespace Tests.Expressions
+{
+    partial class InterpreterTests
+    {
+        [Fact(Skip = "4150")]
+        public static void CompileInterpretCrossCheck_Call_WriteBacks()
+        {
+            foreach (var e in Call_WriteBacks())
+            {
+                Verify(e);
+            }
+        }
+
+        private static IEnumerable<Expression> Call_WriteBacks()
+        {
+            // OK
+            foreach (var t in new[] { typeof(C), typeof(S) })
+            {
+                var p = Expression.Parameter(t);
+                var m = Expression.PropertyOrField(p, "X");
+                var mtd = t.GetTypeInfo().GetDeclaredMethod("Do");
+
+                yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.New(t)), Expression.Call(p, mtd), m);
+            }
+
+            // OK
+            foreach (var t in new[] { typeof(C), typeof(S) })
+            {
+                var p = Expression.Parameter(t.MakeArrayType());
+                var o = Expression.ArrayIndex(p, Expression.Constant(0));
+                var m = Expression.PropertyOrField(o, "X");
+                var mtd = t.GetTypeInfo().GetDeclaredMethod("Do");
+
+                yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.NewArrayInit(t, Expression.New(t))), Expression.Call(o, mtd), m);
+            }
+
+            // OK
+            foreach (var t in new[] { typeof(C), typeof(S) })
+            {
+                var p = Expression.Parameter(t.MakeArrayType(2));
+                var o = Expression.ArrayAccess(p, Expression.Constant(0), Expression.Constant(0));
+                var m = Expression.PropertyOrField(o, "X");
+                var mtd = t.GetTypeInfo().GetDeclaredMethod("Do");
+
+                yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.NewArrayBounds(t, Expression.Constant(1), Expression.Constant(1))), Expression.Assign(o, Expression.New(t)), Expression.Call(o, mtd), m);
+            }
+
+            // FAIL - Issue for struct; compiler doesn't write back but interpreter does
+            foreach (var t in new[] { typeof(C), typeof(S) })
+            {
+                var p = Expression.Parameter(typeof(Holder<>).MakeGenericType(t));
+                var o = Expression.Property(p, "Value");
+                var m = Expression.PropertyOrField(o, "X");
+                var mtd = t.GetTypeInfo().GetDeclaredMethod("Do");
+
+                yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.New(p.Type.GetTypeInfo().DeclaredConstructors.Single(), Expression.New(t))), Expression.Call(o, mtd), m);
+            }
+
+            // OK - Surprising compared to previous
+            foreach (var t in new[] { typeof(C), typeof(S) })
+            {
+                var p = Expression.Parameter(typeof(Holder<>).MakeGenericType(t));
+                var o = Expression.Field(p, "_value");
+                var m = Expression.PropertyOrField(o, "X");
+                var mtd = t.GetTypeInfo().GetDeclaredMethod("Do");
+
+                yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.New(p.Type.GetTypeInfo().DeclaredConstructors.Single(), Expression.New(t))), Expression.Call(o, mtd), m);
+            }
+
+            // FAIL - Issue for struct; compiler doesn't write back but interpreter does
+            foreach (var t in new[] { typeof(C), typeof(S) })
+            {
+                var p = Expression.Parameter(typeof(List<>).MakeGenericType(t));
+                var o = Expression.MakeIndex(p, p.Type.GetRuntimeProperty("Item"), new[] { Expression.Constant(0) });
+                var m = Expression.PropertyOrField(o, "X");
+                var mtd = t.GetTypeInfo().GetDeclaredMethod("Do");
+                var add = p.Type.GetTypeInfo().GetDeclaredMethod("Add");
+
+                yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.ListInit(Expression.New(p.Type), Expression.ElementInit(add, Expression.New(t)))), Expression.Call(o, mtd), m);
+            }
+        }
+
+        class C
+        {
+            public int X;
+
+            public void Do()
+            {
+                X = 1;
+            }
+        }
+
+        struct S
+        {
+            public int X;
+
+            public void Do()
+            {
+                X = 1;
+            }
+        }
+
+        class Holder<T>
+        {
+            public T _value;
+
+            public Holder(T value)
+            {
+                _value = value;
+            }
+
+            public T Value
+            {
+                get
+                {
+                    return _value;
+                }
+                set
+                {
+                    _value = value;
+                }
+            }
+        }
+    }
+}
+#endif

--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Call.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Call.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 #if FEATURE_INTERPRET
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -13,7 +12,7 @@ namespace Tests.Expressions
 {
     partial class InterpreterTests
     {
-        [Fact(Skip = "4150")]
+        [Fact]
         public static void CompileInterpretCrossCheck_Call_WriteBacks()
         {
             foreach (var e in Call_WriteBacks())
@@ -24,7 +23,6 @@ namespace Tests.Expressions
 
         private static IEnumerable<Expression> Call_WriteBacks()
         {
-            // OK
             foreach (var t in new[] { typeof(C), typeof(S) })
             {
                 var p = Expression.Parameter(t);
@@ -34,7 +32,6 @@ namespace Tests.Expressions
                 yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.New(t)), Expression.Call(p, mtd), m);
             }
 
-            // OK
             foreach (var t in new[] { typeof(C), typeof(S) })
             {
                 var p = Expression.Parameter(t.MakeArrayType());
@@ -45,7 +42,6 @@ namespace Tests.Expressions
                 yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.NewArrayInit(t, Expression.New(t))), Expression.Call(o, mtd), m);
             }
 
-            // OK
             foreach (var t in new[] { typeof(C), typeof(S) })
             {
                 var p = Expression.Parameter(t.MakeArrayType(2));
@@ -56,7 +52,6 @@ namespace Tests.Expressions
                 yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.NewArrayBounds(t, Expression.Constant(1), Expression.Constant(1))), Expression.Assign(o, Expression.New(t)), Expression.Call(o, mtd), m);
             }
 
-            // FAIL - Issue for struct; compiler doesn't write back but interpreter does
             foreach (var t in new[] { typeof(C), typeof(S) })
             {
                 var p = Expression.Parameter(typeof(Holder<>).MakeGenericType(t));
@@ -67,7 +62,6 @@ namespace Tests.Expressions
                 yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.New(p.Type.GetTypeInfo().DeclaredConstructors.Single(), Expression.New(t))), Expression.Call(o, mtd), m);
             }
 
-            // OK - Surprising compared to previous
             foreach (var t in new[] { typeof(C), typeof(S) })
             {
                 var p = Expression.Parameter(typeof(Holder<>).MakeGenericType(t));
@@ -78,7 +72,6 @@ namespace Tests.Expressions
                 yield return Expression.Block(new[] { p }, Expression.Assign(p, Expression.New(p.Type.GetTypeInfo().DeclaredConstructors.Single(), Expression.New(t))), Expression.Call(o, mtd), m);
             }
 
-            // FAIL - Issue for struct; compiler doesn't write back but interpreter does
             foreach (var t in new[] { typeof(C), typeof(S) })
             {
                 var p = Expression.Parameter(typeof(List<>).MakeGenericType(t));

--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.cs
@@ -99,7 +99,7 @@ namespace System.Linq.Expressions.Tests
             }
             catch (Exception ex)
             {
-                throw new Exception(string.Format("Error for expression '{0}':\r\n\r\n{1}", typeof(Expression).GetType().GetProperty("DebugView").GetValue(expr), ex.ToString()));
+                throw new Exception(string.Format("Error for expression '{0}':\r\n\r\n{1}", typeof(Expression).GetProperty("DebugView", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(expr), ex.ToString()));
             }
         }
 

--- a/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -10,6 +11,29 @@ namespace System.Linq.Expressions.Tests
     public static class InvocationTests
     {
         public delegate void X(X a);
+
+        private struct Mutable
+        {
+            private int x;
+            public int Foo()
+            {
+                return x++;
+            }
+        }
+
+        private class Wrapper<T>
+        {
+            public const int Zero = 0;
+            public T Field;
+#pragma warning disable 649 // For testing purposes
+            public readonly T ReadOnlyField;
+#pragma warning restore
+            public T Property
+            {
+                get { return Field; }
+                set { Field = value; }
+            }
+        }
 
         [Fact] // [Issue(3224, "https://github.com/dotnet/corefx/issues/3224")]
         public static void SelfApplication()
@@ -98,6 +122,278 @@ namespace System.Linq.Expressions.Tests
             Func<int> act = (Func<int>)Expression.Lambda(inv).Compile(true);
             act();
             Assert.Equal(1, holder.Function());
+        }
+
+        [Fact]
+        public static void UnboxReturnsReferenceCompiled()
+        {
+            var p = Expression.Parameter(typeof(object));
+            var unbox = Expression.Unbox(p, typeof(Mutable));
+            var call = Expression.Call(unbox, typeof(Mutable).GetMethod("Foo"));
+            var lambda = Expression.Lambda<Func<object, int>>(call, p).Compile(false);
+
+            object boxed = new Mutable();
+            Assert.Equal(0, lambda(boxed));
+            Assert.Equal(1, lambda(boxed));
+            Assert.Equal(2, lambda(boxed));
+            Assert.Equal(3, lambda(boxed));
+        }
+
+        [Fact]
+        public static void UnboxReturnsReferenceInterpretted()
+        {
+            var p = Expression.Parameter(typeof(object));
+            var unbox = Expression.Unbox(p, typeof(Mutable));
+            var call = Expression.Call(unbox, typeof(Mutable).GetMethod("Foo"));
+            var lambda = Expression.Lambda<Func<object, int>>(call, p).Compile(true);
+
+            object boxed = new Mutable();
+            Assert.Equal(0, lambda(boxed));
+            Assert.Equal(1, lambda(boxed));
+            Assert.Equal(2, lambda(boxed));
+            Assert.Equal(3, lambda(boxed));
+        }
+
+        [Fact]
+        public static void ArrayWriteBackCompiled()
+        {
+            var p = Expression.Parameter(typeof(Mutable[]));
+            var indexed = Expression.ArrayIndex(p, Expression.Constant(0));
+            var call = Expression.Call(indexed, typeof(Mutable).GetMethod("Foo"));
+            var lambda = Expression.Lambda<Func<Mutable[], int>>(call, p).Compile(false);
+
+            var array = new Mutable[1];
+            Assert.Equal(0, lambda(array));
+            Assert.Equal(1, lambda(array));
+            Assert.Equal(2, lambda(array));
+        }
+
+        [Fact]
+        public static void ArrayWriteBackInterpretted()
+        {
+            var p = Expression.Parameter(typeof(Mutable[]));
+            var indexed = Expression.ArrayIndex(p, Expression.Constant(0));
+            var call = Expression.Call(indexed, typeof(Mutable).GetMethod("Foo"));
+            var lambda = Expression.Lambda<Func<Mutable[], int>>(call, p).Compile(true);
+
+            var array = new Mutable[1];
+            Assert.Equal(0, lambda(array));
+            Assert.Equal(1, lambda(array));
+            Assert.Equal(2, lambda(array));
+        }
+
+        [Fact]
+        public static void MultiRankArrayWriteBackCompiled()
+        {
+            var p = Expression.Parameter(typeof(Mutable[,]));
+            var indexed = Expression.ArrayIndex(p, Expression.Constant(0), Expression.Constant(0));
+            var call = Expression.Call(indexed, typeof(Mutable).GetMethod("Foo"));
+            var lambda = Expression.Lambda<Func<Mutable[,], int>>(call, p).Compile(false);
+
+            var array = new Mutable[1, 1];
+            Assert.Equal(0, lambda(array));
+            Assert.Equal(1, lambda(array));
+            Assert.Equal(2, lambda(array));
+        }
+
+        [Fact]
+        public static void MultiRankArrayWriteBackInterpretted()
+        {
+            var p = Expression.Parameter(typeof(Mutable[,]));
+            var indexed = Expression.ArrayIndex(p, Expression.Constant(0), Expression.Constant(0));
+            var call = Expression.Call(indexed, typeof(Mutable).GetMethod("Foo"));
+            var lambda = Expression.Lambda<Func<Mutable[,], int>>(call, p).Compile(true);
+
+            var array = new Mutable[1, 1];
+            Assert.Equal(0, lambda(array));
+            Assert.Equal(1, lambda(array));
+            Assert.Equal(2, lambda(array));
+        }
+
+        [Fact]
+        public static void ArrayAccessWriteBackCompiled()
+        {
+            var p = Expression.Parameter(typeof(Mutable[]));
+            var indexed = Expression.ArrayAccess(p, Expression.Constant(0));
+            var call = Expression.Call(indexed, typeof(Mutable).GetMethod("Foo"));
+            var lambda = Expression.Lambda<Func<Mutable[], int>>(call, p).Compile(false);
+
+            var array = new Mutable[1];
+            Assert.Equal(0, lambda(array));
+            Assert.Equal(1, lambda(array));
+            Assert.Equal(2, lambda(array));
+        }
+
+        [Fact]
+        public static void ArrayAccessWriteBackInterpretted()
+        {
+            var p = Expression.Parameter(typeof(Mutable[]));
+            var indexed = Expression.ArrayAccess(p, Expression.Constant(0));
+            var call = Expression.Call(indexed, typeof(Mutable).GetMethod("Foo"));
+            var lambda = Expression.Lambda<Func<Mutable[], int>>(call, p).Compile(true);
+
+            var array = new Mutable[1];
+            Assert.Equal(0, lambda(array));
+            Assert.Equal(1, lambda(array));
+            Assert.Equal(2, lambda(array));
+        }
+
+        [Fact]
+        public static void MultiRankArrayAccessWriteBackCompiled()
+        {
+            var p = Expression.Parameter(typeof(Mutable[,]));
+            var indexed = Expression.ArrayAccess(p, Expression.Constant(0), Expression.Constant(0));
+            var call = Expression.Call(indexed, typeof(Mutable).GetMethod("Foo"));
+            var lambda = Expression.Lambda<Func<Mutable[,], int>>(call, p).Compile(false);
+
+            var array = new Mutable[1, 1];
+            Assert.Equal(0, lambda(array));
+            Assert.Equal(1, lambda(array));
+            Assert.Equal(2, lambda(array));
+        }
+
+        [Fact]
+        public static void MultiRankArrayAccessWriteBackInterpretted()
+        {
+            var p = Expression.Parameter(typeof(Mutable[,]));
+            var indexed = Expression.ArrayAccess(p, Expression.Constant(0), Expression.Constant(0));
+            var call = Expression.Call(indexed, typeof(Mutable).GetMethod("Foo"));
+            var lambda = Expression.Lambda<Func<Mutable[,], int>>(call, p).Compile(true);
+
+            var array = new Mutable[1, 1];
+            Assert.Equal(0, lambda(array));
+            Assert.Equal(1, lambda(array));
+            Assert.Equal(2, lambda(array));
+        }
+
+        [Fact]
+        public static void IndexedPropertyAccessNoWriteBackCompiled()
+        {
+            var p = Expression.Parameter(typeof(List<Mutable>));
+            var indexed = Expression.Property(p, typeof(List<Mutable>).GetProperty("Item"), Expression.Constant(0));
+            var call = Expression.Call(indexed, typeof(Mutable).GetMethod("Foo"));
+            var lambda = Expression.Lambda<Func<List<Mutable>, int>>(call, p).Compile(false);
+
+            var list = new List<Mutable> { new Mutable() };
+            Assert.Equal(0, lambda(list));
+            Assert.Equal(0, lambda(list));
+        }
+
+        [Fact]
+        public static void IndexedPropertyAccessNoWriteBackInterpretted()
+        {
+            var p = Expression.Parameter(typeof(List<Mutable>));
+            var indexed = Expression.Property(p, typeof(List<Mutable>).GetProperty("Item"), Expression.Constant(0));
+            var call = Expression.Call(indexed, typeof(Mutable).GetMethod("Foo"));
+            var lambda = Expression.Lambda<Func<List<Mutable>, int>>(call, p).Compile(true);
+
+            var list = new List<Mutable> { new Mutable() };
+            Assert.Equal(0, lambda(list));
+            Assert.Equal(0, lambda(list));
+        }
+
+        [Fact]
+        public static void FieldAccessWriteBackCompiled()
+        {
+            var p = Expression.Parameter(typeof(Wrapper<Mutable>));
+            var member = Expression.Field(p, typeof(Wrapper<Mutable>).GetField("Field"));
+            var call = Expression.Call(member, typeof(Mutable).GetMethod("Foo"));
+            var lambda = Expression.Lambda<Func<Wrapper<Mutable>, int>>(call, p).Compile(false);
+
+            var wrapper = new Wrapper<Mutable>();
+            Assert.Equal(0, lambda(wrapper));
+            Assert.Equal(1, lambda(wrapper));
+            Assert.Equal(2, lambda(wrapper));
+        }
+
+        [Fact]
+        public static void FieldAccessWriteBackIntepretted()
+        {
+            var p = Expression.Parameter(typeof(Wrapper<Mutable>));
+            var member = Expression.Field(p, typeof(Wrapper<Mutable>).GetField("Field"));
+            var call = Expression.Call(member, typeof(Mutable).GetMethod("Foo"));
+            var lambda = Expression.Lambda<Func<Wrapper<Mutable>, int>>(call, p).Compile(true);
+
+            var wrapper = new Wrapper<Mutable>();
+            Assert.Equal(0, lambda(wrapper));
+            Assert.Equal(1, lambda(wrapper));
+            Assert.Equal(2, lambda(wrapper));
+        }
+
+        [Fact]
+        public static void PropertyAccessNoWriteBackCompiled()
+        {
+            var p = Expression.Parameter(typeof(Wrapper<Mutable>));
+            var member = Expression.Property(p, typeof(Wrapper<Mutable>).GetProperty("Property"));
+            var call = Expression.Call(member, typeof(Mutable).GetMethod("Foo"));
+            var lambda = Expression.Lambda<Func<Wrapper<Mutable>, int>>(call, p).Compile(false);
+
+            var wrapper = new Wrapper<Mutable>();
+            Assert.Equal(0, lambda(wrapper));
+            Assert.Equal(0, lambda(wrapper));
+        }
+
+        [Fact]
+        public static void PropertyAccessNoWriteBackIntepretted()
+        {
+            var p = Expression.Parameter(typeof(Wrapper<Mutable>));
+            var member = Expression.Property(p, typeof(Wrapper<Mutable>).GetProperty("Property"));
+            var call = Expression.Call(member, typeof(Mutable).GetMethod("Foo"));
+            var lambda = Expression.Lambda<Func<Wrapper<Mutable>, int>>(call, p).Compile(true);
+
+            var wrapper = new Wrapper<Mutable>();
+            Assert.Equal(0, lambda(wrapper));
+            Assert.Equal(0, lambda(wrapper));
+        }
+
+        [Fact]
+        public static void ReadonlyFieldAccessWriteBackCompiled()
+        {
+            var p = Expression.Parameter(typeof(Wrapper<Mutable>));
+            var member = Expression.Field(p, typeof(Wrapper<Mutable>).GetField("ReadOnlyField"));
+            var call = Expression.Call(member, typeof(Mutable).GetMethod("Foo"));
+            var lambda = Expression.Lambda<Func<Wrapper<Mutable>, int>>(call, p).Compile(false);
+
+            var wrapper = new Wrapper<Mutable>();
+            Assert.Equal(0, lambda(wrapper));
+            Assert.Equal(0, lambda(wrapper));
+            Assert.Equal(0, lambda(wrapper));
+        }
+
+        [Fact]
+        public static void ReadonlyFieldAccessWriteBackInterpreted()
+        {
+            var p = Expression.Parameter(typeof(Wrapper<Mutable>));
+            var member = Expression.Field(p, typeof(Wrapper<Mutable>).GetField("ReadOnlyField"));
+            var call = Expression.Call(member, typeof(Mutable).GetMethod("Foo"));
+            var lambda = Expression.Lambda<Func<Wrapper<Mutable>, int>>(call, p).Compile(true);
+
+            var wrapper = new Wrapper<Mutable>();
+            Assert.Equal(0, lambda(wrapper));
+            Assert.Equal(0, lambda(wrapper));
+            Assert.Equal(0, lambda(wrapper));
+        }
+
+        [Fact]
+        public static void ConstFieldAccessWriteBackCompiled()
+        {
+            var member = Expression.Field(null, typeof(Wrapper<Mutable>).GetField("Zero"));
+            var call = Expression.Call(member, typeof(int).GetMethod("GetType"));
+            var lambda = Expression.Lambda<Func<Type>>(call).Compile(false);
+
+            var wrapper = new Wrapper<Mutable>();
+            Assert.Equal(typeof(int), lambda());
+        }
+
+        [Fact]
+        public static void ConstFieldAccessWriteBackInterpreted()
+        {
+            var member = Expression.Field(null, typeof(Wrapper<Mutable>).GetField("Zero"));
+            var call = Expression.Call(member, typeof(int).GetMethod("GetType"));
+            var lambda = Expression.Lambda<Func<Type>>(call).Compile(true);
+
+            var wrapper = new Wrapper<Mutable>();
+            Assert.Equal(typeof(int), lambda());
         }
     }
 }

--- a/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
@@ -63,5 +63,41 @@ namespace System.Linq.Expressions.Tests
                 Assert.Equal(1, DoItA(this));
             }
         }
+
+        private class FuncHolder
+        {
+            public Func<int> Function;
+
+            public FuncHolder()
+            {
+                Function = () =>
+                {
+                    Function = () => 1;
+                    return 0;
+                };
+            }
+        }
+
+        [Fact]
+        public static void InvocationDoesNotChangeFunctionInvokedCompiled()
+        {
+            FuncHolder holder = new FuncHolder();
+            var fld = Expression.Field(Expression.Constant(holder), "Function");
+            var inv = Expression.Invoke(fld);
+            Func<int> act = (Func<int>)Expression.Lambda(inv).Compile(false);
+            act();
+            Assert.Equal(1, holder.Function());
+        }
+
+        [Fact]
+        public static void InvocationDoesNotChangeFunctionInvokedInterpreted()
+        {
+            FuncHolder holder = new FuncHolder();
+            var fld = Expression.Field(Expression.Constant(holder), "Function");
+            var inv = Expression.Invoke(fld);
+            Func<int> act = (Func<int>)Expression.Lambda(inv).Compile(true);
+            act();
+            Assert.Equal(1, holder.Function());
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
+++ b/src/System.Linq.Expressions/tests/Invoke/InvocationTests.cs
@@ -26,7 +26,7 @@ namespace System.Linq.Expressions.Tests
             b.Compile().DynamicInvoke();
         }
 
-        [Fact(Skip = "4150")]
+        [Fact]
         public static void NoWriteBackToInstance()
         {
             new NoThread(false).DoTest();

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -137,6 +137,7 @@
     <Compile Include="Interpreter\InterpreterTests.Address.cs" />
     <Compile Include="Interpreter\InterpreterTests.cs" />
     <Compile Include="Interpreter\InterpreterTests.Generated.cs" />
+    <Compile Include="Interpreter\InterpreterTests.Call.cs" />
     <Compile Include="Invoke\InvocationTests.cs" />
     <Compile Include="Invoke\InvokeFactoryTests.cs" />
     <Compile Include="Label\LabelTargetTests.cs" />


### PR DESCRIPTION
Adding tests for write-back behavior of MethodCallExpression in the compiler and interpreter

 Interpreted expressions shouldn't write back to delegate instances of calls.

Fixes #4150

Interpreted expressions executing a `‎Call()` write back to the instance of the method after the call, so that mutable structs are mutated correctly. This is harmless in most cases to which it doesn't apply, but can cause bugs when the instance is mutated from the outside over the course of the call, including when delegates are `Invoke()`d as that becomes a `Call()` with the delegate as its instance.

Test writeback of UnboxExpression, and add comment explaining why explicit write-back is not needed.

Tests for different write-back and no-write-back cases.

Consolidate duplicate branches and replace runtime exception on impossible case with assertion.

Fix tests namespaces to remain inline with #2898

Handle readonly and const fields in write-back for both instances and byref parameters (by not writing back).

Closes #4157 as it contains its commits and more.