### PR TITLE
Update code coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@
       </a>
       <br />
       <a href="http://dotnet-ci.cloudapp.net/job/dotnet_corefx/job/code_coverage_windows/Code_Coverage_Report">
-        <img src="http://dotnet-ci.cloudapp.net/job/dotnet_corefx/job/code_coverage_windows/Code_Coverage_Report/badge_combined.svg" alt="Code coverage" />
+        <img src="https://img.shields.io/jenkins/s/http/dotnet-ci.cloudapp.net/job/dotnet_corefx/code_coverage_windows.svg?label=coverage" alt="Code coverage" />
       </a>
     </td>
     <td>


### PR DESCRIPTION
There are two issues with the code coverage badge currently:
1. It's getting cached by the CI server and thus rarely reflects the current state.
2. It shows the most recently successful build, which means we might not know that recent builds have failed.

For now, I'm replacing it with a generic passed/failed badge.  Clicking on it will still take us to the code coverage report.