### PR TITLE
Add Runtime packages for NETStandard.Platform

### DIFF
--- a/src/System.AppContext/pkg/System.AppContext.builds
+++ b/src/System.AppContext/pkg/System.AppContext.builds
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.AppContext.pkgproj"/>
+    <Project Include="any\System.AppContext.pkgproj"/>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.AppContext/pkg/System.AppContext.pkgproj
+++ b/src/System.AppContext/pkg/System.AppContext.pkgproj
@@ -9,12 +9,13 @@
     <ProjectReference Include="..\ref\System.AppContext.csproj">
       <SupportedFramework>netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.AppContext.builds" />
-
-    <!-- Remove when resolving https://github.com/dotnet/corefx/issues/5471 -->
-    <ProjectReference Include="..\src\System.AppContext.csproj">
-      <PackageTargetFramework>dnxcore50</PackageTargetFramework>
+    <ProjectReference Include="..\src\redist\System.AppContext.depproj">
+      <TargetGroup>net46</TargetGroup>
     </ProjectReference>
+    <ProjectReference Include="..\src\System.AppContext.csproj">
+      <TargetGroup>net462</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="any\System.AppContext.pkgproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.AppContext/pkg/any/System.AppContext.pkgproj
+++ b/src/System.AppContext/pkg/any/System.AppContext.pkgproj
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.AppContext.csproj" />
+
+    <!-- Remove when resolving https://github.com/dotnet/corefx/issues/5471 -->
+    <ProjectReference Include="..\..\src\System.AppContext.csproj">
+      <PackageTargetFramework>dnxcore50</PackageTargetFramework>
+    </ProjectReference>
+
+    <ExternalOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Collections/pkg/System.Collections.builds
+++ b/src/System.Collections/pkg/System.Collections.builds
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Collections.pkgproj" />
+    <Project Include="any\System.Collections.pkgproj" />
+    <Project Include="aot\System.Collections.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Collections/pkg/System.Collections.pkgproj
+++ b/src/System.Collections/pkg/System.Collections.pkgproj
@@ -8,7 +8,9 @@
     <ProjectReference Include="..\ref\System.Collections.csproj">
       <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.Collections.builds" />
+    <ProjectReference Include="any\System.Collections.pkgproj" />
+    <ProjectReference Include="aot\System.Collections.pkgproj" />
+    
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net45" />

--- a/src/System.Collections/pkg/any/System.Collections.pkgproj
+++ b/src/System.Collections/pkg/any/System.Collections.pkgproj
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <!-- there is no "jit" rid, so we use any and "aot" will override -->
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Collections.csproj" />
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Collections/pkg/aot/System.Collections.pkgproj
+++ b/src/System.Collections/pkg/aot/System.Collections.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Collections.csproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.Tools/pkg/System.Diagnostics.Tools.builds
+++ b/src/System.Diagnostics.Tools/pkg/System.Diagnostics.Tools.builds
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Diagnostics.Tools.pkgproj" />
+    <Project Include="any\System.Diagnostics.Tools.pkgproj" />
+    <Project Include="aot\System.Diagnostics.Tools.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Diagnostics.Tools/pkg/System.Diagnostics.Tools.pkgproj
+++ b/src/System.Diagnostics.Tools/pkg/System.Diagnostics.Tools.pkgproj
@@ -6,7 +6,8 @@
     <ProjectReference Include="..\ref\System.Diagnostics.Tools.csproj">
       <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.Diagnostics.Tools.builds" />
+    <ProjectReference Include="any\System.Diagnostics.Tools.pkgproj" />
+    <ProjectReference Include="aot\System.Diagnostics.Tools.pkgproj" />
 
     <InboxOnTargetFramework Include="MonoAndroid10"/>
     <InboxOnTargetFramework Include="MonoTouch10"/>

--- a/src/System.Diagnostics.Tools/pkg/any/System.Diagnostics.Tools.pkgproj
+++ b/src/System.Diagnostics.Tools/pkg/any/System.Diagnostics.Tools.pkgproj
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <!-- there is no "jit" rid, so we use any and "aot" will override -->
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Diagnostics.Tools.csproj" />
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.Tools/pkg/aot/System.Diagnostics.Tools.pkgproj
+++ b/src/System.Diagnostics.Tools/pkg/aot/System.Diagnostics.Tools.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Diagnostics.Tools.csproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.builds
+++ b/src/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.builds
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Diagnostics.Tracing.pkgproj" />
+    <Project Include="any\System.Diagnostics.Tracing.pkgproj" />
+    <Project Include="aot\System.Diagnostics.Tracing.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.pkgproj
+++ b/src/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.pkgproj
@@ -14,13 +14,11 @@
     <ProjectReference Include="..\ref\System.Diagnostics.Tracing.csproj">
       <SupportedFramework>netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.Diagnostics.Tracing.builds" />
