### PR TITLE
Added BinarySearch to IList<T> and IList

### DIFF
--- a/src/System.Collections.NonGeneric/src/Resources/Strings.resx
+++ b/src/System.Collections.NonGeneric/src/Resources/Strings.resx
@@ -216,4 +216,13 @@
   <data name="NotSupported_SortedListNestedWrite" xml:space="preserve">
     <value>This operation is not supported on SortedList nested types because they require modifying the original SortedList.</value>
   </data>
+  <data name="ArgumentNull_IComparer" xml:space="preserve">
+    <value>IComparer cannot be null</value>
+  </data>
+  <data name="ArgumentNull_IList" xml:space="preserve">
+    <value>IList instance cannot be null</value>
+  </data>
+  <data name="InvalidOperation_IComparerFailed" xml:space="preserve">
+    <value>Failed to compare two elements</value>
+  </data>
 </root>

--- a/src/System.Collections.NonGeneric/src/System.Collections.NonGeneric.csproj
+++ b/src/System.Collections.NonGeneric/src/System.Collections.NonGeneric.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -20,6 +20,7 @@
     <Compile Include="System\Collections\Comparer.cs" />
     <Compile Include="System\Collections\DictionaryBase.cs" />
     <Compile Include="System\Collections\Hashtable.cs" />
+    <Compile Include="System\Collections\IListExtensions.cs" />
     <Compile Include="System\Collections\KeyValuePairs.cs" />
     <Compile Include="System\Collections\Queue.cs" />
     <Compile Include="System\Collections\ReadOnlyCollectionBase.cs" />

--- a/src/System.Collections.NonGeneric/src/System/Collections/IListExtensions.cs
+++ b/src/System.Collections.NonGeneric/src/System/Collections/IListExtensions.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Contracts;
+
+namespace System.Collections.Generic
+{
+    public static class IListExtensions
+    {
+        // Searches a section of the list for a given element using a binary search
+        // algorithm. Elements of the list are compared to the search value using
+        // the given IComparer interface. If comparer is null, elements of
+        // the list are compared to the search value using the IComparable
+        // interface, which in that case must be implemented by all elements of the
+        // list and the given search value. This method assumes that the given
+        // section of the list is already sorted; if this is not the case, the
+        // result will be incorrect.
+        //
+        // The method returns the index of the given value in the list. If the
+        // list does not contain the given value, the method returns a negative
+        // integer. The bitwise complement operator (~) can be applied to a
+        // negative result to produce the index of the first element (if any) that
+        // is larger than the given search value. This is also the index at which
+        // the search value should be inserted into the list in order for the list
+        // to remain sorted.
+        public static int BinarySearch(this IList list, int index, int count, object item, IComparer comparer)
+        {
+            if (list == null)
+                throw new NullReferenceException(SR.ArgumentNull_IList);
+            if (comparer == null)
+                throw new ArgumentNullException(SR.ArgumentNull_IComparer);
+            if (index < 0)
+                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (count < 0)
+                throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (list.Count - index < count)
+                throw new ArgumentException(SR.Argument_InvalidOffLen);
+            Contract.Ensures(Contract.Result<int>() <= index + count);
+            Contract.EndContractBlock();
+
+            int low = index;
+            int hi = index + count - 1;
+
+            while (low <= hi)
+            {
+                int i = GetMedian(low, hi);
+                int c;
+                try
+                {
+                    c = comparer.Compare(list[i], item);
+                }
+                catch (Exception e)
+                {
+                    throw new InvalidOperationException(SR.InvalidOperation_IComparerFailed, e);
+                }
+                if (c == 0) return i;
+                if (c < 0)
+                {
+                    low = i + 1;
+                }
+                else {
+                    hi = i - 1;
+                }
+            }
+
+            return ~low;
+        }
+
+        public static int BinarySearch(this IList list, object item, IComparer comparer)
+        {
+            Contract.Ensures(Contract.Result<int>() <= list.Count);
+            return list.BinarySearch(0, list.Count, item, comparer);
+        }
+
+        private static int GetMedian(int low, int hi)
+        {
+            Contract.Requires(low <= hi);
+            Contract.Assert(hi - low >= 0, "Length overflow!");
+            return low + ((hi - low) >> 1);
+        }
+    }
+}

