### PR TITLE
Allow block expressions to have zero sub-expressions

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.ControlFlow.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.ControlFlow.cs
@@ -267,6 +267,10 @@ namespace System.Linq.Expressions.Compiler
                         var body = (BlockExpression)expression;
                         // omit empty and debuginfo at the end of the block since they
                         // are not going to emit any IL
+                        if (body.ExpressionCount == 0)
+                        {
+                            return;
+                        }
                         for (int i = body.ExpressionCount - 1; i >= 0; i--)
                         {
                             expression = body.GetExpression(i);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/LambdaCompiler.Statements.cs
@@ -20,11 +20,17 @@ namespace System.Linq.Expressions.Compiler
 
         private void Emit(BlockExpression node, CompilationFlags flags)
         {
+            int count = node.ExpressionCount;
+
+            if (count == 0)
+            {
+                return;
+            }
+
             EnterScope(node);
 
             CompilationFlags emitAs = flags & CompilationFlags.EmitAsTypeMask;
 
-            int count = node.ExpressionCount;
             CompilationFlags tailCall = flags & CompilationFlags.EmitAsTailCallMask;
             for (int index = 0; index < count - 1; index++)
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -492,11 +492,15 @@ namespace System.Linq.Expressions.Interpreter
         private void CompileBlockExpression(Expression expr, bool asVoid)
         {
             var node = (BlockExpression)expr;
-            var end = CompileBlockStart(node);
 
-            var lastExpression = node.Expressions[node.Expressions.Count - 1];
-            Compile(lastExpression, asVoid);
-            CompileBlockEnd(end);
+            if (node.ExpressionCount != 0)
+            {
+                var end = CompileBlockStart(node);
+
+                var lastExpression = node.Expressions[node.Expressions.Count - 1];
+                Compile(lastExpression, asVoid);
+                CompileBlockEnd(end);
+            }
         }
 
         private LocalDefinition[] CompileBlockStart(BlockExpression node)

--- a/src/System.Linq.Expressions/tests/Block/BlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/BlockTests.cs
@@ -159,5 +159,92 @@ namespace System.Linq.Expressions.Tests
                 );
             Assert.NotSame(block, new ParameterChangingVisitor().Visit(block));
         }
+
+        [Fact]
+        public static void EmptyBlockCompiled()
+        {
+            var block = Expression.Block();
+            Assert.Equal(typeof(void), block.Type);
+            Action nop = Expression.Lambda<Action>(block).Compile(false);
+            nop();
+        }
+
+        [Fact]
+        public static void EmptyBlockIntepreted()
+        {
+            var block = Expression.Block();
+            Assert.Equal(typeof(void), block.Type);
+            Action nop = Expression.Lambda<Action>(block).Compile(true);
+            nop();
+        }
+
+        [Fact]
+        public static void EmptyBlockExplicitTypeCompiled()
+        {
+            var block = Expression.Block(typeof(void));
+            Assert.Equal(typeof(void), block.Type);
+            Action nop = Expression.Lambda<Action>(block).Compile(false);
+            nop();
+        }
+
+        [Fact]
+        public static void EmptyBlockExplicitTypeInterpreted()
+        {
+            var block = Expression.Block(typeof(void));
+            Assert.Equal(typeof(void), block.Type);
+            Action nop = Expression.Lambda<Action>(block).Compile(true);
+            nop();
+        }
+
+        [Fact]
+        public static void EmptyBlockWrongExplicitType()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(int)));
+        }
+
+        [Fact]
+        public static void EmptyScopeCompiled()
+        {
+            var scope = Expression.Block(new[] { Expression.Parameter(typeof(int), "x") }, new Expression[0]);
+            Assert.Equal(typeof(void), scope.Type);
+            Action nop = Expression.Lambda<Action>(scope).Compile(false);
+            nop();
+        }
+
+        [Fact]
+        public static void EmptyScopeIntepreted()
+        {
+            var scope = Expression.Block(new[] { Expression.Parameter(typeof(int), "x") }, new Expression[0]);
+            Assert.Equal(typeof(void), scope.Type);
+            Action nop = Expression.Lambda<Action>(scope).Compile(true);
+            nop();
+        }
+
+        [Fact]
+        public static void EmptyScopeExplicitTypeCompiled()
+        {
+            var scope = Expression.Block(typeof(void), new[] { Expression.Parameter(typeof(int), "x") }, new Expression[0]);
+            Assert.Equal(typeof(void), scope.Type);
+            Action nop = Expression.Lambda<Action>(scope).Compile(false);
+            nop();
+        }
+
+        [Fact]
+        public static void EmptyScopeExplicitTypeInterpreted()
+        {
+            var scope = Expression.Block(typeof(void), new[] { Expression.Parameter(typeof(int), "x") }, new Expression[0]);
+            Assert.Equal(typeof(void), scope.Type);
+            Action nop = Expression.Lambda<Action>(scope).Compile(true);
+            nop();
+        }
+
+        [Fact]
+        public static void EmptyScopeExplicitWrongType()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.Block(
+                typeof(int),
+                new[] { Expression.Parameter(typeof(int), "x") },
+                new Expression[0]));
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/Block/NoParameterBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/NoParameterBlockTests.cs
@@ -271,38 +271,11 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<ArgumentOutOfRangeException>("index", () => block.Expressions[blockSize]);
         }
 
