### PR TITLE
Fix build on Windows 7

### DIFF
--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -1,6 +1,9 @@
 @echo off
 setlocal
 
+REM Workaround https://github.com/dotnet/coreclr/issues/2153
+set ComPlus_ReadyToRun=0
+
 set INIT_TOOLS_LOG=%~dp0\init-tools.log
 if [%PACKAGES_DIR%]==[] set PACKAGES_DIR=%~dp0packages\
 if [%TOOLRUNTIME_DIR%]==[] set TOOLRUNTIME_DIR=%~dp0Tools
@@ -39,7 +42,7 @@ set DOTNET_ZIP_NAME=dotnet-win-x64.%DOTNET_VERSION%.zip
 set DOTNET_REMOTE_PATH=https://dotnetcli.blob.core.windows.net/dotnet/dev/Binaries/%DOTNET_VERSION%/%DOTNET_ZIP_NAME%
 set DOTNET_LOCAL_PATH=%DOTNET_PATH%%DOTNET_ZIP_NAME%
 echo Installing '%DOTNET_REMOTE_PATH%' to '%DOTNET_LOCAL_PATH%' >> %INIT_TOOLS_LOG%
-powershell -NoProfile -ExecutionPolicy unrestricted -Command "(New-Object Net.WebClient).DownloadFile('%DOTNET_REMOTE_PATH%', '%DOTNET_LOCAL_PATH%'); Add-Type -assembly 'System.IO.Compression.FileSystem'; [System.IO.Compression.ZipFile]::ExtractToDirectory('%DOTNET_LOCAL_PATH%', '%DOTNET_PATH%')"
+powershell -NoProfile -ExecutionPolicy unrestricted -Command "(New-Object Net.WebClient).DownloadFile('%DOTNET_REMOTE_PATH%', '%DOTNET_LOCAL_PATH%'); Add-Type -Assembly 'System.IO.Compression.FileSystem' -ErrorVariable AddTypeErrors; if ($AddTypeErrors.Count -eq 0) { [System.IO.Compression.ZipFile]::ExtractToDirectory('%DOTNET_LOCAL_PATH%', '%DOTNET_PATH%') } else { (New-Object -com shell.application).namespace('%DOTNET_PATH%').CopyHere((new-object -com shell.application).namespace('%DOTNET_LOCAL_PATH%').Items(),16) }" 2> NUL
 
 :afterdotnetrestore
 


### PR DESCRIPTION
There were two issues that we were hitting (with the first masking the
second).

1. We seem to hit https://github.com/dotnet/coreclr/issues/2153 most of
the time we tried to restore the tool-runtime (which manifested itself
as a AV in CSC).  Until that issue is fixed, we can use the
COMPlus_ReadToRun environment variable to work around the issue.

2. We changed the unzipping part of the powershell init script to use
System.IO.Compression.FileSystem, but that did not work on Windows
7 (Add-Type refuses to load the assembly within PowerShell). I added
some extra logic to fall back to the shell stuff when we can't load the
managed libraries. This does mean we'll pop UI when restoring the tools
on Windows 7, but there's no real harm in doing so.

Fixes #5493