-
-    <!-- Remove when resolving https://github.com/dotnet/corefx/issues/5471 -->
     <ProjectReference Include="..\src\System.Diagnostics.Tracing.csproj">
-      <PackageTargetFramework>dnxcore50</PackageTargetFramework>
+      <TargetGroup>net462</TargetGroup>
     </ProjectReference>
-
+    <ProjectReference Include="any\System.Diagnostics.Tracing.pkgproj" />
+    <ProjectReference Include="aot\System.Diagnostics.Tracing.pkgproj" />
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net45" />

--- a/src/System.Diagnostics.Tracing/pkg/any/System.Diagnostics.Tracing.pkgproj
+++ b/src/System.Diagnostics.Tracing/pkg/any/System.Diagnostics.Tracing.pkgproj
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Diagnostics.Tracing.csproj" />
+
+    <!-- Remove when resolving https://github.com/dotnet/corefx/issues/5471 -->
+    <ProjectReference Include="..\..\src\System.Diagnostics.Tracing.csproj">
+      <PackageTargetFramework>dnxcore50</PackageTargetFramework>
+    </ProjectReference>
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Diagnostics.Tracing/pkg/aot/System.Diagnostics.Tracing.pkgproj
+++ b/src/System.Diagnostics.Tracing/pkg/aot/System.Diagnostics.Tracing.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Diagnostics.Tracing.csproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Globalization.Calendars/pkg/System.Globalization.Calendars.builds
+++ b/src/System.Globalization.Calendars/pkg/System.Globalization.Calendars.builds
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Globalization.Calendars.pkgproj" />
+    <Project Include="any\System.Globalization.Calendars.pkgproj" />
+    <Project Include="aot\System.Globalization.Calendars.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Globalization.Calendars/pkg/System.Globalization.Calendars.pkgproj
+++ b/src/System.Globalization.Calendars/pkg/System.Globalization.Calendars.pkgproj
@@ -6,7 +6,11 @@
     <ProjectReference Include="..\ref\System.Globalization.Calendars.csproj">
       <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.Globalization.Calendars.builds" />
+    <ProjectReference Include="..\src\System.Globalization.Calendars.csproj">
+      <TargetGroup>net46</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="any\System.Globalization.Calendars.pkgproj" />
+    <ProjectReference Include="aot\System.Globalization.Calendars.pkgproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Globalization.Calendars/pkg/any/System.Globalization.Calendars.pkgproj
+++ b/src/System.Globalization.Calendars/pkg/any/System.Globalization.Calendars.pkgproj
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Globalization.Calendars.csproj" />
+    <ProjectReference Include="..\..\src\System.Globalization.Calendars.csproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+
+    <!-- desktop facade is in the ref package -->
+    <ExternalOnTargetFramework Include="net"/>
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Globalization.Calendars/pkg/aot/System.Globalization.Calendars.pkgproj
+++ b/src/System.Globalization.Calendars/pkg/aot/System.Globalization.Calendars.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Globalization.Calendars.csproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Globalization/pkg/System.Globalization.builds
+++ b/src/System.Globalization/pkg/System.Globalization.builds
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Globalization.pkgproj" />
+    <Project Include="any\System.Globalization.pkgproj" />
+    <Project Include="aot\System.Globalization.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Globalization/pkg/System.Globalization.pkgproj
+++ b/src/System.Globalization/pkg/System.Globalization.pkgproj
@@ -8,7 +8,8 @@
     <ProjectReference Include="..\ref\System.Globalization.csproj">
       <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.Globalization.builds" />
+    <ProjectReference Include="any\System.Globalization.pkgproj" />
+    <ProjectReference Include="aot\System.Globalization.pkgproj" />
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net45" />

