### PR TITLE
Several System.Net.Security fixes

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ERR.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.ERR.cs
@@ -14,6 +14,9 @@ internal static partial class Interop
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrGetError")]
         internal static extern ulong ErrGetError();
 
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrPeekError")]
+        internal static extern ulong ErrPeekError();
+
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_ErrGetErrorAlloc")]
         private static extern ulong ErrGetErrorAlloc([MarshalAs(UnmanagedType.Bool)] out bool isAllocFailure);
 

--- a/src/Native/System.Security.Cryptography.Native/pal_err.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_err.cpp
@@ -11,6 +11,10 @@ extern "C" uint64_t CryptoNative_ErrGetError()
     return ERR_get_error();
 }
 
+extern "C" uint64_t CryptoNative_ErrPeekError()
+{
+    return ERR_peek_error();
+}
 extern "C" uint64_t CryptoNative_ErrGetErrorAlloc(int32_t* isAllocFailure)
 {
     unsigned long err = ERR_get_error();

--- a/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -480,7 +480,7 @@ extern "C" X509NameStack* CryptoNative_SslGetClientCAList(SSL* ssl)
 
 extern "C" void CryptoNative_SslCtxSetVerify(SSL_CTX* ctx, SslCtxSetVerifyCallback callback)
 {
-    int mode = SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+    int mode = SSL_VERIFY_PEER;
 
     SSL_CTX_set_verify(ctx, mode, callback);
 }

--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -238,6 +238,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
       <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\Interop.Errors.cs">
+      <Link>Common\Interop\Unix\Interop.Errors.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\libssl\SecuritySafeHandles.cs">
       <Link>Common\Interop\Unix\libssl\SecuritySafeHandles.cs</Link>
     </Compile>

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslState.cs
@@ -596,9 +596,17 @@ namespace System.Net.Security
                         KeyExchangeStrength);
                 }
             }
+            catch (Exception)
+            {
+                // If an exception emerges synchronously, the asynchronous operation was not
+                // initiated, so no operation is in progress.
+                _nestedAuth = 0;
+                throw;
+            }
             finally
             {
-                if (lazyResult == null || _exception != null)
+                // For synchronous operations, the operation has completed.
+                if (lazyResult == null)
                 {
                     _nestedAuth = 0;
                 }

--- a/src/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -12,6 +12,7 @@ namespace System.Net.Security.Tests
 {
     public class CertificateValidationRemoteServer
     {
+        [ActiveIssue(5555, PlatformID.Linux)]
         [Fact]
         public async Task CertificateValidationRemoteServer_EndToEnd_Ok()
         {

--- a/src/System.Net.Security/tests/FunctionalTests/ServerAllowNoEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerAllowNoEncryptionTest.cs
@@ -73,6 +73,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [ActiveIssue(5557, PlatformID.Linux)]
         [Fact]
         public async Task ServerAllowNoEncryption_ClientNoEncryption_ConnectWithNoEncryption()
         {

--- a/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -192,6 +192,9 @@ namespace System.Net.Security.Tests
               X509Chain chain,
               SslPolicyErrors sslPolicyErrors)
         {
+            Assert.True(
+                (sslPolicyErrors & SslPolicyErrors.RemoteCertificateNotAvailable) == SslPolicyErrors.RemoteCertificateNotAvailable,
+                "Client didn't supply a cert, the server required one, yet sslPolicyErrors is " + sslPolicyErrors);
             return true;  // allow everything
         }
 

--- a/src/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
@@ -48,6 +48,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [ActiveIssue(5557, PlatformID.Linux)]
         [Fact]
         public async Task ServerNoEncryption_ClientAllowNoEncryption_ConnectWithNoEncryption()
         {
@@ -72,6 +73,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [ActiveIssue(5557, PlatformID.Linux)]
         [Fact]
         public async Task ServerNoEncryption_ClientNoEncryption_ConnectWithNoEncryption()
         {

--- a/src/System.Net.Security/tests/FunctionalTests/ServerRequireEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerRequireEncryptionTest.cs
@@ -73,6 +73,7 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [ActiveIssue(5557, PlatformID.Linux)]
         [Fact]
         public async Task ServerRequireEncryption_ClientNoEncryption_NoConnect()
         {

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -9,7 +9,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <UnsupportedPlatforms>Linux;OSX;FreeBSD</UnsupportedPlatforms>
+    <UnsupportedPlatforms>OSX;FreeBSD</UnsupportedPlatforms>
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(TargetsWindows)' == 'true' and '$(ProjectJson)' == '' ">


### PR DESCRIPTION
1. Windows and Unix.  The ProcessAuthentication method sets a flag to indicate that an operation is in progress, then kicks off the operation, and then in a finally block potentially resets the flag.  The intent of resetting it is to reset the flag iff the operation is no longer in progress, which would be the case if the operation was synchronous or if the initiation of the asynchronous operation resulted in an exception.  As such, the finally block is checking whether the operation was synchronous or whether an exception has been captured. However, for the exceptional case, this leads to race conditions.  The initiation of the asynchronous operaiton can lead to the operation running concurrently with the remainder of the ProcessAuthentication method, namely concurrently with the finally block.  If the operation starts quickly and fails quickly, it'll store the exception, which will cause the finally block to see that an exception has been captured and mistakenly believe that the operation failed synchronously, thus resetting the flag.  But the operation was actually asynchronous, and when EndAuthentication is called, it'll see that the flag has been reset and think that the EndAuthentication call is erroneous, thus throwing an exception.  While it should throw an exception (the one that caused the operation to fail), it ends up throwing an InvalidOperationException instead to signal that EndAuthentication was used incorrectly. The fix is to move the check for the exceptional situation out of the finally and into a catch block.  The catch block is then used to reset the flag only if an exception emerges synchronously, and the finally block is used to reset the flag only for synchronous operations.  (It's possible that for synchronous operations that fail, the flag could be written as 0 twice... that's fine.) This fixes the failure on both Windows and Unix.  The failure wasn't reproing on Windows but only because of differences in timing... adding a brief pause at the end of the try block would trigger the failure on Windows as well.

2. Unix.  The design of AuthenticateAsServerAsync has a clientCertificatesRequired flag.  On Unix we were mapping that to "SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT", which causes OpenSSL to fail the handshake if no cert is provided.  But the Windows code actually still allows this through, instead setting a policy error to indicate that no certificate was required.  I'm simply removing the SSL_VERIFY_FAIL_IF_NO_PEER_CERT flag to match that design.  I've also updated the test to assert that the error is actually being set.

3. Unix.  When SSL failures occur, there are multiple places to check for errors.  One starts with SSL errors, then potentially examines general crypto errors, and then potentially examines errno values.  Our code wasn't properly handling this, and even for situations where it was, it was potentially conflating all of the values together as the first category, making it more difficult to interpret and tell them apart.  This updates the code to capture the appropriate exception information.  There are still some issues around properly mapping and roundtripping error values between the Unix PAL implementation and the consuming shared code, but this at least makes it easier for a developer of the library to debug issues.

4. Linux.  All of the System.Net.Security tests were disabled on Unix.  I've re-enabled them on Linux now that the causes for the failures have been fixed.  I've not yet verified the fixes on OS X, so I've left them disabled there for now.

cc: @bartonjs, @ericeil, @cipop, @davidsh, @vijaykota 
Fixes https://github.com/dotnet/corefx/issues/4317, https://github.com/dotnet/corefx/issues/4606