### PR TITLE
Add packages for UWP 10 RTM - shared library

### DIFF
--- a/pkg/redist/System.Collections.Concurrent/lib/System.Collections.Concurrent.builds
+++ b/pkg/redist/System.Collections.Concurrent/lib/System.Collections.Concurrent.builds
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Collections.Concurrent.depproj"/>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/pkg/redist/System.Collections.Concurrent/lib/System.Collections.Concurrent.depproj
+++ b/pkg/redist/System.Collections.Concurrent/lib/System.Collections.Concurrent.depproj
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Collections.Concurrent/lib/project.json
+++ b/pkg/redist/System.Collections.Concurrent/lib/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Collections.Concurrent": "4.0.10"
+  },
+  "frameworks": {
+    "dotnet5.4": {}
+  }
+}

--- a/pkg/redist/System.Collections.Concurrent/pkg/System.Collections.Concurrent.builds
+++ b/pkg/redist/System.Collections.Concurrent/pkg/System.Collections.Concurrent.builds
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Collections.Concurrent.pkgproj"/>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/redist/System.Collections.Concurrent/pkg/System.Collections.Concurrent.pkgproj
+++ b/pkg/redist/System.Collections.Concurrent/pkg/System.Collections.Concurrent.pkgproj
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <!-- bump up the version since we are redisting the 4.0.10 bits in a new package -->
+    <Version>4.0.11.0</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SourceDir)System.Collections.Concurrent\ref\4.0.0\System.Collections.Concurrent.depproj">
+      <SupportedFramework>net45;netcore45;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="$(SourceDir)System.Collections.Concurrent\ref\4.0.10\System.Collections.Concurrent.depproj">
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\lib\System.Collections.Concurrent.builds"/>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Collections/lib/System.Collections.builds
+++ b/pkg/redist/System.Collections/lib/System.Collections.builds
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="System.Collections.depproj"/>
     <Project Include="System.Collections.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </Project>

--- a/pkg/redist/System.Collections/lib/System.Collections.builds
+++ b/pkg/redist/System.Collections/lib/System.Collections.builds
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Collections.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </Project>
+    <Project Include="System.Collections.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/pkg/redist/System.Collections/lib/System.Collections.depproj
+++ b/pkg/redist/System.Collections/lib/System.Collections.depproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Collections/lib/System.Collections.depproj
+++ b/pkg/redist/System.Collections/lib/System.Collections.depproj
@@ -1,12 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
-  <PropertyGroup>
-    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.10.0</AssemblyVersion>
     <OutputType>Library</OutputType>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/pkg/redist/System.Collections/lib/project.json
+++ b/pkg/redist/System.Collections/lib/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.10"
+  },
+  "frameworks": {
+    "netcore50": {}
+  },
+  "runtimes": {
+    "win8": {},
+    "win8-aot": {}
+  }
+}

--- a/pkg/redist/System.Collections/lib/project.json
+++ b/pkg/redist/System.Collections/lib/project.json
@@ -3,6 +3,7 @@
     "System.Collections": "4.0.10"
   },
   "frameworks": {
+    "dnxcore50": {},
     "netcore50": {}
   },
   "runtimes": {

--- a/pkg/redist/System.Collections/pkg/System.Collections.builds
+++ b/pkg/redist/System.Collections/pkg/System.Collections.builds
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Collections.pkgproj" />
+    <Project Include="any\System.Collections.pkgproj" />
+    <Project Include="aot\System.Collections.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/redist/System.Collections/pkg/System.Collections.pkgproj
+++ b/pkg/redist/System.Collections/pkg/System.Collections.pkgproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <IsValidationOnlyPackage>true</IsValidationOnlyPackage>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SourceDir)System.Collections\ref\4.0.0\System.Collections.depproj">
+      <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="$(SourceDir)System.Collections\ref\4.0.10\System.Collections.depproj">
+      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
+      <SupportedFramework>net46;netcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="any\System.Collections.pkgproj" />
+    <ProjectReference Include="aot\System.Collections.pkgproj" />
+    
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Collections/pkg/System.Collections.pkgproj
+++ b/pkg/redist/System.Collections/pkg/System.Collections.pkgproj
@@ -9,8 +9,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="$(SourceDir)System.Collections\ref\4.0.10\System.Collections.depproj">
-      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
-      <SupportedFramework>net46;netcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Collections.pkgproj" />
     <ProjectReference Include="aot\System.Collections.pkgproj" />

--- a/pkg/redist/System.Collections/pkg/any/System.Collections.pkgproj
+++ b/pkg/redist/System.Collections/pkg/any/System.Collections.pkgproj
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Collections.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Collections/pkg/any/System.Collections.pkgproj
+++ b/pkg/redist/System.Collections/pkg/any/System.Collections.pkgproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Collections.depproj"/>
     <ProjectReference Include="..\..\lib\System.Collections.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </ProjectReference>

--- a/pkg/redist/System.Collections/pkg/aot/System.Collections.pkgproj
+++ b/pkg/redist/System.Collections/pkg/aot/System.Collections.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Collections.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Diagnostics.Tracing/lib/System.Diagnostics.Tracing.builds
+++ b/pkg/redist/System.Diagnostics.Tracing/lib/System.Diagnostics.Tracing.builds
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="System.Diagnostics.Tracing.depproj" />
     <Project Include="System.Diagnostics.Tracing.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </Project>

--- a/pkg/redist/System.Diagnostics.Tracing/lib/System.Diagnostics.Tracing.builds
+++ b/pkg/redist/System.Diagnostics.Tracing/lib/System.Diagnostics.Tracing.builds
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Diagnostics.Tracing.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </Project>
+    <Project Include="System.Diagnostics.Tracing.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/pkg/redist/System.Diagnostics.Tracing/lib/System.Diagnostics.Tracing.depproj
+++ b/pkg/redist/System.Diagnostics.Tracing/lib/System.Diagnostics.Tracing.depproj
@@ -1,12 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
-  <PropertyGroup>
-    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.20.0</AssemblyVersion>
     <OutputType>Library</OutputType>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/pkg/redist/System.Diagnostics.Tracing/lib/System.Diagnostics.Tracing.depproj
+++ b/pkg/redist/System.Diagnostics.Tracing/lib/System.Diagnostics.Tracing.depproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.20.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Diagnostics.Tracing/lib/project.json
+++ b/pkg/redist/System.Diagnostics.Tracing/lib/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "System.Diagnostics.Tracing": "4.0.20"
+  },
+  "frameworks": {
+    "netcore50": {}
+  },
+  "runtimes": {
+    "win8": {},
+    "win8-aot": {}
+  }
+}

--- a/pkg/redist/System.Diagnostics.Tracing/lib/project.json
+++ b/pkg/redist/System.Diagnostics.Tracing/lib/project.json
@@ -3,6 +3,7 @@
     "System.Diagnostics.Tracing": "4.0.20"
   },
   "frameworks": {
+    "dnxcore50": {},
     "netcore50": {}
   },
   "runtimes": {

--- a/pkg/redist/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.builds
+++ b/pkg/redist/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.builds
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Diagnostics.Tracing.pkgproj" />
+    <Project Include="any\System.Diagnostics.Tracing.pkgproj" />
+    <Project Include="aot\System.Diagnostics.Tracing.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/redist/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.pkgproj
+++ b/pkg/redist/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.pkgproj
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <!-- bump up the version since we are redisting the 4.0.20 bits in a new package -->
+    <Version>4.0.21</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SourceDir)System.Diagnostics.Tracing\ref\4.0.0\System.Diagnostics.Tracing.depproj">
+      <SupportedFramework>net45;netcore45</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="$(SourceDir)System.Diagnostics.Tracing\ref\4.0.10\System.Diagnostics.Tracing.depproj">
+      <SupportedFramework>net451;netcore451;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="$(SourceDir)System.Diagnostics.Tracing\ref\4.0.20\System.Diagnostics.Tracing.depproj">
+      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
+      <SupportedFramework>net46;netcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="any\System.Diagnostics.Tracing.pkgproj" />
+    <ProjectReference Include="aot\System.Diagnostics.Tracing.pkgproj" />
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.pkgproj
+++ b/pkg/redist/System.Diagnostics.Tracing/pkg/System.Diagnostics.Tracing.pkgproj
@@ -13,8 +13,7 @@
       <SupportedFramework>net451;netcore451;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="$(SourceDir)System.Diagnostics.Tracing\ref\4.0.20\System.Diagnostics.Tracing.depproj">
-      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
-      <SupportedFramework>net46;netcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Diagnostics.Tracing.pkgproj" />
     <ProjectReference Include="aot\System.Diagnostics.Tracing.pkgproj" />

--- a/pkg/redist/System.Diagnostics.Tracing/pkg/any/System.Diagnostics.Tracing.pkgproj
+++ b/pkg/redist/System.Diagnostics.Tracing/pkg/any/System.Diagnostics.Tracing.pkgproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Diagnostics.Tracing.depproj" />
     <ProjectReference Include="..\..\lib\System.Diagnostics.Tracing.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </ProjectReference>

--- a/pkg/redist/System.Diagnostics.Tracing/pkg/any/System.Diagnostics.Tracing.pkgproj
+++ b/pkg/redist/System.Diagnostics.Tracing/pkg/any/System.Diagnostics.Tracing.pkgproj
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Diagnostics.Tracing.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Diagnostics.Tracing/pkg/aot/System.Diagnostics.Tracing.pkgproj
+++ b/pkg/redist/System.Diagnostics.Tracing/pkg/aot/System.Diagnostics.Tracing.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Diagnostics.Tracing.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Dynamic.Runtime/lib/System.Dynamic.Runtime.builds
+++ b/pkg/redist/System.Dynamic.Runtime/lib/System.Dynamic.Runtime.builds
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="System.Dynamic.Runtime.depproj" />
     <Project Include="System.Dynamic.Runtime.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </Project>