--- a/src/System.Globalization/pkg/any/System.Globalization.pkgproj
+++ b/src/System.Globalization/pkg/any/System.Globalization.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Globalization.csproj" />
+    <ProjectReference Include="..\..\src\System.Globalization.csproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Globalization/pkg/aot/System.Globalization.pkgproj
+++ b/src/System.Globalization/pkg/aot/System.Globalization.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Globalization.csproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.IO/pkg/System.IO.builds
+++ b/src/System.IO/pkg/System.IO.builds
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.IO.pkgproj" />
+    <Project Include="any\System.IO.pkgproj" />
+    <Project Include="aot\System.IO.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.IO/pkg/System.IO.pkgproj
+++ b/src/System.IO/pkg/System.IO.pkgproj
@@ -8,7 +8,11 @@
     <ProjectReference Include="..\ref\System.IO.csproj">
       <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.IO.builds" />
+    <ProjectReference Include="..\src\System.IO.csproj">
+      <TargetGroup>net46</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="any\System.IO.pkgproj" />
+    <ProjectReference Include="aot\System.IO.pkgproj" />
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net45" />

--- a/src/System.IO/pkg/any/System.IO.pkgproj
+++ b/src/System.IO/pkg/any/System.IO.pkgproj
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.IO.csproj" />
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.IO/pkg/aot/System.IO.pkgproj
+++ b/src/System.IO/pkg/aot/System.IO.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.IO.csproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Linq.Expressions/pkg/any/System.Linq.Expressions.pkgproj
+++ b/src/System.Linq.Expressions/pkg/any/System.Linq.Expressions.pkgproj
@@ -2,7 +2,6 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <!-- there is no "jit" rid, so we use any and "aot" will override -->
     <PackageTargetRuntime>any</PackageTargetRuntime>
     <PreventImplementationReference>true</PreventImplementationReference>
   </PropertyGroup>

--- a/src/System.Reflection.Extensions/pkg/System.Reflection.Extensions.builds
+++ b/src/System.Reflection.Extensions/pkg/System.Reflection.Extensions.builds
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Reflection.Extensions.pkgproj" />
+    <Project Include="any\System.Reflection.Extensions.pkgproj" />
+    <Project Include="aot\System.Reflection.Extensions.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Reflection.Extensions/pkg/System.Reflection.Extensions.pkgproj
+++ b/src/System.Reflection.Extensions/pkg/System.Reflection.Extensions.pkgproj
@@ -6,7 +6,8 @@
     <ProjectReference Include="..\ref\System.Reflection.Extensions.csproj">
       <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.Reflection.Extensions.builds" />
+    <ProjectReference Include="any\System.Reflection.Extensions.pkgproj" />
+    <ProjectReference Include="aot\System.Reflection.Extensions.pkgproj" />
 
     <InboxOnTargetFramework Include="MonoAndroid10"/>
     <InboxOnTargetFramework Include="MonoTouch10"/>

--- a/src/System.Reflection.Extensions/pkg/any/System.Reflection.Extensions.pkgproj
+++ b/src/System.Reflection.Extensions/pkg/any/System.Reflection.Extensions.pkgproj
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Reflection.Extensions.csproj" />
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection.Extensions/pkg/aot/System.Reflection.Extensions.pkgproj
+++ b/src/System.Reflection.Extensions/pkg/aot/System.Reflection.Extensions.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Reflection.Extensions.csproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection.Primitives/pkg/System.Reflection.Primitives.builds
+++ b/src/System.Reflection.Primitives/pkg/System.Reflection.Primitives.builds
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Reflection.Primitives.pkgproj" />
+    <Project Include="any\System.Reflection.Primitives.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Reflection.Primitives/pkg/System.Reflection.Primitives.pkgproj
+++ b/src/System.Reflection.Primitives/pkg/System.Reflection.Primitives.pkgproj
@@ -6,7 +6,7 @@
     <ProjectReference Include="..\ref\System.Reflection.Primitives.csproj">
       <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.Reflection.Primitives.builds" />
+    <ProjectReference Include="any\System.Reflection.Primitives.pkgproj" />
 
     <InboxOnTargetFramework Include="MonoAndroid10"/>
     <InboxOnTargetFramework Include="MonoTouch10"/>

--- a/src/System.Reflection.Primitives/pkg/any/System.Reflection.Primitives.pkgproj
+++ b/src/System.Reflection.Primitives/pkg/any/System.Reflection.Primitives.pkgproj
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Reflection.Primitives.builds" />
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.builds
+++ b/src/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.builds
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Reflection.TypeExtensions.pkgproj" />
+    <Project Include="any\System.Reflection.TypeExtensions.pkgproj" />
+    <Project Include="aot\System.Reflection.TypeExtensions.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.pkgproj
+++ b/src/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.pkgproj
@@ -6,7 +6,11 @@
     <ProjectReference Include="..\ref\System.Reflection.TypeExtensions.csproj">
       <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.Reflection.TypeExtensions.builds" />
