### PR TITLE
Override ReadByte on SslStream

### DIFF
--- a/src/System.Net.Security/src/System/Net/SecureProtocols/SslStream.cs
+++ b/src/System.Net.Security/src/System/Net/SecureProtocols/SslStream.cs
@@ -427,6 +427,11 @@ namespace System.Net.Security
             }
         }
 
+        public override int ReadByte()
+        {
+            return _sslState.SecureStream.ReadByte();
+        }
+
         public override int Read(byte[] buffer, int offset, int count)
         {
             return _sslState.SecureStream.Read(buffer, offset, count);

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -121,6 +121,30 @@ namespace System.Net.Security.Tests
             }
         }
 
+        [Fact]
+        public void SslStream_StreamToStream_Write_ReadByte_Success()
+        {
+            MockNetwork network = new MockNetwork();
+
+            using (var clientStream = new FakeNetworkStream(false, network))
+            using (var serverStream = new FakeNetworkStream(true, network))
+            using (var clientSslStream = new SslStream(clientStream, false, AllowAnyServerCertificate))
+            using (var serverSslStream = new SslStream(serverStream))
+            {
+                bool result = DoHandshake(clientSslStream, serverSslStream);
+                Assert.True(result, "Handshake completed.");
+
+                for (int i = 0; i < 3; i++)
+                {
+                    clientSslStream.Write(_sampleMsg);
+                    foreach (byte b in _sampleMsg)
+                    {
+                        Assert.Equal(b, serverSslStream.ReadByte());
+                    }
+                }
+            }
+        }
+
         private bool VerifyOutput(byte[] actualBuffer, byte[] expectedBuffer)
         {
             return expectedBuffer.SequenceEqual(actualBuffer);


### PR DESCRIPTION
In an application that's using the Redis client library, a significant portion of the allocations are coming from calls to ReadByte on an SslStream.  Since SslStream doesn't override ReadByte, the base Stream.ReadByte is used, and it ends up allocating a temporary array to use in a call to Read.

This commit adds an override of ReadByte on SslStream that returns data from the stream's internal buffer if any is available, otherwise falling back to the old behavior.

On a test that repeatedly writes 1000 bytes and then reads each of those with ReadByte, allocations are reduced by 10x and throughput is doubled. (Note that removing the Interlocked.Exchange in ReadByte yields another 20% improvement in throughput, but I've left it in so as not to impact guarantees of the type.)

cc: @cipop, @davidsh, @vancem 