### PR TITLE
System.ComponentModel: Cache TypeConverter results

### DIFF
--- a/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
+++ b/src/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectTypeDescriptionProvider.cs
@@ -212,7 +212,10 @@ namespace System.ComponentModel
                 if (converterType != null && typeof(TypeConverter).GetTypeInfo().IsAssignableFrom(converterType.GetTypeInfo()))
                 {
                     bool noTypeConstructor = true;
-                    return (TypeConverter)ReflectTypeDescriptionProvider.CreateInstance(converterType, type, ref noTypeConstructor);
+                    object instance = (TypeConverter)ReflectTypeDescriptionProvider.CreateInstance(converterType, type, ref noTypeConstructor);
+                    if (noTypeConstructor)
+                        ReflectTypeDescriptionProvider.IntrinsicTypeConverters[type] = instance;
+                    return (TypeConverter)instance;
                 }
             }
 

--- a/src/System.ComponentModel.TypeConverter/tests/Performance/Perf.TypeDescriptorTests.cs
+++ b/src/System.ComponentModel.TypeConverter/tests/Performance/Perf.TypeDescriptorTests.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections;
+using Xunit;
+using Microsoft.Xunit.Performance;
+
+namespace System.ComponentModel.Tests
+{
+    public class Perf_TypeDescriptorTests
+    {
+        [Benchmark]
+        [InlineData(typeof(bool), typeof(BooleanConverter))]
+        [InlineData(typeof(byte), typeof(ByteConverter))]
+        [InlineData(typeof(SByte), typeof(SByteConverter))]
+        [InlineData(typeof(char), typeof(CharConverter))]
+        [InlineData(typeof(double), typeof(DoubleConverter))]
+        [InlineData(typeof(string), typeof(StringConverter))]
+        [InlineData(typeof(short), typeof(Int16Converter))]
+        [InlineData(typeof(int), typeof(Int32Converter))]
+        [InlineData(typeof(long), typeof(Int64Converter))]
+        [InlineData(typeof(float), typeof(SingleConverter))]
+        [InlineData(typeof(UInt16), typeof(UInt16Converter))]
+        [InlineData(typeof(UInt32), typeof(UInt32Converter))]
+        [InlineData(typeof(UInt64), typeof(UInt64Converter))]
+        [InlineData(typeof(object), typeof(TypeConverter))]
+        [InlineData(typeof(void), typeof(TypeConverter))]
+        [InlineData(typeof(DateTime), typeof(DateTimeConverter))]
+        [InlineData(typeof(DateTimeOffset), typeof(DateTimeOffsetConverter))]
+        [InlineData(typeof(Decimal), typeof(DecimalConverter))]
+        [InlineData(typeof(TimeSpan), typeof(TimeSpanConverter))]
+        [InlineData(typeof(Guid), typeof(GuidConverter))]
+        [InlineData(typeof(Array), typeof(ArrayConverter))]
+        [InlineData(typeof(ICollection), typeof(CollectionConverter))]
+        [InlineData(typeof(Enum), typeof(EnumConverter))]
+        [InlineData(typeof(SomeEnum), typeof(EnumConverter))]
+        [InlineData(typeof(SomeValueType?), typeof(NullableConverter))]
+        [InlineData(typeof(int?), typeof(NullableConverter))]
+        [InlineData(typeof(ClassWithNoConverter), typeof(TypeConverter))]
+        [InlineData(typeof(BaseClass), typeof(BaseClassConverter))]
+        [InlineData(typeof(DerivedClass), typeof(DerivedClassConverter))]
+        [InlineData(typeof(IBase), typeof(IBaseConverter))]
+        [InlineData(typeof(IDerived), typeof(IBaseConverter))]
+        [InlineData(typeof(ClassIBase), typeof(IBaseConverter))]
+        [InlineData(typeof(ClassIDerived), typeof(IBaseConverter))]
+        public static void GetConverter(Type typeToConvert, Type expectedConverter)
+        {
+            const int innerIterations = 100;
+            foreach (var iteration in Benchmark.Iterations)
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < innerIterations; i++)
+                    {
+                        TypeConverter converter = TypeDescriptor.GetConverter(typeToConvert);
+                        Assert.NotNull(converter);
+                        Assert.Equal(expectedConverter, converter.GetType());
+                        Assert.True(converter.CanConvertTo(typeof(string)));
+                    }
+        }
+    }
+}

--- a/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
+++ b/src/System.ComponentModel.TypeConverter/tests/System.ComponentModel.TypeConverter.Tests.csproj
@@ -8,6 +8,7 @@
     <ProjectGuid>{3F0326A1-9E19-4A6C-95CE-63E65C9D2030}</ProjectGuid>
     <RootNamespace>System.ComponentModel.TypeConverter.Tests</RootNamespace>
     <AssemblyName>System.ComponentModel.TypeConverter.Tests</AssemblyName>
+    <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
   <PropertyGroup>
     <DebugEngines>{2E36F1D4-B23C-435D-AB41-18E608940038}</DebugEngines>
@@ -47,6 +48,11 @@
     <Compile Include="UInt16ConverterTests.cs" />
     <Compile Include="UInt32ConverterTests.cs" />
     <Compile Include="UInt64ConverterTests.cs" />
+    <!-- Performance Tests -->
+    <Compile Include="Performance\Perf.TypeDescriptorTests.cs" />
+    <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
+      <Link>Common\System\PerfUtils.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.ComponentModel.TypeConverter.csproj">

--- a/src/System.ComponentModel.TypeConverter/tests/project.json
+++ b/src/System.ComponentModel.TypeConverter/tests/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "Microsoft.DotNet.xunit.performance": "1.0.0-alpha-build0025",
     "System.ComponentModel": "4.0.0",
     "System.ComponentModel.Primitives": "4.0.0",
     "System.Globalization": "4.0.10",


### PR DESCRIPTION
Uses the IntrinsicTypes table and performs a check for existing entries in that table before doing anything else. Also adds performance tests for GetConverter.

Works for types that declare a Converter through an attribute as well as built-in types.

resolves #5337

@Tanya-Solyanik 