### PR TITLE
Add several missing test projects

### DIFF
--- a/src/Microsoft.CSharp/Microsoft.CSharp.sln
+++ b/src/Microsoft.CSharp/Microsoft.CSharp.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.CSharp", "src\Microsoft.CSharp.csproj", "{96AA2060-C846-4E56-9509-E8CB9C114C8F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.CSharp", "tests\Microsoft.CSharp.Tests.csproj", "{82B54697-0251-47A1-8546-FC507D0F3B08}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{A595FB46-5F47-4E70-BDCD-53350879188C}"
 	ProjectSection(SolutionItems) = preProject
 		..\.nuget\packages.Windows_NT.config = ..\.nuget\packages.Windows_NT.config
@@ -20,6 +22,10 @@ Global
 		{96AA2060-C846-4E56-9509-E8CB9C114C8F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{96AA2060-C846-4E56-9509-E8CB9C114C8F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{96AA2060-C846-4E56-9509-E8CB9C114C8F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Microsoft.CSharp/tests/CSharpArgumentInfoTests.cs
+++ b/src/Microsoft.CSharp/tests/CSharpArgumentInfoTests.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace Microsoft.CSharp.RuntimeBinder.Tests
+{
+    public class CSharpArgumentInfoTests
+    {
+        [Fact]
+        public void Create_ResultNotNull()
+        {
+            CSharpArgumentInfo ai = CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.Constant, "argName");
+            Assert.NotNull(ai);
+        }
+    }
+}

--- a/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
+++ b/src/Microsoft.CSharp/tests/Microsoft.CSharp.Tests.csproj
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{82B54697-0251-47A1-8546-FC507D0F3B08}</ProjectGuid>
+    <AssemblyName>Microsoft.CSharp.Tests</AssemblyName>
+    <RootNamespace>Microsoft.CSharp.Tests</RootNamespace>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="CSharpArgumentInfoTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\Microsoft.CSharp.csproj">
+      <Project>{96AA2060-C846-4E56-9509-E8CB9C114C8F}</Project>
+      <Name>Microsoft.CSharp</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Microsoft.CSharp/tests/project.json
+++ b/src/Microsoft.CSharp/tests/project.json
@@ -1,0 +1,27 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.10",
+    "System.Diagnostics.Debug": "4.0.10",
+    "System.Diagnostics.Tools": "4.0.0",
+    "System.Dynamic.Runtime": "4.0.0",
+    "System.Globalization": "4.0.10",
+    "System.Linq": "4.0.0",
+    "System.Linq.Expressions": "4.0.0",
+    "System.ObjectModel": "4.0.10",
+    "System.Reflection": "4.0.10",
+    "System.Reflection.Extensions": "4.0.0",
+    "System.Reflection.Primitives": "4.0.0",
+    "System.Reflection.TypeExtensions": "4.0.0",
+    "System.Resources.ResourceManager": "4.0.0",
+    "System.Runtime": "4.0.20",
+    "System.Runtime.Extensions": "4.0.10",
+    "System.Runtime.InteropServices": "4.0.20",
+    "System.Threading": "4.0.10",
+    "System.Threading.Tasks": "4.0.10",
+    "xunit": "2.1.0",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/Microsoft.VisualBasic/Microsoft.VisualBasic.sln
+++ b/src/Microsoft.VisualBasic/Microsoft.VisualBasic.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "Microsoft.VisualBasic", "src\Microsoft.VisualBasic.vbproj", "{FE25D593-8029-4726-ABC2-944522B5BE04}"
 EndProject
+Project("{F184B08F-C81C-45F6-A57F-5ABD9991F28F}") = "Microsoft.VisualBasic.Tests", "src\Microsoft.VisualBasic.Tests.csproj", "{82B54697-0251-47A1-8546-FC507D0F3B08}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,8 +17,13 @@ Global
 		{FE25D593-8029-4726-ABC2-944522B5BE04}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FE25D593-8029-4726-ABC2-944522B5BE04}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FE25D593-8029-4726-ABC2-944522B5BE04}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal
+

--- a/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.csproj
+++ b/src/Microsoft.VisualBasic/tests/Microsoft.VisualBasic.Tests.csproj
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{82B54697-0251-47A1-8546-FC507D0F3B08}</ProjectGuid>
+    <AssemblyName>Microsoft.VisualBasic.Tests</AssemblyName>
+    <RootNamespace>Microsoft.VisualBasic.Tests</RootNamespace>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="StringsTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\Microsoft.VisualBasic.vbproj">
+      <Project>{FE25D593-8029-4726-ABC2-944522B5BE04}</Project>
+      <Name>Microsoft.VisualBasic</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Microsoft.VisualBasic/tests/StringsTests.cs
+++ b/src/Microsoft.VisualBasic/tests/StringsTests.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.VisualBasic.Tests
+{
+    public class StringsTests
+    {
+        [Fact]
+        public void AscWTest()
+        {
+            Assert.Equal('3', Strings.AscW('3'));
+
+            Assert.Throws<ArgumentException>(() => Strings.AscW(null));
+            Assert.Throws<ArgumentException>(() => Strings.AscW(""));
+
+            Assert.Equal('3', Strings.AscW("3"));
+            Assert.Equal('3', Strings.AscW("345"));
+        }
+    }
+}

--- a/src/Microsoft.VisualBasic/tests/project.json
+++ b/src/Microsoft.VisualBasic/tests/project.json
@@ -1,0 +1,29 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.10",
+    "System.Diagnostics.Debug": "4.0.10",
+    "System.Dynamic.Runtime": "4.0.10",
+    "System.Globalization": "4.0.10",
+    "System.IO": "4.0.10",
+    "System.Linq": "4.0.0",
+    "System.Linq.Expressions": "4.0.10",
+    "System.ObjectModel": "4.0.10",
+    "System.Reflection": "4.0.10",
+    "System.Reflection.Extensions": "4.0.0",
+    "System.Reflection.Primitives": "4.0.0",
+    "System.Reflection.TypeExtensions": "4.0.0",
+    "System.Resources.ResourceManager": "4.0.0",
+    "System.Runtime": "4.0.20",
+    "System.Runtime.Extensions": "4.0.10",
+    "System.Runtime.Handles": "4.0.0",
+    "System.Runtime.InteropServices": "4.0.20",
+    "System.Text.Encoding": "4.0.10",
+    "System.Threading": "4.0.10",
+    "System.Threading.Tasks": "4.0.10",
+    "xunit": "2.1.0",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/Microsoft.Win32.Registry.AccessControl/Microsoft.Win32.Registry.AccessControl.sln
+++ b/src/Microsoft.Win32.Registry.AccessControl/Microsoft.Win32.Registry.AccessControl.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Win32.Registry.AccessControl", "src\Microsoft.Win32.Registry.AccessControl.csproj", "{63B68403-290D-4034-AD85-F1E37F995432}"
 EndProject
@@ -9,7 +9,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{43D98B79-6BF
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{8F7F8A86-C2F6-49D7-A9B8-2EBF3411E466}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{62D128E0-A08B-4E77-85C6-2ADFA715432C}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Win32.Registry.AccessControl", "ref\Microsoft.Win32.Registry.AccessControl.csproj", "{EB1C5ECC-5787-4D50-A242-EBC9CAD4760C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Win32.Registry.AccessControl.Tests", "tests\Microsoft.Win32.Registry.AccessControl.Tests.csproj", "{82B54697-0251-47A1-8546-FC507D0F3B08}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -40,6 +44,16 @@ Global
 		{EB1C5ECC-5787-4D50-A242-EBC9CAD4760C}.Windows_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EB1C5ECC-5787-4D50-A242-EBC9CAD4760C}.Windows_Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{EB1C5ECC-5787-4D50-A242-EBC9CAD4760C}.Windows_Release|Any CPU.Build.0 = Debug|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.net46_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.net46_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.net46_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.net46_Release|Any CPU.Build.0 = Release|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Windows_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Windows_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Windows_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Windows_Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -47,5 +61,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{63B68403-290D-4034-AD85-F1E37F995432} = {43D98B79-6BFB-4526-8BF7-CAE34EB88E60}
 		{EB1C5ECC-5787-4D50-A242-EBC9CAD4760C} = {8F7F8A86-C2F6-49D7-A9B8-2EBF3411E466}
+		{82B54697-0251-47A1-8546-FC507D0F3B08} = {62D128E0-A08B-4E77-85C6-2ADFA715432C}
 	EndGlobalSection
 EndGlobal

--- a/src/Microsoft.Win32.Registry.AccessControl/tests/Microsoft.Win32.Registry.AccessControl.Tests.csproj
+++ b/src/Microsoft.Win32.Registry.AccessControl/tests/Microsoft.Win32.Registry.AccessControl.Tests.csproj
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{82B54697-0251-47A1-8546-FC507D0F3B08}</ProjectGuid>
+    <AssemblyName>Microsoft.Win32.Registry.AccessControl.Tests</AssemblyName>
+    <RootNamespace>Microsoft.Win32.Registry.AccessControl.Tests</RootNamespace>
+    <UnsupportedPlatforms>Linux;OSX</UnsupportedPlatforms>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="RegistryAclExtensionsTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\Microsoft.Win32.Registry.AccessControl.csproj">
+      <Name>Microsoft.Win32.Registry.AccessControl</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/Microsoft.Win32.Registry.AccessControl/tests/RegistryAclExtensionsTests.cs
+++ b/src/Microsoft.Win32.Registry.AccessControl/tests/RegistryAclExtensionsTests.cs
@@ -1,0 +1,18 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Xunit;
+
+namespace Microsoft.Win32
+{
+    public class RegistryAclExtensionsTests
+    {
+        [Fact]
+        public void GetAccessControl_NullArgument_Throws()
+        {
+            Assert.Throws<NullReferenceException>(() => RegistryAclExtensions.GetAccessControl(null));
+        }
+    }
+}

--- a/src/Microsoft.Win32.Registry.AccessControl/tests/project.json
+++ b/src/Microsoft.Win32.Registry.AccessControl/tests/project.json
@@ -1,0 +1,17 @@
+{
+  "dependencies": {
+    "Microsoft.Win32.Registry": "4.0.0-rc3-23729",
+    "System.IO": "4.0.10",
+    "System.Runtime.Handles": "4.0.00",
+    "System.Resources.ResourceManager": "4.0.0",
+    "System.Runtime": "4.0.20",
+    "System.Runtime.InteropServices": "4.0.20",
+    "System.Security.AccessControl": "4.0.0-rc3-23729",
+    "System.Security.Principal.Windows": "4.0.0-rc3-23729",
+    "xunit": "2.1.0",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Data.Common/System.Data.Common.sln
+++ b/src/System.Data.Common/System.Data.Common.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Data.Common", "src\System.Data.Common.csproj", "{29EF8D53-8E84-4E49-B90F-5950A2FE7D54}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Data.Common.Tests", "tests\System.Data.Common.Tests.csproj", "{82B54697-0251-47A1-8546-FC507D0F3B08}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{29EF8D53-8E84-4E49-B90F-5950A2FE7D54}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{29EF8D53-8E84-4E49-B90F-5950A2FE7D54}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{29EF8D53-8E84-4E49-B90F-5950A2FE7D54}.Release|Any CPU.Build.0 = Release|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{82B54697-0251-47A1-8546-FC507D0F3B08}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Data.Common/tests/DbExceptionTests.cs
+++ b/src/System.Data.Common/tests/DbExceptionTests.cs
@@ -1,0 +1,29 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Data.Common
+{
+    public class DbExceptionTests
+    {
+        [Fact]
+        public void ArgumentsStored()
+        {
+            Assert.Equal("test", new CustomDbException("test").Message);
+            Assert.Equal("another test", new CustomDbException("test", new Exception("another test")).InnerException.Message);
+        }
+
+        private class CustomDbException : DbException
+        {
+            public CustomDbException(string message) : base(message)
+            {
+            }
+
+            public CustomDbException(string message, Exception innerException) : base(message, innerException)
+            {
+            }
+        }
+    }
+}

--- a/src/System.Data.Common/tests/System.Data.Common.Tests.csproj
+++ b/src/System.Data.Common/tests/System.Data.Common.Tests.csproj
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{82B54697-0251-47A1-8546-FC507D0F3B08}</ProjectGuid>
+    <AssemblyName>System.Data.Common.Tests</AssemblyName>
+    <RootNamespace>System.Data.Common.Tests</RootNamespace>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="DbExceptionTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Data.Common.csproj">
+      <Name>System.Data.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Data.Common/tests/project.json
+++ b/src/System.Data.Common/tests/project.json
@@ -1,0 +1,19 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.10",
+    "System.Collections.NonGeneric": "4.0.0",
+    "System.Globalization": "4.0.0",
+    "System.IO": "4.0.0",
+    "System.Resources.ResourceManager": "4.0.0",
+    "System.Text.RegularExpressions": "4.0.0",
+    "System.Runtime": "4.0.20",
+    "System.Runtime.Extensions": "4.0.10",
+    "System.Threading.Tasks": "4.0.10",
+    "System.Diagnostics.Tools": "4.0.0",
+    "xunit": "2.1.0",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
+++ b/src/System.IO.FileSystem.AccessControl/tests/FileSystemAclExtensionsTests.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.IO
+{
+    public class FileSystemAclExtensionsTests
+    {
+        [Fact]
+        public void GetAccessControl_InvalidArguments()
+        {
+            Assert.Throws<NullReferenceException>(() => FileSystemAclExtensions.GetAccessControl((DirectoryInfo)null));
+        }
+    }
+}

--- a/src/System.IO.FileSystem.AccessControl/tests/System.IO.FileSystem.AccessControl.Tests.csproj
+++ b/src/System.IO.FileSystem.AccessControl/tests/System.IO.FileSystem.AccessControl.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{D77FBA6C-1AA6-45A4-93E2-97A370672C53}</ProjectGuid>
+    <AssemblyName>System.IO.FileSystem.AccessControl.Tests</AssemblyName>
+    <RootNamespace>System.IO.FileSystem.AccessControl.Tests</RootNamespace>
+    <UnsupportedPlatforms>Linux;OSX</UnsupportedPlatforms>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="FileSystemAclExtensionsTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.IO.FileSystem.AccessControl.csproj">
+      <Project>{96AA2060-C846-4E56-9509-E8CB9C114C8F}</Project>
+      <Name>System.IO.FileSystem.AccessControl</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.IO.FileSystem.AccessControl/tests/project.json
+++ b/src/System.IO.FileSystem.AccessControl/tests/project.json
@@ -1,0 +1,23 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.10",
+    "System.Diagnostics.Contracts": "4.0.0",
+    "System.Diagnostics.Debug": "4.0.10",
+    "System.IO": "4.0.10",
+    "System.IO.FileSystem": "4.0.0",
+    "System.IO.FileSystem.Primitives": "4.0.0",
+    "System.Resources.ResourceManager": "4.0.0",
+    "System.Runtime": "4.0.20",
+    "System.Runtime.Extensions": "4.0.10",
+    "System.Runtime.Handles": "4.0.0",
+    "System.Runtime.InteropServices": "4.0.20",
+    "System.Security.AccessControl": "4.0.0-rc3-23729",
+    "System.Security.Principal": "4.0.0",
+    "System.Security.Principal.Windows": "4.0.0-rc3-23729",
+    "xunit": "2.1.0",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Reflection.Context/System.Reflection.Context.sln
+++ b/src/System.Reflection.Context/System.Reflection.Context.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Reflection.Context", "src\System.Reflection.Context.csproj", "{404DB891-B5AF-41E6-B89D-29E3F4573C4F}"
 EndProject
@@ -9,7 +9,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{F7E06955-4DA
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{2CC35A3F-E502-4E9F-A46B-EF54F6F567CE}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{8D6656E0-A8EE-4C2B-8219-967C0257B6F1}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Reflection.Context", "ref\System.Reflection.Context.csproj", "{0F892412-310A-4369-8721-6700EBF26B20}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Reflection.Context.Tests", "tests\System.Reflection.Context.Tests.csproj", "{D77FBA6C-1AA6-45A4-93E2-97A370672C53}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,18 +22,24 @@ Global
 		netcore50_Release|Any CPU = netcore50_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{404DB891-B5AF-41E6-B89D-29E3F4573C4F}.Debug|Any CPU.ActiveCfg = netcore50_Debug|Any CPU
-		{404DB891-B5AF-41E6-B89D-29E3F4573C4F}.Debug|Any CPU.Build.0 = netcore50_Debug|Any CPU
-		{404DB891-B5AF-41E6-B89D-29E3F4573C4F}.netcore50_Debug|Any CPU.ActiveCfg = netcore50_Debug|Any CPU
-		{404DB891-B5AF-41E6-B89D-29E3F4573C4F}.netcore50_Debug|Any CPU.Build.0 = netcore50_Debug|Any CPU
-		{404DB891-B5AF-41E6-B89D-29E3F4573C4F}.netcore50_Release|Any CPU.ActiveCfg = netcore50_Release|Any CPU
-		{404DB891-B5AF-41E6-B89D-29E3F4573C4F}.netcore50_Release|Any CPU.Build.0 = netcore50_Release|Any CPU
+		{404DB891-B5AF-41E6-B89D-29E3F4573C4F}.Debug|Any CPU.ActiveCfg = Windows_netcore50_Debug|Any CPU
+		{404DB891-B5AF-41E6-B89D-29E3F4573C4F}.Debug|Any CPU.Build.0 = Windows_netcore50_Debug|Any CPU
+		{404DB891-B5AF-41E6-B89D-29E3F4573C4F}.netcore50_Debug|Any CPU.ActiveCfg = Windows_netcore50_Debug|Any CPU
+		{404DB891-B5AF-41E6-B89D-29E3F4573C4F}.netcore50_Debug|Any CPU.Build.0 = Windows_netcore50_Debug|Any CPU
+		{404DB891-B5AF-41E6-B89D-29E3F4573C4F}.netcore50_Release|Any CPU.ActiveCfg = Windows_netcore50_Release|Any CPU
+		{404DB891-B5AF-41E6-B89D-29E3F4573C4F}.netcore50_Release|Any CPU.Build.0 = Windows_netcore50_Release|Any CPU
 		{0F892412-310A-4369-8721-6700EBF26B20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0F892412-310A-4369-8721-6700EBF26B20}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0F892412-310A-4369-8721-6700EBF26B20}.netcore50_Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0F892412-310A-4369-8721-6700EBF26B20}.netcore50_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0F892412-310A-4369-8721-6700EBF26B20}.netcore50_Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{0F892412-310A-4369-8721-6700EBF26B20}.netcore50_Release|Any CPU.Build.0 = Debug|Any CPU
+		{D77FBA6C-1AA6-45A4-93E2-97A370672C53}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D77FBA6C-1AA6-45A4-93E2-97A370672C53}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D77FBA6C-1AA6-45A4-93E2-97A370672C53}.netcore50_Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D77FBA6C-1AA6-45A4-93E2-97A370672C53}.netcore50_Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D77FBA6C-1AA6-45A4-93E2-97A370672C53}.netcore50_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D77FBA6C-1AA6-45A4-93E2-97A370672C53}.netcore50_Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -37,5 +47,6 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{404DB891-B5AF-41E6-B89D-29E3F4573C4F} = {2CC35A3F-E502-4E9F-A46B-EF54F6F567CE}
 		{0F892412-310A-4369-8721-6700EBF26B20} = {F7E06955-4DAA-4C19-885A-CF02917F4D91}
