### PR TITLE
Respect BUILDTOOLS_OVERRIDE_RUNTIME in init-tools.

### DIFF
--- a/init-tools.sh
+++ b/init-tools.sh
@@ -38,7 +38,14 @@ if [ ! -e $__PROJECT_JSON_FILE ]; then
     mkdir -p "$__DOTNET_PATH"
     wget -q -O $__DOTNET_PATH/dotnet.tar https://dotnetcli.blob.core.windows.net/dotnet/dev/Binaries/Latest/${__DOTNET_PKG}.latest.tar.gz
     cd $__DOTNET_PATH
-    tar -xvf $__DOTNET_PATH/dotnet.tar
+    tar -xf $__DOTNET_PATH/dotnet.tar
+    if [ -n $BUILDTOOLS_OVERRIDE_RUNTIME ]; then
+        find $__DOTNET_PATH -name *.ni.* | xargs rm 2>/dev/null
+        cp -R $BUILDTOOLS_OVERRIDE_RUNTIME/* $__DOTNET_PATH/bin
+        cp -R $BUILDTOOLS_OVERRIDE_RUNTIME/* $__DOTNET_PATH/bin/dnx
+        cp -R $BUILDTOOLS_OVERRIDE_RUNTIME/* $__DOTNET_PATH/runtime/coreclr
+    fi
+
     cd $__scriptpath
  fi
 


### PR DESCRIPTION
If the user has specified a value for BUILDTOOLS_OVERRIDE_RUNTIME
(e.g. if they are building on an OS or distro for which a package
is not available), copy the specified runtime into the necessary
locations for dotnet, dnx, etc.