### PR TITLE
Clean-up build package versions

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -86,6 +86,9 @@
     <ValidationPattern Include="^(System\..*TestData)$">
       <ExpectedVersion>1.0.0-prerelease</ExpectedVersion>
     </ValidationPattern>
+    <ValidationPattern Include="^(Microsoft\.TargetingPack\.NetFramework.%2A)$">
+      <ExpectedVersion>1.0.0</ExpectedVersion>
+    </ValidationPattern>
     <ValidationPattern Include="^xunit$">
       <ExpectedVersion>2.1.0</ExpectedVersion>
     </ValidationPattern>

--- a/dir.props
+++ b/dir.props
@@ -80,7 +80,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ValidationPattern Include="^((System\..*)|(Microsoft\.CSharp)|(Microsoft\.NETCore.*)|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?&lt;!TestData)$">
+    <ValidationPattern Include="^((System\..*)|(Microsoft\.CSharp)|(Microsoft\.NETCore.*)|(Microsoft\.TargetingPack\.Private.*)|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?&lt;!TestData)$">
       <ExpectedPrerelease>rc3-23722</ExpectedPrerelease>
     </ValidationPattern>
     <ValidationPattern Include="^(System\..*TestData)$">

--- a/src/System.AppContext/src/project.json
+++ b/src/System.AppContext/src/project.json
@@ -1,8 +1,8 @@
 {
   "frameworks": {
-    "dnxcore50":{
+    "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23530"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
@@ -14,9 +14,9 @@
         "System.Threading": "4.0.0"
       }
     },
-    "net462":{
+    "net462": {
       "dependencies": {
-        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0",
+        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0"
       }
     }
   }

--- a/src/System.Collections/src/project.json
+++ b/src/System.Collections/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23520"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "net46": {

--- a/src/System.Diagnostics.Contracts/src/netcore50aot/project.json
+++ b/src/System.Diagnostics.Contracts/src/netcore50aot/project.json
@@ -1,9 +1,9 @@
 {
-    "frameworks": {
-        "netcore50": {
-            "dependencies": {
-                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
-            }
-        }
+  "frameworks": {
+    "netcore50": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722"
+      }
     }
+  }
 }

--- a/src/System.Diagnostics.Contracts/src/project.json
+++ b/src/System.Diagnostics.Contracts/src/project.json
@@ -2,12 +2,12 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23616"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23616"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "net46": {

--- a/src/System.Diagnostics.Debug/src/project.json
+++ b/src/System.Diagnostics.Debug/src/project.json
@@ -1,18 +1,18 @@
 {
   "frameworks": {
     "dnxcore50": {
-        "dependencies": {
-            "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
-        }
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
+      }
     },
     "netcore50": {
-            "dependencies": {
-                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
-            }
-    },
-    "net46":{
       "dependencies": {
-            "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0-rc2-23530"
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722"
+      }
+    },
+    "net46": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0-rc2-23530"
       }
     }
   }

--- a/src/System.Diagnostics.Debug/src/project.json
+++ b/src/System.Diagnostics.Debug/src/project.json
@@ -12,7 +12,7 @@
     },
     "net46": {
       "dependencies": {
-        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0-rc2-23530"
+        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0"
       }
     }
   }

--- a/src/System.Diagnostics.Debug/tests/project.json
+++ b/src/System.Diagnostics.Debug/tests/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23520",
+    "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },

--- a/src/System.Diagnostics.StackTrace/src/project.json
+++ b/src/System.Diagnostics.StackTrace/src/project.json
@@ -2,12 +2,12 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23530"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23530"
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722"
       }
     },
     "net46": {

--- a/src/System.Diagnostics.StackTrace/src/project.json
+++ b/src/System.Diagnostics.StackTrace/src/project.json
@@ -12,7 +12,7 @@
     },
     "net46": {
       "dependencies": {
-        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0-rc2-23530"
+        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0"
       }
     }
   }

