### PR TITLE
Fix HttpWebRequest to allow content-related headers without content

### DIFF
--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -14,8 +14,6 @@ namespace System.Net
     {
         private const int DefaultContinueTimeout = 350; // Current default value from .NET Desktop.
 
-        private readonly byte[] _emptyBytes = new byte[0];
-
         private WebHeaderCollection _webHeaderCollection = new WebHeaderCollection();
 
         private Uri _requestUri;
@@ -409,7 +407,7 @@ namespace System.Net
                     if (request.Content == null)
                     {
                         // Create empty content so that we can send the entity-body header.
-                        request.Content = new ByteArrayContent(_emptyBytes);
+                        request.Content = new ByteArrayContent(Array.Empty<byte>());
                     }
 
                     request.Content.Headers.TryAddWithoutValidation(headerName, _webHeaderCollection[headerName]);

--- a/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
+++ b/src/System.Net.Requests/src/System/Net/HttpWebRequest.cs
@@ -14,6 +14,8 @@ namespace System.Net
     {
         private const int DefaultContinueTimeout = 350; // Current default value from .NET Desktop.
 
+        private readonly byte[] _emptyBytes = new byte[0];
+
         private WebHeaderCollection _webHeaderCollection = new WebHeaderCollection();
 
         private Uri _requestUri;
@@ -401,15 +403,16 @@ namespace System.Net
             {
                 // The System.Net.Http APIs require HttpRequestMessage headers to be properly divided between the request headers
                 // collection and the request content headers colllection for all well-known header names.  And custom headers
-                // are only allowed in the request headers collection and not in the request content headers collection.  If a well-known
-                // content related (entity-body) header is found and there is no actual content being sent (i.e. it's a GET verb),
-                // then we'll need to drop the header on the floor.
+                // are only allowed in the request headers collection and not in the request content headers collection.
                 if (IsWellKnownContentHeader(headerName))
                 {
-                    if (request.Content != null)
+                    if (request.Content == null)
                     {
-                        request.Content.Headers.TryAddWithoutValidation(headerName, _webHeaderCollection[headerName]);
+                        // Create empty content so that we can send the entity-body header.
+                        request.Content = new ByteArrayContent(_emptyBytes);
                     }
+
+                    request.Content.Headers.TryAddWithoutValidation(headerName, _webHeaderCollection[headerName]);
                 }
                 else
                 {

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 using Xunit;
+using Xunit.Abstractions;
 
 namespace System.Net.Tests
 {
@@ -23,8 +24,14 @@ namespace System.Net.Tests
         private Exception _savedResponseException = null;
         private int _requestStreamCallbackCallCount = 0;
         private int _responseCallbackCallCount = 0;
+        private readonly ITestOutputHelper _output;
 
         public readonly static object[][] EchoServers = HttpTestServers.EchoServers;
+
+        public HttpWebRequestTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
 
         [Theory, MemberData("EchoServers")]
         public void Ctor_VerifyDefaults_Success(Uri remoteServer)
@@ -480,6 +487,25 @@ namespace System.Net.Tests
             }
 
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Theory, MemberData("EchoServers")]
+        public async Task ContentType_AddHeaderWithNoContent_SendRequest_HeaderGetsSent(Uri remoteServer)
+        {
+            HttpWebRequest request = HttpWebRequest.CreateHttp(remoteServer);
+            request.ContentType = "application/json";
+            
+            HttpWebResponse response = (HttpWebResponse) await request.GetResponseAsync();
+            Stream responseStream = response.GetResponseStream();
+            String responseBody;
+            using (var sr = new StreamReader(responseStream))
+            {
+                responseBody = sr.ReadToEnd();
+            }
+            _output.WriteLine(responseBody);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.True(responseBody.Contains("Content-Type"));
         }
 
         [Theory, MemberData("EchoServers")]


### PR DESCRIPTION
HttpWebRequest, part of the System.Net.Requests contract, has historically allowed any request header to be sent. However, in CoreFx it is built on top of System.Net.Http. And System.Net.Http has a stricter object model where it requires headers to be added only to specific collections.

The bug was trying to add a content-related header without any content being sent. This worked in .NET Framework (Desktop). While we encourage developers to migrate to the newer System.Net.Http library, we try to maintain app-compat where possible for HttpWebRequest.

The fix is to internally create an empty HttpContent object when calling into System.Net.Http and place the content-related headers into that collection.

Fixes #5565.