### PR TITLE
Disable WaitForPeerProcess test

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
@@ -122,6 +122,7 @@ namespace System.Diagnostics.Tests
             }
         }
 
+        [ActiveIssue(5780, PlatformID.AnyUnix)]
         [Fact]
         public void WaitForPeerProcess()
         {


### PR DESCRIPTION
This test has started to fail quite frequently in the past few days (I'd not seen it ever fail before).  Disabling while we investigate.
#5780