### PR TITLE
Fixing assert conditions for System.Net.Security.

### DIFF
--- a/src/Common/src/Interop/Windows/SChannel/SslConnectionInfo.cs
+++ b/src/Common/src/Interop/Windows/SChannel/SslConnectionInfo.cs
@@ -42,6 +42,7 @@ namespace System.Net
                     {
                         GlobalLog.Assert("SslConnectionInfo::.ctor", "Negative size.");
                     }
+
                     Debug.Fail("SslConnectionInfo::.ctor", "Negative size.");
                     throw;
                 }

--- a/src/Common/src/Interop/Windows/sspicli/SSPIAuthType.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SSPIAuthType.cs
@@ -105,13 +105,13 @@ namespace System.Net
                 context.DangerousRelease();
             }
 
-
             if (status == 0 && qop == Interop.SspiCli.SECQOP_WRAP_NO_ENCRYPT)
             {
                 if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("SspiCli.DecryptMessage", "Expected qop = 0, returned value = " + qop.ToString("x", CultureInfo.InvariantCulture));
                 }
+
                 Debug.Fail("SspiCli.DecryptMessage", "Expected qop = 0, returned value = " + qop.ToString("x", CultureInfo.InvariantCulture));
                 throw new InvalidOperationException(SR.net_auth_message_not_encrypted);
             }

--- a/src/Common/src/Interop/Windows/sspicli/SSPIWrapper.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SSPIWrapper.cs
@@ -413,6 +413,7 @@ namespace System.Net
                             {
                                 GlobalLog.Assert("SSPIWrapper::EncryptDecryptHelper", "Unknown OP: " + op);
                             }
+
                             Debug.Fail("SSPIWrapper::EncryptDecryptHelper", "Unknown OP: " + op);
                             throw NotImplemented.ByDesignWithMessage(SR.net_MethodNotImplementedException);
                     }
@@ -458,6 +459,7 @@ namespace System.Net
                                     {
                                         GlobalLog.Assert("SSPIWrapper::EncryptDecryptHelper", "Output buffer out of range.");
                                     }
+
                                     Debug.Fail("SSPIWrapper::EncryptDecryptHelper", "Output buffer out of range.");
                                     iBuffer.size = 0;
                                     iBuffer.offset = 0;
@@ -473,14 +475,17 @@ namespace System.Net
                             {
                                 GlobalLog.AssertFormat("SSPIWrapper::EncryptDecryptHelper|'offset' out of range.  [{0}]", iBuffer.offset);
                             }
+
                             Debug.Fail("SSPIWrapper::EncryptDecryptHelper|'offset' out of range.  [" + iBuffer.offset + "]");
                         }
+
                         if (iBuffer.size < 0 || iBuffer.size > (iBuffer.token == null ? 0 : iBuffer.token.Length - iBuffer.offset))
                         {
                             if (GlobalLog.IsEnabled)
                             {
                                 GlobalLog.AssertFormat("SSPIWrapper::EncryptDecryptHelper|'size' out of range.  [{0}]", iBuffer.size);
                             }
+
                             Debug.Fail("SSPIWrapper::EncryptDecryptHelper|'size' out of range.  [" + iBuffer.size + "]");
                         }
                     }

--- a/src/Common/src/Interop/Windows/sspicli/SecSizes.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SecSizes.cs
@@ -34,6 +34,7 @@ namespace System.Net
                     {
                         GlobalLog.Assert("SecSizes::.ctor", "Negative size.");
                     }
+
                     Debug.Fail("SecSizes::.ctor", "Negative size.");
                     throw;
                 }

--- a/src/Common/src/Interop/Windows/sspicli/SecuritySafeHandles.cs
+++ b/src/Common/src/Interop/Windows/sspicli/SecuritySafeHandles.cs
@@ -549,6 +549,7 @@ namespace System.Net.Security
                 {
                     GlobalLog.Assert("SafeDeleteContext::InitializeSecurityContext()|outSecBuffer != null");
                 }
+
                 Debug.Fail("SafeDeleteContext::InitializeSecurityContext()|outSecBuffer != null");
             }
             if (inSecBuffer != null && inSecBuffers != null)
