### PR TITLE
Use FileStream's ctor instead of File.Open when all access is synchronous

### DIFF
--- a/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Unix.cs
+++ b/src/System.Diagnostics.FileVersionInfo/src/System/Diagnostics/FileVersionInfo.Unix.cs
@@ -43,7 +43,7 @@ namespace System.Diagnostics
             try
             {
                 // Try to load the file using the managed metadata reader
-                using (FileStream assemblyStream = File.OpenRead(_fileName))
+                using (FileStream assemblyStream = new FileStream(_fileName, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 0x1000, useAsync: false))
                 using (PEReader peReader = new PEReader(assemblyStream))
                 {
                     if (peReader.HasMetadata)

--- a/src/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.cs
+++ b/src/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFile.cs
@@ -158,7 +158,7 @@ namespace System.IO.Compression
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]  // See comment in the body.
         public static ZipArchive Open(String archiveFileName, ZipArchiveMode mode, Encoding entryNameEncoding)
         {
-            // Relies on File.Open for checking of archiveFileName
+            // Relies on FileStream's ctor for checking of archiveFileName
 
             FileMode fileMode;
             FileAccess access;
@@ -193,7 +193,7 @@ namespace System.IO.Compression
             // If the ctor completes without throwing, we know fs has been successfully stores in the archive;
             // If the ctor throws, we need to close it here.
 
-            FileStream fs = File.Open(archiveFileName, fileMode, access, fileShare);
+            FileStream fs = new FileStream(archiveFileName, fileMode, access, fileShare, bufferSize: 0x1000, useAsync: false);
 
             try
             {

--- a/src/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.cs
+++ b/src/System.IO.Compression.ZipFile/src/System/IO/Compression/ZipFileExtensions.cs
@@ -178,11 +178,11 @@ namespace System.IO.Compression
             // Checking of compressionLevel is passed down to DeflateStream and the IDeflater implementation
             // as it is a pugable component that completely encapsulates the meaning of compressionLevel.
 
-            // Argument checking gets passed down to File.Open and CreateEntry
+            // Argument checking gets passed down to FileStream's ctor and CreateEntry
             Contract.Ensures(Contract.Result<ZipArchiveEntry>() != null);
             Contract.EndContractBlock();
 
-            using (Stream fs = File.Open(sourceFileName, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (Stream fs = new FileStream(sourceFileName, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 0x1000, useAsync: false))
             {
                 ZipArchiveEntry entry = compressionLevel.HasValue
                                                 ? destination.CreateEntry(entryName, compressionLevel.Value)
@@ -276,13 +276,13 @@ namespace System.IO.Compression
             if (destinationFileName == null)
                 throw new ArgumentNullException("destinationFileName");
 
-            // Rely on File.Open for further checking destinationFileName parameter
+            // Rely on FileStream's ctor for further checking destinationFileName parameter
 
             Contract.EndContractBlock();
 
             FileMode fMode = overwrite ? FileMode.Create : FileMode.CreateNew;
 
-            using (Stream fs = File.Open(destinationFileName, fMode, FileAccess.Write, FileShare.None))
+            using (Stream fs = new FileStream(destinationFileName, fMode, FileAccess.Write, FileShare.None, bufferSize: 0x1000, useAsync: false))
             {
                 using (Stream es = source.Open())
                     es.CopyTo(fs);

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/StringParsingHelpers.Statistics.cs
@@ -397,7 +397,7 @@ namespace System.Net.NetworkInformation
 
         internal static IPInterfaceStatisticsTable ParseInterfaceStatisticsTableFromFile(string filePath, string name)
         {
-            using (StreamReader sr = File.OpenText(filePath))
+            using (StreamReader sr = new StreamReader(new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 0x1000, useAsync: false)))
             {
                 sr.ReadLine();
                 sr.ReadLine();


### PR DESCRIPTION
Several places in our libraries use use File.Open* methods.  These are simple wrappers for FileStream's constructors, and all use the default "useAsync" value of true (this varies from the the full framework, where the default is false).  When only using synchronous Stream methods, a value of true is pure overhead, as each Read/Write/Flush method needs to schedule the asynchronous operation and then block waiting for it to complete.  In the few places we're using File.Open* in this manner, I've changed them to instead use FileStream's ctor directly, to avoid the unnecessary access overheads.

cc: @ericstj, @ianhays, @mellinoe 