### PR TITLE
Override ReadByte on DeflateStream and GZipStream

### DIFF
--- a/src/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -109,6 +110,12 @@ namespace System.IO.Compression
             throw new NotSupportedException(SR.NotSupported);
         }
 
+        public override int ReadByte()
+        {
+            CheckDeflateStream();
+            return _deflateStream.ReadByte();
+        }
+
         public override int Read(byte[] array, int offset, int count)
         {
             CheckDeflateStream();
@@ -174,8 +181,14 @@ namespace System.IO.Compression
         {
             if (_deflateStream == null)
             {
-                throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
+                ThrowStreamClosedException();
             }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ThrowStreamClosedException()
+        {
+            throw new ObjectDisposedException(null, SR.ObjectDisposed_StreamClosed);
         }
     }
 }

--- a/src/System.IO.Compression/src/System/IO/Compression/Inflater.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/Inflater.cs
@@ -50,29 +50,56 @@ namespace System.IO.Compression
             return _finished && _zlibStream.AvailIn == 0 && _zlibStream.AvailOut == 0;
         }
 
-        public int Inflate(byte[] bytes, int offset, int length)
+        public unsafe bool Inflate(out byte b)
         {
-            Debug.Assert(null != bytes, "Can't pass in a null output buffer!");
+            // If Inflate is called on an invalid or unready inflater, return 0 to indicate no bytes have been read.
+            if (NeedsInput() || _inputBufferHandle == null || !_inputBufferHandle.IsAllocated)
+            {
+                b = 0;
+                return false;
+            }
 
-            // If Inflate is called on an invalid or unready inflater, return 0 to indicate no bytes
-            // have been read
+            fixed (byte* bufPtr = &b)
+            {
+                int bytesRead = InflateVerified(bufPtr, 1);
+                Debug.Assert(bytesRead == 0 || bytesRead == 1);
+                return bytesRead != 0;
+            }
+        }
+
+        public unsafe int Inflate(byte[] bytes, int offset, int length)
+        {
+            // If Inflate is called on an invalid or unready inflater, return 0 to indicate no bytes have been read.
             if (NeedsInput() || _inputBufferHandle == null || !_inputBufferHandle.IsAllocated || length == 0)
                 return 0;
 
+            Debug.Assert(null != bytes, "Can't pass in a null output buffer!");
+            fixed (byte* bufPtr = bytes)
+            {
+                return InflateVerified(bufPtr + offset, length);
+            }
+        }
+
+        public unsafe int InflateVerified(byte* bufPtr, int length)
+        {
             // State is valid; attempt inflation
+            Debug.Assert(!NeedsInput() && _inputBufferHandle != null && _inputBufferHandle.IsAllocated && length != 0);
             try
             {
                 int bytesRead;
-                ZLibNative.ErrorCode errc = ReadInflateOutput(bytes, offset, length, ZLibNative.FlushCode.NoFlush, out bytesRead);
-                if (errc == ZLibNative.ErrorCode.StreamEnd)
+                if (ReadInflateOutput(bufPtr, length, ZLibNative.FlushCode.NoFlush, out bytesRead) == ZLibNative.ErrorCode.StreamEnd)
+                {
                     _finished = true;
+                }
                 return bytesRead;
             }
             finally
             {
                 // Before returning, make sure to release input buffer if necesary:
                 if (0 == _zlibStream.AvailIn && _inputBufferHandle.IsAllocated)
+                {
                     DeallocateInputBufferHandle();
+                }
             }
         }
 
@@ -166,23 +193,19 @@ namespace System.IO.Compression
         }
 
         /// <summary>
-        /// Translates the given byte array to a GCHandle so that it can be passed to the ZLib
-        /// Inflate function, then returns the result of that call.
+        /// Wrapper around the ZLib inflate function, configuring the stream appropriately.
         /// </summary>
-        private unsafe ZLibNative.ErrorCode ReadInflateOutput(byte[] outputBuffer, int offset, int length, ZLibNative.FlushCode flushCode, out int bytesRead)
+        private unsafe ZLibNative.ErrorCode ReadInflateOutput(byte* bufPtr, int length, ZLibNative.FlushCode flushCode, out int bytesRead)
         {
             lock (_syncLock)
             {
-                fixed (byte* bufPtr = outputBuffer)
-                {
-                    _zlibStream.NextOut = (IntPtr)bufPtr + offset;
-                    _zlibStream.AvailOut = (uint)length;
+                _zlibStream.NextOut = (IntPtr)bufPtr;
+                _zlibStream.AvailOut = (uint)length;
 
-                    ZLibNative.ErrorCode errC = Inflate(flushCode);
-                    bytesRead = length - (int)_zlibStream.AvailOut;
+                ZLibNative.ErrorCode errC = Inflate(flushCode);
+                bytesRead = length - (int)_zlibStream.AvailOut;
 
-                    return errC;
-                }
+                return errC;
             }
         }
 

--- a/src/System.IO.Compression/tests/DeflateStreamTests.cs
+++ b/src/System.IO.Compression/tests/DeflateStreamTests.cs
@@ -678,7 +678,6 @@ namespace System.IO.Compression.Tests
             }
             compressed.Position = 0;
 
-            var decompressed = new MemoryStream();
             using (var decompressor = new DeflateStream(compressed, CompressionMode.Decompress, true))
             {
                 int i, j;
@@ -694,6 +693,26 @@ namespace System.IO.Compression.Tests
                 decompressor.Read(array2, 0, array2.Length);
                 for (j = 0; j < array2.Length; j++)
                     Assert.Equal(data[j], array[j]);
+            }
+        }
+
+        [Fact]
+        public void Roundtrip_Write_ReadByte()
+        {
+            byte[] data = new byte[1024 * 10];
+            new Random(42).NextBytes(data);
+
+            var compressed = new MemoryStream();
+            using (var compressor = new DeflateStream(compressed, CompressionMode.Compress, true))
+            {
+                compressor.Write(data, 0, data.Length);
+            }
+            compressed.Position = 0;
+
+            using (var decompressor = new DeflateStream(compressed, CompressionMode.Decompress, true))
+            {
+                for (int i = 0; i < data.Length; i++)
+                    Assert.Equal(data[i], decompressor.ReadByte());
             }
         }
 


### PR DESCRIPTION
Improves throughput of ReadByte by ~15-20% and mostly eliminates involved allocations.

cc: @ianhays 