### PR TITLE
Port https://github.com/dotnet/corefx/pull/5562 to rc2

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentBag.cs
@@ -513,7 +513,7 @@ namespace System.Collections.Concurrent
         {
             // Short path if the bag is empty
             if (_headList == null)
-                return new T[0];
+                return Array.Empty<T>();
 
             bool lockTaken = false;
             try

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -669,8 +669,12 @@ namespace System.Collections.Concurrent
                     }
                 }
 
-                KeyValuePair<TKey, TValue>[] array = new KeyValuePair<TKey, TValue>[count];
+                if (count == 0)
+                {
+                    return Array.Empty<KeyValuePair<TKey, TValue>>();
+                }
 
+                KeyValuePair<TKey, TValue>[] array = new KeyValuePair<TKey, TValue>[count];
                 CopyToPairs(array, 0);
                 return array;
             }

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentQueue.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentQueue.cs
@@ -257,6 +257,7 @@ namespace System.Collections.Concurrent
         {
             return ToList().ToArray();
         }
+
 #pragma warning disable 0420 // No warning for Interlocked.xxx if compiled with new managed compiler (Roslyn)
         /// <summary>
         /// Copies the <see cref="ConcurrentQueue{T}"/> elements to a new <see

--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentStack.cs
@@ -698,19 +698,30 @@ namespace System.Collections.Concurrent
         /// cref="ConcurrentStack{T}"/>.</returns>
         public T[] ToArray()
         {
-            return ToList().ToArray();
+            Node curr = _head;
+            return curr == null ?
+                Array.Empty<T>() :
+                ToList(curr).ToArray();
         }
 
         /// <summary>
         /// Returns an array containing a snapshot of the list's contents, using
         /// the target list node as the head of a region in the list.
         /// </summary>
-        /// <returns>An array of the list's contents.</returns>
+        /// <returns>A list of the stack's contents.</returns>
         private List<T> ToList()