--- a/src/System.Collections.NonGeneric/tests/IListExtensions/IListBinarySearch.cs
+++ b/src/System.Collections.NonGeneric/tests/IListExtensions/IListBinarySearch.cs
@@ -1,0 +1,147 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Collections.Test
+{
+    public class IListBinarySearch
+    {
+        private static string[] _dota =
+        {
+            "Abaddon","Alchemist","Ancient Apparition","Anti-Mage","Arc Warden","Axe","Bane","Batrider","Beastmaster","Bloodseeker","Bounty Hunter","Brewmaster","Bristleback","Broodmother","Centaur Warrunner","Chaos Knight","Chen","Clinkz"
+        };
+
+        [Fact]
+        public static void BinarySearchTest()
+        {
+            IList list = new List<string>(_dota);
+
+            //search for each item
+            for (int i = 0; i < list.Count; i++)
+                Assert.Equal(i, list.BinarySearch(list[i], new StringComparer())); //"Binary Search should have returned the same index."
+
+            //ensure no side effects
+            for (int i = 0; i < list.Count; i++)
+                Assert.Equal(list[i], list[i]); //"Should not have changed the items in the array/list."
+
+            //search for each item starting from last item
+            for (int i = list.Count - 1; i >= 0; i--)
+                Assert.Equal(i, list.BinarySearch(list[i], new StringComparer())); //"Binary Search should have returned the same index starting from the tend."
+
+            //ensure no side effects
+            for (int i = 0; i < list.Count; i++)
+                Assert.Equal(list[i], list[i]); //"Should not have changed the items in the array/list."
+        }
+
+        [Fact]
+        public static void BinarySearchSubsetTest()
+        {
+            IList list = new List<string>(_dota);
+            int index = 5;
+            int count = list.Count - 5;
+            //search for each item
+            for (int i = index; i < index + count; i++)
+            {
+                Assert.Equal(i, list.BinarySearch(index, count, list[i], new StringComparer())); //"Binary search should have returned the same index starting search from the beginning"
+            }
+
+            //ensure no side effects
+            for (int i = 0; i < list.Count; i++)
+                Assert.Equal(list[i], list[i]); //"Should not have changed the items in the array/list."
+
+            //search for each item starting from last item
+            for (int i = index + count - 1; i >= index; i--)
+            {
+                Assert.Equal(i, list.BinarySearch(index, count, list[i], new StringComparer())); //"Binary search should have returned the same index starting search from the end"
+            }
+
+            //ensure no side effects
+            for (int i = 0; i < list.Count; i++)
+                Assert.Equal(list[i], list[i]); //"Should not have changed the items in the array/list."
+        }
+
+        [Fact]
+        public static void BinarySearchNegativeTest()
+        {
+            IList listX = new List<int>();
+            for (int i = 0; i < 100; i++)
+            {
+                listX.Add(i);
+            }
+            IList listY = new List<int>();
+            for (int i = 0; i < 10; i++)
+            {
+                listY.Add(100 + i);
+            }
+            //search for each item
+            for (int i = 0; i < listY.Count; i++)
+                Assert.True(-1 >= listX.BinarySearch(listY[i], new IntComparer())); //"Should not have found item with BinarySearch."
+
+            //ensure no side effects
+            for (int i = 0; i < listX.Count; i++)
+                Assert.Equal(listX[i], listX[i]); //"Should not have changed the items in the array/list."
+        }
+
+        [Fact]
+        public static void BinarySearchNullIListThowsNullReferenceExceptionTest()
+        {
+            IList list = null;
+            Assert.Throws<NullReferenceException>(() => list.BinarySearch(1, new IntComparer())); //"Should have thrown NullReferenceException with null IList"
+        }
+
+        [Fact]
+        public static void BinarySearchValidationsTest()
+        {
+            IList list = new List<string>(_dota);
+            Assert.Throws<ArgumentNullException>(()=> list.BinarySearch(1,null));//"ArgumentNullException should be thrown when IComparer is null."
+            Assert.Throws<ArgumentException>(() => list.BinarySearch(0, list.Count + 1, list[0], new StringComparer())); //"Finding items longer than array should throw ArgumentException"
+            Assert.Throws<ArgumentOutOfRangeException>(() => list.BinarySearch(-1, list.Count, list[0], new StringComparer())); //"ArgumentOutOfRangeException should be thrown on negative index."
+            Assert.Throws<ArgumentOutOfRangeException>(() => list.BinarySearch(0, -1, list[0], new StringComparer())); //"ArgumentOutOfRangeException should be thrown on negative count."
+            Assert.Throws<ArgumentException>(() => list.BinarySearch(list.Count + 1, list.Count, list[0], new StringComparer())); //"ArgumentException should be thrown on index greater than length of array."
+        }
+
+        private class StringComparer : IComparer
+        {
+            public int Compare(object x, object y)
+            {
+                if (null == x)
+                    if (null == y)
+                        return 0;
+                    else
+                        return -1;
+                if (null == y)
+                    return 1;
+                if (null == x as string)
+                    if (null == y as string)
+                        return 0;
+                    else
+                        return -1;
+                return (x as string).CompareTo((string)y);
+            }
+        }
+
+        private class IntComparer : IComparer
+        {
+            public int Compare(object x, object y)
+            {
+                int xInt;
+                int yInt;
+                if (null == x)
+                    if (null == y)
+                        return 0;
+                    else
+                        return -1;
+                if (null == y)
+                    return 1;
+
+                xInt = Convert.ToInt32(x);
+                yInt = Convert.ToInt32(y);
+
+                return xInt.CompareTo(yInt);
+            }
+        }
+    }
+}
+

