### PR TITLE
Adding fallback logic to NTLM

### DIFF
--- a/src/Common/src/Interop/Linux/System.Net.Security.Native/SecuritySafeHandles.cs
+++ b/src/Common/src/Interop/Linux/System.Net.Security.Native/SecuritySafeHandles.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Win32.SafeHandles;
+using System.Diagnostics;
+
+namespace System.Net.Security
+{
+    internal sealed partial class SafeFreeNegoCredentials : SafeFreeCredentials
+    {
+        private readonly string _password;
+
+        public string Password
+        {
+            get { return _password; }
+        }
+
+        public SafeFreeNegoCredentials(bool ntlmOnly, string username, string password, string domain) : base(IntPtr.Zero, true)
+        {
+            _isNtlm = ntlmOnly;
+            _isdefault = string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(password);
+            if (!ntlmOnly)
+            {
+                try
+                {
+                    _credential = SafeGssCredHandle.Create(username, password, domain);
+                }
+                catch
+                {
+                    // NTLM fallback is not possible with default credentials
+                    if (_isdefault)
+                    {
+                        throw new PlatformNotSupportedException(SR.net_ntlm_not_possible_default_cred);
+                    }
+
+                    _isNtlm = true;
+                }
+            }
+
+            // Even if Kerberos TGT could be obtained, we might later need
+            // to fall back to NTLM if service ticket cannot be fetched
+            _username = username;
+            _password = password;
+            _domain = domain;
+        }
+    }
+
+    internal sealed partial class SafeDeleteNegoContext : SafeDeleteContext
+    {
+        private readonly Interop.NetNtlmNative.NtlmFlags _flags;
+        private Interop.HeimdalNtlm.SigningKey _serverSignKey;
+        private Interop.HeimdalNtlm.SealingKey _serverSealKey;
+        private Interop.HeimdalNtlm.SigningKey _clientSignKey;
+        private Interop.HeimdalNtlm.SealingKey _clientSealKey;
+
+        public Interop.NetNtlmNative.NtlmFlags Flags
+        {
+            get { return _flags; }
+        }
+
+        public SafeDeleteNegoContext(SafeFreeNegoCredentials credential, Interop.NetNtlmNative.NtlmFlags flags)
+            : base(credential)
+        {
+            _flags = flags;
+            _isNtlm = true;
+        }
+
+        public void SetKeys(byte[] sessionKey)
+        {
+            Interop.HeimdalNtlm.CreateKeys(sessionKey, out _serverSignKey, out _serverSealKey, out _clientSignKey, out _clientSealKey);
+        }
+
+        public byte[] MakeClientSignature(byte[] buffer, int offset, int count)
+        {
+            Debug.Assert(_clientSignKey != null, "_clientSignKey cannot be null");
+            return _clientSignKey.Sign(_clientSealKey, buffer, offset, count);
+        }
+
+        public byte[] MakeServerSignature(byte[] buffer, int offset, int count)
+        {
+            Debug.Assert(_serverSignKey != null, "_serverSignKey cannot be null");
+            return _serverSignKey.Sign(_serverSealKey, buffer, offset, count);
+        }
+
+        public byte[] Encrypt(byte[] buffer, int offset, int count)
+        {
+            Debug.Assert(_clientSignKey != null, "_clientSealKey cannot be null");
+            return _clientSealKey.SealOrUnseal(buffer, offset, count);
+        }
+
+        public byte[] Decrypt(byte[] buffer, int offset, int count)
+        {
+            Debug.Assert(_serverSignKey != null, "_serverSealKey cannot be null");
+            return _serverSealKey.SealOrUnseal(buffer, offset, count);
+        }
+    }
+}

