### PR TITLE
Remove dependencies on WindowsIdentity from Unix binaries

### DIFF
--- a/src/Common/src/System/Net/ContextAwareResult.Unix.cs
+++ b/src/Common/src/System/Net/ContextAwareResult.Unix.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Net
+{
+    partial class ContextAwareResult
+    {
+        private void SafeCaptureIdentity()
+        {
+            // WindowsIdentity is not supported on Unix
+        }
+
+        private void CleanupInternal()
+        {
+            // Nothing to cleanup
+        }
+    }
+}

--- a/src/Common/src/System/Net/ContextAwareResult.Windows.cs
+++ b/src/Common/src/System/Net/ContextAwareResult.Windows.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using System.Security;
+using System.Security.Principal;
+using System.Threading;
+
+namespace System.Net
+{
+    partial class ContextAwareResult
+    {
+        private WindowsIdentity _windowsIdentity;
+
+        // Security: We need an assert for a call into WindowsIdentity.GetCurrent.
+        private void SafeCaptureIdentity()
+        {
+            _windowsIdentity = WindowsIdentity.GetCurrent();
+        }
+
+        // Just like ContextCopy.
+        internal WindowsIdentity Identity
+        {
+            get
+            {
+                if (InternalPeekCompleted)
+                {
+                    if ((_flags & StateFlags.ThreadSafeContextCopy) == 0)
+                    {
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|Called on completed result.", LoggingHash.HashString(this));
+                        }
+                        Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::Identity |Called on completed result.");
+                    }
+
+                    throw new InvalidOperationException(SR.net_completed_result);
+                }
+
+                if (_windowsIdentity != null)
+                {
+                    return _windowsIdentity;
+                }
+
+                // Make sure the identity was requested.
+                if ((_flags & StateFlags.CaptureIdentity) == 0)
+                {
+                    if (GlobalLog.IsEnabled)
+                    {
+                        GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|No identity captured - specify captureIdentity.", LoggingHash.HashString(this));
+                    }
+                    Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::Identity |No identity captured - specify captureIdentity.");
+                }
+
+                // Just use the lock to block.  We might be on the thread that owns the lock which is great, it means we
+                // don't need an identity anyway.
+                if ((_flags & StateFlags.PostBlockFinished) == 0)
+                {
+                    if (_lock == null)
+                    {
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|Must lock (StartPostingAsyncOp()) { ... FinishPostingAsyncOp(); } when calling Identity (unless it's only called after FinishPostingAsyncOp).", LoggingHash.HashString(this));
+                        }
+                        Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::Identity |Must lock (StartPostingAsyncOp()) { ... FinishPostingAsyncOp(); } when calling Identity (unless it's only called after FinishPostingAsyncOp).");
+                    }
+                    lock (_lock) { }
+                }
+
+                if (InternalPeekCompleted)
+                {
+                    if ((_flags & StateFlags.ThreadSafeContextCopy) == 0)
+                    {
+                        if (GlobalLog.IsEnabled)
+                        {
+                            GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|Result became completed during call.", LoggingHash.HashString(this));
+                        }
+                        Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::Identity |Result became completed during call.");
+                    }
+
+                    throw new InvalidOperationException(SR.net_completed_result);
+                }
+
+                return _windowsIdentity;
+            }
+        }
+
+        private void CleanupInternal()
+        {
+            if (_windowsIdentity != null)
+            {
+                _windowsIdentity.Dispose();
+                _windowsIdentity = null;
+            }
+        }
+    }
+}

--- a/src/Common/src/System/Net/ContextAwareResult.cs
+++ b/src/Common/src/System/Net/ContextAwareResult.cs
@@ -70,7 +70,7 @@ namespace System.Net
 
     // This class will ensure that the correct context is restored on the thread before invoking
     // a user callback.
-    internal class ContextAwareResult : LazyAsyncResult
+    internal partial class ContextAwareResult : LazyAsyncResult
     {
         [Flags]
         private enum StateFlags
@@ -88,9 +88,6 @@ namespace System.Net
         private object _lock;
         private StateFlags _flags;
 
-#if !NetNative
-        private WindowsIdentity _windowsIdentity;
-#endif
 
         internal ContextAwareResult(object myObject, object myState, AsyncCallback myCallBack) :
             this(false, false, myObject, myState, myCallBack)
@@ -123,14 +120,6 @@ namespace System.Net
             {
                 _flags |= StateFlags.ThreadSafeContextCopy;
             }
-        }
-
-        // Security: We need an assert for a call into WindowsIdentity.GetCurrent.
-        private void SafeCaptureIdentity()
-        {
-#if !NetNative
-            _windowsIdentity = WindowsIdentity.GetCurrent();
-#endif
         }
 
         // This can be used to establish a context during an async op for something like calling a delegate or demanding a permission.
