### PR TITLE
Enable tests blocked due to Issue#5067

### DIFF
--- a/src/System.Collections.Immutable/tests/ImmutableListTestBase.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListTestBase.cs
@@ -394,7 +394,6 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
-        [ActiveIssue(5067, PlatformID.Windows)]
         public void BinarySearch()
         {
             var basis = new List<int>(Enumerable.Range(1, 50).Select(n => n * 2));
@@ -420,7 +419,6 @@ namespace System.Collections.Immutable.Tests
         }
 
         [Fact]
-        [ActiveIssue(5067, PlatformID.Windows)]
         public void BinarySearchPartialSortedList()
         {
             var reverseSorted = ImmutableArray.CreateRange(Enumerable.Range(1, 150).Select(n => n * 2).Reverse());

--- a/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Generated.cs
+++ b/src/System.Linq.Expressions/tests/Interpreter/InterpreterTests.Generated.cs
@@ -112,7 +112,6 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
-        [ActiveIssue(5067, PlatformID.Windows)]
         public static void CompileInterpretCrossCheck_Call()
         {
             var exprs = default(IEnumerable<Expression>);
@@ -402,7 +401,6 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
-        [ActiveIssue(5067, PlatformID.Windows)]
         public static void CompileInterpretCrossCheck_MemberAccess()
         {
             var exprs = default(IEnumerable<Expression>);


### PR DESCRIPTION
As #5067 has been resolved, enabling the tests which were affected by it.