--- a/pkg/redist/System.Dynamic.Runtime/lib/System.Dynamic.Runtime.builds
+++ b/pkg/redist/System.Dynamic.Runtime/lib/System.Dynamic.Runtime.builds
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Dynamic.Runtime.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </Project>
+    <Project Include="System.Dynamic.Runtime.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/pkg/redist/System.Dynamic.Runtime/lib/System.Dynamic.Runtime.depproj
+++ b/pkg/redist/System.Dynamic.Runtime/lib/System.Dynamic.Runtime.depproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Dynamic.Runtime/lib/System.Dynamic.Runtime.depproj
+++ b/pkg/redist/System.Dynamic.Runtime/lib/System.Dynamic.Runtime.depproj
@@ -1,12 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
-  <PropertyGroup>
-    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.10.0</AssemblyVersion>
     <OutputType>Library</OutputType>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/pkg/redist/System.Dynamic.Runtime/lib/project.json
+++ b/pkg/redist/System.Dynamic.Runtime/lib/project.json
@@ -3,6 +3,7 @@
     "System.Dynamic.Runtime": "4.0.10"
   },
   "frameworks": {
+    "dnxcore50": {},
     "netcore50": {}
   },
   "runtimes": {

--- a/pkg/redist/System.Dynamic.Runtime/lib/project.json
+++ b/pkg/redist/System.Dynamic.Runtime/lib/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "System.Dynamic.Runtime": "4.0.10"
+  },
+  "frameworks": {
+    "netcore50": {}
+  },
+  "runtimes": {
+    "win8": {},
+    "win8-aot": {}
+  }
+}

--- a/pkg/redist/System.Dynamic.Runtime/pkg/System.Dynamic.Runtime.builds
+++ b/pkg/redist/System.Dynamic.Runtime/pkg/System.Dynamic.Runtime.builds
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="any\System.Dynamic.Runtime.pkgproj" />
+    <Project Include="aot\System.Dynamic.Runtime.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/redist/System.Dynamic.Runtime/pkg/System.Dynamic.Runtime.builds
+++ b/pkg/redist/System.Dynamic.Runtime/pkg/System.Dynamic.Runtime.builds
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="System.Dynamic.Runtime.pkgproj" />
     <Project Include="any\System.Dynamic.Runtime.pkgproj" />
     <Project Include="aot\System.Dynamic.Runtime.pkgproj" />
   </ItemGroup>

--- a/pkg/redist/System.Dynamic.Runtime/pkg/System.Dynamic.Runtime.pkgproj
+++ b/pkg/redist/System.Dynamic.Runtime/pkg/System.Dynamic.Runtime.pkgproj
@@ -9,8 +9,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="$(SourceDir)System.Dynamic.Runtime\ref\4.0.10\System.Dynamic.Runtime.depproj">
-      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
-      <SupportedFramework>net46;netcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Dynamic.Runtime.pkgproj" />
     <ProjectReference Include="aot\System.Dynamic.Runtime.pkgproj" />

--- a/pkg/redist/System.Dynamic.Runtime/pkg/System.Dynamic.Runtime.pkgproj
+++ b/pkg/redist/System.Dynamic.Runtime/pkg/System.Dynamic.Runtime.pkgproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <IsValidationOnlyPackage>true</IsValidationOnlyPackage>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SourceDir)System.Dynamic.Runtime\ref\4.0.0\System.Dynamic.Runtime.depproj">
+      <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="$(SourceDir)System.Dynamic.Runtime\ref\4.0.10\System.Dynamic.Runtime.depproj">
+      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
+      <SupportedFramework>net46;netcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="any\System.Dynamic.Runtime.pkgproj" />
+    <ProjectReference Include="aot\System.Dynamic.Runtime.pkgproj" />
+    
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Dynamic.Runtime/pkg/any/System.Dynamic.Runtime.pkgproj
+++ b/pkg/redist/System.Dynamic.Runtime/pkg/any/System.Dynamic.Runtime.pkgproj
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Dynamic.Runtime.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Dynamic.Runtime/pkg/any/System.Dynamic.Runtime.pkgproj
+++ b/pkg/redist/System.Dynamic.Runtime/pkg/any/System.Dynamic.Runtime.pkgproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Dynamic.Runtime.depproj" />
     <ProjectReference Include="..\..\lib\System.Dynamic.Runtime.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </ProjectReference>

--- a/pkg/redist/System.Dynamic.Runtime/pkg/aot/System.Dynamic.Runtime.pkgproj
+++ b/pkg/redist/System.Dynamic.Runtime/pkg/aot/System.Dynamic.Runtime.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Dynamic.Runtime.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.IO/lib/System.IO.builds
+++ b/pkg/redist/System.IO/lib/System.IO.builds
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.IO.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </Project>
+    <Project Include="System.IO.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/pkg/redist/System.IO/lib/System.IO.builds
+++ b/pkg/redist/System.IO/lib/System.IO.builds
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="System.IO.depproj" />
     <Project Include="System.IO.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </Project>

--- a/pkg/redist/System.IO/lib/System.IO.depproj
+++ b/pkg/redist/System.IO/lib/System.IO.depproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.IO/lib/System.IO.depproj
+++ b/pkg/redist/System.IO/lib/System.IO.depproj
@@ -1,12 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
-  <PropertyGroup>
-    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.10.0</AssemblyVersion>
     <OutputType>Library</OutputType>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/pkg/redist/System.IO/lib/project.json
+++ b/pkg/redist/System.IO/lib/project.json
@@ -3,6 +3,7 @@
     "System.IO": "4.0.10"
   },
   "frameworks": {
+    "dnxcore50": {},
     "netcore50": {}
   },
   "runtimes": {

--- a/pkg/redist/System.IO/lib/project.json
+++ b/pkg/redist/System.IO/lib/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "System.IO": "4.0.10"
+  },
+  "frameworks": {
+    "netcore50": {}
+  },
+  "runtimes": {
+    "win8": {},
+    "win8-aot": {}
+  }
+}

--- a/pkg/redist/System.IO/pkg/System.IO.builds
+++ b/pkg/redist/System.IO/pkg/System.IO.builds
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.IO.pkgproj" />
+    <Project Include="any\System.IO.pkgproj" />
+    <Project Include="aot\System.IO.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/redist/System.IO/pkg/System.IO.pkgproj
+++ b/pkg/redist/System.IO/pkg/System.IO.pkgproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <!-- bump up the version since we are redisting the 4.0.10 bits in a new package -->
+    <Version>4.0.11</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SourceDir)System.IO\ref\4.0.0\System.IO.depproj">
+      <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="$(SourceDir)System.IO\ref\4.0.10\System.IO.depproj">
+      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
+      <SupportedFramework>net46;netcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="any\System.IO.pkgproj" />
+    <ProjectReference Include="aot\System.IO.pkgproj" />
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.IO/pkg/System.IO.pkgproj
+++ b/pkg/redist/System.IO/pkg/System.IO.pkgproj
@@ -10,8 +10,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="$(SourceDir)System.IO\ref\4.0.10\System.IO.depproj">
-      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
-      <SupportedFramework>net46;netcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.IO.pkgproj" />
     <ProjectReference Include="aot\System.IO.pkgproj" />

--- a/pkg/redist/System.IO/pkg/any/System.IO.pkgproj
+++ b/pkg/redist/System.IO/pkg/any/System.IO.pkgproj
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.IO.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.IO/pkg/any/System.IO.pkgproj
+++ b/pkg/redist/System.IO/pkg/any/System.IO.pkgproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.IO.depproj"/>
     <ProjectReference Include="..\..\lib\System.IO.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </ProjectReference>

--- a/pkg/redist/System.IO/pkg/aot/System.IO.pkgproj
+++ b/pkg/redist/System.IO/pkg/aot/System.IO.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.IO.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Linq.Expressions/lib/System.Linq.Expressions.builds
+++ b/pkg/redist/System.Linq.Expressions/lib/System.Linq.Expressions.builds
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Linq.Expressions.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </Project>
+    <Project Include="System.Linq.Expressions.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/pkg/redist/System.Linq.Expressions/lib/System.Linq.Expressions.builds
+++ b/pkg/redist/System.Linq.Expressions/lib/System.Linq.Expressions.builds
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="System.Linq.Expressions.depproj" />
     <Project Include="System.Linq.Expressions.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </Project>

--- a/pkg/redist/System.Linq.Expressions/lib/System.Linq.Expressions.depproj
+++ b/pkg/redist/System.Linq.Expressions/lib/System.Linq.Expressions.depproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Linq.Expressions/lib/System.Linq.Expressions.depproj
+++ b/pkg/redist/System.Linq.Expressions/lib/System.Linq.Expressions.depproj
@@ -1,12 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
-  <PropertyGroup>
-    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.10.0</AssemblyVersion>
     <OutputType>Library</OutputType>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/pkg/redist/System.Linq.Expressions/lib/project.json
