### PR TITLE
Combine linq list optimisations

### DIFF
--- a/src/System.Linq/src/System/Linq/Buffer.cs
+++ b/src/System.Linq/src/System/Linq/Buffer.cs
@@ -14,7 +14,7 @@ namespace System.Linq
 
         internal Buffer(IEnumerable<TElement> source)
         {
-            IArrayProvider<TElement> iterator = source as IArrayProvider<TElement>;
+            IIListProvider<TElement> iterator = source as IIListProvider<TElement>;
             if (iterator != null)
             {
                 TElement[] array = iterator.ToArray();

--- a/src/System.Linq/src/System/Linq/Count.cs
+++ b/src/System.Linq/src/System/Linq/Count.cs
@@ -15,6 +15,8 @@ namespace System.Linq
             if (source == null) throw Error.ArgumentNull("source");
             ICollection<TSource> collectionoft = source as ICollection<TSource>;
             if (collectionoft != null) return collectionoft.Count;
+            IIListProvider<TSource> listProv = source as IIListProvider<TSource>;
+            if (listProv != null) return listProv.GetCount(onlyIfCheap: false);
             ICollection collection = source as ICollection;
             if (collection != null) return collection.Count;
             int count = 0;

--- a/src/System.Linq/src/System/Linq/Grouping.cs
+++ b/src/System.Linq/src/System/Linq/Grouping.cs
@@ -172,7 +172,7 @@ namespace System.Linq
         }
     }
 
-    internal class GroupedEnumerable<TSource, TKey, TElement, TResult> : IEnumerable<TResult>
+    internal class GroupedEnumerable<TSource, TKey, TElement, TResult> : IIListProvider<TResult>
     {
         private IEnumerable<TSource> _source;
         private Func<TSource, TKey> _keySelector;
@@ -203,9 +203,24 @@ namespace System.Linq
         {
             return GetEnumerator();
         }
+
+        public TResult[] ToArray()
+        {
+            return Lookup<TKey, TElement>.Create(_source, _keySelector, _elementSelector, _comparer).ToArray(_resultSelector);
+        }
+
+        public List<TResult> ToList()
+        {
+            return Lookup<TKey, TElement>.Create(_source, _keySelector, _elementSelector, _comparer).ToList(_resultSelector);
+        }
+
+        public int GetCount(bool onlyIfCheap)
+        {
+            return onlyIfCheap ? -1 : Lookup<TKey, TElement>.Create(_source, _keySelector, _elementSelector, _comparer).Count;
+        }
     }
 
-    internal class GroupedEnumerable<TSource, TKey, TElement> : IEnumerable<IGrouping<TKey, TElement>>, IArrayProvider<IGrouping<TKey, TElement>>, IListProvider<IGrouping<TKey, TElement>>
+    internal class GroupedEnumerable<TSource, TKey, TElement> : IIListProvider<IGrouping<TKey, TElement>>
     {
         private IEnumerable<TSource> _source;
         private Func<TSource, TKey> _keySelector;
@@ -235,14 +250,19 @@ namespace System.Linq
 
         public IGrouping<TKey, TElement>[] ToArray()
         {
-            IArrayProvider<IGrouping<TKey, TElement>> lookup = Lookup<TKey, TElement>.Create(_source, _keySelector, _elementSelector, _comparer);
+            IIListProvider<IGrouping<TKey, TElement>> lookup = Lookup<TKey, TElement>.Create(_source, _keySelector, _elementSelector, _comparer);
             return lookup.ToArray();
         }
 
         public List<IGrouping<TKey, TElement>> ToList()
         {
-            IListProvider<IGrouping<TKey, TElement>> lookup = Lookup<TKey, TElement>.Create(_source, _keySelector, _elementSelector, _comparer);
+            IIListProvider<IGrouping<TKey, TElement>> lookup = Lookup<TKey, TElement>.Create(_source, _keySelector, _elementSelector, _comparer);
             return lookup.ToList();
+        }
+
+        public int GetCount(bool onlyIfCheap)
+        {
+            return onlyIfCheap ? -1 : Lookup<TKey, TElement>.Create(_source, _keySelector, _elementSelector, _comparer).Count;
         }
     }
 }