+		{D77FBA6C-1AA6-45A4-93E2-97A370672C53} = {8D6656E0-A8EE-4C2B-8219-967C0257B6F1}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Reflection.Context/tests/CustomReflectionContextTests.cs
+++ b/src/System.Reflection.Context/tests/CustomReflectionContextTests.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Reflection.Context
+{
+    public class CustomReflectionContextTests
+    {
+        [Fact]
+        public void InstantiateContext_Throws()
+        {
+            Assert.Throws<PlatformNotSupportedException>(() => new DerivedContext());
+        }
+
+        private class DerivedContext : CustomReflectionContext { }
+    }
+}

--- a/src/System.Reflection.Context/tests/System.Reflection.Context.Tests.csproj
+++ b/src/System.Reflection.Context/tests/System.Reflection.Context.Tests.csproj
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{D77FBA6C-1AA6-45A4-93E2-97A370672C53}</ProjectGuid>
+    <AssemblyName>System.Reflection.Context.Tests</AssemblyName>
+    <RootNamespace>System.Reflection.Context.Tests</RootNamespace>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="CustomReflectionContextTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Reflection.Context.csproj">
+      <Project>{96AA2060-C846-4E56-9509-E8CB9C114C8F}</Project>
+      <Name>System.Reflection.Context</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection.Context/tests/project.json
+++ b/src/System.Reflection.Context/tests/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "System.Reflection.Primitives": "4.0.0",
+    "System.Reflection": "4.0.10",
+    "System.Runtime": "4.0.20",
+    "xunit": "2.1.0",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Security.Claims/tests/ClaimTests.cs
+++ b/src/System.Security.Claims/tests/ClaimTests.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Security.Claims
+{
+    public class ClaimTests
+    {
+        [Fact]
+        public void Ctor_ArgumentValidation()
+        {
+            Assert.Throws<ArgumentNullException>(() => new Claim(null));
+        }
+    }
+}