+++ b/pkg/redist/System.Linq.Expressions/lib/project.json
@@ -3,6 +3,7 @@
     "System.Linq.Expressions": "4.0.10"
   },
   "frameworks": {
+    "dnxcore50": {},
     "netcore50": {}
   },
   "runtimes": {

--- a/pkg/redist/System.Linq.Expressions/lib/project.json
+++ b/pkg/redist/System.Linq.Expressions/lib/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "System.Linq.Expressions": "4.0.10"
+  },
+  "frameworks": {
+    "netcore50": {}
+  },
+  "runtimes": {
+    "win8": {},
+    "win8-aot": {}
+  }
+}

--- a/pkg/redist/System.Linq.Expressions/pkg/System.Linq.Expressions.builds
+++ b/pkg/redist/System.Linq.Expressions/pkg/System.Linq.Expressions.builds
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="any\System.Linq.Expressions.pkgproj" />
+    <Project Include="aot\System.Linq.Expressions.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/redist/System.Linq.Expressions/pkg/System.Linq.Expressions.builds
+++ b/pkg/redist/System.Linq.Expressions/pkg/System.Linq.Expressions.builds
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="System.Linq.Expressions.pkgproj" />
     <Project Include="any\System.Linq.Expressions.pkgproj" />
     <Project Include="aot\System.Linq.Expressions.pkgproj" />
   </ItemGroup>

--- a/pkg/redist/System.Linq.Expressions/pkg/System.Linq.Expressions.pkgproj
+++ b/pkg/redist/System.Linq.Expressions/pkg/System.Linq.Expressions.pkgproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <IsValidationOnlyPackage>true</IsValidationOnlyPackage>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SourceDir)System.Linq.Expressions\ref\4.0.0\System.Linq.Expressions.depproj">
+      <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="$(SourceDir)System.Linq.Expressions\ref\4.0.10\System.Linq.Expressions.depproj">
+      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
+      <SupportedFramework>net46;netcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="any\System.Linq.Expressions.pkgproj" />
+    <ProjectReference Include="aot\System.Linq.Expressions.pkgproj" />
+    
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Linq.Expressions/pkg/System.Linq.Expressions.pkgproj
+++ b/pkg/redist/System.Linq.Expressions/pkg/System.Linq.Expressions.pkgproj
@@ -9,8 +9,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="$(SourceDir)System.Linq.Expressions\ref\4.0.10\System.Linq.Expressions.depproj">
-      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
-      <SupportedFramework>net46;netcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Linq.Expressions.pkgproj" />
     <ProjectReference Include="aot\System.Linq.Expressions.pkgproj" />

--- a/pkg/redist/System.Linq.Expressions/pkg/any/System.Linq.Expressions.pkgproj
+++ b/pkg/redist/System.Linq.Expressions/pkg/any/System.Linq.Expressions.pkgproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Linq.Expressions.depproj" />
     <ProjectReference Include="..\..\lib\System.Linq.Expressions.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </ProjectReference>

--- a/pkg/redist/System.Linq.Expressions/pkg/any/System.Linq.Expressions.pkgproj
+++ b/pkg/redist/System.Linq.Expressions/pkg/any/System.Linq.Expressions.pkgproj
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Linq.Expressions.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Linq.Expressions/pkg/aot/System.Linq.Expressions.pkgproj
+++ b/pkg/redist/System.Linq.Expressions/pkg/aot/System.Linq.Expressions.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Linq.Expressions.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Linq/lib/System.Linq.builds
+++ b/pkg/redist/System.Linq/lib/System.Linq.builds
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Linq.depproj"/>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/pkg/redist/System.Linq/lib/System.Linq.depproj
+++ b/pkg/redist/System.Linq/lib/System.Linq.depproj
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Linq/lib/project.json
+++ b/pkg/redist/System.Linq/lib/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Linq": "4.0.0"
+  },
+  "frameworks": {
+    "dotnet5.4": {}
+  }
+}

--- a/pkg/redist/System.Linq/pkg/System.Linq.builds
+++ b/pkg/redist/System.Linq/pkg/System.Linq.builds
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Linq.pkgproj"/>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/redist/System.Linq/pkg/System.Linq.pkgproj
+++ b/pkg/redist/System.Linq/pkg/System.Linq.pkgproj
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <!-- bump up the version since we are redisting the 4.0.0 bits in a new package -->
+    <Version>4.0.1.0</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SourceDir)System.Linq\ref\4.0.0\System.Linq.depproj">
+      <SupportedFramework>net45;netcore45;dnxcore50;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\lib\System.Linq.builds"/>
+
+    <InboxOnTargetFramework Include="MonoAndroid10"/>
+    <InboxOnTargetFramework Include="MonoTouch10"/>
+    <InboxOnTargetFramework Include="net45"/>
+    <InboxOnTargetFramework Include="win8"/>
+    <InboxOnTargetFramework Include="wp80"/>
+    <InboxOnTargetFramework Include="wpa81"/>
+    <InboxOnTargetFramework Include="xamarinios10"/>
+    <InboxOnTargetFramework Include="xamarinmac20"/>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.ObjectModel/lib/System.ObjectModel.builds
+++ b/pkg/redist/System.ObjectModel/lib/System.ObjectModel.builds
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.ObjectModel.depproj"/>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/pkg/redist/System.ObjectModel/lib/System.ObjectModel.depproj
+++ b/pkg/redist/System.ObjectModel/lib/System.ObjectModel.depproj
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.ObjectModel/lib/project.json
+++ b/pkg/redist/System.ObjectModel/lib/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.ObjectModel": "4.0.10"
+  },
+  "frameworks": {
+    "dotnet5.4": {}
+  }
+}

--- a/pkg/redist/System.ObjectModel/pkg/System.ObjectModel.builds
+++ b/pkg/redist/System.ObjectModel/pkg/System.ObjectModel.builds
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.ObjectModel.pkgproj"/>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/redist/System.ObjectModel/pkg/System.ObjectModel.pkgproj
+++ b/pkg/redist/System.ObjectModel/pkg/System.ObjectModel.pkgproj
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <!-- bump up the version since we are redisting the 4.0.10 bits in a new package -->
+    <Version>4.0.11.0</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SourceDir)System.ObjectModel\ref\4.0.0\System.ObjectModel.depproj">
+      <SupportedFramework>net45;netcore45;wpa81;wp8</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="$(SourceDir)System.ObjectModel\ref\4.0.10\System.ObjectModel.depproj">
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\lib\System.ObjectModel.builds"/>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Reflection.Extensions/lib/System.Reflection.Extensions.builds
+++ b/pkg/redist/System.Reflection.Extensions/lib/System.Reflection.Extensions.builds
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Reflection.Extensions.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </Project>
+    <Project Include="System.Reflection.Extensions.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/pkg/redist/System.Reflection.Extensions/lib/System.Reflection.Extensions.builds
+++ b/pkg/redist/System.Reflection.Extensions/lib/System.Reflection.Extensions.builds
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="System.Reflection.Extensions.depproj" />
     <Project Include="System.Reflection.Extensions.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </Project>

--- a/pkg/redist/System.Reflection.Extensions/lib/System.Reflection.Extensions.depproj
+++ b/pkg/redist/System.Reflection.Extensions/lib/System.Reflection.Extensions.depproj
@@ -1,12 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
-  <PropertyGroup>
-    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/pkg/redist/System.Reflection.Extensions/lib/System.Reflection.Extensions.depproj
+++ b/pkg/redist/System.Reflection.Extensions/lib/System.Reflection.Extensions.depproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Reflection.Extensions/lib/project.json
+++ b/pkg/redist/System.Reflection.Extensions/lib/project.json
@@ -3,6 +3,7 @@
     "System.Reflection.Extensions": "4.0.0"
   },
   "frameworks": {
+    "dnxcore50": {},
     "netcore50": {}
   },
   "runtimes": {

--- a/pkg/redist/System.Reflection.Extensions/lib/project.json
+++ b/pkg/redist/System.Reflection.Extensions/lib/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "System.Reflection.Extensions": "4.0.0"
+  },
+  "frameworks": {
+    "netcore50": {}
+  },
+  "runtimes": {
+    "win8": {},
+    "win8-aot": {}
+  }
+}

--- a/pkg/redist/System.Reflection.Extensions/pkg/System.Reflection.Extensions.builds
+++ b/pkg/redist/System.Reflection.Extensions/pkg/System.Reflection.Extensions.builds
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="any\System.Reflection.Extensions.pkgproj" />
+    <Project Include="aot\System.Reflection.Extensions.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/redist/System.Reflection.Extensions/pkg/System.Reflection.Extensions.builds
+++ b/pkg/redist/System.Reflection.Extensions/pkg/System.Reflection.Extensions.builds
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="System.Reflection.Extensions.pkgproj" />
     <Project Include="any\System.Reflection.Extensions.pkgproj" />
     <Project Include="aot\System.Reflection.Extensions.pkgproj" />
   </ItemGroup>

--- a/pkg/redist/System.Reflection.Extensions/pkg/System.Reflection.Extensions.pkgproj
+++ b/pkg/redist/System.Reflection.Extensions/pkg/System.Reflection.Extensions.pkgproj
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <IsValidationOnlyPackage>true</IsValidationOnlyPackage>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SourceDir)System.Reflection.Extensions\ref\4.0.0\System.Reflection.Extensions.depproj">
+      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
+      <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="any\System.Reflection.Extensions.pkgproj" />
+    <ProjectReference Include="aot\System.Reflection.Extensions.pkgproj" />
+    
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Reflection.Extensions/pkg/System.Reflection.Extensions.pkgproj
+++ b/pkg/redist/System.Reflection.Extensions/pkg/System.Reflection.Extensions.pkgproj
@@ -6,8 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(SourceDir)System.Reflection.Extensions\ref\4.0.0\System.Reflection.Extensions.depproj">
-      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
-      <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;wp8;wpa81;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Reflection.Extensions.pkgproj" />
     <ProjectReference Include="aot\System.Reflection.Extensions.pkgproj" />