--- a/src/System.Linq/src/System/Linq/Partition.cs
+++ b/src/System.Linq/src/System/Linq/Partition.cs
@@ -5,35 +5,38 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace System.Linq
 {
     /// <summary>
-    /// An iterator that can produce an array through an optimized path.
+    /// An iterator that can produce an array or <see cref="List{TElement}"/> through an optimized path.
     /// </summary>
-    internal interface IArrayProvider<TElement>
+    internal interface IIListProvider<TElement> : IEnumerable<TElement>
     {
         /// <summary>
         /// Produce an array of the sequence through an optimized path.
         /// </summary>
         /// <returns>The array.</returns>
         TElement[] ToArray();
-    }
 
-    /// <summary>
-    /// An iterator that can produce a <see cref="List{TElement}"/> through an optimized path.
-    /// </summary>
-    internal interface IListProvider<TElement>
-    {
         /// <summary>
         /// Produce a <see cref="List{TElement}"/> of the sequence through an optimized path.
         /// </summary>
         /// <returns>The <see cref="List{TElement}"/>.</returns>
         List<TElement> ToList();
+
+        /// <summary>
+        /// Returns the count of elements in the sequence.
+        /// </summary>
+        /// <param name="onlyIfCheap">If true then the count should only be calculated if doing
+        /// so is quick (sure or likely to be constant time), otherwise -1 should be returned.</param>
+        /// <returns>The number of elements.</returns>
+        int GetCount(bool onlyIfCheap);
     }
 
-    internal interface IPartition<TElement> : IEnumerable<TElement>, IArrayProvider<TElement>
+    internal interface IPartition<TElement> : IIListProvider<TElement>
     {
         IPartition<TElement> Skip(int count);
 
@@ -52,7 +55,7 @@ namespace System.Linq
         TElement LastOrDefault();
     }
 
-    internal sealed class EmptyPartition<TElement> : IPartition<TElement>, IListProvider<TElement>, IEnumerator<TElement>
+    internal sealed class EmptyPartition<TElement> : IPartition<TElement>, IEnumerator<TElement>
     {
         public EmptyPartition()
         {
@@ -144,6 +147,11 @@ namespace System.Linq
         {
             return new List<TElement>();
         }
+
+        public int GetCount(bool onlyIfCheap)
+        {
+            return 0;
+        }
     }
 
     internal sealed class OrderedPartition<TElement> : IPartition<TElement>
@@ -180,7 +188,7 @@ namespace System.Linq
         public IPartition<TElement> Take(int count)
         {
             int maxIndex = _minIndex + count - 1;
-            if (maxIndex >= _maxIndex) maxIndex = _maxIndex;
+            if ((uint)maxIndex >= (uint)_maxIndex) maxIndex = _maxIndex;
             return new OrderedPartition<TElement>(_source, _minIndex, maxIndex);
         }
 
@@ -220,6 +228,140 @@ namespace System.Linq
         public TElement[] ToArray()
         {
             return _source.ToArray(_minIndex, _maxIndex);
+        }
+
+        public List<TElement> ToList()
+        {
+            return _source.ToList(_minIndex, _maxIndex);
+        }
+
+        public int GetCount(bool onlyIfCheap)
+        {
+            return _source.GetCount(_minIndex, _maxIndex, onlyIfCheap);
+        }
+    }
+
+    public static partial class Enumerable
+    {
+        private sealed class ListPartition<TSource> : Iterator<TSource>, IPartition<TSource>
+        {
+            private readonly IList<TSource> _source;
+            private readonly int _minIndex;
+            private readonly int _maxIndex;
+            private int _index;
+
+            public ListPartition(IList<TSource> source, int minIndexInclusive, int maxIndexInclusive)
+            {
+                Debug.Assert(source != null);
+                Debug.Assert(minIndexInclusive >= 0);
+                Debug.Assert(minIndexInclusive <= maxIndexInclusive);
+                _source = source;
+                _minIndex = minIndexInclusive;
+                _maxIndex = maxIndexInclusive;
+                _index = minIndexInclusive;
+            }
+
+            public override Iterator<TSource> Clone()
+            {
+                return new ListPartition<TSource>(_source, _minIndex, _maxIndex);
+            }
+
+            public override bool MoveNext()
+            {
+                if ((state == 1 & _index <= _maxIndex) && _index < _source.Count)
+                {
+                    current = _source[_index];
+                    ++_index;
+                    return true;
+                }
+                Dispose();
+                return false;
+            }
+
+            public IPartition<TSource> Skip(int count)
+            {
+                int minIndex = _minIndex + count;
+                return minIndex >= _maxIndex
+                    ? (IPartition<TSource>)new EmptyPartition<TSource>()
+                    : new ListPartition<TSource>(_source, minIndex, _maxIndex);
+            }
+
+            public IPartition<TSource> Take(int count)
+            {
+                int maxIndex = _minIndex + count - 1;
+                return new ListPartition<TSource>(_source, _minIndex, (uint)maxIndex >= (uint)_maxIndex ? _maxIndex : maxIndex);
+            }
+
+            public TSource ElementAt(int index)
+            {
+                if (((uint)index > (uint)_maxIndex - _minIndex) || (index >= _source.Count - _minIndex)) throw Error.ArgumentOutOfRange("index");
+                return _source[_minIndex + index];
+            }
+
+            public TSource ElementAtOrDefault(int index)
+            {
+                return ((uint)index > (uint)_maxIndex - _minIndex) || (index >= _source.Count - _minIndex) ? default(TSource) : _source[_minIndex + index];
+            }
+
+            public TSource First()
+            {
+                if (_source.Count <= _minIndex) throw Error.NoElements();
+                return _source[_minIndex];
+            }
+
+            public TSource FirstOrDefault()
+            {
+                return _source.Count <= _minIndex ? default(TSource) : _source[_minIndex];
+            }
+
+            public TSource Last()
+            {
+                int lastIndex = _source.Count - 1;
+                if (lastIndex < _minIndex) throw Error.NoElements();
+                return _source[Math.Min(lastIndex, _maxIndex)];
+            }
+
+            public TSource LastOrDefault()
+            {
+                int lastIndex = _source.Count - 1;
+                return lastIndex < _minIndex ? default(TSource) : _source[Math.Min(lastIndex, _maxIndex)];
+            }
+
+            private int Count
+            {
+                get
+                {
+                    int count = _source.Count;
+                    if (count <= _minIndex) return 0;
+                    return Math.Min(count - 1, _maxIndex) - _minIndex + 1;
+                }
+            }
+
+            public TSource[] ToArray()
+            {
+                int count = Count;
+                if (count == 0) return Array.Empty<TSource>();
+                TSource[] array = new TSource[count];
+                for (int i = 0, curIdx = _minIndex; i != array.Length; ++i, ++curIdx)
+                    array[i] = _source[curIdx];
+                return array;
+            }
+
+            public List<TSource> ToList()
+            {
+                int count = Count;
+                if (count == 0) return new List<TSource>();
+                List<TSource> list = new List<TSource>(count);
+                int end = _minIndex + count;
+                for (int i = _minIndex; i != end; ++i)
+                    list.Add(_source[i]);
+                return list;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                return Count;
+            }
         }
     }
 }

--- a/src/System.Linq/src/System/Linq/Range.cs
+++ b/src/System.Linq/src/System/Linq/Range.cs
@@ -18,7 +18,7 @@ namespace System.Linq
             return new RangeIterator(start, count);
         }
 
-        private sealed class RangeIterator : Iterator<int>, IArrayProvider<int>, IListProvider<int>, IPartition<int>
+        private sealed class RangeIterator : Iterator<int>, IPartition<int>
         {
             private readonly int _start;
             private readonly int _end;
@@ -79,6 +79,11 @@ namespace System.Linq
                 }
 
                 return list;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                return _end - _start;
             }
 
             public IPartition<int> Skip(int count)

--- a/src/System.Linq/src/System/Linq/Repeat.cs
+++ b/src/System.Linq/src/System/Linq/Repeat.cs
@@ -17,7 +17,7 @@ namespace System.Linq
             return new RepeatIterator<TResult>(element, count);
         }
 
