### PR TITLE
Add table of terms

### DIFF
--- a/Documentation/project-docs/glossary.md
+++ b/Documentation/project-docs/glossary.md
@@ -1,8 +1,10 @@
-# Platform Names
+# Glossary
 
-Over the years, we've accumulated quite a few names, platforms, and components that can make it hard for folks (including us) to understand what we're referring to. This document has a list that will help to qualify what we mean by what.
+Over the years, we've accumulated quite a few terms, platforms, and components that can make it hard for folks (including us) to understand what we're referring to. This document has a list that will help to qualify what we mean by what.
 
 This will also list some aliases. As you'll see the aliases aren't always correct -- they are merely listed to help you find the better and less confusing terminology.
+
+## Terms
 
 In this document, the following terms are used:
 
@@ -24,7 +26,9 @@ In this document, the following terms are used:
 
 * **CoreFX**. Core framework. Conceptually a set of `System.*` (and to a limited extent `Microsoft.*`) libraries that make up the lower layer of the .NET library stack. It's what most people would think of as the Base Class Library (BCL). The BCL is a general purpose, lower level set of functionality that higher-level frameworks, such as WCF and ASP.NET, build on. The source code of the .NET Core library stack is contained in the [CoreFX repo](http://github.com/dotnet/corefx). However, the majority of the .NET Core APIs are also available in the .NET Framework, so you can think of CoreFX as a fork of the .NET Framework library stack.
 
-## .NET Framework
+## Platforms
+
+### .NET Framework
 
 **Also referred to as**: Desktop, full framework, in-box framework
 
@@ -32,7 +36,7 @@ This refers to the .NET Framework that first shipped in 2002 and has been update
 
 The .NET Framework was designed to run on Windows only. Some versions of the .NET Framework come pre-installed with Windows, some require to be installed. However, in both cases the .NET Framework is a system-wide component. Applications do not include .NET Framework DLLs when deploying; the correct .NET version must be on the machine.
 
-## .NET Core
+### .NET Core
 
 **Also referred to as**: UWP, ~~Store~~
 
@@ -42,7 +46,7 @@ Today, .NET Core is no longer just for store applications. .NET Core is the name
 
 That's why referring to .NET Core as 'Store' is no longer correct. But you can think of today's .NET Core as an evolution of the original APIs available for store applications. Many of the original design goals are still relevant, especially around layering and portability.
 
-## Universal Windows Platform (UWP)
+### Universal Windows Platform (UWP)
 
 **Also referred to as**: Store, WinRT, Metro
 
@@ -50,7 +54,7 @@ The Universal Windows Platform (UWP) is the platform that is used for building m
 
 UWP provides many services, such as a centralized app store, an execution environment (AppContainer), and a set of Windows APIs to use instead of Win32 (WinRT). UWP has no dependency on .NET; apps can be written in C++, C#, VB.NET, and JavaScript. When using C# and VB.NET the .NET APIs are provided by .NET Core.
 
-## .NET Native
+### .NET Native
 
 **Also referred to as**: ahead-of-time (AOT), IL compiler (ILC)
 
@@ -60,7 +64,7 @@ You can think of .NET Native as an evolution of NGEN (Native Image Generator): N
 
 UWP was the first application model that was supported by .NET Native. We now also support building native console applications for Windows, OS X and Linux.
 
-## Rotor
+### Rotor
 
 **Also referred to as**: Shared Source Common Language Infrastructure (SSCLI)
 
@@ -70,7 +74,7 @@ While parts of the source were identical with the .NET Framework, many pieces ha
 
 It's also worth pointing out that the source code of Rotor was not released under an open source license (i.e. not approved by OSI) and has not been officially updated since .NET Framework 2.0.
 
-## Mono
+### Mono
 
 Mono is an open source alternative to the .NET Framework. Mono started around the same time the .NET Framework was first released. Since Microsoft didn't release Rotor as open source, Mono was forced to start from scratch and is thus a complete re-implementation of the .NET Framework with no shared code.
 
