### PR TITLE
Fix two issues with x-plat NuGet package builds

### DIFF
--- a/src/Microsoft.VisualBasic/pkg/Microsoft.VisualBasic.builds
+++ b/src/Microsoft.VisualBasic/pkg/Microsoft.VisualBasic.builds
@@ -2,7 +2,8 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="Microsoft.VisualBasic.pkgproj" />
+    <!-- Temporary workaround, VisualBasic projects cannot be built on non-Windows platforms. See issue #5230. -->
+    <Project Include="Microsoft.VisualBasic.pkgproj" Condition="'$(OSEnvironment)' == 'Windows_NT'" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.IO.FileSystem/pkg/System.IO.FileSystem.pkgproj
+++ b/src/System.IO.FileSystem/pkg/System.IO.FileSystem.pkgproj
@@ -5,7 +5,7 @@
     <ProjectReference Include="..\ref\System.IO.FileSystem.csproj">
       <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\Facade\System.IO.FileSystem.csproj">
+    <ProjectReference Include="..\src\facade\System.IO.FileSystem.csproj">
       <AdditionalProperties>TargetGroup=net46</AdditionalProperties>
     </ProjectReference>
     <ProjectReference Include="win\System.IO.FileSystem.pkgproj" />


### PR DESCRIPTION
Building packages is possible x-plat now, but there's still a couple minor issues:

* Microsoft.VisualBasic needs to be disabled because the source project cannot be built outside Windows.
* System.IO.FileSystem had an incorrectly-cased path, which I fixed.

@ericstj 