### PR TITLE
Enable Client Auth Certs for Unix SslStream.

### DIFF
--- a/src/System.Net.Security/src/System/Net/SecureChannel.cs
+++ b/src/System.Net.Security/src/System/Net/SecureChannel.cs
@@ -646,7 +646,10 @@ namespace System.Net.Security
                 // We can probably do some optimization here. If the selectedCert is returned by the delegate
                 // we can always go ahead and use the certificate to create our credential
                 // (instead of going anonymous as we do here).
-                if (sessionRestartAttempt && cachedCredentialHandle == null && selectedCert != null)
+                if (sessionRestartAttempt &&
+                    cachedCredentialHandle == null &&
+                    selectedCert != null &&
+                    SslStreamPal.StartMutualAuthAsAnonymous)
                 {
                     if (GlobalLog.IsEnabled)
                     {

--- a/src/System.Net.Security/src/System/Net/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/SslStreamPal.Unix.cs
@@ -19,6 +19,11 @@ namespace System.Net
             return new Interop.OpenSsl.SslException((int)status);
         }
 
+        public static bool StartMutualAuthAsAnonymous
+        {
+            get { return false; }
+        }
+
         public static void VerifyPackageInfo()
         {
         }

--- a/src/System.Net.Security/src/System/Net/SslStreamPal.Windows.cs
+++ b/src/System.Net.Security/src/System/Net/SslStreamPal.Windows.cs
@@ -32,6 +32,11 @@ namespace System.Net
             return new Win32Exception(win32Code);
         }
 
+        public static bool StartMutualAuthAsAnonymous
+        {
+            get { return true; }
+        }
+
         public static void VerifyPackageInfo()
         {
             SSPIWrapper.GetVerifyPackageInfo(GlobalSSPI.SSPISecureChannel, SecurityPackage, true);

--- a/src/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
@@ -29,9 +29,12 @@ namespace System.Net.Security.Tests
             _clientCertificate = TestConfiguration.GetClientCertificate();
         }
 
-        [Fact]
-        [ActiveIssue(4467)]
-        public async Task CertificateValidationClientServer_EndToEnd_Ok()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        [ActiveIssue(4467, PlatformID.Windows)]
+        public async Task CertificateValidationClientServer_EndToEnd_Ok(
+            bool useClientSelectionCallback)
         {
             IPEndPoint endPoint = new IPEndPoint(IPAddress.IPv6Loopback, 0);
             var server = new TcpListener(endPoint);
@@ -50,11 +53,19 @@ namespace System.Net.Security.Tests
                         TestConfiguration.PassingTestTimeoutMilliseconds),
                     "Client/Server TCP Connect timed out.");
 
+                LocalCertificateSelectionCallback clientCertCallback = null;
+
+                if (useClientSelectionCallback)
+                {
+                    clientCertCallback = ClientCertSelectionCallback;
+                }
+
                 using (TcpClient serverConnection = await serverAccept)
                 using (SslStream sslClientStream = new SslStream(
                     clientConnection.GetStream(),
                     false,
-                    ClientSideRemoteServerCertificateValidation))
+                    ClientSideRemoteServerCertificateValidation,
+                    clientCertCallback))
                 using (SslStream sslServerStream = new SslStream(
                     serverConnection.GetStream(),
                     false,
@@ -62,10 +73,12 @@ namespace System.Net.Security.Tests
 
                 {
                     string serverName = _serverCertificate.GetNameInfo(X509NameType.SimpleName, false);
-                    string clientName = _clientCertificate.GetNameInfo(X509NameType.SimpleName, false);
-
                     var clientCerts = new X509CertificateCollection();
-                    clientCerts.Add(_clientCertificate);
+
+                    if (!useClientSelectionCallback)
+                    {
+                        clientCerts.Add(_clientCertificate);
+                    }
 
                     Task clientAuthentication = sslClientStream.AuthenticateAsClientAsync(
                         serverName,
@@ -84,8 +97,24 @@ namespace System.Net.Security.Tests
                             new Task[] { clientAuthentication, serverAuthentication },
                             TestConfiguration.PassingTestTimeoutMilliseconds),
                         "Client/Server Authentication timed out.");
+
+                    Assert.True(sslClientStream.IsMutuallyAuthenticated, "sslClientStream.IsMutuallyAuthenticated");
+                    Assert.True(sslServerStream.IsMutuallyAuthenticated, "sslServerStream.IsMutuallyAuthenticated");
+
+                    Assert.Equal(sslClientStream.RemoteCertificate.Subject, _serverCertificate.Subject);
+                    Assert.Equal(sslServerStream.RemoteCertificate.Subject, _clientCertificate.Subject);
                 }
             }
+        }
+
+        private X509Certificate ClientCertSelectionCallback(
+            object sender,
+            string targetHost,
+            X509CertificateCollection localCertificates,
+            X509Certificate remoteCertificate,
+            string[] acceptableIssuers)
+        {
+            return _clientCertificate;
         }
 
         private bool ServerSideRemoteClientCertificateValidation(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)


### PR DESCRIPTION
1) Pass the handle

The Windows SslStream flow is to start a TLS session as server auth, then
process a CredentialsRequired during the handshake, add credentials to
the existing session, and continue.

It's hard to maintain symmetry on that flow for the Unix pathway, due to
the API differences in OpenSSL and SChannel.  So, the Unix session will
always pass down to native the provided client auth credentials, and
OpenSSL can use them when it sees appropriate.

2) Untrusted certificates should still complete handshake

The Unix SslStream implementation had two different places that a client
authentication certificate was validated.  The first one was from an
OpenSSL callback, and reporting an error will interrupt the TLS handshake.
The second was from after the handshake, and presents the results to the
user validation callback to determine if data should be sent after the handshake.

In the ideal case the first version is redundant, in a user-handled case it caused
a failure when success was expected; so it should just be removed.

3) Enable the end-to-end client authentication cert test for Unix

Also asserts that the IsMutuallyAuthenticated property gets set, the certificates
used were the correct ones, and that both forward and callback versions of
providing the certificate function.

Fixes #5667.
cc: @CIPop @davidsh 