### PR TITLE
Initial set of dev workflow scripts for windows

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -4,7 +4,7 @@ setlocal
 :: Note: We've disabled node reuse because it causes file locking issues.
 ::       The issue is that we extend the build with our own targets which
 ::       means that that rebuilding cannot successfully delete the task
-::       assembly. 
+::       assembly.
 
 if not defined VisualStudioVersion (
     if defined VS140COMNTOOLS (
@@ -12,19 +12,14 @@ if not defined VisualStudioVersion (
         goto :CheckNative
     )
 
-    if defined VS120COMNTOOLS (
-        call "%VS120COMNTOOLS%\VsDevCmd.bat"
-        goto :CheckNative
-    )
-
-    echo Error: build.cmd requires Visual Studio 2013 or 2015.  
+    echo Error: build.cmd requires Visual Studio 2015.
     echo        Please see https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/developer-guide.md for build instructions.
     exit /b 1
 )
 
 :CheckNative
 
-call init-tools.cmd
+call %~dp0init-tools.cmd
 
 :: Run the Native Windows build
 echo [%time%] Building Native Libraries...

--- a/build.proj
+++ b/build.proj
@@ -26,6 +26,14 @@
   <Import Project="dir.traversal.targets" />
 
   <PropertyGroup>
+    <!--
+      Until we have the full clean\sync\build dev workflow in place we still default to restoring during build.
+      For those that wish to opt-out they can set RestoreDuringBuild=false or pass /p:RestoreDuringBuild=false.
+    -->
+    <RestoreDuringBuild Condition="'$(RestoreDuringBuild)'==''">true</RestoreDuringBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(RestoreDuringBuild)'=='true'">
     <TraversalBuildDependsOn>
       ValidateAllProjectDependencies;
       BatchRestorePackages;
@@ -75,6 +83,19 @@
   <!-- Override clean from dir.traversal.targets and just remove the full BinDir -->
   <Target Name="Clean">
     <RemoveDir Directories="$(BinDir)" />
+  </Target>
+
+  <PropertyGroup>
+    <UserLocalFolder Condition="'$(OsEnvironment)'!='Unix'">$(LocalAppData)/</UserLocalFolder>
+    <UserLocalFolder Condition="'$(OsEnvironment)'=='Unix'">$(HOME)/.local/share/</UserLocalFolder>
+  </PropertyGroup>
+
+  <Target Name="CleanPackages">
+    <RemoveDir Directories="$(PackagesDir)" />
+  </Target>
+
+  <Target Name="CleanPackagesCache">
+    <RemoveDir Directories="$(UserLocalFolder)NuGet/Cache/;$(UserLocalFolder)NuGet/v3-cache/;$(UserLocalFolder)dnu/cache/" />
   </Target>
 
 </Project>

--- a/clean.cmd
+++ b/clean.cmd
@@ -1,0 +1,106 @@
+@echo off
+setlocal
+
+set cleanlog=%~dp0clean.log
+echo Running Clean.cmd %* > %cleanlog%
+
+if [%1] == [] (
+  set clean_targets=Clean
+  goto Begin
+)
+
+set clean_targets=
+set clean_src=
+set clean_tools=
+set clean_all=
+
+:Loop
+if [%1] == [] goto Begin
+
+if /I [%1] == [/?] goto Usage
+
+if /I [%1] == [/b] (
+  set clean_targets=Clean;%clean_targets%
+  goto Next
+)
+
+if /I [%1] == [/p] (
+  set clean_targets=CleanPackages;%clean_targets%
+  goto Next
+)
+
+if /I [%1] == [/c] (
+  set clean_targets=CleanPackagesCache;%clean_targets%
+  goto Next
+)
+
+if /I [%1] == [/s] (
+  set clean_src=true
+  goto Next
+)
+
+if /I [%1] == [/t] (
+  set clean_tools=true
+  goto Next
+)
+
+if /I [%1] == [/all] (
+  set clean_src=
+  set clean_tools=
+  set clean_targets=Clean;CleanPackages;CleanPackagesCache;
+  set clean_all=true
+  goto Begin
+)
+
+echo Unrecognized argument '%1'
+goto Usage
+
+:Next
+shift /1
+goto Loop
+
+:Begin
+
+call %~dp0init-tools.cmd
+
+if /I [%clean_src%] == [true] (
+  echo Cleaning src directory ...
+  call git clean %~dp0src -xdf >> %cleanlog%
+)
+
+if NOT "%clean_targets%" == "" (
+  echo Running msbuild clean targets "%clean_targets:~0,-1%" ...
+  echo msbuild.exe %~dp0build.proj /t:%clean_targets:~0,-1% /nologo /v:minimal /flp:v=diag;Append;LogFile=%cleanlog% >> %cleanlog%
+  call msbuild.exe %~dp0build.proj /t:%clean_targets:~0,-1% /nologo /v:minimal /flp:v=diag;Append;LogFile=%cleanlog%
+  if NOT [%ERRORLEVEL%]==[0] (
+    echo ERROR: An error occurred while cleaning, see %cleanlog% for more details.
+    exit /b
+  )
+)
+
+if /I [%clean_tools%] == [true] (
+  echo Cleaning tools directory ...
+  rmdir /s /q %~dp0tools >> %cleanlog%dir
+)
+
+if /I [%clean_all%] == [true] (
+  echo Cleaning entire working directory ...
+  call git clean %~dp0 -xdf >> %cleanlog%
+)
+
+echo Done Cleaning.
+exit /b 0
+
+:Usage
+echo.
+echo Repository cleaning script.
+echo.
+echo Options:
+echo     /b     - Deletes the binary output directory.
+echo     /p     - Deletes the repo-local nuget package directory.
+echo     /c     - Deleted the user-local nuget package cache.
+echo     /t     - Deletes the tools directory.
+echo     /s     - Deletes the untracked files under src directory (git clean src -xdf).
+echo     /all   - Combines all of the above.
+echo.
+echo If no option is specified then clean.cmd /b is implied.

--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -29,14 +29,14 @@ if exist "%BUILD_TOOLS_SEMAPHORE%" (
   goto :EOF
 )
 
-mkdir "%PROJECT_JSON_PATH%"
+if NOT exist "%PROJECT_JSON_PATH%" mkdir "%PROJECT_JSON_PATH%"
 echo %PROJECT_JSON_CONTENTS% > %PROJECT_JSON_FILE%
 echo Running %0 > %INIT_TOOLS_LOG%
 
 if exist "%DOTNET_CMD%" goto :afterdotnetrestore
 
 echo Installing dotnet cli...
-mkdir "%DOTNET_PATH%"
+if NOT exist "%DOTNET_PATH%" mkdir "%DOTNET_PATH%"
 set /p DOTNET_VERSION=< %~dp0DotnetCLIVersion.txt
 set DOTNET_ZIP_NAME=dotnet-win-x64.%DOTNET_VERSION%.zip
 set DOTNET_REMOTE_PATH=https://dotnetcli.blob.core.windows.net/dotnet/dev/Binaries/%DOTNET_VERSION%/%DOTNET_ZIP_NAME%

--- a/sync.cmd
+++ b/sync.cmd
@@ -1,0 +1,74 @@
+@echo off
+setlocal
+
+set synclog=sync.log
+echo Running Sync.cmd %* > %synclog%
+
+if [%1]==[] (
+  set src=true
+  set packages=true
+  goto Begin
+)
+
+set src=false
+set packages=false
+
+:Loop
+if [%1]==[] goto Begin
+
+if /I [%1]==[/?] goto Usage
+
+if /I [%1] == [/p] (
+    set packages=true
+    goto Next
+)
+
+if /I [%1] == [/s] (
+    set src=true
+    goto Next
+)
+
+echo Unrecognized argument '%1'
+goto Usage
+
+:Next
+shift /1
+goto Loop
+
+:Begin
+
+call %~dp0init-tools.cmd
+
+if [%src%] == [true] (
+  echo Fetching git database from remote repos ...
+  call git fetch --all -p >> %synclog%
+  if NOT [%ERRORLEVEL%]==[0] (
+    echo ERROR: An error occurred while fetching remote source code, see %synclog% for more details.
+    exit /b
+  )
+)
+
+if [%packages%] == [true] (
+  echo Restoring all packages ...
+  echo msbuild.exe %~dp0build.proj /t:BatchRestorePackages /nologo /v:minimal /p:RestoreDuringBuild=true /flp:v=diag;Append;LogFile=%synclog% >> %synclog%
+  call msbuild.exe %~dp0build.proj /t:BatchRestorePackages /nologo /v:minimal /p:RestoreDuringBuild=true /flp:v=diag;Append;LogFile=%synclog%
+  if NOT [%ERRORLEVEL%]==[0] (
+    echo ERROR: An error occurred while syncing packages, see %synclog% for more details. There may have been networking problems so please try again in a few minutes.
+    exit /b
+  )
+)
+
+echo Done Syncing.
+exit /b 0
+
+goto :EOF
+
+:Usage
+echo.
+echo Repository syncing script.
+echo.
+echo Options:
+echo     /s     - Fetches source history from all configured remotes (git fetch --all)
+echo     /p     - Restores all nuget packages for repository
+echo.
+echo If no option is specified then sync.cmd /s /p is implied.


### PR DESCRIPTION
I've been getting very annoyed with how long it takes to do BatchRestorePackages and I kept disabling it locally so I figured I would go ahead an push us in the direction of our dev workflow that we are going to be moving towards anyway. This gets us a step in the direction and gives people a way to disable batch restore during root builds.

@maririos @naamunds @joperezr PTAL

Adds Clean.cmd and Sync.cmd

There is also an option added for disabling batch restore of packages
during the build. Right now it restore is still enabled by default
but eventually it will be disabled and restore will only happen when
you call sync.cmd or build an individual project.

To disable batch restoring during build people can do one of 2 things:
1) set RestoreDuringBuild=false in your enviroment
2) pass /p:RestoreDuringBuild=false to build.cmd