-        private sealed class RepeatIterator<TResult> : Iterator<TResult>, IArrayProvider<TResult>, IListProvider<TResult>, IPartition<TResult>
+        private sealed class RepeatIterator<TResult> : Iterator<TResult>, IPartition<TResult>
         {
             private readonly int _count;
             private int _sent;
@@ -68,6 +68,11 @@ namespace System.Linq
                 for (int i = 0; i != _count; ++i) list.Add(current);
 
                 return list;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                return _count;
             }
 
             public IPartition<TResult> Skip(int count)

--- a/src/System.Linq/src/System/Linq/Select.cs
+++ b/src/System.Linq/src/System/Linq/Select.cs
@@ -105,7 +105,7 @@ namespace System.Linq
             }
         }
 
-        internal sealed class SelectArrayIterator<TSource, TResult> : Iterator<TResult>, IArrayProvider<TResult>, IListProvider<TResult>
+        internal sealed class SelectArrayIterator<TSource, TResult> : Iterator<TResult>, IIListProvider<TResult>
         {
             private readonly TSource[] _source;
             private readonly Func<TSource, TResult> _selector;
@@ -165,9 +165,14 @@ namespace System.Linq
                 }
                 return results;
             }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                return _source.Length;
+            }
         }
 
-        internal sealed class SelectListIterator<TSource, TResult> : Iterator<TResult>, IArrayProvider<TResult>, IListProvider<TResult>
+        internal sealed class SelectListIterator<TSource, TResult> : Iterator<TResult>, IIListProvider<TResult>
         {
             private readonly List<TSource> _source;
             private readonly Func<TSource, TResult> _selector;
@@ -237,9 +242,14 @@ namespace System.Linq
                 }
                 return results;
             }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                return _source.Count;
+            }
         }
 
-        internal sealed class SelectIListIterator<TSource, TResult> : Iterator<TResult>, IArrayProvider<TResult>, IListProvider<TResult>
+        internal sealed class SelectIListIterator<TSource, TResult> : Iterator<TResult>, IIListProvider<TResult>
         {
             private readonly IList<TSource> _source;
             private readonly Func<TSource, TResult> _selector;
@@ -318,6 +328,11 @@ namespace System.Linq
                     results.Add(_selector(_source[i]));
                 }
                 return results;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                return _source.Count;
             }
         }
     }

--- a/src/System.Linq/src/System/Linq/Skip.cs
+++ b/src/System.Linq/src/System/Linq/Skip.cs
@@ -16,15 +16,8 @@ namespace System.Linq
             IPartition<TSource> partition = source as IPartition<TSource>;
             if (partition != null) return partition.Skip(count);
             IList<TSource> sourceList = source as IList<TSource>;
-            return sourceList != null ? SkipList(sourceList, count) : SkipIterator<TSource>(source, count);
-        }
-
-        private static IEnumerable<TSource> SkipList<TSource>(IList<TSource> source, int count)
-        {
-            while (count < source.Count)
-            {
-                yield return source[count++];
-            }
+            if (sourceList != null) return new ListPartition<TSource>(sourceList, count, int.MaxValue);
+            return SkipIterator(source, count);
         }
 
         private static IEnumerable<TSource> SkipIterator<TSource>(IEnumerable<TSource> source, int count)

--- a/src/System.Linq/src/System/Linq/Take.cs
+++ b/src/System.Linq/src/System/Linq/Take.cs
@@ -15,6 +15,8 @@ namespace System.Linq
             if (count <= 0) return new EmptyPartition<TSource>();
             IPartition<TSource> partition = source as IPartition<TSource>;
             if (partition != null) return partition.Take(count);
+            IList<TSource> sourceList = source as IList<TSource>;
+            if (sourceList != null) return new ListPartition<TSource>(sourceList, 0, count - 1);
             return TakeIterator(source, count);
         }
 

--- a/src/System.Linq/src/System/Linq/ToCollection.cs
+++ b/src/System.Linq/src/System/Linq/ToCollection.cs
@@ -12,14 +12,14 @@ namespace System.Linq
         public static TSource[] ToArray<TSource>(this IEnumerable<TSource> source)
         {
             if (source == null) throw Error.ArgumentNull("source");
-            IArrayProvider<TSource> arrayProvider = source as IArrayProvider<TSource>;
+            IIListProvider<TSource> arrayProvider = source as IIListProvider<TSource>;
             return arrayProvider != null ? arrayProvider.ToArray() : EnumerableHelpers.ToArray(source);
         }
 
         public static List<TSource> ToList<TSource>(this IEnumerable<TSource> source)
         {
             if (source == null) throw Error.ArgumentNull("source");
-            IListProvider<TSource> listProvider = source as IListProvider<TSource>;
+            IIListProvider<TSource> listProvider = source as IIListProvider<TSource>;
             return listProvider != null ? listProvider.ToList() : new List<TSource>(source);
         }
 

--- a/src/System.Linq/tests/GroupByTests.cs
+++ b/src/System.Linq/tests/GroupByTests.cs
@@ -631,5 +631,73 @@ namespace System.Linq.Tests
             Assert.Equal(4, groupedList.Count);
             Assert.Equal(source.GroupBy(r => r.Name, (r, e) => e), groupedList);
         }
