### PR TITLE
Inline selector use in aggregate methods.

### DIFF
--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -2288,52 +2288,124 @@ namespace System.Linq
 
         public static int Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector)
         {
-            return Enumerable.Sum(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            int sum = 0;
+            checked
+            {
+                foreach (TSource item in source) sum += selector(item);
+            }
+            return sum;
         }
 
         public static int? Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector)
         {
-            return Enumerable.Sum(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            int sum = 0;
+            checked
+            {
+                foreach (TSource item in source)
+                {
+                    int? v = selector(item);
+                    if (v != null) sum += v.GetValueOrDefault();
+                }
+            }
+            return sum;
         }
 
         public static long Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector)
         {
-            return Enumerable.Sum(Enumerable.Select(source, selector));
+            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null) throw Error.ArgumentNull("source");
+            long sum = 0;
+            checked
+            {
+                foreach (TSource item in source) sum += selector(item);
+            }
+            return sum;
         }
 
         public static long? Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector)
         {
-            return Enumerable.Sum(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            long sum = 0;
+            checked
+            {
+                foreach (TSource item in source)
+                {
+                    long? v = selector(item);
+                    if (v != null) sum += v.GetValueOrDefault();
+                }
+            }
+            return sum;
         }
 
         public static float Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector)
         {
-            return Enumerable.Sum(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            double sum = 0;
+            foreach (TSource item in source) sum += selector(item);
+            return (float)sum;
         }
 
         public static float? Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector)
         {
-            return Enumerable.Sum(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            double sum = 0;
+            foreach (TSource item in source)
+            {
+                float? v = selector(item);
+                if (v != null) sum += v.GetValueOrDefault();
+            }
+            return (float)sum;
         }
 
         public static double Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector)
         {
-            return Enumerable.Sum(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            double sum = 0;
+            foreach (TSource item in source) sum += selector(item);
+            return sum;
         }
 
         public static double? Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector)
         {
-            return Enumerable.Sum(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            double sum = 0;
+            foreach (TSource item in source)
+            {
+                double? v = selector(item);
+                if (v != null) sum += v.GetValueOrDefault();
+            }
+            return sum;
         }
 
         public static decimal Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector)
         {
-            return Enumerable.Sum(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            decimal sum = 0;
+            foreach (TSource item in source) sum += selector(item);
+            return sum;
         }
 
         public static decimal? Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
         {
-            return Enumerable.Sum(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            decimal sum = 0;
+            foreach (TSource item in source)
+            {
+                decimal? v = selector(item);
+                if (v != null) sum += v.GetValueOrDefault();
+            }
+            return sum;
         }
 
         public static int Min(this IEnumerable<int> source)
@@ -2616,57 +2688,291 @@ namespace System.Linq
 
         public static int Min<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector)
         {
-            return Enumerable.Min(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            int value;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext()) throw Error.NoElements();
+                value = selector(e.Current);
+                while (e.MoveNext())
+                {
+                    int x = selector(e.Current);
+                    if (x < value) value = x;
+                }
+            }
+            return value;
         }
 
         public static int? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector)
         {
-            return Enumerable.Min(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            int? value = null;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                // Start off knowing that we've a non-null value (or exit here, knowing we don't)
+                // so we don't have to keep testing for nullity.
+                do
+                {
+                    if (!e.MoveNext()) return value;
+                    value = selector(e.Current);
+                } while (!value.HasValue);
+                // Keep hold of the wrapped value, and do comparisons on that, rather than
+                // using the lifted operation each time.
+                int valueVal = value.GetValueOrDefault();
+                while (e.MoveNext())
+                {
+                    int? cur = selector(e.Current);
+                    int x = cur.GetValueOrDefault();
+                    // Do not replace & with &&. The branch prediction cost outweighs the extra operation
+                    // unless nulls either never happen or always happen.
+                    if (cur.HasValue & x < valueVal)
+                    {
+                        valueVal = x;
+                        value = cur;
+                    }
+                }
+            }
+            return value;
         }
 
         public static long Min<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector)
         {
-            return Enumerable.Min(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            long value;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext()) throw Error.NoElements();
+                value = selector(e.Current);
+                while (e.MoveNext())
+                {
+                    long x = selector(e.Current);
+                    if (x < value) value = x;
+                }
+            }
+            return value;
         }
 
         public static long? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector)
         {
-            return Enumerable.Min(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            long? value = null;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext()) return value;
+                    value = selector(e.Current);
+                } while (!value.HasValue);
+                long valueVal = value.GetValueOrDefault();
+                while (e.MoveNext())
+                {
+                    long? cur = selector(e.Current);
+                    long x = cur.GetValueOrDefault();
+                    // Do not replace & with &&. The branch prediction cost outweighs the extra operation
+                    // unless nulls either never happen or always happen.
+                    if (cur.HasValue & x < valueVal)
+                    {
+                        valueVal = x;
+                        value = cur;
+                    }
+                }
+            }
+            return value;
         }
 
         public static float Min<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector)
         {
-            return Enumerable.Min(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            float value;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext()) throw Error.NoElements();
+                value = selector(e.Current);
+                while (e.MoveNext())
+                {
+                    float x = selector(e.Current);
+                    if (x < value) value = x;
+                    // Normally NaN < anything is false, as is anything < NaN
+                    // However, this leads to some irksome outcomes in Min and Max.
+                    // If we use those semantics then Min(NaN, 5.0) is NaN, but
+                    // Min(5.0, NaN) is 5.0!  To fix this, we impose a total
+                    // ordering where NaN is smaller than every value, including
+                    // negative infinity.
+                    // Not testing for NaN therefore isn't an option, but since we
+                    // can't find a smaller value, we can short-circuit.
+                    else if (float.IsNaN(x)) return x;
+                }
+            }
+            return value;
         }
 
         public static float? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector)
         {
-            return Enumerable.Min(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            float? value = null;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext()) return value;
+                    value = selector(e.Current);
+                } while (!value.HasValue);
+                float valueVal = value.GetValueOrDefault();
+                while (e.MoveNext())
+                {
+                    float? cur = selector(e.Current);
+                    if (cur.HasValue)
+                    {
+                        float x = cur.GetValueOrDefault();
+                        if (x < valueVal)
+                        {
+                            valueVal = x;
+                            value = cur;
+                        }
+                        else if (float.IsNaN(x)) return cur;
+                    }
+                }
+            }
+            return value;
         }
 
         public static double Min<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector)
         {
-            return Enumerable.Min(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            double value;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext()) throw Error.NoElements();
+                value = selector(e.Current);
+                while (e.MoveNext())
+                {
+                    double x = selector(e.Current);
+                    if (x < value) value = x;
+                    else if (double.IsNaN(x)) return x;
+                }
+            }
+            return value;
         }
 
         public static double? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector)
         {
-            return Enumerable.Min(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            double? value = null;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext()) return value;
+                    value = selector(e.Current);
+                } while (!value.HasValue);
+                double valueVal = value.GetValueOrDefault();
+                while (e.MoveNext())
+                {
+                    double? cur = selector(e.Current);
+                    if (cur.HasValue)
+                    {
+                        double x = cur.GetValueOrDefault();
+                        if (x < valueVal)
+                        {
+                            valueVal = x;
+                            value = cur;
+                        }
+                        else if (double.IsNaN(x)) return cur;
+                    }
+                }
+            }
+            return value;
         }
 
         public static decimal Min<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector)
         {
-            return Enumerable.Min(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            decimal value;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext()) throw Error.NoElements();
+                value = selector(e.Current);
+                while (e.MoveNext())
+                {
+                    decimal x = selector(e.Current);
+                    if (x < value) value = x;
+                }
+            }
+            return value;
         }
 
         public static decimal? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
         {
-            return Enumerable.Min(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            decimal? value = null;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext()) return value;
+                    value = selector(e.Current);
+                } while (!value.HasValue);
+                decimal valueVal = value.GetValueOrDefault();
+                while (e.MoveNext())
+                {
+                    decimal? cur = selector(e.Current);
+                    decimal x = cur.GetValueOrDefault();
+                    if (cur.HasValue && x < valueVal)
+                    {
+                        valueVal = x;
+                        value = cur;
+                    }
+                }
+            }
+            return value;
         }
 
         public static TResult Min<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
         {
-            return Enumerable.Min(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            Comparer<TResult> comparer = Comparer<TResult>.Default;
+            TResult value = default(TResult);
+            if (value == null)
+            {
+                using (IEnumerator<TSource> e = source.GetEnumerator())
+                {
+                    do
+                    {
+                        if (!e.MoveNext()) return value;
+                        value = selector(e.Current);
+                    } while (value == null);
+                    while (e.MoveNext())
+                    {
+                        TResult x = selector(e.Current);
+                        if (x != null && comparer.Compare(x, value) < 0) value = x;
+                    }
+                }
+            }
+            else
+            {
+                using (IEnumerator<TSource> e = source.GetEnumerator())
+                {
+                    if (!e.MoveNext()) throw Error.NoElements();
+                    value = selector(e.Current);
+                    while (e.MoveNext())
+                    {
+                        TResult x = selector(e.Current);
+                        if (comparer.Compare(x, value) < 0) value = x;
+                    }
+                }
+            }
+            return value;
         }
 
         public static int Max(this IEnumerable<int> source)
@@ -2995,57 +3301,337 @@ namespace System.Linq
 
         public static int Max<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector)
         {
-            return Enumerable.Max(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            int value;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext()) throw Error.NoElements();
+                value = selector(e.Current);
+                while (e.MoveNext())
+                {
+                    int x = selector(e.Current);
+                    if (x > value) value = x;
+                }
+            }
+            return value;
         }
 
         public static int? Max<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector)
         {
-            return Enumerable.Max(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            int? value = null;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext()) return value;
+                    value = selector(e.Current);
+                } while (!value.HasValue);
+                int valueVal = value.GetValueOrDefault();
+                if (valueVal >= 0)
+                {
+                    // We can fast-path this case where we know HasValue will
+                    // never affect the outcome, without constantly checking
+                    // if we're in such a state. Similar fast-paths could
+                    // be done for other cases, but as all-positive
+                    // or mostly-positive integer values are quite common in real-world
+                    // uses, it's only been done in this direction for int? and long?.
+                    while (e.MoveNext())
+                    {
+                        int? cur = selector(e.Current);
+                        int x = cur.GetValueOrDefault();
+                        if (x > valueVal)
+                        {
+                            valueVal = x;
+                            value = cur;
+                        }
+                    }
+                }
+                else
+                {
+                    while (e.MoveNext())
+                    {
+                        int? cur = selector(e.Current);
+                        int x = cur.GetValueOrDefault();
+                        // Do not replace & with &&. The branch prediction cost outweighs the extra operation
+                        // unless nulls either never happen or always happen.
+                        if (cur.HasValue & x > valueVal)
+                        {
+                            valueVal = x;
+                            value = cur;
+                        }
+                    }
+                }
+            }
+            return value;
         }
 
         public static long Max<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector)
         {
-            return Enumerable.Max(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            long value;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext()) throw Error.NoElements();
+                value = selector(e.Current);
+                while (e.MoveNext())
+                {
+                    long x = selector(e.Current);
+                    if (x > value) value = x;
+                }
+            }
+            return value;
         }
 
         public static long? Max<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector)
         {
-            return Enumerable.Max(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            long? value = null;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext()) return value;
+                    value = selector(e.Current);
+                } while (!value.HasValue);
+                long valueVal = value.GetValueOrDefault();
+                if (valueVal >= 0)
+                {
+                    while (e.MoveNext())
+                    {
+                        long? cur = selector(e.Current);
+                        long x = cur.GetValueOrDefault();
+                        if (x > valueVal)
+                        {
+                            valueVal = x;
+                            value = cur;
+                        }
+                    }
+                }
+                else
+                {
+                    while (e.MoveNext())
+                    {
+                        long? cur = selector(e.Current);
+                        long x = cur.GetValueOrDefault();
+                        // Do not replace & with &&. The branch prediction cost outweighs the extra operation
+                        // unless nulls either never happen or always happen.
+                        if (cur.HasValue & x > valueVal)
+                        {
+                            valueVal = x;
+                            value = cur;
+                        }
+                    }
+                }
+            }
+            return value;
         }
 
         public static float Max<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector)
         {
-            return Enumerable.Max(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            float value;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext()) throw Error.NoElements();
+                value = selector(e.Current);
+                while (float.IsNaN(value))
+                {
+                    if (!e.MoveNext()) return value;
+                    value = selector(e.Current);
+                }
+                while (e.MoveNext())
+                {
+                    float x = selector(e.Current);
+                    if (x > value) value = x;
+                }
+            }
+            return value;
         }
 
         public static float? Max<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector)
         {
-            return Enumerable.Max(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            float? value = null;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext()) return value;
+                    value = selector(e.Current);
+                } while (!value.HasValue);
+                float valueVal = value.GetValueOrDefault();
+                while (float.IsNaN(valueVal))
+                {
+                    if (!e.MoveNext()) return value;
+                    float? cur = selector(e.Current);
+                    if (cur.HasValue) valueVal = (value = cur).GetValueOrDefault();
+                }
+                while (e.MoveNext())
+                {
+                    float? cur = selector(e.Current);
+                    float x = cur.GetValueOrDefault();
+                    // Do not replace & with &&. The branch prediction cost outweighs the extra operation
+                    // unless nulls either never happen or always happen.
+                    if (cur.HasValue & x > valueVal)
+                    {
+                        valueVal = x;
+                        value = cur;
+                    }
+                }
+            }
+            return value;
         }
 
         public static double Max<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector)
         {
-            return Enumerable.Max(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            double value;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext()) throw Error.NoElements();
+                value = selector(e.Current);
+                // As described in a comment on Min(this IEnumerable<double>) NaN is ordered
+                // less than all other values. We need to do explicit checks to ensure this, but
+                // once we've found a value that is not NaN we need no longer worry about it,
+                // so first loop until such a value is found (or not, as the case may be).
+                while (double.IsNaN(value))
+                {
+                    if (!e.MoveNext()) return value;
+                    value = selector(e.Current);
+                }
+                while (e.MoveNext())
+                {
+                    double x = selector(e.Current);
+                    if (x > value) value = x;
+                }
+            }
+            return value;
         }
 
         public static double? Max<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector)
         {
-            return Enumerable.Max(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            double? value = null;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext()) return value;
+                    value = selector(e.Current);
+                } while (!value.HasValue);
+                double valueVal = value.GetValueOrDefault();
+                while (double.IsNaN(valueVal))
+                {
+                    if (!e.MoveNext()) return value;
+                    double? cur = selector(e.Current);
+                    if (cur.HasValue) valueVal = (value = cur).GetValueOrDefault();
+                }
+                while (e.MoveNext())
+                {
+                    double? cur = selector(e.Current);
+                    double x = cur.GetValueOrDefault();
+                    // Do not replace & with &&. The branch prediction cost outweighs the extra operation
+                    // unless nulls either never happen or always happen.
+                    if (cur.HasValue & x > valueVal)
+                    {
+                        valueVal = x;
+                        value = cur;
+                    }
+                }
+            }
+            return value;
         }
 
         public static decimal Max<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector)
         {
-            return Enumerable.Max(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            decimal value;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext()) throw Error.NoElements();
+                value = selector(e.Current);
+                while (e.MoveNext())
+                {
+                    decimal x = selector(e.Current);
+                    if (x > value) value = x;
+                }
+            }
+            return value;
         }
 
         public static decimal? Max<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
         {
-            return Enumerable.Max(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            decimal? value = null;
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                do
+                {
+                    if (!e.MoveNext()) return value;
+                    value = selector(e.Current);
+                } while (!value.HasValue);
+                decimal valueVal = value.GetValueOrDefault();
+                while (e.MoveNext())
+                {
+                    decimal? cur = selector(e.Current);
+                    decimal x = cur.GetValueOrDefault();
+                    if (cur.HasValue && x > valueVal)
+                    {
+                        valueVal = x;
+                        value = cur;
+                    }
+                }
+            }
+            return value;
         }
 
         public static TResult Max<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
         {
-            return Enumerable.Max(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            Comparer<TResult> comparer = Comparer<TResult>.Default;
+            TResult value = default(TResult);
+            if (value == null)
+            {
+                using (IEnumerator<TSource> e = source.GetEnumerator())
+                {
+                    do
+                    {
+                        if (!e.MoveNext()) return value;
+                        value = selector(e.Current);
+                    } while (value == null);
+                    while (e.MoveNext())
+                    {
+                        TResult x = selector(e.Current);
+                        if (x != null && comparer.Compare(x, value) > 0) value = x;
+                    }
+                }
+            }
+            else
+            {
+                using (IEnumerator<TSource> e = source.GetEnumerator())
+                {
+                    if (!e.MoveNext()) throw Error.NoElements();
+                    value = selector(e.Current);
+                    while (e.MoveNext())
+                    {
+                        TResult x = selector(e.Current);
+                        if (comparer.Compare(x, value) > 0) value = x;
+                    }
+                }
+            }
+            return value;
         }
 
         public static double Average(this IEnumerable<int> source)
@@ -3296,52 +3882,258 @@ namespace System.Linq
 
         public static double Average<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector)
         {
-            return Enumerable.Average(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext()) throw Error.NoElements();
+                long sum = selector(e.Current);
+                long count = 1;
+                checked
+                {
+                    while (e.MoveNext())
+                    {
+                        sum += selector(e.Current);
+                        ++count;
+                    }
+                }
+                return (double)sum / count;
+            }
         }
 
         public static double? Average<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector)
         {
-            return Enumerable.Average(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                while (e.MoveNext())
+                {
+                    int? v = selector(e.Current);
+                    if (v.HasValue)
+                    {
+                        long sum = v.GetValueOrDefault();
+                        long count = 1;
+                        checked
+                        {
+                            while (e.MoveNext())
+                            {
+                                v = selector(e.Current);
+                                if (v.HasValue)
+                                {
+                                    sum += v.GetValueOrDefault();
+                                    ++count;
+                                }
+                            }
+                        }
+                        return (double)sum / count;
+                    }
+                }
+            }
+            return null;
         }
 
         public static double Average<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector)
         {
-            return Enumerable.Average(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext()) throw Error.NoElements();
+                long sum = selector(e.Current);
+                long count = 1;
+                checked
+                {
+                    while (e.MoveNext())
+                    {
+                        sum += selector(e.Current);
+                        ++count;
+                    }
+                }
+                return (double)sum / count;
+            }
         }
 
         public static double? Average<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector)
         {
-            return Enumerable.Average(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                while (e.MoveNext())
+                {
+                    long? v = selector(e.Current);
+                    if (v.HasValue)
+                    {
+                        long sum = v.GetValueOrDefault();
+                        long count = 1;
+                        checked
+                        {
+                            while (e.MoveNext())
+                            {
+                                v = selector(e.Current);
+                                if (v.HasValue)
+                                {
+                                    sum += v.GetValueOrDefault();
+                                    ++count;
+                                }
+                            }
+                        }
+                        return (double)sum / count;
+                    }
+                }
+            }
+            return null;
         }
 
         public static float Average<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector)
         {
-            return Enumerable.Average(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext()) throw Error.NoElements();
+                double sum = selector(e.Current);
+                long count = 1;
+                while (e.MoveNext())
+                {
+                    sum += selector(e.Current);
+                    ++count;
+                }
+                return (float)(sum / count);
+            }
         }
 
         public static float? Average<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector)
         {
-            return Enumerable.Average(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                while (e.MoveNext())
+                {
+                    float? v = selector(e.Current);
+                    if (v.HasValue)
+                    {
+                        double sum = v.GetValueOrDefault();
+                        long count = 1;
+                        checked
+                        {
+                            while (e.MoveNext())
+                            {
+                                v = selector(e.Current);
+                                if (v.HasValue)
+                                {
+                                    sum += v.GetValueOrDefault();
+                                    ++count;
+                                }
+                            }
+                        }
+                        return (float)(sum / count);
+                    }
+                }
+            }
+            return null;
         }
 
         public static double Average<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector)
         {
-            return Enumerable.Average(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext()) throw Error.NoElements();
+                double sum = selector(e.Current);
+                long count = 1;
+                while (e.MoveNext())
+                {
+                    // There is an opportunity to short-circuit here, in that if e.Current is
+                    // ever NaN then the result will always be NaN. Assuming that this case is
+                    // rare enough that not checking is the better approach generally.
+                    sum += selector(e.Current);
+                    ++count;
+                }
+                return sum / count;
+            }
         }
 
         public static double? Average<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector)
         {
-            return Enumerable.Average(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                while (e.MoveNext())
+                {
+                    double? v = selector(e.Current);
+                    if (v.HasValue)
+                    {
+                        double sum = v.GetValueOrDefault();
+                        long count = 1;
+                        checked
+                        {
+                            while (e.MoveNext())
+                            {
+                                v = selector(e.Current);
+                                if (v.HasValue)
+                                {
+                                    sum += v.GetValueOrDefault();
+                                    ++count;
+                                }
+                            }
+                        }
+                        return sum / count;
+                    }
+                }
+            }
+            return null;
         }
 
         public static decimal Average<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector)
         {
-            return Enumerable.Average(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                if (!e.MoveNext()) throw Error.NoElements();
+                decimal sum = selector(e.Current);
+                long count = 1;
+                while (e.MoveNext())
+                {
+                    sum += selector(e.Current);
+                    ++count;
+                }
+                return sum / count;
+            }
         }
 
         public static decimal? Average<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
         {
-            return Enumerable.Average(Enumerable.Select(source, selector));
+            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null) throw Error.ArgumentNull("selector");
+            using (IEnumerator<TSource> e = source.GetEnumerator())
+            {
+                while (e.MoveNext())
+                {
+                    decimal? v = selector(e.Current);
+                    if (v.HasValue)
+                    {
+                        decimal sum = v.GetValueOrDefault();
+                        long count = 1;
+                        while (e.MoveNext())
+                        {
+                            v = selector(e.Current);
+                            if (v.HasValue)
+                            {
+                                sum += v.GetValueOrDefault();
+                                ++count;
+                            }
+                        }
+                        return sum / count;
+                    }
+                }
+            }
+            return null;
         }
     }
 

