### PR TITLE
Add Canterbury Corpus perf tests to Compression

### DIFF
--- a/src/System.IO.Compression/tests/Performance/Perf.DeflateStream.cs
+++ b/src/System.IO.Compression/tests/Performance/Perf.DeflateStream.cs
@@ -11,14 +11,13 @@ namespace System.IO.Compression.Tests
 {
     public class Perf_DeflateStream
     {
-        /// <returns></returns>
         private static string CreateCompressedFile(CompressionType type)
         {
-            const int fileSize = 100000000;
+            const int fileSize = 1000000;
             PerfUtils utils = new PerfUtils();
             string filePath = utils.GetTestFilePath() + ".gz";
             switch (type)
-            {    
+            {
                 case CompressionType.CryptoRandom:
                     using (RandomNumberGenerator rand = RandomNumberGenerator.Create())
                     {
@@ -54,7 +53,7 @@ namespace System.IO.Compression.Tests
 
         private static byte[] CreateBytesToCompress(CompressionType type)
         {
-            const int fileSize = 100000000;
+            const int fileSize = 500000;
             byte[] bytes = new byte[fileSize];
             switch (type)
             {
@@ -89,6 +88,14 @@ namespace System.IO.Compression.Tests
             return bytes;
         }
 
+        public enum CompressionType
+        {
+            CryptoRandom = 1,
+            RepeatedSegments = 2,
+            VeryRepetitive = 3,
+            NormalData = 4
+        }
+
         [Benchmark]
         [InlineData(CompressionType.CryptoRandom)]
         [InlineData(CompressionType.RepeatedSegments)]
@@ -103,7 +110,7 @@ namespace System.IO.Compression.Tests
             using (MemoryStream strippedMs = StripHeaderAndFooter.Strip(gzStream))
                 foreach (var iteration in Benchmark.Iterations)
                     using (iteration.StartMeasurement())
-                        for (int i = 0; i < 20000; i++)
+                        for (int i = 0; i < 10000; i++)
                         {
                             using (DeflateStream zip = new DeflateStream(strippedMs, CompressionMode.Decompress, leaveOpen: true))
                             {
@@ -138,13 +145,5 @@ namespace System.IO.Compression.Tests
                 File.Delete(filePath);
             }
         }
-    }
-
-    public enum CompressionType
-    {
-        CryptoRandom = 1,
-        RepeatedSegments = 2,
-        VeryRepetitive = 3,
-        NormalData = 4
     }
 }

--- a/src/System.IO.Compression/tests/Performance/Perf.GZipStream.cs
+++ b/src/System.IO.Compression/tests/Performance/Perf.GZipStream.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Xunit;
+using Microsoft.Xunit.Performance;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+
+namespace System.IO.Compression.Tests
+{
+    public class Perf_GZipStream
+    {
+        public static IEnumerable<object[]> CanterburyCorpus()
+        {
+            foreach (CompressionLevel compressionLevel in Enum.GetValues(typeof(CompressionLevel)))
+            {
+                foreach (int innerIterations in new int[] { 1, 10 })
+                {
+                    yield return new object[] { innerIterations, "alice29.txt", compressionLevel };
+                    yield return new object[] { innerIterations, "asyoulik.txt", compressionLevel };
+                    yield return new object[] { innerIterations, "cp.html", compressionLevel };
+                    yield return new object[] { innerIterations, "fields.c", compressionLevel };
+                    yield return new object[] { innerIterations, "grammar.lsp", compressionLevel };
+                    yield return new object[] { innerIterations, "kennedy.xls", compressionLevel };
+                    yield return new object[] { innerIterations, "lcet10.txt", compressionLevel };
+                    yield return new object[] { innerIterations, "plrabn12.txt", compressionLevel };
+                    yield return new object[] { innerIterations, "ptt5", compressionLevel };
+                    yield return new object[] { innerIterations, "sum", compressionLevel };
+                    yield return new object[] { innerIterations, "xargs.1", compressionLevel };
+                }
+            }
+        }
+
+        /// <summary>
+        /// Benchmark tests to measure the performance of individually compressing each file in the
+        /// Canterbury Corpus
+        /// </summary>
+        [Benchmark]
+        [MemberData("CanterburyCorpus")]
+        public void Compress_Canterbury(int innerIterations, string fileName, CompressionLevel compressLevel)
+        {
+            byte[] bytes = File.ReadAllBytes(Path.Combine("GZTestData", "Canterbury", fileName));
+            PerfUtils utils = new PerfUtils();
+            FileStream[] filestreams = new FileStream[innerIterations];
+            GZipStream[] gzips = new GZipStream[innerIterations];
+            string[] paths = new string[innerIterations];
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                for (int i = 0; i < innerIterations; i++)
+                {
+                    paths[i] = utils.GetTestFilePath();
+                    filestreams[i] = File.Create(paths[i]);
+                }
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < innerIterations; i++)
+                    {
+                        gzips[i] = new GZipStream(filestreams[i], compressLevel);
+                        gzips[i].Write(bytes, 0, bytes.Length);
+                        gzips[i].Flush();
+                        gzips[i].Dispose();
+                        filestreams[i].Dispose();
+                    }
+                for (int i = 0; i < innerIterations; i++)
+                    File.Delete(paths[i]);
+            }
+        }
+
+        /// <summary>
+        /// Benchmark tests to measure the performance of individually compressing each file in the
+        /// Canterbury Corpus
+        /// </summary>
+        [Benchmark]
+        [MemberData("CanterburyCorpus")]
+        public void Decompress_Canterbury(int innerIterations, string fileName, CompressionLevel compressLevel)
+        {
+            string zipFilePath = Path.Combine("GZTestData", "Canterbury", "GZcompressed", fileName + ".gz");
+            string sourceFilePath = Path.Combine("GZTestData", "Canterbury", fileName);
+            byte[] outputRead = new byte[new FileInfo(sourceFilePath).Length];
+            MemoryStream[] memories = new MemoryStream[innerIterations];
+            GZipStream[] gzips = new GZipStream[innerIterations];
+            foreach (var iteration in Benchmark.Iterations)
+            {
+                for (int i = 0; i < innerIterations; i++)
+                    memories[i] = new MemoryStream(File.ReadAllBytes(zipFilePath));
+
+                using (iteration.StartMeasurement())
+                    for (int i = 0; i < innerIterations; i++)
+                        using (GZipStream unzip = new GZipStream(memories[i], CompressionMode.Decompress))
+                            unzip.Read(outputRead, 0, outputRead.Length);
+
+                for (int i = 0; i < innerIterations; i++)
+                    memories[i].Dispose();
+            }
+        }
+    }
+
+}

--- a/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
@@ -52,12 +52,13 @@
     </Compile>
     <!-- Performance Tests -->
     <Compile Include="Performance\Perf.DeflateStream.cs" />
+    <Compile Include="Performance\Perf.GZipStream.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)System.IO.Compression.TestData\1.0.1-prerelease\content\**\*.*" />
+    <SupplementalTestData Include="$(PackagesDir)System.IO.Compression.TestData\1.0.2-prerelease\content\**\*.*" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.Compression/tests/project.json
+++ b/src/System.IO.Compression/tests/project.json
@@ -7,7 +7,7 @@
     "System.Diagnostics.Debug": "4.0.10",
     "System.IO": "4.0.10",
     "System.IO.Compression": "4.0.0",
-    "System.IO.Compression.TestData": "1.0.1-prerelease",
+    "System.IO.Compression.TestData": "1.0.2-prerelease",
     "System.IO.FileSystem": "4.0.0",
     "System.Linq": "4.0.0",
     "System.Runtime": "4.0.20",


### PR DESCRIPTION
Our System.IO.Compression tests were using deterministically generated random data to test compression/decompression time. While the results were useful, they missed a scope of tests that is required for good compression testing. This commit adds perf tests for GZipStream that make use of the popular Canterbury Corpus testing suite.

resolves #5423. Requires https://github.com/dotnet/corefx-testdata/pull/7

@stephentoub @bjjones 