+
+        [Fact]
+        public void GroupingCount()
+        {
+            Record[] source = new Record[]
+            {
+                new Record { Name = "Tim", Score = 55 },
+                new Record { Name = "Chris", Score = 49 },
+                new Record { Name = "Robert", Score = -100 },
+                new Record { Name = "Chris", Score = 24 },
+                new Record { Name = "Prakash", Score = 9 },
+                new Record { Name = "Tim", Score = 25 }
+            };
+
+            Assert.Equal(4, source.GroupBy(r => r.Name).Count());
+        }
+
+        [Fact]
+        public void GroupingWithResultsCount()
+        {
+            Record[] source = new Record[]
+            {
+                new Record { Name = "Tim", Score = 55 },
+                new Record { Name = "Chris", Score = 49 },
+                new Record { Name = "Robert", Score = -100 },
+                new Record { Name = "Chris", Score = 24 },
+                new Record { Name = "Prakash", Score = 9 },
+                new Record { Name = "Tim", Score = 25 }
+            };
+
+            Assert.Equal(4, source.GroupBy(r => r.Name, (r, e) => e).Count());
+        }
+
+        [Fact]
+        public void EmptyGroupingToArray()
+        {
+            Assert.Empty(Enumerable.Empty<int>().GroupBy(i => i).ToArray());
+        }
+
+        [Fact]
+        public void EmptyGroupingToList()
+        {
+            Assert.Empty(Enumerable.Empty<int>().GroupBy(i => i).ToList());
+        }
+
+        [Fact]
+        public void EmptyGroupingCount()
+        {
+            Assert.Equal(0, Enumerable.Empty<int>().GroupBy(i => i).Count());
+        }
+
+        [Fact]
+        public void EmptyGroupingWithResultToArray()
+        {
+            Assert.Empty(Enumerable.Empty<int>().GroupBy(i => i, (x, y) => x + y.Count()).ToArray());
+        }
+
+        [Fact]
+        public void EmptyGroupingWithResultToList()
+        {
+            Assert.Empty(Enumerable.Empty<int>().GroupBy(i => i, (x, y) => x + y.Count()).ToList());
+        }
+
+        [Fact]
+        public void EmptyGroupingWithResultCount()
+        {
+            Assert.Equal(0, Enumerable.Empty<int>().GroupBy(i => i, (x, y) => x + y.Count()).Count());
+        }
     }
 }

--- a/src/System.Linq/tests/OrderByTests.cs
+++ b/src/System.Linq/tests/OrderByTests.cs
@@ -54,6 +54,13 @@ namespace System.Linq.Tests
             Assert.Empty(source.OrderBy(e => e));
         }
 
+        [Fact]
+        public void OrderedCount()
+        {
+            var source = Enumerable.Range(0, 20).Shuffle();
+            Assert.Equal(20, source.OrderBy(i => i).Count());
+        }
+
         //FIXME: This will hang with a larger source. Do we want to deal with that case?
         [Fact]
         public void SurviveBadComparerAlwaysReturnsNegative()

--- a/src/System.Linq/tests/OrderedSubsetting.cs
+++ b/src/System.Linq/tests/OrderedSubsetting.cs
@@ -209,6 +209,7 @@ namespace System.Linq.Tests
             var ordered = source.OrderBy(i => i);
             Assert.Equal(Enumerable.Range(20, 60), ordered.Skip(20).Take(60));
             Assert.Equal(Enumerable.Range(30, 20), ordered.Skip(20).Skip(10).Take(50).Take(20));
+            Assert.Equal(Enumerable.Range(30, 20), ordered.Skip(20).Skip(10).Take(20).Take(int.MaxValue));
             Assert.Empty(ordered.Skip(10).Take(9).Take(0));
             Assert.Empty(ordered.Skip(200).Take(10));
             Assert.Empty(ordered.Skip(3).Take(0));
@@ -304,9 +305,34 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void ToList()
+        {
+            Assert.Equal(Enumerable.Range(10, 20), Enumerable.Range(0, 100).Shuffle().OrderBy(i => i).Skip(10).Take(20).ToList());
+        }
+
+        [Fact]
+        public void Count()
+        {
+            Assert.Equal(20, Enumerable.Range(0, 100).Shuffle().OrderBy(i => i).Skip(10).Take(20).Count());
+        }
+
+        [Fact]
         public void EmptyToArray()
         {
             Assert.Empty(Enumerable.Range(0, 100).Shuffle().OrderBy(i => i).Skip(100).ToArray());
+        }
+
+        [Fact]
+        public void EmptyToList()
+        {
+            Assert.Empty(Enumerable.Range(0, 100).Shuffle().OrderBy(i => i).Skip(100).ToList());
+        }
+
+        [Fact]
+        public void EmptyCount()
+        {
+            Assert.Equal(0, Enumerable.Range(0, 100).Shuffle().OrderBy(i => i).Skip(100).Count());
+            Assert.Equal(0, Enumerable.Range(0, 100).Shuffle().OrderBy(i => i).Take(0).Count());
         }
 
         [Fact]
@@ -316,9 +342,33 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void AttemptedMoreList()
+        {
+            Assert.Equal(Enumerable.Range(0, 20), Enumerable.Range(0, 20).Shuffle().OrderBy(i => i).Take(30).ToList());
+        }
+
+        [Fact]
+        public void AttemptedMoreCount()
+        {
+            Assert.Equal(20, Enumerable.Range(0, 20).Shuffle().OrderBy(i => i).Take(30).Count());
+        }
+
+        [Fact]
         public void SingleElementToArray()
         {
             Assert.Equal(Enumerable.Repeat(10, 1), Enumerable.Range(0, 20).Shuffle().OrderBy(i => i).Skip(10).Take(1).ToArray());
+        }
+
+        [Fact]
+        public void SingleElementToList()
+        {
+            Assert.Equal(Enumerable.Repeat(10, 1), Enumerable.Range(0, 20).Shuffle().OrderBy(i => i).Skip(10).Take(1).ToList());
+        }
+
+        [Fact]
+        public void SingleElementCount()
+        {
+            Assert.Equal(1, Enumerable.Range(0, 20).Shuffle().OrderBy(i => i).Skip(10).Take(1).Count());
         }
 
         [Fact]

--- a/src/System.Linq/tests/RepeatTests.cs
+++ b/src/System.Linq/tests/RepeatTests.cs
@@ -225,5 +225,11 @@ namespace System.Linq.Tests
         {
             Assert.Equal(0, Enumerable.Repeat(3, 3).ElementAtOrDefault(100));
         }
+
+        [Fact]
+        public void Count()
+        {
+            Assert.Equal(42, Enumerable.Repeat("Test", 42).Count());
+        }
     }
 }