@@ -557,6 +558,7 @@ namespace System.Net.Security
                 {
                     GlobalLog.Assert("SafeDeleteContext::InitializeSecurityContext()|inSecBuffer == null || inSecBuffers == null");
                 }
+
                 Debug.Fail("SafeDeleteContext::InitializeSecurityContext()|inSecBuffer == null || inSecBuffers == null");
             }
 
@@ -859,6 +861,7 @@ namespace System.Net.Security
                 {
                     GlobalLog.Assert("SafeDeleteContext::AcceptSecurityContext()|outSecBuffer != null");
                 }
+
                 Debug.Fail("SafeDeleteContext::AcceptSecurityContext()|outSecBuffer != null");
             }
             if (inSecBuffer != null && inSecBuffers != null)
@@ -867,6 +870,7 @@ namespace System.Net.Security
                 {
                     GlobalLog.Assert("SafeDeleteContext::AcceptSecurityContext()|inSecBuffer == null || inSecBuffers == null");
                 }
+
                 Debug.Fail("SafeDeleteContext::AcceptSecurityContext()|outSecBuffer != null");
             }
 
@@ -1142,6 +1146,7 @@ namespace System.Net.Security
                 {
                     GlobalLog.Assert("SafeDeleteContext::CompleteAuthToken()|inSecBuffers == null");
                 }
+
                 Debug.Fail("SafeDeleteContext::CompleteAuthToken()|inSecBuffers == null");
             }
 

--- a/src/Common/src/Interop/Windows/sspicli/StreamSizes.cs
+++ b/src/Common/src/Interop/Windows/sspicli/StreamSizes.cs
@@ -36,6 +36,7 @@ namespace System.Net
                     {
                         GlobalLog.Assert("StreamSizes::.ctor", "Negative size.");
                     }
+
                     Debug.Fail("StreamSizes::.ctor", "Negative size.");
                     throw;
                 }

--- a/src/Common/src/System/Net/ContextAwareResult.Windows.cs
+++ b/src/Common/src/System/Net/ContextAwareResult.Windows.cs
@@ -31,6 +31,7 @@ namespace System.Net
                         {
                             GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|Called on completed result.", LoggingHash.HashString(this));
                         }
+
                         Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::Identity |Called on completed result.");
                     }
 
@@ -49,6 +50,7 @@ namespace System.Net
                     {
                         GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|No identity captured - specify captureIdentity.", LoggingHash.HashString(this));
                     }
+
                     Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::Identity |No identity captured - specify captureIdentity.");
                 }
 
@@ -62,8 +64,10 @@ namespace System.Net
                         {
                             GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|Must lock (StartPostingAsyncOp()) { ... FinishPostingAsyncOp(); } when calling Identity (unless it's only called after FinishPostingAsyncOp).", LoggingHash.HashString(this));
                         }
+
                         Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::Identity |Must lock (StartPostingAsyncOp()) { ... FinishPostingAsyncOp(); } when calling Identity (unless it's only called after FinishPostingAsyncOp).");
                     }
+
                     lock (_lock) { }
                 }
 
@@ -75,6 +79,7 @@ namespace System.Net
                         {
                             GlobalLog.AssertFormat("ContextAwareResult#{0}::Identity|Result became completed during call.", LoggingHash.HashString(this));
                         }
+
                         Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::Identity |Result became completed during call.");
                     }
 

--- a/src/Common/src/System/Net/ContextAwareResult.cs
+++ b/src/Common/src/System/Net/ContextAwareResult.cs
@@ -138,6 +138,7 @@ namespace System.Net
                         {
                             GlobalLog.AssertFormat("ContextAwareResult#{0}::ContextCopy|Called on completed result.", LoggingHash.HashString(this));
                         }
+
                         Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::ContextCopy |Called on completed result.");
                     }
 
@@ -157,6 +158,7 @@ namespace System.Net
                     {
                         GlobalLog.AssertFormat("ContextAwareResult#{0}::ContextCopy|No context captured - specify a callback or forceCaptureContext.", LoggingHash.HashString(this));
                     }
+
                     Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::ContextCopy |No context captured - specify a callback or forceCaptureContext.");
                 }
 
