### PR TITLE
RC2: Add hashcode checks to ConcurrentDictionary

### DIFF
--- a/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
+++ b/src/System.Collections.Concurrent/src/System/Collections/Concurrent/ConcurrentDictionary.cs
@@ -383,7 +383,7 @@ namespace System.Collections.Concurrent
                     {
                         Debug.Assert((prev == null && curr == tables._buckets[bucketNo]) || prev._next == curr);
 
-                        if (_comparer.Equals(curr._key, key))
+                        if (hashcode == curr._hashcode && _comparer.Equals(curr._key, key))
                         {
                             if (matchValue)
                             {
@@ -451,7 +451,7 @@ namespace System.Collections.Concurrent
 
             while (n != null)
             {
-                if (_comparer.Equals(n._key, key))
+                if (hashcode == n._hashcode && _comparer.Equals(n._key, key))
                 {
                     value = n._value;
                     return true;
@@ -528,7 +528,7 @@ namespace System.Collections.Concurrent
                     for (Node node = tables._buckets[bucketNo]; node != null; node = node._next)
                     {
                         Debug.Assert((prev == null && node == tables._buckets[bucketNo]) || prev._next == node);
-                        if (_comparer.Equals(node._key, key))
+                        if (hashcode == node._hashcode && _comparer.Equals(node._key, key))
                         {
                             if (valueComparer.Equals(node._value, comparisonValue))
                             {
@@ -787,7 +787,7 @@ namespace System.Collections.Concurrent
                     for (Node node = tables._buckets[bucketNo]; node != null; node = node._next)
                     {
                         Debug.Assert((prev == null && node == tables._buckets[bucketNo]) || prev._next == node);
-                        if (_comparer.Equals(node._key, key))
+                        if (hashcode == node._hashcode && _comparer.Equals(node._key, key))
                         {
                             // The key was found in the dictionary. If updates are allowed, update the value for that key.
                             // We need to create a new node for the update, in order to support TValue types that cannot


### PR DESCRIPTION
https://github.com/dotnet/corefx/pull/5675

Both Dictionary and ConcurrentDictionary store with each key a hashcode of that key.  Any time a comparison between two keys is done, Dictionary first checks whether the hash codes match, as a quick-way to avoid having to run a potentially expensive comparer operation if we’re certain the objects don’t match because their hash codes are different.  ConcurrentDictionary has neglected to do this, leading to additional costs proportional to the expensive of the comparer being used.