### PR TITLE
Fix StringBuffer.Trim buffer underrun

### DIFF
--- a/src/Common/src/System/Runtime/InteropServices/StringBuffer.cs
+++ b/src/Common/src/System/Runtime/InteropServices/StringBuffer.cs
@@ -269,9 +269,9 @@ namespace System.Runtime.InteropServices
 
             char* end = CharPointer + _length - 1;
 
-            while (Array.IndexOf(values, *end) >= 0)
+            while (_length > 0 && Array.IndexOf(values, *end) >= 0)
             {
-                Length--;
+                Length = _length - 1;
                 end--;
             }
         }

--- a/src/Common/tests/Tests/System/Runtime/InteropServices/StringBufferTests.cs
+++ b/src/Common/tests/Tests/System/Runtime/InteropServices/StringBufferTests.cs
@@ -375,6 +375,9 @@ namespace Tests.System.Runtime.InteropServices
             InlineData("", new char[] { 'b' }, ""),
             InlineData("foo", new char[] { 'o' }, "f"),
             InlineData("foo", new char[] { 'o', 'f' }, ""),
+            // Add a couple cases to try and get the trim to walk off the front of the buffer.
+            InlineData("foo", new char[] { 'o', 'f', '\0' }, ""),
+            InlineData("foo", new char[] { 'o', 'f', '\u9000' }, "")
             ]
         public void TrimEnd(string content, char[] trimChars, string expected)
         {


### PR DESCRIPTION
Validate we already haven't hit the start of the buffer before derefing the
pointer.

#4855
@stephentoub 