### PR TITLE
Script to find conflicting project configurations

### DIFF
--- a/FindConflictingProjectConfigurations.ps1
+++ b/FindConflictingProjectConfigurations.ps1
@@ -1,0 +1,39 @@
+msbuild /nologo /v:quiet build.proj /t:build /flp1:v=detailed`;LogFile=dumptargets.log /p:SkipTests=true
+
+$targets = gc dumptargets.log | ? { $_.Contains("DumpTargets>") -or ($_.Contains("is building") -and ($_.Contains("default target") -or $_.Contains("Build"))) }
+
+$ht = new-object Hashtable
+$duplicates = @();
+$foundConflict = $false;
+$lastIsBuilding = "";
+
+foreach($target in $targets)
+{
+  #"->" + $target
+  if ($target.Contains("is building"))
+  {
+    $lastIsBuilding = $target;
+    continue;
+  }
+
+  if ($ht.Contains($target))
+  {
+    $buildingProject = $ht[$target];
+
+    "Conflict:"
+    "$target"
+    "1> $buildingProject"
+    "2> $lastIsBuilding"
+    "`n"
+    $foundConflict = $true;
+  }
+  else
+  {
+    $ht.Add($target, $lastIsBuilding);
+  }
+}
+
+if ($foundConflict -eq $false)
+{
+  "Found no conflicts";
+}

--- a/src/Scenarios/tests/InterProcessCommunication/InterProcessCommunication.Tests.csproj
+++ b/src/Scenarios/tests/InterProcessCommunication/InterProcessCommunication.Tests.csproj
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Windows_Debug</Configuration>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{C8B651EA-21B8-45B3-9617-3BA952D0F12B}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>InterProcessCommunication.Tests</RootNamespace>
@@ -11,8 +12,8 @@
     <NuGetPackageImportStamp>b62eec4b</NuGetPackageImportStamp>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="AnonymousPipesTests.cs" />
     <Compile Include="MemoryMappedFilesTests.cs" />

--- a/src/System.Collections/src/System.Collections.csproj
+++ b/src/System.Collections/src/System.Collections.csproj
@@ -18,7 +18,7 @@
   <ItemGroup Condition="'$(TargetGroup)' == ''">
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj">
-      <AdditionalProperties>OSGroup=Windows_NT</AdditionalProperties>
+      <OSGroup>Windows_NT</OSGroup>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net46'">

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.TestAssembly/System.Diagnostics.FileVersionInfo.TestAssembly.csproj
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.TestAssembly/System.Diagnostics.FileVersionInfo.TestAssembly.csproj
@@ -6,17 +6,14 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <OutputType>Library</OutputType>
     <AssemblyName>System.Diagnostics.FileVersionInfo.TestAssembly</AssemblyName>
     <NuGetPackageImportStamp>62805582</NuGetPackageImportStamp>
     <ProjectGuid>{28EB14BE-3BC9-4543-ABA6-A932424DFBD0}</ProjectGuid>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
   <!-- Compiled Source Files -->
   <ItemGroup>
     <Compile Include="Assembly1.cs" />

--- a/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/System.Diagnostics.FileVersionInfo.Tests.csproj
+++ b/src/System.Diagnostics.FileVersionInfo/tests/System.Diagnostics.FileVersionInfo.Tests/System.Diagnostics.FileVersionInfo.Tests.csproj
@@ -6,9 +6,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>System.Diagnostics.FileVersionInfo.Tests</AssemblyName>
     <ProjectGuid>{6DFDB760-CC88-48AE-BD81-C64844EA3CBC}</ProjectGuid>

--- a/src/System.IO.FileSystem/pkg/System.IO.FileSystem.pkgproj
+++ b/src/System.IO.FileSystem/pkg/System.IO.FileSystem.pkgproj
@@ -6,7 +6,7 @@
       <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\facade\System.IO.FileSystem.csproj">
-      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+      <TargetGroup>net46</TargetGroup>
     </ProjectReference>
     <ProjectReference Include="win\System.IO.FileSystem.pkgproj" />
     <ProjectReference Include="unix\System.IO.FileSystem.pkgproj" />