@@ -170,6 +172,7 @@ namespace System.Net
                         {
                             GlobalLog.AssertFormat("ContextAwareResult#{0}::ContextCopy|Must lock (StartPostingAsyncOp()) { ... FinishPostingAsyncOp(); } when calling ContextCopy (unless it's only called after FinishPostingAsyncOp).", LoggingHash.HashString(this));
                         }
+
                         Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) +"::ContextCopy |Must lock (StartPostingAsyncOp()) { ... FinishPostingAsyncOp(); } when calling ContextCopy (unless it's only called after FinishPostingAsyncOp).");
                     }
                     lock (_lock) { }
@@ -183,6 +186,7 @@ namespace System.Net
                         {
                             GlobalLog.AssertFormat("ContextAwareResult#{0}::ContextCopy|Result became completed during call.", LoggingHash.HashString(this));
                         }
+
                         Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::ContextCopy |Result became completed during call.");
                     }
 
@@ -221,6 +225,7 @@ namespace System.Net
                 {
                     GlobalLog.AssertFormat("ContextAwareResult#{0}::StartPostingAsyncOp|Called on completed result.", LoggingHash.HashString(this));
                 }
+
                 Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::StartPostingAsyncOp |Called on completed result.");
             }
 
@@ -318,6 +323,7 @@ namespace System.Net
                 {
                     GlobalLog.AssertFormat("ContextAwareResult#{0}::CaptureOrComplete|Called without calling StartPostingAsyncOp.", LoggingHash.HashString(this));
                 }
+
                 Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::CaptureOrComplete |Called without calling StartPostingAsyncOp.");
             }
 
@@ -384,6 +390,7 @@ namespace System.Net
                     {
                         GlobalLog.AssertFormat("ContextAwareResult#{0}::CaptureOrComplete|Didn't capture context, but didn't complete synchronously!", LoggingHash.HashString(this));
                     }
+
                     Debug.Fail("ContextAwareResult#" + LoggingHash.HashString(this) + "::CaptureOrComplete |Didn't capture context, but didn't complete synchronously!");
                 }
             }

--- a/src/Common/src/System/Net/InternalException.cs
+++ b/src/Common/src/System/Net/InternalException.cs
@@ -13,6 +13,7 @@ namespace System.Net
             {
                 GlobalLog.Assert("InternalException thrown.");
             }
+
             Debug.Fail("InternalException thrown.");
         }
     }

--- a/src/Common/src/System/Net/LazyAsyncResult.cs
+++ b/src/Common/src/System/Net/LazyAsyncResult.cs
@@ -79,6 +79,7 @@ namespace System.Net
                 {
                     GlobalLog.AssertFormat("LazyAsyncResult#{0}::.ctor()|Result can't be set to DBNull - it's a special internal value.", LoggingHash.HashString(this));
                 }
+
                 Debug.Fail("LazyAsyncResult#" + LoggingHash.HashString(this) + "::.ctor()|Result can't be set to DBNull - it's a special internal value.");
             }
 
@@ -335,14 +336,17 @@ namespace System.Net
                     {
                         GlobalLog.AssertFormat("LazyAsyncResult#{0}::set_Result()|Result can't be set to DBNull - it's a special internal value.", LoggingHash.HashString(this));
                     }
+
                     Debug.Fail("LazyAsyncResult#" + LoggingHash.HashString(this) + "::set_Result()|Result can't be set to DBNull - it's a special internal value.");
                 }
+
                 if (InternalPeekCompleted)
                 {
                     if (GlobalLog.IsEnabled)
                     {
                         GlobalLog.AssertFormat("LazyAsyncResult#{0}::set_Result()|Called on completed result.", LoggingHash.HashString(this));
                     }
+
                     Debug.Fail("LazyAsyncResult#" + LoggingHash.HashString(this) + "::set_Result()|Called on completed result.");
                 }
                 _result = value;

--- a/src/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/CertificateValidationPal.Windows.cs
@@ -163,6 +163,7 @@ namespace System.Net
                                 {
                                     GlobalLog.Assert("SecureChannel::GetIssuers()", "Interop.SspiCli._CERT_CHAIN_ELEMENT size is not positive: " + pIL2->cbSize.ToString());
                                 }
+
                                 Debug.Fail("SecureChannel::GetIssuers()", "Interop.SspiCli._CERT_CHAIN_ELEMENT size is not positive: " + pIL2->cbSize.ToString());
                             }
 
