### PR TITLE
Add build.cmd property to toggle native build

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -6,10 +6,18 @@ setlocal
 ::       means that that rebuilding cannot successfully delete the task
 ::       assembly.
 
+:ReadArguments
+:: Read in the args to determine whether to run the native build, managed build, or both (default)
+set "__args=%*"
+if /i [%1] == [native] (set __buildSpec=native&&set "__args=%__args:~6%"&&shift&&goto Tools)
+if /i [%1] == [managed] (set __buildSpec=managed&&set "__args=%__args:~7%"&&shift&&goto Tools)
+
+:Tools
+:: Setup VS
 if not defined VisualStudioVersion (
     if defined VS140COMNTOOLS (
         call "%VS140COMNTOOLS%\VsDevCmd.bat"
-        goto :CheckNative
+        goto :Build
     )
 
     echo Error: build.cmd requires Visual Studio 2015.
@@ -17,19 +25,27 @@ if not defined VisualStudioVersion (
     exit /b 1
 )
 
-:CheckNative
-
+:Build
+:: Restore the Tools directory
 call %~dp0init-tools.cmd
 
+:: Call the builds
+if "%__buildSpec%"=="managed"  goto :BuildManaged
+
+:BuildNative
 :: Run the Native Windows build
 echo [%time%] Building Native Libraries...
-call %~dp0src\native\Windows\build-native.cmd %* >nativebuild.log
+call %~dp0src\native\Windows\build-native.cmd %__args% >nativebuild.log
 IF ERRORLEVEL 1 (
     echo Native component build failed see nativebuild.log for more details.
+) else (
+    echo [%time%] Successfully built Native Libraries.
 )
 
-:EnvSet
+:: If we only wanted to build the native components, exit
+if "%__buildSpec%"=="native" goto :eof 
 
+:BuildManaged
 :: Clear the 'Platform' env variable for this session,
 :: as it's a per-project setting within the build, and
 :: misleading value (such as 'MCD' in HP PCs) may lead
@@ -41,18 +57,18 @@ set _buildproj=%~dp0build.proj
 set _buildlog=%~dp0msbuild.log
 set _buildprefix=echo
 set _buildpostfix=^> "%_buildlog%"
-call :build %*
+call :build %__args%
 
 :: Build
 set _buildprefix=
 set _buildpostfix=
 echo [%time%] Building Managed Libraries...
-call :build %*
+call :build %__args%
 
 goto :AfterBuild
 
 :build
-%_buildprefix% msbuild "%_buildproj%" /nologo /maxcpucount /v:minimal /clp:Summary /nodeReuse:false /flp:v=normal;LogFile="%_buildlog%";Append %* %_buildpostfix%
+%_buildprefix% msbuild "%_buildproj%" /nologo /maxcpucount /v:minimal /clp:Summary /nodeReuse:false /flp:v=normal;LogFile="%_buildlog%";Append %__args% %_buildpostfix%
 set BUILDERRORLEVEL=%ERRORLEVEL%
 goto :eof
 


### PR DESCRIPTION
Currently the native Windows build will run whenever build.cmd is called. This commit adds a toggle through msbuild Property syntax to enable/disable the native or managed build. By default both are built.

To build just the native components: ./build.cmd /p:buildspec=native
To build just the managed components: ./build.cmd /p:buildspec=managed
To build both: ./build.cmd <b>or</b> ./build.cmd /p:buildspec=both

I opted to use syntax of the msbuild format so that the args can then be passed as %* to msbuild without causing errors. I originally used "native" or "managed" but it felt jarring against the other args to build.cmd and required passing a cloned args array to msbuild. Using a property seemed cleaner.

resolves #5311

@weshaggard @stephentoub 