### PR TITLE
Open packages for NETStandard.Library

### DIFF
--- a/pkg/descriptions.json
+++ b/pkg/descriptions.json
@@ -1075,7 +1075,8 @@
             "System.UInt32",
             "System.UInt64",
             "System.IDisposable",
-            "System.Uri"
+            "System.Uri",
+            "System.Runtime.InteropServices.GCHandle"
         ]
     },
     {
@@ -1122,13 +1123,22 @@
     },
     {
         "Name": "System.Runtime.InteropServices",
-        "Description": "Provides types that support COM interop and platform invoke services.",
+        "Description": "Provides Windows/Legacy types that support COM interop and platform invoke services. Cross platform Interop types have been moved and forwarded to System.Runtime.InteropServices.PInvoke.  Cross platform members of Marshal have also been moved to PInvokeMarshal in System.Runtime.InteropServices.PInvoke.",
         "CommonTypes": [
-            "System.Runtime.InteropServices.GCHandle",
-            "System.Runtime.InteropServices.GuidAttribute",
             "System.Runtime.InteropServices.COMException",
+            "System.Runtime.InteropServices.Marshal"
+        ]
+    },
+    {
+        "Name": "System.Runtime.InteropServices.PInvoke",
+        "Description": "Provides types that support platform invoke services.",
+        "CommonTypes": [
             "System.DllNotFoundException",
-            "System.Runtime.InteropServices.DllImportAttribute"
+            "System.Runtime.InteropServices.DllImportAttribute",
+            "System.Runtime.InteropServices.GuidAttribute",
+            "System.Runtime.InteropServices.PInvokeMarshal",
+            "System.Runtime.InteropServices.MarshalAsAttribute",
+            "System.Runtime.InteropServices.SafeBuffer"
         ]
     },
     {

--- a/src/System.Collections/pkg/System.Collections.builds
+++ b/src/System.Collections/pkg/System.Collections.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Collections.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Collections/pkg/System.Collections.pkgproj
+++ b/src/System.Collections/pkg/System.Collections.pkgproj
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\ref\4.0.0\System.Collections.depproj">
+      <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\ref\System.Collections.csproj">
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Collections.builds" />
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Collections/src/System.Collections.builds
+++ b/src/System.Collections/src/System.Collections.builds
@@ -3,11 +3,12 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Collections.csproj" />
+    <!-- Net46 facade is currently inbox for 4.0
     <Project Include="System.Collections.csproj">
       <TargetGroup>net46</TargetGroup>
-    </Project>
+    </Project> -->
     <Project Include="System.Collections.csproj">
-      <TargetGroup>netcore50</TargetGroup>
+      <TargetGroup>netcore50aot</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Collections/src/System.Collections.csproj
+++ b/src/System.Collections/src/System.Collections.csproj
@@ -3,18 +3,19 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{D5FF747F-7A0B-9003-885A-FE9A63E755E5}</ProjectGuid>
-    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' != 'netcore50aot'">true</IsPartialFacadeAssembly>
     <AssemblyName>System.Collections</AssemblyName>
     <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aotao_Release|AnyCPU'" />
   <ItemGroup Condition="'$(TargetGroup)' == ''">
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.Diagnostics.Debug\src\System.Diagnostics.Debug.csproj">
@@ -43,7 +44,7 @@
       <Link>Common\System\Collections\Generic\EnumerableHelpers.cs</Link>
     </Compile>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)' == 'netcore50'">
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
     <Compile Include="System\Collections\BitArray.cs" />
     <Compile Include="System\Collections\Generic\Comparer.cs" />
     <Compile Include="System\Collections\Generic\Dictionary.cs" />

--- a/src/System.Collections/src/project.json
+++ b/src/System.Collections/src/project.json
@@ -12,13 +12,13 @@
     },
     "netcore50": {
       "dependencies": {
-        "System.Diagnostics.Contracts": "4.0.1-rc2-23713",
-        "System.Diagnostics.Debug": "4.0.11-rc2-23713",
-        "System.Diagnostics.Tools": "4.0.1-rc2-23713",
-        "System.Threading": "4.0.11-rc2-23713",
-        "System.Resources.ResourceManager": "4.0.1-rc2-23713",
-        "System.Runtime": "4.0.21-rc2-23713",
-        "System.Runtime.Extensions": "4.0.11-rc2-23713"
+        "System.Diagnostics.Contracts": "4.0.0",
+        "System.Diagnostics.Debug": "4.0.0",
+        "System.Diagnostics.Tools": "4.0.0",
+        "System.Threading": "4.0.0",
+        "System.Resources.ResourceManager": "4.0.0",
+        "System.Runtime": "4.0.20",
+        "System.Runtime.Extensions": "4.0.0"
       }
     }
   }

