### PR TITLE
Disable thread-tracking in SpinLock in ArrayPool

### DIFF
--- a/src/System.Buffers/src/System/Buffers/DefaultArrayPoolBucket.cs
+++ b/src/System.Buffers/src/System/Buffers/DefaultArrayPoolBucket.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Diagnostics;
 using System.Threading;
 
@@ -25,7 +24,7 @@ namespace System.Buffers
         /// </summary>
         internal DefaultArrayPoolBucket(int bufferLength, int numberOfBuffers, int poolId)
         {
-            _lock = new SpinLock();
+            _lock = new SpinLock(Debugger.IsAttached); // only enable thread tracking if debugger is attached; it adds non-trivial overheads to Enter/Exit
             _data = new T[numberOfBuffers][];
             _bufferLength = bufferLength;
             _exhaustedEventSent = false;


### PR DESCRIPTION
It's great for debugging purposes but adds cost.  On a simple microbenchmark that repeatedly does:
```C#
byte[] buffer = ArrayPool<byte>.Shared.Rent(4096);
ArrayPool<byte>.Shared.Return(buffer);
```
turning it off improves throughput by ~2.5x on my machine.

cc: @sokket, @KrzysztofCwalina, @rynowak 