### PR TITLE
Permit ECDH keys in ECDsaCng objects for PFX compatibility

### DIFF
--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDsaCng.Key.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDsaCng.Key.cs
@@ -44,7 +44,7 @@ namespace System.Security.Cryptography
             {
                 CngKey key = value;
                 Debug.Assert(key != null, "key != null");
-                if (key.AlgorithmGroup != CngAlgorithmGroup.ECDsa)
+                if (!IsEccAlgorithmGroup(key.AlgorithmGroup))
                     throw new ArgumentException(SR.Cryptography_ArgECDsaRequiresECDsaKey, "value");
                 _core.SetKey(key);
                 KeySize = key.KeySize;

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDsaCng.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/ECDsaCng.cs
@@ -43,7 +43,7 @@ namespace System.Security.Cryptography
             if (key == null)
                 throw new ArgumentNullException("key");
 
-            if (key.AlgorithmGroup != CngAlgorithmGroup.ECDsa)
+            if (!IsEccAlgorithmGroup(key.AlgorithmGroup))
                 throw new ArgumentException(SR.Cryptography_ArgECDsaRequiresECDsaKey, "key");
 
             Key = CngAlgorithmCore.Duplicate(key);
@@ -60,6 +60,16 @@ namespace System.Security.Cryptography
         protected override void Dispose(bool disposing)
         {
             _core.Dispose();
+        }
+
+        private static bool IsEccAlgorithmGroup(CngAlgorithmGroup algorithmGroup)
+        {
+            // Sometimes, when reading from certificates, ECDSA keys get identified as ECDH.
+            // Windows allows the ECDH keys to perform both key exchange (ECDH) and signing (ECDSA),
+            // so either value is acceptable for the ECDSA wrapper object.
+            //
+            // It is worth noting, however, that ECDSA-identified keys cannot be used for key exchange (ECDH) in CNG.
+            return algorithmGroup == CngAlgorithmGroup.ECDsa || algorithmGroup == CngAlgorithmGroup.ECDiffieHellman;
         }
 
         private CngAlgorithmCore _core;

--- a/src/System.Security.Cryptography.Cng/tests/TestData.cs
+++ b/src/System.Security.Cryptography.Cng/tests/TestData.cs
@@ -45,13 +45,16 @@ namespace System.Security.Cryptography.Cng.Tests
                + "183e9ae8b6d5308a78da207c6e556af2053983321a5f8ac057b787089ee783c99093b9f2afb2f9a1e9a560ad3095b9667aa6"
                + "99fa").HexToByteArray(), CngKeyBlobFormat.GenericPrivateBlob);
 
+        internal static readonly byte[] s_ecdsa521KeyBlob =
+             ("454353364200000001f9f06ea4e00fd3fecc1753af7983b43cb9b692941ee6364616c9c4168845fce804beca7aa23d0a5049"
+            + "910db45dfb61112f4cb02e93ff62af1be203ad248dd70952015ddc31d1ad7411ca5996b8b76a40ea65f286c665225114bec8"
+            + "557365aa4bc79358f8c68b873cb76a1c86a5a394185d8eeb9602b8b968db1e4ac49b7cc51f83c7170055ad9b0b2d0d5d2306"
+            + "a66bf87a256a3739696121eb131e64ae61991ea23db99b397c32df95efb0cb284147a929c65e9f671073ca3c7a084cb9211d"
+            + "ceb06c987277").HexToByteArray();
+
         public static readonly CngKey s_ECDsa521Key =
             CngKey.Import(
-                ("454353364200000001f9f06ea4e00fd3fecc1753af7983b43cb9b692941ee6364616c9c4168845fce804beca7aa23d0a5049"
-               + "910db45dfb61112f4cb02e93ff62af1be203ad248dd70952015ddc31d1ad7411ca5996b8b76a40ea65f286c665225114bec8"
-               + "557365aa4bc79358f8c68b873cb76a1c86a5a394185d8eeb9602b8b968db1e4ac49b7cc51f83c7170055ad9b0b2d0d5d2306"
-               + "a66bf87a256a3739696121eb131e64ae61991ea23db99b397c32df95efb0cb284147a929c65e9f671073ca3c7a084cb9211d"
-               + "ceb06c987277").HexToByteArray(), CngKeyBlobFormat.GenericPrivateBlob);
+                s_ecdsa521KeyBlob, CngKeyBlobFormat.GenericPrivateBlob);
 
         public static readonly byte[] s_hashSha1 = ("77dbd8b3ef3084e1cc475c8bf955a972214b5f36").HexToByteArray();
         public static readonly byte[] s_hashSha512 = 


### PR DESCRIPTION
When Windows cannot determine that a private key is ECDSA-only it calls
the key ECDH, but the ECDH key handle can be used for both key
agreement and signatures.  Therefore, to interop with ECC PFX files created
on other systems, we should allow both ECDH and ECDSA keys into the
ECDsaCng object.

While this is the entirety of the code required to address #3771, the tests can't be added at this time due to PFX reading being in a downstream contract.  So I'll leave that issue open as "add the tests"