--- a/src/System.Diagnostics.Tools/pkg/System.Diagnostics.Tools.builds
+++ b/src/System.Diagnostics.Tools/pkg/System.Diagnostics.Tools.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Diagnostics.Tools.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Diagnostics.Tools/pkg/System.Diagnostics.Tools.pkgproj
+++ b/src/System.Diagnostics.Tools/pkg/System.Diagnostics.Tools.pkgproj
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <ItemGroup>
+    <ProjectReference Include="..\ref\System.Diagnostics.Tools.csproj">
+      <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Diagnostics.Tools.builds" />
+
+    <InboxOnTargetFramework Include="MonoAndroid10"/>
+    <InboxOnTargetFramework Include="MonoTouch10"/>
+    <InboxOnTargetFramework Include="net45"/>
+    <InboxOnTargetFramework Include="win8"/>
+    <InboxOnTargetFramework Include="wp80"/>
+    <InboxOnTargetFramework Include="wpa81"/>
+    <InboxOnTargetFramework Include="xamarinios10"/>
+    <InboxOnTargetFramework Include="xamarinmac20"/>
+  </ItemGroup>
+  
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.Tools/src/System.Diagnostics.Tools.builds
+++ b/src/System.Diagnostics.Tools/src/System.Diagnostics.Tools.builds
@@ -3,9 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Diagnostics.Tools.csproj" />
+    <!-- Net46 facade is currently inbox for 4.0
     <Project Include="System.Diagnostics.Tools.csproj">
       <TargetGroup>net46</TargetGroup>
-    </Project>
+    </Project> -->
     <Project Include="System.Diagnostics.Tools.csproj">
       <TargetGroup>netcore50aot</TargetGroup>
     </Project>

--- a/src/System.Diagnostics.Tools/src/System.Diagnostics.Tools.csproj
+++ b/src/System.Diagnostics.Tools/src/System.Diagnostics.Tools.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>System.Diagnostics.Tools</AssemblyName>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
   <!-- Help VS understand available configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.builds
+++ b/src/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Diagnostics.Tracing.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.pkgproj
+++ b/src/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.pkgproj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\ref\4.0.0\System.Diagnostics.Tracing.depproj">
+      <SupportedFramework>net45;netcore45</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\ref\4.0.10\System.Diagnostics.Tracing.depproj">
+      <SupportedFramework>net451;netcore451;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\ref\System.Diagnostics.Tracing.csproj">
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Diagnostics.Tracing.builds" />
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.builds
+++ b/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.builds
@@ -3,11 +3,12 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Diagnostics.Tracing.csproj" />
+    <!-- Net46 facade is currently inbox for 4.0
     <Project Include="System.Diagnostics.Tracing.csproj">
       <TargetGroup>net46</TargetGroup>
-    </Project>
+    </Project> -->
     <Project Include="System.Diagnostics.Tracing.csproj">
-      <TargetGroup>netcore50</TargetGroup>
+      <TargetGroup>netcore50aot</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
+++ b/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
@@ -6,11 +6,12 @@
     <ProjectGuid>{EB880FDC-326D-42B3-A3FD-0CD3BA29A7F4}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyVersion>4.0.21.0</AssemblyVersion>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetGroup)'!='netcore50'">
+  <PropertyGroup Condition="'$(TargetGroup)'!='netcore50aot'">
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetGroup)'=='netcore50'">
+  <PropertyGroup Condition="'$(TargetGroup)'=='netcore50aot'">
     <DefineConstants>$(DefineConstants);PROJECTN</DefineConstants>
     <!-- Need to remove reference to System.Reflection.TypeExtensions
     which is included transitively via System.Reflection -->
@@ -19,15 +20,15 @@
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
   <ItemGroup Condition="'$(TargetGroup)'==''">
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
     <Compile Include="System\Diagnostics\Tracing\EventCounter.cs" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetGroup)'=='netcore50'">
+  <ItemGroup Condition="'$(TargetGroup)'=='netcore50aot'">
     <Compile Include="System\Diagnostics\Tracing\ActivityTracker.cs" />
     <Compile Include="System\Diagnostics\Tracing\EventActivityOptions.cs" />
     <Compile Include="System\Diagnostics\Tracing\EventDescriptor.cs" />
@@ -99,7 +100,7 @@
     <EmbeddedResource Include="$(MsBuildThisFileDirectory)Resources\$(AssemblyName).rd.xml" />
   </ItemGroup>
   <ItemGroup>
