### PR TITLE
Test fixes for System.Net.Security

### DIFF
--- a/src/Common/tests/Common.Tests.csproj
+++ b/src/Common/tests/Common.Tests.csproj
@@ -60,6 +60,17 @@
     <Compile Include="Tests\System\Runtime\InteropServices\NativeBufferTests.cs" />
     <Compile Include="Tests\System\Runtime\InteropServices\StringBufferTests.cs" />
     <Compile Include="Tests\System\Runtime\InteropServices\SafeHeapHandleCacheTests.cs" />
+    <Compile Include="System\Net\Sockets\Fletcher32.cs">
+      <Link>System\Net\Sockets\Fletcher32.cs</Link>
+    </Compile>
+    <Compile Include="System\Net\VirtualNetwork\VirtualNetwork.cs">
+      <Link>System\Net\VirtualNetwork\VirtualNetwork.cs</Link>
+    </Compile>
+    <Compile Include="System\Net\VirtualNetwork\VirtualNetworkStream.cs">
+      <Link>System\Net\VirtualNetwork\VirtualNetworkStream.cs</Link>
+    </Compile>
+    <Compile Include="Tests\System\Net\VirtualNetworkTest.cs" />
+    <Compile Include="Tests\System\Net\VirtualNetworkStreamTest.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetsWindows)'=='true'">
     <Compile Include="$(CommonPath)\System\IO\PathInternal.Windows.cs">