@@ -254,6 +255,7 @@ namespace System.Net
                                 {
                                     GlobalLog.Assert("SecureChannel::EnsureStoreOpened()", "Failed to open cert store, location:" + storeLocation + " exception:" + exception);
                                 }
+
                                 Debug.Fail("SecureChannel::EnsureStoreOpened()", "Failed to open cert store, location:" + storeLocation + " exception:" + exception);
                                 return null;
                             }

--- a/src/System.Net.Security/src/System/Net/NTAuthentication.cs
+++ b/src/System.Net.Security/src/System/Net/NTAuthentication.cs
@@ -200,12 +200,13 @@ namespace System.Net
         {
             get
             {
-                if ((IsCompleted && IsValidContext))
+                if (!(IsCompleted && IsValidContext))
                 {
                     if (GlobalLog.IsEnabled)
                     {
-                        GlobalLog.Assert("NTAuthentication#{0}::MaxDataSize|The context is not completed or invalid.", LoggingHash.HashString(this));
+                        GlobalLog.AssertFormat("NTAuthentication#{0}::MaxDataSize|The context is not completed or invalid.", LoggingHash.HashString(this));
                     }
+
                     Debug.Fail("NTAuthentication#" + LoggingHash.HashString(this) + "::MaxDataSize |The context is not completed or invalid.");
                 }
 
@@ -339,21 +340,23 @@ namespace System.Net
         // This token can be used for impersonation. We use it to create a WindowsIdentity and hand it out to the server app.
         internal SecurityContextTokenHandle GetContextToken(out Interop.SecurityStatus status)
         {
-            if ((IsCompleted && IsValidContext))
+            if (!(IsCompleted && IsValidContext))
             {
                 if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.AssertFormat("NTAuthentication#{0}::GetContextToken|Should be called only when completed with success, currently is not!", LoggingHash.HashString(this));
                 }
+
                 Debug.Fail("NTAuthentication#" + LoggingHash.HashString(this) + "::GetContextToken |Should be called only when completed with success, currently is not!");
             }
 
-            if (IsServer)
+            if (!IsServer)
             {
                 if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.AssertFormat("NTAuthentication#{0}::GetContextToken|The method must not be called by the client side!", LoggingHash.HashString(this));
                 }
+
                 Debug.Fail("NTAuthentication#" + LoggingHash.HashString(this) + "::GetContextToken |The method must not be called by the client side!");
             }
 
@@ -525,12 +528,13 @@ namespace System.Net
             if (statusCode == Interop.SecurityStatus.OK)
             {
                 // Success.
-                if ((statusCode == Interop.SecurityStatus.OK))
+                if (statusCode != Interop.SecurityStatus.OK)
                 {
                     if (GlobalLog.IsEnabled)
                     {
                         GlobalLog.AssertFormat("NTAuthentication#{0}::GetOutgoingBlob()|statusCode:[0x{1:x8}] ({2}) m_SecurityContext#{3}::Handle:[{4}] [STATUS != OK]", LoggingHash.HashString(this), (int)statusCode, statusCode, LoggingHash.HashString(_securityContext), LoggingHash.ObjectToString(_securityContext));
                     }
+
                     Debug.Fail("NTAuthentication#" + LoggingHash.HashString(this) + "::GetOutgoingBlob()|statusCode:[0x" + ((int)statusCode).ToString("x8") + "] (" + statusCode + ") m_SecurityContext#" + LoggingHash.HashString(_securityContext) + "::Handle:[" + LoggingHash.ObjectToString(_securityContext) + "] [STATUS != OK]");
                 }
 
@@ -571,6 +575,7 @@ namespace System.Net
                     {
                         GlobalLog.Assert("NTAuthentication#" + LoggingHash.HashString(this) + "::Encrypt", "Arguments out of range.");
                     }
+
                     Debug.Fail("NTAuthentication#" + LoggingHash.HashString(this) + "::Encrypt", "Arguments out of range.");
                 }
 
@@ -652,6 +657,7 @@ namespace System.Net
                 {
                     GlobalLog.Assert("NTAuthentication#" + LoggingHash.HashString(this) + "::Decrypt", "Argument 'offset' out of range.");
                 }
+
                 Debug.Fail("NTAuthentication#" + LoggingHash.HashString(this) + "::Decrypt", "Argument 'offset' out of range.");
 
                 throw new ArgumentOutOfRangeException("offset");
@@ -663,6 +669,7 @@ namespace System.Net
                 {
                     GlobalLog.Assert("NTAuthentication#" + LoggingHash.HashString(this) + "::Decrypt", "Argument 'count' out of range.");
                 }
+
                 Debug.Fail("NTAuthentication#" + LoggingHash.HashString(this) + "::Decrypt", "Argument 'count' out of range.");
 
                 throw new ArgumentOutOfRangeException("count");
@@ -710,12 +717,13 @@ namespace System.Net
 
         private string GetClientSpecifiedSpn()
         {
-            if ((IsValidContext && IsCompleted))
+            if (!(IsValidContext && IsCompleted))
             {
                 if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("NTAuthentication: Trying to get the client SPN before handshaking is done!");
                 }
+
                 Debug.Fail("NTAuthentication: Trying to get the client SPN before handshaking is done!");
             }
 
@@ -738,6 +746,7 @@ namespace System.Net
                 {
                     GlobalLog.Assert("NTAuthentication#" + LoggingHash.HashString(this) + "::DecryptNtlm", "Argument 'count' out of range.");
                 }
+
                 Debug.Fail("NTAuthentication#" + LoggingHash.HashString(this) + "::DecryptNtlm", "Argument 'count' out of range.");
 
                 throw new ArgumentOutOfRangeException("count");
@@ -767,6 +776,7 @@ namespace System.Net
                 {
                     GlobalLog.Print("NTAuthentication#" + LoggingHash.HashString(this) + "::Decrypt() throw Error = " + errorCode.ToString("x", NumberFormatInfo.InvariantInfo));
                 }
+
                 throw new Win32Exception(errorCode);
             }
 