--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -10,7 +10,6 @@
     <ProjectGuid>{EE95AE39-845A-42D3-86D0-8065DBE56612}</ProjectGuid>
     <IncludePerformanceTests>true</IncludePerformanceTests>
   </PropertyGroup>
-
   <!-- Default configurations to help VS understand the configurations -->
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
   </PropertyGroup>
@@ -91,6 +90,7 @@
     <Compile Include="Hashtable\PropertyValuesTests.cs" />
     <Compile Include="Hashtable\RemoveTests.cs" />
     <Compile Include="Hashtable\SynchronizedTests.cs" />
+    <Compile Include="IListExtensions\IListBinarySearch.cs" />
     <Compile Include="Queue\Queue_Clear.cs" />
     <Compile Include="Queue\Queue_Clone.cs" />
     <Compile Include="Queue\Queue_Contains.cs" />
@@ -162,5 +162,6 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Collections/ref/System.Collections.cs
+++ b/src/System.Collections/ref/System.Collections.cs
@@ -595,4 +595,10 @@ namespace System.Collections.Generic
             void System.Collections.IEnumerator.Reset() { }
         }
     }
+    public static partial class IListExtensions
+    {
+        public static int BinarySearch<T>(this IList<T> list, int index, int count, T item, IComparer<T> comparer) { return default(int); }
+        public static int BinarySearch<T>(this IList<T> list, T item) { return default(int); }
+        public static int BinarySearch<T>(this IList<T> list, T item, IComparer<T> comparer) { return default(int); }
+    }
 }

--- a/src/System.Collections/src/Resources/Strings.resx
+++ b/src/System.Collections/src/Resources/Strings.resx
@@ -228,4 +228,10 @@
   <data name="NotSupported_SortedListNestedWrite" xml:space="preserve">
     <value>This operation is not supported on SortedList nested types because they require modifying the original SortedList.</value>
   </data>
+  <data name="ArgumentNull_IList" xml:space="preserve">
+    <value>IList instance cannot be null</value>
+  </data>
+  <data name="InvalidOperation_IComparerFailed" xml:space="preserve">
+    <value>Failed to compare two elements</value>
+  </data>
 </root>