--- a/src/Common/tests/System/Net/HttpTestServers.cs
+++ b/src/Common/tests/System/Net/HttpTestServers.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
-namespace System.Net.Tests
+namespace System.Net.Test.Common
 {
     internal class HttpTestServers
     {

--- a/src/Common/tests/System/Net/WebSocketTestServers.cs
+++ b/src/Common/tests/System/Net/WebSocketTestServers.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-namespace System.Net.Tests
+namespace System.Net.Test.Common
 {
     internal class WebSocketTestServers
     {

--- a/src/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs
+++ b/src/Common/tests/System/Threading/Tasks/TaskTimeoutExtensions.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+/// <summary>
+/// Task timeout helper based on http://blogs.msdn.com/b/pfxteam/archive/2011/11/10/10235834.aspx
+/// </summary>
+namespace System.Threading.Tasks
+{
+    public static class TaskTimeoutExtensions
+    {
+        public static async Task TimeoutAfter(this Task task, int millisecondsTimeout)
+        {
+            var cts = new CancellationTokenSource();
+
+            if (task == await Task.WhenAny(task, Task.Delay(millisecondsTimeout, cts.Token)))
+            {
+                cts.Cancel();
+                await task;
+            }
+            else
+            {
+                throw new TimeoutException();
+            }
+        }
+    }
+}

--- a/src/Common/tests/Tests/System/Net/VirtualNetworkStreamTest.cs
+++ b/src/Common/tests/Tests/System/Net/VirtualNetworkStreamTest.cs
@@ -1,0 +1,145 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Net.Sockets.Tests;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace System.Net.Test.Common
+{
+    public class VirtualNetworkStreamTest
+    {
+        [Fact]
+        public void VirtualNetworkStream_SingleThreadIntegrityTest_Ok()
+        {
+            var rnd = new Random();
+            var network = new VirtualNetwork();
+
+            using (var client = new VirtualNetworkStream(network, isServer: false))
+            using (var server = new VirtualNetworkStream(network, isServer: true))
+            {
+                for (int i = 0; i < 100000; i++)
+                {
+                    int bufferSize = rnd.Next(1, 2048);
+
+                    byte[] writeFrame = new byte[bufferSize];
+                    rnd.NextBytes(writeFrame);
+                    uint writeChecksum = Fletcher32.Checksum(writeFrame, 0, writeFrame.Length);
+                    client.Write(writeFrame, 0, writeFrame.Length);
+
+                    var readFrame = new byte[writeFrame.Length];
+                    server.Read(readFrame, 0, readFrame.Length);
+                    uint readChecksum = Fletcher32.Checksum(readFrame, 0, readFrame.Length);
+
+                    Assert.Equal(writeChecksum, readChecksum);
+                }
+            }
+        }
+
+        [Fact]
+        public void VirtualNetworkStream_WriteMoreThanRead_Ok()
+        {
+            var network = new VirtualNetwork();
+
+            using (var client = new VirtualNetworkStream(network, isServer: false))
+            using (var server = new VirtualNetworkStream(network, isServer: true))
+            {
+                var writeFrame = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+                int expectedReceivedBytes = writeFrame.Length / 2;
+
+                client.Write(writeFrame, 0, expectedReceivedBytes);
+
+                var readFrame = new byte [expectedReceivedBytes];
+                server.Read(readFrame, 0, expectedReceivedBytes);
+
+                var expectedFrame = new byte[expectedReceivedBytes];
+                Array.Copy(writeFrame, expectedFrame, expectedReceivedBytes);
+
+                Assert.Equal(expectedFrame, readFrame);
+            }
+        }
+
+        [Fact]
+        public void VirtualNetworkStream_ReadMoreThanWrite_Ok()
+        {
+            var network = new VirtualNetwork();
+
+            using (var client = new VirtualNetworkStream(network, isServer: false))
+            using (var server = new VirtualNetworkStream(network, isServer: true))
+            {
+                var writeFrame = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+                int frame1Len = writeFrame.Length / 2;
+
+                client.Write(writeFrame, 0, frame1Len);
+                client.Write(writeFrame, frame1Len, writeFrame.Length - frame1Len);
+
+                int expectedReceivedBytes = writeFrame.Length;
+                var readFrame = new byte[expectedReceivedBytes];
+
+                int bytesRead = 0;
+
+                do
+                {
+                    bytesRead += server.Read(readFrame, bytesRead, expectedReceivedBytes - bytesRead);
+                }
+                while (bytesRead < expectedReceivedBytes); 
+
+                Assert.Equal(writeFrame, readFrame);
+            }
+        }
+
+        [Fact]
+        public void VirtualNetworkStream_MultiThreadIntegrityTest_Ok()
+        {
+            int maxFrameSize = 2048;
+            Assert.True(maxFrameSize > sizeof(int) + 1);
+
+            var rnd = new Random();
+            var network = new VirtualNetwork();
+            var checksumAndLengths = new ConcurrentDictionary<int, Tuple<uint, int>>();
+
+            object readLock = new object();
+
+            using (var client = new VirtualNetworkStream(network, isServer: false))
+            using (var server = new VirtualNetworkStream(network, isServer: true))
+            {
+                Parallel.For(0, 100000, async (int i) =>
+                {
+                    int bufferSize = rnd.Next(sizeof(int) + 1, maxFrameSize);
+
+                    byte[] writeFrame = new byte[bufferSize];
+                    rnd.NextBytes(writeFrame);
+
+                    // First 4 bytes represent the sequence number.
+                    byte[] sequenceNo = BitConverter.GetBytes(i);
+                    sequenceNo.CopyTo(writeFrame, 0);
+
+                    uint writeChecksum = Fletcher32.Checksum(writeFrame, 0, writeFrame.Length);
+                    var writeFrameInfo = new Tuple<uint, int>(writeChecksum, writeFrame.Length);
+
+                    checksumAndLengths.AddOrUpdate(i, writeFrameInfo, (seq, checkSum) => { Debug.Fail("Attempt to update checksum."); return new Tuple<uint, int>(0, 0); });
+
+                    await client.WriteAsync(writeFrame, 0, writeFrame.Length);
+                    
+                    int delayMilliseconds = rnd.Next(0, 10);
+                    await Task.Delay(delayMilliseconds);
+
+                    // First read the index to know how much data to read from this frame.
+                    var readFrame = new byte[maxFrameSize];
+                    int readLen = await server.ReadAsync(readFrame, 0, maxFrameSize);
+
+                    int idx = BitConverter.ToInt32(readFrame, 0);
+                    Tuple<uint, int> expectedFrameInfo = checksumAndLengths[idx];
+
+                    Assert.Equal(expectedFrameInfo.Item2, readLen);
+                    uint readChecksum = Fletcher32.Checksum(readFrame, 0, readLen);
+                    Assert.Equal(expectedFrameInfo.Item1, readChecksum);
+                });
+            }
+        }
+    }
+}

--- a/src/Common/tests/Tests/System/Net/VirtualNetworkTest.cs
+++ b/src/Common/tests/Tests/System/Net/VirtualNetworkTest.cs
@@ -1,0 +1,79 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Net.Sockets.Tests;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace System.Net.Test.Common
+{
+    public class VirtualNetworkTest
+    {
+        [Fact]
+        public void VirtualNetwork_SingleThreadIntegrityTest_Ok()
+        {
+            var rnd = new Random();
+
+            var network = new VirtualNetwork();
+
+            for (int i = 0; i < 100000; i++)
+            {
+                int bufferSize = rnd.Next(1, 2048);
+
+                byte [] writeFrame = new byte[bufferSize];
+                rnd.NextBytes(writeFrame);
+                uint writeChecksum = Fletcher32.Checksum(writeFrame, 0, writeFrame.Length);
+
+                network.WriteFrame(i % 2 == 0, writeFrame);
+
+                byte [] readFrame;
+                network.ReadFrame(i % 2 == 1, out readFrame);
+
+                uint readChecksum = Fletcher32.Checksum(readFrame, 0, readFrame.Length);
+
+                Assert.Equal(writeChecksum, readChecksum);
+            }
+        }
+
+        [Fact]
+        public void VirtualNetwork_MultiThreadIntegrityTest_Ok()
+        {
+            var rnd = new Random();
+
+            var network = new VirtualNetwork();
+            var checksums = new ConcurrentDictionary<int, uint>();
+
+            Parallel.For(0, 100000, async (int i) =>
+            {
+                int bufferSize = rnd.Next(5, 2048);
+
+                byte[] writeFrame = new byte[bufferSize];
+                rnd.NextBytes(writeFrame);
+                
+                // First 4 bytes represent the sequence number.
+                byte [] sequenceNo = BitConverter.GetBytes(i);
+                sequenceNo.CopyTo(writeFrame, 0);
+
+                uint writeChecksum = Fletcher32.Checksum(writeFrame, 0, writeFrame.Length);
+                checksums.AddOrUpdate(i, writeChecksum, (seq, checkSum) => { Debug.Fail("Attempt to update checksum."); return 0; });
+
+                network.WriteFrame(i % 2 == 0, writeFrame);
+
+                int delayMilliseconds = rnd.Next(0, 1000);
+                await Task.Delay(delayMilliseconds);
+
+                byte[] readFrame;
+                network.ReadFrame(i % 2 == 1, out readFrame);
+
+                uint readChecksum = Fletcher32.Checksum(readFrame, 0, readFrame.Length);
+
+                int idx = BitConverter.ToInt32(readFrame, 0);
+                Assert.Equal(checksums[idx], readChecksum);
+            });
+        }
+    }
+}

--- a/src/Common/tests/project.json
+++ b/src/Common/tests/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "System.Collections.Concurrent": "4.0.10",
     "System.Diagnostics.Contracts": "4.0.0",
     "System.Diagnostics.Debug": "4.0.10",
     "System.Globalization": "4.0.10",
@@ -12,6 +13,7 @@
     "System.Runtime.Handles": "4.0.0",
     "System.Runtime.InteropServices": "4.0.20",
     "System.Threading.Tasks": "4.0.10",
+    "System.Threading.Tasks.Parallel": "4.0.0",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ServerCertificateTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/ServerCertificateTest.cs
@@ -7,7 +7,7 @@ using System.ComponentModel;
 using System.Net;
 using System.Net.Http;
 using System.Net.Security;
-using System.Net.Tests;
+using System.Net.Test.Common;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;

--- a/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/FunctionalTests/WinHttpHandlerTest.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Net;
 using System.Net.Http;
-using System.Net.Tests;
+using System.Net.Test.Common;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientHandlerTest.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.IO;
 using System.Net.Http.Headers;
-using System.Net.Tests;
+using System.Net.Test.Common;
 using System.Security.Authentication.ExtendedProtection;
 using System.Text;
 using System.Threading;

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Net;
 using System.Net.Http;
-using System.Net.Tests;
+using System.Net.Test.Common;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/PostScenarioTest.cs
@@ -5,7 +5,7 @@
 using System;
 using System.IO;
 using System.Net.Http.Headers;
-using System.Net.Tests;
+using System.Net.Test.Common;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;

--- a/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.IO;
-using System.Net.Tests;
+using System.Net.Test.Common;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
+++ b/src/System.Net.NameResolution/tests/PalTests/NameResolutionPalTests.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Net.Sockets;
-using System.Net.Tests;
+using System.Net.Test.Common;
 using Xunit;
 
 namespace System.Net.NameResolution.PalTests

--- a/src/System.Net.Requests/tests/HttpWebRequestTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebRequestTest.cs
@@ -4,6 +4,7 @@
 
 using System.IO;
 using System.Net.Http;
+using System.Net.Test.Common;
 using System.Text;
 using System.Threading.Tasks;
 

--- a/src/System.Net.Requests/tests/HttpWebResponseTest.cs
+++ b/src/System.Net.Requests/tests/HttpWebResponseTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Net.Http;
+using System.Net.Test.Common;
 using System.Threading.Tasks;
 
 using Xunit;

--- a/src/System.Net.Requests/tests/RequestStreamTest.cs
+++ b/src/System.Net.Requests/tests/RequestStreamTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
+using System.Net.Test.Common;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/CertificateValidationClientServer.cs
@@ -2,14 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Net.Sockets;
 using System.Net.Test.Common;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 
 using Xunit;
-using Xunit.Abstractions;
 
 namespace System.Net.Security.Tests
 {
@@ -33,8 +31,7 @@ namespace System.Net.Security.Tests
         [InlineData(false)]
         [InlineData(true)]
         [ActiveIssue(4467, PlatformID.Windows)]
-        public async Task CertificateValidationClientServer_EndToEnd_Ok(
-            bool useClientSelectionCallback)
+        public async Task CertificateValidationClientServer_EndToEnd_Ok(bool useClientSelectionCallback)
         {
             IPEndPoint endPoint = new IPEndPoint(IPAddress.IPv6Loopback, 0);
             var server = new TcpListener(endPoint);

--- a/src/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/CertificateValidationRemoteServer.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Net.Sockets;
-using System.Net.Tests;
+using System.Net.Test.Common;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 

--- a/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
@@ -138,9 +138,8 @@ namespace System.Net.Security.Tests
                 await client.ConnectAsync(server.RemoteEndPoint.Address, server.RemoteEndPoint.Port);
                 using (SslStream sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null))
                 {
-                    Task async = sslStream.AuthenticateAsClientAsync("localhost", null, clientSslProtocols, false);
-                    Assert.True(((IAsyncResult)async).AsyncWaitHandle.WaitOne(TestConfiguration.PassingTestTimeoutMilliseconds), "Timed Out");
-                    async.GetAwaiter().GetResult();
+                    Task clientAuthTask = sslStream.AuthenticateAsClientAsync("localhost", null, clientSslProtocols, false);
+                    await clientAuthTask.TimeoutAfter(TestConfiguration.PassingTestTimeoutMilliseconds);
 
                     _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
                         client.Client.LocalEndPoint, client.Client.RemoteEndPoint,

--- a/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/NegotiateStreamStreamToStreamTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Linq;
+using System.Net.Test.Common;
 using System.Security.Principal;
 using System.Text;
 using System.Threading.Tasks;
@@ -20,10 +21,10 @@ namespace System.Net.Security.Tests
         [PlatformSpecific(PlatformID.Windows)]
         public void NegotiateStream_StreamToStream_Authentication_Success()
         {
-            MockNetwork network = new MockNetwork();
+            VirtualNetwork network = new VirtualNetwork();
 
-            using (var clientStream = new FakeNetworkStream(false, network))
-            using (var serverStream = new FakeNetworkStream(true, network))
+            using (var clientStream = new VirtualNetworkStream(network, isServer: false))
+            using (var serverStream = new VirtualNetworkStream(network, isServer: true))
             using (var client = new NegotiateStream(clientStream))
             using (var server = new NegotiateStream(serverStream))
             {
@@ -75,10 +76,10 @@ namespace System.Net.Security.Tests
         {
             string targetName = "testTargetName";
 
-            MockNetwork network = new MockNetwork();
+            VirtualNetwork network = new VirtualNetwork();
 
-            using (var clientStream = new FakeNetworkStream(false, network))
-            using (var serverStream = new FakeNetworkStream(true, network))
+            using (var clientStream = new VirtualNetworkStream(network, isServer: false))
+            using (var serverStream = new VirtualNetworkStream(network, isServer: true))
             using (var client = new NegotiateStream(clientStream))
             using (var server = new NegotiateStream(serverStream))
             {
@@ -137,10 +138,10 @@ namespace System.Net.Security.Tests
             Assert.NotEqual(emptyNetworkCredential, CredentialCache.DefaultCredentials);
             Assert.NotEqual(emptyNetworkCredential, CredentialCache.DefaultNetworkCredentials);
 
-            MockNetwork network = new MockNetwork();
+            VirtualNetwork network = new VirtualNetwork();
 
-            using (var clientStream = new FakeNetworkStream(false, network))
-            using (var serverStream = new FakeNetworkStream(true, network))
+            using (var clientStream = new VirtualNetworkStream(network, isServer: false))
+            using (var serverStream = new VirtualNetworkStream(network, isServer: true))
             using (var client = new NegotiateStream(clientStream))
             using (var server = new NegotiateStream(serverStream))
             {
@@ -195,10 +196,10 @@ namespace System.Net.Security.Tests
         public void NegotiateStream_StreamToStream_Successive_ClientWrite_Sync_Success()
         {
             byte[] recvBuf = new byte[_sampleMsg.Length];
-            MockNetwork network = new MockNetwork();
+            VirtualNetwork network = new VirtualNetwork();
 
-            using (var clientStream = new FakeNetworkStream(false, network))
-            using (var serverStream = new FakeNetworkStream(true, network))
+            using (var clientStream = new VirtualNetworkStream(network, isServer: false))
+            using (var serverStream = new VirtualNetworkStream(network, isServer: true))
             using (var client = new NegotiateStream(clientStream))
             using (var server = new NegotiateStream(serverStream))
             {
@@ -230,10 +231,10 @@ namespace System.Net.Security.Tests
         public void NegotiateStream_StreamToStream_Successive_ClientWrite_Async_Success()
         {
             byte[] recvBuf = new byte[_sampleMsg.Length];
-            MockNetwork network = new MockNetwork();
+            VirtualNetwork network = new VirtualNetwork();
 
-            using (var clientStream = new FakeNetworkStream(false, network))
-            using (var serverStream = new FakeNetworkStream(true, network))
+            using (var clientStream = new VirtualNetworkStream(network, isServer: false))
+            using (var serverStream = new VirtualNetworkStream(network, isServer: true))
             using (var client = new NegotiateStream(clientStream))
             using (var server = new NegotiateStream(serverStream))
             {
@@ -265,7 +266,7 @@ namespace System.Net.Security.Tests
         [PlatformSpecific(PlatformID.Linux | PlatformID.OSX)]
         public void NegotiateStream_Ctor_Throws()
         {
-            Assert.Throws<PlatformNotSupportedException>(() => new NegotiateStream(new FakeNetworkStream(false, null)));
+            Assert.Throws<PlatformNotSupportedException>(() => new NegotiateStream(new VirtualNetworkStream(null, isServer: false)));
         }
     }
 }

--- a/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/SslStreamStreamToStreamTest.cs
@@ -17,14 +17,14 @@ namespace System.Net.Security.Tests
     {
         private readonly byte[] _sampleMsg = Encoding.UTF8.GetBytes("Sample Test Message");
 
-        [Fact]
         [ActiveIssue(4467)]
+        [Fact]
         public void SslStream_StreamToStream_Authentication_Success()
         {
-            MockNetwork network = new MockNetwork();
+            VirtualNetwork network = new VirtualNetwork();
 
-            using (var clientStream = new FakeNetworkStream(false, network))
-            using (var serverStream = new FakeNetworkStream(true, network))
+            using (var clientStream = new VirtualNetworkStream(network, isServer: false))
+            using (var serverStream = new VirtualNetworkStream(network, isServer: true))
             using (var client = new SslStream(clientStream, false, AllowAnyServerCertificate))
             using (var server = new SslStream(serverStream))
             {
@@ -41,10 +41,10 @@ namespace System.Net.Security.Tests
         [Fact]
         public void SslStream_StreamToStream_Authentication_IncorrectServerName_Fail()
         {
-            MockNetwork network = new MockNetwork();
+            VirtualNetwork network = new VirtualNetwork();
 
-            using (var clientStream = new FakeNetworkStream(false, network))
-            using (var serverStream = new FakeNetworkStream(true, network))
+            using (var clientStream = new VirtualNetworkStream(network, isServer: false))
+            using (var serverStream = new VirtualNetworkStream(network, isServer: true))
             using (var client = new SslStream(clientStream))
             using (var server = new SslStream(serverStream))
             {
@@ -65,10 +65,10 @@ namespace System.Net.Security.Tests
         public void SslStream_StreamToStream_Successive_ClientWrite_Sync_Success()
         {
             byte[] recvBuf = new byte[_sampleMsg.Length];
-            MockNetwork network = new MockNetwork();
+            VirtualNetwork network = new VirtualNetwork();
 
-            using (var clientStream = new FakeNetworkStream(false, network))
-            using (var serverStream = new FakeNetworkStream(true, network))
+            using (var clientStream = new VirtualNetworkStream(network, isServer: false))
+            using (var serverStream = new VirtualNetworkStream(network, isServer: true))
             using (var clientSslStream = new SslStream(clientStream, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(serverStream))
             {
@@ -94,10 +94,10 @@ namespace System.Net.Security.Tests
         [ActiveIssue(5896, PlatformID.OSX)]
         public void SslStream_StreamToStream_LargeWrites_Sync_Success()
         {
-            MockNetwork network = new MockNetwork();
+            VirtualNetwork network = new VirtualNetwork();
 
-            using (var clientStream = new FakeNetworkStream(false, network))
-            using (var serverStream = new FakeNetworkStream(true, network))
+            using (var clientStream = new VirtualNetworkStream(network, isServer:false))
+            using (var serverStream = new VirtualNetworkStream(network, isServer:true))
             using (var clientSslStream = new SslStream(clientStream, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(serverStream))
             {
@@ -130,10 +130,10 @@ namespace System.Net.Security.Tests
         public void SslStream_StreamToStream_Successive_ClientWrite_Async_Success()
         {
             byte[] recvBuf = new byte[_sampleMsg.Length];
-            MockNetwork network = new MockNetwork();
+            VirtualNetwork network = new VirtualNetwork();
 
-            using (var clientStream = new FakeNetworkStream(false, network))
-            using (var serverStream = new FakeNetworkStream(true, network))
+            using (var clientStream = new VirtualNetworkStream(network, isServer: false))
+            using (var serverStream = new VirtualNetworkStream(network, isServer: true))
             using (var clientSslStream = new SslStream(clientStream, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(serverStream))
             {
@@ -160,10 +160,10 @@ namespace System.Net.Security.Tests
         [Fact]
         public void SslStream_StreamToStream_Write_ReadByte_Success()
         {
-            MockNetwork network = new MockNetwork();
+            VirtualNetwork network = new VirtualNetwork();
 
-            using (var clientStream = new FakeNetworkStream(false, network))
-            using (var serverStream = new FakeNetworkStream(true, network))
+            using (var clientStream = new VirtualNetworkStream(network, isServer:false))
+            using (var serverStream = new VirtualNetworkStream(network, isServer:true))
             using (var clientSslStream = new SslStream(clientStream, false, AllowAnyServerCertificate))
             using (var serverSslStream = new SslStream(serverStream))
             {

--- a/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
+++ b/src/System.Net.Security/tests/FunctionalTests/System.Net.Security.Tests.csproj
@@ -30,8 +30,6 @@
 
   <ItemGroup>
     <Compile Include="DummyTcpServer.cs" />
-    <Compile Include="FakeNetworkStream.cs" />
-    <Compile Include="MockNetwork.cs" />
     <Compile Include="TestConfiguration.cs" />
 
     <!-- SslStream Tests -->
@@ -72,8 +70,17 @@
     <Compile Include="$(CommonTestPath)\System\Net\EventSourceTestLogging.cs">
       <Link>Common\System\Net\EventSourceTestLogging.cs</Link>
     </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\VirtualNetwork\VirtualNetwork.cs">
+      <Link>Common\System\Net\VirtualNetwork\VirtualNetwork.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Net\VirtualNetwork\VirtualNetworkStream.cs">
+      <Link>Common\System\Net\VirtualNetwork\VirtualNetworkStream.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskAPMExtensions.cs">
       <Link>Common\System\Threading\Tasks\TaskAPMExtensions.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonTestPath)\System\Threading\Tasks\TaskTimeoutExtensions.cs">
+      <Link>Common\System\Threading\Tasks\TaskTimeoutExtensions.cs</Link>
     </Compile>
   </ItemGroup>
   

--- a/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
@@ -6,7 +6,7 @@ using Xunit;
 using Xunit.Abstractions;
 
 using System.Threading.Tasks;
-using System.Net.Tests;
+using System.Net.Test.Common;
 using System.Text;
 
 namespace System.Net.Sockets.Tests

--- a/src/System.Net.WebSockets.Client/tests/ClientWebSocketTest.cs
+++ b/src/System.Net.WebSockets.Client/tests/ClientWebSocketTest.cs
@@ -3,7 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Net.Tests;
+using System.Net.Test.Common;
 using System.Threading;
 using System.Threading.Tasks;
 


### PR DESCRIPTION
* Renaming/moving the `VirtualNetwork/Stream` classes.
* A few concurrency fixes for the `VirtualNetwork/Stream` classes.
* Adding VirtualNetwork/Stream tests.
* Adding the TaskTimeoutExtensions and correcting the timeout pattern within one of the S.N.Security tests.
* Moving all common test code within the System.Net.Test.Common namespace.

@davidsh @stephentoub @shrutigarg PTAL