### PR TITLE
Update System.Diagnostics.Tracing to 4.1.0.0

### DIFF
--- a/dir.props
+++ b/dir.props
@@ -64,6 +64,14 @@
     <NativePackagePath>$(MSBuildThisFileDirectory)src/Native/pkg</NativePackagePath>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- temporarily include 462 validation until it is added to BuildTools -->
+    <DefaultValidateFramework Include="net462" Condition="'$(ExcludeFromDesktopSupportValidation)' != 'true'">
+      <!-- add additional win7 RIDs to validate up-level authoring -->
+      <RuntimeIDs>win-x86;win-x64;win7-x86;win7-x64</RuntimeIDs>
+    </DefaultValidateFramework>
+  </ItemGroup>
+
   <!-- Import Build tools common props file where repo-independent properties are found -->
   <Import Project="$(ToolsDir)Build.Common.props" />
 

--- a/src/System.AppContext/pkg/System.AppContext.pkgproj
+++ b/src/System.AppContext/pkg/System.AppContext.pkgproj
@@ -7,7 +7,7 @@
       <SupportedFramework>net46</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\ref\System.AppContext.csproj">
-      <SupportedFramework>netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net462;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.AppContext.builds" />
   </ItemGroup>

--- a/src/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.pkgproj
+++ b/src/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.pkgproj
@@ -8,8 +8,11 @@
     <ProjectReference Include="..\ref\4.0.10\System.Diagnostics.Tracing.depproj">
       <SupportedFramework>net451;netcore451;wpa81</SupportedFramework>
     </ProjectReference>
+    <ProjectReference Include="..\ref\4.0.20\System.Diagnostics.Tracing.depproj">
+      <SupportedFramework>net46</SupportedFramework>
+    </ProjectReference>
     <ProjectReference Include="..\ref\System.Diagnostics.Tracing.csproj">
-      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+      <SupportedFramework>net462;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Diagnostics.Tracing.builds" />
     <InboxOnTargetFramework Include="MonoAndroid10" />

--- a/src/System.Diagnostics.Tracing/ref/4.0.20/System.Diagnostics.Tracing.depproj
+++ b/src/System.Diagnostics.Tracing/ref/4.0.20/System.Diagnostics.Tracing.depproj
@@ -2,15 +2,11 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <AssemblyVersion>4.0.20.0</AssemblyVersion>
     <OutputType>Library</OutputType>
-    <PackageTargetFramework>dotnet5.6</PackageTargetFramework>
-    <NuGetTargetMoniker>.NETPlatform,Version=v5.6</NuGetTargetMoniker>
+    <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETPlatform,Version=v5.4</NuGetTargetMoniker>
   </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="System.Diagnostics.Tracing.cs" />
-  </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/System.Diagnostics.Tracing/ref/4.0.20/project.json
+++ b/src/System.Diagnostics.Tracing/ref/4.0.20/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Diagnostics.Tracing": "4.0.20"
+  },
+  "frameworks": {
+    "dotnet5.4": {}
+  }
+}

--- a/src/System.Diagnostics.Tracing/ref/project.json
+++ b/src/System.Diagnostics.Tracing/ref/project.json
@@ -3,6 +3,6 @@
     "System.Runtime": "4.0.0"
   },
   "frameworks": {
-    "dotnet5.4": {}
+    "dotnet5.6": {}
   }
 }

--- a/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.builds
+++ b/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.builds
@@ -3,10 +3,9 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Diagnostics.Tracing.csproj" />
-    <!-- Net46 facade is currently inbox for 4.0
     <Project Include="System.Diagnostics.Tracing.csproj">
-      <TargetGroup>net46</TargetGroup>
-    </Project> -->
+      <TargetGroup>net462</TargetGroup>
+    </Project>
     <Project Include="System.Diagnostics.Tracing.csproj">
       <TargetGroup>netcore50aot</TargetGroup>
     </Project>

--- a/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
+++ b/src/System.Diagnostics.Tracing/src/System.Diagnostics.Tracing.csproj
@@ -5,8 +5,10 @@
     <AssemblyName>System.Diagnostics.Tracing</AssemblyName>
     <ProjectGuid>{EB880FDC-326D-42B3-A3FD-0CD3BA29A7F4}</ProjectGuid>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AssemblyVersion>4.0.21.0</AssemblyVersion>
-    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.6</PackageTargetFramework>
+    <!-- The following line needs to be removed once we have a targeting pack for 4.6.2 -->
+    <TargetingPackNugetPackageId Condition="'$(TargetGroup)'=='net462'">Microsoft.TargetingPack.NETFramework.v4.6.1</TargetingPackNugetPackageId>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetGroup)'!='netcore50aot'">
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
@@ -22,8 +24,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50aot_Release|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net462_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net462_Release|AnyCPU'" />
   <ItemGroup Condition="'$(TargetGroup)'==''">
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
     <Compile Include="System\Diagnostics\Tracing\EventCounter.cs" />

--- a/src/System.Diagnostics.Tracing/src/project.json
+++ b/src/System.Diagnostics.Tracing/src/project.json
@@ -22,9 +22,9 @@
         "System.Threading": "4.0.10.0"
       }
     },
-    "net46": {
+    "net462": {
       "dependencies": {
-        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.0-rc2-23530"
+        "Microsoft.TargetingPack.NETFramework.v4.6.1": "1.0.0-rc2-23530"
       }
     }
   }


### PR DESCRIPTION
Fix assembly version for tracing and include previous version to support .NET 4.6.

Fixes https://github.com/dotnet/corefx/issues/5706

/cc @cshung @davmason