--- a/src/Common/src/Interop/OSX/System.Net.Security.Native/SecuritySafeHandles.cs
+++ b/src/Common/src/Interop/OSX/System.Net.Security.Native/SecuritySafeHandles.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace System.Net.Security
+{
+    internal sealed partial class SafeFreeNegoCredentials : SafeFreeCredentials
+    {
+
+        public SafeFreeNegoCredentials(bool ntlmOnly, string username, string password, string domain) : base(IntPtr.Zero, true)
+        {
+            _isNtlm = ntlmOnly;
+            _isdefault = string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(password);
+            _username = username;
+            _domain = domain;
+            _credential = SafeGssCredHandle.Create(username, password, domain);
+        }
+    }
+
+    internal sealed partial class SafeDeleteNegoContext : SafeDeleteContext
+    {
+        private const char At = '@';
+        public SafeDeleteNegoContext(SafeFreeNegoCredentials credential)
+            : base(credential)
+        {
+            // Try to construct target in user@domain format
+            string targetName = credential.UserName;
+            string domain = credential.Domain;
+
+            //remove any leading and trailing whitespace
+            if (domain != null)
+            {
+                domain = domain.Trim();
+            }
+
+            if ((targetName.IndexOf(At) < 0) && !string.IsNullOrEmpty(domain))
+            {
+                targetName += At + domain;
+            }
+
+            try
+            {
+                _targetName = SafeGssNameHandle.CreatePrincipal(targetName);
+            }
+            catch
+            {
+                Dispose();
+                throw;
+            }
+        }
+
+        public byte[] MakeClientSignature(byte[] buffer, int offset, int count)
+        {
+            //MakeClientSignature is not supported on OSX
+            throw new PlatformNotSupportedException();
+        }
+
+        public byte[] MakeServerSignature(byte[] buffer, int offset, int count)
+        {
+            //MakeServerSignature is not supported on OSX
+            throw new PlatformNotSupportedException();
+        }
+
+        public byte[] Encrypt(byte[] buffer, int offset, int count)
+        {
+            //Encrypt is not supported on OSX
+            throw new PlatformNotSupportedException();
+        }
+
+        public byte[] Decrypt(byte[] buffer, int offset, int count)
+        {
+            //Decrypt is not supported on OSX
+            throw new PlatformNotSupportedException();
+        }
+    }
+}

--- a/src/Common/src/Interop/Unix/System.Net.Security.Native/SecuritySafeHandles.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Security.Native/SecuritySafeHandles.cs
@@ -10,9 +10,33 @@ using Microsoft.Win32.SafeHandles;
 
 namespace System.Net.Security
 {
-    internal sealed class SafeFreeNegoCredentials : SafeFreeCredentials
+    internal sealed partial class SafeFreeNegoCredentials : SafeFreeCredentials
     {
         private SafeGssCredHandle _credential;
+        private bool _isdefault;
+        private readonly string _username;
+        private readonly string _domain;
+        private bool _isNtlm;
+
+        public bool IsDefault
+        {
+            get { return _isdefault; }
+        }
+
+        public string UserName
+        {
+            get { return _username; }
+        }
+
+        public string Domain
+        {
+            get { return _domain; }
+        }
+
+        public bool IsNtlm
+        {
+            get { return _isNtlm; }
+        }
 
         public SafeGssCredHandle GssCredential
         {
@@ -39,10 +63,11 @@ namespace System.Net.Security
         }
     }
 
-    internal sealed class SafeDeleteNegoContext : SafeDeleteContext
+    internal sealed partial class SafeDeleteNegoContext : SafeDeleteContext
     {
         private SafeGssNameHandle _targetName;
         private SafeGssContextHandle _context;
+        private bool _isNtlm;
 
         public SafeGssNameHandle TargetName
         {
@@ -52,6 +77,11 @@ namespace System.Net.Security
         public SafeGssContextHandle GssContext
         {
             get { return _context; }
+        }
+
+        public bool IsNtlm
+        {
+            get { return _isNtlm; }
         }
 
         public SafeDeleteNegoContext(SafeFreeNegoCredentials credential, string targetName)
@@ -69,10 +99,11 @@ namespace System.Net.Security
             }
         }
 
-        public void SetGssContext(SafeGssContextHandle context)
+        public void SetGssContext(SafeGssContextHandle context, bool isNtlm)
         {
             Debug.Assert(!context.IsInvalid, "Invalid context passed to SafeDeleteNegoContext");
             _context = context;
+            _isNtlm = isNtlm;
         }
 
         protected override void Dispose(bool disposing)

--- a/src/System.Net.Security/src/Resources/Strings.resx
+++ b/src/System.Net.Security/src/Resources/Strings.resx
@@ -432,13 +432,16 @@
   <data name="net_context_buffer_too_small" xml:space="preserve">
     <value>Insufficient buffer space. Required: {0} Actual: {1}.</value>
   </data>
+  <data name="net_ntlm_not_possible_default_cred" xml:space="preserve">
+    <value>NTLM authentication is not possible with default credentials which are no-op.</value>
+  </data>
   <data name="net_nego_channel_binding_not_supported" xml:space="preserve">
     <value>No support for channel binding on operating systems other than Windows</value>
   </data>
-  <data name="net_nego_ntlm_not_supported" xml:space="preserve">
-    <value>NTLM is not supported</value>
-  </data>
   <data name="net_nego_server_not_supported" xml:space="preserve">
     <value>Server implementation is not supported</value>
+  </data>
+  <data name="net_generic_ntlm_operation_failed" xml:space="preserve">
+    <value>NTLM  operation failed with status: {0})</value>
   </data>
 </root>

