### PR TITLE
Override ReadByte and WriteByte on CryptoStream

### DIFF
--- a/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoStream.cs
+++ b/src/System.Security.Cryptography.Primitives/src/System/Security/Cryptography/CryptoStream.cs
@@ -178,6 +178,40 @@ namespace System.Security.Cryptography
             }
         }
 
+        public override int ReadByte()
+        {
+            // If we have enough bytes in the buffer such that reading 1 will still leave bytes
+            // in the buffer, then take the faster path of simply returning the first byte.
+            // (This unfortunately still involves shifting down the bytes in the buffer, as it
+            // does in Read.  If/when that's fixed for Read, it should be fixed here, too.)
+            if (_outputBufferIndex > 1)
+            {
+                byte b = _outputBuffer[0];
+                Buffer.BlockCopy(_outputBuffer, 1, _outputBuffer, 0, _outputBufferIndex - 1);
+                _outputBufferIndex -= 1;
+                return b;
+            }
+
+            // Otherwise, fall back to the more robust but expensive path of using the base 
+            // Stream.ReadByte to call Read.
+            return base.ReadByte();
+        }
+
+        public override void WriteByte(byte value)
+        {
+            // If there's room in the input buffer such that even with this byte we wouldn't
+            // complete a block, simply add the byte to the input buffer.
+            if (_inputBufferIndex + 1 < _inputBlockSize)
+            {
+                _inputBuffer[_inputBufferIndex++] = value;
+                return;
+            }
+
+            // Otherwise, the logic is complicated, so we simply fall back to the base 
+            // implementation that'll use Write.
+            base.WriteByte(value);
+        }
+
         public override int Read(byte[] buffer, int offset, int count)
         {
             CheckReadArguments(buffer, offset, count);

--- a/src/System.Security.Cryptography.Primitives/tests/CryptoStream.cs
+++ b/src/System.Security.Cryptography.Primitives/tests/CryptoStream.cs
@@ -131,6 +131,18 @@ namespace System.Security.Cryptography.Encryption.Tests.Asymmetric
                 Assert.Equal(
                     LoremText + LoremText + LoremText + LoremText,
                     reader.ReadToEndAsync().GetAwaiter().GetResult());
+            }            
+            
+            // Read/decrypt one byte at a time with ReadByte
+            stream = new MemoryStream(stream.ToArray()); // CryptoStream.Dispose disposes the stream
+            using (CryptoStream decryptStream = new CryptoStream(stream, decryptor, CryptoStreamMode.Read))
+            {
+                string expectedStr = LoremText + LoremText + LoremText + LoremText;
+                foreach (char c in expectedStr)
+                {
+                    Assert.Equal(c, decryptStream.ReadByte()); // relies on LoremText being ASCII
+                }
+                Assert.Equal(-1, decryptStream.ReadByte());
             }
         }
 


### PR DESCRIPTION
Rather than using the base ReadByte and WriteByte methods, which allocate temporary arrays and delegate to Read and Write, respectively, this commit adds overrides of ReadByte and WriteByte to CryptoStream.  In a test that uses these methods repeatedly with AES to write and read 10MB one byte at a time, write throughput was improved by ~5x and read throughput was improved by ~3x.  For both read and write, allocations were reduced by ~10x.

cc: @bartonjs, @AtsushiKan, @vancem 