--- a/src/System.Linq/tests/SelectTests.cs
+++ b/src/System.Linq/tests/SelectTests.cs
@@ -43,7 +43,7 @@ namespace System.Linq.Tests
         [Fact]
         public void SelectProperty()
         {
-            var source = new []{
+            var source = new[]{
                 new { name="Prakash", custID=98088 },
                 new { name="Bob", custID=29099 },
                 new { name="Chris", custID=39033 },
@@ -759,12 +759,34 @@ namespace System.Linq.Tests
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }
+
         [Fact]
         public void ForcedToEnumeratorDoesntEnumerateIList()
         {
             var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).ToList().AsReadOnly().Select(i => i);
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
+        }
+
+        [Fact]
+        public void Select_SourceIsArray_Count()
+        {
+            var source = new[] { 1, 2, 3, 4 };
+            Assert.Equal(source.Length, source.Select(i => i * 2).Count());
+        }
+
+        [Fact]
+        public void Select_SourceIsAList_Count()
+        {
+            var source = new List<int> { 1, 2, 3, 4 };
+            Assert.Equal(source.Count, source.Select(i => i * 2).Count());
+        }
+
+        [Fact]
+        public void Select_SourceIsAnIList_Count()
+        {
+            var souce = new List<int> { 1, 2, 3, 4 }.AsReadOnly();
+            Assert.Equal(souce.Count, souce.Select(i => i * 2).Count());
         }
     }
 }

--- a/src/System.Linq/tests/SkipTests.cs
+++ b/src/System.Linq/tests/SkipTests.cs
@@ -214,5 +214,247 @@ namespace System.Linq.Tests
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }
+
+        [Fact]
+        public void Count()
+        {
+            Assert.Equal(2, NumberRangeGuaranteedNotCollectionType(0, 3).Skip(1).Count());
+            Assert.Equal(2, new[] { 1, 2, 3 }.Skip(1).Count());
+        }
+
+        [Fact]
+        public void FollowWithTake()
+        {
+            var source = new[] { 5, 6, 7, 8 };
+            var expected = new[] { 6, 7 };
+            Assert.Equal(expected, source.Skip(1).Take(2));
+        }
+
+        [Fact]
+        public void FollowWithTakeNotIList()
+        {
+            var source = NumberRangeGuaranteedNotCollectionType(5, 4);
+            var expected = new[] { 6, 7 };
+            Assert.Equal(expected, source.Skip(1).Take(2));
+        }
+
+        [Fact]
+        public void FollowWithTakeThenMassiveTake()
+        {
+            var source = new[] { 5, 6, 7, 8 };
+            var expected = new[] { 7 };
+            Assert.Equal(expected, source.Skip(2).Take(1).Take(int.MaxValue));
+        }
+        [Fact]
+        public void FollowWithTakeThenMassiveTakeNotIList()
+        {
+            var source = NumberRangeGuaranteedNotCollectionType(5, 4);
+            var expected = new[] { 7 };
+            Assert.Equal(expected, source.Skip(2).Take(1).Take(int.MaxValue));
+        }
+
+        [Fact]
+        public void FollowWithSkip()
+        {
+            var source = new[] { 1, 2, 3, 4, 5, 6 };
+            var expected = new[] { 4, 5, 6 };
+            Assert.Equal(expected, source.Skip(1).Skip(2).Skip(-4));
+        }
+
+        [Fact]
+        public void FollowWithSkipNotIList()
+        {
+            var source = NumberRangeGuaranteedNotCollectionType(1, 6);
+            var expected = new[] { 4, 5, 6 };
+            Assert.Equal(expected, source.Skip(1).Skip(2).Skip(-4));
+        }
+
+        [Fact]
+        public void ElementAt()
+        {
+            var source = new[] { 1, 2, 3, 4, 5, 6 };
+            var remaining = source.Skip(2);
+            Assert.Equal(3, remaining.ElementAt(0));
+            Assert.Equal(4, remaining.ElementAt(1));
+            Assert.Equal(6, remaining.ElementAt(3));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => remaining.ElementAt(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => remaining.ElementAt(4));
+        }
+
+        [Fact]
+        public void ElementAtNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5, 6 });
+            var remaining = source.Skip(2);
+            Assert.Equal(3, remaining.ElementAt(0));
+            Assert.Equal(4, remaining.ElementAt(1));
+            Assert.Equal(6, remaining.ElementAt(3));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => remaining.ElementAt(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => remaining.ElementAt(4));
+        }
+
+        [Fact]
+        public void ElementAtOrDefault()
+        {
+            var source = new[] { 1, 2, 3, 4, 5, 6 };
+            var remaining = source.Skip(2);
+            Assert.Equal(3, remaining.ElementAtOrDefault(0));
+            Assert.Equal(4, remaining.ElementAtOrDefault(1));
+            Assert.Equal(6, remaining.ElementAtOrDefault(3));
+            Assert.Equal(0, remaining.ElementAtOrDefault(-1));
+            Assert.Equal(0, remaining.ElementAtOrDefault(4));
+        }
+
+        [Fact]
+        public void ElementAtOrDefaultNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5, 6 });
+            var remaining = source.Skip(2);
+            Assert.Equal(3, remaining.ElementAtOrDefault(0));
+            Assert.Equal(4, remaining.ElementAtOrDefault(1));
+            Assert.Equal(6, remaining.ElementAtOrDefault(3));
+            Assert.Equal(0, remaining.ElementAtOrDefault(-1));
+            Assert.Equal(0, remaining.ElementAtOrDefault(4));
+        }
+
+        [Fact]
+        public void First()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(1, source.Skip(0).First());
+            Assert.Equal(3, source.Skip(2).First());
+            Assert.Equal(5, source.Skip(4).First());
+            Assert.Throws<InvalidOperationException>(() => source.Skip(5).First());
+        }
+
+        [Fact]
+        public void FirstNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(1, source.Skip(0).First());
+            Assert.Equal(3, source.Skip(2).First());
+            Assert.Equal(5, source.Skip(4).First());
+            Assert.Throws<InvalidOperationException>(() => source.Skip(5).First());
+        }
+
+        [Fact]
+        public void FirstOrDefault()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(1, source.Skip(0).FirstOrDefault());
+            Assert.Equal(3, source.Skip(2).FirstOrDefault());
+            Assert.Equal(5, source.Skip(4).FirstOrDefault());
+            Assert.Equal(0, source.Skip(5).FirstOrDefault());
+        }
+
+        [Fact]
+        public void FirstOrDefaultNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(1, source.Skip(0).FirstOrDefault());
+            Assert.Equal(3, source.Skip(2).FirstOrDefault());
+            Assert.Equal(5, source.Skip(4).FirstOrDefault());
+            Assert.Equal(0, source.Skip(5).FirstOrDefault());
+        }
+
+        [Fact]
+        public void Last()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(5, source.Skip(0).Last());
+            Assert.Equal(5, source.Skip(1).Last());
+            Assert.Equal(5, source.Skip(4).Last());
+            Assert.Throws<InvalidOperationException>(() => source.Skip(5).Last());
+        }
+
+        [Fact]
+        public void LastNotList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(5, source.Skip(0).Last());
+            Assert.Equal(5, source.Skip(1).Last());
+            Assert.Equal(5, source.Skip(4).Last());
+            Assert.Throws<InvalidOperationException>(() => source.Skip(5).Last());
+        }
+
+        [Fact]
+        public void LastOrDefault()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(5, source.Skip(0).LastOrDefault());
+            Assert.Equal(5, source.Skip(1).LastOrDefault());
+            Assert.Equal(5, source.Skip(4).LastOrDefault());
+            Assert.Equal(0, source.Skip(5).LastOrDefault());
+        }
+
+        [Fact]
+        public void LastOrDefaultNotList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(5, source.Skip(0).LastOrDefault());
+            Assert.Equal(5, source.Skip(1).LastOrDefault());
+            Assert.Equal(5, source.Skip(4).LastOrDefault());
+            Assert.Equal(0, source.Skip(5).LastOrDefault());
+        }
+
+        [Fact]
+        public void ToArray()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Skip(0).ToArray());
+            Assert.Equal(new[] { 2, 3, 4, 5 }, source.Skip(1).ToArray());
+            Assert.Equal(5, source.Skip(4).ToArray().Single());
+            Assert.Empty(source.Skip(5).ToArray());
+            Assert.Empty(source.Skip(40).ToArray());
+        }
+
+        [Fact]
+        public void ToArrayNotList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Skip(0).ToArray());
+            Assert.Equal(new[] { 2, 3, 4, 5 }, source.Skip(1).ToArray());
+            Assert.Equal(5, source.Skip(4).ToArray().Single());
+            Assert.Empty(source.Skip(5).ToArray());
+            Assert.Empty(source.Skip(40).ToArray());
+        }
+
+        [Fact]
+        public void ToList()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Skip(0).ToList());
+            Assert.Equal(new[] { 2, 3, 4, 5 }, source.Skip(1).ToList());
+            Assert.Equal(5, source.Skip(4).ToList().Single());
+            Assert.Empty(source.Skip(5).ToList());
+            Assert.Empty(source.Skip(40).ToList());
+        }
+
+        [Fact]
+        public void ToListNotList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Skip(0).ToList());
+            Assert.Equal(new[] { 2, 3, 4, 5 }, source.Skip(1).ToList());
+            Assert.Equal(5, source.Skip(4).ToList().Single());
+            Assert.Empty(source.Skip(5).ToList());
+            Assert.Empty(source.Skip(40).ToList());
+        }
+
+        [Fact]
+        public void RepeatEnumerating()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            var remaining = source.Skip(1);
+            Assert.Equal(remaining, remaining);
+        }
+
+        [Fact]
+        public void RepeatEnumeratingNotList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            var remaining = source.Skip(1);
+            Assert.Equal(remaining, remaining);
+        }
     }
 }

