### PR TITLE
Updating .gitignore file to ignore VS 2015 Update 1 files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ _Chutzpah*
 ipch/
 *.aps
 *.ncb
+*.opendb
 *.opensdf
 *.sdf
 *.cachefile
@@ -140,6 +141,7 @@ publish/
 
 # NuGet Packages
 *.nuget.props
+*.nuget.targets
 *.nupkg
 **/packages/*
 


### PR DESCRIPTION
Ignoring:
- *.opendb files created by Visual C++
- *.nuget.targets files created by NuGet

See the https://github.com/github/gitignore/blob/master/VisualStudio.gitignore template where these file extensions were already added.

@stephentoub @ellismg 