### PR TITLE
Fix HttpClientHandler UseDefaultCredentials=false

### DIFF
--- a/src/Common/tests/System/Net/HttpTestServers.cs
+++ b/src/Common/tests/System/Net/HttpTestServers.cs
@@ -37,6 +37,16 @@ namespace System.Net.Tests
         public readonly static object[][] CompressedServers = { new object[] { RemoteDeflateServer }, new object[] { RemoteGZipServer } };
         public readonly static object[][] Http2Servers = { new object[] { new Uri("https://" + Http2Host) } };
 
+        public static Uri NegotiateAuthUriForDefaultCreds(bool secure)
+        {
+            return new Uri(
+                string.Format(
+                    "{0}://{1}/{2}?auth=negotiate",
+                    secure ? HttpsScheme : HttpScheme,
+                    Host,
+                    EchoHandler));
+        }
+
         public static Uri BasicAuthUriForCreds(bool secure, string userName, string password)
         {
             return new Uri(

--- a/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpClientHandler.Windows.cs
@@ -84,12 +84,18 @@ namespace System.Net.Http
             {
                 if (value)
                 {
+                    _winHttpHandler.DefaultProxyCredentials = CredentialCache.DefaultCredentials;
                     _winHttpHandler.ServerCredentials = CredentialCache.DefaultCredentials;
                 }
-                else if (_winHttpHandler.ServerCredentials == CredentialCache.DefaultCredentials)
+                else
                 {
-                    // Only clear out the ServerCredentials property if it was a DefaultCredentials.
-                    _winHttpHandler.ServerCredentials = null;
+                    _winHttpHandler.DefaultProxyCredentials = null;
+
+                    if (_winHttpHandler.ServerCredentials == CredentialCache.DefaultCredentials)
+                    {
+                        // Only clear out the ServerCredentials property if it was a DefaultCredentials.
+                        _winHttpHandler.ServerCredentials = null;
+                    }
                 }
             }
         }

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -116,6 +116,25 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task UseDefaultCredentials_SetToFalseAndServerNeedsAuth_StatusCodeUnauthorized(bool useProxy)
+        {
+            var handler = new HttpClientHandler();
+            handler.UseProxy = useProxy;
+            handler.UseDefaultCredentials = false;
+            using (var client = new HttpClient(handler))
+            {
+                Uri uri = HttpTestServers.NegotiateAuthUriForDefaultCreds(secure:false);
+                _output.WriteLine("Uri: {0}", uri);
+                using (HttpResponseMessage response = await client.GetAsync(uri))
+                {
+                    Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+                }
+            }
+        }
+
         [Theory, MemberData("EchoServers")]
         public async Task SendAsync_SimpleGet_Success(Uri remoteServer)
         {


### PR DESCRIPTION
HttpClientHandler (on Windows) was attempting to use default credentials against a server that needed auth even when the property .UseDefaultCredentials was set to false.

In order to map the different HttpClientHandler properties to the WinHttpHandler properties, the HttpClientHandler .UseDefaultCredentials. needs to turn on/off two credentials related properties of WinHttpHandler, .ServerCredentials and .DefaultProxyCredentials. However, it was only toggling the single .ServerCredentials property. The fix is to update both properties accordingly.

Fixes #5045.