@@ -203,75 +192,6 @@ namespace System.Net
                 return _context; // No need to copy on CoreCLR; ExecutionContext is immutable
             }
         }
-
-#if !NetNative
-        // Just like ContextCopy.
-        internal WindowsIdentity Identity
-        {
-            get
-            {
-                if (InternalPeekCompleted)
-                {
-                    if ((_flags & StateFlags.ThreadSafeContextCopy) == 0)
-                    {
-                        if (GlobalLog.IsEnabled)
-                        {
-                            GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|Called on completed result.", LoggingHash.HashString(this));
-                        }
-                        Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::Identity |Called on completed result.");
-                    }
-
-                    throw new InvalidOperationException(SR.net_completed_result);
-                }
-
-                if (_windowsIdentity != null)
-                {
-                    return _windowsIdentity;
-                }
-
-                // Make sure the identity was requested.
-                if ((_flags & StateFlags.CaptureIdentity) == 0)
-                {
-                    if (GlobalLog.IsEnabled)
-                    {
-                        GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|No identity captured - specify captureIdentity.", LoggingHash.HashString(this));
-                    }
-                    Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::Identity |No identity captured - specify captureIdentity.");
-                }
-
-                // Just use the lock to block.  We might be on the thread that owns the lock which is great, it means we
-                // don't need an identity anyway.
-                if ((_flags & StateFlags.PostBlockFinished) == 0)
-                {
-                    if (_lock == null)
-                    {
-                        if (GlobalLog.IsEnabled)
-                        {
-                            GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|Must lock (StartPostingAsyncOp()) { ... FinishPostingAsyncOp(); } when calling Identity (unless it's only called after FinishPostingAsyncOp).", LoggingHash.HashString(this));
-                        }
-                        Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::Identity |Must lock (StartPostingAsyncOp()) { ... FinishPostingAsyncOp(); } when calling Identity (unless it's only called after FinishPostingAsyncOp).");
-                    }
-                    lock (_lock) { }
-                }
-
-                if (InternalPeekCompleted)
-                {
-                    if ((_flags & StateFlags.ThreadSafeContextCopy) == 0)
-                    {
-                        if (GlobalLog.IsEnabled)
-                        {
-                            GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|Result became completed during call.", LoggingHash.HashString(this));
-                        }
-                        Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::Identity |Result became completed during call.");
-                    }
-
-                    throw new InvalidOperationException(SR.net_completed_result);
-                }
-
-                return _windowsIdentity;
-            }
-        }
-#endif
 
 #if DEBUG
         // Want to be able to verify that the Identity was requested.  If it was requested but isn't available
@@ -382,13 +302,7 @@ namespace System.Net
                 GlobalLog.Print("ContextAwareResult#" + LoggingHash.HashString(this) + "::Cleanup()");
             }
 
-#if !NetNative
-            if (_windowsIdentity != null)
-            {
-                _windowsIdentity.Dispose();
-                _windowsIdentity = null;
-            }
-#endif
+            CleanupInternal();
         }
 
         // This must be called right before returning the result to the user.  It might call the callback itself,

--- a/src/Common/src/System/Net/ContextAwareResult.netcore50.cs
+++ b/src/Common/src/System/Net/ContextAwareResult.netcore50.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace System.Net
+{
+    partial class ContextAwareResult
+    {
+        private void SafeCaptureIdentity()
+        {
+            // WindowsIdentity is not supported on NETCore50
+        }
+
+        private void CleanupInternal()
+        {
+            // Nothing to cleanup
+        }
+    }
+}

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.builds
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.builds
@@ -2,7 +2,12 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Data.SqlClient.csproj" />
+    <Project Include="System.Data.SqlClient.csproj">
+      <OSGroup>Linux</OSGroup>
+    </Project>
+    <Project Include="System.Data.SqlClient.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
     <Project Include="facade\System.Data.SqlClient.csproj">
       <TargetGroup>net46</TargetGroup>
     </Project>

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -13,10 +13,10 @@
   <PropertyGroup Condition=" '$(TargetsWindows)' != 'true' ">
     <DefineConstants>$(DefineConstants);MANAGED_SNI</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="Interop\SNINativeMethodWrapper.cs" />
     <Compile Include="Microsoft\SqlServer\Server\ITypedGetters.cs" />
