### PR TITLE
Extend range of expressions covered in type binary tests.

### DIFF
--- a/src/System.Linq.Expressions/tests/TypeBinary/TypeBinaryTests.cs
+++ b/src/System.Linq.Expressions/tests/TypeBinary/TypeBinaryTests.cs
@@ -27,11 +27,21 @@ namespace System.Linq.Expressions.Tests
             }
         }
 
+        protected enum ByteBased : byte
+        {
+            A, B, C, D
+        }
+
+        protected enum SByteBased : byte
+        {
+            A, B, C, D
+        }
+
         private static IEnumerable<Type> Types
         {
             get
             {
-                return new[] { typeof(void), typeof(int), typeof(object), typeof(string), typeof(long), typeof(Type), typeof(Uri), typeof(BinaryExpression), typeof(Expression), typeof(DateTime), typeof(DateTime?), typeof(IComparable) };
+                return new[] { typeof(void), typeof(int), typeof(object), typeof(string), typeof(long), typeof(Type), typeof(Uri), typeof(BinaryExpression), typeof(Expression), typeof(DateTime), typeof(DateTime?), typeof(IComparable), typeof(ByteBased), typeof(ByteBased?), typeof(SByteBased), typeof(StringComparison) };
             }
         }
 
@@ -44,12 +54,33 @@ namespace System.Linq.Expressions.Tests
                 yield return Expression.Constant(1);
                 yield return Expression.Constant(DateTime.MinValue);
                 yield return Expression.Constant("hello");
+                yield return Expression.Constant("hello", typeof(object));
                 yield return Expression.Constant(Expression.Empty());
                 yield return Expression.Constant(Expression.And(Expression.Constant(1), Expression.Constant(2)));
                 yield return Expression.Constant(typeof(int));
                 yield return Expression.New(typeof(string).GetConstructor(new[] { typeof(char[]) }), Expression.Constant(new[] { 't', 'e', 's', 't' }));
                 yield return Expression.Convert(Expression.Constant(DateTime.MaxValue), typeof(DateTime?));
                 yield return Expression.Constant(1, typeof(int?));
+                yield return Expression.Constant(1, typeof(object));
+                yield return Expression.Constant(1, typeof(IComparable));
+                yield return Expression.Constant(DateTime.MinValue, typeof(object));
+                yield return Expression.Constant(1, typeof(ValueType));
+                yield return Expression.Constant(DateTime.MinValue, typeof(ValueType));
+                yield return Expression.Constant(DateTime.MinValue, typeof(IComparable));
+                yield return Expression.Constant(ByteBased.A);
+                yield return Expression.Constant(ByteBased.D, typeof(ByteBased?));
+                yield return Expression.Constant(ByteBased.B, typeof(object));
+                yield return Expression.Constant(ByteBased.C, typeof(Enum));
+                yield return Expression.Constant(ByteBased.C, typeof(IComparable));
+                yield return Expression.Constant(SByteBased.A);
+                yield return Expression.Constant(SByteBased.B, typeof(object));
+                yield return Expression.Constant(SByteBased.C, typeof(Enum));
+                yield return Expression.Constant(SByteBased.C, typeof(IComparable));
+                yield return Expression.Constant(StringComparison.CurrentCulture);
+                yield return Expression.Constant(StringComparison.CurrentCultureIgnoreCase, typeof(object));
+                yield return Expression.Constant(StringComparison.Ordinal, typeof(Enum));
+                yield return Expression.Constant(StringComparison.OrdinalIgnoreCase, typeof(IComparable));
+                yield return Expression.Constant(new NullReferenceException(), typeof(Exception));
             }
         }
 


### PR DESCRIPTION
Include value-type values of expressions that are typed to reference types
(object, ValueType or interface type).

This will catch #5610 and as such should not pass CI until #5624 is merged.