--- a/pkg/redist/System.Reflection.Extensions/pkg/any/System.Reflection.Extensions.pkgproj
+++ b/pkg/redist/System.Reflection.Extensions/pkg/any/System.Reflection.Extensions.pkgproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Reflection.Extensions.depproj" />
     <ProjectReference Include="..\..\lib\System.Reflection.Extensions.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </ProjectReference>

--- a/pkg/redist/System.Reflection.Extensions/pkg/any/System.Reflection.Extensions.pkgproj
+++ b/pkg/redist/System.Reflection.Extensions/pkg/any/System.Reflection.Extensions.pkgproj
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Reflection.Extensions.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Reflection.Extensions/pkg/aot/System.Reflection.Extensions.pkgproj
+++ b/pkg/redist/System.Reflection.Extensions/pkg/aot/System.Reflection.Extensions.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Reflection.Extensions.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Reflection.Primitives/lib/System.Reflection.Primitives.builds
+++ b/pkg/redist/System.Reflection.Primitives/lib/System.Reflection.Primitives.builds
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="System.Reflection.Primitives.depproj" />
     <Project Include="System.Reflection.Primitives.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </Project>

--- a/pkg/redist/System.Reflection.Primitives/lib/System.Reflection.Primitives.builds
+++ b/pkg/redist/System.Reflection.Primitives/lib/System.Reflection.Primitives.builds
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Reflection.Primitives.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </Project>
+    <Project Include="System.Reflection.Primitives.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/pkg/redist/System.Reflection.Primitives/lib/System.Reflection.Primitives.depproj
+++ b/pkg/redist/System.Reflection.Primitives/lib/System.Reflection.Primitives.depproj
@@ -1,12 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
-  <PropertyGroup>
-    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/pkg/redist/System.Reflection.Primitives/lib/System.Reflection.Primitives.depproj
+++ b/pkg/redist/System.Reflection.Primitives/lib/System.Reflection.Primitives.depproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Reflection.Primitives/lib/project.json
+++ b/pkg/redist/System.Reflection.Primitives/lib/project.json
@@ -3,6 +3,7 @@
     "System.Reflection.Primitives": "4.0.0"
   },
   "frameworks": {
+    "dnxcore50": {},
     "netcore50": {}
   },
   "runtimes": {

--- a/pkg/redist/System.Reflection.Primitives/lib/project.json
+++ b/pkg/redist/System.Reflection.Primitives/lib/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "System.Reflection.Primitives": "4.0.0"
+  },
+  "frameworks": {
+    "netcore50": {}
+  },
+  "runtimes": {
+    "win8": {},
+    "win8-aot": {}
+  }
+}

--- a/pkg/redist/System.Reflection.Primitives/pkg/System.Reflection.Primitives.builds
+++ b/pkg/redist/System.Reflection.Primitives/pkg/System.Reflection.Primitives.builds
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="any\System.Reflection.Primitives.pkgproj" />
+    <Project Include="aot\System.Reflection.Primitives.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/redist/System.Reflection.Primitives/pkg/System.Reflection.Primitives.builds
+++ b/pkg/redist/System.Reflection.Primitives/pkg/System.Reflection.Primitives.builds
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="System.Reflection.Primitives.pkgproj" />
     <Project Include="any\System.Reflection.Primitives.pkgproj" />
     <Project Include="aot\System.Reflection.Primitives.pkgproj" />
   </ItemGroup>

--- a/pkg/redist/System.Reflection.Primitives/pkg/System.Reflection.Primitives.pkgproj
+++ b/pkg/redist/System.Reflection.Primitives/pkg/System.Reflection.Primitives.pkgproj
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <IsValidationOnlyPackage>true</IsValidationOnlyPackage>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SourceDir)System.Reflection.Primitives\ref\4.0.0\System.Reflection.Primitives.depproj">
+      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
+      <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="any\System.Reflection.Primitives.pkgproj" />
+    <ProjectReference Include="aot\System.Reflection.Primitives.pkgproj" />
+    
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Reflection.Primitives/pkg/System.Reflection.Primitives.pkgproj
+++ b/pkg/redist/System.Reflection.Primitives/pkg/System.Reflection.Primitives.pkgproj
@@ -6,8 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(SourceDir)System.Reflection.Primitives\ref\4.0.0\System.Reflection.Primitives.depproj">
-      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
-      <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;wp8;wpa81;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Reflection.Primitives.pkgproj" />
     <ProjectReference Include="aot\System.Reflection.Primitives.pkgproj" />

--- a/pkg/redist/System.Reflection.Primitives/pkg/any/System.Reflection.Primitives.pkgproj
+++ b/pkg/redist/System.Reflection.Primitives/pkg/any/System.Reflection.Primitives.pkgproj
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Reflection.Primitives.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Reflection.Primitives/pkg/any/System.Reflection.Primitives.pkgproj
+++ b/pkg/redist/System.Reflection.Primitives/pkg/any/System.Reflection.Primitives.pkgproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Reflection.Primitives.depproj" />
     <ProjectReference Include="..\..\lib\System.Reflection.Primitives.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </ProjectReference>

--- a/pkg/redist/System.Reflection.Primitives/pkg/aot/System.Reflection.Primitives.pkgproj
+++ b/pkg/redist/System.Reflection.Primitives/pkg/aot/System.Reflection.Primitives.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Reflection.Primitives.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Reflection.TypeExtensions/lib/System.Reflection.TypeExtensions.builds
+++ b/pkg/redist/System.Reflection.TypeExtensions/lib/System.Reflection.TypeExtensions.builds
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Reflection.TypeExtensions.depproj">
+      <TargetGroup>net46</TargetGroup>
+    </Project>
+    <Project Include="System.Reflection.TypeExtensions.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </Project>
+    <Project Include="System.Reflection.TypeExtensions.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/pkg/redist/System.Reflection.TypeExtensions/lib/System.Reflection.TypeExtensions.builds
+++ b/pkg/redist/System.Reflection.TypeExtensions/lib/System.Reflection.TypeExtensions.builds
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="System.Reflection.TypeExtensions.depproj"/>
     <Project Include="System.Reflection.TypeExtensions.depproj">
       <TargetGroup>net46</TargetGroup>
     </Project>

--- a/pkg/redist/System.Reflection.TypeExtensions/lib/System.Reflection.TypeExtensions.depproj
+++ b/pkg/redist/System.Reflection.TypeExtensions/lib/System.Reflection.TypeExtensions.depproj
@@ -1,12 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
-  <PropertyGroup>
-    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/pkg/redist/System.Reflection.TypeExtensions/lib/System.Reflection.TypeExtensions.depproj
+++ b/pkg/redist/System.Reflection.TypeExtensions/lib/System.Reflection.TypeExtensions.depproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Reflection.TypeExtensions/lib/project.json
+++ b/pkg/redist/System.Reflection.TypeExtensions/lib/project.json
@@ -4,6 +4,7 @@
   },
   "frameworks": {
     "net46": {},
+    "dnxcore50": {},
     "netcore50": {}
   },
   "runtimes": {

--- a/pkg/redist/System.Reflection.TypeExtensions/lib/project.json
+++ b/pkg/redist/System.Reflection.TypeExtensions/lib/project.json
@@ -1,0 +1,13 @@
+{
+  "dependencies": {
+    "System.Reflection.TypeExtensions": "4.0.0"
+  },
+  "frameworks": {
+    "net46": {},
+    "netcore50": {}
+  },
+  "runtimes": {
+    "win8": {},
+    "win8-aot": {}
+  }
+}

--- a/pkg/redist/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.builds
+++ b/pkg/redist/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.builds
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Reflection.TypeExtensions.pkgproj" />
+    <Project Include="any\System.Reflection.TypeExtensions.pkgproj" />
+    <Project Include="aot\System.Reflection.TypeExtensions.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/redist/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.pkgproj
+++ b/pkg/redist/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.pkgproj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <!-- bump up the version since we are redisting the 4.0.0 bits in a new package -->
+    <Version>4.0.1</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SourceDir)System.Reflection.TypeExtensions\ref\4.0.0\System.Reflection.TypeExtensions.depproj">
+      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
+      <SupportedFramework>net46;netcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\lib\System.Reflection.TypeExtensions.depproj">
+      <TargetGroup>net46</TargetGroup>
+    </ProjectReference>
+    <ProjectReference Include="any\System.Reflection.TypeExtensions.pkgproj" />
+    <ProjectReference Include="aot\System.Reflection.TypeExtensions.pkgproj" />
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.pkgproj
+++ b/pkg/redist/System.Reflection.TypeExtensions/pkg/System.Reflection.TypeExtensions.pkgproj
@@ -7,8 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(SourceDir)System.Reflection.TypeExtensions\ref\4.0.0\System.Reflection.TypeExtensions.depproj">
-      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
-      <SupportedFramework>net46;netcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="..\lib\System.Reflection.TypeExtensions.depproj">
       <TargetGroup>net46</TargetGroup>