--- a/src/System.Net.Security/src/System.Net.Security.csproj
+++ b/src/System.Net.Security/src/System.Net.Security.csproj
@@ -46,8 +46,6 @@
     <Compile Include="System\Net\SecureProtocols\AuthenticationException.cs" />
     <Compile Include="System\Net\SecureProtocols\FixedSizeReader.cs" />
     <Compile Include="System\Net\SecureProtocols\ProtectionLevel.cs" />
-
-    <!-- NegotiateStream -->    
     <Compile Include="System\Net\ContextFlagsPal.cs" />
     <Compile Include="System\Net\NTAuthentication.cs" />
     <Compile Include="System\Net\SSPIHandleCache.cs" />
@@ -151,8 +149,6 @@
     <Compile Include="System\Net\SecurityContextTokenHandle.cs" />
     <Compile Include="System\Net\CertificateValidationPal.Windows.cs" />
     <Compile Include="System\Net\SecurityStatusAdapterPal.Windows.cs" />
-	
-    <!-- NegotiateStream -->
     <Compile Include="System\Net\SpnDictionary.cs" />
     <Compile Include="System\Net\NegotiateStreamPal.Windows.cs" />
     <Compile Include="System\Net\ContextFlagsAdapterPal.Windows.cs" />
@@ -238,8 +234,6 @@
   <ItemGroup Condition=" '$(TargetsUnix)' == 'true' ">
     <Compile Include="System\Net\SslStreamPal.Unix.cs" />
     <Compile Include="System\Net\CertificateValidationPal.Unix.cs" />
-
-    <!-- NegotiateStream -->    
     <Compile Include="System\Net\NegotiateStreamPal.Unix.cs" />
     <Compile Include="System\Net\ContextFlagsAdapterPal.Unix.cs" />
     
@@ -348,6 +342,60 @@
     </Compile>
   </ItemGroup>
   