--- a/src/System.IO/src/System.IO.csproj
+++ b/src/System.IO/src/System.IO.csproj
@@ -31,6 +31,7 @@
     <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj">
       <Project>{E7E8DE8A-9EC1-46A8-A6EE-727DB32DBEB8}</Project>
       <Name>System.Diagnostics.Debug</Name>
+      <OSGroup>Windows_NT</OSGroup>
     </ProjectReference>
   </ItemGroup>
 

--- a/src/System.Linq.Expressions/pkg/System.Linq.Expressions.pkgproj
+++ b/src/System.Linq.Expressions/pkg/System.Linq.Expressions.pkgproj
@@ -11,8 +11,8 @@
 
     <!-- not yet needed
     <ProjectReference Include="..\src\Facade\System.Linq.Expressions.csproj">
-      <AdditionalProperties>TargetGroup=net46</AdditionalProperties> 
-    </ProjectReference>  
+      <TargetGroup>net46</TargetGroup>
+    </ProjectReference>
     -->
 
     <ProjectReference Include="any\System.Linq.Expressions.pkgproj" />

--- a/src/System.Linq.Expressions/pkg/any/System.Linq.Expressions.pkgproj
+++ b/src/System.Linq.Expressions/pkg/any/System.Linq.Expressions.pkgproj
@@ -6,13 +6,11 @@
     <PackageTargetRuntime>any</PackageTargetRuntime>
     <PreventImplementationReference>true</PreventImplementationReference>
   </PropertyGroup>
-  
+
   <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Linq.Expressions.csproj" />
     <ProjectReference Include="..\..\src\System.Linq.Expressions.csproj">
-      <AdditionalProperties>TargetGroup=</AdditionalProperties> 
-    </ProjectReference>
-    <ProjectReference Include="..\..\src\System.Linq.Expressions.csproj">
-      <AdditionalProperties>TargetGroup=netcore50</AdditionalProperties> 
+      <TargetGroup>netcore50</TargetGroup>
     </ProjectReference>
 
     <!-- AOT implementation comes from AOT package -->

--- a/src/System.Linq.Expressions/pkg/aot/System.Linq.Expressions.pkgproj
+++ b/src/System.Linq.Expressions/pkg/aot/System.Linq.Expressions.pkgproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\System.Linq.Expressions.csproj">
-      <AdditionalProperties>TargetGroup=netcore50aot</AdditionalProperties> 
+      <TargetGroup>netcore50aot</TargetGroup>
     </ProjectReference>
 
     <InboxOnTargetFramework Include="MonoAndroid10" />

--- a/src/System.Runtime.Extensions/pkg/System.Runtime.Extensions.pkgproj
+++ b/src/System.Runtime.Extensions/pkg/System.Runtime.Extensions.pkgproj
@@ -9,7 +9,7 @@
       <SupportedFramework>netcore50;dnxcore50;net46;</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.Extensions.csproj" >
-      <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
+      <TargetGroup>net46</TargetGroup>
     </ProjectReference>
     <ProjectReference Include="win\System.Runtime.Extensions.pkgproj" />
     <ProjectReference Include="unix\System.Runtime.Extensions.pkgproj" />

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -31,7 +31,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50aot_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windoww_netcore50aot_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_netcore50aot_Release|AnyCPU'" />
 
   <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
     <SkipCommonResourcesIncludes>true</SkipCommonResourcesIncludes>

--- a/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
+++ b/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
@@ -36,9 +36,7 @@
     <ProjectReference Include="..\..\System.ObjectModel\src\System.ObjectModel.csproj"/>
     <ProjectReference Include="..\..\System.Private.Uri\src\System.Private.Uri.csproj" />
     <ProjectReference Include="..\..\System.Runtime.InteropServices.WindowsRuntime\src\System.Runtime.InteropServices.WindowsRuntime.csproj" />
-    <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj">
-      <AdditionalProperties>OSGroup=AnyOS</AdditionalProperties>
-    </ProjectReference>
+    <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
     <Compile Include="System\IO\StreamOperationAsyncResult.dotnet53.cs" />
     <Compile Include="System\Runtime\InteropServices\WindowsRuntime\MarshalingHelpers.cs" />
     <Compile Include="System\Runtime\InteropServices\WindowsRuntime\RestrictedErrorInfoHelper.cs" />