--- a/pkg/redist/System.Reflection.TypeExtensions/pkg/any/System.Reflection.TypeExtensions.pkgproj
+++ b/pkg/redist/System.Reflection.TypeExtensions/pkg/any/System.Reflection.TypeExtensions.pkgproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Reflection.TypeExtensions.depproj" />
     <ProjectReference Include="..\..\lib\System.Reflection.TypeExtensions.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </ProjectReference>

--- a/pkg/redist/System.Reflection.TypeExtensions/pkg/any/System.Reflection.TypeExtensions.pkgproj
+++ b/pkg/redist/System.Reflection.TypeExtensions/pkg/any/System.Reflection.TypeExtensions.pkgproj
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Reflection.TypeExtensions.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Reflection.TypeExtensions/pkg/aot/System.Reflection.TypeExtensions.pkgproj
+++ b/pkg/redist/System.Reflection.TypeExtensions/pkg/aot/System.Reflection.TypeExtensions.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Reflection.TypeExtensions.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Resources.ResourceManager/lib/System.Resources.ResourceManager.builds
+++ b/pkg/redist/System.Resources.ResourceManager/lib/System.Resources.ResourceManager.builds
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="System.Resources.ResourceManager.depproj" />
     <Project Include="System.Resources.ResourceManager.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </Project>

--- a/pkg/redist/System.Resources.ResourceManager/lib/System.Resources.ResourceManager.builds
+++ b/pkg/redist/System.Resources.ResourceManager/lib/System.Resources.ResourceManager.builds
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Resources.ResourceManager.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </Project>
+    <Project Include="System.Resources.ResourceManager.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/pkg/redist/System.Resources.ResourceManager/lib/System.Resources.ResourceManager.depproj
+++ b/pkg/redist/System.Resources.ResourceManager/lib/System.Resources.ResourceManager.depproj
@@ -1,12 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
-  <PropertyGroup>
-    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/pkg/redist/System.Resources.ResourceManager/lib/System.Resources.ResourceManager.depproj
+++ b/pkg/redist/System.Resources.ResourceManager/lib/System.Resources.ResourceManager.depproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Resources.ResourceManager/lib/project.json
+++ b/pkg/redist/System.Resources.ResourceManager/lib/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "System.Resources.ResourceManager": "4.0.0"
+  },
+  "frameworks": {
+    "netcore50": {}
+  },
+  "runtimes": {
+    "win8": {},
+    "win8-aot": {}
+  }
+}

--- a/pkg/redist/System.Resources.ResourceManager/lib/project.json
+++ b/pkg/redist/System.Resources.ResourceManager/lib/project.json
@@ -3,6 +3,7 @@
     "System.Resources.ResourceManager": "4.0.0"
   },
   "frameworks": {
+    "dnxcore50": {},
     "netcore50": {}
   },
   "runtimes": {

--- a/pkg/redist/System.Resources.ResourceManager/pkg/System.Resources.ResourceManager.builds
+++ b/pkg/redist/System.Resources.ResourceManager/pkg/System.Resources.ResourceManager.builds
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="System.Resources.ResourceManager.pkgproj" />
     <Project Include="any\System.Resources.ResourceManager.pkgproj" />
     <Project Include="aot\System.Resources.ResourceManager.pkgproj" />
   </ItemGroup>

--- a/pkg/redist/System.Resources.ResourceManager/pkg/System.Resources.ResourceManager.builds
+++ b/pkg/redist/System.Resources.ResourceManager/pkg/System.Resources.ResourceManager.builds
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="any\System.Resources.ResourceManager.pkgproj" />
+    <Project Include="aot\System.Resources.ResourceManager.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/redist/System.Resources.ResourceManager/pkg/System.Resources.ResourceManager.pkgproj
+++ b/pkg/redist/System.Resources.ResourceManager/pkg/System.Resources.ResourceManager.pkgproj
@@ -6,8 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(SourceDir)System.Resources.ResourceManager\ref\4.0.0\System.Resources.ResourceManager.depproj">
-      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
-      <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
+      <SupportedFramework>net45;netcore45;wp8;wpa81;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Resources.ResourceManager.pkgproj" />
     <ProjectReference Include="aot\System.Resources.ResourceManager.pkgproj" />

--- a/pkg/redist/System.Resources.ResourceManager/pkg/System.Resources.ResourceManager.pkgproj
+++ b/pkg/redist/System.Resources.ResourceManager/pkg/System.Resources.ResourceManager.pkgproj
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <IsValidationOnlyPackage>true</IsValidationOnlyPackage>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SourceDir)System.Resources.ResourceManager\ref\4.0.0\System.Resources.ResourceManager.depproj">
+      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
+      <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="any\System.Resources.ResourceManager.pkgproj" />
+    <ProjectReference Include="aot\System.Resources.ResourceManager.pkgproj" />
+    
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Resources.ResourceManager/pkg/any/System.Resources.ResourceManager.pkgproj
+++ b/pkg/redist/System.Resources.ResourceManager/pkg/any/System.Resources.ResourceManager.pkgproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Resources.ResourceManager.depproj" />
     <ProjectReference Include="..\..\lib\System.Resources.ResourceManager.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </ProjectReference>

--- a/pkg/redist/System.Resources.ResourceManager/pkg/any/System.Resources.ResourceManager.pkgproj
+++ b/pkg/redist/System.Resources.ResourceManager/pkg/any/System.Resources.ResourceManager.pkgproj
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Resources.ResourceManager.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Resources.ResourceManager/pkg/aot/System.Resources.ResourceManager.pkgproj
+++ b/pkg/redist/System.Resources.ResourceManager/pkg/aot/System.Resources.ResourceManager.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Resources.ResourceManager.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Runtime.Extensions/lib/System.Runtime.Extensions.builds
+++ b/pkg/redist/System.Runtime.Extensions/lib/System.Runtime.Extensions.builds
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="System.Runtime.Extensions.depproj" />
     <Project Include="System.Runtime.Extensions.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </Project>

--- a/pkg/redist/System.Runtime.Extensions/lib/System.Runtime.Extensions.builds
+++ b/pkg/redist/System.Runtime.Extensions/lib/System.Runtime.Extensions.builds
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Runtime.Extensions.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </Project>
+    <Project Include="System.Runtime.Extensions.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/pkg/redist/System.Runtime.Extensions/lib/System.Runtime.Extensions.depproj
+++ b/pkg/redist/System.Runtime.Extensions/lib/System.Runtime.Extensions.depproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Runtime.Extensions/lib/System.Runtime.Extensions.depproj
+++ b/pkg/redist/System.Runtime.Extensions/lib/System.Runtime.Extensions.depproj
@@ -1,12 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
-  <PropertyGroup>
-    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.10.0</AssemblyVersion>
     <OutputType>Library</OutputType>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/pkg/redist/System.Runtime.Extensions/lib/project.json
+++ b/pkg/redist/System.Runtime.Extensions/lib/project.json
@@ -3,6 +3,7 @@
     "System.Runtime.Extensions": "4.0.10"
   },
   "frameworks": {
+    "dnxcore50": {},
     "netcore50": {}
   },
   "runtimes": {

--- a/pkg/redist/System.Runtime.Extensions/lib/project.json
+++ b/pkg/redist/System.Runtime.Extensions/lib/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "System.Runtime.Extensions": "4.0.10"
+  },
+  "frameworks": {
+    "netcore50": {}
+  },
+  "runtimes": {
+    "win8": {},
+    "win8-aot": {}
+  }
+}

--- a/pkg/redist/System.Runtime.Extensions/pkg/System.Runtime.Extensions.builds
+++ b/pkg/redist/System.Runtime.Extensions/pkg/System.Runtime.Extensions.builds
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Runtime.Extensions.pkgproj" />
+    <Project Include="any\System.Runtime.Extensions.pkgproj" />
+    <Project Include="aot\System.Runtime.Extensions.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/redist/System.Runtime.Extensions/pkg/System.Runtime.Extensions.pkgproj
+++ b/pkg/redist/System.Runtime.Extensions/pkg/System.Runtime.Extensions.pkgproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <!-- bump up the version since we are redisting the 4.0.10 bits in a new package -->
+    <Version>4.0.11</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SourceDir)System.Runtime.Extensions\ref\4.0.0\System.Runtime.Extensions.depproj">
+      <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="$(SourceDir)System.Runtime.Extensions\ref\4.0.10\System.Runtime.Extensions.depproj">
+      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
+      <SupportedFramework>net46;netcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="any\System.Runtime.Extensions.pkgproj" />
+    <ProjectReference Include="aot\System.Runtime.Extensions.pkgproj" />
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Runtime.Extensions/pkg/System.Runtime.Extensions.pkgproj
+++ b/pkg/redist/System.Runtime.Extensions/pkg/System.Runtime.Extensions.pkgproj
@@ -10,8 +10,7 @@
       <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="$(SourceDir)System.Runtime.Extensions\ref\4.0.10\System.Runtime.Extensions.depproj">
-      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
-      <SupportedFramework>net46;netcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Runtime.Extensions.pkgproj" />
     <ProjectReference Include="aot\System.Runtime.Extensions.pkgproj" />

--- a/pkg/redist/System.Runtime.Extensions/pkg/any/System.Runtime.Extensions.pkgproj
+++ b/pkg/redist/System.Runtime.Extensions/pkg/any/System.Runtime.Extensions.pkgproj
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Runtime.Extensions.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Runtime.Extensions/pkg/any/System.Runtime.Extensions.pkgproj
+++ b/pkg/redist/System.Runtime.Extensions/pkg/any/System.Runtime.Extensions.pkgproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Runtime.Extensions.depproj" />
     <ProjectReference Include="..\..\lib\System.Runtime.Extensions.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </ProjectReference>