--- a/src/System.Security.Claims/tests/System.Security.Claims.Tests.csproj
+++ b/src/System.Security.Claims/tests/System.Security.Claims.Tests.csproj
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{82B54697-0251-47A1-8546-FC507D0F3B08}</ProjectGuid>
+    <AssemblyName>System.Security.Claims.Tests</AssemblyName>
+    <RootNamespace>System.Security.Claims.Tests</RootNamespace>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="ClaimTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Security.Claims.csproj">
+      <Name>System.Security.Claims</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.Claims/tests/project.json
+++ b/src/System.Security.Claims/tests/project.json
@@ -1,0 +1,17 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.10",
+    "System.Diagnostics.Contracts": "4.0.0",
+    "System.Globalization": "4.0.0",
+    "System.IO": "4.0.0",
+    "System.Resources.ResourceManager": "4.0.0",
+    "System.Runtime": "4.0.20",
+    "System.Runtime.Extensions": "4.0.10",
+    "System.Security.Principal": "4.0.0",
+    "xunit": "2.1.0",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Threading.AccessControl/tests/MutexSecurityTests.cs
+++ b/src/System.Threading.AccessControl/tests/MutexSecurityTests.cs
@@ -1,0 +1,17 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Security.AccessControl
+{
+    public class MutexSecurityTests
+    {
+        [Fact]
+        public void Ctor_Success()
+        {
+            new MutexSecurity();
+        }
+    }
+}

