### PR TITLE
Reduce checks made by SkipWhile

### DIFF
--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -939,11 +939,19 @@ namespace System.Linq
 
         private static IEnumerable<TSource> SkipWhileIterator<TSource>(IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            bool yielding = false;
-            foreach (TSource element in source)
+            using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (!yielding && !predicate(element)) yielding = true;
-                if (yielding) yield return element;
+                while (e.MoveNext())
+                {
+                    TSource element = e.Current;
+                    if (!predicate(element))
+                    {
+                        yield return element;
+                        while (e.MoveNext())
+                            yield return e.Current;
+                        yield break;
+                    }
+                }
             }
         }
 
@@ -956,13 +964,21 @@ namespace System.Linq
 
         private static IEnumerable<TSource> SkipWhileIterator<TSource>(IEnumerable<TSource> source, Func<TSource, int, bool> predicate)
         {
-            int index = -1;
-            bool yielding = false;
-            foreach (TSource element in source)
+            using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                checked { index++; }
-                if (!yielding && !predicate(element, index)) yielding = true;
-                if (yielding) yield return element;
+                int index = -1;
+                while (e.MoveNext())
+                {
+                    checked { index++; }
+                    TSource element = e.Current;
+                    if (!predicate(element, index))
+                    {
+                        yield return element;
+                        while (e.MoveNext())
+                            yield return e.Current;
+                        yield break;
+                    }
+                }
             }
         }
 
@@ -2422,7 +2438,7 @@ namespace System.Linq
             {
                 if (!e.MoveNext()) throw Error.NoElements();
                 value = e.Current;
-                while(e.MoveNext())
+                while (e.MoveNext())
                 {
                     float x = e.Current;
                     if (x < value) value = x;
@@ -2478,7 +2494,7 @@ namespace System.Linq
             {
                 if (!e.MoveNext()) throw Error.NoElements();
                 value = e.Current;
-                while(e.MoveNext())
+                while (e.MoveNext())
                 {
                     double x = e.Current;
                     if (x < value) value = x;


### PR DESCRIPTION
`SkipWhile` continuously checks if it needs to test the current element, and in the indexed version continuously increments the index.

Change this to a direct pass-through once the first unskipped element is seen.

With a microbenchmark of:

```C#
public static IEnumerable<object[]> SizeAndSkip
{
    get
    {
        yield return new object[] { 10, 5 };
        yield return new object[] { 100, 5 };
        yield return new object[] { 100, 50 };
        yield return new object[] { 100, 95 };
        yield return new object[] { 1000, 5 };
        yield return new object[] { 1000, 500 };
        yield return new object[] { 1000, 995 };
        yield return new object[] { 10000, 5 };
        yield return new object[] { 10000, 5000 };
        yield return new object[] { 10000, 9995 };
    }
}

[Benchmark]
[MemberData("SizeAndSkip")]
public static void MeasureSkipWhile<T>(int size, int skip)
{
    var source = Enumerable.Range(0, size).SkipWhile(x => x < skip);
    foreach (var iteration in Benchmark.Iterations)
    {
        using (iteration.StartMeasurement())
        {
            for (int i = 0; i < 1000; i++)
            {
                foreach(var item in source)
                {

                }
            }
        }
    }
}
```

And the equivalent for the index-taking form, this showed a small but consistent performance improvement:

Non-indexed Before:

Test|Unit|Min|Mean|Max|Margin|StdDev
----|----|---|----|---|------|------
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 10, skip: 5)|ms|0.185|0.222|5.05|4.5%|0.159
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 100, skip: 5)|ms|1.53|1.73|2.69|0.6%|0.117
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 100, skip: 50)|ms|1.29|1.46|2.46|0.5%|0.102
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 100, skip: 95)|ms|1.02|1.16|2.39|0.6%|0.0979
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 1000, skip: 5)|ms|15.6|16.4|18.9|0.7%|0.458
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 1000, skip: 500)|ms|12.8|13.5|16.3|0.7%|0.411
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 1000, skip: 995)|ms|9.85|10.3|12|0.7%|0.339
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 10000, skip: 5)|ms|159|162|164|0.6%|1.54
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 10000, skip: 5000)|ms|131|133|134|0.6%|1.18
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 10000, skip: 9995)|ms|99.5|103|120|3.7%|5.62

Non-indexed After:

Test|Unit|Min|Mean|Max|Margin|StdDev
----|----|---|----|---|------|------
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 10, skip: 5)|ms|0.182|0.211|4.42|4.3%|0.147
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 100, skip: 5)|ms|1.47|1.63|2.54|0.5%|0.0947
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 100, skip: 50)|ms|1.25|1.38|2.38|0.5%|0.0885
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 100, skip: 95)|ms|0.995|1.1|1.66|0.4%|0.0683
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 1000, skip: 5)|ms|14.9|15.8|17.2|0.7%|0.42
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 1000, skip: 500)|ms|12.4|12.8|13.5|0.4%|0.207
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 1000, skip: 995)|ms|9.52|9.85|10.3|0.3%|0.169
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 10000, skip: 5)|ms|154|156|162|0.9%|2.17
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 10000, skip: 5000)|ms|125|127|127|0.4%|0.758
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 10000, skip: 9995)|ms|95.5|97.7|99.1|0.7%|1.03

Indexed Before:

Test|Unit|Min|Mean|Max|Margin|StdDev
----|----|---|----|---|------|------
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 10, skip: 5)|ms|0.251|0.283|6.46|4.5%|0.207
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 100, skip: 5)|ms|2.07|2.13|2.82|0.3%|0.0793
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 100, skip: 50)|ms|1.78|1.84|2.83|0.5%|0.103
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 100, skip: 95)|ms|1.47|1.52|2.52|0.4%|0.0761
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 1000, skip: 5)|ms|20.1|20.5|25|1.3%|0.967
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 1000, skip: 500)|ms|16.9|17|18.1|0.3%|0.177
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 1000, skip: 995)|ms|13.6|13.8|16.9|0.7%|0.39
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 10000, skip: 5)|ms|200|204|232|3.0%|9.27
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 10000, skip: 5000)|ms|168|169|171|0.3%|0.868
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 10000, skip: 9995)|ms|135|136|140|0.7%|1.49

Indexed After:

Test|Unit|Min|Mean|Max|Margin|StdDev
----|----|---|----|---|------|------
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 10, skip: 5)|ms|0.188|0.229|5.06|4.7%|0.173
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 100, skip: 5)|ms|1.52|1.72|2.9|0.6%|0.132
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 100, skip: 50)|ms|1.29|1.46|2.65|0.7%|0.126
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 100, skip: 95)|ms|1.03|1.16|2.16|0.7%|0.117
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 1000, skip: 5)|ms|15.5|16.3|19.2|0.9%|0.615
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 1000, skip: 500)|ms|12.7|13.4|15.8|0.8%|0.454
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 1000, skip: 995)|ms|9.86|10.4|12.9|0.7%|0.376
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 10000, skip: 5)|ms|154|162|175|2.1%|5.03
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 10000, skip: 5000)|ms|129|134|150|3.2%|6.32
System.Linq.Tests.Perf_Linq.MeasureSkipWhile(size: 10000, skip: 9995)|ms|99.5|102|115|3.0%|4.57

There is an observable change on the indexed version if the source has more than `int.MaxValue` elements and the amount skipped is less in that currently this throws but after this change it will not. Since an exception in this case is probably undesirable, and since it would be unlikey to occur anyway, this is probably a reasonable, if not desirable, change.