--- a/pkg/redist/System.Runtime.Extensions/pkg/aot/System.Runtime.Extensions.pkgproj
+++ b/pkg/redist/System.Runtime.Extensions/pkg/aot/System.Runtime.Extensions.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Runtime.Extensions.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Runtime/lib/System.Runtime.builds
+++ b/pkg/redist/System.Runtime/lib/System.Runtime.builds
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Runtime.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </Project>
+    <Project Include="System.Runtime.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </Project>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/pkg/redist/System.Runtime/lib/System.Runtime.builds
+++ b/pkg/redist/System.Runtime/lib/System.Runtime.builds
@@ -2,6 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
+    <Project Include="System.Runtime.depproj" />
     <Project Include="System.Runtime.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </Project>

--- a/pkg/redist/System.Runtime/lib/System.Runtime.depproj
+++ b/pkg/redist/System.Runtime/lib/System.Runtime.depproj
@@ -1,12 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
-  <PropertyGroup>
-    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
-  </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyVersion>4.0.20.0</AssemblyVersion>
     <OutputType>Library</OutputType>
+    <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/pkg/redist/System.Runtime/lib/System.Runtime.depproj
+++ b/pkg/redist/System.Runtime/lib/System.Runtime.depproj
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <PropertyGroup>
+    <TargetGroup Condition="'$(TargetGroup)' == ''">netcore50</TargetGroup>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.20.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Runtime/lib/project.json
+++ b/pkg/redist/System.Runtime/lib/project.json
@@ -3,6 +3,7 @@
     "System.Runtime": "4.0.20"
   },
   "frameworks": {
+    "dnxcore50": {},
     "netcore50": {}
   },
   "runtimes": {

--- a/pkg/redist/System.Runtime/lib/project.json
+++ b/pkg/redist/System.Runtime/lib/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "System.Runtime": "4.0.20"
+  },
+  "frameworks": {
+    "netcore50": {}
+  },
+  "runtimes": {
+    "win8": {},
+    "win8-aot": {}
+  }
+}

--- a/pkg/redist/System.Runtime/pkg/System.Runtime.builds
+++ b/pkg/redist/System.Runtime/pkg/System.Runtime.builds
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Runtime.pkgproj" />
+    <Project Include="any\System.Runtime.pkgproj" />
+    <Project Include="aot\System.Runtime.pkgproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/redist/System.Runtime/pkg/System.Runtime.pkgproj
+++ b/pkg/redist/System.Runtime/pkg/System.Runtime.pkgproj
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <!-- bump up the version since we are redisting the 4.0.20 bits in a new package -->
+    <Version>4.0.21</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SourceDir)System.Runtime\ref\4.0.0\System.Runtime.depproj">
+      <SupportedFramework>net45;netcore45;wp8</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="$(SourceDir)System.Runtime\ref\4.0.10\System.Runtime.depproj">
+      <SupportedFramework>net451;netcore451;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="$(SourceDir)System.Runtime\ref\4.0.20\System.Runtime.depproj">
+      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
+      <SupportedFramework>net46;netcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="any\System.Runtime.pkgproj" />
+    <ProjectReference Include="aot\System.Runtime.pkgproj" />
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Runtime/pkg/System.Runtime.pkgproj
+++ b/pkg/redist/System.Runtime/pkg/System.Runtime.pkgproj
@@ -13,8 +13,7 @@
       <SupportedFramework>net451;netcore451;wpa81</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="$(SourceDir)System.Runtime\ref\4.0.20\System.Runtime.depproj">
-      <!-- Intentionally omit dnxcore50 because it requires a different lineup -->
-      <SupportedFramework>net46;netcore50</SupportedFramework>
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
     </ProjectReference>
     <ProjectReference Include="any\System.Runtime.pkgproj" />
     <ProjectReference Include="aot\System.Runtime.pkgproj" />

--- a/pkg/redist/System.Runtime/pkg/any/System.Runtime.pkgproj
+++ b/pkg/redist/System.Runtime/pkg/any/System.Runtime.pkgproj
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <PackageTargetRuntime>any</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Runtime.depproj">
+      <TargetGroup>netcore50</TargetGroup>
+    </ProjectReference>
+
+    <!-- AOT implementation comes from AOT package -->
+    <ExternalOnTargetFramework Include="netcore50">
+      <PackageTargetRuntime>aot</PackageTargetRuntime>
+    </ExternalOnTargetFramework>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Runtime/pkg/any/System.Runtime.pkgproj
+++ b/pkg/redist/System.Runtime/pkg/any/System.Runtime.pkgproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Runtime.depproj" />
     <ProjectReference Include="..\..\lib\System.Runtime.depproj">
       <TargetGroup>netcore50</TargetGroup>
     </ProjectReference>

--- a/pkg/redist/System.Runtime/pkg/aot/System.Runtime.pkgproj
+++ b/pkg/redist/System.Runtime/pkg/aot/System.Runtime.pkgproj
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <PropertyGroup>
+    <PackageTargetRuntime>aot</PackageTargetRuntime>
+    <PreventImplementationReference>true</PreventImplementationReference>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\lib\System.Runtime.depproj">
+      <TargetGroup>netcore50aot</TargetGroup>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Text.RegularExpressions/lib/System.Text.RegularExpressions.builds
+++ b/pkg/redist/System.Text.RegularExpressions/lib/System.Text.RegularExpressions.builds
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Text.RegularExpressions.depproj"/>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/pkg/redist/System.Text.RegularExpressions/lib/System.Text.RegularExpressions.depproj
+++ b/pkg/redist/System.Text.RegularExpressions/lib/System.Text.RegularExpressions.depproj
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/System.Text.RegularExpressions/lib/project.json
+++ b/pkg/redist/System.Text.RegularExpressions/lib/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Text.RegularExpressions": "4.0.10"
+  },
+  "frameworks": {
+    "dotnet5.4": {}
+  }
+}

--- a/pkg/redist/System.Text.RegularExpressions/pkg/System.Text.RegularExpressions.builds
+++ b/pkg/redist/System.Text.RegularExpressions/pkg/System.Text.RegularExpressions.builds
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="System.Text.RegularExpressions.pkgproj"/>
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/redist/System.Text.RegularExpressions/pkg/System.Text.RegularExpressions.pkgproj
+++ b/pkg/redist/System.Text.RegularExpressions/pkg/System.Text.RegularExpressions.pkgproj
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <!-- bump up the version since we are redisting the 4.0.10 bits in a new package -->
+    <Version>4.0.11.0</Version>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$(SourceDir)System.Text.RegularExpressions\ref\4.0.0\System.Text.RegularExpressions.depproj">
+      <SupportedFramework>net45;netcore45;wp8;wpa81</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="$(SourceDir)System.Text.RegularExpressions\ref\4.0.10\System.Text.RegularExpressions.depproj">
+      <SupportedFramework>net46;netcore50;dnxcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\lib\System.Text.RegularExpressions.builds"/>
+
+    <InboxOnTargetFramework Include="MonoAndroid10" />
+    <InboxOnTargetFramework Include="MonoTouch10" />
+    <InboxOnTargetFramework Include="net45" />
+    <InboxOnTargetFramework Include="win8" />
+    <InboxOnTargetFramework Include="wp80" />
+    <InboxOnTargetFramework Include="wpa81" />
+    <InboxOnTargetFramework Include="xamarinios10" />
+    <InboxOnTargetFramework Include="xamarinmac20" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/pkg/redist/dir.props
+++ b/pkg/redist/dir.props
@@ -1,0 +1,10 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <NuspecSuffix>-redist</NuspecSuffix>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., dir.props))\dir.props" />
+  <PropertyGroup>
+    <OutputPath>$(BaseOutputPath)redist/$(OSPlatformConfig)/$(MSBuildProjectName)/$(TargetOutputRelPath)</OutputPath>
+    <IntermediateOutputPath>$(BaseIntermediateOutputPath)redist/$(OSPlatformConfig)/$(MSBuildProjectName)/$(TargetOutputRelPath)</IntermediateOutputPath>
+  </PropertyGroup>
+</Project>

--- a/pkg/redist/dir.targets
+++ b/pkg/redist/dir.targets
@@ -1,0 +1,29 @@
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)\.., dir.targets))\dir.targets" />
+  <PropertyGroup>
+    <NuGetRuntimeIdentifier Condition="'$(TargetGroup)' == 'netcore50'">win8</NuGetRuntimeIdentifier>
+    <NuGetRuntimeIdentifier Condition="'$(TargetGroup)' == 'netcore50aot'">win8-aot</NuGetRuntimeIdentifier>
+    <!-- workaround typo in Dev14 RTM -->
+    <RuntimeIndentifier Condition="'$(NuGetRuntimeIdentifier)' != ''">$(NuGetRuntimeIdentifier)</RuntimeIndentifier>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(IsValidationOnlyPackage)' == 'true'">
+    <ShouldGenerateNuSpec>false</ShouldGenerateNuSpec>
+    <ShouldCreatePackage>false</ShouldCreatePackage>
+    <BuildDependsOn>ValidatePackage</BuildDependsOn>
+  </PropertyGroup>
+  
+  <Target Name="OmitTransitiveRuntimeAssets" AfterTargets="ResolveNuGetPackages">
+    <ItemGroup>
+      <!-- get all references from nuget packages as ID so that we can substract the direct ref IDs-->
+      <_ReferenceCopyLocalPathsAsPackageId Include="@(ReferenceCopyLocalPaths->'%(NuGetPackageId)')" Condition="'%(ReferenceCopyLocalPaths.NuGetPackageId)' != ''">
+        <OriginalIdentity>%(Identity)</OriginalIdentity>
+      </_ReferenceCopyLocalPathsAsPackageId>
+      <!-- Indirect references are any references whose PackageId isn't in the direct reference set: ReferencedNuGetPackages -->
+      <_IndirectReferenceAsPackageId Include="@(_ReferenceCopyLocalPathsAsPackageId)" Exclude="@(ReferencedNuGetPackages)" />
+      <!-- Transform back to original -->
+      <IndirectReference Include="@(_IndirectReferenceAsPackageId->'%(OriginalIdentity)')" />
+      <ReferenceCopyLocalPaths Remove="@(IndirectReference)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/pkg/redist/dir.targets
+++ b/pkg/redist/dir.targets
@@ -24,6 +24,9 @@
       <!-- Transform back to original -->
       <IndirectReference Include="@(_IndirectReferenceAsPackageId->'%(OriginalIdentity)')" />
       <ReferenceCopyLocalPaths Remove="@(IndirectReference)" />