+  <ItemGroup Condition=" '$(TargetsLinux)' == 'true' ">  
+    <Compile Include="System\Net\NegotiateStreamPal.Linux.cs" />
+
+    <!-- Interop -->
+    <Compile Include="$(CommonPath)\Interop\Linux\System.Net.Security.Native\SecuritySafeHandles.cs"> 
+      <Link>Common\Interop\Linux\System.Net.Security.Native\SecuritySafeHandles.cs</Link> 
+    </Compile> 
+    <Compile Include="$(CommonPath)\Interop\Linux\System.Net.Ntlm.Native\Interop.NetNtlmNative.cs">
+      <Link>Common\Interop\Linux\System.Net.Ntlm.Native\Interop.NetNtlmNative.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Linux\System.Net.Ntlm.Native\Interop.NtlmException.cs"> 
+      <Link>Common\Interop\Linux\System.Net.Ntlm.Native\Interop.NtlmException.cs</Link> 
+    </Compile> 
+    <Compile Include="$(CommonPath)\Interop\Linux\System.Net.Ntlm.Native\Interop.Ntlm.cs"> 
+      <Link>Common\Interop\Linux\System.Net.Ntlm.Native\Interop.Ntlm.cs</Link> 
+    </Compile> 
+    <Compile Include="$(CommonPath)\Interop\Linux\System.Net.Ntlm.Native\Interop.NtlmBuffer.cs"> 
+      <Link>Common\Interop\Linux\System.Net.Ntlm.Native\Interop.NtlmBuffer.cs</Link> 
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Linux\System.Net.Ntlm.Native\Interop.NtlmType3Message.cs"> 
+      <Link>Common\Interop\Linux\System.Net.Ntlm.Native\Interop.NtlmType3Message.cs</Link> 
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\NtlmSecuritySafeHandles.cs"> 
+      <Link>Common\Microsoft\Win32\SafeHandles\NtlmSecuritySafeHandles.cs</Link> 
+    </Compile> 
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.Hmac.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.Hmac.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEvpMdCtxHandle.Unix.cs">
+      <Link>Microsoft\Win32\SafeHandles\SafeEvpMdCtxHandle.Unix.cs</Link>
+    </Compile>
+     <Compile Include="$(CommonPath)\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.Cipher.cs">
+      <Link>Common\Interop\Unix\System.Security.Cryptography.Native\Interop.EVP.Cipher.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeEvpCipherCtxHandle.Unix.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeEvpCipherCtxHandle.Unix.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Microsoft\Win32\SafeHandles\SafeHmacCtxHandle.Unix.cs">
+      <Link>Common\Microsoft\Win32\SafeHandles\SafeHmacCtxHandle.Unix.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetsOSX)' == 'true' ">
+    <Compile Include="System\Net\NegotiateStreamPal.OSX.cs" />
+
+    <!-- Interop -->
+    <Compile Include="$(CommonPath)\Interop\OSX\System.Net.Security.Native\SecuritySafeHandles.cs"> 
+      <Link>Common\Interop\OSX\System.Net.Security.Native\SecuritySafeHandles.cs</Link> 
+    </Compile> 
+  </ItemGroup>
+  
+
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/System.Net.Security/src/System/Net/NegotiateStreamPal.Linux.cs
+++ b/src/System.Net.Security/src/System/Net/NegotiateStreamPal.Linux.cs
@@ -1,0 +1,91 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+
+namespace System.Net.Security
+{
+    internal static partial class NegotiateStreamPal
+    {
+        private static bool EstablishNtlmSecurityContext(
+            SafeFreeNegoCredentials credential,
+            ref SafeDeleteContext context,
+            string targetName,
+            ContextFlagsPal inFlags,
+            SecurityBuffer inputBuffer,
+            SecurityBuffer outputBuffer,
+            ref ContextFlagsPal outFlags)
+        {
+            bool retVal;
+            Interop.NetNtlmNative.NtlmFlags flags;
+            if (null == context)
+            {
+                flags = GetInteropNtlmFromContextFlagsPal(inFlags);
+                context = new SafeDeleteNegoContext(credential, flags);
+                outputBuffer.token = Interop.Ntlm.CreateNegotiateMessage((uint) flags);
+                retVal = false;
+            }
+            else
+            {
+                SafeDeleteNegoContext negoContext = (SafeDeleteNegoContext) context;
+                flags = negoContext.Flags;
+                byte[] sessionKey;
+                outputBuffer.token = Interop.Ntlm.CreateAuthenticateMessage(
+                    (uint) flags,
+                    credential.UserName,
+                    credential.Password,
+                    credential.Domain,
+                    inputBuffer.token,
+                    inputBuffer.offset,
+                    inputBuffer.size,
+                    out sessionKey);
+                negoContext.SetKeys(sessionKey);
+                retVal = true;
+            }
+
+            outFlags = inFlags;
+            outputBuffer.size = outputBuffer.token.Length;
+            return retVal;
+        }
+
+        private static ContextFlagsPal GetContextFlagsPalFromInteropNtlm(Interop.NetNtlmNative.NtlmFlags ntlmFlags)
+        {
+            ContextFlagsPal flags = ContextFlagsPal.Zero;
+            if ((ntlmFlags & Interop.NetNtlmNative.NtlmFlags.NTLMSSP_NEGOTIATE_SEAL) != 0)
+            {
+                flags |= ContextFlagsPal.Confidentiality;
+            }
+
+            if ((ntlmFlags & Interop.NetNtlmNative.NtlmFlags.NTLMSSP_NEGOTIATE_SIGN) != 0)
+            {
+                // No NTLM server support so not setting AcceptIntegrity flag
+                flags |= ContextFlagsPal.InitIntegrity;
+                flags |= ContextFlagsPal.ReplayDetect | ContextFlagsPal.SequenceDetect;
+            }
+
+            return flags;
+        }
+
+        private static Interop.NetNtlmNative.NtlmFlags GetInteropNtlmFromContextFlagsPal(ContextFlagsPal flags)
+        {
+            Interop.NetNtlmNative.NtlmFlags ntlmFlags = Interop.NetNtlmNative.NtlmFlags.NTLMSSP_NEGOTIATE_UNICODE | Interop.NetNtlmNative.NtlmFlags.NTLMSSP_REQUEST_TARGET;
+            if ((flags & (ContextFlagsPal.AcceptIntegrity | ContextFlagsPal.InitIntegrity | ContextFlagsPal.Confidentiality)) != 0)
+            {
+                ntlmFlags |= Interop.NetNtlmNative.NtlmFlags.NTLMSSP_NEGOTIATE_SIGN
+                    | Interop.NetNtlmNative.NtlmFlags.NTLMSSP_NEGOTIATE_ALWAYS_SIGN
+                    | Interop.NetNtlmNative.NtlmFlags.NTLMSSP_NEGOTIATE_NTLM
+                    | Interop.NetNtlmNative.NtlmFlags.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY
+                    | Interop.NetNtlmNative.NtlmFlags.NTLMSSP_NEGOTIATE_128
+                    | Interop.NetNtlmNative.NtlmFlags.NTLMSSP_NEGOTIATE_KEY_EXCH;
+            }
+
+            if ((flags & ContextFlagsPal.Confidentiality) != 0)
+            {
+                ntlmFlags |= Interop.NetNtlmNative.NtlmFlags.NTLMSSP_NEGOTIATE_SEAL;
+            }
+
+            return ntlmFlags;
+        }
+    }
+}