-    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50'" />
+    <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Globalization.Calendars/pkg/System.Globalization.Calendars.builds
+++ b/src/System.Globalization.Calendars/pkg/System.Globalization.Calendars.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Globalization.Calendars.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Globalization.Calendars/pkg/System.Globalization.Calendars.pkgproj
+++ b/src/System.Globalization.Calendars/pkg/System.Globalization.Calendars.pkgproj
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\ref\System.Globalization.Calendars.csproj">
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Globalization.Calendars.builds" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Globalization.Calendars/src/System.Globalization.Calendars.csproj
+++ b/src/System.Globalization.Calendars/src/System.Globalization.Calendars.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>System.Globalization.Calendars</AssemblyName>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->

--- a/src/System.Globalization/pkg/System.Globalization.builds
+++ b/src/System.Globalization/pkg/System.Globalization.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Globalization.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Globalization/pkg/System.Globalization.pkgproj
+++ b/src/System.Globalization/pkg/System.Globalization.pkgproj
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\ref\4.0.0\System.Globalization.depproj">
+      <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\ref\System.Globalization.csproj">
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Globalization.builds" />
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Globalization/src/System.Globalization.builds
+++ b/src/System.Globalization/src/System.Globalization.builds
@@ -3,9 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Globalization.csproj" />
+    <!-- Net46 facade is currently inbox for 4.0
     <Project Include="System.Globalization.csproj">
       <TargetGroup>net46</TargetGroup>
-    </Project>
+    </Project> -->
     <Project Include="System.Globalization.csproj">
       <TargetGroup>netcore50</TargetGroup>
     </Project>

--- a/src/System.Globalization/src/System.Globalization.csproj
+++ b/src/System.Globalization/src/System.Globalization.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>System.Globalization</AssemblyName>
     <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->

--- a/src/System.IO/pkg/System.IO.builds
+++ b/src/System.IO/pkg/System.IO.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.IO.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.IO/pkg/System.IO.pkgproj
+++ b/src/System.IO/pkg/System.IO.pkgproj
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\ref\4.0.0\System.IO.depproj">
+      <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\ref\System.IO.csproj">
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.IO.builds" />
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.IO/src/System.IO.csproj
+++ b/src/System.IO/src/System.IO.csproj
@@ -6,6 +6,7 @@
     <ProjectGuid>{07390899-C8F6-4e83-A3A9-6867B8CB46A0}</ProjectGuid>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
 
   <!-- Default configurations to help VS understand the options -->

--- a/src/System.IO/src/project.json
+++ b/src/System.IO/src/project.json
@@ -10,10 +10,10 @@
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",
-        "System.Globalization": "4.0.10",
+        "System.Globalization": "4.0.0",
         "System.Runtime.Extensions": "4.0.10",
-        "System.Text.Encoding.Extensions": "4.0.10",
-        "System.Threading": "4.0.10",
+        "System.Text.Encoding.Extensions": "4.0.0",
+        "System.Threading": "4.0.0",
         "System.Threading.Tasks": "4.0.10",
         "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23704"
       }

--- a/src/System.Linq/pkg/System.Linq.builds
+++ b/src/System.Linq/pkg/System.Linq.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Linq.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Linq/pkg/System.Linq.pkgproj
+++ b/src/System.Linq/pkg/System.Linq.pkgproj
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <ItemGroup>
+    <ProjectReference Include="..\ref\System.Linq.csproj">
+      <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Linq.builds" />
+    
+    <InboxOnTargetFramework Include="MonoAndroid10"/>
+    <InboxOnTargetFramework Include="MonoTouch10"/>
+    <InboxOnTargetFramework Include="net45"/>
+    <InboxOnTargetFramework Include="win8"/>
+    <InboxOnTargetFramework Include="wp80"/>
+    <InboxOnTargetFramework Include="wpa81"/>
+    <InboxOnTargetFramework Include="xamarinios10"/>
+    <InboxOnTargetFramework Include="xamarinmac20"/>
+  </ItemGroup>
+  
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Linq/src/System.Linq.builds
+++ b/src/System.Linq/src/System.Linq.builds
@@ -3,9 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Linq.csproj" />
+    <!-- Net46 facade is currently inbox for 4.0
     <Project Include="facade\System.Linq.csproj">
       <TargetGroup>net46</TargetGroup>
