### PR TITLE
Fix hang when WinHttpHandler response stream reads are canceled

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -139,9 +139,9 @@ namespace System.Net.Http
                     {
                         _state.TcsReadFromResponseStream.TrySetException(previousTask.Exception.InnerException);
                     }
-                    else if (previousTask.IsCanceled)
+                    else if (previousTask.IsCanceled || token.IsCancellationRequested)
                     {
-                        _state.TcsReadFromResponseStream.TrySetCanceled();
+                        _state.TcsReadFromResponseStream.TrySetCanceled(token);
                     }
                     else
                     {
@@ -170,7 +170,7 @@ namespace System.Net.Http
                         }
                     }
                 }, 
-                token, TaskContinuationOptions.None, TaskScheduler.Default);
+                CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
 
             // TODO: Issue #2165. Register callback on cancellation token to cancel WinHTTP operation.
                 

--- a/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.IO;
 using System.Net.Tests;
+using System.Threading;
 using System.Threading.Tasks;
 
 using Xunit;
@@ -65,6 +66,26 @@ namespace System.Net.Http.Functional.Tests
                 string responseBody = reader.ReadToEnd();
                 _output.WriteLine(responseBody);
                 Assert.True(IsValidResponseBody(responseBody));
+            }
+        }
+
+        [Fact]
+        public async Task ReadAsStreamAsync_Cancel_TaskIsCanceled()
+        {
+            var cts = new CancellationTokenSource();
+
+            using (var client = new HttpClient())
+            using (HttpResponseMessage response =
+                    await client.GetAsync(HttpTestServers.RemoteEchoServer, HttpCompletionOption.ResponseHeadersRead))
+            using (Stream stream = await response.Content.ReadAsStreamAsync())
+            {
+                var buffer = new byte[2048];
+                Task task = stream.ReadAsync(buffer, 0, buffer.Length, cts.Token);
+                cts.Cancel();
+
+                // Verify that the task completes successfully or is canceled.
+                Assert.True(((IAsyncResult)task).AsyncWaitHandle.WaitOne(new TimeSpan(0, 0, 3)));
+                Assert.True(task.Status == TaskStatus.RanToCompletion || task.Status == TaskStatus.Canceled);
             }
         }
 


### PR DESCRIPTION
The task from ReadAsync was never moving to a terminal state (i.e. "hanging") if the token was marked for cancellation after starting the task. The problem was that our task continuation wasn't being called if the token was cancelled before the continuation was scheduled.

The fix is to avoid passing in the token during the .ContinueWith call. Instead, the token is checked inside the continuation. This puts all the logic in the same place for checking the final status of the ReadAsync operation (which has multiple inner operations) including whether it should fault due to an error or have a successful completion.

Fixes #5560.