### PR TITLE
Port to rc2: Add stack-protector compile option for native code

### DIFF
--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -78,6 +78,11 @@ endif ()
 
 if (APPLE)
     add_definitions(-D__APPLE_USE_RFC_3542)
+   
+   # We cannot enable "stack-protector-strong" on OS X due to a bug in clang compiler (current version 7.0.2)  
+   add_compile_options(-fstack-protector)  
+else ()  
+   add_compile_options(-fstack-protector-strong)  
 endif ()
 
 include(configure.cmake)


### PR DESCRIPTION
For #5424

Kept the same check for apple as in corefx - https://github.com/dotnet/coreclr/pull/2616/files.

