### PR TITLE
Enable System.Net.Security tests on OS X

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -12,7 +12,7 @@ namespace System.Net.Security.Tests
 {
     public class CertificateValidationRemoteServer
     {
-        [ActiveIssue(5555, PlatformID.Linux)]
+        [ActiveIssue(5555, PlatformID.AnyUnix)]
         [Fact]
         public async Task CertificateValidationRemoteServer_EndToEnd_Ok()
         {

--- a/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
@@ -62,28 +62,6 @@ namespace System.Net.Security.Tests
             await Assert.ThrowsAsync(expectedException, () => ClientAsyncSslHelper(serverProtocol, clientProtocol));
         }
 
-        [Theory]
-        [MemberData("ProtocolMismatchData_Tls11_Tls12_Windows_Linux")]
-        [PlatformSpecific(PlatformID.Windows | PlatformID.Linux)]
-        public async Task ClientAsyncAuthenticate_MismatchProtocols_Tls11_Tls12_Fails_Linux_Windows(
-            SslProtocols serverProtocol,
-            SslProtocols clientProtocol,
-            Type expectedException)
-        {
-            await Assert.ThrowsAsync(expectedException, () => ClientAsyncSslHelper(serverProtocol, clientProtocol));
-        }
-
-        [Theory]
-        [MemberData("ProtocolMismatchData_Tls11_Tls12_OSX")]
-        [PlatformSpecific(PlatformID.OSX)]
-        public async Task ClientAsyncAuthenticate_MismatchProtocols_Tls11_Tls12_Fails_OSX(
-            SslProtocols serverProtocols,
-            SslProtocols clientProtocols,
-            Type expectedException)
-        {
-            await Assert.ThrowsAsync(expectedException, () => ClientAsyncSslHelper(serverProtocols, clientProtocols));
-        }
-
         [Fact]
         public async Task ClientAsyncAuthenticate_AllServerAllClient_Success()
         {
@@ -128,16 +106,7 @@ namespace System.Net.Security.Tests
             yield return new object[] { SslProtocols.Tls11, SslProtocols.Tls, typeof(AuthenticationException) };
             yield return new object[] { SslProtocols.Tls12, SslProtocols.Tls, typeof(AuthenticationException) };
             yield return new object[] { SslProtocols.Tls12, SslProtocols.Tls11, typeof(AuthenticationException) };
-        }
-
-        private static IEnumerable<object[]> ProtocolMismatchData_Tls11_Tls12_Windows_Linux()
-        {
             yield return new object[] { SslProtocols.Tls11, SslProtocols.Tls12, typeof(IOException) };
-        }
-
-        private static IEnumerable<object[]> ProtocolMismatchData_Tls11_Tls12_OSX()
-        {
-            yield return new object[] { SslProtocols.Tls11, SslProtocols.Tls12, typeof(AuthenticationException) };
         }
 
         #region Helpers

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -9,7 +9,6 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{A55A2B9A-830F-4330-A0E7-02A9FB30ABD2}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <UnsupportedPlatforms>OSX;FreeBSD</UnsupportedPlatforms>
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(TargetsWindows)' == 'true' and '$(ProjectJson)' == '' ">


### PR DESCRIPTION
Fixes #4606 
cc: @bartonjs, @vijaykota, @cipop, @davidsh 