### PR TITLE
Stop Expression.TypeEquals throwing on Nullable<T> parameter.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
@@ -79,11 +79,17 @@ namespace System.Linq.Expressions
                 return ReduceConstantTypeEqual();
             }
 
-            // If the operand type is a sealed reference type or a nullable
-            // type, it will match if value is not null
-            if (cType.GetTypeInfo().IsSealed && (cType == _typeOperand))
+            // If the expression type is a sealed reference type or a nullable
+            // type, it will match if the value is not null and the type operand
+            // either matches or one is a nullable type while the other is its
+            // type argument (T to the other's T?).
+            if (cType.GetTypeInfo().IsSealed)
             {
-                if (cType.IsNullableType())
+                if (cType.GetNonNullableType() != _typeOperand.GetNonNullableType())
+                {
+                    return Expression.Block(Expression, Expression.Constant(false));
+                }
+                else if (cType.IsNullableType())
                 {
                     return Expression.NotEqual(Expression, Expression.Constant(null, Expression.Type));
                 }
@@ -92,6 +98,8 @@ namespace System.Linq.Expressions
                     return Expression.ReferenceNotEqual(Expression, Expression.Constant(null, Expression.Type));
                 }
             }
+
+            Debug.Assert(TypeUtils.AreReferenceAssignable(typeof(object), Expression.Type), "Expecting reference types only after this point.");
 
             // expression is a ByVal parameter. Can safely reevaluate.
             var parameter = Expression as ParameterExpression;
@@ -103,16 +111,9 @@ namespace System.Linq.Expressions
             // Create a temp so we only evaluate the left side once
             parameter = Expression.Parameter(typeof(object));
 
-            // Convert to object if necessary
-            var expression = Expression;
-            if (!TypeUtils.AreReferenceAssignable(typeof(object), expression.Type))
-            {
-                expression = Expression.Convert(expression, typeof(object));
-            }
-
             return Expression.Block(
                 new[] { parameter },
-                Expression.Assign(parameter, expression),
+                Expression.Assign(parameter, Expression),
                 ByValParameterTypeEqual(parameter)
             );
         }

--- a/src/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
+++ b/src/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
@@ -122,8 +122,6 @@ namespace System.Linq.Expressions.Tests
         {
             if (expression.Type == typeof(void))
                 return; // Can't have void parameter.
-            if (expression.Type.IsConstructedGenericType && expression.Type.GetGenericTypeDefinition() == typeof(Nullable<>) && expression.Type != type)
-                return; // ActiveIssue 5272
             bool expected;
             if (type == typeof(void))
                 expected = false;
@@ -155,8 +153,6 @@ namespace System.Linq.Expressions.Tests
         {
             if (expression.Type == typeof(void))
                 return; // Can't have void parameter.
-            if (expression.Type.IsConstructedGenericType && expression.Type.GetGenericTypeDefinition() == typeof(Nullable<>) && expression.Type != type)
-                return; // ActiveIssue 5272
             bool expected;
             if (type == typeof(void))
                 expected = false;


### PR DESCRIPTION
Fixes #5272

Does not contain the bogus further check that caused #5610