--- a/src/System.Net.Security/src/System/Net/SSPIHandleCache.cs
+++ b/src/System.Net.Security/src/System/Net/SSPIHandleCache.cs
@@ -46,6 +46,7 @@ namespace System.Net.Security
                     {
                         GlobalLog.Assert("SSPIHandlCache", "Attempted to throw: " + e.ToString());
                     }
+
                     Debug.Fail("SSPIHandlCache", "Attempted to throw: " + e.ToString());
                 }
             }

--- a/src/System.Net.Security/src/System/Net/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/SecureChannel.cs
@@ -74,6 +74,7 @@ namespace System.Net.Security
                 {
                     GlobalLog.AssertFormat("SecureChannel#{0}::.ctor()|hostname == null", LoggingHash.HashString(this));
                 }
+
                 Debug.Fail("SecureChannel#" + LoggingHash.HashString(this) + "::.ctor()|hostname == null");
             }
             _hostName = hostname;
@@ -623,6 +624,7 @@ namespace System.Net.Security
                 {
                     GlobalLog.Assert("AcquireClientCredentials()|'selectedCert' does not match 'clientCertificate'.");
                 }
+
                 Debug.Fail("AcquireClientCredentials()|'selectedCert' does not match 'clientCertificate'.");
             }
 
@@ -749,6 +751,7 @@ namespace System.Net.Security
                 {
                     GlobalLog.Assert("AcquireServerCredentials()|'selectedCert' does not match 'localCertificate'.");
                 }
+
                 Debug.Fail("AcquireServerCredentials()|'selectedCert' does not match 'localCertificate'.");
             }
 
@@ -849,6 +852,7 @@ namespace System.Net.Security
                 {
                     GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::GenerateToken", "Argument 'offset' out of range.");
                 }
+
                 Debug.Fail("SecureChannel#" + LoggingHash.HashString(this) + "::GenerateToken", "Argument 'offset' out of range.");
                 throw new ArgumentOutOfRangeException("offset");
             }
@@ -859,6 +863,7 @@ namespace System.Net.Security
                 {
                     GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::GenerateToken", "Argument 'count' out of range.");
                 }
+
                 Debug.Fail("SecureChannel#" + LoggingHash.HashString(this) + "::GenerateToken", "Argument 'count' out of range.");
                 throw new ArgumentOutOfRangeException("count");
             }
