### PR TITLE
Unique names for GlobalizationNative exports

### DIFF
--- a/src/Common/src/Interop/Unix/System.Globalization.Native/Interop.Idna.cs
+++ b/src/Common/src/Interop/Unix/System.Globalization.Native/Interop.Idna.cs
@@ -12,10 +12,10 @@ internal static partial class Interop
         internal const int AllowUnassigned = 0x1;
         internal const int UseStd3AsciiRules = 0x2;
 
-        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ToAscii")]
         internal static extern int ToAscii(uint flags, string src, int srcLen, char[] dstBuffer, int dstBufferCapacity);
 
-        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ToUnicode")]
         internal static extern int ToUnicode(uint flags, string src, int srcLen, char[] dstBuffer, int dstBufferCapacity);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Globalization.Native/Interop.Normalization.cs
+++ b/src/Common/src/Interop/Unix/System.Globalization.Native/Interop.Normalization.cs
@@ -10,10 +10,10 @@ internal static partial class Interop
 {
     internal static partial class GlobalizationNative
     {
-        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_IsNormalized")]
         internal static extern int IsNormalized(NormalizationForm normalizationForm, string src, int srcLen);
 
-        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode)]
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_NormalizeString")]
         internal static extern int NormalizeString(NormalizationForm normalizationForm, string src, int srcLen, [Out] char[] dstBuffer, int dstBufferCapacity);
     }
 }

--- a/src/Common/src/Interop/Windows/mincore/Interop.Idna.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.Idna.cs
@@ -1,0 +1,39 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+
+internal partial class Interop
+{
+    internal partial class mincore
+    {
+        //
+        //  Idn APIs
+        //
+
+        [DllImport("api-ms-win-core-localization-l1-2-0.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern int IdnToAscii(
+                                        uint dwFlags,
+                                        string lpUnicodeCharStr,
+                                        int cchUnicodeChar,
+                                        [System.Runtime.InteropServices.OutAttribute()]
+
+                                        char[] lpASCIICharStr,
+                                        int cchASCIIChar);
+
+        [DllImport("api-ms-win-core-localization-l1-2-0.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        internal static extern int IdnToUnicode(
+                                        uint dwFlags,
+                                        string lpASCIICharStr,
+                                        int cchASCIIChar,
+                                        [System.Runtime.InteropServices.OutAttribute()]
+
+                                        char[] lpUnicodeCharStr,
+                                        int cchUnicodeChar);
+
+        internal const int IDN_ALLOW_UNASSIGNED = 0x1;
+        internal const int IDN_USE_STD3_ASCII_RULES = 0x2;
+    }
+}

--- a/src/Common/src/Interop/Windows/mincore/Interop.Normalization.cs
+++ b/src/Common/src/Interop/Windows/mincore/Interop.Normalization.cs
@@ -22,29 +22,6 @@ internal partial class Interop
     internal partial class mincore
     {
         //
-        //  Idn APIs
-        //
-
-        [DllImport("api-ms-win-core-localization-l1-2-0.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern int IdnToAscii(
-                                        uint dwFlags,
-                                        string lpUnicodeCharStr,
-                                        int cchUnicodeChar,
-                                        [System.Runtime.InteropServices.OutAttribute()]
-
-                                        char[] lpASCIICharStr,
-                                        int cchASCIIChar);
-
-        [DllImport("api-ms-win-core-localization-l1-2-0.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        internal static extern int IdnToUnicode(
-                                        uint dwFlags,
-                                        string lpASCIICharStr,
-                                        int cchASCIIChar,
-                                        [System.Runtime.InteropServices.OutAttribute()]
-
-                                        char[] lpUnicodeCharStr,
-                                        int cchUnicodeChar);
-        //
         //  Normalization APIs
         //
 
@@ -59,13 +36,5 @@ internal partial class Interop
                                         [System.Runtime.InteropServices.OutAttribute()]
                                         char[] destenation,
                                         int destenationLength);
-
-
-        internal const int IDN_ALLOW_UNASSIGNED = 0x1;
-        internal const int IDN_USE_STD3_ASCII_RULES = 0x2;
     }
 }
-
-
-
-

--- a/src/System.Globalization.Extensions/src/System.Globalization.Extensions.csproj
+++ b/src/System.Globalization.Extensions/src/System.Globalization.Extensions.csproj
@@ -39,8 +39,11 @@
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.SetLastError.cs">
       <Link>Common\Interop\Windows\Interop.SetLastError.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Interop.Globalization.Extensions.manual.cs">
-      <Link>Common\Interop\Interop.Globalization.Extensions.manual.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.Normalization.cs">
+      <Link>Common\Interop\Windows\mincore\Interop.Normalization.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.Idna.cs">
+      <Link>Common\Interop\Windows\mincore\Interop.Idna.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\System\StringNormalizationExtensions.Windows.cs">
       <Link>Common\System\StringNormalizationExtensions.Windows.cs</Link>

--- a/src/System.Private.Uri/src/System.Private.Uri.csproj
+++ b/src/System.Private.Uri/src/System.Private.Uri.csproj
@@ -82,8 +82,11 @@
     <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.SetLastError.cs">
       <Link>Common\Interop\Windows\mincore\Interop.SetLastError.cs</Link>
     </Compile>
-    <Compile Include="$(CommonPath)\Interop\Interop.Globalization.Extensions.manual.cs">
-      <Link>Common\Interop\Interop.Globalization.Extensions.manual.cs</Link>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.Normalization.cs">
+      <Link>Common\Interop\Windows\mincore\Interop.Normalization.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.Idna.cs">
+      <Link>Common\Interop\Windows\mincore\Interop.Idna.cs</Link>
     </Compile>
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsUnix)' == 'true'">


### PR DESCRIPTION
- CoreFX counter part of https://github.com/dotnet/coreclr/pull/2917.
- Refactored related Windows interop files to follow the convention