--- a/src/System.Linq/tests/AverageTests.cs
+++ b/src/System.Linq/tests/AverageTests.cs
@@ -39,6 +39,15 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void EmptyNullableFloatSourceWithSelector()
+        {
+            float?[] source = { };
+            float? expected = null;
+
+            Assert.Equal(expected, source.Average(i => i));
+        }
+
+        [Fact]
         public void NullNFloatSource()
         {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<float?>)null).Average());
@@ -103,6 +112,15 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void MultipleNullableFloatSourceAllNullWithSelector()
+        {
+            float?[] source = { null, null, null, null, null };
+            float? expected = null;
+
+            Assert.Equal(expected, source.Average(i => i));
+        }
+
+        [Fact]
         public void NullableFloatFromSelector()
         {
             var source = new []
@@ -122,6 +140,14 @@ namespace System.Linq.Tests
             int[] source = { };
             
             Assert.Throws<InvalidOperationException>(() => source.Average());
+        }
+
+        [Fact]
+        public void EmptyIntSourceWithSelector()
+        {
+            int[] source = { };
+
+            Assert.Throws<InvalidOperationException>(() => source.Average(i => i));
         }
 
         [Fact]
@@ -194,6 +220,15 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void EmptyNullableIntSourceWithSelector()
+        {
+            int?[] source = { };
+            double? expected = null;
+
+            Assert.Equal(expected, source.Average(i => i));
+        }
+
+        [Fact]
         public void NullNIntSource()
         {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<int?>)null).Average());
