### PR TITLE
Escape *'s in dependency validation regex

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -80,11 +80,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ValidationPattern Include="^((System\..*)|(Microsoft\.CSharp)|(Microsoft\.NETCore.*)|(Microsoft\.TargetingPack\.Private.*)|(Microsoft\.Win32\..*)|(Microsoft\.VisualBasic))(?&lt;!TestData)$">
+    <ValidationPattern Include="^((System\..%2A)|(Microsoft\.CSharp)|(Microsoft\.NETCore.%2A)|(Microsoft\.TargetingPack\.Private.%2A)|(Microsoft\.Win32\..%2A)|(Microsoft\.VisualBasic))(?&lt;!TestData)$">
       <ExpectedPrerelease>rc3-23722</ExpectedPrerelease>
-    </ValidationPattern>
-    <ValidationPattern Include="^(System\..*TestData)$">
-      <ExpectedVersion>1.0.0-prerelease</ExpectedVersion>
     </ValidationPattern>
     <ValidationPattern Include="^(Microsoft\.TargetingPack\.NetFramework.%2A)$">
       <ExpectedVersion>1.0.0</ExpectedVersion>


### PR DESCRIPTION
MSBuild uses `*` as a special character in `Include`, so when there is only one `*` in the dependency validation rule regex MSBuild fails to find a match and the rule is ignored. I [escaped](https://msdn.microsoft.com/en-us/library/bb383819.aspx) the regexes. Thanks @weshaggard for finding this (https://github.com/dotnet/corefx/pull/5651).

I also removed the TestData rule because it doesn't seem to be validateable. Some packages are 1.0.0-prerelease and others are 1.0.1-prerelease, but TestData packages aren't produced in lockstep versions so this is normal.

cc @weshaggard @ericstj