--- a/src/System.Collections/src/System.Collections.csproj
+++ b/src/System.Collections/src/System.Collections.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -65,6 +65,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="System\Collections\Generic\IListExtensions.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Collections/src/System/Collections/Generic/IListExtensions.cs
+++ b/src/System.Collections/src/System/Collections/Generic/IListExtensions.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics.Contracts;
+
+namespace System.Collections.Generic
+{
+    public static class IListExtensions
+    {
+        // Searches a section of the list for a given element using a binary search
+        // algorithm. Elements of the list are compared to the search value using
+        // the given IComparer interface. If comparer is null, elements of
+        // the list are compared to the search value using the IComparable
+        // interface, which in that case must be implemented by all elements of the
+        // list and the given search value. This method assumes that the given
+        // section of the list is already sorted; if this is not the case, the
+        // result will be incorrect.
+        //
+        // The method returns the index of the given value in the list. If the
+        // list does not contain the given value, the method returns a negative
+        // integer. The bitwise complement operator (~) can be applied to a
+        // negative result to produce the index of the first element (if any) that
+        // is larger than the given search value. This is also the index at which
+        // the search value should be inserted into the list in order for the list
+        // to remain sorted.
+        public static int BinarySearch<T>(this IList<T> list, int index, int count, T item, IComparer<T> comparer)
+        {
+            if (list == null)
+                throw new NullReferenceException(SR.ArgumentNull_IList);
+            if (index < 0)
+                throw new ArgumentOutOfRangeException("index", SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (count < 0)
+                throw new ArgumentOutOfRangeException("count", SR.ArgumentOutOfRange_NeedNonNegNum);
+            if (list.Count - index < count)
+                throw new ArgumentException(SR.Argument_InvalidOffLen);
+            Contract.Ensures(Contract.Result<int>() <= index + count);
+            Contract.EndContractBlock();
+
+            if (comparer == null) comparer = Comparer<T>.Default;
+
+            int low = index;
+            int hi = index + count - 1;
+
+            while (low <= hi)
+            {
+                int i = GetMedian(low, hi);
+                int c;
+                try
+                {
+                    c = comparer.Compare(list[i], item);
+                }
+                catch (Exception e)
+                {
+                    throw new InvalidOperationException(SR.InvalidOperation_IComparerFailed, e);
+                }
+                if (c == 0) return i;
+                if (c < 0)
+                {
+                    low = i + 1;
+                }
+                else {
+                    hi = i - 1;
+                }
+            }
+
+            return ~low;
+        }
+
+        public static int BinarySearch<T>(this IList<T> list, T item)
+        {
+            Contract.Ensures(Contract.Result<int>() <= list.Count);
+            return list.BinarySearch(0, list.Count, item, null);
+        }
+
+        public static int BinarySearch<T>(this IList<T> list, T item, IComparer<T> comparer)
+        {
+            Contract.Ensures(Contract.Result<int>() <= list.Count);
+            return list.BinarySearch(0, list.Count, item, comparer);
+        }
+
+        private static int GetMedian(int low, int hi)
+        {
+            Contract.Requires(low <= hi);
+            Contract.Assert(hi - low >= 0, "Length overflow!");
+            return low + ((hi - low) >> 1);
+        }
+    }
+}

--- a/src/System.Collections/tests/Generic/IListExtensions/IListBinarySearch.cs
+++ b/src/System.Collections/tests/Generic/IListExtensions/IListBinarySearch.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Generic;
+using Xunit;
+
+namespace System.Collections.Test
+{
+    public class IListBinarySearch
+    {
+        private static string[] _dota =
+        {
+            "Abaddon","Alchemist","Ancient Apparition","Anti-Mage","Arc Warden","Axe","Bane","Batrider","Beastmaster","Bloodseeker","Bounty Hunter","Brewmaster","Bristleback","Broodmother","Centaur Warrunner","Chaos Knight","Chen","Clinkz"
+        };
+
+        [Fact]
+        public static void BinarySearchTest()
+        {
+            IList<string> list = new List<string>(_dota);
+            
+            //search for each item
+            for (int i = 0; i < list.Count; i++)
+                Assert.Equal(i, list.BinarySearch(list[i])); //"Binary Search should have returned the same index."
+
+            //ensure no side effects
+            for (int i = 0; i < list.Count; i++)
+                Assert.Equal(list[i], list[i]); //"Should not have changed the items in the array/list."
+
+            //search for each item starting from last item
+            for (int i = list.Count - 1; i >= 0; i--)
+                Assert.Equal(i, list.BinarySearch(list[i])); //"Binary Search should have returned the same index starting from the tend."
+
+            //ensure no side effects
+            for (int i = 0; i < list.Count; i++)
+                Assert.Equal(list[i], list[i]); //"Should not have changed the items in the array/list."
+        }
+
+        [Fact]
+        public static void BinarySearchSubsetTest()
+        {
+            IList<string> list = new List<string>(_dota);
+            int index = 5;
+            int count = list.Count - 5;
+            //search for each item
+            for (int i = index; i < index + count; i++)
+            {
+                Assert.Equal(i, list.BinarySearch(index, count, list[i], new ValueComparer<string>())); //"Binary search should have returned the same index starting search from the beginning"
+            }
+
+            //ensure no side effects
+            for (int i = 0; i < list.Count; i++)
+                Assert.Equal(list[i], list[i]); //"Should not have changed the items in the array/list."
+
+            //search for each item starting from last item
+            for (int i = index + count - 1; i >= index; i--)
+            {
+                Assert.Equal(i, list.BinarySearch(index, count, list[i], new ValueComparer<string>())); //"Binary search should have returned the same index starting search from the end"
+            }
+
+            //ensure no side effects
+            for (int i = 0; i < list.Count; i++)
+                Assert.Equal(list[i], list[i]); //"Should not have changed the items in the array/list."
+        }
+
+        [Fact]
+        public static void BinarySearchNegativeTest()
+        {
+            IList<int> listX = new List<int>();
+            for (int i = 0; i < 100; i++)
+            {
+                listX.Add(i);
+            }
+            IList<int> listY = new List<int>();
+            for (int i = 0; i < 10; i++)
+            {
+                listY.Add(100 + i);
+            }
+            //search for each item
+            for (int i = 0; i < listY.Count; i++)
+                Assert.True(-1 >= listX.BinarySearch(listY[i], new ValueComparer<int>())); //"Should not have found item with BinarySearch."
+
+            //ensure no side effects
+            for (int i = 0; i < listX.Count; i++)
+                Assert.Equal(listX[i], listX[i]); //"Should not have changed the items in the array/list."
+        }
+
+        [Fact]
+        public static void BinarySearchNullIListThowsNullReferenceExceptionTest()
+        {
+            IList<int> list = null;
+            Assert.Throws<NullReferenceException>(() => list.BinarySearch(1)); //"Should have thrown NullReferenceException with null IList"
+        }
+
+        [Fact]
+        public static void BinarySearchValidationsTest()
+        {
+            IList<string> list = new List<string>(_dota);
+            Assert.Throws<ArgumentException>(() => list.BinarySearch(0, list.Count + 1, list[0], new ValueComparer<string>())); //"Finding items longer than array should throw ArgumentException"
+            Assert.Throws<ArgumentOutOfRangeException>(() => list.BinarySearch(-1, list.Count, list[0], new ValueComparer<string>())); //"ArgumentOutOfRangeException should be thrown on negative index."
+            Assert.Throws<ArgumentOutOfRangeException>(() => list.BinarySearch(0, -1, list[0], new ValueComparer<string>())); //"ArgumentOutOfRangeException should be thrown on negative count."
+            Assert.Throws<ArgumentException>(() => list.BinarySearch(list.Count + 1, list.Count, list[0], new ValueComparer<string>())); //"ArgumentException should be thrown on index greater than length of array."
+        }
+
+        private class ValueComparer<T> : IComparer<T> where T : IComparable<T>
+        {
+            public int Compare(T x, T y)
+            {
+                if (null == x)
+                    if (null == y)
+                        return 0;
+                    else
+                        return -1;
+                if (null == y)
+                    return 1;
+
+                return x.CompareTo(y);
+            }
+        }
+    }
+}
+

--- a/src/System.Collections/tests/System.Collections.Tests.csproj
+++ b/src/System.Collections/tests/System.Collections.Tests.csproj
@@ -23,6 +23,8 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
     </ProjectReference>
+    <ProjectReference Include="..\ref\System.Collections.csproj">
+    </ProjectReference>
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <OutputItemType>Content</OutputItemType>
@@ -71,6 +73,7 @@
     <Compile Include="Generic\HashSet\SetCollectionComparerTests.cs" />
     <Compile Include="Generic\HashSet\SetCollectionDuplicateItemTests.cs" />
     <Compile Include="Generic\HashSet\SetCollectionRelationshipTests.cs" />
+    <Compile Include="Generic\IListExtensions\IListBinarySearch.cs" />
     <Compile Include="Generic\LinkedList\LinkedListNodeTests.cs" />
     <Compile Include="Generic\LinkedList\LinkedList_AddBeforeAfterTests.cs" />
     <Compile Include="Generic\LinkedList\LinkedList_AddTests.cs" />


### PR DESCRIPTION
Issue: #4697 
Added extension method on IList<T> and IList.
Added tests for the same.

Note: To make the test compile and run I had to add direct project reference from System.Collections.Test project to ref/System.Collections. I hope this will not cause any unintended side effects.