-    </Project>
+    </Project> -->
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Private.Uri/pkg/System.Private.Uri.builds
+++ b/src/System.Private.Uri/pkg/System.Private.Uri.builds
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Private.Uri.pkgproj"/>
+    <Project Include="win\System.Private.Uri.pkgproj">
+      <OSGroup>Windows_NT</OSGroup>
+    </Project>
+    <Project Include="unix\System.Private.Uri.pkgproj">
+      <OSGroup>Linux</OSGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Private.Uri/pkg/System.Private.Uri.pkgproj
+++ b/src/System.Private.Uri/pkg/System.Private.Uri.pkgproj
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <!-- Ideally we'd harvest this from the runtime dependencies -->
+    <Version>4.0.1</Version>
+    <!-- The Unix implementations place the asset in a generation folder,
+         however the assembly won't reference any generation-based contracts -->
+    <SkipGenerationCheck>true</SkipGenerationCheck>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <!-- Implementation only package -->
+    <File Include="$(PlaceholderFile)">
+      <TargetPath>ref/dnxcore50</TargetPath>
+    </File>
+    <File Include="$(PlaceholderFile)">
+      <TargetPath>ref/netcore50</TargetPath>
+    </File>
+
+    <ProjectReference Include="win\System.Private.Uri.pkgproj" />
+    <ProjectReference Include="unix\System.Private.Uri.pkgproj" />
+  </ItemGroup>
+  
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Private.Uri/pkg/unix/System.Private.Uri.pkgproj
+++ b/src/System.Private.Uri/pkg/unix/System.Private.Uri.pkgproj
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>unix</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Private.Uri.builds" >
+      <AdditionalProperties>FilterToOSGroup=Linux</AdditionalProperties>
+    </ProjectReference>
+
+    <ProjectReference Include="$(NativePackagePath)\runtime.native.System\runtime.native.System.pkgproj" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Private.Uri/pkg/win/System.Private.Uri.pkgproj
+++ b/src/System.Private.Uri/pkg/win/System.Private.Uri.pkgproj
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>win7</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Private.Uri.builds">
+      <AdditionalProperties>FilterToOSGroup=Windows_NT</AdditionalProperties>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection.Extensions/pkg/System.Reflection.Extensions.builds
+++ b/src/System.Reflection.Extensions/pkg/System.Reflection.Extensions.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Reflection.Extensions.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Reflection.Extensions/pkg/System.Reflection.Extensions.pkgproj
+++ b/src/System.Reflection.Extensions/pkg/System.Reflection.Extensions.pkgproj
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <ItemGroup>
+    <ProjectReference Include="..\ref\System.Reflection.Extensions.csproj">
+      <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Reflection.Extensions.builds" />
+
+    <InboxOnTargetFramework Include="MonoAndroid10"/>
+    <InboxOnTargetFramework Include="MonoTouch10"/>
+    <InboxOnTargetFramework Include="net45"/>
+    <InboxOnTargetFramework Include="win8"/>
+    <InboxOnTargetFramework Include="wp80"/>
+    <InboxOnTargetFramework Include="wpa81"/>
+    <InboxOnTargetFramework Include="xamarinios10"/>
+    <InboxOnTargetFramework Include="xamarinmac20"/>
+  </ItemGroup>
+  
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection.Extensions/src/System.Reflection.Extensions.builds
+++ b/src/System.Reflection.Extensions/src/System.Reflection.Extensions.builds
@@ -3,9 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Reflection.Extensions.csproj" />
+    <!-- Net46 facade is currently inbox for 4.0
     <Project Include="System.Reflection.Extensions.csproj">
       <TargetGroup>net46</TargetGroup>
-    </Project>
+    </Project> -->
     <Project Include="System.Reflection.Extensions.csproj">
       <TargetGroup>netcore50aot</TargetGroup>
     </Project>

--- a/src/System.Reflection.Extensions/src/System.Reflection.Extensions.csproj
+++ b/src/System.Reflection.Extensions/src/System.Reflection.Extensions.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>System.Reflection.Extensions</AssemblyName>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->

--- a/src/System.Reflection.Extensions/src/project.json
+++ b/src/System.Reflection.Extensions/src/project.json
@@ -14,7 +14,7 @@
         "System.Reflection.Primitives": "4.0.0",
         "System.Resources.ResourceManager": "4.0.0",
         "System.Runtime": "4.0.20.0",
