### PR TITLE
Disable TestMachineNameProperty test on OS X

### DIFF
--- a/src/System.Runtime.Extensions/tests/System/Environment.MachineName.cs
+++ b/src/System.Runtime.Extensions/tests/System/Environment.MachineName.cs
@@ -9,6 +9,7 @@ namespace System.Runtime.Extensions.Tests
 {
     public class Environment_MachineName
     {
+        [ActiveIssue(5732, PlatformID.OSX)]
         [Fact]
         public void TestMachineNameProperty()
         {


### PR DESCRIPTION
cc: @Priya91 
#5732