### PR TITLE
Update new libraries be be fully signed with Open key

### DIFF
--- a/src/System.Buffers/src/System.Buffers.csproj
+++ b/src/System.Buffers/src/System.Buffers.csproj
@@ -6,6 +6,7 @@
     <ProjectGuid>{2ADDB484-6F57-4D71-A3FE-A57EC6329A2B}</ProjectGuid>
     <PackageTargetFramework>dotnet5.2</PackageTargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <UseOpenKey>true</UseOpenKey>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the options -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />

--- a/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
+++ b/src/System.Diagnostics.DiagnosticSource/src/System.Diagnostics.DiagnosticSource.csproj
@@ -7,6 +7,7 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <PackageTargetFramework>dotnet5.2</PackageTargetFramework>
+    <UseOpenKey>true</UseOpenKey>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
+++ b/src/System.Text.Encodings.Web/src/System.Text.Encodings.Web.csproj
@@ -8,6 +8,7 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTargetFramework>dotnet5.1</PackageTargetFramework>
+    <UseOpenKey>true</UseOpenKey>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
+++ b/src/System.Threading.Tasks.Extensions/src/System.Threading.Tasks.Extensions.csproj
@@ -7,6 +7,7 @@
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <PackageTargetFramework>dotnet5.1</PackageTargetFramework>
+    <UseOpenKey>true</UseOpenKey>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />


### PR DESCRIPTION
This cannot be merged until the associated PR in BuildTools https://github.com/dotnet/buildtools/pull/407 is published. I'm submitting the PR early to settle on the libraries we want to sign with this new open key.

Fixes https://github.com/dotnet/corefx/issues/5153 @davidfowl 

@terrajobst please take a look to see if there are any other libraries we should switch to using this new open key. 

FYI for the owners of the libraries
@sokket @KrzysztofCwalina @vancem @davmason @stephentoub 