### PR TITLE
Disallow nil MethodDef token as an entry-point in Portable PDB

### DIFF
--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MetadataReader.cs
@@ -486,7 +486,7 @@ namespace System.Reflection.Metadata
             }
         }
 
-        private int[] ReadMetadataTableRowCounts(ref BlobReader memReader, ulong presentTableMask)
+        private static int[] ReadMetadataTableRowCounts(ref BlobReader memReader, ulong presentTableMask)
         {
             ulong currentTableBit = 1;
 
@@ -515,7 +515,8 @@ namespace System.Reflection.Metadata
             return rowCounts;
         }
 
-        private void ReadStandalonePortablePdbStream(MemoryBlock block, out DebugMetadataHeader debugMetadataHeader, out int[] externalTableRowCounts)
+        // internal for testing
+        internal static void ReadStandalonePortablePdbStream(MemoryBlock block, out DebugMetadataHeader debugMetadataHeader, out int[] externalTableRowCounts)
         {
             var reader = new BlobReader(block);
 
@@ -529,7 +530,8 @@ namespace System.Reflection.Metadata
             // The return type of the entry point method shall be void, int32, or unsigned int32. 
             // The entry point method cannot be defined in a generic class.
             uint entryPointToken = reader.ReadUInt32();
-            if (entryPointToken != 0 && (entryPointToken & TokenTypeIds.TypeMask) != TokenTypeIds.MethodDef)
+            int entryPointRowId = (int)(entryPointToken & TokenTypeIds.RIDMask);
+            if (entryPointToken != 0 && ((entryPointToken & TokenTypeIds.TypeMask) != TokenTypeIds.MethodDef || entryPointRowId == 0))
             {
                 throw new BadImageFormatException(string.Format(SR.InvalidEntryPointToken, entryPointToken));
             }
@@ -548,7 +550,7 @@ namespace System.Reflection.Metadata
 
             debugMetadataHeader = new DebugMetadataHeader(
                 ImmutableByteArrayInterop.DangerousCreateFromUnderlyingArray(ref pdbId),
-                MethodDefinitionHandle.FromRowId((int)(entryPointToken & TokenTypeIds.RIDMask)));
+                MethodDefinitionHandle.FromRowId(entryPointRowId));
         }
 
         private const int SmallIndexSize = 2;

--- a/src/System.Reflection.Metadata/tests/Metadata/PortablePdb/StandalonePortablePdbStreamTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/PortablePdb/StandalonePortablePdbStreamTests.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection.Internal;
+using System.Reflection.Metadata.Ecma335;
+using Xunit;
+
+namespace System.Reflection.Metadata.Tests
+{
+    public class StandalonePortablePdbStreamTests
+    {
+        private unsafe static void ReadHeader(out DebugMetadataHeader header, out int[] externalRowCounts, byte[] buffer)
+        {
+            fixed (byte* bufferPtr = &buffer[0])
+            {
+                MetadataReader.ReadStandalonePortablePdbStream(new MemoryBlock(bufferPtr, buffer.Length), out header, out externalRowCounts);
+            }
+        }
+
+        [Fact]
+        public void IdAndEntryPoint()
+        {
+            int[] externalRowCounts;
+            DebugMetadataHeader header;
+
+            ReadHeader(out header, out externalRowCounts, new byte[]
+            {
+                // ID:
+                0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13,
+
+                // entry point:
+                0x00, 0x00, 0x00, 0x00,
+
+                // external table mask:
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+            });
+
+            Assert.True(header.EntryPoint.IsNil);
+            Assert.Equal(new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13 }, header.Id);
+
+            // entry point is nil MethodDef:
+            Assert.Throws<BadImageFormatException>(() =>
+                ReadHeader(out header, out externalRowCounts, new byte[]
+                {
+                    // ID:
+                    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13,
+
+                    // entry point:
+                    0x00, 0x00, 0x00, 0x06,
+
+                    // external table mask:
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+                }));
+
+            // entry point not a MethodDef:
+            Assert.Throws<BadImageFormatException>(() =>
+                ReadHeader(out header, out externalRowCounts, new byte[]
+                {
+                    // ID:
+                    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13,
+
+                    // entry point:
+                    0x01, 0x00, 0x00, 0x2b,
+
+                    // external table mask:
+                    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+                }));
+        }
+    }
+}

--- a/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Metadata\MetadataReaderTestHelpers.cs" />
     <Compile Include="Metadata\MetadataReaderTests.cs" />
     <Compile Include="Metadata\MethodImportRow.cs" />
+    <Compile Include="Metadata\PortablePdb\StandalonePortablePdbStreamTests.cs" />
     <Compile Include="Metadata\TagToTokenTests.cs" />
     <Compile Include="Metadata\PortablePdb\DocumentNameTests.cs" />
     <Compile Include="PortableExecutable\AbstractMemoryBlockTests.cs" />


### PR DESCRIPTION
The spec is clear - the value has to either be 0 or a valid MethodDef. 0x06000000 is not valid.
Discovered that this is not checked by making a mistake in metadata writer :)