### PR TITLE
Allow a SwitchExpression that has no SwitchCase

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -1468,6 +1468,26 @@ namespace System.Linq.Expressions.Interpreter
 
             if (node.Cases.All(c => c.TestValues.All(t => t is ConstantExpression)))
             {
+                if (node.Cases.Count == 0)
+                {
+                    // Emit the switch value in case it has side-effects, but as void
+                    // since the value is ignored.
+                    CompileAsVoid(node.SwitchValue);
+
+                    // Now if there is a default body, it happens unconditionally.
+                    if (node.DefaultBody != null)
+                    {
+                        Compile(node.DefaultBody);
+                    }
+                    else
+                    {
+                        // If there are no cases and no default then the type must be void.
+                        // Assert that earlier validation caught any exceptions to that.
+                        Debug.Assert(expr.Type == typeof(void));
+                    }
+                    return;
+                }
+
                 var switchType = System.Dynamic.Utils.TypeExtensions.GetTypeCode(node.SwitchValue.Type);
 
                 if (node.Comparison == null)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchExpression.cs
@@ -202,11 +202,18 @@ namespace System.Linq.Expressions
             if (switchValue.Type == typeof(void)) throw Error.ArgumentCannotBeOfTypeVoid();
 
             var caseList = cases.ToReadOnly();
-            ContractUtils.RequiresNotEmpty(caseList, "cases");
             ContractUtils.RequiresNotNullItems(caseList, "cases");
 
             // Type of the result. Either provided, or it is type of the branches.
-            Type resultType = type ?? caseList[0].Body.Type;
+            Type resultType;
+            if (type != null)
+                resultType = type;
+            else if (caseList.Count != 0)
+                resultType = caseList[0].Body.Type;
+            else if (defaultBody != null)
+                resultType = defaultBody.Type;
+            else
+                resultType = typeof(void);
             bool customType = type != null;
 
             if (comparison != null)
@@ -254,7 +261,7 @@ namespace System.Linq.Expressions
                     }
                 }
             }
-            else
+            else if (caseList.Count != 0)
             {
                 // When comparison method is not present, all the test values must have
                 // the same type. Use the first test value's type as the baseline.

--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -3725,6 +3725,176 @@ namespace System.Linq.Expressions.Tests
             Assert.Equal("null", f(null));
         }
 