--- a/src/System.Diagnostics.Tools/src/project.json
+++ b/src/System.Diagnostics.Tools/src/project.json
@@ -1,18 +1,18 @@
 {
   "frameworks": {
-    "dnxcore50":{
+    "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23530"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
-    "net46":{
+    "net46": {
       "dependencies": {
         "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0"
       }
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23530"
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722"
       }
     }
   }

--- a/src/System.Diagnostics.Tracing/src/project.json
+++ b/src/System.Diagnostics.Tracing/src/project.json
@@ -1,31 +1,31 @@
 {
   "frameworks": {
-    "dnxcore50":{
+    "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23530"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
       "dependencies": {
-        "System.Collections":"4.0.10.0",
-        "System.Diagnostics.Contracts":"4.0.0.0",
-        "System.Diagnostics.Debug":"4.0.0.0",
-        "System.Diagnostics.Tools":"4.0.0.0",
-        "System.Globalization":"4.0.0.0",
-        "System.Reflection":"4.0.10.0",
-        "System.Reflection.Extensions":"4.0.0.0",
-        "System.Resources.ResourceManager" :"4.0.0.0",
+        "System.Collections": "4.0.10.0",
+        "System.Diagnostics.Contracts": "4.0.0.0",
+        "System.Diagnostics.Debug": "4.0.0.0",
+        "System.Diagnostics.Tools": "4.0.0.0",
+        "System.Globalization": "4.0.0.0",
+        "System.Reflection": "4.0.10.0",
+        "System.Reflection.Extensions": "4.0.0.0",
+        "System.Resources.ResourceManager": "4.0.0.0",
         "System.Runtime": "4.0.20.0",
-        "System.Runtime.Extensions":"4.0.10.0",
-        "System.Runtime.InteropServices":"4.0.0.0",
-        "System.Text.Encoding":"4.0.0.0",
-        "System.Threading":"4.0.10.0"
+        "System.Runtime.Extensions": "4.0.10.0",
+        "System.Runtime.InteropServices": "4.0.0.0",
+        "System.Text.Encoding": "4.0.0.0",
+        "System.Threading": "4.0.10.0"
       }
     },
     "net46": {
       "dependencies": {
         "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
-        }
+      }
     }
   }
 }

--- a/src/System.Globalization.Calendars/src/netcore50aot/project.json
+++ b/src/System.Globalization.Calendars/src/netcore50aot/project.json
@@ -1,9 +1,9 @@
 {
-    "frameworks": {
-        "netcore50": {
-            "dependencies": {
-                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
-            }
-        }
+  "frameworks": {
+    "netcore50": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722"
+      }
     }
+  }
 }

--- a/src/System.Globalization.Calendars/src/project.json
+++ b/src/System.Globalization.Calendars/src/project.json
@@ -2,12 +2,12 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "net46": {

--- a/src/System.Globalization/src/netcore50aot/project.json
+++ b/src/System.Globalization/src/netcore50aot/project.json
@@ -1,9 +1,9 @@
 {
-    "frameworks": {
-        "netcore50": {
-            "dependencies": {
-                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
-            }
-        }
+  "frameworks": {
+    "netcore50": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722"
+      }
     }
+  }
 }

--- a/src/System.Globalization/src/project.json
+++ b/src/System.Globalization/src/project.json
@@ -2,12 +2,12 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "net46": {

--- a/src/System.IO.FileSystem/src/project.json
+++ b/src/System.IO.FileSystem/src/project.json
@@ -24,6 +24,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722",
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.0",
         "System.Globalization": "4.0.10",
         "System.Reflection": "4.0.10",
         "System.Reflection.Primitives": "4.0.0",

--- a/src/System.IO.FileSystem/src/project.json
+++ b/src/System.IO.FileSystem/src/project.json
@@ -23,7 +23,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23530",
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722",
         "System.Globalization": "4.0.10",
         "System.Reflection": "4.0.10",
         "System.Reflection.Primitives": "4.0.0",

--- a/src/System.IO.IsolatedStorage/src/project.json
+++ b/src/System.IO.IsolatedStorage/src/project.json
@@ -2,18 +2,18 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23530",
-        "System.Collections":"4.0.0.0",
-        "System.Diagnostics.Contracts":"4.0.0.0",
-        "System.IO":"4.0.10.0",
-        "System.IO.FileSystem":"4.0.0.0",
-        "System.IO.FileSystem.Primitives":"4.0.0.0",
-        "System.Linq":"4.0.0.0",
-        "System.Resources.ResourceManager":"4.0.0.0",
-        "System.Runtime":"4.0.20.0",
-        "System.Runtime.Extensions":"4.0.10.0",
-        "System.Threading":"4.0.10.0",
-        "System.Threading.Tasks":"4.0.10.0"
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722",
+        "System.Collections": "4.0.0.0",
+        "System.Diagnostics.Contracts": "4.0.0.0",
+        "System.IO": "4.0.10.0",
+        "System.IO.FileSystem": "4.0.0.0",
+        "System.IO.FileSystem.Primitives": "4.0.0.0",
+        "System.Linq": "4.0.0.0",
+        "System.Resources.ResourceManager": "4.0.0.0",
+        "System.Runtime": "4.0.20.0",
+        "System.Runtime.Extensions": "4.0.10.0",
+        "System.Threading": "4.0.10.0",
+        "System.Threading.Tasks": "4.0.10.0"
       }
     }
   }