-        // See https://github.com/dotnet/corefx/issues/3043
-        [Fact]
-        public void EmptyBlockNotAllowed()
-        {
-            Assert.Throws<ArgumentException>("expressions", () => Expression.Block());
-            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(void)));
-            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(Enumerable.Empty<Expression>()));
-            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(void), Enumerable.Empty<Expression>()));
-        }
-
-        [Fact]
-        public void EmptyBlockWithParametersNotAllowed()
-        {
-            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(Enumerable.Repeat<ParameterExpression>(Expression.Parameter(typeof(int)), 1)));
-            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(Enumerable.Repeat<ParameterExpression>(Expression.Parameter(typeof(int)), 1), Enumerable.Empty<Expression>()));
-            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(void), Enumerable.Repeat<ParameterExpression>(Expression.Parameter(typeof(int)), 1)));
-            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(void), Enumerable.Repeat<ParameterExpression>(Expression.Parameter(typeof(int)), 1), Enumerable.Empty<Expression>()));
-        }
-
-        // If https://github.com/dotnet/corefx/issues/3043 is ever actioned, this case would still be prohibited.
         [Fact]
         public void EmptyBlockWithNonVoidTypeNotAllowed()
         {
-            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(int)));
-            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(int), Enumerable.Empty<Expression>()));
-        }
-
-        [Fact]
-        public void EmptyBlockWithParametersAndNonVoidTypeNotAllowed()
-        {
-            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(int), Enumerable.Repeat<ParameterExpression>(Expression.Parameter(typeof(int)), 1)));
-            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(int), Enumerable.Repeat<ParameterExpression>(Expression.Parameter(typeof(int)), 1), Enumerable.Empty<Expression>()));
+            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(int)));
+            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(int), Enumerable.Empty<Expression>()));
         }
 
         [Theory]

--- a/src/System.Linq.Expressions/tests/Block/ParameterBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/ParameterBlockTests.cs
@@ -146,22 +146,11 @@ namespace System.Linq.Expressions.Tests
             Assert.Throws<ArgumentOutOfRangeException>("index", () => block.Expressions[blockSize]);
         }
 
-        // See https://github.com/dotnet/corefx/issues/3043
-        [Fact]
-        public void EmptyBlockWithParametersNotAllowed()
-        {
-            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(SingleParameter));
-            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(SingleParameter, Enumerable.Empty<Expression>()));
-            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(void), SingleParameter));
-            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(void), SingleParameter, Enumerable.Empty<Expression>()));
-        }
-
-        // If https://github.com/dotnet/corefx/issues/3043 is ever actioned, this case would still be prohibited.
         [Fact]
         public void EmptyBlockWithParametersAndNonVoidTypeNotAllowed()
         {
-            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(int), SingleParameter));
-            Assert.Throws<ArgumentException>("expressions", () => Expression.Block(typeof(int), SingleParameter, Enumerable.Empty<Expression>()));
+            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(int), SingleParameter));
+            Assert.Throws<ArgumentException>(() => Expression.Block(typeof(int), SingleParameter, Enumerable.Empty<Expression>()));
         }
 
         [Theory]


### PR DESCRIPTION
Fixes #3043

Type of the block is always void, with attempts to set it to anything else erroring.

As with #5547 there was a previous attempt at this that worked by reducing such nodes. This version does not.