### PR TITLE
Read all of the certs from a Unix root cert bundle file

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Security.Cryptography.X509Certificates.Tests
@@ -174,6 +175,37 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     // Assert.DoesNotThrow
                     store.Open(permissions);
                 }
+            }
+        }
+
+        [Fact]
+        public static void MachineRootStore_NonEmpty()
+        {
+            // On everything except OS X we're using the normal system default trust store.
+            // So, if we've read things right, there should be a respectable amount of
+            // certificates in the store.
+            //
+            // On OSX this devolves into a "can we open the store and load the collection
+            // without throwing" test, but eventually we'll have tighter guarantees there.
+            //
+            // This test will fail on systems where the administrator has gone out of their
+            // way to prune the trusted CA list down below this threshold.
+            //
+            // As of 2016-01-25, Ubuntu 14.04 has 169, and CentOS 7.1 has 175, so that'd be
+            // quite a lot of pruning.
+            int minimumThreshold = 5;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                minimumThreshold = 0;
+            }
+
+            using (X509Store store = new X509Store(StoreName.Root, StoreLocation.LocalMachine))
+            {
+                store.Open(OpenFlags.ReadOnly);
+
+                int certCount = store.Certificates.Count;
+                Assert.InRange(certCount, minimumThreshold, int.MaxValue);
             }
         }
     }


### PR DESCRIPTION
Ubuntu used a hybrid of "one cert per file" and "one file for the entire CA bundle", and that, combined with cert-from-file not working at the time, led to the store only reading the first cert from each file.

CentOS only pushes one file as the whole of the CA bundle.  In supporting this change we also stop calling ReadAllBytes() and moves reading potentially large files back to as-needed streaming models.

This would also solve the problem in #5555 for CentOS, but not OS X.
Fixes #5685.

cc: @stephentoub