### PR TITLE
[Port to RC2] Fix serialization of recursive collections in data contract serializers

### DIFF
--- a/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
+++ b/src/System.Private.DataContractSerialization/src/Resources/Strings.resx
@@ -1097,6 +1097,9 @@
   </data>
   <data name="FactoryObjectContainsSelfReference" xml:space="preserve">
     <value>Object graph of type '{0}' with Id '{2}' contains a reference to itself. The object has been replaced with a new object of type '{1}' either because it implements IObjectReference or because it is surrogated. The serializer does not support fixing up the nested reference to the new object and cannot deserialize this object. Consider changing the object to remove the nested self-reference.</value>
+  </data>  
+  <data name="RecursiveCollectionType" xml:space="preserve">
+    <value>Type '{0}' is a recursive collection data contract which is not supported. Consider modifying the definition of collection '{0}' to remove references to itself.</value>
   </data>
   <data name="UnknownXmlType" xml:space="preserve">
     <value>Type '{0}' is not a valid XML type.</value>

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -1747,6 +1747,15 @@ public static partial class DataContractJsonSerializerTests
         }
     }
 
+    [Fact]
+    public static void DCS_RecursiveCollection()
+    {
+        Assert.Throws<InvalidDataContractException>(() =>
+        {
+            (new DataContractSerializer(typeof(RecursiveCollection))).WriteObject(new MemoryStream(), new RecursiveCollection());
+        });
+    }
+
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractJsonSerializerSettings settings = null, Func<DataContractJsonSerializer> serializerFactory = null, bool skipStringCompare = false)
     {
         DataContractJsonSerializer dcjs;

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -1968,6 +1968,15 @@ public static partial class DataContractSerializerTests
     }
 
     [Fact]
+    public static void DCS_RecursiveCollection()
+    {
+        Assert.Throws<InvalidDataContractException>(() =>
+        {
+            (new DataContractSerializer(typeof (RecursiveCollection))).WriteObject(new MemoryStream(), new RecursiveCollection());
+        });
+    }
+
+    [Fact]
     public static void DCS_XmlElementAsRoot()
     {
         XmlDocument xDoc = new XmlDocument();

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -2781,3 +2781,21 @@ public class TypeWithEnumerableInterfaceGetOnlyCollection
         this.items = items;
     }
 }
+
+[CollectionDataContract]
+public class RecursiveCollection : List<RecursiveCollection2>
+{
+
+}
+
+[CollectionDataContract]
+public class RecursiveCollection2 : List<RecursiveCollection3>
+{
+
+}
+
+[CollectionDataContract]
+public class RecursiveCollection3 : List<RecursiveCollection>
+{
+
+}


### PR DESCRIPTION
Porting https://github.com/dotnet/corefx/pull/5398 to release/1.0.0-rc2 branch.