### PR TITLE
Updates ArrayPool comments and names

### DIFF
--- a/src/System.Buffers/src/System/Buffers/DefaultArrayPool.cs
+++ b/src/System.Buffers/src/System/Buffers/DefaultArrayPool.cs
@@ -2,18 +2,22 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics.Tracing;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Threading;
-
 namespace System.Buffers
 {
     internal sealed class DefaultArrayPool<T> : ArrayPool<T>
     {
-        private const int MinimiumArraySize = 16;
-        private DefaultArrayPoolBucket<T>[] _buckets;
+        /// <summary>The default maximum number of arrays per bucket that are available for rent.</summary>
+        private const int DefaultMaxNumberOfArraysPerBucket = 50;
+        /// <summary>The default maximum length of each array in the pool (2^20).</summary>
+        private const int DefaultMaxArrayLength = 1024 * 1024;
+        /// <summary>The minimum length of an array in the pool.</summary>
+        private const int MinimumArrayLength = 16;
+
+        private readonly DefaultArrayPoolBucket<T>[] _buckets;
+
+        internal DefaultArrayPool() : this(DefaultMaxArrayLength, DefaultMaxNumberOfArraysPerBucket)
+        {
+        }
 
         internal DefaultArrayPool(int maxLength, int arraysPerBucket)
         {
@@ -23,8 +27,8 @@ namespace System.Buffers
                 throw new ArgumentOutOfRangeException("arraysPerBucket");
 
             // Our bucketing algorithm has a minimum length of 16
-            if (maxLength < MinimiumArraySize)
-                maxLength = MinimiumArraySize;
+            if (maxLength < MinimumArrayLength)
+                maxLength = MinimumArrayLength;
 
             int maxBuckets = Utilities.SelectBucketIndex(maxLength);
             _buckets = new DefaultArrayPoolBucket<T>[maxBuckets + 1];

--- a/src/System.Buffers/src/System/Buffers/Utilities.cs
+++ b/src/System.Buffers/src/System/Buffers/Utilities.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Runtime.CompilerServices;
 
 namespace System.Buffers


### PR DESCRIPTION
- A parameter name in the public ArrayPool surface area was incorrect: ````numberOfArrays``` implied that was how many arrays could be stored in the whole pool, whereas it's actually the number per bucket (and the pool can have multiple buckets).
- Some of the (non-public) comments were wrong, e.g. stating that each array was of a fixed max length, whereas that's actually the max length an array can be and frequently they're shorter
- Some of the constant names were similarly misleading
- Other comments benefited from more elaboration

Fixes https://github.com/dotnet/corefx/pull/5816/files#r51691088
cc: @sokket, @benaadams

@sokket, @KrzysztofCwalina, as I was updating these, it struck me that we've exposed this "bucket" concept through the APIs, but only partially.  We don't describe the bucketing scheme imposed by the pool, which also means a developer using Create to create their own instance doesn't actually know the maximum number of arrays that'll be stored, since the max number is maxNumberOfBuckets*maxArraysPerBucket, but we don't expose the ability to control or even know what maxNumberOfBuckets is.  Thoughts?  I realize some of the speed of the implementation comes from being able to translate from an array length to a bucket quickly, but I wonder if, given appropriate thought, we could devise a way to still keep that speed while also enabling a developer to control the number of buckets, e.g. a Create method like:
```C#
public static ArrayPool<T> Create(params KeyValuePair<int, int>[] buckets)
{
    foreach (KeyValuePair<int, int> bucket in buckets)
    {
        int maxArrays = bucket.Key;
        int maxArrayLength = bucket.Value;
        ...
    }
}
```
We could potentially do this with another internal ```ArrayPool<T>```-derived type, leaving the current default optimized for the current we-control-the-number-of-buckets case, and having another ```CustomizedBucketsArrayPool<T>``` created by this factory method.  This Create would allow developers more control.  For example, if they know they're going to need lots of 4K buffers and want to store lots of those, but don't expect to need many 1MB buffers and only want to hold onto at most a couple of those.  Or potentially they expect to have lots of 6K buffers, and don't want to pay the extra overhead of us automatically rounding each of those up to 8K.  Etc.

Seems like if we're going to expose the "buckets" concept in the API (which we implicitly do, even before my naming change, via the Create(int, int) overload), we need to more fully describe it and potentially allow control of it.