### PR TITLE
Ignore default proxy credentials in CurlHandler

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -330,7 +330,8 @@ namespace System.Net.Http
 
                 KeyValuePair<NetworkCredential, CURLAUTH> credentialScheme = GetCredentials(_handler.Proxy.Credentials, _requestMessage.RequestUri);
                 NetworkCredential credentials = credentialScheme.Key;
-                if (credentials != null)
+                if (credentials != null && // no credentials to set
+                    credentials != CredentialCache.DefaultCredentials) // no "default credentials" on Unix; nop just like UseDefaultCredentials
                 {
                     if (string.IsNullOrEmpty(credentials.UserName))
                     {


### PR DESCRIPTION
There aren't "default credentials" on unix.  Just as CurlHandler treats UseDefaultCredentials as a nop, it should treat default proxy credentials as a nop rather than throwing an ArgumentException.

Fixes https://github.com/dotnet/corefx/issues/5538
cc: @ericeil, @davidsh, @vijaykota, @kapilash 