--- a/src/System.Threading.AccessControl/tests/System.Threading.AccessControl.Tests.csproj
+++ b/src/System.Threading.AccessControl/tests/System.Threading.AccessControl.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <ProjectGuid>{D77FBA6C-1AA6-45A4-93E2-97A370672C53}</ProjectGuid>
+    <AssemblyName>System.Threading.AccessControl.Tests</AssemblyName>
+    <RootNamespace>System.Threading.AccessControl.Tests</RootNamespace>
+    <UnsupportedPlatforms>Linux;OSX</UnsupportedPlatforms>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="MutexSecurityTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\System.Threading.AccessControl.csproj">
+      <Project>{E3ED83FD-3015-4BD8-A1B8-6294986E6CFA}</Project>
+      <Name>System.Threading.AccessControl</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Threading.AccessControl/tests/project.json
+++ b/src/System.Threading.AccessControl/tests/project.json
@@ -1,0 +1,18 @@
+{
+  "dependencies": {
+    "System.Diagnostics.Contracts": "4.0.0",
+    "System.Runtime.Handles": "4.0.0",
+    "System.Resources.ResourceManager": "4.0.0",
+    "System.Runtime": "4.0.20",
+    "System.Runtime.InteropServices": "4.0.20",
+    "System.Security.AccessControl": "4.0.0-rc3-23729",
+    "System.Security.Principal.Windows": "4.0.0-rc3-23729",
+    "System.Threading": "4.0.10",
+    "System.Threading.Tasks": "4.0.10",
+    "xunit": "2.1.0",
+    "xunit.netcore.extensions": "1.0.0-prerelease-00123"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}


### PR DESCRIPTION
Adding these gives us a place to put tests for the associated libraries, and also ensures that the libraries show up in code coverage.  Each library is empty with the exception of a single test that's necessary for code coverage to pick it up.  includes skeleton projects for:
- Microsoft.CSharp
- Microsoft.VisualBasic
- Microsoft.Win32.Registry.AccessControl
- System.Data.Common
- System.IO.FileSystem.AccessControl
- System.Reflection.Context
- System.Security.Claims
- System.threading.AccessControl