-        "System.Runtime.Extensions": "4.0.10.0" 
+        "System.Runtime.Extensions": "4.0.10.0"
       }
     },
     "net46": {

--- a/src/System.Reflection.Primitives/pkg/System.Reflection.Primitives.builds
+++ b/src/System.Reflection.Primitives/pkg/System.Reflection.Primitives.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Reflection.Primitives.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Reflection.Primitives/pkg/System.Reflection.Primitives.pkgproj
+++ b/src/System.Reflection.Primitives/pkg/System.Reflection.Primitives.pkgproj
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <ItemGroup>
+    <ProjectReference Include="..\ref\System.Reflection.Primitives.csproj">
+      <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Reflection.Primitives.builds" />
+
+    <InboxOnTargetFramework Include="MonoAndroid10"/>
+    <InboxOnTargetFramework Include="MonoTouch10"/>
+    <InboxOnTargetFramework Include="net45"/>
+    <InboxOnTargetFramework Include="win8"/>
+    <InboxOnTargetFramework Include="wp80"/>
+    <InboxOnTargetFramework Include="wpa81"/>
+    <InboxOnTargetFramework Include="xamarinios10"/>
+    <InboxOnTargetFramework Include="xamarinmac20"/>
+  </ItemGroup>
+  
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection.Primitives/src/System.Reflection.Primitives.builds
+++ b/src/System.Reflection.Primitives/src/System.Reflection.Primitives.builds
@@ -3,9 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Reflection.Primitives.csproj" />
+    <!-- Net46 facade is currently inbox for 4.0
     <Project Include="System.Reflection.Primitives.csproj">
       <TargetGroup>net46</TargetGroup>
-    </Project>
+    </Project> -->
     <Project Include="System.Reflection.Primitives.csproj">
       <TargetGroup>netcore50</TargetGroup>
     </Project>

--- a/src/System.Reflection.Primitives/src/System.Reflection.Primitives.csproj
+++ b/src/System.Reflection.Primitives/src/System.Reflection.Primitives.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>System.Reflection.Primitives</AssemblyName>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)'!='netcore50'">true</IsPartialFacadeAssembly>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->

--- a/src/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.builds
+++ b/src/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Reflection.TypeExtensions.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.pkgproj
+++ b/src/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.pkgproj
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\ref\System.Reflection.TypeExtensions.csproj">
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Reflection.TypeExtensions.builds" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection.TypeExtensions/src/System.Reflection.TypeExtensions.csproj
+++ b/src/System.Reflection.TypeExtensions/src/System.Reflection.TypeExtensions.csproj
@@ -7,6 +7,7 @@
     <IsPartialFacadeAssembly Condition="'$(TargetGroup)' != 'netcore50aot'">true</IsPartialFacadeAssembly>
     <NuGetTargetFrameworkMoniker>DNXCore,Version=v5.0</NuGetTargetFrameworkMoniker>
     <ProjectGuid>{1E689C1B-690C-4799-BDE9-6E7990585894}</ProjectGuid>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Reflection/pkg/System.Reflection.builds
+++ b/src/System.Reflection/pkg/System.Reflection.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Reflection.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Reflection/pkg/System.Reflection.pkgproj
+++ b/src/System.Reflection/pkg/System.Reflection.pkgproj
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\ref\4.0.0\System.Reflection.depproj">
+      <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\ref\System.Reflection.csproj">
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Reflection.builds" />
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection/src/System.Reflection.csproj
+++ b/src/System.Reflection/src/System.Reflection.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>System.Reflection</AssemblyName>
     <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->

--- a/src/System.Runtime.Handles/pkg/System.Runtime.Handles.builds
+++ b/src/System.Runtime.Handles/pkg/System.Runtime.Handles.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Runtime.Handles.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Runtime.Handles/pkg/System.Runtime.Handles.pkgproj
+++ b/src/System.Runtime.Handles/pkg/System.Runtime.Handles.pkgproj
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\ref\System.Runtime.Handles.csproj">
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Runtime.Handles.builds" />
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net46" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Handles/src/System.Runtime.Handles.builds
+++ b/src/System.Runtime.Handles/src/System.Runtime.Handles.builds
@@ -3,9 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Runtime.Handles.csproj" />
+    <!-- Net46 facade is currently inbox for 4.0
     <Project Include="System.Runtime.Handles.csproj">
       <TargetGroup>net46</TargetGroup>
-    </Project>
+    </Project> -->
     <Project Include="System.Runtime.Handles.csproj">
       <TargetGroup>netcore50aot</TargetGroup>
     </Project>

--- a/src/System.Runtime.Handles/src/System.Runtime.Handles.csproj
+++ b/src/System.Runtime.Handles/src/System.Runtime.Handles.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>System.Runtime.Handles</AssemblyName>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Runtime.InteropServices.PInvoke/pkg/System.Runtime.InteropServices.PInvoke.builds
+++ b/src/System.Runtime.InteropServices.PInvoke/pkg/System.Runtime.InteropServices.PInvoke.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Runtime.InteropServices.PInvoke.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Runtime.InteropServices.PInvoke/pkg/System.Runtime.InteropServices.PInvoke.pkgproj
+++ b/src/System.Runtime.InteropServices.PInvoke/pkg/System.Runtime.InteropServices.PInvoke.pkgproj
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\ref\System.Runtime.InteropServices.PInvoke.csproj">
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Runtime.InteropServices.PInvoke.builds" />
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.InteropServices.PInvoke/src/System.Runtime.InteropServices.PInvoke.builds
+++ b/src/System.Runtime.InteropServices.PInvoke/src/System.Runtime.InteropServices.PInvoke.builds
@@ -7,7 +7,6 @@
       <TargetGroup>net46</TargetGroup>
     </Project>
     <Project Include="System.Runtime.InteropServices.PInvoke.csproj">