+    <ProjectReference Include="..\src\System.Reflection.TypeExtensions.csproj">
+      <TargetGroup>net46</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="any\System.Reflection.TypeExtensions.pkgproj" />
+    <ProjectReference Include="aot\System.Reflection.TypeExtensions.pkgproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Reflection.TypeExtensions/pkg/any/System.Reflection.TypeExtensions.pkgproj
+++ b/src/System.Reflection.TypeExtensions/pkg/any/System.Reflection.TypeExtensions.pkgproj
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Reflection.TypeExtensions.csproj" />
+
+    <!-- Desktop facade comes from the reference package -->
+    <ExternalOnTargetFramework Include="net" />
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection.TypeExtensions/pkg/aot/System.Reflection.TypeExtensions.pkgproj
+++ b/src/System.Reflection.TypeExtensions/pkg/aot/System.Reflection.TypeExtensions.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Reflection.TypeExtensions.csproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection/pkg/System.Reflection.builds
+++ b/src/System.Reflection/pkg/System.Reflection.builds
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Reflection.pkgproj" />
+    <Project Include="any\System.Reflection.pkgproj" />
+    <Project Include="aot\System.Reflection.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Reflection/pkg/System.Reflection.pkgproj
+++ b/src/System.Reflection/pkg/System.Reflection.pkgproj
@@ -8,7 +8,11 @@
     <ProjectReference Include="..\ref\System.Reflection.csproj">
       <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.Reflection.builds" />
+    <ProjectReference Include="..\src\System.Reflection.csproj">
+      <TargetGroup>net46</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="any\System.Reflection.pkgproj" />
+    <ProjectReference Include="aot\System.Reflection.pkgproj" />
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net45" />

--- a/src/System.Reflection/pkg/any/System.Reflection.pkgproj
+++ b/src/System.Reflection/pkg/any/System.Reflection.pkgproj
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Reflection.csproj" />
+    <ProjectReference Include="..\..\src\System.Reflection.csproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection/pkg/aot/System.Reflection.pkgproj
+++ b/src/System.Reflection/pkg/aot/System.Reflection.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Reflection.csproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Handles/pkg/System.Runtime.Handles.builds
+++ b/src/System.Runtime.Handles/pkg/System.Runtime.Handles.builds
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Runtime.Handles.pkgproj" />
+    <Project Include="any\System.Runtime.Handles.pkgproj" />
+    <Project Include="aot\System.Runtime.Handles.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Runtime.Handles/pkg/System.Runtime.Handles.pkgproj
+++ b/src/System.Runtime.Handles/pkg/System.Runtime.Handles.pkgproj
@@ -6,7 +6,8 @@
     <ProjectReference Include="..\ref\System.Runtime.Handles.csproj">
       <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.Runtime.Handles.builds" />
+    <ProjectReference Include="any\System.Runtime.Handles.pkgproj" />
+    <ProjectReference Include="aot\System.Runtime.Handles.pkgproj" />
 
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />

--- a/src/System.Runtime.Handles/pkg/any/System.Runtime.Handles.pkgproj
+++ b/src/System.Runtime.Handles/pkg/any/System.Runtime.Handles.pkgproj
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Runtime.Handles.csproj" />
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net46" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Handles/pkg/aot/System.Runtime.Handles.pkgproj
+++ b/src/System.Runtime.Handles/pkg/aot/System.Runtime.Handles.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Runtime.Handles.csproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.InteropServices/pkg/System.Runtime.InteropServices.builds
+++ b/src/System.Runtime.InteropServices/pkg/System.Runtime.InteropServices.builds
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Runtime.InteropServices.pkgproj" />
+    <Project Include="any\System.Runtime.InteropServices.pkgproj" />
+    <Project Include="aot\System.Runtime.InteropServices.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Runtime.InteropServices/pkg/System.Runtime.InteropServices.pkgproj
+++ b/src/System.Runtime.InteropServices/pkg/System.Runtime.InteropServices.pkgproj
@@ -11,7 +11,11 @@
     <ProjectReference Include="..\ref\System.Runtime.InteropServices.csproj">
       <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.Runtime.InteropServices.builds" />
+    <ProjectReference Include="..\src\System.Runtime.InteropServices.csproj">
+      <TargetGroup>net46</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="any\System.Runtime.InteropServices.pkgproj" />
+    <ProjectReference Include="aot\System.Runtime.InteropServices.pkgproj" />
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net45" />