@@ -258,6 +293,15 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void MultipleNullableIntSourceAllNullWithSelector()
+        {
+            int?[] source = { null, null, null, null, null };
+            double? expected = null;
+
+            Assert.Equal(expected, source.Average(i => i));
+        }
+
+        [Fact]
         public void NullableIntFromSelector()
         {
             var source = new []
@@ -275,8 +319,16 @@ namespace System.Linq.Tests
         public void EmptyLongSource()
         {
             long[] source = { };
-            
+
             Assert.Throws<InvalidOperationException>(() => source.Average());
+        }
+
+        [Fact]
+        public void EmptyLongSourceWithSelector()
+        {
+            long[] source = { };
+
+            Assert.Throws<InvalidOperationException>(() => source.Average(i => i));
         }
 
         [Fact]
@@ -357,6 +409,15 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void EmptyNullableLongSourceWithSelector()
+        {
+            long?[] source = { };
+            double? expected = null;
+
+            Assert.Equal(expected, source.Average(i => i));
+        }
+
+        [Fact]
         public void NullNLongSource()
         {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<long?>)null).Average());
@@ -421,6 +482,15 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void MultipleNullableLongSourceAllNullWithSelector()
+        {
+            long?[] source = { null, null, null, null, null };
+            double? expected = null;
+
+            Assert.Equal(expected, source.Average(i => i));
+        }
+
+        [Fact]
         public void NullableLongFromSelector()
         {
             var source = new []
@@ -438,8 +508,16 @@ namespace System.Linq.Tests
         public void EmptyDoubleSource()
         {
             double[] source = { };
-            
+
             Assert.Throws<InvalidOperationException>(() => source.Average());
+        }
+
+        [Fact]
+        public void EmptyDoubleSourceWithSelector()
+        {
+            double[] source = { };
+
+            Assert.Throws<InvalidOperationException>(() => source.Average(i => i));
         }
 
         [Fact]
@@ -521,6 +599,15 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void EmptyNullableDoubleSourceWithSelector()
+        {
+            double?[] source = { };
+            double? expected = null;
+
+            Assert.Equal(expected, source.Average(i => i));
+        }
+
+        [Fact]
         public void NullNDoubleSource()
         {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<double?>)null).Average());