-      <OSGroup>Windows_NT</OSGroup>
       <TargetGroup>netcore50aot</TargetGroup>
     </Project>
   </ItemGroup>

--- a/src/System.Runtime.InteropServices.PInvoke/src/System.Runtime.InteropServices.PInvoke.csproj
+++ b/src/System.Runtime.InteropServices.PInvoke/src/System.Runtime.InteropServices.PInvoke.csproj
@@ -9,6 +9,7 @@
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <!-- Force string resources to be excluded for full facades. -->
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' != ''">None</ResourcesSourceOutputDirectory>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Runtime.InteropServices/pkg/System.Runtime.InteropServices.builds
+++ b/src/System.Runtime.InteropServices/pkg/System.Runtime.InteropServices.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Runtime.InteropServices.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Runtime.InteropServices/pkg/System.Runtime.InteropServices.pkgproj
+++ b/src/System.Runtime.InteropServices/pkg/System.Runtime.InteropServices.pkgproj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\ref\4.0.0\System.Runtime.InteropServices.depproj">
+      <SupportedFramework>net45;netcore45</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\ref\4.0.10\System.Runtime.InteropServices.depproj">
+      <SupportedFramework>net451;netcore451;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\ref\System.Runtime.InteropServices.csproj">
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Runtime.InteropServices.builds" />
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.InteropServices/src/System.Runtime.InteropServices.builds
+++ b/src/System.Runtime.InteropServices/src/System.Runtime.InteropServices.builds
@@ -2,18 +2,11 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="System.Runtime.InteropServices.csproj">
-      <OSGroup>Linux</OSGroup>
-    </Project>
-    <Project Include="System.Runtime.InteropServices.csproj">
-      <OSGroup>OSX</OSGroup>
-    </Project>
-    <Project Include="System.Runtime.InteropServices.csproj">
-      <OSGroup>Windows_NT</OSGroup>
-    </Project>
+    <Project Include="System.Runtime.InteropServices.csproj" />
+    <!-- Net46 facade is currently inbox for 4.0
     <Project Include="System.Runtime.InteropServices.csproj">
       <TargetGroup>net46</TargetGroup>
-    </Project>
+    </Project> -->
     <Project Include="System.Runtime.InteropServices.csproj">
       <TargetGroup>netcore50aot</TargetGroup>
     </Project>

--- a/src/System.Runtime.InteropServices/src/System.Runtime.InteropServices.builds
+++ b/src/System.Runtime.InteropServices/src/System.Runtime.InteropServices.builds
@@ -3,10 +3,9 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Runtime.InteropServices.csproj" />
-    <!-- Net46 facade is currently inbox for 4.0
     <Project Include="System.Runtime.InteropServices.csproj">
       <TargetGroup>net46</TargetGroup>
-    </Project> -->
+    </Project>
     <Project Include="System.Runtime.InteropServices.csproj">
       <TargetGroup>netcore50aot</TargetGroup>
     </Project>

--- a/src/System.Runtime.InteropServices/src/System.Runtime.InteropServices.csproj
+++ b/src/System.Runtime.InteropServices/src/System.Runtime.InteropServices.csproj
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{EC6AA4D9-B3E8-4CCA-8AB1-8BBFD89266AE}</ProjectGuid>
@@ -12,14 +9,11 @@
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <!-- Force string resources to be excluded for full facades. -->
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' != ''">None</ResourcesSourceOutputDirectory>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'OSX_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'OSX_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />

--- a/src/System.Runtime.Numerics/pkg/System.Runtime.Numerics.builds
+++ b/src/System.Runtime.Numerics/pkg/System.Runtime.Numerics.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Runtime.Numerics.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Runtime.Numerics/pkg/System.Runtime.Numerics.pkgproj
+++ b/src/System.Runtime.Numerics/pkg/System.Runtime.Numerics.pkgproj
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\ref\System.Runtime.Numerics.csproj">
+      <SupportedFramework>net45;netcore45;dnxcore50;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Runtime.Numerics.builds" />
+
+    <InboxOnTargetFramework Include="MonoAndroid10"/>
+    <InboxOnTargetFramework Include="MonoTouch10"/>
+    <InboxOnTargetFramework Include="net45"/>
+    <InboxOnTargetFramework Include="win8"/>
+    <InboxOnTargetFramework Include="wpa81"/>
+    <InboxOnTargetFramework Include="xamarinios10"/>
+    <InboxOnTargetFramework Include="xamarinmac20"/>
+  </ItemGroup>
+  
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Numerics/src/System.Runtime.Numerics.builds
+++ b/src/System.Runtime.Numerics/src/System.Runtime.Numerics.builds
@@ -3,9 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Runtime.Numerics.csproj" />
+    <!-- Net46 facade is currently inbox for 4.0
     <Project Include="facade\System.Runtime.Numerics.csproj">
       <TargetGroup>net46</TargetGroup>
