### PR TITLE
Default to the Windows build of SqlClient

### DIFF
--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
+  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Data.SqlClient</AssemblyName>


### PR DESCRIPTION
During the TFS build this project was getting built without
setting the OSGroup.  This causes OSGroup to default
to "AnyOS" meaning that the build is not OS specific.
As a result "TargetsWindows" was not set and
the binary produced was incorrect.

/cc @saurabh500 @weshaggard 