@@ -80,6 +84,6 @@ Mono is primarily used to run .NET applications on Linux and Mac OS X (though to
 
 Mono has implementations (though not necessarily complete) of WinForms, ASP.NET, and System.Drawing.
 
-## Xamarin
+### Xamarin
 
 Xamarin is a commercial offering for building mobile applications targeting Android, iOS and Mac OS X Store. It's based on Mono, and on iOS and Android surfaces a different API profile, called the mobile profile. The subsetting was necessary to reduce the footprint, both by shipping smaller versions of the system libraries as well as making them more linker friendly. While Mono runs on Mac OS X without Xamarin, their linker is required make the app package for the Mac App Store.  Xamarin ships a full static compiler on iOS, as the platform does not support dynamic code generation.

--- a/Documentation/project-docs/platform-names.md
+++ b/Documentation/project-docs/platform-names.md
@@ -4,6 +4,26 @@ Over the years, we've accumulated quite a few names, platforms, and components t
 
 This will also list some aliases. As you'll see the aliases aren't always correct -- they are merely listed to help you find the better and less confusing terminology.
 
+In this document, the following terms are used:
+
+* **IL**. Intermediate language. Higher level .NET languages, such as C#, compile down to a hardware agnostic instruction set, which is called Intermediate Language (IL). IL is sometimes referred to as MSIL (Microsoft IL) or CIL (Common IL).
+
+* **GC**. Garbage collector. Garbage collection is an implementation of automatic memory management. .NET Framework and .NET Core currently uses a generational garbage collector, i.e. it groups objects into generations to limit the number of nodes it has to walk for determining which objects are alive. This speeds up collection times.
+
+* **JIT**. Just in time compiler. This technology compiles IL to machine code that the processor understands. It's called JIT because compilation happens on demand and is performed on the same machine the code needs to run on. Since JIT compilation occurs during execution of the application, compile time is part of the run time. Thus, JIT compilers have to trade spending more time optimizing code with the savings the resulting code can produce. But a JIT knows the actual hardware and can free developers from having to ship different implementations. For instance, our vector library relies on the JIT to use the highest available SIMD instruction set.
+
+* **AOT**. Ahead of time compiler. Similar to JIT, this compiler also translates IL to machine code. In contrast to JIT compilation, AOT compilation happens before the application is executed and is usually performed on a different machine. AOT tool chains don't trade runtime for compile time and thus can spend more time optimizing. Since the context of AOT is the entire application, the AOT compiler can also perform cross module linking and whole program analysis, which means that all references are followed and a single executable is produced.
+
+* **NGEN**. Native (image) generation. You can think of this technology as a persistent JIT compiler. It usually compiles code on the machine where the code will be executed, but compilation typically occurs at install time.
+
+* **CLR**. Common language runtime. The exact meaning depends on context, but it usually refers to the runtime of the .NET Framework and includes several components. The CLR is a virtual machine, i.e. it includes the facilities to generate and compile code on-the-fly using a JIT compiler. The existing Microsoft CLR implementation is Windows only.
+
+* **CoreCLR**. Core common language runtime. It's built from the same code base as the CLR. Originally, CoreCLR was the runtime of Silverlight and was designed to run on multiple platforms, specifically Windows and OS X. CoreCLR is now part of .NET Core and represents a simplified version of the CLR. It's still a [cross platform](https://github.com/dotnet/coreclr#build-status) runtime. CoreCLR is also a virtual machine with a JIT.
+
+* **CoreRT**. Core runtime. In contrast to the CLR/CoreCLR, CoreRT is not a virtual machine, i.e. it doesn't include the facilities to generate and run code on-the-fly because it doesn't include a JIT. It does, however, include the GC and the ability for runtime type identification (RTTI) as well as reflection. However, its type system is designed so that metadata for reflection can be omitted. This enables having an AOT tool chain that can link away superfluous metadata and (more importantly) identify code that the application doesn't use.
+
+* **CoreFX**. Core framework. Conceptually a set of `System.*` (and to a limited extent `Microsoft.*`) libraries that make up the lower layer of the .NET library stack. It's what most people would think of as the Base Class Library (BCL). The BCL is a general purpose, lower level set of functionality that higher-level frameworks, such as WCF and ASP.NET, build on. The source code of the .NET Core library stack is contained in the [CoreFX repo](http://github.com/dotnet/corefx). However, the majority of the .NET Core APIs are also available in the .NET Framework, so you can think of CoreFX as a fork of the .NET Framework library stack.
+
 ## .NET Framework
 
 **Also referred to as**: Desktop, full framework, in-box framework
@@ -38,7 +58,7 @@ UWP provides many services, such as a centralized app store, an execution enviro
 
 You can think of .NET Native as an evolution of NGEN (Native Image Generator): NGEN basically simply runs the JIT up front, the code quality and behavior is identical to the JITed version. Another downside of NGEN is that it happens on the user's machine, rather than the developer's machine. NGEN is also at the module level, i.e. for each MSIL assembly there is a corresponding NGEN'ed assembly that contains the native code. .NET Native on the other hand is a C++ like compiler and linker. It will remove unused code, spend more time optimizing it, and produce a single, merged module that represents the closure of the application.
 
-UWP was the first application model that was supported by .NET Native. We now also support building native console applications for Windows, Mac and Linux.
+UWP was the first application model that was supported by .NET Native. We now also support building native console applications for Windows, OS X and Linux.
 
 ## Rotor
 


### PR DESCRIPTION
The document uses many terms that aren't defined. In order to avoid breaking the flow of the document, it's best if those are defined at the top of the file.

This addresses much of the feedback raised in #5760.