--- a/src/System.Linq/tests/TakeTests.cs
+++ b/src/System.Linq/tests/TakeTests.cs
@@ -10,12 +10,28 @@ namespace System.Linq.Tests
 {
     public class TakeTests : EnumerableTests
     {
+        private static IEnumerable<T> GuaranteeNotIList<T>(IEnumerable<T> source)
+        {
+            foreach (T element in source)
+                yield return element;
+        }
+
         [Fact]
         public void SameResultsRepeatCallsIntQuery()
         {
             var q = from x in new[] { 9999, 0, 888, -1, 66, -777, 1, 2, -12345 }
                     where x > Int32.MinValue
                     select x;
+
+            Assert.Equal(q.Take(9), q.Take(9));
+        }
+
+        [Fact]
+        public void SameResultsRepeatCallsIntQueryIList()
+        {
+            var q = (from x in new[] { 9999, 0, 888, -1, 66, -777, 1, 2, -12345 }
+                     where x > Int32.MinValue
+                     select x).ToList();
 
             Assert.Equal(q.Take(9), q.Take(9));
         }
@@ -31,9 +47,26 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void SameResultsRepeatCallsStringQueryIList()
+        {
+            var q = (from x in new[] { "!@#$%^", "C", "AAA", "", "Calling Twice", "SoS", String.Empty }
+                     where !String.IsNullOrEmpty(x)
+                     select x).ToList();
+
+            Assert.Equal(q.Take(7), q.Take(7));
+        }
+
+        [Fact]
         public void SourceEmptyCountPositive()
         {
             int[] source = { };
+            Assert.Empty(source.Take(5));
+        }
+
+        [Fact]
+        public void SourceEmptyCountPositiveNotIList()
+        {
+            var source = NumberRangeGuaranteedNotCollectionType(0, 0);
             Assert.Empty(source.Take(5));
         }
 
@@ -45,9 +78,23 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void SourceNonEmptyCountNegativeNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 2, 5, 9, 1 });
+            Assert.Empty(source.Take(-5));
+        }
+
+        [Fact]
         public void SourceNonEmptyCountZero()
         {
             int[] source = { 2, 5, 9, 1 };
+            Assert.Empty(source.Take(0));
+        }
+
+        [Fact]
+        public void SourceNonEmptyCountZeroNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 2, 5, 9, 1 });
             Assert.Empty(source.Take(0));
         }
 
@@ -61,11 +108,28 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void SourceNonEmptyCountOneNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 2, 5, 9, 1 });
+            int[] expected = { 2 };
+
+            Assert.Equal(expected, source.Take(1));
+        }
+
+        [Fact]
         public void SourceNonEmptyTakeAllExactly()
         {
             int[] source = { 2, 5, 9, 1 };
-            
+
             Assert.Equal(source, source.Take(source.Length));
+        }
+
+        [Fact]
+        public void SourceNonEmptyTakeAllExactlyNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 2, 5, 9, 1 });
+
+            Assert.Equal(source, source.Take(source.Count()));
         }
 
         [Fact]