-    </Project>
+    </Project> -->
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Runtime/pkg/System.Runtime.builds
+++ b/src/System.Runtime/pkg/System.Runtime.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Runtime.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Runtime/pkg/System.Runtime.pkgproj
+++ b/src/System.Runtime/pkg/System.Runtime.pkgproj
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\ref\4.0.0\System.Runtime.depproj">
+      <SupportedFramework>net45;netcore45;wp8</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\ref\4.0.10\System.Runtime.depproj">
+      <SupportedFramework>net451;netcore451;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\ref\System.Runtime.csproj">
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Runtime.builds" />
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+
+    <ProjectReference Include="..\..\System.Private.Uri\pkg\System.Private.Uri.pkgproj">
+      <PackageTargetFramework>dnxcore50</PackageTargetFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\..\System.Private.Uri\pkg\System.Private.Uri.pkgproj">
+      <PackageTargetFramework>netcore50</PackageTargetFramework>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime/src/System.Runtime.builds
+++ b/src/System.Runtime/src/System.Runtime.builds
@@ -3,10 +3,9 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Runtime.csproj" />
-    <!-- Net46 facade is currently inbox for 4.0
     <Project Include="System.Runtime.csproj">
       <TargetGroup>net46</TargetGroup>
-    </Project> -->
+    </Project>
     <Project Include="System.Runtime.csproj">
       <TargetGroup>netcore50aot</TargetGroup>
     </Project>

--- a/src/System.Runtime/src/System.Runtime.builds
+++ b/src/System.Runtime/src/System.Runtime.builds
@@ -3,9 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Runtime.csproj" />
+    <!-- Net46 facade is currently inbox for 4.0
     <Project Include="System.Runtime.csproj">
       <TargetGroup>net46</TargetGroup>
-    </Project>
+    </Project> -->
     <Project Include="System.Runtime.csproj">
       <TargetGroup>netcore50aot</TargetGroup>
     </Project>

--- a/src/System.Text.Encoding.Extensions/pkg/System.Text.Encoding.Extensions.builds
+++ b/src/System.Text.Encoding.Extensions/pkg/System.Text.Encoding.Extensions.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Text.Encoding.Extensions.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Text.Encoding.Extensions/pkg/System.Text.Encoding.Extensions.pkgproj
+++ b/src/System.Text.Encoding.Extensions/pkg/System.Text.Encoding.Extensions.pkgproj
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\ref\4.0.0\System.Text.Encoding.Extensions.depproj">
+      <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\ref\System.Text.Encoding.Extensions.csproj">
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Text.Encoding.Extensions.builds" />
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Text.Encoding.Extensions/src/System.Text.Encoding.Extensions.builds
+++ b/src/System.Text.Encoding.Extensions/src/System.Text.Encoding.Extensions.builds
@@ -3,9 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Text.Encoding.Extensions.csproj" />
+    <!-- Net46 facade is currently inbox for 4.0
     <Project Include="System.Text.Encoding.Extensions.csproj">
       <TargetGroup>net46</TargetGroup>
-    </Project>
+    </Project> -->
     <Project Include="System.Text.Encoding.Extensions.csproj">
       <TargetGroup>netcore50</TargetGroup>
     </Project>

--- a/src/System.Text.Encoding.Extensions/src/System.Text.Encoding.Extensions.csproj
+++ b/src/System.Text.Encoding.Extensions/src/System.Text.Encoding.Extensions.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>System.Text.Encoding.Extensions</AssemblyName>
     <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->

--- a/src/System.Text.Encoding/pkg/System.Text.Encoding.builds
+++ b/src/System.Text.Encoding/pkg/System.Text.Encoding.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Text.Encoding.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Text.Encoding/pkg/System.Text.Encoding.pkgproj
+++ b/src/System.Text.Encoding/pkg/System.Text.Encoding.pkgproj
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\ref\4.0.0\System.Text.Encoding.depproj">
+      <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\ref\System.Text.Encoding.csproj">
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Text.Encoding.builds" />
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Text.Encoding/src/System.Text.Encoding.builds
+++ b/src/System.Text.Encoding/src/System.Text.Encoding.builds
@@ -3,9 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Text.Encoding.csproj" />
+    <!-- Net46 facade is currently inbox for 4.0
     <Project Include="System.Text.Encoding.csproj">
       <TargetGroup>net46</TargetGroup>