+
+      <!-- Don't pass anything to RAR -->
+      <Reference Remove="@(Reference)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/pkg/redist/dirs.proj
+++ b/pkg/redist/dirs.proj
@@ -1,0 +1,10 @@
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <ItemGroup>
+    <Project Include="lib.builds" />
+    <Project Include="pkg.builds" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/redist/lib.builds
+++ b/pkg/redist/lib.builds
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="*\lib\*.builds" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/redist/pkg.builds
+++ b/pkg/redist/pkg.builds
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="BuildAndTest" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="*\pkg\*.builds" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>

--- a/pkg/redist/readme.md
+++ b/pkg/redist/readme.md
@@ -1,0 +1,53 @@
+These packages are used for UWP 10 RTM - shared library
+
+They contain the same libraries shipped at UWP RTM, repackaged in the 
+latest nuget format (netstandard, runtime packages, etc).
+
+We use them as the baseline for package dependencies so that we can have
+CoreFx packages use updated packages with netstandard support without 
+breaking shared library.
+
+Directory structure:
+Folder per package that will be redistributed.
+
+Lib folder contains a deployment project (depproj) to restore and wrap 
+the old implementation DLLs.
+
+We reuse the ref depproj's in the src tree to restore and wrap the old 
+reference DLLs.
+
+New package projects are created depending on what type of project we 
+are trying to redist.
+
+Standalone packages contain a single package,  redisting ref and lib.
+
+Runtime packages with API change in latest contain a reference package 
+redisting ref, and runtime packages redisting lib.
+
+Runtime packages with no API change in latest contain runtime packages 
+redisting lib, and a validation-only package for reference.  These
+validation-only packages do not actually build any output since the live
+reference packages are sufficient (no API change).
+
+In any case where we needed to insert a version that would collide with 
+the latest package version we bumped up the current package version.
+
+Here's a table of what is contained here:
+
+Package name | UWP RTM version | Live version | What we need to ship
+-------------|-----------------|--------------|---------------------
+System.Collections | 4.0.10.0 | 4.0.11.0 | runtime packages
+System.Collections.Concurrent | 4.0.10.0 | 4.0.11.0 | pre-versioned standalone package
+System.Diagnostics.Tracing | 4.0.20.0 | 4.1.0.0 | pre-versioned ref + runtime packages
+System.Dynamic.Runtime | 4.0.10.0 | 4.0.11.0 | runtime packages
+System.IO | 4.0.10.0 | 4.1.0.0 | pre-versioned ref + runtime packages
+System.Linq | 4.0.0.0 | 4.0.1.0 | pre-versioned standalone package
+System.Linq.Expressions | 4.0.10.0 | 4.0.11.0 | runtime packages
+System.ObjectModel | 4.0.10.0 | 4.0.11.0 | pre-versioned standalone package
+System.Reflection.Extensions | 4.0.0.0 | 4.0.1.0 | runtime packages
+System.Reflection.Primitives | 4.0.0.0 | 4.0.1.0 | runtime packages
+System.Reflection.TypeExtensions | 4.0.0.0 | 4.1.0.0 | pre-versioned ref + runtime packages
+System.Resources.ResourceManager | 4.0.0.0 | 4.0.1.0 | runtime packages
+System.Runtime.Extensions | 4.0.10.0 | 4.1.0.0 | pre-versioned ref + runtime packages
+System.Runtime | 4.0.20.0 | 4.1.0.0 | pre-versioned ref + runtime packages
+System.Text.RegularExpressions | 4.0.10.0 | 4.0.11.0 | pre-versioned standalone package

--- a/src/System.Collections.Concurrent/ref/4.0.10/System.Collections.Concurrent.depproj
+++ b/src/System.Collections.Concurrent/ref/4.0.10/System.Collections.Concurrent.depproj
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETPlatform,Version=v5.4</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Collections.Concurrent/ref/4.0.10/project.json
+++ b/src/System.Collections.Concurrent/ref/4.0.10/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Collections.Concurrent": "4.0.10"
+  },
+  "frameworks": {
+    "dotnet5.4": {}
+  }
+}

--- a/src/System.Collections.Concurrent/ref/System.Collections.Concurrent.csproj
+++ b/src/System.Collections.Concurrent/ref/System.Collections.Concurrent.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <AssemblyVersion>4.0.12.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
     <NuGetTargetMoniker>.NETPlatform,Version=v5.4</NuGetTargetMoniker>

--- a/src/System.Collections.Concurrent/src/System.Collections.Concurrent.csproj
+++ b/src/System.Collections.Concurrent/src/System.Collections.Concurrent.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{96AA2060-C846-4E56-9509-E8CB9C114C8F}</ProjectGuid>
     <AssemblyName>System.Collections.Concurrent</AssemblyName>
-    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <AssemblyVersion>4.0.12.0</AssemblyVersion>
     <RootNamespace>System.Collections.Concurrent</RootNamespace>
     <DefineConstants>FEATURE_TRACING</DefineConstants>
     <PackageTargetFramework>dotnet5.4</PackageTargetFramework>

--- a/src/System.Collections.Concurrent/src/facade/System.Collections.Concurrent.csproj
+++ b/src/System.Collections.Concurrent/src/facade/System.Collections.Concurrent.csproj
@@ -7,7 +7,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Collections.Concurrent</AssemblyName>
-    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <AssemblyVersion>4.0.12.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
   </PropertyGroup>
 

--- a/src/System.Collections/ref/4.0.10/System.Collections.depproj
+++ b/src/System.Collections/ref/4.0.10/System.Collections.depproj
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETPlatform,Version=v5.4</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Collections/ref/4.0.10/project.json
+++ b/src/System.Collections/ref/4.0.10/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.10"
+  },
+  "frameworks": {
+    "dotnet5.4": {}
+  }
+}

--- a/src/System.Dynamic.Runtime/ref/4.0.10/System.Dynamic.Runtime.depproj
+++ b/src/System.Dynamic.Runtime/ref/4.0.10/System.Dynamic.Runtime.depproj
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETPlatform,Version=v5.4</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Dynamic.Runtime/ref/4.0.10/project.json
+++ b/src/System.Dynamic.Runtime/ref/4.0.10/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Dynamic.Runtime": "4.0.10"
+  },
+  "frameworks": {
+    "dotnet5.4": {}
+  }
+}

--- a/src/System.IO/ref/4.0.10/System.IO.depproj
+++ b/src/System.IO/ref/4.0.10/System.IO.depproj
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETPlatform,Version=v5.4</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.IO/ref/4.0.10/project.json
+++ b/src/System.IO/ref/4.0.10/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.IO": "4.0.10"
+  },
+  "frameworks": {
+    "dotnet5.4": {}
+  }
+}

--- a/src/System.Linq.Expressions/ref/4.0.10/System.Linq.Expressions.depproj
+++ b/src/System.Linq.Expressions/ref/4.0.10/System.Linq.Expressions.depproj
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETPlatform,Version=v5.4</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Linq.Expressions/ref/4.0.10/project.json
+++ b/src/System.Linq.Expressions/ref/4.0.10/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Linq.Expressions": "4.0.10"
+  },
+  "frameworks": {
+    "dotnet5.4": {}
+  }
+}

--- a/src/System.Linq/ref/4.0.0/System.Linq.depproj
+++ b/src/System.Linq/ref/4.0.0/System.Linq.depproj
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>dotnet5.1</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETPlatform,Version=v5.1</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Linq/ref/4.0.0/project.json
+++ b/src/System.Linq/ref/4.0.0/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Linq": "4.0.0"
+  },
+  "frameworks": {
+    "dotnet5.1": {}
+  }
+}

--- a/src/System.Linq/ref/System.Linq.csproj
+++ b/src/System.Linq/ref/System.Linq.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>dotnet5.1</PackageTargetFramework>
     <NuGetTargetMoniker>.NETPlatform,Version=v5.1</NuGetTargetMoniker>

--- a/src/System.Linq/src/System.Linq.csproj
+++ b/src/System.Linq/src/System.Linq.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{CA488507-3B6E-4494-B7BE-7B4EEEB2C4D1}</ProjectGuid>
     <AssemblyName>System.Linq</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <RootNamespace>System.Linq</RootNamespace>
     <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
   </PropertyGroup>