@@ -1001,6 +1006,7 @@ namespace System.Net.Security
                         {
                             GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::ProcessHandshakeSuccess", "StreamSizes out of range.");
                         }
+
                         Debug.Fail("SecureChannel#" + LoggingHash.HashString(this) + "::ProcessHandshakeSuccess", "StreamSizes out of range.");
                     }
 
@@ -1073,6 +1079,7 @@ namespace System.Net.Security
                     {
                         GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Arguments out of range.");
                     }
+
                     Debug.Fail("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Arguments out of range.");
                 }
 
@@ -1113,6 +1120,7 @@ namespace System.Net.Security
                 {
                     GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Argument 'offset' out of range.");
                 }
+
                 Debug.Fail("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Argument 'offset' out of range.");
                 throw new ArgumentOutOfRangeException("offset");
             }
@@ -1123,6 +1131,7 @@ namespace System.Net.Security
                 {
                     GlobalLog.Assert("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Argument 'count' out of range.");
                 }
+
                 Debug.Fail("SecureChannel#" + LoggingHash.HashString(this) + "::Encrypt", "Argument 'count' out of range.");
                 throw new ArgumentOutOfRangeException("count");
             }

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/FixedSizeReader.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/FixedSizeReader.cs
@@ -111,6 +111,7 @@ namespace System.Net
                 {
                     GlobalLog.AssertFormat("FixedSizeReader::CheckCompletion()|State got out of range. Total:{0} Count:{1}", _totalRead + bytes, _request.Count);
                 }
+
                 Debug.Fail("FixedSizeReader::CheckCompletion()|State got out of range. Total:" + (_totalRead + bytes) + " Count:" + _request.Count);
             }
 
@@ -131,6 +132,7 @@ namespace System.Net
                 {
                     GlobalLog.Assert("ReadCallback|State type is wrong, expected FixedSizeReader.");
                 }
+
                 Debug.Fail("ReadCallback|State type is wrong, expected FixedSizeReader.");
             }
 

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/HelperAsyncResults.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/HelperAsyncResults.cs
@@ -47,6 +47,7 @@ namespace System.Net
                 {
                     GlobalLog.Assert("AsyncProtocolRequest()|userAsyncResult == null");
                 }
+
                 Debug.Fail("AsyncProtocolRequest()|userAsyncResult == null");
             }
             if (userAsyncResult.InternalPeekCompleted)
@@ -55,6 +56,7 @@ namespace System.Net
                 {
                     GlobalLog.Assert("AsyncProtocolRequest()|userAsyncResult is already completed.");
                 }
+
                 Debug.Fail("AsyncProtocolRequest()|userAsyncResult is already completed.");
             }
             UserAsyncResult = userAsyncResult;

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/InternalNegotiateStream.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/InternalNegotiateStream.cs
@@ -301,12 +301,13 @@ namespace System.Net.Security
                 return 0;
             }
 
-            if ((readBytes == _ReadHeader.Length))
+            if (!(readBytes == _ReadHeader.Length))
             {
                 if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.AssertFormat("NegoStream::ProcessHeader()|Frame size must be 4 but received {0} bytes.", readBytes);
                 }
+
                 Debug.Fail("NegoStream::ProcessHeader()|Frame size must be 4 but received " + readBytes + " bytes.");
             }
 
@@ -398,12 +399,13 @@ namespace System.Net.Security
                 return;
             }
 
-            if ((transportResult.AsyncState is AsyncProtocolRequest))
+            if (!(transportResult.AsyncState is AsyncProtocolRequest))
             {
                 if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("NegotiateSteam::WriteCallback|State type is wrong, expected AsyncProtocolRequest.");
                 }
+
                 Debug.Fail("NegotiateSteam::WriteCallback|State type is wrong, expected AsyncProtocolRequest.");
             }
 

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/NegoState.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/NegoState.Windows.cs
@@ -755,12 +755,13 @@ namespace System.Net.Security
 
         private static void WriteCallback(IAsyncResult transportResult)
         {
-            if ((transportResult.AsyncState is LazyAsyncResult))
+            if (!(transportResult.AsyncState is LazyAsyncResult))
             {
                 if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("WriteCallback|State type is wrong, expected LazyAsyncResult.");
                 }
+
                 Debug.Fail("WriteCallback|State type is wrong, expected LazyAsyncResult.");
             }
 