-    </Project>
+    </Project> -->
     <Project Include="System.Text.Encoding.csproj">
       <TargetGroup>netcore50</TargetGroup>
     </Project>

--- a/src/System.Text.Encoding/src/System.Text.Encoding.csproj
+++ b/src/System.Text.Encoding/src/System.Text.Encoding.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>System.Text.Encoding</AssemblyName>
     <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->

--- a/src/System.Text.RegularExpressions/pkg/System.Text.RegularExpressions.builds
+++ b/src/System.Text.RegularExpressions/pkg/System.Text.RegularExpressions.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Text.RegularExpressions.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Text.RegularExpressions/pkg/System.Text.RegularExpressions.pkgproj
+++ b/src/System.Text.RegularExpressions/pkg/System.Text.RegularExpressions.pkgproj
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\ref\4.0.0\System.Text.RegularExpressions.depproj">
+      <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\ref\System.Text.RegularExpressions.csproj">
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Text.RegularExpressions.builds" />
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.builds
+++ b/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.builds
@@ -3,9 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Text.RegularExpressions.csproj" />
+    <!-- Net46 facade is currently inbox for 4.0
     <Project Include="facade\System.Text.RegularExpressions.csproj">
       <TargetGroup>net46</TargetGroup>
-    </Project>
+    </Project> -->
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Threading.Tasks/pkg/System.Threading.Tasks.builds
+++ b/src/System.Threading.Tasks/pkg/System.Threading.Tasks.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Threading.Tasks.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Threading.Tasks/pkg/System.Threading.Tasks.pkgproj
+++ b/src/System.Threading.Tasks/pkg/System.Threading.Tasks.pkgproj
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <ProjectReference Include="..\ref\4.0.0\System.Threading.Tasks.depproj">
+      <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\ref\System.Threading.Tasks.csproj">
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Threading.Tasks.builds" />
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Threading.Tasks/src/System.Threading.Tasks.builds
+++ b/src/System.Threading.Tasks/src/System.Threading.Tasks.builds
@@ -3,9 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Threading.Tasks.csproj" />
+    <!-- Net46 facade is currently inbox for 4.0
     <Project Include="System.Threading.Tasks.csproj">
       <TargetGroup>net46</TargetGroup>
-    </Project>
+    </Project> -->
     <Project Include="System.Threading.Tasks.csproj">
       <TargetGroup>netcore50aot</TargetGroup>
     </Project>

--- a/src/System.Threading.Tasks/src/System.Threading.Tasks.csproj
+++ b/src/System.Threading.Tasks/src/System.Threading.Tasks.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>System.Threading.Tasks</AssemblyName>
     <AssemblyVersion>4.0.11.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Threading.Timer/pkg/System.Threading.Timer.builds
+++ b/src/System.Threading.Timer/pkg/System.Threading.Timer.builds
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Threading.Timer.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/src/System.Threading.Timer/pkg/System.Threading.Timer.pkgproj
+++ b/src/System.Threading.Timer/pkg/System.Threading.Timer.pkgproj
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  
+  <ItemGroup>
+    <ProjectReference Include="..\ref\System.Threading.Timer.csproj">
+      <SupportedFramework>net451;netcore451;dnxcore50;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Threading.Timer.builds" />
+
+    <InboxOnTargetFramework Include="MonoAndroid10"/>
+    <InboxOnTargetFramework Include="MonoTouch10"/>
+    <InboxOnTargetFramework Include="net451"/>
+    <InboxOnTargetFramework Include="win81"/>
+    <InboxOnTargetFramework Include="wpa81"/>
+    <InboxOnTargetFramework Include="xamarinios10"/>
+    <InboxOnTargetFramework Include="xamarinmac20"/>
+  </ItemGroup>
+  
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Threading.Timer/src/System.Threading.Timer.builds
+++ b/src/System.Threading.Timer/src/System.Threading.Timer.builds
@@ -3,9 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Threading.Timer.csproj" />
+    <!-- Net46 facade is currently inbox for 4.0
     <Project Include="System.Threading.Timer.csproj">
       <TargetGroup>net46</TargetGroup>
-    </Project>
+    </Project> -->
     <Project Include="System.Threading.Timer.csproj">
       <TargetGroup>netcore50</TargetGroup>
     </Project>

--- a/src/System.Threading.Timer/src/System.Threading.Timer.csproj
+++ b/src/System.Threading.Timer/src/System.Threading.Timer.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>System.Threading.Timer</AssemblyName>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->


### PR DESCRIPTION
This moves all library packages that make up
NETStandard.Library to the open.

I'll follow up with some refactoring of these
to ensure that all packages with NETStandard.Platform
use runtime packages to garuntee that they can
be replaced with an alternate implementation.