### PR TITLE
Add test for DateTime parsing

### DIFF
--- a/src/System.Runtime/tests/System/DateTime.cs
+++ b/src/System.Runtime/tests/System/DateTime.cs
@@ -247,6 +247,19 @@ public static unsafe class DateTimeTests
     }
 
     [Fact]
+    public static void TestParseExact_EscapedSingleQuotes()
+    {
+        var formatInfo = DateTimeFormatInfo.GetInstance(new CultureInfo("mt-MT"));
+        const string format = @"dddd, d' ta\' 'MMMM yyyy";
+
+        DateTime expected = new DateTime(1999, 2, 28, 17, 00, 01);
+        string formatted = expected.ToString(format, formatInfo);
+        DateTime actual = DateTime.ParseExact(formatted, format, formatInfo);
+
+        Assert.Equal(expected.Date, actual.Date);
+    }
+
+    [Fact]
     public static void TestTryParse2()
     {
         DateTime src = DateTime.MaxValue;


### PR DESCRIPTION
Adds a test for https://github.com/dotnet/coreclr/pull/2894.  Won't pass until that's merged and a new package is available with the fix.

cc: @tarekgh 