### PR TITLE
In Enumerable.ToArray Use EnumerableHelpers rather than Buffer

### DIFF
--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -1289,7 +1289,7 @@ namespace System.Linq
         {
             if (source == null) throw Error.ArgumentNull("source");
             IArrayProvider<TSource> arrayProvider = source as IArrayProvider<TSource>;
-            return arrayProvider != null ? arrayProvider.ToArray() : new Buffer<TSource>(source).ToArray();
+            return arrayProvider != null ? arrayProvider.ToArray() : EnumerableHelpers.ToArray(source);
         }
 
         public static List<TSource> ToList<TSource>(this IEnumerable<TSource> source)
@@ -4690,15 +4690,6 @@ namespace System.Linq
             {
                 items = EnumerableHelpers.ToArray(source, out count);
             }
-        }
-
-        internal TElement[] ToArray()
-        {
-            if (items.Length == count) return items;
-
-            var arr = new TElement[count];
-            Array.Copy(items, 0, arr, 0, count);
-            return arr;
         }
     }
 


### PR DESCRIPTION
ToArray checks for the possibility of a fast-path and otherwise
creates a buffer and calls ToArray on it.

Creating a buffer checks for the same possibility of a fast-path
and otherwise calls the overload of EnumerableHelpers.ToArray
that returns a count. Then its ToArray trims it.

Just calling the overload of EnumerableHelpers.ToArray that
doesn't return a count calls the other overload before trimming. As
such it doesn't repeat the fast-path check that had already been made.

Therefore use it instead.