### PR TITLE
Remove dead code from System.IO.Path.GetDirectoryName

### DIFF
--- a/src/System.Runtime.Extensions/src/System/IO/Path.cs
+++ b/src/System.Runtime.Extensions/src/System/IO/Path.cs
@@ -76,8 +76,6 @@ namespace System.IO
                 int i = path.Length;
                 if (i > root)
                 {
-                    i = path.Length;
-                    if (i == root) return null;
                     while (i > root && !PathInternal.IsDirectorySeparator(path[--i])) ;
                     return path.Substring(0, i);
                 }

--- a/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
+++ b/src/System.Runtime.Extensions/tests/System/IO/PathTests.cs
@@ -53,7 +53,9 @@ public static class PathTests
         InlineData(@"dir\\baz", @"dir"),
         InlineData(@" dir\baz", @" dir"),
         InlineData(@" C:\dir\baz", @"C:\dir"),
-        InlineData(@"..\..\files.txt", @"..\..")
+        InlineData(@"..\..\files.txt", @"..\.."),
+        InlineData(@"C:\", null),
+        InlineData(@"C:", null)
         ]
     [PlatformSpecific(PlatformID.Windows)]
     public static void GetDirectoryName_Windows(string path, string expected)
@@ -66,7 +68,8 @@ public static class PathTests
         InlineData(@"dir//baz", @"dir"),
         InlineData(@"dir\baz", @""),
         InlineData(@"dir/baz/bar", @"dir/baz"),
-        InlineData(@"../../files.txt", @"../..")
+        InlineData(@"../../files.txt", @"../.."),
+        InlineData(@"/", null)
         ]
     [PlatformSpecific(PlatformID.AnyUnix)]
     public static void GetDirectoryName_Unix(string path, string expected)


### PR DESCRIPTION
- `int i` was just assigned to path.Length, so there is no point in
setting it to the same value again
- since path.Length is the same, i`!=root`, as we just checked above if
`i>root`

- Added some tests