### PR TITLE
Add hashcode checks to ConcurrentDictionary

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -383,7 +383,7 @@ namespace System.Collections.Concurrent
                     {
                         Debug.Assert((prev == null && curr == tables._buckets[bucketNo]) || prev._next == curr);
 
-                        if (_comparer.Equals(curr._key, key))
+                        if (hashcode == curr._hashcode && _comparer.Equals(curr._key, key))
                         {
                             if (matchValue)
                             {
@@ -451,7 +451,7 @@ namespace System.Collections.Concurrent
 
             while (n != null)
             {
-                if (_comparer.Equals(n._key, key))
+                if (hashcode == n._hashcode && _comparer.Equals(n._key, key))
                 {
                     value = n._value;
                     return true;
@@ -528,7 +528,7 @@ namespace System.Collections.Concurrent
                     for (Node node = tables._buckets[bucketNo]; node != null; node = node._next)
                     {
                         Debug.Assert((prev == null && node == tables._buckets[bucketNo]) || prev._next == node);
-                        if (_comparer.Equals(node._key, key))
+                        if (hashcode == node._hashcode && _comparer.Equals(node._key, key))
                         {
                             if (valueComparer.Equals(node._value, comparisonValue))
                             {
@@ -787,7 +787,7 @@ namespace System.Collections.Concurrent
                     for (Node node = tables._buckets[bucketNo]; node != null; node = node._next)
                     {
                         Debug.Assert((prev == null && node == tables._buckets[bucketNo]) || prev._next == node);
-                        if (_comparer.Equals(node._key, key))
+                        if (hashcode == node._hashcode && _comparer.Equals(node._key, key))
                         {
                             // The key was found in the dictionary. If updates are allowed, update the value for that key.
                             // We need to create a new node for the update, in order to support TValue types that cannot


### PR DESCRIPTION
As with Dictionary, ConcurrentDictionary stores the hashcode of a key in the node with a key.  However, whereas Dictionary uses that hashcode in comparisons prior to invoking the comparer, ConcurrentDictionary currently does not.  This fixes that by adding the hashcode comparison check.  For cases where multiple keys need to be examined from the same bucket and where the comparison operation isn't cheap, this reduces overheads by saving on comparison invocations.

Fixes #5518 (see comments at end)
cc: @vancem, @ellismg 