--- a/src/System.Runtime.InteropServices/pkg/any/System.Runtime.InteropServices.pkgproj
+++ b/src/System.Runtime.InteropServices/pkg/any/System.Runtime.InteropServices.pkgproj
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Runtime.InteropServices.csproj" />
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.InteropServices/pkg/aot/System.Runtime.InteropServices.pkgproj
+++ b/src/System.Runtime.InteropServices/pkg/aot/System.Runtime.InteropServices.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Runtime.InteropServices.csproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime/pkg/System.Runtime.builds
+++ b/src/System.Runtime/pkg/System.Runtime.builds
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Runtime.pkgproj" />
+    <Project Include="any\System.Runtime.pkgproj" />
+    <Project Include="aot\System.Runtime.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Runtime/pkg/System.Runtime.pkgproj
+++ b/src/System.Runtime/pkg/System.Runtime.pkgproj
@@ -11,7 +11,12 @@
     <ProjectReference Include="..\ref\System.Runtime.csproj">
       <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.Runtime.builds" />
+    <ProjectReference Include="..\src\System.Runtime.csproj">
+      <TargetGroup>net46</TargetGroup>
+    </ProjectReference>
+
+    <ProjectReference Include="any\System.Runtime.pkgproj" />
+    <ProjectReference Include="aot\System.Runtime.pkgproj" />
 
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
@@ -21,13 +26,6 @@
     <InboxOnTargetFramework Include="wpa81" />
     <InboxOnTargetFramework Include="xamarinios10" />
     <InboxOnTargetFramework Include="xamarinmac20" />
-
-    <ProjectReference Include="..\..\System.Private.Uri\pkg\System.Private.Uri.pkgproj">
-      <PackageTargetFramework>dnxcore50</PackageTargetFramework>
-    </ProjectReference>
-    <ProjectReference Include="..\..\System.Private.Uri\pkg\System.Private.Uri.pkgproj">
-      <PackageTargetFramework>netcore50</PackageTargetFramework>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Runtime/pkg/any/System.Runtime.pkgproj
+++ b/src/System.Runtime/pkg/any/System.Runtime.pkgproj
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Runtime.csproj" />
+
+    <ProjectReference Include="..\..\..\System.Private.Uri\pkg\System.Private.Uri.pkgproj"/>
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime/pkg/aot/System.Runtime.pkgproj
+++ b/src/System.Runtime/pkg/aot/System.Runtime.pkgproj
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Runtime.csproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\System.Private.Uri\pkg\System.Private.Uri.pkgproj"/>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Text.Encoding.Extensions/pkg/System.Text.Encoding.Extensions.builds
+++ b/src/System.Text.Encoding.Extensions/pkg/System.Text.Encoding.Extensions.builds
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Text.Encoding.Extensions.pkgproj" />
+    <Project Include="any\System.Text.Encoding.Extensions.pkgproj" />
+    <Project Include="aot\System.Text.Encoding.Extensions.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Text.Encoding.Extensions/pkg/System.Text.Encoding.Extensions.pkgproj
+++ b/src/System.Text.Encoding.Extensions/pkg/System.Text.Encoding.Extensions.pkgproj
@@ -8,7 +8,8 @@
     <ProjectReference Include="..\ref\System.Text.Encoding.Extensions.csproj">
       <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.Text.Encoding.Extensions.builds" />
+    <ProjectReference Include="any\System.Text.Encoding.Extensions.pkgproj" />
+    <ProjectReference Include="aot\System.Text.Encoding.Extensions.pkgproj" />
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net45" />

--- a/src/System.Text.Encoding.Extensions/pkg/any/System.Text.Encoding.Extensions.pkgproj
+++ b/src/System.Text.Encoding.Extensions/pkg/any/System.Text.Encoding.Extensions.pkgproj
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Text.Encoding.Extensions.csproj" />
+    <ProjectReference Include="..\..\src\System.Text.Encoding.Extensions.csproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Text.Encoding.Extensions/pkg/aot/System.Text.Encoding.Extensions.pkgproj
+++ b/src/System.Text.Encoding.Extensions/pkg/aot/System.Text.Encoding.Extensions.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Text.Encoding.Extensions.csproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Text.Encoding/pkg/System.Text.Encoding.builds
+++ b/src/System.Text.Encoding/pkg/System.Text.Encoding.builds
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Text.Encoding.pkgproj" />
+    <Project Include="any\System.Text.Encoding.pkgproj" />
+    <Project Include="aot\System.Text.Encoding.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Text.Encoding/pkg/System.Text.Encoding.pkgproj
+++ b/src/System.Text.Encoding/pkg/System.Text.Encoding.pkgproj
@@ -8,7 +8,8 @@
     <ProjectReference Include="..\ref\System.Text.Encoding.csproj">
       <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.Text.Encoding.builds" />