@@ -800,12 +801,13 @@ namespace System.Net.Security
 
         private static void ReadCallback(IAsyncResult transportResult)
         {
-            if ((transportResult.AsyncState is LazyAsyncResult))
+            if (!(transportResult.AsyncState is LazyAsyncResult))
             {
                 if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("ReadCallback|State type is wrong, expected LazyAsyncResult.");
                 }
+
                 Debug.Fail("ReadCallback|State type is wrong, expected LazyAsyncResult.");
             }
 

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslState.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslState.cs
@@ -1057,6 +1057,7 @@ namespace System.Net.Security
                     {
                         GlobalLog.Assert("SslState::WriteCallback", "Exception while decoding context. type:" + exception.GetType().ToString() + " message:" + exception.Message);
                     }
+
                     Debug.Fail("SslState::WriteCallback", "Exception while decoding context. type:" + exception.GetType().ToString() + " message:" + exception.Message);
                 }
 
@@ -1576,13 +1577,14 @@ namespace System.Net.Security
 
             int version = -1;
 
-            if ((bytes == null || bytes.Length == 0))
+            if ((bytes == null || bytes.Length <= 0))
             {
                 if (GlobalLog.IsEnabled)
                 {
-                    GlobalLog.Assert("SslState::DetectFraming()|Header buffer is not allocated will boom shortly.");
+                    GlobalLog.Assert("SslState::DetectFraming()|Header buffer is not allocated.");
                 }
-                Debug.Fail("SslState::DetectFraming()|Header buffer is not allocated will boom shortly.");
+
+                Debug.Fail("SslState::DetectFraming()|Header buffer is not allocated.");
             }
 
             // If the first byte is SSL3 HandShake, then check if we have a SSLv3 Type3 client hello.
@@ -1807,14 +1809,17 @@ namespace System.Net.Security
                 {
                     GlobalLog.Assert("SslState::RehandshakeCompleteCallback()|result is null!");
                 }
+
                 Debug.Fail("SslState::RehandshakeCompleteCallback()|result is null!");
             }
+
             if (!lazyAsyncResult.InternalPeekCompleted)
             {
                 if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("SslState::RehandshakeCompleteCallback()|result is not completed!");
                 }
+
                 Debug.Fail("SslState::RehandshakeCompleteCallback()|result is not completed!");
             }
 

--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslStreamContext.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslStreamContext.cs
@@ -17,6 +17,7 @@ namespace System.Net
                 {
                     GlobalLog.Assert("SslStreamContext..ctor(): Not expecting a null sslStream!");
                 }
+
                 Debug.Fail("SslStreamContext..ctor(): Not expecting a null sslStream!");
             }
 

--- a/src/System.Net.Security/src/System/Net/SecurityBuffer.cs
+++ b/src/System.Net.Security/src/System/Net/SecurityBuffer.cs
@@ -23,14 +23,17 @@ namespace System.Net.Security
                 {
                     GlobalLog.Assert("SecurityBuffer::.ctor", "'offset' out of range.  [" + offset + "]");
                 }
+
                 Debug.Fail("SecurityBuffer::.ctor", "'offset' out of range.  [" + offset + "]");
             }
+
             if (size < 0 || size > (data == null ? 0 : data.Length - offset))
             {
                 if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("SecurityBuffer::.ctor", "'size' out of range.  [" + size + "]");
                 }
+
                 Debug.Fail("SecurityBuffer::.ctor", "'size' out of range.  [" + size + "]");
             }
 
@@ -55,6 +58,7 @@ namespace System.Net.Security
                 {
                     GlobalLog.Assert("SecurityBuffer::.ctor", "'size' out of range.  [" + size + "]");
                 }
+
                 Debug.Fail("SecurityBuffer::.ctor", "'size' out of range.  [" + size + "]");
             }
 

--- a/src/System.Net.Security/src/System/Net/SslSessionsCache.cs
+++ b/src/System.Net.Security/src/System/Net/SslSessionsCache.cs
@@ -169,6 +169,7 @@ namespace System.Net.Security
                 {
                     GlobalLog.Assert("CacheCredential|creds == null");
                 }
+
                 Debug.Fail("CacheCredential|creds == null");
             }
 