+        [Fact]
+        public static void DefaultOnlySwitchCompiled()
+        {
+            var p = Expression.Parameter(typeof(int));
+            var s = Expression.Switch(p, Expression.Constant(42));
+
+            var fInt32Int32 = Expression.Lambda<Func<int, int>>(s, p).Compile(false);
+
+            Assert.Equal(42, fInt32Int32(0));
+            Assert.Equal(42, fInt32Int32(1));
+            Assert.Equal(42, fInt32Int32(-1));
+
+            s = Expression.Switch(typeof(object), p, Expression.Constant("A test string"), null);
+
+            var fInt32Object = Expression.Lambda<Func<int, object>>(s, p).Compile(false);
+
+            Assert.Equal("A test string", fInt32Object(0));
+            Assert.Equal("A test string", fInt32Object(1));
+            Assert.Equal("A test string", fInt32Object(-1));
+
+            p = Expression.Parameter(typeof(string));
+            s = Expression.Switch(p, Expression.Constant("foo"));
+
+            var fStringString = Expression.Lambda<Func<string, string>>(s, p).Compile(false);
+
+            Assert.Equal("foo", fStringString("bar"));
+            Assert.Equal("foo", fStringString(null));
+            Assert.Equal("foo", fStringString("foo"));
+        }
+
+        [Fact]
+        public static void DefaultOnlySwitchInterpreted()
+        {
+            var p = Expression.Parameter(typeof(int));
+            var s = Expression.Switch(p, Expression.Constant(42));
+
+            var fInt32Int32 = Expression.Lambda<Func<int, int>>(s, p).Compile(true);
+
+            Assert.Equal(42, fInt32Int32(0));
+            Assert.Equal(42, fInt32Int32(1));
+            Assert.Equal(42, fInt32Int32(-1));
+
+            s = Expression.Switch(typeof(object), p, Expression.Constant("A test string"), null);
+
+            var fInt32Object = Expression.Lambda<Func<int, object>>(s, p).Compile(true);
+
+            Assert.Equal("A test string", fInt32Object(0));
+            Assert.Equal("A test string", fInt32Object(1));
+            Assert.Equal("A test string", fInt32Object(-1));
+
+            p = Expression.Parameter(typeof(string));
+            s = Expression.Switch(p, Expression.Constant("foo"));
+
+            var fStringString = Expression.Lambda<Func<string, string>>(s, p).Compile(true);
+
+            Assert.Equal("foo", fStringString("bar"));
+            Assert.Equal("foo", fStringString(null));
+            Assert.Equal("foo", fStringString("foo"));
+        }
+
+        [Fact]
+        public static void NoDefaultOrCasesSwitchCompiled()
+        {
+            var p = Expression.Parameter(typeof(int));
+            var s = Expression.Switch(p, (Expression)null);
+
+            var f = Expression.Lambda<Action<int>>(s, p).Compile(false);
+
+            f(0);
+
+            Assert.Equal(s.Type, typeof(void));
+        }
+
+        [Fact]
+        public static void NoDefaultOrCasesSwitchInterpreted()
+        {
+            var p = Expression.Parameter(typeof(int));
+            var s = Expression.Switch(p, (Expression)null);
+
+            var f = Expression.Lambda<Action<int>>(s, p).Compile(true);
+
+            f(0);
+
+            Assert.Equal(s.Type, typeof(void));
+        }
+
+        [Fact]
+        public static void TypedNoDefaultOrCasesSwitch()
+        {
+            var p = Expression.Parameter(typeof(int));
+            // A SwitchExpression with neither a defaultBody nor any cases can not be any type except void.
+            Assert.Throws<ArgumentException>(() => Expression.Switch(typeof(int), p, (Expression)null, null));
+        }
+
+        private delegate int RefSettingDelegate(ref bool changed);
+
+        private delegate void JustRefSettingDelegate(ref bool changed);
+
+        public static int QuestionMeaning(ref bool changed)
+        {
+            changed = true;
+            return 42;
+        }
+
+        [Fact]
+        public static void DefaultOnlySwitchWithSideEffectCompiled()
+        {
+            bool changed = false;
+            var pOut = Expression.Parameter(typeof(bool).MakeByRefType(), "changed");
+            var switchValue = Expression.Call(typeof(Compiler_Tests).GetMethod("QuestionMeaning"), pOut);
+            var s = Expression.Switch(switchValue, Expression.Constant(42));
+
+            var fInt32Int32 = Expression.Lambda<RefSettingDelegate>(s, pOut).Compile(false);
+
+            Assert.False(changed);
+            Assert.Equal(42, fInt32Int32(ref changed));
+            Assert.True(changed);
+            changed = false;
+            Assert.Equal(42, fInt32Int32(ref changed));
+            Assert.True(changed);
+        }
+
+        [Fact]
+        public static void DefaultOnlySwitchWithSideEffectInterpreted()
+        {
+            bool changed = false;
+            var pOut = Expression.Parameter(typeof(bool).MakeByRefType(), "changed");
+            var switchValue = Expression.Call(typeof(Compiler_Tests).GetMethod("QuestionMeaning"), pOut);
+            var s = Expression.Switch(switchValue, Expression.Constant(42));
+
+            var fInt32Int32 = Expression.Lambda<RefSettingDelegate>(s, pOut).Compile(true);
+
+            Assert.False(changed);
+            Assert.Equal(42, fInt32Int32(ref changed));
+            Assert.True(changed);
+            changed = false;
+            Assert.Equal(42, fInt32Int32(ref changed));
+            Assert.True(changed);
+        }
+
+        [Fact]
+        public static void NoDefaultOrCasesSwitchWithSideEffectCompiled()
+        {
+            bool changed = false;
+            var pOut = Expression.Parameter(typeof(bool).MakeByRefType(), "changed");
+            var switchValue = Expression.Call(typeof(Compiler_Tests).GetMethod("QuestionMeaning"), pOut);
+            var s = Expression.Switch(switchValue, (Expression)null);
+
+            var f = Expression.Lambda<JustRefSettingDelegate>(s, pOut).Compile(false);
+
+            Assert.False(changed);
+            f(ref changed);
+            Assert.True(changed);
+        }
+
+        [Fact]
+        public static void NoDefaultOrCasesSwitchWithSideEffectInterpreted()
+        {
+            bool changed = false;
+            var pOut = Expression.Parameter(typeof(bool).MakeByRefType(), "changed");
+            var switchValue = Expression.Call(typeof(Compiler_Tests).GetMethod("QuestionMeaning"), pOut);
+            var s = Expression.Switch(switchValue, (Expression)null);
+
+            var f = Expression.Lambda<JustRefSettingDelegate>(s, pOut).Compile(true);
+
+            Assert.False(changed);
+            f(ref changed);
+            Assert.True(changed);
+        }
+
         static class System_Linq_Expressions_Expression_TDelegate__1
         {
             public static T Default<T>() { return default(T); }


### PR DESCRIPTION
Fixes #1877

SwitchValue is evaluated in case it has side effects, then DefaultBody if present.

DefaultBody supplies implicit type (or void if absent). If there is an explicit type and no ‎DefaultBody then that explicit type must be void.

Previous approaches to this either re-wrote the SwitchExpression to have a case, or made it reducible. In a [comment](https://github.com/dotnet/corefx/pull/2803#issuecomment-136514021) on one of those, @VSadov said: 

> After some discussing it seems we are coming to a conclusion that it is better to just allow switches with no cases.

> *   it seems that ET compiler and interpreter already can handle such constructs, although tests need to be added
*  it is unlikely that it will be a backward compatibility issue since relying on something not working would seem uncommon.

> The proposal is to:
1) allow empty case list
2) when there are no cases and type is not provided, we should use the type of "default", if "default" is also not provided, we should use Void.

This is the approach taken here.