### PR TITLE
RC2: Remove spinning from MRES in socket operations

### DIFF
--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -615,7 +615,7 @@ namespace System.Net.Sockets
                 return errorCode;
             }
 
-            using (var @event = new ManualResetEventSlim())
+            using (var @event = new ManualResetEventSlim(false, 0))
             {
                 var operation = new AcceptOperation {
                     Event = @event,
@@ -710,7 +710,7 @@ namespace System.Net.Sockets
                 return errorCode;
             }
 
-            using (var @event = new ManualResetEventSlim())
+            using (var @event = new ManualResetEventSlim(false, 0))
             {
                 var operation = new ConnectOperation {
                     Event = @event,
@@ -798,7 +798,7 @@ namespace System.Net.Sockets
                 return errorCode;
             }
 
-            using (var @event = new ManualResetEventSlim())
+            using (var @event = new ManualResetEventSlim(false, 0))
             {
                 var operation = new ReceiveOperation {
                     Event = @event,
@@ -908,7 +908,7 @@ namespace System.Net.Sockets
                 return errorCode;
             }
 
-            using (var @event = new ManualResetEventSlim())
+            using (var @event = new ManualResetEventSlim(false, 0))
             {
                 var operation = new ReceiveOperation {
                     Event = @event,
@@ -1004,7 +1004,7 @@ namespace System.Net.Sockets
                 return errorCode;
             }
 
-            using (var @event = new ManualResetEventSlim())
+            using (var @event = new ManualResetEventSlim(false, 0))
             {
                 var operation = new ReceiveMessageFromOperation {
                     Event = @event,
@@ -1124,7 +1124,7 @@ namespace System.Net.Sockets
                 return errorCode;
             }
 
-            using (var @event = new ManualResetEventSlim())
+            using (var @event = new ManualResetEventSlim(false, 0))
             {
                 var operation = new SendOperation {
                     Event = @event,
@@ -1227,7 +1227,7 @@ namespace System.Net.Sockets
                 return errorCode;
             }
 
-            using (var @event = new ManualResetEventSlim())
+            using (var @event = new ManualResetEventSlim(false, 0))
             {
                 var operation = new SendOperation {
                     Event = @event,


### PR DESCRIPTION
https://github.com/dotnet/corefx/pull/5655

Showed up in traces of NetEase’s app.  Currently synchronous socket operations are implemented as wrappers around asynchronous operations, blocking with a ManualResetEventSlim until the operation completes.  If the operation doesn’t actually complete synchronously, it’s unlikely to complete very quickly, but we’re using the default MRES behavior of spinning a bit in hopes that the operation will complete synchronously.  This means we’re wasting CPU cycles on unnecessary spinning.