@@ -178,6 +179,7 @@ namespace System.Net.Security
                 {
                     GlobalLog.Print("CacheCredential() Refused to cache an Invalid Handle = " + creds.ToString() + ", Current Cache Count = " + s_CachedCreds.Count);
                 }
+
                 return;
             }
 

--- a/src/System.Net.Security/src/System/Net/StreamFramer.cs
+++ b/src/System.Net.Security/src/System/Net/StreamFramer.cs
@@ -153,12 +153,13 @@ namespace System.Net
 
         private void ReadFrameCallback(IAsyncResult transportResult)
         {
-            if ((transportResult.AsyncState is WorkerAsyncResult))
+            if (!(transportResult.AsyncState is WorkerAsyncResult))
             {
                 if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.Assert("StreamFramer::ReadFrameCallback|The state expected to be WorkerAsyncResult, received:{0}.", transportResult.GetType().FullName);
                 }
+
                 Debug.Fail("StreamFramer::ReadFrameCallback|The state expected to be WorkerAsyncResult, received:" + transportResult.GetType().FullName + ".");
             }
 
@@ -200,12 +201,13 @@ namespace System.Net
         {
             do
             {
-                if ((transportResult.AsyncState is WorkerAsyncResult))
+                if (!(transportResult.AsyncState is WorkerAsyncResult))
                 {
                     if (GlobalLog.IsEnabled)
                     {
                         GlobalLog.AssertFormat("StreamFramer::ReadFrameComplete|The state expected to be WorkerAsyncResult, received:{0}.", transportResult.GetType().FullName);
                     }
+
                     Debug.Fail("StreamFramer::ReadFrameComplete|The state expected to be WorkerAsyncResult, received:" + transportResult.GetType().FullName + ".");
                 }
 
@@ -214,12 +216,13 @@ namespace System.Net
                 int bytesRead = _transportAPM.EndRead(transportResult);
                 workerResult.Offset += bytesRead;
 
-                if ((workerResult.Offset <= workerResult.End))
+                if (!(workerResult.Offset <= workerResult.End))
                 {
                     if (GlobalLog.IsEnabled)
                     {
                         GlobalLog.AssertFormat("StreamFramer::ReadFrameCallback|WRONG: offset - end = {0}", workerResult.Offset - workerResult.End);
                     }
+
                     Debug.Fail("StreamFramer::ReadFrameCallback|WRONG: offset - end = " + (workerResult.Offset - workerResult.End));
                 }
 
@@ -390,12 +393,13 @@ namespace System.Net
 
         private void BeginWriteCallback(IAsyncResult transportResult)
         {
-            if ((transportResult.AsyncState is WorkerAsyncResult))
+            if (!(transportResult.AsyncState is WorkerAsyncResult))
             {
                 if (GlobalLog.IsEnabled)
                 {
                     GlobalLog.AssertFormat("StreamFramer::BeginWriteCallback|The state expected to be WorkerAsyncResult, received:{0}.", transportResult.AsyncState.GetType().FullName);
                 }
+
                 Debug.Fail("StreamFramer::BeginWriteCallback|The state expected to be WorkerAsyncResult, received:" + transportResult.AsyncState.GetType().FullName + ".");
             }
 

--- a/src/System.Net.Security/src/System/PinnableBufferCache.cs
+++ b/src/System.Net.Security/src/System/PinnableBufferCache.cs
@@ -151,7 +151,6 @@ namespace System
                 }
 
                 // We have no buffers in the aged freelist, so get one from the newer list.   Try to pick the best one.
-                // Debug.Assert(_notGen2.Count != 0);
                 int idx = _notGen2.Count - 1;
                 if (GC.GetGeneration(_notGen2[idx]) < GC.MaxGeneration && GC.GetGeneration(_notGen2[0]) == GC.MaxGeneration)
                 {


### PR DESCRIPTION
Fixing incorrectly converted Debug.Assert during NegotiateStream port (9a414b0af4230b59a06dd9e255a36400582f482e). 
These affect DBG builds, will render incorrect ETW in production builds and impact test execution.

Tested locally by removing all ActiveIssues temporarily to ensure we get enough coverage.

@davidsh @stephentoub @shrutigarg PTAL