### PR TITLE
Port to rc2: Make Directory/FileInfo follow symlinks again

### DIFF
--- a/src/System.IO.FileSystem/tests/Directory/Exists.cs
+++ b/src/System.IO.FileSystem/tests/Directory/Exists.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Linq;
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.IO.Tests
@@ -313,6 +314,19 @@ namespace System.IO.Tests
         public void SubdirectoryOnNonExistentDriveAsPath_ReturnsFalse()
         {
             Assert.False(Exists(Path.Combine(IOServices.GetNonExistentDrive(), "nonexistentsubdir")));
+        }
+
+
+        [ConditionalFact("CanCreateSymbolicLinks")]
+        public void SymlinkToNewDirectory()
+        {
+            string targetPath = GetTestFilePath();
+            Directory.CreateDirectory(targetPath);
+
+            string linkPath = GetTestFilePath();
+            Assert.True(MountHelper.CreateSymbolicLink(linkPath, targetPath));
+
+            Assert.NotEqual(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), Directory.Exists(linkPath));
         }
 
         #endregion

--- a/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
+++ b/src/System.IO.FileSystem/tests/DirectoryInfo/Exists.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.IO.Tests
@@ -93,6 +94,18 @@ namespace System.IO.Tests
             File.Create(fileName).Dispose();
             DirectoryInfo di = new DirectoryInfo(fileName);
             Assert.False(di.Exists);
+        }
+
+        [ConditionalFact("CanCreateSymbolicLinks")]
+        public void SymlinkToNewDirectoryInfo()
+        {
+            string targetPath = GetTestFilePath();
+            new DirectoryInfo(targetPath).Create();
+
+            string linkPath = GetTestFilePath();
+            Assert.True(MountHelper.CreateSymbolicLink(linkPath, targetPath));
+
+            Assert.NotEqual(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), new DirectoryInfo(linkPath).Exists);
         }
     }
 }

--- a/src/System.IO.FileSystem/tests/FileInfo/Exists.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Exists.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.IO.Tests
@@ -84,7 +85,7 @@ namespace System.IO.Tests
         // the symbolic link may fail to create. Only run this test if it creates
         // links successfully.
         [ConditionalFact("CanCreateSymbolicLinks")]
-        public void SymLinksExistIndependentlyOfTarget()
+        public void SymLinksMayExistIndependentlyOfTarget()
         {
             var path = GetTestFilePath();
             var linkPath = GetTestFilePath();
@@ -92,23 +93,14 @@ namespace System.IO.Tests
             Assert.True(MountHelper.CreateSymbolicLink(linkPath, path));
             File.Delete(path);
 
+            // We've delete the target file, so it shouldn't exist.
             var info = new FileInfo(path);
-            var linkInfo = new FileInfo(linkPath);
-            Assert.True(linkInfo.Exists);
             Assert.False(info.Exists);
-        }
 
-        private static bool CanCreateSymbolicLinks
-        {
-            get
-            {
-                var path = Path.GetTempFileName();
-                var linkPath = path + ".link";
-                var ret = MountHelper.CreateSymbolicLink(linkPath, path);
-                try { File.Delete(path); } catch { }
-                try { File.Delete(linkPath); } catch { }
-                return ret;
-            }
+            // On Windows we report about the existence of the symlink file itself, so
+            // does still exist.  On Unix, we report about the target, where it doesn't.
+            var linkInfo = new FileInfo(linkPath);
+            Assert.Equal(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), linkInfo.Exists);
         }
     }
 }

--- a/src/System.IO.FileSystem/tests/FileInfo/Length.cs
+++ b/src/System.IO.FileSystem/tests/FileInfo/Length.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.IO.Tests
@@ -53,25 +54,12 @@ namespace System.IO.Tests
                 Assert.True(MountHelper.CreateSymbolicLink(linkPath, path));
 
                 var info = new FileInfo(path);
-                var linkInfo = new FileInfo(linkPath);
                 Assert.Equal(2000, info.Length);
-                // On Windows, sym links report 0 size; on Linux, their size is the length of the path they point to
-                // Confirm that the size we get is not the size of the target file (and that it's less, since our temporary
-                // sym links should never exceed 500 bytes.
-                Assert.True(2000 > linkInfo.Length);
-            }
-        }
 
-        private static bool CanCreateSymbolicLinks
-        {
-            get
-            {
-                var path = Path.GetTempFileName();
-                var linkPath = path + ".link";
-                var ret = MountHelper.CreateSymbolicLink(linkPath, path);
-                try { File.Delete(path); } catch { }
-                try { File.Delete(linkPath); } catch { }
-                return ret;
+                // On Windows, symlinks have length 0.  
+                // On Unix, we follow to the target and report on the target's size.
+                var linkInfo = new FileInfo(linkPath);
+                Assert.Equal(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 0 : info.Length, linkInfo.Length);
             }
         }
     }

--- a/src/System.IO.FileSystem/tests/FileSystemTest.cs
+++ b/src/System.IO.FileSystem/tests/FileSystemTest.cs
@@ -6,5 +6,18 @@ namespace System.IO.Tests
     public abstract class FileSystemTest : FileCleanupTestBase
     {
         public static readonly byte[] TestBuffer = { 0xBA, 0x5E, 0xBA, 0x11, 0xF0, 0x07, 0xBA, 0x11 };
+
+        protected static bool CanCreateSymbolicLinks
+        {
+            get
+            {
+                var path = Path.GetTempFileName();
+                var linkPath = path + ".link";
+                var ret = MountHelper.CreateSymbolicLink(linkPath, path);
+                try { File.Delete(path); } catch { }
+                try { File.Delete(linkPath); } catch { }
+                return ret;
+            }
+        }
     }
 }


### PR DESCRIPTION
https://github.com/dotnet/corefx/pull/5635

Directory/DirectoryInfo.Exists doesn’t follow symlinks.  Because our X509Certificates library checks this prior to enumerating root certs, and because that’s done by HttpClient when connecting to https sites, using HttpClient to connect to https sites fails with an exception about being unable to validate peer certificates.