@@ -73,7 +137,16 @@ namespace System.Linq.Tests
         {
             int[] source = { 2, 5, 9, 1 };
             int[] expected = { 2, 5, 9 };
-            
+
+            Assert.Equal(expected, source.Take(3));
+        }
+
+        [Fact]
+        public void SourceNonEmptyTakeAllButOneNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 2, 5, 9, 1 });
+            int[] expected = { 2, 5, 9 };
+
             Assert.Equal(expected, source.Take(3));
         }
 
@@ -84,7 +157,15 @@ namespace System.Linq.Tests
 
             Assert.Equal(source, source.Take(source.Length + 1));
         }
-        
+
+        [Fact]
+        public void SourceNonEmptyTakeExcessiveNotIList()
+        {
+            var source = GuaranteeNotIList(new int?[] { 2, 5, null, 9, 1 });
+
+            Assert.Equal(source, source.Take(source.Count() + 1));
+        }
+
         [Fact]
         public void ThrowsOnNullSource()
         {
@@ -99,6 +180,255 @@ namespace System.Linq.Tests
             // Don't insist on this behaviour, but check its correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
+        }
+
+        [Fact]
+        public void Count()
+        {
+            Assert.Equal(2, NumberRangeGuaranteedNotCollectionType(0, 3).Take(2).Count());
+            Assert.Equal(2, new[] { 1, 2, 3 }.Take(2).Count());
+            Assert.Equal(0, NumberRangeGuaranteedNotCollectionType(0, 3).Take(0).Count());
+        }
+
+        [Fact]
+        public void ForcedToEnumeratorDoesntEnumerateIList()
+        {
+            var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).ToList().Take(2);
+            // Don't insist on this behaviour, but check its correct if it happens
+            var en = iterator as IEnumerator<int>;
+            Assert.False(en != null && en.MoveNext());
+        }
+
+        [Fact]
+        public void FollowWithTake()
+        {
+            var source = new[] { 5, 6, 7, 8 };
+            var expected = new[] { 5, 6 };
+            Assert.Equal(expected, source.Take(5).Take(3).Take(2).Take(40));
+        }
+
+        [Fact]
+        public void FollowWithTakeNotIList()
+        {
+            var source = NumberRangeGuaranteedNotCollectionType(5, 4);
+            var expected = new[] { 5, 6 };
+            Assert.Equal(expected, source.Take(5).Take(3).Take(2));
+        }
+
+        [Fact]
+        public void FollowWithSkip()
+        {
+            var source = new[] { 1, 2, 3, 4, 5, 6 };
+            var expected = new[] { 3, 4, 5 };
+            Assert.Equal(expected, source.Take(5).Skip(2).Skip(-4));
+        }
+
+        [Fact]
+        public void FollowWithSkipNotIList()
+        {
+            var source = NumberRangeGuaranteedNotCollectionType(1, 6);
+            var expected = new[] { 3, 4, 5 };
+            Assert.Equal(expected, source.Take(5).Skip(2).Skip(-4));
+        }
+
+        [Fact]
+        public void ElementAt()
+        {
+            var source = new[] { 1, 2, 3, 4, 5, 6 };
+            var taken = source.Take(3);
+            Assert.Equal(1, taken.ElementAt(0));
+            Assert.Equal(3, taken.ElementAt(2));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => taken.ElementAt(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => taken.ElementAt(3));
+        }
+
+        [Fact]
+        public void ElementAtNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5, 6 });
+            var taken = source.Take(3);
+            Assert.Equal(1, taken.ElementAt(0));
+            Assert.Equal(3, taken.ElementAt(2));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => taken.ElementAt(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => taken.ElementAt(3));
+        }
+
+        [Fact]
+        public void ElementAtOrDefault()
+        {
+            var source = new[] { 1, 2, 3, 4, 5, 6 };
+            var taken = source.Take(3);
+            Assert.Equal(1, taken.ElementAtOrDefault(0));
+            Assert.Equal(3, taken.ElementAtOrDefault(2));
+            Assert.Equal(0, taken.ElementAtOrDefault(-1));
+            Assert.Equal(0, taken.ElementAtOrDefault(3));
+        }
+
+        [Fact]
+        public void ElementAtOrDefaultNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5, 6 });
+            var taken = source.Take(3);
+            Assert.Equal(1, taken.ElementAtOrDefault(0));
+            Assert.Equal(3, taken.ElementAtOrDefault(2));
+            Assert.Equal(0, taken.ElementAtOrDefault(-1));
+            Assert.Equal(0, taken.ElementAtOrDefault(3));
+        }
+
+        [Fact]
+        public void First()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(1, source.Take(1).First());
+            Assert.Equal(1, source.Take(4).First());
+            Assert.Equal(1, source.Take(40).First());
+            Assert.Throws<InvalidOperationException>(() => source.Take(0).First());
+            Assert.Throws<InvalidOperationException>(() => source.Skip(5).Take(10).First());
+        }
+
+        [Fact]
+        public void FirstNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(1, source.Take(1).First());
+            Assert.Equal(1, source.Take(4).First());
+            Assert.Equal(1, source.Take(40).First());
+            Assert.Throws<InvalidOperationException>(() => source.Take(0).First());
+            Assert.Throws<InvalidOperationException>(() => source.Skip(5).Take(10).First());
+        }
+
+        [Fact]
+        public void FirstOrDefault()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(1, source.Take(1).FirstOrDefault());
+            Assert.Equal(1, source.Take(4).FirstOrDefault());
+            Assert.Equal(1, source.Take(40).FirstOrDefault());
+            Assert.Equal(0, source.Take(0).FirstOrDefault());
+            Assert.Equal(0, source.Skip(5).Take(10).FirstOrDefault());
+        }
+
+        [Fact]
+        public void FirstOrDefaultNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(1, source.Take(1).FirstOrDefault());
+            Assert.Equal(1, source.Take(4).FirstOrDefault());
+            Assert.Equal(1, source.Take(40).FirstOrDefault());
+            Assert.Equal(0, source.Take(0).FirstOrDefault());
+            Assert.Equal(0, source.Skip(5).Take(10).FirstOrDefault());
+        }
+
+        [Fact]
+        public void Last()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(1, source.Take(1).Last());
+            Assert.Equal(5, source.Take(5).Last());
+            Assert.Equal(5, source.Take(40).Last());
+            Assert.Throws<InvalidOperationException>(() => source.Take(0).Last());
+            Assert.Throws<InvalidOperationException>(() => Array.Empty<int>().Take(40).Last());
+        }
+
+        [Fact]
+        public void LastNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(1, source.Take(1).Last());
+            Assert.Equal(5, source.Take(5).Last());
+            Assert.Equal(5, source.Take(40).Last());
+            Assert.Throws<InvalidOperationException>(() => source.Take(0).Last());
+            Assert.Throws<InvalidOperationException>(() => GuaranteeNotIList(Array.Empty<int>()).Take(40).Last());
+        }
+
+        [Fact]
+        public void LastOrDefault()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(1, source.Take(1).LastOrDefault());
+            Assert.Equal(5, source.Take(5).LastOrDefault());
+            Assert.Equal(5, source.Take(40).LastOrDefault());
+            Assert.Equal(0, source.Take(0).LastOrDefault());
+            Assert.Equal(0, Array.Empty<int>().Take(40).LastOrDefault());
+        }
+
+        [Fact]
+        public void LastOrDefaultNotIList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(1, source.Take(1).LastOrDefault());
+            Assert.Equal(5, source.Take(5).LastOrDefault());
+            Assert.Equal(5, source.Take(40).LastOrDefault());
+            Assert.Equal(0, source.Take(0).LastOrDefault());
+            Assert.Equal(0, GuaranteeNotIList(Array.Empty<int>()).Take(40).LastOrDefault());
+        }
+
+        [Fact]
+        public void ToArray()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Take(5).ToArray());
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Take(6).ToArray());
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Take(40).ToArray());
+            Assert.Equal(new[] { 1, 2, 3, 4 }, source.Take(4).ToArray());
+            Assert.Equal(1, source.Take(1).ToArray().Single());
+            Assert.Empty(source.Take(0).ToArray());
+            Assert.Empty(source.Take(-10).ToArray());
+        }
+
+        [Fact]
+        public void ToArrayNotList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Take(5).ToArray());
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Take(6).ToArray());
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Take(40).ToArray());
+            Assert.Equal(new[] { 1, 2, 3, 4 }, source.Take(4).ToArray());
+            Assert.Equal(1, source.Take(1).ToArray().Single());
+            Assert.Empty(source.Take(0).ToArray());
+            Assert.Empty(source.Take(-10).ToArray());
+        }
+
+        [Fact]
+        public void ToList()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Take(5).ToList());
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Take(6).ToList());
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Take(40).ToList());
+            Assert.Equal(new[] { 1, 2, 3, 4 }, source.Take(4).ToList());
+            Assert.Equal(1, source.Take(1).ToList().Single());
+            Assert.Empty(source.Take(0).ToList());
+            Assert.Empty(source.Take(-10).ToList());
+        }
+
+        [Fact]
+        public void ToListNotList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Take(5).ToList());
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Take(6).ToList());
+            Assert.Equal(new[] { 1, 2, 3, 4, 5 }, source.Take(40).ToList());
+            Assert.Equal(new[] { 1, 2, 3, 4 }, source.Take(4).ToList());
+            Assert.Equal(1, source.Take(1).ToList().Single());
+            Assert.Empty(source.Take(0).ToList());
+            Assert.Empty(source.Take(-10).ToList());
+        }
+
+        [Fact]
+        public void RepeatEnumerating()
+        {
+            var source = new[] { 1, 2, 3, 4, 5 };
+            var taken = source.Take(3);
+            Assert.Equal(taken, taken);
+        }
+
+        [Fact]
+        public void RepeatEnumeratingNotList()
+        {
+            var source = GuaranteeNotIList(new[] { 1, 2, 3, 4, 5 });
+            var taken = source.Take(3);
+            Assert.Equal(taken, taken);
         }
     }
 }