--- a/src/System.Net.Security/src/System/Net/NegotiateStreamPal.OSX.cs
+++ b/src/System.Net.Security/src/System/Net/NegotiateStreamPal.OSX.cs
@@ -1,0 +1,51 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+
+namespace System.Net.Security
+{
+    internal static partial class NegotiateStreamPal
+    {
+        private static bool EstablishNtlmSecurityContext(
+            SafeFreeNegoCredentials credential,
+            ref SafeDeleteContext context,
+            string targetName,
+            ContextFlagsPal inFlags,
+            SecurityBuffer inputBuffer,
+            SecurityBuffer outputBuffer,
+            ref ContextFlagsPal outFlags)
+        {
+            if (context == null)
+            {
+                context = new SafeDeleteNegoContext(credential);
+            }
+
+            SafeDeleteNegoContext negoContext = (SafeDeleteNegoContext) context;
+            SafeGssContextHandle contextHandle = negoContext.GssContext;
+
+            uint outputFlags;
+            Interop.NetSecurityNative.GssFlags inputFlags = ContextFlagsAdapterPal.GetInteropFromContextFlagsPal(inFlags);
+            bool done = Interop.GssApi.EstablishSecurityContext(
+                ref contextHandle,
+                credential.GssCredential,
+                true,
+                negoContext.TargetName,
+                inputFlags,
+                ((inputBuffer != null) ? inputBuffer.token : null),
+                out outputBuffer.token,
+                out outputFlags);
+
+            outFlags = ContextFlagsAdapterPal.GetContextFlagsPalFromInterop((Interop.NetSecurityNative.GssFlags) outputFlags);
+
+            // Save the inner context handle for further calls to NetSecurityNative
+            if (null == negoContext.GssContext)
+            {
+                negoContext.SetGssContext(contextHandle, true);
+            }
+
+            return done;
+        }
+    }
+}


### PR DESCRIPTION
This includes
 implementing the NTLM logic for OSX/Linux.
fallback logic to ntlm if Kerberos fails.

tested locally as linux client against windows server.
ongoing testing with OSX client , will update here once testing is done. 

Please refer to commit 5 for the changes.. other commits are maintained and reviewed separately in separate PRs. 
cc @stephentoub @bartonjs @vijaykota 