### PR TITLE
Tweak ConcurrentDictionary perf

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -57,13 +57,6 @@ namespace System.Collections.Concurrent
         private readonly bool _growLockArray; // Whether to dynamically increase the size of the striped lock
         private int _budget; // The maximum number of elements per lock before a resize operation is triggered
 
-        // The default concurrency level is DEFAULT_CONCURRENCY_MULTIPLIER * #CPUs. The higher the
-        // DEFAULT_CONCURRENCY_MULTIPLIER, the more concurrent writes can take place without interference
-        // and blocking, but also the more expensive operations that require all locks become (e.g. table
-        // resizing, ToArray, Count, etc). According to brief benchmarks that we ran, 4 seems like a good
-        // compromise.
-        private const int DEFAULT_CONCURRENCY_MULTIPLIER = 4;
-
         // The default capacity, i.e. the initial # of buckets. When choosing this value, we are making
         // a trade-off between the size of a very small dictionary, and the number of resizes when
         // constructing a large dictionary. Also, the capacity should not be divisible by a small prime.
@@ -1757,7 +1750,7 @@ namespace System.Collections.Concurrent
         /// </summary>
         private static int DefaultConcurrencyLevel
         {
-            get { return DEFAULT_CONCURRENCY_MULTIPLIER * PlatformHelper.ProcessorCount; }
+            get { return PlatformHelper.ProcessorCount; }
         }
 
         /// <summary>

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using System.Threading;
 
 namespace System.Collections.Concurrent
