### PR TITLE
Unix LM\Root X509Store should also read SSL_CERT_FILE

### DIFF
--- a/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
+++ b/src/Common/src/Interop/Unix/System.Security.Cryptography.Native/Interop.Crypto.cs
@@ -75,8 +75,16 @@ internal static partial class Interop
             return Marshal.PtrToStringAnsi(GetX509RootStorePath_private());
         }
 
+        internal static string GetX509RootStoreFile()
+        {
+            return Marshal.PtrToStringAnsi(GetX509RootStoreFile_private());
+        }
+
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509RootStorePath")]
         private static extern IntPtr GetX509RootStorePath_private();
+
+        [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_GetX509RootStoreFile")]
+        private static extern IntPtr GetX509RootStoreFile_private();
 
         [DllImport(Libraries.CryptoNative, EntryPoint = "CryptoNative_SetX509ChainVerifyTime")]
         private static extern int SetX509ChainVerifyTime(

--- a/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
+++ b/src/Native/System.Security.Cryptography.Native/CMakeLists.txt
@@ -34,6 +34,7 @@ set(NATIVECRYPTO_SOURCES
     pal_ssl.cpp
     pal_x509.cpp
     pal_x509_name.cpp
+    pal_x509_root.cpp
     pal_x509ext.cpp
 )
 

--- a/src/Native/System.Security.Cryptography.Native/openssl.c
+++ b/src/Native/System.Security.Cryptography.Native/openssl.c
@@ -1052,29 +1052,6 @@ extern int32_t CryptoNative_SetX509ChainVerifyTime(X509_STORE_CTX* ctx,
 
 /*
 Function:
-GetX509RootStorePath
-
-Used by System.Security.Cryptography.X509Certificates' Unix StorePal to determine the path to use
-for the LocalMachine\Root X509 store.
-
-Return values:
-The directory which would be applied for X509_LOOKUP_add_dir(ctx, NULL). That is, the value of the
-SSL_CERT_DIR environment variable, or the value of the X509_CERT_DIR compile-time constant.
-*/
-extern const char* CryptoNative_GetX509RootStorePath()
-{
-    const char* dir = getenv(X509_get_default_cert_dir_env());
-
-    if (!dir)
-    {
-        dir = X509_get_default_cert_dir();
-    }
-
-    return dir;
-}
-
-/*
-Function:
 ReadX509AsDerFromBio
 
 Used by System.Security.Cryptography.X509Certificates' OpenSslX509CertificateReader when attempting

--- a/src/Native/System.Security.Cryptography.Native/pal_x509_root.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509_root.cpp
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#include "pal_x509_root.h"
+
+#include <assert.h>
+#include <openssl/pem.h>
+#include <openssl/x509v3.h>
+
+extern "C" const char* CryptoNative_GetX509RootStorePath()
+{
+    const char* dir = getenv(X509_get_default_cert_dir_env());
+
+    if (!dir)
+    {
+        dir = X509_get_default_cert_dir();
+    }
+
+    return dir;
+}
+
+extern "C" const char* CryptoNative_GetX509RootStoreFile()
+{
+    const char* file = getenv(X509_get_default_cert_file_env());
+
+    if (!file)
+    {
+        file = X509_get_default_cert_file();
+    }
+
+    return file;
+}

--- a/src/Native/System.Security.Cryptography.Native/pal_x509_root.h
+++ b/src/Native/System.Security.Cryptography.Native/pal_x509_root.h
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+/*
+Look up the directory in which all certificate files therein are considered
+trusted (root or trusted intermediate).
+*/
+extern "C" const char* CryptoNative_GetX509RootStorePath();
+
+/*
+Look up the file in which all certificates are considered trusted
+(root or trusted intermediate), in addition to those files in
+the root store path.
+*/
+extern "C" const char* CryptoNative_GetX509RootStoreFile();

--- a/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/X509StoreTests.cs
@@ -185,31 +185,21 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         [Fact]
         public static void MachineRootStore_NonEmpty()
         {
-            // On everything except OS X we're using the normal system default trust store.
-            // So, if we've read things right, there should be a respectable amount of
-            // certificates in the store.
-            //
-            // On OSX this devolves into a "can we open the store and load the collection
-            // without throwing" test, but eventually we'll have tighter guarantees there.
-            //
             // This test will fail on systems where the administrator has gone out of their
             // way to prune the trusted CA list down below this threshold.
             //
             // As of 2016-01-25, Ubuntu 14.04 has 169, and CentOS 7.1 has 175, so that'd be
             // quite a lot of pruning.
-            int minimumThreshold = 5;
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                minimumThreshold = 0;
-            }
+            //
+            // And as of 2016-01-29 we understand the Homebrew-installed root store, with 180.
+            const int MinimumThreshold = 5;
 
             using (X509Store store = new X509Store(StoreName.Root, StoreLocation.LocalMachine))
             {
                 store.Open(OpenFlags.ReadOnly);
 
                 int certCount = store.Certificates.Count;
-                Assert.InRange(certCount, minimumThreshold, int.MaxValue);
+                Assert.InRange(certCount, MinimumThreshold, int.MaxValue);
             }
         }
     }


### PR DESCRIPTION
The default resolver in OpenSSL has two providers
1) SSL_CERT_DIR
Every file in this directory has all certificates therein read as a trusted cert.
2) SSL_CERT_FILE
This one extra file is also read, and all certificates therein are trusted certs.

Up until now we've only emulated the SSL_CERT_DIR approach, and that
worked on the Linux distributions tested thus far (Ubuntu 14.04/15.04,
CentOS 7.1, others).

The Homebrew provided OpenSSL for OS X, however, builds the root
store in a single file in the location pointed to by SSL_CERT_FILE.

So, now, read the SSL_CERT_FILE-based content in addition to the
SSL_CERT_DIR content, and things should work better on OS X (and better
match the behavior of an application that would directly be using OpenSSL).

Fixes #5173.
Will address #5555 (OSX) after the packages baseline is updated.
cc: @stephentoub