--- a/src/System.Runtime/src/System.Runtime.csproj
+++ b/src/System.Runtime/src/System.Runtime.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' != 'net46'">
     <ProjectReference Include="..\..\System.Private.Uri\src\System.Private.Uri.csproj">
-      <AdditionalProperties>OSGroup=Windows_NT</AdditionalProperties>
+      <OSGroup>Windows_NT</OSGroup>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'!='netcore50aot'">

--- a/src/System.Security.Cryptography.Algorithms/pkg/System.Security.Cryptography.Algorithms.pkgproj
+++ b/src/System.Security.Cryptography.Algorithms/pkg/System.Security.Cryptography.Algorithms.pkgproj
@@ -6,7 +6,8 @@
       <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Security.Cryptography.Algorithms.csproj">
-      <AdditionalProperties>TargetGroup=net46;OSGroup=Windows_NT</AdditionalProperties>
+      <OSGroup>Windows_NT</OSGroup>
+      <TargetGroup>net46</TargetGroup>
     </ProjectReference>
     <ProjectReference Include="win\System.Security.Cryptography.Algorithms.pkgproj" />
     <ProjectReference Include="unix\System.Security.Cryptography.Algorithms.pkgproj" />

--- a/src/System.Threading.Tasks/src/System.Threading.Tasks.csproj
+++ b/src/System.Threading.Tasks/src/System.Threading.Tasks.csproj
@@ -16,7 +16,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
   <ItemGroup Condition="'$(TargetGroup)' == ''">
     <Compile Include="System\Threading\Tasks\TaskExtensions.CoreCLR.cs" />
-    <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj" />
+    <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
     <TargetingPackReference Include="mscorlib" />

--- a/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
+++ b/src/System.Threading.Tasks/tests/System.Threading.Tasks.Tests.csproj
@@ -2,8 +2,6 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <AssemblyName>System.Threading.Tasks.Tests</AssemblyName>
     <ProjectGuid>{B6C09633-D161-499A-8FE1-46B2D53A16E7}</ProjectGuid>

--- a/src/System.Threading/src/System.Threading.csproj
+++ b/src/System.Threading/src/System.Threading.csproj
@@ -26,7 +26,9 @@
     <Compile Include="System\Threading\ReaderWriterLockSlim.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == ''">
-    <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj" />
+    <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj">
+      <OSGroup>Windows_NT</OSGroup>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)' == 'net46'">
     <TargetingPackReference Include="mscorlib" />

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -17,8 +17,8 @@
 
   <Import Project="..\override.targets" Condition="Exists('..\override.targets')"/>
 
-  <Target Name="DumpTargets">
-    <Message Text="$(MSBuildProjectName), OS=$(OSGroup), Target=$(TargetGroup)" Importance="High"/>
+  <Target Name="DumpTargets" BeforeTargets="ResolveProjectReferences">
+    <Message Text="DumpTargets> $(OutputPath), C=[$(Configuration)], CG=[$(ConfigurationGroup)], OG=[$(OSGroup)], TG=[$(TargetGroup)]" Importance="Low" />
   </Target>
 
 </Project>

--- a/src/ref.builds
+++ b/src/ref.builds
@@ -3,7 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="*\ref\**\*.*proj">
-      <OSGroup>AnyOS</OSGroup>
+      <UndefineProperties>OSGroup;TargetGroup</UndefineProperties>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />


### PR DESCRIPTION
With all the new build changes we have had various projects being built multiple times with the same configuration but with different global properties so then ended up with race conditions that could be hit. To help detect this I've created a script that will do a build and detect any time where the same library is built more than once in a full build. From there we can determine which projects are causing them to be built and try and fix the global properties or configurations to avoid the conflicts and ensure it is only built once.

This PR has the script that can be ran manually and updates all current existing conflicts that were found. It also updates the projects to take advantage of the new BuildTools version that adds metadata shortcuts (https://github.com/dotnet/buildtools/pull/400). 

@ericstj PTAL