### PR TITLE
Port https://github.com/dotnet/corefx/pull/5554 to rc2

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -330,7 +330,8 @@ namespace System.Net.Http
 
                 KeyValuePair<NetworkCredential, CURLAUTH> credentialScheme = GetCredentials(_handler.Proxy.Credentials, _requestMessage.RequestUri);
                 NetworkCredential credentials = credentialScheme.Key;
-                if (credentials != null)
+                if (credentials != null && // no credentials to set
+                    credentials != CredentialCache.DefaultCredentials) // no "default credentials" on Unix; nop just like UseDefaultCredentials
                 {
                     if (string.IsNullOrEmpty(credentials.UserName))
                     {


### PR DESCRIPTION
There’s no notion of “default credentials” on Unix, so we treat them as a nop when supplied to HttpClient (since they’re effectively not providing any credentials).  However, we were neglecting to check for default credentials when setting proxy options, resulting in an ArgumentException being thrown any time they were. (Issue #5538)