### PR TITLE
Tests for validating Default Assembly Load Context support

### DIFF
--- a/src/System.Runtime.Loader/System.Runtime.Loader.sln
+++ b/src/System.Runtime.Loader/System.Runtime.Loader.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.Loader.Tests
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.Loader.Test.Assembly", "tests\System.Runtime.Loader.Test.Assembly\System.Runtime.Loader.Test.Assembly.csproj", "{396D6EBF-60BD-4DAF-8783-FB403E070A56}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Runtime.Loader.DefaultContext.Tests", "tests\DefaultContext\System.Runtime.Loader.DefaultContext.Tests.csproj", "{701CB3BC-00DC-435D-BDE4-C5FC29A708A8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -16,6 +18,10 @@ Global
 		{701CB3BC-00DC-435D-BDE4-C5FC29A708A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{396D6EBF-60BD-4DAF-8783-FB403E070A56}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{396D6EBF-60BD-4DAF-8783-FB403E070A56}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{396D6EBF-60BD-4DAF-8783-FB403E070A57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{396D6EBF-60BD-4DAF-8783-FB403E070A57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{701CB3BC-00DC-435D-BDE4-C5FC29A708A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{701CB3BC-00DC-435D-BDE4-C5FC29A708A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
+++ b/src/System.Runtime.Loader/tests/DefaultContext/DefaultLoadContextTest.cs
@@ -1,0 +1,90 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+
+namespace System.Runtime.Loader.Tests
+{
+    public class DefaultLoadContextTests
+    {
+        private static Assembly ResolveAssembly(AssemblyLoadContext sender, AssemblyName assembly)
+        {
+            string assemblyFilename = assembly.Name + ".dll";
+            
+            return sender.LoadFromAssemblyPath(Path.Combine(Path.GetTempPath(), assemblyFilename));
+        }
+
+        private static void Init()
+        {
+            // Delete the assembly from the temp location if it exists.
+            var assemblyFilename = "System.Runtime.Loader.Noop.Assembly.dll";
+            var targetPath = Path.Combine(Path.GetTempPath(), assemblyFilename);
+            if (File.Exists(targetPath))
+            {
+                File.Delete(targetPath);
+            }
+
+            // Rename the file local to the test folder.
+            var sourcePath = Path.Combine(Directory.GetCurrentDirectory(),assemblyFilename);
+            var targetRenamedPath = Path.Combine(Directory.GetCurrentDirectory(), "System.Runtime.Loader.Noop.Assembly_test.dll");
+            if (File.Exists(sourcePath))
+            {
+                if (File.Exists(targetRenamedPath))
+                {
+                    File.Delete(targetRenamedPath);
+                }
+
+                File.Move(sourcePath, targetRenamedPath);
+            }
+
+            // Finally, copy the file to the temp location from where we expect to load it
+            File.Copy(targetRenamedPath, targetPath); 
+        }
+
+        [Fact]
+        public static void LoadInDefaultContext()
+        {
+            Init();
+
+           // This will attempt to load an assembly, by path, in the Default Load context via the Resolving event
+           var assemblyName = "System.Runtime.Loader.Noop.Assembly";
+
+            AssemblyLoadContext.Default.Resolving += ResolveAssembly;
+            var assemblyExpected = AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName(assemblyName));
+            
+            // We should have successfully loaded the assembly in default context.
+            Assert.NotNull(assemblyExpected);
+
+            // And make sure the simplename matches
+            Assert.Equal(assemblyExpected.GetName().Name, assemblyName);
+
+            // Unwire the Resolving event.
+            AssemblyLoadContext.Default.Resolving -= ResolveAssembly;
+
+            // Unwire the Resolving event and attempt to load the assembly again. This time
+            // it should be found in the Default Load Context.
+            var assemblyLoaded = Assembly.Load(new AssemblyName(assemblyName));
+
+            // We should have successfully found the assembly in default context.
+            Assert.NotNull(assemblyLoaded);
+
+            // Ensure that we got the same assembly reference back.
+            Assert.Equal(assemblyExpected, assemblyLoaded);
+        }
+
+        [Fact]
+        public static void LoadNonExistentInDefaultContext()
+        {
+            // Now, try to load an assembly that does not exist
+            Assert.Throws(typeof(FileNotFoundException), 
+                () => AssemblyLoadContext.Default.LoadFromAssemblyName(new AssemblyName("System.Runtime.Loader.NonExistent.Assembly")));
+        }
+    }
+}

--- a/src/System.Runtime.Loader/tests/DefaultContext/System.Runtime.Loader.DefaultContext.Tests.csproj
+++ b/src/System.Runtime.Loader/tests/DefaultContext/System.Runtime.Loader.DefaultContext.Tests.csproj
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>System.Runtime.Loader.DefaultContext.Tests</RootNamespace>
+    <AssemblyName>System.Runtime.Loader.DefaultContext.Tests</AssemblyName>
+    <ProjectGuid>{701CB3BC-00DC-435D-BDE4-C5FC29A708A8}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="DefaultLoadContextTest.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../System.Runtime.Loader.Noop.Assembly/System.Runtime.Loader.Noop.Assembly.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Loader/tests/DefaultContext/project.json
+++ b/src/System.Runtime.Loader/tests/DefaultContext/project.json
@@ -1,0 +1,21 @@
+{
+  "dependencies": {
+    "System.Diagnostics.Tools": "4.0.0",
+    "System.Diagnostics.Debug": "4.0.10",
+    "System.IO": "4.0.10",
+    "System.IO.FileSystem": "4.0.0",
+    "System.Linq": "4.0.0",
+    "System.Reflection": "4.0.10",
+    "System.Runtime": "4.0.20",
+    "System.Runtime.Extensions": "4.0.10",
+    "System.Runtime.Loader": "4.0.0-rc3-23729",
+    "System.Threading.Tasks": "4.0.10",
+    "xunit": "2.1.0",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+  },
+  "frameworks": {
+    "dnxcore50": {
+      "imports": "portable-net45+win8"
+    }
+  }
+}

--- a/src/System.Runtime.Loader/tests/System.Runtime.Loader.Noop.Assembly/System.Runtime.Loader.Noop.Assembly.csproj
+++ b/src/System.Runtime.Loader/tests/System.Runtime.Loader.Noop.Assembly/System.Runtime.Loader.Noop.Assembly.csproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>System.Runtime.Loader.Noop.Assembly</RootNamespace>
+    <AssemblyName>System.Runtime.Loader.Noop.Assembly</AssemblyName>
+    <ProjectGuid>{396D6EBF-60BD-4DAF-8783-FB403E070A57}</ProjectGuid>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="TestClass.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Loader/tests/System.Runtime.Loader.Noop.Assembly/TestClass.cs
+++ b/src/System.Runtime.Loader/tests/System.Runtime.Loader.Noop.Assembly/TestClass.cs
@@ -1,0 +1,10 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Runtime.Loader.Tests
+{
+    public class TestClass
+    {
+    }
+}

--- a/src/System.Runtime.Loader/tests/System.Runtime.Loader.Noop.Assembly/project.json
+++ b/src/System.Runtime.Loader/tests/System.Runtime.Loader.Noop.Assembly/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Runtime": "4.0.20"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
+++ b/src/System.Runtime.Loader/tests/System.Runtime.Loader.Tests.csproj
@@ -22,8 +22,4 @@
     <EmbeddedResource Include="System.Runtime.Loader.Test.Assembly.dll" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>
-    </PostBuildEvent>
-  </PropertyGroup>
-</Project>
+  </Project>


### PR DESCRIPTION
1) Validate loading assemblies into Default ALC
2) Validate resolution via Resolving event
3) Validate that once loaded in Default ALC, assembly is found even if Resolving event is unwired
4) Non existent assembly load  fails as expected.

@jkotas @weshaggard PTAL.

I will squash the commits before committing.