--- a/src/System.Linq/tests/ToLookupTests.cs
+++ b/src/System.Linq/tests/ToLookupTests.cs
@@ -94,7 +94,7 @@ namespace System.Linq.Tests
         {
             string[] key = { "Chris", "Prakash", "Robert" };
             int[] element = { 50, 80, 100, 95, 99, 56 };
-            var source = new []
+            var source = new[]
             {
                 new { Name = key[0], Score = element[0] },
                 new { Name = key[1], Score = element[2] },
@@ -105,6 +105,24 @@ namespace System.Linq.Tests
             };
 
             AssertMatches(key, element, source.ToLookup(e => e.Name, e => e.Score, new AnagramEqualityComparer()));
+        }
+
+        [Fact]
+        public void Count()
+        {
+            string[] key = { "Chris", "Prakash", "Robert" };
+            int[] element = { 50, 80, 100, 95, 99, 56 };
+            var source = new[]
+            {
+                new { Name = key[0], Score = element[0] },
+                new { Name = key[1], Score = element[2] },
+                new { Name = key[2], Score = element[5] },
+                new { Name = key[1], Score = element[3] },
+                new { Name = key[0], Score = element[1] },
+                new { Name = key[1], Score = element[4] }
+            };
+
+            Assert.Equal(3, source.ToLookup(e => e.Name, e => e.Score).Count());
         }
 
         [Fact]


### PR DESCRIPTION
A few different optimisations to Linq added recently can be usefully combined with each other.

### Combine `IArrayProvider` and `IListProvider`

Anything that can be one can be the other, so merge the two interfaces into `IIListProvider`.

Anything implementing these can also fast-path `Count()`, so do so.

### Have `IList<T>` optimised result of `Skip()` partitionable.

Optimisation of `Skip()` for `IList<T>` sources from #4551 fits with optimisations of `Skip()` and `Take()` for other sources from #2401.

Combine the approaches, extending how the result of `Skip()` on a list handles subsequent operations