--- a/src/System.IO.IsolatedStorage/src/project.json
+++ b/src/System.IO.IsolatedStorage/src/project.json
@@ -3,6 +3,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722",
+        "Microsoft.TargetingPack.Private.WinRt": "1.0.0",
         "System.Collections": "4.0.0.0",
         "System.Diagnostics.Contracts": "4.0.0.0",
         "System.IO": "4.0.10.0",

--- a/src/System.IO/src/project.json
+++ b/src/System.IO/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23520"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
@@ -15,7 +15,7 @@
         "System.Text.Encoding.Extensions": "4.0.0",
         "System.Threading": "4.0.0",
         "System.Threading.Tasks": "4.0.10",
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23704"
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722"
       }
     },
     "net46": {

--- a/src/System.Linq.Expressions/src/netcore50aot/project.json
+++ b/src/System.Linq.Expressions/src/netcore50aot/project.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23530",
+    "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722",
     "System.Collections": "4.0.10",
     "System.Diagnostics.Contracts": "4.0.0",
     "System.Diagnostics.Debug": "4.0.10",

--- a/src/System.Private.DataContractSerialization/src/project.json
+++ b/src/System.Private.DataContractSerialization/src/project.json
@@ -29,7 +29,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc2-23714",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23722",
         "System.Collections": "4.0.10",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",

--- a/src/System.Private.Uri/src/project.json
+++ b/src/System.Private.Uri/src/project.json
@@ -1,13 +1,13 @@
 {
   "frameworks": {
     "dotnet5.1": {
-   	  "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23616"
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23616"
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722"
       }
     }
   }

--- a/src/System.Reflection.DispatchProxy/src/facade/project.json
+++ b/src/System.Reflection.DispatchProxy/src/facade/project.json
@@ -1,9 +1,9 @@
 {
-    "frameworks": {
-        "netcore50": {
-            "dependencies": {
-                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
-            }
-        }
+  "frameworks": {
+    "netcore50": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722"
+      }
     }
+  }
 }

--- a/src/System.Reflection.Emit.ILGeneration/src/project.json
+++ b/src/System.Reflection.Emit.ILGeneration/src/project.json
@@ -2,12 +2,12 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "net46": {

--- a/src/System.Reflection.Emit.Lightweight/src/project.json
+++ b/src/System.Reflection.Emit.Lightweight/src/project.json
@@ -2,12 +2,12 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "net46": {

--- a/src/System.Reflection.Emit/src/project.json
+++ b/src/System.Reflection.Emit/src/project.json
@@ -2,12 +2,12 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "net46": {

--- a/src/System.Reflection.Extensions/src/project.json
+++ b/src/System.Reflection.Extensions/src/project.json
@@ -9,8 +9,9 @@
       "dependencies": {
         "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc2-23720",
         "System.Diagnostics.Contracts": "4.0.0",
-        "System.Diagnostics.Debug": "4.0.10.0",
-        "System.Reflection": "4.0.10.0",
+        "System.Diagnostics.Debug": "4.0.10",
+        "System.IO": "4.0.10",
+        "System.Reflection": "4.1.0-rc3-23722",
         "System.Reflection.Primitives": "4.0.0",
         "System.Resources.ResourceManager": "4.0.0",
         "System.Runtime": "4.0.20.0",

--- a/src/System.Reflection.Extensions/src/project.json
+++ b/src/System.Reflection.Extensions/src/project.json
@@ -2,12 +2,12 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23720"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc2-23720",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23722",
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",
         "System.IO": "4.0.10",

--- a/src/System.Reflection.Primitives/src/project.json
+++ b/src/System.Reflection.Primitives/src/project.json
@@ -2,14 +2,14 @@
   "frameworks": {
     "dotnet5.1": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23714"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
       "dependencies": {
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Runtime": "4.0.0",
-        "System.Threading": "4.0.0"        
+        "System.Threading": "4.0.0"
       }
     },
     "net46": {

--- a/src/System.Reflection.TypeExtensions/src/project.json
+++ b/src/System.Reflection.TypeExtensions/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23714"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "net46": {
@@ -17,7 +17,7 @@
         "System.Linq": "4.0.0",
         "System.Reflection": "4.0.10",
         "System.Runtime.Extensions": "4.0.10",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc2-23714"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23722"
       }
     }
   }

--- a/src/System.Reflection/src/netcore50aot/project.json
+++ b/src/System.Reflection/src/netcore50aot/project.json
@@ -1,9 +1,9 @@
 {
-    "frameworks": {
-        "netcore50": {
-            "dependencies": {
-                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
-            }
-        }
+  "frameworks": {
+    "netcore50": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722"
+      }
     }
+  }
 }

--- a/src/System.Reflection/src/project.json
+++ b/src/System.Reflection/src/project.json
@@ -2,12 +2,12 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "net46": {

--- a/src/System.Resources.ResourceManager/src/netcore50aot/project.json
+++ b/src/System.Resources.ResourceManager/src/netcore50aot/project.json
@@ -8,7 +8,7 @@
         "System.Diagnostics.Tracing": "4.0.0",
         "System.Globalization": "4.0.0",
         "System.Reflection": "4.0.10",
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc2-23707"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23722"
       }
     }
   }