+        {
+            return ToList(_head);
+        }
+
+        /// <summary>
+        /// Returns an array containing a snapshot of the list's contents starting at the specified node.
+        /// </summary>
+        /// <returns>A list of the stack's contents starting at the specified node.</returns>
+        private List<T> ToList(Node curr)
         {
             List<T> list = new List<T>();
 
-            Node curr = _head;
             while (curr != null)
             {
                 list.Add(curr._value);

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -1510,7 +1510,12 @@ namespace System.Collections.Generic
         /// <returns></returns>
         internal T[] ToArray()
         {
-            T[] newArray = new T[Count];
+            if (_count == 0)
+            {
+                return Array.Empty<T>();
+            }
+
+            T[] newArray = new T[_count];
             CopyTo(newArray);
             return newArray;
         }

--- a/src/System.Collections/src/System/Collections/Generic/List.cs
+++ b/src/System.Collections/src/System/Collections/Generic/List.cs
@@ -1131,6 +1131,11 @@ namespace System.Collections.Generic
             Contract.Ensures(Contract.Result<T[]>() != null);
             Contract.Ensures(Contract.Result<T[]>().Length == Count);
 
+            if (_size == 0)
+            {
+                return _emptyArray;
+            }
+
             T[] array = new T[_size];
             Array.Copy(_items, 0, array, 0, _size);
             return array;

--- a/src/System.Collections/src/System/Collections/Generic/Queue.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Queue.cs
@@ -297,9 +297,12 @@ namespace System.Collections.Generic
         /// <include file='doc\Queue.uex' path='docs/doc[@for="Queue.ToArray"]/*' />
         public T[] ToArray()
         {
-            T[] arr = new T[_size];
             if (_size == 0)
-                return arr; // consider replacing with Array.Empty<T>() to be consistent with non-generic Queue
+            {
+                return Array.Empty<T>();
+            }
+
+            T[] arr = new T[_size];
             
             if (_head < _tail)
             {

--- a/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedSet.cs
@@ -1080,7 +1080,13 @@ namespace System.Collections.Generic
         /// <returns></returns>
         internal T[] ToArray()
         {
-            T[] newArray = new T[Count];
+            int count = Count;
+            if (count == 0)
+            {
+                return Array.Empty<T>();
+            }
+
+            T[] newArray = new T[count];
             CopyTo(newArray);
             return newArray;
         }

--- a/src/System.Collections/src/System/Collections/Generic/Stack.cs
+++ b/src/System.Collections/src/System/Collections/Generic/Stack.cs
@@ -252,6 +252,11 @@ namespace System.Collections.Generic
         // Copies the Stack to an array, in the same order Pop would return the items.
         public T[] ToArray()
         {
+            if (_size == 0)
+            {
+                return Array.Empty<T>();
+            }
+
             T[] objArray = new T[_size];
             int i = 0;
             while (i < _size)

--- a/src/System.Collections/tests/Generic/Queue/QueueTests.cs
+++ b/src/System.Collections/tests/Generic/Queue/QueueTests.cs
@@ -542,7 +542,7 @@ namespace System.Collections.Tests
 
             // Verify behavior with an empty queue
             Assert.NotNull(q.ToArray());
-            Assert.NotSame(q.ToArray(), q.ToArray());
+            Assert.Same(q.ToArray(), q.ToArray());
 
             // Verify behavior with some elements
             for (int i = 0; i < 4; i++)

--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -567,6 +567,11 @@ namespace System.Linq
 
             public TResult[] ToArray()
             {
+                if (_source.Length == 0)
+                {
+                    return Array.Empty<TResult>();
+                }
+
                 var results = new TResult[_source.Length];
                 for (int i = 0; i < results.Length; i++)
                 {
@@ -633,7 +638,13 @@ namespace System.Linq
 
             public TResult[] ToArray()
             {
-                var results = new TResult[_source.Count];
+                int count = _source.Count;
+                if (count == 0)
+                {
+                    return Array.Empty<TResult>();
+                }
+
+                var results = new TResult[count];
                 for (int i = 0; i < results.Length; i++)
                 {
                     results[i] = _selector(_source[i]);
@@ -709,7 +720,13 @@ namespace System.Linq
 
             public TResult[] ToArray()
             {
-                var results = new TResult[_source.Count];
+                int count = _source.Count;
+                if (count == 0)
+                {
+                    return Array.Empty<TResult>();
+                }
+
+                var results = new TResult[count];
                 for (int i = 0; i < results.Length; i++)
                 {
                     results[i] = _selector(_source[i]);
@@ -1794,6 +1811,7 @@ namespace System.Linq
 
             public RangeIterator(int start, int count)
             {
+                Debug.Assert(count > 0);
                 _start = start;
                 _end = start + count;
             }
@@ -1897,7 +1915,7 @@ namespace System.Linq
         public static IEnumerable<TResult> Repeat<TResult>(TResult element, int count)
         {
             if (count < 0) throw Error.ArgumentOutOfRange("count");
-            if (count == 0) new EmptyPartition<TResult>();
+            if (count == 0) return new EmptyPartition<TResult>();
             return new RepeatIterator<TResult>(element, count);
         }
 
@@ -1908,6 +1926,7 @@ namespace System.Linq
 
             public RepeatIterator(TResult element, int count)
             {
+                Debug.Assert(count > 0);
                 current = element;
                 _count = count;
             }
@@ -3931,12 +3950,12 @@ namespace System.Linq
 
         public TElement[] ToArray()
         {
-            return new TElement[0]; // consider replacing with Array.Empty<TElement>()
+            return Array.Empty<TElement>();
         }
 
         public List<TElement> ToList()
         {
-            return new List<TElement>(0);
+            return new List<TElement>();
         }
     }
 
@@ -4044,13 +4063,16 @@ namespace System.Linq
         public TElement[] ToArray()
         {
             Buffer<TElement> buffer = new Buffer<TElement>(source);
+
             int count = buffer.count;
-            TElement[] array = new TElement[count];
-            if (count > 0)
+            if (count == 0)
             {
-                int[] map = SortedMap(buffer);
-                for (int i = 0; i != array.Length; i++) array[i] = buffer.items[map[i]];
+                return buffer.items;
             }
+
+            TElement[] array = new TElement[count];
+            int[] map = SortedMap(buffer);
+            for (int i = 0; i != array.Length; i++) array[i] = buffer.items[map[i]];
 
             return array;
         }
@@ -4093,7 +4115,7 @@ namespace System.Linq
         {
             Buffer<TElement> buffer = new Buffer<TElement>(source);
             int count = buffer.count;
-            if (count <= minIdx) return new TElement[0];
+            if (count <= minIdx) return Array.Empty<TElement>();
             if (count <= maxIdx) maxIdx = count - 1;
             if (minIdx == maxIdx) return new TElement[] { GetEnumerableSorter().ElementAt(buffer.items, count, minIdx) };
             int[] map = SortedMap(buffer, minIdx, maxIdx);
@@ -4671,7 +4693,6 @@ namespace System.Linq
 
         internal TElement[] ToArray()
         {
-            if (count == 0) return new TElement[0]; // consider replacing with Array.Empty<TElement>()
             if (items.Length == count) return items;
 
             var arr = new TElement[count];

--- a/src/System.Linq/tests/ToArrayTests.cs
+++ b/src/System.Linq/tests/ToArrayTests.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -14,17 +15,33 @@ namespace System.Linq.Tests
     public class ToArrayTests : EnumerableTests
     {
         [Fact]
-        public void ToArray_AlwaysCreateACopy()
+        public void ToArray_CreateACopyWhenNotEmpty()
         {
             int[] sourceArray = new int[] { 1, 2, 3, 4, 5 };
             int[] resultArray = sourceArray.ToArray();
 
             Assert.NotSame(sourceArray, resultArray);
             Assert.Equal(sourceArray, resultArray);
+        }
 
+        [Fact]
+        public void ToArray_UseArrayEmptyWhenEmpty()
+        {
             int[] emptySourceArray = Array.Empty<int>();
-            Assert.NotSame(emptySourceArray.ToArray(), emptySourceArray.ToArray());
-            Assert.NotSame(emptySourceArray.Select(i => i).ToArray(), emptySourceArray.Select(i => i).ToArray());
+            Assert.Same(emptySourceArray.ToArray(), emptySourceArray.ToArray());
+
+            Assert.Same(emptySourceArray.Select(i => i).ToArray(), emptySourceArray.Select(i => i).ToArray());
+            Assert.Same(emptySourceArray.ToList().Select(i => i).ToArray(), emptySourceArray.ToList().Select(i => i).ToArray());
+            Assert.Same(new Collection<int>(emptySourceArray).Select(i => i).ToArray(), new Collection<int>(emptySourceArray).Select(i => i).ToArray());
+            Assert.Same(emptySourceArray.OrderBy(i => i).ToArray(), emptySourceArray.OrderBy(i => i).ToArray());
+
+            Assert.Same(Enumerable.Range(5, 0).ToArray(), Enumerable.Range(3, 0).ToArray());
+            Assert.Same(Enumerable.Range(5, 3).Take(0).ToArray(), Enumerable.Range(3, 0).ToArray());
+            Assert.Same(Enumerable.Range(5, 3).Skip(3).ToArray(), Enumerable.Range(3, 0).ToArray());
+
+            Assert.Same(Enumerable.Repeat(42, 0).ToArray(), Enumerable.Range(84, 0).ToArray());
+            Assert.Same(Enumerable.Repeat(42, 3).Take(0).ToArray(), Enumerable.Range(84, 3).Take(0).ToArray());
+            Assert.Same(Enumerable.Repeat(42, 3).Skip(3).ToArray(), Enumerable.Range(84, 3).Skip(3).ToArray());
         }
 
 
@@ -200,9 +217,9 @@ namespace System.Linq.Tests
         }
         
         [Fact]
-        public void EmptyArraysNotSameObject()
+        public void EmptyArraysSameObject()
         {
-            Assert.NotSame(Enumerable.Empty<int>().ToArray(), Enumerable.Empty<int>().ToArray());
+            Assert.Same(Enumerable.Empty<int>().ToArray(), Enumerable.Empty<int>().ToArray());
             
             var array = new int[0];
             Assert.NotSame(array, array.ToArray());


### PR DESCRIPTION
ToArray() calls in our collections and in LINQ allocate a new array even if the collection/enumerable is empty.  This is unnecessary garbage, which can result in extra GCs, extra overhead, etc. (Issue #2363)