@@ -585,6 +672,15 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void MultipleNullableDoubleSourceAllNullWithSelector()
+        {
+            double?[] source = { null, null, null, null, null };
+            double? expected = null;
+
+            Assert.Equal(expected, source.Average(i => i));
+        }
+
+        [Fact]
         public void MultipleNullableDoubleSourceIncludingNaN()
         {
             double?[] source = { -23.5, 0, Double.NaN, 54.3, 0.56 };
@@ -613,6 +709,14 @@ namespace System.Linq.Tests
             decimal[] source = { };
 
             Assert.Throws<InvalidOperationException>(() => source.Average());
+        }
+
+        [Fact]
+        public void EmptyDecimalSourceWithSelector()
+        {
+            decimal[] source = { };
+
+            Assert.Throws<InvalidOperationException>(() => source.Average(i => i));
         }
 
         [Fact]
@@ -684,6 +788,15 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void EmptyNullableDecimalSourceWithSelector()
+        {
+            decimal?[] source = { };
+            decimal? expected = null;
+
+            Assert.Equal(expected, source.Average(i => i));
+        }
+
+        [Fact]
         public void NullNDecimalSource()
         {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<decimal?>)null).Average());
@@ -748,6 +861,15 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void MultipleNullableDecimalSourceAllNullWithSelector()
+        {
+            decimal?[] source = { null, null, null, null, null };
+            decimal? expected = null;
+
+            Assert.Equal(expected, source.Average(i => i));
+        }
+
+        [Fact]
         public void NullableDecimalFromSelector()
         {
             var source = new[]
@@ -775,6 +897,14 @@ namespace System.Linq.Tests
             float[] source = { };
 
             Assert.Throws<InvalidOperationException>(() => source.Average());
+        }
+
+        [Fact]
+        public void EmptyFloatSourceWithSelector()
+        {
+            float[] source = { };
+
+            Assert.Throws<InvalidOperationException>(() => source.Average(i => i));
         }
 
         [Fact]