@@ -221,7 +222,7 @@ namespace System.Collections.Concurrent
             TValue dummy;
             foreach (KeyValuePair<TKey, TValue> pair in collection)
             {
-                if (pair.Key == null) throw new ArgumentNullException("key");
+                if (pair.Key == null) ThrowKeyNullException();
 
                 if (!TryAddInternal(pair.Key, _comparer.GetHashCode(pair.Key), pair.Value, false, false, out dummy))
                 {
@@ -309,7 +310,7 @@ namespace System.Collections.Concurrent
         /// contains too many elements.</exception>
         public bool TryAdd(TKey key, TValue value)
         {
-            if (key == null) throw new ArgumentNullException("key");
+            if (key == null) ThrowKeyNullException();
             TValue dummy;
             return TryAddInternal(key, _comparer.GetHashCode(key), value, false, true, out dummy);
         }
@@ -326,7 +327,7 @@ namespace System.Collections.Concurrent
         /// (Nothing in Visual Basic).</exception>
         public bool ContainsKey(TKey key)
         {
-            if (key == null) throw new ArgumentNullException("key");
+            if (key == null) ThrowKeyNullException();
 
             TValue throwAwayValue;
             return TryGetValue(key, out throwAwayValue);
@@ -346,7 +347,7 @@ namespace System.Collections.Concurrent
         /// (Nothing in Visual Basic).</exception>
         public bool TryRemove(TKey key, out TValue value)
         {
-            if (key == null) throw new ArgumentNullException("key");
+            if (key == null) ThrowKeyNullException();
 
             return TryRemoveInternal(key, out value, false, default(TValue));
         }
@@ -434,7 +435,7 @@ namespace System.Collections.Concurrent
         /// (Nothing in Visual Basic).</exception>
         public bool TryGetValue(TKey key, out TValue value)
         {
-            if (key == null) throw new ArgumentNullException("key");
+            if (key == null) ThrowKeyNullException();
             return TryGetValueInternal(key, _comparer.GetHashCode(key), out value);
         }
 
@@ -482,7 +483,7 @@ namespace System.Collections.Concurrent
         /// reference.</exception>
         public bool TryUpdate(TKey key, TValue newValue, TValue comparisonValue)
         {
-            if (key == null) throw new ArgumentNullException("key");
+            if (key == null) ThrowKeyNullException();
             return TryUpdateInternal(key, _comparer.GetHashCode(key), newValue, comparisonValue);
         }
 
@@ -880,16 +881,28 @@ namespace System.Collections.Concurrent
                 TValue value;
                 if (!TryGetValue(key, out value))
                 {
-                    throw new KeyNotFoundException();
+                    ThrowKeyNotFoundException();
                 }
                 return value;
             }
             set
             {
-                if (key == null) throw new ArgumentNullException("key");
+                if (key == null) ThrowKeyNullException();
                 TValue dummy;
                 TryAddInternal(key, _comparer.GetHashCode(key), value, true, true, out dummy);
             }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowKeyNotFoundException()
+        {
+            throw new KeyNotFoundException();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowKeyNullException()
+        {
+            throw new ArgumentNullException("key");
         }
 
         /// <summary>
@@ -948,7 +961,7 @@ namespace System.Collections.Concurrent
         /// if the key was not in the dictionary.</returns>
         public TValue GetOrAdd(TKey key, Func<TKey, TValue> valueFactory)
         {
-            if (key == null) throw new ArgumentNullException("key");
+            if (key == null) ThrowKeyNullException();
             if (valueFactory == null) throw new ArgumentNullException("valueFactory");
 
             int hashcode = _comparer.GetHashCode(key);
@@ -975,7 +988,7 @@ namespace System.Collections.Concurrent
         /// key is already in the dictionary, or the new value if the key was not in the dictionary.</returns>
         public TValue GetOrAdd(TKey key, TValue value)
         {
-            if (key == null) throw new ArgumentNullException("key");
+            if (key == null) ThrowKeyNullException();
 
             int hashcode = _comparer.GetHashCode(key);
 
@@ -1008,7 +1021,7 @@ namespace System.Collections.Concurrent
         /// absent) or the result of updateValueFactory (if the key was present).</returns>
         public TValue AddOrUpdate(TKey key, Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory)
         {
-            if (key == null) throw new ArgumentNullException("key");
+            if (key == null) ThrowKeyNullException();
             if (addValueFactory == null) throw new ArgumentNullException("addValueFactory");
             if (updateValueFactory == null) throw new ArgumentNullException("updateValueFactory");
 
@@ -1056,7 +1069,7 @@ namespace System.Collections.Concurrent
         /// absent) or the result of updateValueFactory (if the key was present).</returns>
         public TValue AddOrUpdate(TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory)
         {
-            if (key == null) throw new ArgumentNullException("key");
+            if (key == null) ThrowKeyNullException();
             if (updateValueFactory == null) throw new ArgumentNullException("updateValueFactory");
 
             int hashcode = _comparer.GetHashCode(key);
@@ -1316,7 +1329,7 @@ namespace System.Collections.Concurrent
         /// </exception>
         void IDictionary.Add(object key, object value)
         {
-            if (key == null) throw new ArgumentNullException("key");
+            if (key == null) ThrowKeyNullException();
             if (!(key is TKey)) throw new ArgumentException(SR.ConcurrentDictionary_TypeOfKeyIncorrect);
 
             TValue typedValue;
@@ -1344,7 +1357,7 @@ namespace System.Collections.Concurrent
         /// (Nothing in Visual Basic).</exception>
         bool IDictionary.Contains(object key)
         {
-            if (key == null) throw new ArgumentNullException("key");
+            if (key == null) ThrowKeyNullException();
 
             return (key is TKey) && this.ContainsKey((TKey)key);
         }
@@ -1404,7 +1417,7 @@ namespace System.Collections.Concurrent
         /// (Nothing in Visual Basic).</exception>
         void IDictionary.Remove(object key)
         {
-            if (key == null) throw new ArgumentNullException("key");
+            if (key == null) ThrowKeyNullException();
 
             TValue throwAwayValue;
             if (key is TKey)
@@ -1446,7 +1459,7 @@ namespace System.Collections.Concurrent
         {
             get
             {
-                if (key == null) throw new ArgumentNullException("key");
+                if (key == null) ThrowKeyNullException();
 
                 TValue value;
                 if (key is TKey && TryGetValue((TKey)key, out value))
@@ -1458,7 +1471,7 @@ namespace System.Collections.Concurrent
             }
             set
             {
-                if (key == null) throw new ArgumentNullException("key");
+                if (key == null) ThrowKeyNullException();
 
                 if (!(key is TKey)) throw new ArgumentException(SR.ConcurrentDictionary_TypeOfKeyIncorrect);
                 if (!(value is TValue)) throw new ArgumentException(SR.ConcurrentDictionary_TypeOfValueIncorrect);

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -14,7 +14,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -39,7 +38,7 @@ namespace System.Collections.Concurrent
         /// Wrapping the three tables in a single object allows us to atomically
         /// replace all tables at once.
         /// </summary>
-        private class Tables
+        private sealed class Tables
         {
             internal readonly Node[] _buckets; // A singly-linked list for each bucket.
             internal readonly object[] _locks; // A set of locks, each guarding a section of the table.
@@ -1883,12 +1882,12 @@ namespace System.Collections.Concurrent
         /// <summary>
         /// A node in a singly-linked list representing a particular hash table bucket.
         /// </summary>
-        private class Node
+        private sealed class Node
         {
-            internal TKey _key;
+            internal readonly TKey _key;
             internal TValue _value;
             internal volatile Node _next;
-            internal int _hashcode;
+            internal readonly int _hashcode;
 
             internal Node(TKey key, TValue value, int hashcode, Node next)
             {
@@ -1903,7 +1902,7 @@ namespace System.Collections.Concurrent
         /// A private class to represent enumeration over the dictionary that implements the 
         /// IDictionaryEnumerator interface.
         /// </summary>
-        private class DictionaryEnumerator : IDictionaryEnumerator
+        private sealed class DictionaryEnumerator : IDictionaryEnumerator
         {
             IEnumerator<KeyValuePair<TKey, TValue>> _enumerator; // Enumerator over the dictionary.
 

--- a/src/System.Collections.Concurrent/src/project.json
+++ b/src/System.Collections.Concurrent/src/project.json
@@ -6,6 +6,7 @@
     "System.Diagnostics.Tools": "4.0.0",
     "System.Diagnostics.Tracing": "4.0.20",
     "System.Globalization": "4.0.10",
+    "System.Reflection":"4.0.10",
     "System.Runtime": "4.0.20",
     "System.Runtime.Extensions": "4.0.10",
     "System.Threading": "4.0.10",


### PR DESCRIPTION
- Decrease memory consumption when using default ctor.  Today by default ConcurrentDictionary assumes a default concurrencyLevel of Environment.ProcessCount * 4.  That multiple results in only marginal throughput improvements even on extremely write-heavy workloads, but it results in significant additional memory consumption for small-to-medium sized dictionaries, due to allocating the various objects used for striped locking.  I've changed the default to lose the multiple and just be Environment.ProcessorCount.  I was unable to find a workload that produced a meaningful regression (in fact some seemed to get a bit faster).  I was able to find regressions if I used a default lower than that, e.g. defaulting 1... developers can always choose to explicitly specify a concurrencyLevel of 1 via the ctor, in which case memory consumption will be lowered and all writes will be serialized on that one lock (reads are always lock-free, regardless of concurrency level).  We can of course consider changing the default down to 1 in the future.

- Made several read operations more inlineable.  Methods like TryGetValue weren't being inlined due to the JIT's size estimate saying it'd be too big.  By factoring out the throw expressions into non-inlineable methods, the JIT now inlines them.  In various microbenchmarks, this improved TryGetValue, ContainsKey, etc. throughput upwards of ~20%.

- Made a few types sealed and a few members readonly.

- Fixed up several style issues.

cc: @vancem, @AlfredoMS 