### PR TITLE
Fixed typo in unit test name

### DIFF
--- a/src/System.Buffers/tests/ArrayPool/UnitTests.cs
+++ b/src/System.Buffers/tests/ArrayPool/UnitTests.cs
@@ -97,7 +97,7 @@ namespace System.Buffers.ArrayPool.Tests
         }
 
         [Fact]
-        public static void RentingAnArrayWithLengthGreaterThanSpecifiedInCreateSillSucceeds()
+        public static void RentingAnArrayWithLengthGreaterThanSpecifiedInCreateStillSucceeds()
         {
             Assert.NotNull(ArrayPool<byte>.Create(maxArrayLength: 100, numberOfArrays: 1).Rent(200));
         }


### PR DESCRIPTION
System.Buffers test case misspells "still" as "sill". Nothing else refers to it by name, unit tests are not available to the public, so this should hopefully be a no impact change.