--- a/src/System.Linq/tests/MaxTests.cs
+++ b/src/System.Linq/tests/MaxTests.cs
@@ -196,6 +196,19 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void SeveralNaNSingleWithSelector()
+        {
+            Assert.True(float.IsNaN(Enumerable.Repeat(float.NaN, 5).Max(i => i)));
+        }
+
+        [Fact]
+        public void SeveralNaNOrNullSingleWithSelector()
+        {
+            float?[] source = new float?[] { float.NaN, null, float.NaN, null };
+            Assert.True(float.IsNaN(source.Max(i => i).Value));
+        }
+
+        [Fact]
         public void NullSingleSource()
         {
             Assert.Throws<ArgumentNullException>("source", () => ((IEnumerable<float>)null).Max());
@@ -206,6 +219,13 @@ namespace System.Linq.Tests
         {
             float[] source = { float.NaN, 6.8f, 9.4f, 10f, 0, -5.6f };
             Assert.Equal(10f, source.Max());
+        }
+
+        [Fact]
+        public void SingleNaNFirstWithSelector()
+        {
+            float[] source = { float.NaN, 6.8f, 9.4f, 10f, 0, -5.6f };
+            Assert.Equal(10f, source.Max(i => i));
         }
 
         [Fact]
@@ -266,6 +286,19 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void DoubleAllNaNWithSelector()
+        {
+            Assert.True(double.IsNaN(Enumerable.Repeat(double.NaN, 5).Max(i => i)));
+        }
+
+        [Fact]
+        public void SeveralNaNOrNullDoubleWithSelector()
+        {
+            double?[] source = new double?[] { double.NaN, null, double.NaN, null };
+            Assert.True(double.IsNaN(source.Max(i => i).Value));
+        }
+
+        [Fact]
         public void DoubleMaximumFirst()
         {
             double[] source = { 112.5, 4.9, 30, 4.7, 28 };
@@ -305,6 +338,13 @@ namespace System.Linq.Tests
         {
             double[] source = { double.NaN, double.NegativeInfinity };
             Assert.True(double.IsNegativeInfinity(source.Max()));
+        }
+
+        [Fact]
+        public void DoubleNaNThenNegativeInfinityWithSelector()
+        {
+            double[] source = { double.NaN, double.NegativeInfinity };
+            Assert.True(double.IsNegativeInfinity(source.Max(i => i)));
         }
 
         [Fact]
@@ -1159,6 +1199,7 @@ namespace System.Linq.Tests
             var thousand = new[] { default(long?), -16L, 0, 50, 100, 1000 };
             Assert.Equal(42, Enumerable.Repeat((long?)42, 1).Max(x => x));
             Assert.Equal(10, ten.Max(x => x));
+            Assert.Equal(10, ten.Concat(new[] { default(long?) }).Max(x => x));
             Assert.Equal(-10, minusTen.Max(x => x));
             Assert.Equal(1000, thousand.Max(x => x));
             Assert.Equal(long.MaxValue, thousand.Concat(Enumerable.Repeat((long?)long.MaxValue, 1)).Max(x => x));
@@ -1386,6 +1427,12 @@ namespace System.Linq.Tests
             Assert.Equal(new DateTime(2000, 12, 31), newYearsEve.Max(x => x));
             Assert.Equal(new DateTime(3000, 1, 1), threeThousand.Max(x => x));
             Assert.Equal(DateTime.MaxValue, threeThousand.Concat(Enumerable.Repeat(DateTime.MaxValue, 1)).Max(x => x));
+        }
+
+        [Fact]
+        public void EmptyMaxDateTimeWithSelector()
+        {
+            Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<DateTime>().Max(i => i));
         }
 
         [Fact]