--- a/src/System.Resources.ResourceManager/src/project.json
+++ b/src/System.Resources.ResourceManager/src/project.json
@@ -2,12 +2,12 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "net46": {

--- a/src/System.Runtime.CompilerServices.VisualC/src/project.json
+++ b/src/System.Runtime.CompilerServices.VisualC/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "net46": {

--- a/src/System.Runtime.Extensions/src/project.json
+++ b/src/System.Runtime.Extensions/src/project.json
@@ -1,19 +1,19 @@
 {
   "frameworks": {
     "dnxcore50": {
-        "dependencies": {
-            "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23707"
-        }
-    },
-    "net46":{
       "dependencies": {
-            "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
-    "netcore50":{
+    "net46": {
       "dependencies": {
-            "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc2-23707",
-            "Microsoft.TargetingPack.Private.WinRT": "1.0.0"
+        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0"
+      }
+    },
+    "netcore50": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23722",
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.0"
       }
     }
   }

--- a/src/System.Runtime.Handles/src/project.json
+++ b/src/System.Runtime.Handles/src/project.json
@@ -1,18 +1,18 @@
 {
   "frameworks": {
     "dnxcore50": {
-        "dependencies": {
-            "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23520"
-        }
-    },
-    "netcore50":{
       "dependencies": {
-            "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
-    "net46":{
+    "netcore50": {
       "dependencies": {
-            "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0-rc2-23530"
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722"
+      }
+    },
+    "net46": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0-rc2-23530"
       }
     }
   }

--- a/src/System.Runtime.Handles/src/project.json
+++ b/src/System.Runtime.Handles/src/project.json
@@ -12,7 +12,7 @@
     },
     "net46": {
       "dependencies": {
-        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0-rc2-23530"
+        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0"
       }
     }
   }

--- a/src/System.Runtime.InteropServices.PInvoke/src/project.json
+++ b/src/System.Runtime.InteropServices.PInvoke/src/project.json
@@ -1,18 +1,18 @@
 {
   "frameworks": {
     "dnxcore50": {
-        "dependencies": {
-            "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23607"
-        }
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
+      }
     },
     "netcore50": {
-            "dependencies": {
-                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
-            }
-    },
-    "net46":{
       "dependencies": {
-            "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0"
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722"
+      }
+    },
+    "net46": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0"
       }
     }
   }

--- a/src/System.Runtime.InteropServices.WindowsRuntime/src/project.json
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/src/project.json
@@ -2,12 +2,12 @@
   "frameworks": {
     "dotnet5.4": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23607"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722"
       }
     },
     "net46": {

--- a/src/System.Runtime.InteropServices/src/project.json
+++ b/src/System.Runtime.InteropServices/src/project.json
@@ -1,18 +1,18 @@
 {
   "frameworks": {
     "dnxcore50": {
-        "dependencies": {
-            "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23520"
-        }
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
+      }
     },
     "netcore50": {
-            "dependencies": {
-                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
-            }
-    },
-    "net46":{
       "dependencies": {
-            "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0"
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722"
+      }
+    },
+    "net46": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0"
       }
     }
   }