--- a/src/System.Linq/src/facade/System.Linq.csproj
+++ b/src/System.Linq/src/facade/System.Linq.csproj
@@ -7,7 +7,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Linq</AssemblyName>
-    <AssemblyVersion>4.0.1.0</AssemblyVersion>
+    <AssemblyVersion>4.0.2.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
   </PropertyGroup>
 

--- a/src/System.ObjectModel/ref/4.0.10/System.ObjectModel.depproj
+++ b/src/System.ObjectModel/ref/4.0.10/System.ObjectModel.depproj
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETPlatform,Version=v5.4</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.ObjectModel/ref/4.0.10/project.json
+++ b/src/System.ObjectModel/ref/4.0.10/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.ObjectModel": "4.0.10"
+  },
+  "frameworks": {
+    "dotnet5.4": {}
+  }
+}

--- a/src/System.ObjectModel/ref/System.ObjectModel.csproj
+++ b/src/System.ObjectModel/ref/System.ObjectModel.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <AssemblyVersion>4.0.12.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
     <NuGetTargetMoniker>.NETPlatform,Version=v5.4</NuGetTargetMoniker>

--- a/src/System.ObjectModel/src/System.ObjectModel.csproj
+++ b/src/System.ObjectModel/src/System.ObjectModel.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{F24D3391-2928-4E83-AADE-A4461E5CAE50}</ProjectGuid>
     <AssemblyName>System.ObjectModel</AssemblyName>
-    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <AssemblyVersion>4.0.12.0</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
   </PropertyGroup>

--- a/src/System.ObjectModel/src/facade/System.ObjectModel.csproj
+++ b/src/System.ObjectModel/src/facade/System.ObjectModel.csproj
@@ -7,7 +7,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.ObjectModel</AssemblyName>
-    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <AssemblyVersion>4.0.12.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
   </PropertyGroup>
 

--- a/src/System.Reflection.Extensions/ref/4.0.0/System.Reflection.Extensions.depproj
+++ b/src/System.Reflection.Extensions/ref/4.0.0/System.Reflection.Extensions.depproj
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>dotnet5.1</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETPlatform,Version=v5.1</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection.Extensions/ref/4.0.0/project.json
+++ b/src/System.Reflection.Extensions/ref/4.0.0/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Reflection.Extensions": "4.0.0"
+  },
+  "frameworks": {
+    "dotnet5.1": {}
+  }
+}

--- a/src/System.Reflection.Primitives/ref/4.0.0/System.Reflection.Primitives.depproj
+++ b/src/System.Reflection.Primitives/ref/4.0.0/System.Reflection.Primitives.depproj
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>dotnet5.1</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETPlatform,Version=v5.1</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection.Primitives/ref/4.0.0/project.json
+++ b/src/System.Reflection.Primitives/ref/4.0.0/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Reflection.Primitives": "4.0.0"
+  },
+  "frameworks": {
+    "dotnet5.1": {}
+  }
+}

--- a/src/System.Reflection.TypeExtensions/ref/4.0.0/System.Reflection.TypeExtensions.depproj
+++ b/src/System.Reflection.TypeExtensions/ref/4.0.0/System.Reflection.TypeExtensions.depproj
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETPlatform,Version=v5.4</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Reflection.TypeExtensions/ref/4.0.0/project.json
+++ b/src/System.Reflection.TypeExtensions/ref/4.0.0/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Reflection.TypeExtensions": "4.0.0"
+  },
+  "frameworks": {
+    "dotnet5.1": {}
+  }
+}

--- a/src/System.Resources.ResourceManager/ref/4.0.0/System.Resources.ResourceManager.depproj
+++ b/src/System.Resources.ResourceManager/ref/4.0.0/System.Resources.ResourceManager.depproj
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>dotnet5.1</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETPlatform,Version=v5.1</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Resources.ResourceManager/ref/4.0.0/project.json
+++ b/src/System.Resources.ResourceManager/ref/4.0.0/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Resources.ResourceManager": "4.0.0"
+  },
+  "frameworks": {
+    "dotnet5.1": {}
+  }
+}

--- a/src/System.Runtime.Extensions/ref/4.0.10/System.Runtime.Extensions.depproj
+++ b/src/System.Runtime.Extensions/ref/4.0.10/System.Runtime.Extensions.depproj
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETPlatform,Version=v5.4</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime.Extensions/ref/4.0.10/project.json
+++ b/src/System.Runtime.Extensions/ref/4.0.10/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Runtime.Extensions": "4.0.10"
+  },
+  "frameworks": {
+    "dotnet5.4": {}
+  }
+}

--- a/src/System.Runtime/ref/4.0.20/System.Runtime.depproj
+++ b/src/System.Runtime/ref/4.0.20/System.Runtime.depproj
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.20.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETPlatform,Version=v5.4</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Runtime/ref/4.0.20/project.json
+++ b/src/System.Runtime/ref/4.0.20/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Runtime": "4.0.20"
+  },
+  "frameworks": {
+    "dotnet5.4": {}
+  }
+}

--- a/src/System.Text.RegularExpressions/ref/4.0.10/System.Text.RegularExpressions.depproj
+++ b/src/System.Text.RegularExpressions/ref/4.0.10/System.Text.RegularExpressions.depproj
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyVersion>4.0.10.0</AssemblyVersion>
+    <OutputType>Library</OutputType>
+    <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
+    <NuGetTargetMoniker>.NETPlatform,Version=v5.4</NuGetTargetMoniker>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Text.RegularExpressions/ref/4.0.10/project.json
+++ b/src/System.Text.RegularExpressions/ref/4.0.10/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Text.RegularExpressions": "4.0.10"
+  },
+  "frameworks": {
+    "dotnet5.4": {}
+  }
+}

--- a/src/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.csproj
+++ b/src/System.Text.RegularExpressions/ref/System.Text.RegularExpressions.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <AssemblyVersion>4.0.12.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
     <NuGetTargetMoniker>.NETPlatform,Version=v5.4</NuGetTargetMoniker>

--- a/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
+++ b/src/System.Text.RegularExpressions/src/System.Text.RegularExpressions.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ProjectGuid>{BE28323E-327A-4E0F-B7F9-16AB7EAB59DD}</ProjectGuid>
     <AssemblyName>System.Text.RegularExpressions</AssemblyName>
-    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <AssemblyVersion>4.0.12.0</AssemblyVersion>
     <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->

--- a/src/System.Text.RegularExpressions/src/facade/System.Text.RegularExpressions.csproj
+++ b/src/System.Text.RegularExpressions/src/facade/System.Text.RegularExpressions.csproj
@@ -7,7 +7,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <AssemblyName>System.Text.RegularExpressions</AssemblyName>
-    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <AssemblyVersion>4.0.12.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
   </PropertyGroup>
 


### PR DESCRIPTION
These contain the same libraries shipped at UWP RTM, repackaged in the
latest nuget format (netstandard, runtime packages, etc).

We use them as the baseline for package dependencies so that we can have
CoreFx packages use updated packages with netstandard support without
breaking shared library.

Directory structure:
Folder per package that will be redistributed.

Lib folder contains a deployment project (depproj) to restore and wrap
the old implementation DLLs.

We reuse the ref depproj's in the src tree to restore and wrap the old
reference DLLs.

New package projects are created depending on what type of project we
are trying to redist.

Standalone packages contain a single package,  redisting ref and lib.

Runtime packages with API change in latest contain a reference package
redisting ref, and runtime packages redisting lib.

Runtime packages with no API change in latest contain runtime packages
redisting lib, and a validation-only package for reference.  These
validation-only packages do not actually build any output since the live
reference packages are sufficient (no API change).

In any case where we needed to insert a version that would collide with
the latest package version we bumped up the current package version.

Here's a table of what is contained here:

Package name | UWP RTM version | Live version | What we need to ship
-------------|-----------------|--------------|---------------------
System.Collections | 4.0.10.0 | 4.0.11.0 | runtime packages
System.Collections.Concurrent | 4.0.10.0 | 4.0.11.0 | pre-versioned standalone package
System.Diagnostics.Tracing | 4.0.20.0 | 4.1.0.0 | pre-versioned ref + runtime packages
System.Dynamic.Runtime | 4.0.10.0 | 4.0.11.0 | runtime packages
System.IO | 4.0.10.0 | 4.1.0.0 | pre-versioned ref + runtime packages
System.Linq | 4.0.0.0 | 4.0.1.0 | pre-versioned standalone package
System.Linq.Expressions | 4.0.10.0 | 4.0.11.0 | runtime packages
System.ObjectModel | 4.0.10.0 | 4.0.11.0 | pre-versioned standalone package
System.Reflection.Extensions | 4.0.0.0 | 4.0.1.0 | runtime packages
System.Reflection.Primitives | 4.0.0.0 | 4.0.1.0 | runtime packages
System.Reflection.TypeExtensions | 4.0.0.0 | 4.1.0.0 | pre-versioned ref + runtime packages
System.Resources.ResourceManager | 4.0.0.0 | 4.0.1.0 | runtime packages
System.Runtime.Extensions | 4.0.10.0 | 4.1.0.0 | pre-versioned ref + runtime packages
System.Runtime | 4.0.20.0 | 4.1.0.0 | pre-versioned ref + runtime packages
System.Text.RegularExpressions | 4.0.10.0 | 4.0.11.0 | pre-versioned standalone package

This is part of the work for https://github.com/dotnet/corefx/issues/5707.  /cc @weshaggard @chcosta 