+    <ProjectReference Include="any\System.Text.Encoding.pkgproj" />
+    <ProjectReference Include="aot\System.Text.Encoding.pkgproj" />
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net45" />

--- a/src/System.Text.Encoding/pkg/any/System.Text.Encoding.pkgproj
+++ b/src/System.Text.Encoding/pkg/any/System.Text.Encoding.pkgproj
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Text.Encoding.csproj" />
+    <ProjectReference Include="..\..\src\System.Text.Encoding.csproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Text.Encoding/pkg/aot/System.Text.Encoding.pkgproj
+++ b/src/System.Text.Encoding/pkg/aot/System.Text.Encoding.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Text.Encoding.csproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Threading.Tasks/pkg/System.Threading.Tasks.builds
+++ b/src/System.Threading.Tasks/pkg/System.Threading.Tasks.builds
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Threading.Tasks.pkgproj" />
+    <Project Include="any\System.Threading.Tasks.pkgproj" />
+    <Project Include="aot\System.Threading.Tasks.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Threading.Tasks/pkg/System.Threading.Tasks.pkgproj
+++ b/src/System.Threading.Tasks/pkg/System.Threading.Tasks.pkgproj
@@ -8,7 +8,8 @@
     <ProjectReference Include="..\ref\System.Threading.Tasks.csproj">
       <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.Threading.Tasks.builds" />
+    <ProjectReference Include="any\System.Threading.Tasks.pkgproj" />
+    <ProjectReference Include="aot\System.Threading.Tasks.pkgproj" />
     <InboxOnTargetFramework Include="MonoAndroid10" />
     <InboxOnTargetFramework Include="MonoTouch10" />
     <InboxOnTargetFramework Include="net45" />

--- a/src/System.Threading.Tasks/pkg/any/System.Threading.Tasks.pkgproj
+++ b/src/System.Threading.Tasks/pkg/any/System.Threading.Tasks.pkgproj
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Threading.Tasks.csproj" />
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Threading.Tasks/pkg/aot/System.Threading.Tasks.pkgproj
+++ b/src/System.Threading.Tasks/pkg/aot/System.Threading.Tasks.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Threading.Tasks.csproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Threading.Timer/pkg/System.Threading.Timer.builds
+++ b/src/System.Threading.Timer/pkg/System.Threading.Timer.builds
@@ -3,6 +3,8 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Threading.Timer.pkgproj" />
+    <Project Include="any\System.Threading.Timer.pkgproj" />
+    <Project Include="aot\System.Threading.Timer.pkgproj" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Threading.Timer/pkg/System.Threading.Timer.pkgproj
+++ b/src/System.Threading.Timer/pkg/System.Threading.Timer.pkgproj
@@ -6,7 +6,8 @@
     <ProjectReference Include="..\ref\System.Threading.Timer.csproj">
       <SupportedFramework>net451;netcore451;dnxcore50;wpa81</SupportedFramework>
     </ProjectReference>
-    <ProjectReference Include="..\src\System.Threading.Timer.builds" />
+    <ProjectReference Include="any\System.Threading.Timer.pkgproj" />
+    <ProjectReference Include="aot\System.Threading.Timer.pkgproj" />
 
     <InboxOnTargetFramework Include="MonoAndroid10"/>
     <InboxOnTargetFramework Include="MonoTouch10"/>

--- a/src/System.Threading.Timer/pkg/any/System.Threading.Timer.pkgproj
+++ b/src/System.Threading.Timer/pkg/any/System.Threading.Timer.pkgproj
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Threading.Timer.csproj" />
+    <ProjectReference Include="..\..\src\System.Threading.Timer.csproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Threading.Timer/pkg/aot/System.Threading.Timer.pkgproj
+++ b/src/System.Threading.Timer/pkg/aot/System.Threading.Timer.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\System.Threading.Timer.csproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>


### PR DESCRIPTION
This changes all the packages in NETStandard.Platform
to be split into ref/impl packages.

This enables the implementation packages to be different
for different runtimes, such as the UWP case where we
want to keep the packages consistent with the shared library.

/cc @weshaggard 