--- a/src/System.Linq/tests/MinTests.cs
+++ b/src/System.Linq/tests/MinTests.cs
@@ -563,6 +563,13 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void NullableSingleNaNLastWithNullsWithSelector()
+        {
+            float?[] source = { 6.8f, 9.4f, 10f, 0, null, -5.6f, float.NaN };
+            Assert.True(float.IsNaN(source.Min(i => i).Value));
+        }
+
+        [Fact]
         public void NullableSingleNaNThenNegativeInfinity()
         {
             float?[] source = { float.NaN, float.NegativeInfinity };
@@ -658,6 +665,13 @@ namespace System.Linq.Tests
         {
             double?[] source = { double.NaN, 6.8, 9.4, 10.0, 0.0, null, -5.6 };
             Assert.True(double.IsNaN(source.Min().Value));
+        }
+
+        [Fact]
+        public void NullableDoubleNaNLastWIthNullsWithSelector()
+        {
+            double?[] source = { 6.8, 9.4, 10, 0.0, null, -5.6f, double.NaN };
+            Assert.True(double.IsNaN(source.Min(i => i).Value));
         }
 
         [Fact]


### PR DESCRIPTION
Change all selector-taking aggregate methods to perform the operation
directly rather than calling Select followed by the non-selector-taking
form.

Fixes #5549 (Pros and cons discussed there).