### PR TITLE
Disable nuget package generation in x-plat builds.

### DIFF
--- a/src/packages.builds
+++ b/src/packages.builds
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="BuildAndTest" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
-  <ItemGroup>
+  <!-- NuGet packages cannot be built outside Windows. See GitHub issue #5233. -->
+  <ItemGroup Condition="'$(OSEnvironment)' == 'Windows_NT'">
     <Project Include="Native\pkg\**\*.builds">
       <AdditionalProperties>SkipCreatePackageOnMissingFiles=true</AdditionalProperties>
     </Project>


### PR DESCRIPTION
Temporary workaround for https://github.com/dotnet/corefx/issues/5233.

@ericstj , @weshaggard 