@@ -146,9 +146,11 @@
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
     <Compile Include="Interop\LocaleMapper.Windows.cs" />
+    <Compile Include="System\Data\ProviderBase\DbConnectionPoolIdentity.Windows.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' != 'true' ">
     <Compile Include="System\Data\Locale\LocaleMapper.Unix.cs" />
+    <Compile Include="System\Data\ProviderBase\DbConnectionPoolIdentity.Unix.cs" />
     <Compile Include="System\Data\SqlClient\SNI\SNIError.cs" />
     <Compile Include="System\Data\SqlClient\SNI\SNIHandle.cs" />
     <Compile Include="System\Data\SqlClient\SNI\SNILoadHandle.cs" />

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolIdentity.Unix.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolIdentity.Unix.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+//------------------------------------------------------------------------------
+
+using System.Security.Principal;
+
+
+namespace System.Data.ProviderBase
+{
+    partial class DbConnectionPoolIdentity
+    {
+        static internal DbConnectionPoolIdentity GetCurrent()
+        {
+            throw new PlatformNotSupportedException();
+        }
+    }
+}
+

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolIdentity.Windows.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolIdentity.Windows.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+
+//------------------------------------------------------------------------------
+
+using System.Security.Principal;
+
+
+namespace System.Data.ProviderBase
+{
+    partial class DbConnectionPoolIdentity
+    {
+        static private DbConnectionPoolIdentity s_lastIdentity = null;
+
+        static internal DbConnectionPoolIdentity GetCurrent()
+        {
+            DbConnectionPoolIdentity current;
+            using (WindowsIdentity identity = WindowsIdentity.GetCurrent())
+            {
+                IntPtr token = identity.AccessToken.DangerousGetHandle();
+                bool isNetwork = identity.User.IsWellKnown(WellKnownSidType.NetworkSid);
+                string sidString = identity.User.Value;
+
+                // Win32NativeMethods.IsTokenRestricted will raise exception if the native call fails
+                bool isRestricted = Win32NativeMethods.IsTokenRestrictedWrapper(token);
+
+                var lastIdentity = s_lastIdentity;
+                if ((lastIdentity != null) && (lastIdentity._sidString == sidString) && (lastIdentity._isRestricted == isRestricted) && (lastIdentity._isNetwork == isNetwork))
+                {
+                    current = lastIdentity;
+                }
+                else
+                {
+                    current = new DbConnectionPoolIdentity(sidString, isRestricted, isNetwork);
+                }
+            }
+            s_lastIdentity = current;
+            return current;
+        }
+    }
+}
+

--- a/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolIdentity.cs
+++ b/src/System.Data.SqlClient/src/System/Data/ProviderBase/DbConnectionPoolIdentity.cs
@@ -9,10 +9,9 @@ using System.Security.Principal;
 
 namespace System.Data.ProviderBase
 {
-    sealed internal class DbConnectionPoolIdentity
+    sealed internal partial class DbConnectionPoolIdentity
     {
         static public readonly DbConnectionPoolIdentity NoIdentity = new DbConnectionPoolIdentity(String.Empty, false, true);
-        static private DbConnectionPoolIdentity s_lastIdentity = null;
 
         private readonly string _sidString;
         private readonly bool _isRestricted;
@@ -42,32 +41,6 @@ namespace System.Data.ProviderBase
                 result = ((_sidString == that._sidString) && (_isRestricted == that._isRestricted) && (_isNetwork == that._isNetwork));
             }
             return result;
-        }
-
-        static internal DbConnectionPoolIdentity GetCurrent()
-        {
-            DbConnectionPoolIdentity current;
-            using (WindowsIdentity identity = WindowsIdentity.GetCurrent())
-            {
-                IntPtr token = identity.AccessToken.DangerousGetHandle();
-                bool isNetwork = identity.User.IsWellKnown(WellKnownSidType.NetworkSid);
-                string sidString = identity.User.Value;
-
-                // Win32NativeMethods.IsTokenRestricted will raise exception if the native call fails
-                bool isRestricted = Win32NativeMethods.IsTokenRestrictedWrapper(token);
-
-                var lastIdentity = s_lastIdentity;
-                if ((lastIdentity != null) && (lastIdentity._sidString == sidString) && (lastIdentity._isRestricted == isRestricted) && (lastIdentity._isNetwork == isNetwork))
-                {
-                    current = lastIdentity;
-                }
-                else
-                {
-                    current = new DbConnectionPoolIdentity(sidString, isRestricted, isNetwork);
-                }
-            }
-            s_lastIdentity = current;
-            return current;
         }
 
         override public int GetHashCode()

