### PR TITLE
Remove personal copyright from License Headers

### DIFF
--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/Assign.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/OpAssign.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/Assignment/OpAssign.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/BinaryOperators/GeneralBinaryTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/GeneralBinaryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceEqual.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceEqual.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceEqualityTests.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceEqualityTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceNotEqual.cs
+++ b/src/System.Linq.Expressions/tests/BinaryOperators/ReferenceComparison/ReferenceNotEqual.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/Block/NoParameterBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/NoParameterBlockTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/Block/ParameterBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/ParameterBlockTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/Block/SharedBlockTests.cs
+++ b/src/System.Linq.Expressions/tests/Block/SharedBlockTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Jon Hanna. All rights reserved.
+// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
+++ b/src/System.Linq.Expressions/tests/ExceptionHandling/ExceptionHandlingExpressions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/ExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/ExpressionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/Goto/Break.cs
+++ b/src/System.Linq.Expressions/tests/Goto/Break.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/Goto/Continue.cs
+++ b/src/System.Linq.Expressions/tests/Goto/Continue.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/Goto/Goto.cs
+++ b/src/System.Linq.Expressions/tests/Goto/Goto.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/Goto/GotoExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/Goto/GotoExpressionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/Goto/Return.cs
+++ b/src/System.Linq.Expressions/tests/Goto/Return.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/Label/LabelTargetTests.cs
+++ b/src/System.Linq.Expressions/tests/Label/LabelTargetTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/Label/LabelTests.cs
+++ b/src/System.Linq.Expressions/tests/Label/LabelTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/TestExtensions/TestOrderAttribute.cs
+++ b/src/System.Linq.Expressions/tests/TestExtensions/TestOrderAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/TestExtensions/TestOrderer.cs
+++ b/src/System.Linq.Expressions/tests/TestExtensions/TestOrderer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/TypeBinary/TypeBinaryTests.cs
+++ b/src/System.Linq.Expressions/tests/TypeBinary/TypeBinaryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
+++ b/src/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/TypeBinary/TypeIs.cs
+++ b/src/System.Linq.Expressions/tests/TypeBinary/TypeIs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/IncDecAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/IncDecAssignTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostDecrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostDecrementAssignTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostIncrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PostIncrementAssignTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PreDecrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PreDecrementAssignTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PreIncrementAssignTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/IncDecAssign/PreIncrementAssignTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation and contributors. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/Unary/UnboxTests.cs
+++ b/src/System.Linq.Expressions/tests/Unary/UnboxTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/Variables/ParameterExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/ParameterExpressionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/ParameterTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/Variables/RuntimeVariablesTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/RuntimeVariablesTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Expressions/tests/Variables/VariableTests.cs
+++ b/src/System.Linq.Expressions/tests/Variables/VariableTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Queryable/tests/EnumerableQueryTests.cs
+++ b/src/System.Linq.Queryable/tests/EnumerableQueryTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq.Queryable/tests/QueryFromExpressionTests.cs
+++ b/src/System.Linq.Queryable/tests/QueryFromExpressionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq/tests/EmptyPartitionTests.cs
+++ b/src/System.Linq/tests/EmptyPartitionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq/tests/OrderedSubsetting.cs
+++ b/src/System.Linq/tests/OrderedSubsetting.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;

--- a/src/System.Linq/tests/Shuffler.cs
+++ b/src/System.Linq/tests/Shuffler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Jon Hanna. All rights reserved.
+﻿// Copyright (c) .NET Foundation and Contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;


### PR DESCRIPTION
Change all license headers © Jon Hanna to .NET Foundation and Contributors.

Change all license headers © .NET Foundation and contributors. (lower case) to
.NET Foundation and Contributors to match form in project license file.