--- a/src/System.Runtime.Loader/src/project.json
+++ b/src/System.Runtime.Loader/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     }
   }

--- a/src/System.Runtime.Serialization.Json/src/netcore50aot/project.json
+++ b/src/System.Runtime.Serialization.Json/src/netcore50aot/project.json
@@ -1,9 +1,9 @@
 {
-    "frameworks": {
-        "netcore50": {
-            "dependencies": {
-                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
-            }
-        }
+  "frameworks": {
+    "netcore50": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722"
+      }
     }
+  }
 }

--- a/src/System.Runtime.Serialization.Json/src/project.json
+++ b/src/System.Runtime.Serialization.Json/src/project.json
@@ -2,12 +2,12 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "net46": {

--- a/src/System.Runtime.Serialization.Xml/src/netcore50aot/project.json
+++ b/src/System.Runtime.Serialization.Xml/src/netcore50aot/project.json
@@ -1,9 +1,9 @@
 {
-    "frameworks": {
-        "netcore50": {
-            "dependencies": {
-                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23713"
-            }
-        }
+  "frameworks": {
+    "netcore50": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722"
+      }
     }
+  }
 }

--- a/src/System.Runtime.Serialization.Xml/src/project.json
+++ b/src/System.Runtime.Serialization.Xml/src/project.json
@@ -2,12 +2,12 @@
   "frameworks": {
     "dotnet5.4": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23713"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23713"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "net46": {

--- a/src/System.Runtime.WindowsRuntime/src/project.json
+++ b/src/System.Runtime.WindowsRuntime/src/project.json
@@ -9,6 +9,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722",
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.0",
         "System.Collections": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Dynamic.Runtime": "4.0.10",

--- a/src/System.Runtime.WindowsRuntime/src/project.json
+++ b/src/System.Runtime.WindowsRuntime/src/project.json
@@ -1,27 +1,27 @@
 {
   "frameworks": {
-    "dotnet5.3":{
+    "dotnet5.3": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23616",
-        "Microsoft.TargetingPack.Private.WinRT":"1.0.0"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722",
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.0"
       }
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23616",
-        "System.Collections" :"4.0.0",
-        "System.Diagnostics.Debug":"4.0.10",
-        "System.Dynamic.Runtime":"4.0.10",
-        "System.Globalization":"4.0.0",
-        "System.IO":"4.0.10",
-        "System.Reflection":"4.0.0",
-        "System.Resources.ResourceManager":"4.0.0",
-        "System.Runtime":"4.0.20",
-        "System.Runtime.Extensions":"4.0.0",
-        "System.Runtime.InteropServices":"4.0.20",
-        "System.Runtime.InteropServices.WindowsRuntime":"4.0.0",
-        "System.Threading":"4.0.10.0",
-        "System.Threading.Tasks":"4.0.10.0"
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722",
+        "System.Collections": "4.0.0",
+        "System.Diagnostics.Debug": "4.0.10",
+        "System.Dynamic.Runtime": "4.0.10",
+        "System.Globalization": "4.0.0",
+        "System.IO": "4.0.10",
+        "System.Reflection": "4.0.0",
+        "System.Resources.ResourceManager": "4.0.0",
+        "System.Runtime": "4.0.20",
+        "System.Runtime.Extensions": "4.0.0",
+        "System.Runtime.InteropServices": "4.0.20",
+        "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+        "System.Threading": "4.0.10.0",
+        "System.Threading.Tasks": "4.0.10.0"
       }
     }
   }

--- a/src/System.Runtime/src/project.json
+++ b/src/System.Runtime/src/project.json
@@ -1,18 +1,18 @@
 {
   "frameworks": {
     "dnxcore50": {
-        "dependencies": {
-            "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23520"
-        }
-    },
-    "netcore50":{
-        "dependencies": {
-            "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23530"
-        }
-    },
-    "net46":{
       "dependencies": {
-            "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0-rc2-23530"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
+      }
+    },
+    "netcore50": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722"
+      }
+    },
+    "net46": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0-rc2-23530"
       }
     }
   }