--- a/src/System.Net.NameResolution/src/System.Net.NameResolution.csproj
+++ b/src/System.Net.NameResolution/src/System.Net.NameResolution.csproj
@@ -164,11 +164,17 @@
   </ItemGroup>
   
   <!-- Windows : Win32 only -->
-  <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(EnableWinRT)' != 'true'">
+  <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(EnableWinRT)' != 'true' AND '$(TargetGroup)' != 'net46'">
+    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Windows.cs">
+      <Link>Common\System\Net\ContextAwareResult.Windows.cs</Link>
+    </Compile>
   </ItemGroup>
   
   <!-- Windows : Win32 + WinRT -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(EnableWinRT)' == 'true'">
+    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.netcore50.cs">
+      <Link>Common\System\Net\ContextAwareResult.netcore50.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
@@ -176,6 +182,9 @@
 
     <Compile Include="$(CommonPath)\System\Net\ByteOrder.cs">
       <Link>Common\System\Net\Internals\ByteOrder.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Unix.cs">
+      <Link>Common\System\Net\ContextAwareResult.Unix.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\Net\InteropIPAddressExtensions.Unix.cs">
       <Link>Common\System\Net\InteropIPAddressExtensions.Unix.cs</Link>

--- a/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -160,6 +160,9 @@
     <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.cs">
       <Link>Common\System\Net\ContextAwareResult.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Windows.cs">
+      <Link>Common\System\Net\ContextAwareResult.Windows.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\LazyAsyncResult.cs">
       <Link>Common\System\Net\LazyAsyncResult.cs</Link>
     </Compile>

--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -222,6 +222,9 @@
     <Compile Include="$(CommonPath)\Interop\Windows\sspicli\StreamSizes.cs">
       <Link>Common\Interop\Windows\sspicli\StreamSizes.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Windows.cs">
+      <Link>Common\System\Net\ContextAwareResult.Windows.cs</Link>
+    </Compile>
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
@@ -309,6 +312,9 @@
     </Compile>
     <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs">
       <Link>Common\Microsoft\Win32\SafeHandles\Asn1SafeHandles.Unix.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Unix.cs">
+      <Link>Common\System\Net\ContextAwareResult.Unix.cs</Link>
     </Compile>
   </ItemGroup>
   

--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -323,10 +323,16 @@
     <Compile Include="$(CommonPath)\Interop\Windows\mincore_obsolete\Interop.LocalFree.cs" >
       <Link>Common\Interop\Windows\mincore_obsolete\Interop.LocalFree.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Windows.cs">
+      <Link>Common\System\Net\ContextAwareResult.Windows.cs</Link>
+    </Compile>
   </ItemGroup>
   
   <!-- Windows : Win32 + WinRT -->
   <ItemGroup Condition="'$(TargetsWindows)' == 'true' AND '$(EnableWinRT)' == 'true'">
+    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.netcore50.cs">
+      <Link>Common\System\Net\ContextAwareResult.netcore50.cs</Link>
+    </Compile>
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
@@ -342,6 +348,9 @@
     <Compile Include="System\Net\Sockets\SocketAsyncEventArgs.Unix.cs" />
     <Compile Include="System\Net\Sockets\SocketPal.Unix.cs" />
 
+    <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Unix.cs">
+      <Link>Common\System\Net\ContextAwareResult.Unix.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\InteropIPAddressExtensions.Unix.cs">
       <Link>Common\System\Net\InteropIPAddressExtensions.Unix.cs</Link>
     </Compile>


### PR DESCRIPTION
It looks like a couple libraries were using
System.Security.Principal.Windows unintentionally in their
Unix implementations.  @dagood discovered this when
trying to restore our tools-runtime project for unix RIDs.

This fix removes the dependencies from those libs
in the CoreFx repro.
/cc @CIPop @saurabh500

It looks like WCF also has this problem as well,
since it hasn't split System.Private.ServiceModel
into windows specific packages.
/cc @StephenBonikowsky