### PR TITLE
API for exposing the Schema Column from DbDataReader

### DIFF
--- a/src/System.Data.Common/src/System.Data.Common.csproj
+++ b/src/System.Data.Common/src/System.Data.Common.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Data\Common\DbColumn.cs" />
+    <Compile Include="System\Data\DbSchemaFactory.cs" />
     <Compile Include="System\DBNull.cs" />
     <Compile Include="System\Data\CommandBehavior.cs" />
     <Compile Include="System\Data\CommandType.cs" />

--- a/src/System.Data.Common/src/System/Data/DbSchemaFactory.cs
+++ b/src/System.Data.Common/src/System/Data/DbSchemaFactory.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+
+namespace System.Data.Common
+{
+    public abstract class DbSchemaFactory
+    {
+        abstract public List<DbColumn> GetColumnSchema(DbDataReader dataReader);
+    }
+}


### PR DESCRIPTION
Adding a DbSchemaFactory and a method to retrieve the schema from the DbDataReader

A new class was added because of the following:

1. A new method added to the existing DbDataReader would not allow type
forwarding which is needed so that the libraries written on .Net Core can
interop with the .Net Framework

2. A new class can be added to the facade of the .Net core so that the
implementation can be bridged with the .Net framework.