### PR TITLE
Fix FileSystem related permissions failures.

### DIFF
--- a/src/System.IO.FileSystem/tests/File/ReadWriteAllText.cs
+++ b/src/System.IO.FileSystem/tests/File/ReadWriteAllText.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Runtime.InteropServices;
 using System.Text;
 using Xunit;
 
@@ -106,15 +107,32 @@ namespace System.IO.Tests
             Assert.Throws<FileNotFoundException>(() => Read(path));
         }
 
-        [ActiveIssue(4605, PlatformID.OSX)]
+        /// <summary>
+        /// On Unix, modifying a file that is ReadOnly will fail under normal permissions.
+        /// If the test is being run under the superuser, however, modification of a ReadOnly
+        /// file is allowed.
+        /// </summary>
         [Fact]
-        public void WriteToReadOnlyFile_UnauthException()
+        public void WriteToReadOnlyFile()
         {
             string path = GetTestFilePath();
             File.Create(path).Dispose();
             File.SetAttributes(path, FileAttributes.ReadOnly);
-            Assert.Throws<UnauthorizedAccessException>(() => Write(path, "text"));
-            File.SetAttributes(path, FileAttributes.Normal);
+            try
+            {
+                // Operation succeeds when being run by the Unix superuser
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && geteuid() == 0)
+                {
+                    Write(path, "text");
+                    Assert.Equal("text", Read(path));
+                }
+                else
+                    Assert.Throws<UnauthorizedAccessException>(() => Write(path, "text"));
+            }
+            finally
+            {
+                File.SetAttributes(path, FileAttributes.Normal);
+            }
         }
 
         #endregion

--- a/src/System.IO.FileSystem/tests/FileSystemTest.cs
+++ b/src/System.IO.FileSystem/tests/FileSystemTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Runtime.InteropServices;
+
 namespace System.IO.Tests
 {
     public abstract class FileSystemTest : FileCleanupTestBase
@@ -19,5 +21,8 @@ namespace System.IO.Tests
                 return ret;
             }
         }
+
+        [DllImport("libc", SetLastError = true)]
+        protected static extern int geteuid();
     }
 }

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Win32.SafeHandles;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.IO.MemoryMappedFiles.Tests
@@ -616,14 +617,15 @@ namespace System.IO.MemoryMappedFiles.Tests
         }
 
         /// <summary>
-        /// Test the behavior of various access levels when working with a read-only file.
+        /// On Unix, modifying a file that is ReadOnly will fail under normal permissions.
+        /// If the test is being run under the superuser, however, modification of a ReadOnly
+        /// file is allowed.
         /// </summary>
-        [ActiveIssue(4605, PlatformID.OSX)]
         [Theory]
         [InlineData(MemoryMappedFileAccess.Read)]
         [InlineData(MemoryMappedFileAccess.ReadWrite)]
         [InlineData(MemoryMappedFileAccess.CopyOnWrite)]
-        public void ReadOnlyFile(MemoryMappedFileAccess access)
+        public void WriteToReadOnlyFile(MemoryMappedFileAccess access)
         {
             const int Capacity = 4096;
             using (TempFile file = new TempFile(GetTestFilePath(), Capacity))
@@ -632,26 +634,22 @@ namespace System.IO.MemoryMappedFiles.Tests
                 File.SetAttributes(file.Path, FileAttributes.ReadOnly);
                 try
                 {
-                    if (access == MemoryMappedFileAccess.Read)
-                    {
-                        // The only access requested is Read; this should work with a read-only file.
+                    if (access == MemoryMappedFileAccess.Read || (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && geteuid() == 0))
                         using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(file.Path, FileMode.Open, null, Capacity, access))
-                        {
                             ValidateMemoryMappedFile(mmf, Capacity, MemoryMappedFileAccess.Read);
-                        }
-                    }
                     else
-                    {
-                        // All write-access is denied with a read-only file.
                         Assert.Throws<UnauthorizedAccessException>(() => MemoryMappedFile.CreateFromFile(file.Path, FileMode.Open, null, Capacity, access));
-                    }
                 }
                 finally
                 {
                     File.SetAttributes(file.Path, original);
                 }
             }
+
         }
+
+        [DllImport("libc", SetLastError = true)]
+        private static extern int geteuid();
 
         /// <summary>
         /// Test to ensure that leaveOpen is appropriately respected, either leaving the FileStream open


### PR DESCRIPTION
A number of tests involving ReadOnly files were failing on Unix and Linux when run with elevated user permissions (e.g. sudo). This commit modifies those Unix tests to accommodate either set of permissions and verify the result accordingly. This unfortunately means we can't verify if the behavior is 'right', only that it is executed correctly. Windows is unchanged.

resolves #5039, #5041, #4605