--- a/src/System.Runtime/src/project.json
+++ b/src/System.Runtime/src/project.json
@@ -12,7 +12,7 @@
     },
     "net46": {
       "dependencies": {
-        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0-rc2-23530"
+        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0"
       }
     }
   }

--- a/src/System.Text.Encoding.Extensions/src/netcore50aot/project.json
+++ b/src/System.Text.Encoding.Extensions/src/netcore50aot/project.json
@@ -1,9 +1,9 @@
 {
-    "frameworks": {
-        "netcore50": {
-            "dependencies": {
-                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
-            }
-        }
+  "frameworks": {
+    "netcore50": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722"
+      }
     }
+  }
 }

--- a/src/System.Text.Encoding.Extensions/src/project.json
+++ b/src/System.Text.Encoding.Extensions/src/project.json
@@ -2,12 +2,12 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "net46": {

--- a/src/System.Text.Encoding/src/netcore50aot/project.json
+++ b/src/System.Text.Encoding/src/netcore50aot/project.json
@@ -1,9 +1,9 @@
 {
-    "frameworks": {
-        "netcore50": {
-            "dependencies": {
-                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
-            }
-        }
+  "frameworks": {
+    "netcore50": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722"
+      }
     }
+  }
 }

--- a/src/System.Text.Encoding/src/project.json
+++ b/src/System.Text.Encoding/src/project.json
@@ -2,12 +2,12 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "net46": {

--- a/src/System.Threading.Overlapped/src/project.json
+++ b/src/System.Threading.Overlapped/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "dotnet5.1": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23713"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
@@ -10,13 +10,13 @@
         "System.Diagnostics.Debug": "4.0.0.0",
         "System.Resources.ResourceManager": "4.0.0.0",
         "System.Runtime": "4.0.20.0",
-        "System.Runtime.Extensions": "4.0.0.0",       
+        "System.Runtime.Extensions": "4.0.0.0",
         "System.Runtime.Handles": "4.0.00.0",
-        "System.Runtime.InteropServices": "4.0.20.0",        
+        "System.Runtime.InteropServices": "4.0.20.0",
         "System.Threading": "4.0.10.0"
       }
     },
-    "net46":{
+    "net46": {
       "dependencies": {
         "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0"
       }

--- a/src/System.Threading.Tasks/src/project.json
+++ b/src/System.Threading.Tasks/src/project.json
@@ -2,17 +2,17 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23713"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
-    "net46":{
+    "net46": {
       "dependencies": {
         "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0"
       }
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc2-23713"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23722"
       }
     }
   }

--- a/src/System.Threading.Thread/src/project.json
+++ b/src/System.Threading.Thread/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "net46": {

--- a/src/System.Threading.ThreadPool/src/project.json
+++ b/src/System.Threading.ThreadPool/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "net46": {

--- a/src/System.Threading.Timer/src/netcore50aot/project.json
+++ b/src/System.Threading.Timer/src/netcore50aot/project.json
@@ -1,9 +1,9 @@
 {
-    "frameworks": {
-        "netcore50": {
-            "dependencies": {
-                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
-            }
-        }
+  "frameworks": {
+    "netcore50": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722"
+      }
     }
+  }
 }

--- a/src/System.Threading.Timer/src/project.json
+++ b/src/System.Threading.Timer/src/project.json
@@ -2,12 +2,12 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
       }
     },
     "net46": {

--- a/src/System.Threading/src/project.json
+++ b/src/System.Threading/src/project.json
@@ -1,18 +1,18 @@
 {
   "frameworks": {
     "dnxcore50": {
-        "dependencies": {
-            "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc2-23604"
-        }
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23722"
+      }
     },
     "netcore50": {
-            "dependencies": {
-                "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc2-23607"
-            }
-    },
-    "net46":{
       "dependencies": {
-            "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0"
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23722"
+      }
+    },
+    "net46": {
+      "dependencies": {
+        "Microsoft.TargetingPack.NetFramework.v4.6": "1.0.0"
       }
     }
   }


### PR DESCRIPTION
Fixes build warnings about version conflicts with System.Runtime.Extensions.

Add validation for Microsoft.TargetingPack.* packages and also normalizes them to the correct versions. 