### PR TITLE
RC2: Read all of the certs from a Unix root cert bundle file

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
@@ -1,3 +1,4 @@
+using System.Runtime.InteropServices;
 using Xunit;
 
 namespace System.Security.Cryptography.X509Certificates.Tests
@@ -174,6 +175,37 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                     // Assert.DoesNotThrow
                     store.Open(permissions);
                 }
+            }
+        }
+
+        [Fact]
+        public static void MachineRootStore_NonEmpty()
+        {
+            // On everything except OS X we're using the normal system default trust store.
+            // So, if we've read things right, there should be a respectable amount of
+            // certificates in the store.
+            //
+            // On OSX this devolves into a "can we open the store and load the collection
+            // without throwing" test, but eventually we'll have tighter guarantees there.
+            //
+            // This test will fail on systems where the administrator has gone out of their
+            // way to prune the trusted CA list down below this threshold.
+            //
+            // As of 2016-01-25, Ubuntu 14.04 has 169, and CentOS 7.1 has 175, so that'd be
+            // quite a lot of pruning.
+            int minimumThreshold = 5;
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                minimumThreshold = 0;
+            }
+
+            using (X509Store store = new X509Store(StoreName.Root, StoreLocation.LocalMachine))
+            {
+                store.Open(OpenFlags.ReadOnly);
+
+                int certCount = store.Certificates.Count;
+                Assert.InRange(certCount, minimumThreshold, int.MaxValue);
             }
         }
     }


### PR DESCRIPTION
RC2 version of #5686.

Ubuntu uses a hybrid model of "one giant file" and "one cert per file", which led to the initial implementation of X509Store being what it is.

CentOS just uses the "one giant file" approach, so we only read the first cert out of it and call it a day.

When reading the system cert files we should read until the file is drained.