### PR TITLE
Disable Unix workarounds for Connect'ing to multiple endpoints

### DIFF
--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -75,6 +75,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BeginConnect_EndPoint_AddressFamily_Throws_NotSupported()
         {
             Assert.Throws<NotSupportedException>(() => GetSocket(AddressFamily.InterNetwork).BeginConnect(new DnsEndPoint("localhost", 1, AddressFamily.InterNetworkV6), TheAsyncCallback, null));
@@ -94,6 +95,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BeginConnect_Host_ListeningSocket_Throws_InvalidOperation()
         {
             using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
@@ -143,6 +145,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void BeginConnect_IPAddresses_ListeningSocket_Throws_InvalidOperation()
         {
             using (var socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DnsEndPointTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DnsEndPointTest.cs
@@ -15,6 +15,7 @@ namespace System.Net.Sockets.Tests
         private const int UnusedPort = 8;
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void Socket_ConnectDnsEndPoint_Success()
         {
             int port;
@@ -28,6 +29,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void Socket_ConnectDnsEndPoint_Failure()
         {
             using (Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
@@ -80,6 +82,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void Socket_BeginConnectDnsEndPoint_Success()
         {
             int port;
@@ -94,6 +97,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void Socket_BeginConnectDnsEndPoint_Failure()
         {
             using (Socket sock = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
@@ -139,6 +143,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void Socket_ConnectAsyncDnsEndPoint_Success()
         {
             int port;
@@ -168,6 +173,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void Socket_ConnectAsyncDnsEndPoint_HostNotFound()
         {
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
@@ -192,6 +198,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
         public void Socket_ConnectAsyncDnsEndPoint_ConnectionRefused()
         {
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
@@ -218,7 +225,6 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        [ActiveIssue(4002, PlatformID.AnyUnix)]
         public void Socket_StaticConnectAsync_Success()
         {
             Assert.True(Capability.IPv6Support() && Capability.IPv4Support());
@@ -228,7 +234,7 @@ namespace System.Net.Sockets.Tests
             SocketTestServer server6 = SocketTestServer.SocketTestServerFactory(IPAddress.IPv6Loopback, out port6);
 
             SocketAsyncEventArgs args = new SocketAsyncEventArgs();
-            args.RemoteEndPoint = new DnsEndPoint("localhost", port4);
+            args.RemoteEndPoint = new DnsEndPoint("127.0.0.1", port4);
             args.Completed += OnConnectAsyncCompleted;
 
             ManualResetEvent complete = new ManualResetEvent(false);
@@ -246,7 +252,7 @@ namespace System.Net.Sockets.Tests
 
             args.ConnectSocket.Dispose();
 
-            args.RemoteEndPoint = new DnsEndPoint("localhost", port6);
+            args.RemoteEndPoint = new DnsEndPoint("::1", port6);
             complete.Reset();
 
             Assert.True(Socket.ConnectAsync(SocketType.Stream, ProtocolType.Tcp, args));

--- a/src/System.Net.Sockets/src/Resources/Strings.resx
+++ b/src/System.Net.Sockets/src/Resources/Strings.resx
@@ -273,4 +273,7 @@
   <data name="ArgumentOutOfRange_Bounds_Lower_Upper" xml:space="preserve">
     <value>Argument must be between {0} and {1}.</value>
   </data>
+  <data name="net_sockets_connect_multiaddress_notsupported" xml:space="preserve">
+    <value>Sockets on this platform are invalid for use after a failed connection attempt, and as a result do not support attempts to connect to multiple endpoints.  Use the static Connect methods or the instance Connect methods that take a single, non-DNS endpoint.</value>
+  </data>
 </root>

--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
@@ -198,7 +198,7 @@
     <Compile Include="System\Net\Sockets\Socket.Windows.cs" />
     <Compile Include="System\Net\Sockets\SocketAsyncEventArgs.Windows.cs" />
     <Compile Include="System\Net\Sockets\SocketPal.Windows.cs" />
-
+    <Compile Include="System\Net\Sockets\TCPClient.Windows.cs" />
     <Compile Include="$(CommonPath)\System\Net\SafeCloseSocket.Windows.cs">
       <Link>Common\System\Net\SafeCloseSocket.Windows.cs</Link>
     </Compile>    
@@ -347,7 +347,7 @@
     <Compile Include="System\Net\Sockets\SocketAsyncEngine.Unix.cs" />
     <Compile Include="System\Net\Sockets\SocketAsyncEventArgs.Unix.cs" />
     <Compile Include="System\Net\Sockets\SocketPal.Unix.cs" />
-
+    <Compile Include="System\Net\Sockets\TCPClient.Unix.cs" />
     <Compile Include="$(CommonPath)\System\Net\ContextAwareResult.Unix.cs">
       <Link>Common\System\Net\ContextAwareResult.Unix.cs</Link>
     </Compile>

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -2,16 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections.Generic;
 using System.Collections;
-using System.ComponentModel;
+using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
-using System.IO;
-using System.Net;
 using System.Runtime.InteropServices;
-using System.Threading.Tasks;
-using System.Threading;
 
 namespace System.Net.Sockets
 {
@@ -38,7 +32,6 @@ namespace System.Net.Sockets
             //       - SocketError.OperationNotSupported
             //       - SocketError.ProtocolFamilyNotSupported
             //       - SocketError.NoBufferSpaceAvailable
-            //       - SocketError.Shutdown
             //       - SocketError.HostDown
             //       - SocketError.ProcessLimit
             //
@@ -60,6 +53,7 @@ namespace System.Net.Sockets
                 case Interop.Error.EFAULT:
                     return SocketError.Fault;
 
+                case Interop.Error.EBADF:
                 case Interop.Error.EINVAL:
                     return SocketError.InvalidArgument;
 
@@ -133,6 +127,9 @@ namespace System.Net.Sockets
 
                 case Interop.Error.EHOSTUNREACH:
                     return SocketError.HostUnreachable;
+
+                case Interop.Error.EPIPE:
+                    return SocketError.Shutdown;
 
                 default:
                     return SocketError.SocketError;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Unix.cs
@@ -1,0 +1,424 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Net.Sockets
+{
+    partial class TcpClient
+    {
+        // The Unix implementation is separate from the Windows implementation due to a fundamental
+        // difference in socket support on the two platforms: on Unix once a socket has been used
+        // in a failed connect, its state is undefined and it can no longer be used (Windows supports
+        // this).  This then means that the instance Socket.Connect methods that take either multiple
+        // addresses or a string host name that could be mapped to multiple addresses via DNS don't
+        // work, because we can't try to individually connect to a second address after failing the
+        // first.  That then impacts TcpClient, which exposes not only such Connect methods that
+        // just delegate to the underlying Socket, but also the Socket itself.
+        //
+        // To address the most common cases, where the Socket isn't actually accessed directly by
+        // a consumer of TcpClient, whereas on Windows TcpClient creates the socket during construction,
+        // on Unix we create the socket on-demand, either when it's explicitly asked for via the Client
+        // property or when the TcpClient.Connect methods are called.  In the former case, we have no
+        // choice but to create a Socket, after which point we'll throw PlatformNotSupportedException
+        // on any subsequent attempts to use Connect with multiple addresses.  In the latter case, though,
+        // we can create a new Socket for each address we try, and only store as the "real" Client socket
+        // the one that successfully connected.
+        //
+        // However, TcpClient also exposes some properties for common configuration of the Socket, and
+        // if we simply forwarded those through Client, we'd frequently end up forcing the Socket's
+        // creation before Connect is used, thwarting this whole scheme.  To address that, we maintain
+        // shadow values for the relevant state.  When the properties are read, we read them initially
+        // from a temporary socket created just for the purpose of getting the system's default. When
+        // the properties are written, we store their values into these shadow properties instead of into
+        // an actual socket (though we do also create a temporary socket and store the property onto it,
+        // enabling errors to be caught earlier).  This is a relatively expensive, but it enables
+        // TcpClient to be used in its recommended fashion and with its most popular APIs.
+
+        // Shadow values for storing data set through TcpClient's properties.
+        // We use a separate bool field to store whether the value has been set.
+        // We don't use nullables, due to one of the properties being a refernece type.
+
+        private int _exclusiveAddressUse;
+        private bool _exclusiveAddressUseInitialized;
+
+        private int _receiveBufferSize;
+        private bool _receiveBufferSizeInitialized;
+
+        private int _sendBufferSize;
+        private bool _sendBufferSizeInitialized;
+
+        private int _receiveTimeout;
+        private bool _receiveTimeoutInitialized;
+
+        private int _sendTimeout;
+        private bool _sendTimeoutInitialized;
+
+        private LingerOption _lingerState;
+        private bool _lingerStateInitialized;
+
+        private int _noDelay;
+        private bool _noDelayInitialized;
+
+        private int _connectRunning; // tracks whether a connect operation that could set _clientSocket is currently running
+
+        private void InitializeClientSocket()
+        {
+            // Nop.  We want to lazily-allocate the socket.
+        }
+
+        private Socket ClientCore
+        {
+            get
+            {
+                EnterClientLock();
+                try
+                {
+                    // The Client socket is being explicitly accessed, so we're forced
+                    // to create it if it doesn't exist.
+                    if (_clientSocket == null)
+                    {
+                        // Create the socket, and transfer to it any of our shadow properties.
+                        _clientSocket = CreateSocket();
+                        TransferInitializedValuesToSocket(_clientSocket);
+                    }
+                    return _clientSocket;
+                }
+                finally
+                {
+                    ExitClientLock();
+                }
+            }
+            set
+            {
+                EnterClientLock();
+                try
+                {
+                    _clientSocket = value;
+                    ClearInitializedValues();
+                }
+                finally
+                {
+                    ExitClientLock();
+                }
+            }
+        }
+
+        private void TransferInitializedValuesToSocket(Socket socket)
+        {
+            // For each shadow property where we have an initialized value,
+            // transfer that value to the provided socket.
+
+            if (_exclusiveAddressUseInitialized)
+            {
+                socket.ExclusiveAddressUse = _exclusiveAddressUse != 0;
+            }
+
+            if (_receiveBufferSizeInitialized)
+            {
+                socket.ReceiveBufferSize = _receiveBufferSize;
+            }
+
+            if (_sendBufferSizeInitialized)
+            {
+                socket.SendBufferSize = _sendBufferSize;
+            }
+
+            if (_receiveTimeoutInitialized)
+            {
+                socket.ReceiveTimeout = _receiveTimeout;
+            }
+
+            if (_sendTimeoutInitialized)
+            {
+                socket.SendTimeout = _sendTimeout;
+            }
+
+            if (_lingerStateInitialized)
+            {
+                socket.LingerState = _lingerState;
+            }
+
+            if (_noDelayInitialized)
+            {
+                socket.NoDelay = _noDelay != 0;
+            }
+        }
+
+        private void ClearInitializedValues()
+        {
+            // Clear the initialized fields for all of our shadow properties.
+            _exclusiveAddressUseInitialized =
+                _receiveBufferSizeInitialized =
+                _sendBufferSizeInitialized =
+                _receiveTimeoutInitialized =
+                _sendTimeoutInitialized =
+                _lingerStateInitialized =
+                _noDelayInitialized =
+                false;
+        }
+
+        private int AvailableCore
+        {
+            get
+            {
+                // If we have a client socket, return its available value.
+                // Otherwise, there isn't data available, so return 0.
+                return _clientSocket != null ? _clientSocket.Available : 0;
+            }
+        }
+
+        private bool ConnectedCore
+        {
+            get
+            {
+                // If we have a client socket, return whether it's connected.
+                // Otherwise as we don't have a socket, by definition it's not.
+                return _clientSocket != null ? _clientSocket.Connected : false;
+            }
+        }
+
+        private Task ConnectAsyncCore(string host, int port)
+        {
+            // Validate the args, similar to how Socket.Connect(string, int) would.
+            if (host == null)
+            {
+                throw new ArgumentNullException("host");
+            }
+            if (!TcpValidationHelpers.ValidatePortNumber(port))
+            {
+                throw new ArgumentOutOfRangeException("port");
+            }
+
+            // If the client socket has already materialized, this API can't be used.
+            if (_clientSocket != null)
+            {
+                throw new PlatformNotSupportedException(SR.net_sockets_connect_multiaddress_notsupported);
+            }
+
+            // Do the real work.
+            EnterClientLock();
+            return ConnectAsyncCorePrivate(host, port);
+        }
+
+        private async Task ConnectAsyncCorePrivate(string host, int port)
+        {
+            try
+            {
+                // Since Socket.Connect(host, port) won't work, get the addresses manually,
+                // and then delegate to Connect(IPAddress[], int).
+                IPAddress[] addresses = await Dns.GetHostAddressesAsync(host).ConfigureAwait(false);
+                await ConnectAsyncCorePrivate(addresses, port).ConfigureAwait(false);
+            }
+            finally
+            {
+                ExitClientLock();
+            }
+        }
+
+        private Task ConnectAsyncCore(IPAddress[] addresses, int port)
+        {
+            // Validate the args, similar to how Socket.Connect(IPAddress[], int) would.
+            if (addresses == null)
+            {
+                throw new ArgumentNullException("addresses");
+            }
+            if (addresses.Length == 0)
+            {
+                throw new ArgumentException(SR.net_invalidAddressList, "addresses");
+            }
+            if (!TcpValidationHelpers.ValidatePortNumber(port))
+            {
+                throw new ArgumentOutOfRangeException("port");
+            }
+
+            // If the client socket has already materialized, this API can't be used.
+            // Similarly if another operation to set the socket is already in progress.
+            if (_clientSocket != null)
+            {
+                throw new PlatformNotSupportedException(SR.net_sockets_connect_multiaddress_notsupported);
+            }
+
+            // Do the real work.
+            EnterClientLock();
+            return ConnectAsyncCorePrivate(addresses, port);
+        }
+
+        private async Task ConnectAsyncCorePrivate(IPAddress[] addresses, int port)
+        {
+            try
+            {
+                // For each address, create a new socket (configured appropriately) and try to connect
+                // to the endpoint.  If we're successful, set the newly connected socket as the client
+                // socket, and we're done.  If we're unsuccessful, try the next address.
+                ExceptionDispatchInfo lastException = null;
+                foreach (IPAddress address in addresses)
+                {
+                    try
+                    {
+                        Socket s = CreateSocket();
+                        TransferInitializedValuesToSocket(s);
+                        await s.ConnectAsync(address, port).ConfigureAwait(false);
+
+                        _clientSocket = s;
+                        _active = true;
+
+                        return;
+                    }
+                    catch (Exception exc)
+                    {
+                        lastException = ExceptionDispatchInfo.Capture(exc);
+                    }
+                }
+
+                // None of the addresses worked.  Throw whatever exception we last captured, or a
+                // new one if something went terribly wrong.
+
+                if (lastException != null)
+                {
+                    lastException.Throw();
+                }
+
+                throw new ArgumentException(SR.net_invalidAddressList, "addresses");
+            }
+            finally
+            {
+                ExitClientLock();
+            }
+        }
+
+        private int ReceiveBufferSizeCore
+        {
+            get { return GetOption(ref _receiveBufferSize, ref _receiveBufferSizeInitialized, SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer); }
+            set { SetOption(ref _receiveBufferSize, ref _receiveBufferSizeInitialized, SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer, value); }
+        }
+
+        private int SendBufferSizeCore
+        {
+            get { return GetOption(ref _sendBufferSize, ref _sendBufferSizeInitialized, SocketOptionLevel.Socket, SocketOptionName.SendBuffer); }
+            set { SetOption(ref _sendBufferSize, ref _sendBufferSizeInitialized, SocketOptionLevel.Socket, SocketOptionName.SendBuffer, value); }
+        }
+
+        private int ReceiveTimeoutCore
+        {
+            get { return GetOption(ref _receiveTimeout, ref _receiveTimeoutInitialized, SocketOptionLevel.Socket, SocketOptionName.ReceiveTimeout); }
+            set { SetOption(ref _receiveTimeout, ref _receiveTimeoutInitialized, SocketOptionLevel.Socket, SocketOptionName.ReceiveTimeout, value); }
+        }
+
+        private int SendTimeoutCore
+        {
+            get { return GetOption(ref _sendTimeout, ref _sendTimeoutInitialized, SocketOptionLevel.Socket, SocketOptionName.SendTimeout); }
+            set { SetOption(ref _sendTimeout, ref _sendTimeoutInitialized, SocketOptionLevel.Socket, SocketOptionName.SendTimeout, value); }
+        }
+
+        private LingerOption LingerStateCore
+        {
+            get { return GetOption(ref _lingerState, ref _lingerStateInitialized, SocketOptionLevel.Socket, SocketOptionName.Linger); }
+            set { SetOption(ref _lingerState, ref _lingerStateInitialized, SocketOptionLevel.Socket, SocketOptionName.Linger, value); }
+        }
+
+        private bool NoDelayCore
+        {
+            get { return GetOption(ref _noDelay, ref _noDelayInitialized, SocketOptionLevel.Tcp, SocketOptionName.NoDelay) != 0; }
+            set { SetOption(ref _noDelay, ref _noDelayInitialized, SocketOptionLevel.Tcp, SocketOptionName.NoDelay, value ? 1 : 0); }
+        }
+
+        private bool ExclusiveAddressUseCore
+        {
+            get
+            {
+                return GetOption(ref _exclusiveAddressUse, ref _exclusiveAddressUseInitialized, SocketOptionLevel.Socket, SocketOptionName.ExclusiveAddressUse) != 0;
+            }
+            set
+            {
+                // Unlike the rest of the properties, we code this one explicitly, so as to take advantage of validation done by Socket's property.
+                _exclusiveAddressUse = value ? 1 : 0;
+                _exclusiveAddressUseInitialized = true;
+                if (_clientSocket != null)
+                {
+                    _clientSocket.ExclusiveAddressUse = value; // Use setter explicitly as it does additional validation beyond that done by SetOption
+                }
+            }
+        }
+
+        private T GetOption<T>(ref T location, ref bool initialized, SocketOptionLevel level, SocketOptionName name)
+        {
+            // Used in the getter for each shadow property.  
+
+            // If we already have our client socket set up, just get its value for the option.  
+            // Otherwise, return our shadow property.  If that shadow hasn't yet been initialized, 
+            // first initialize it by creating a temporary socket from which we can obtain a default value.
+
+            if (_clientSocket != null)
+            {
+                return (T)_clientSocket.GetSocketOption(level, name);
+            }
+
+            if (!initialized)
+            {
+                using (Socket s = CreateSocket())
+                {
+                    location = (T)s.GetSocketOption(level, name);
+                }
+                initialized = true;
+            }
+
+            return location;
+        }
+
+        private void SetOption<T>(ref T location, ref bool initialized, SocketOptionLevel level, SocketOptionName name, T value)
+        {
+            // Used in the setter for each shadow property.
+
+            // Store the value into our shadow
+            location = value;
+            initialized = true;
+
+            // Then store the option on to the client socket.  If the client socket isn't yet set, we still want to set
+            // the property onto a socket so we can get validation performed by the underlying system on the option being
+            // set... so, albeit being a bit expensive, we create a temporary socket we can use for validation purposes.
+            Socket s = _clientSocket ?? CreateSocket();
+            try
+            {
+                if (typeof(T) == typeof(int))
+                {
+                    s.SetSocketOption(level, name, (int)(object)value);
+                }
+                else
+                {
+                    Debug.Assert(typeof(T) == typeof(LingerOption));
+                    s.SetSocketOption(level, name, value);
+                }
+            }
+            finally
+            {
+                if (s != _clientSocket)
+                {
+                    s.Dispose();
+                }
+            }
+        }
+
+        private void EnterClientLock()
+        {
+            // TcpClient is not safe to be used concurrently.  But in case someone does access various members
+            // while an async Connect operation is running that could asynchronously transition _clientSocket
+            // from null to non-null, we have a simple lock... if it's taken when you try to take it, it throws
+            // a PlatformNotSupportedException indicating the limitations of Connect.
+            if (Interlocked.CompareExchange(ref _connectRunning, 1, 0) != 0)
+            {
+                throw new PlatformNotSupportedException(SR.net_sockets_connect_multiaddress_notsupported);
+            }
+        }
+
+        private void ExitClientLock()
+        {
+            Volatile.Write(ref _connectRunning, 0);
+        }
+
+    }
+}

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Windows.cs
@@ -1,0 +1,175 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+
+namespace System.Net.Sockets
+{
+    partial class TcpClient
+    {
+        private void InitializeClientSocket()
+        {
+            Client = CreateSocket();
+        }
+
+        // Used by the class to provide the underlying network socket.
+        private Socket ClientCore
+        {
+            get
+            {
+                return _clientSocket;
+            }
+            set
+            {
+                _clientSocket = value;
+            }
+        }
+
+        private int AvailableCore { get { return _clientSocket.Available; } }
+
+        private bool ConnectedCore { get { return _clientSocket.Connected; } }
+
+        private bool ExclusiveAddressUseCore
+        {
+            get
+            {
+                return _clientSocket.ExclusiveAddressUse;
+            }
+            set
+            {
+                _clientSocket.ExclusiveAddressUse = value;
+            }
+        }
+
+        private IAsyncResult BeginConnect(string host, int port, AsyncCallback requestCallback, object state)
+        {
+            if (NetEventSource.Log.IsEnabled())
+            {
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginConnect", host);
+            }
+
+            IAsyncResult result = Client.BeginConnect(host, port, requestCallback, state);
+            if (NetEventSource.Log.IsEnabled())
+            {
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginConnect", null);
+            }
+
+            return result;
+        }
+
+        private IAsyncResult BeginConnect(IPAddress[] addresses, int port, AsyncCallback requestCallback, object state)
+        {
+            if (NetEventSource.Log.IsEnabled())
+            {
+                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginConnect", addresses);
+            }
+
+            IAsyncResult result = Client.BeginConnect(addresses, port, requestCallback, state);
+            if (NetEventSource.Log.IsEnabled())
+            {
+                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginConnect", null);
+            }
+
+            return result;
+        }
+
+        private Task ConnectAsyncCore(string host, int port)
+        {
+            return Task.Factory.FromAsync(
+                (targetHost, targetPort, callback, state) => ((TcpClient)state).BeginConnect(targetHost, targetPort, callback, state),
+                asyncResult => ((TcpClient)asyncResult.AsyncState).EndConnect(asyncResult),
+                host,
+                port,
+                state: this);
+        }
+
+        private Task ConnectAsyncCore(IPAddress[] addresses, int port)
+        {
+            return Task.Factory.FromAsync(
+                (targetAddresses, targetPort, callback, state) => ((TcpClient)state).BeginConnect(targetAddresses, targetPort, callback, state),
+                asyncResult => ((TcpClient)asyncResult.AsyncState).EndConnect(asyncResult),
+                addresses,
+                port,
+                state: this);
+        }
+
+        // Gets or sets the size of the receive buffer in bytes.
+        private int ReceiveBufferSizeCore
+        {
+            get
+            {
+                return (int)Client.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer);
+            }
+            set
+            {
+                Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer, value);
+            }
+        }
+
+        // Gets or sets the size of the send buffer in bytes.
+        private int SendBufferSizeCore
+        {
+            get
+            {
+                return (int)Client.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.SendBuffer);
+            }
+            set
+            {
+                Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.SendBuffer, value);
+            }
+        }
+
+        // Gets or sets the receive time out value of the connection in milliseconds.
+        private int ReceiveTimeoutCore
+        {
+            get
+            {
+                return (int)Client.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveTimeout);
+            }
+            set
+            {
+                Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveTimeout, value);
+            }
+        }
+
+        // Gets or sets the send time out value of the connection in milliseconds.
+        private int SendTimeoutCore
+        {
+            get
+            {
+                return (int)Client.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.SendTimeout);
+            }
+            set
+            {
+                Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.SendTimeout, value);
+            }
+        }
+
+        // Gets or sets the value of the connection's linger option.
+        private LingerOption LingerStateCore
+        {
+            get
+            {
+                return (LingerOption)Client.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Linger);
+            }
+            set
+            {
+                Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Linger, value);
+            }
+        }
+
+        // Enables or disables delay when send or receive buffers are full.
+        private bool NoDelayCore
+        {
+            get
+            {
+                return (int)Client.GetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.NoDelay) != 0;
+            }
+            set
+            {
+                Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.NoDelay, value ? 1 : 0);
+            }
+        }
+    }
+}

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
@@ -289,6 +289,5 @@ namespace System.Net.Sockets
         {
             return new Socket(_family, SocketType.Stream, ProtocolType.Tcp);
         }
-
     }
 }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
@@ -2,7 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace System.Net.Sockets
@@ -10,29 +10,17 @@ namespace System.Net.Sockets
     // The System.Net.Sockets.TcpClient class provide TCP services at a higher level
     // of abstraction than the System.Net.Sockets.Socket class. System.Net.Sockets.TcpClient
     // is used to create a Client connection to a remote host.
-    public class TcpClient : IDisposable
+    public partial class TcpClient : IDisposable
     {
+        private readonly AddressFamily _family;
         private Socket _clientSocket;
-        private bool _active;
         private NetworkStream _dataStream;
-
-        // IPv6: Maintain address family for the client.
-        private AddressFamily _family = AddressFamily.InterNetwork;
-
+        private bool _cleanedUp = false;
+        private bool _active;
 
         // Initializes a new instance of the System.Net.Sockets.TcpClient class.
-        public TcpClient()
-            : this(AddressFamily.InterNetwork)
+        public TcpClient() : this(AddressFamily.InterNetwork)
         {
-            if (NetEventSource.Log.IsEnabled())
-            {
-                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "TcpClient", null);
-            }
-
-            if (NetEventSource.Log.IsEnabled())
-            {
-                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "TcpClient", null);
-            }
         }
 
         // Initializes a new instance of the System.Net.Sockets.TcpClient class.
@@ -50,8 +38,8 @@ namespace System.Net.Sockets
             }
 
             _family = family;
+            InitializeClientSocket();
 
-            initialize();
             if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "TcpClient", null);
@@ -66,8 +54,9 @@ namespace System.Net.Sockets
                 NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "TcpClient", acceptedSocket);
             }
 
-            Client = acceptedSocket;
+            _clientSocket = acceptedSocket;
             _active = true;
+
             if (NetEventSource.Log.IsEnabled())
             {
                 NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "TcpClient", null);
@@ -75,62 +64,51 @@ namespace System.Net.Sockets
         }
 
         // Used by the class to provide the underlying network socket.
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)] // TODO: Remove once https://github.com/dotnet/corefx/issues/5868 is addressed.
         public Socket Client
         {
-            get
-            {
-                return _clientSocket;
-            }
-            set
-            {
-                _clientSocket = value;
-            }
+            get { return ClientCore; }
+            set { ClientCore = value; }
         }
 
         // Used by the class to indicate that a connection has been made.
         protected bool Active
         {
-            get
-            {
-                return _active;
-            }
-            set
-            {
-                _active = value;
-            }
+            get { return _active; }
+            set { _active = value; }
         }
 
-        public int Available { get { return _clientSocket.Available; } }
-        public bool Connected { get { return _clientSocket.Connected; } }
+        public int Available { get { return AvailableCore; } }
+
+        public bool Connected { get { return ConnectedCore; } }
+
         public bool ExclusiveAddressUse
         {
-            get
-            {
-                return _clientSocket.ExclusiveAddressUse;
-            }
-            set
-            {
-                _clientSocket.ExclusiveAddressUse = value;
-            }
+            get { return ExclusiveAddressUseCore; }
+            set { ExclusiveAddressUseCore = value; }
         }
 
-        internal IAsyncResult BeginConnect(string host, int port, AsyncCallback requestCallback, object state)
+        public Task ConnectAsync(IPAddress address, int port)
         {
-            if (NetEventSource.Log.IsEnabled())
-            {
-                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginConnect", host);
-            }
-
-            IAsyncResult result = Client.BeginConnect(host, port, requestCallback, state);
-            if (NetEventSource.Log.IsEnabled())
-            {
-                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginConnect", null);
-            }
-
-            return result;
+            return Task.Factory.FromAsync(
+                (targetAddess, targetPort, callback, state) => ((TcpClient)state).BeginConnect(targetAddess, targetPort, callback, state),
+                asyncResult => ((TcpClient)asyncResult.AsyncState).EndConnect(asyncResult),
+                address,
+                port,
+                state: this);
         }
 
-        internal IAsyncResult BeginConnect(IPAddress address, int port, AsyncCallback requestCallback, object state)
+        public Task ConnectAsync(string host, int port)
+        {
+            return ConnectAsyncCore(host, port);
+        }
+
+        public Task ConnectAsync(IPAddress[] addresses, int port)
+        {
+            return ConnectAsyncCore(addresses, port);
+        }
+
+        private IAsyncResult BeginConnect(IPAddress address, int port, AsyncCallback requestCallback, object state)
         {
             if (NetEventSource.Log.IsEnabled())
             {
@@ -146,23 +124,7 @@ namespace System.Net.Sockets
             return result;
         }
 
-        internal IAsyncResult BeginConnect(IPAddress[] addresses, int port, AsyncCallback requestCallback, object state)
-        {
-            if (NetEventSource.Log.IsEnabled())
-            {
-                NetEventSource.Enter(NetEventSource.ComponentType.Socket, this, "BeginConnect", addresses);
-            }
-
-            IAsyncResult result = Client.BeginConnect(addresses, port, requestCallback, state);
-            if (NetEventSource.Log.IsEnabled())
-            {
-                NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "BeginConnect", null);
-            }
-
-            return result;
-        }
-
-        internal void EndConnect(IAsyncResult asyncResult)
+        private void EndConnect(IAsyncResult asyncResult)
         {
             if (NetEventSource.Log.IsEnabled())
             {
@@ -175,36 +137,6 @@ namespace System.Net.Sockets
             {
                 NetEventSource.Exit(NetEventSource.ComponentType.Socket, this, "EndConnect", null);
             }
-        }
-
-        public Task ConnectAsync(IPAddress address, int port)
-        {
-            return Task.Factory.FromAsync(
-                (targetAddess, targetPort, callback, state) => ((TcpClient)state).BeginConnect(targetAddess, targetPort, callback, state),
-                asyncResult => ((TcpClient)asyncResult.AsyncState).EndConnect(asyncResult),
-                address,
-                port,
-                state: this);
-        }
-
-        public Task ConnectAsync(string host, int port)
-        {
-            return Task.Factory.FromAsync(
-                (targetHost, targetPort, callback, state) => ((TcpClient)state).BeginConnect(targetHost, targetPort, callback, state),
-                asyncResult => ((TcpClient)asyncResult.AsyncState).EndConnect(asyncResult),
-                host,
-                port,
-                state: this);
-        }
-
-        public Task ConnectAsync(IPAddress[] addresses, int port)
-        {
-            return Task.Factory.FromAsync(
-                (targetAddresses, targetPort, callback, state) => ((TcpClient)state).BeginConnect(targetAddresses, targetPort, callback, state),
-                asyncResult => ((TcpClient)asyncResult.AsyncState).EndConnect(asyncResult),
-                addresses,
-                port,
-                state: this);
         }
 
         // Returns the stream used to read and write data to the remote host.
@@ -237,8 +169,6 @@ namespace System.Net.Sockets
             return _dataStream;
         }
 
-        private bool _cleanedUp = false;
-
         // Disposes the Tcp connection.
         protected virtual void Dispose(bool disposing)
         {
@@ -270,7 +200,7 @@ namespace System.Net.Sockets
                     // still be there and needs to be closed. In the case in which
                     // we are bound to a local IPEndPoint this will remove the
                     // binding and free up the IPEndPoint for later uses.
-                    Socket chkClientSocket = Client;
+                    Socket chkClientSocket = _clientSocket;
                     if (chkClientSocket != null)
                     {
                         try
@@ -280,7 +210,7 @@ namespace System.Net.Sockets
                         finally
                         {
                             chkClientSocket.Dispose();
-                            Client = null;
+                            _clientSocket = null;
                         }
                     }
                 }
@@ -316,96 +246,49 @@ namespace System.Net.Sockets
         // Gets or sets the size of the receive buffer in bytes.
         public int ReceiveBufferSize
         {
-            get
-            {
-                return numericOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer);
-            }
-            set
-            {
-                Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReceiveBuffer, value);
-            }
+            get { return ReceiveBufferSizeCore; }
+            set { ReceiveBufferSizeCore = value; }
         }
 
         // Gets or sets the size of the send buffer in bytes.
         public int SendBufferSize
         {
-            get
-            {
-                return numericOption(SocketOptionLevel.Socket, SocketOptionName.SendBuffer);
-            }
-
-            set
-            {
-                Client.SetSocketOption(SocketOptionLevel.Socket,
-                                  SocketOptionName.SendBuffer, value);
-            }
+            get { return SendBufferSizeCore; }
+            set { SendBufferSizeCore = value; }
         }
 
         // Gets or sets the receive time out value of the connection in milliseconds.
         public int ReceiveTimeout
         {
-            get
-            {
-                return numericOption(SocketOptionLevel.Socket,
-                                     SocketOptionName.ReceiveTimeout);
-            }
-            set
-            {
-                Client.SetSocketOption(SocketOptionLevel.Socket,
-                                  SocketOptionName.ReceiveTimeout, value);
-            }
+            get { return ReceiveTimeoutCore; }
+            set { ReceiveTimeoutCore = value; }
         }
 
         // Gets or sets the send time out value of the connection in milliseconds.
         public int SendTimeout
         {
-            get
-            {
-                return numericOption(SocketOptionLevel.Socket, SocketOptionName.SendTimeout);
-            }
-
-            set
-            {
-                Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.SendTimeout, value);
-            }
+            get { return SendTimeoutCore; }
+            set { SendTimeoutCore = value; }
         }
 
         // Gets or sets the value of the connection's linger option.
         public LingerOption LingerState
         {
-            get
-            {
-                return (LingerOption)Client.GetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Linger);
-            }
-            set
-            {
-                Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Linger, value);
-            }
+            get { return LingerStateCore; }
+            set { LingerStateCore = value; }
         }
 
         // Enables or disables delay when send or receive buffers are full.
         public bool NoDelay
         {
-            get
-            {
-                return numericOption(SocketOptionLevel.Tcp, SocketOptionName.NoDelay) != 0 ? true : false;
-            }
-            set
-            {
-                Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.NoDelay, value ? 1 : 0);
-            }
+            get { return NoDelayCore; }
+            set { NoDelayCore = value; }
         }
 
-        private void initialize()
+        private Socket CreateSocket()
         {
-            // IPv6: Use the address family from the constructor (or Connect method).
-            Client = new Socket(_family, SocketType.Stream, ProtocolType.Tcp);
-            _active = false;
+            return new Socket(_family, SocketType.Stream, ProtocolType.Tcp);
         }
 
-        private int numericOption(SocketOptionLevel optionLevel, SocketOptionName optionName)
-        {
-            return (int)Client.GetSocketOption(optionLevel, optionName);
-        }
     }
 }

--- a/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -698,5 +698,85 @@ namespace System.Net.Sockets.Tests
         {
             Assert.Throws<ArgumentNullException>(() => GetSocket().SendToAsync(s_eventArgs));
         }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public void Socket_Connect_DnsEndPoint_NotSupported()
+        {
+            using (Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => s.Connect(new DnsEndPoint("localhost", 12345)));
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public void Socket_Connect_StringHost_NotSupported()
+        {
+            using (Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => s.Connect("localhost", 12345));
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public void Socket_Connect_MultipleAddresses_NotSupported()
+        {
+            using (Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => s.Connect(new[] { IPAddress.Loopback }, 12345));
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public void Socket_ConnectAsync_DnsEndPoint_NotSupported()
+        {
+            using (Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => { s.ConnectAsync(new DnsEndPoint("localhost", 12345)); });
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public void Socket_ConnectAsync_StringHost_NotSupported()
+        {
+            using (Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => { s.ConnectAsync("localhost", 12345); });
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public void Socket_ConnectAsync_MultipleAddresses_NotSupported()
+        {
+            using (Socket s = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp))
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => { s.ConnectAsync(new[] { IPAddress.Loopback }, 12345); });
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public void TcpClient_ConnectAsync_StringHost_NotSupported()
+        {
+            using (TcpClient client = new TcpClient())
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => { client.ConnectAsync("localhost", 12345); });
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public void TcpClient_ConnectAsync_MultipleAddresses_NotSupported()
+        {
+            using (TcpClient client = new TcpClient())
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => { client.ConnectAsync(new[] { IPAddress.Loopback }, 12345); });
+            }
+        }
     }
 }

--- a/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -761,20 +761,22 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [PlatformSpecific(PlatformID.AnyUnix)]
-        public void TcpClient_ConnectAsync_StringHost_NotSupported()
+        public void TcpClient_ConnectAsync_StringHost_NotSupportedAfterClientAccess()
         {
             using (TcpClient client = new TcpClient())
             {
+                var tmp = client.Client;
                 Assert.Throws<PlatformNotSupportedException>(() => { client.ConnectAsync("localhost", 12345); });
             }
         }
 
         [Fact]
         [PlatformSpecific(PlatformID.AnyUnix)]
-        public void TcpClient_ConnectAsync_MultipleAddresses_NotSupported()
+        public void TcpClient_ConnectAsync_MultipleAddresses_NotSupportedAfterClientAccess()
         {
             using (TcpClient client = new TcpClient())
             {
+                var tmp = client.Client;
                 Assert.Throws<PlatformNotSupportedException>(() => { client.ConnectAsync(new[] { IPAddress.Loopback }, 12345); });
             }
         }

--- a/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DnsEndPointTest.cs
@@ -30,6 +30,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [Trait("IPv4", "true")]
+        [PlatformSpecific(PlatformID.Windows)]
         public void Socket_ConnectAsyncDnsEndPoint_Success()
         {
             Assert.True(Capability.IPv4Support());
@@ -59,6 +60,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [Trait("IPv4", "true")]
+        [PlatformSpecific(PlatformID.Windows)]
         public void Socket_ConnectAsyncDnsEndPoint_HostNotFound()
         {
             Assert.True(Capability.IPv4Support());
@@ -86,6 +88,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [Trait("IPv4", "true")]
+        [PlatformSpecific(PlatformID.Windows)]
         public void Socket_ConnectAsyncDnsEndPoint_ConnectionRefused()
         {
             Assert.True(Capability.IPv4Support());

--- a/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -132,26 +132,10 @@ namespace System.Net.Sockets.Tests
 
         #region ConnectAsync to DnsEndPoint
 
-        [Fact]
-        public void DualModeSocket_ConnectAsyncDnsEndPointToV4Host_Success()
-        {
-            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.Loopback, false);
-        }
-
-        [Fact]
-        [ActiveIssue(4002, PlatformID.AnyUnix)]
-        public void DualModeSocket_ConnectAsyncDnsEndPointToV6Host_Success()
-        {
-            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.IPv6Loopback, false);
-        }
-
-        [Fact]
-        public void DualModeSocket_ConnectAsyncDnsEndPointToDualHost_Success()
-        {
-            DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress.IPv6Any, true);
-        }
-
-        private void DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer)
+        [Theory]
+        [MemberData("DualMode_Connect_IPAddress_DualMode_Data")]
+        [PlatformSpecific(PlatformID.Windows)]
+        public void DualModeConnectAsync_DnsEndPointToHost_Helper(IPAddress listenOn, bool dualModeServer)
         {
             int port;
             using (Socket socket = new Socket(SocketType.Stream, ProtocolType.Tcp))
@@ -628,9 +612,15 @@ namespace System.Net.Sockets.Tests
                 GC.WaitForPendingFinalizers();
             }
         }
-        #endregion 
+        #endregion
 
         #region Helpers
+
+        public static readonly object[][] DualMode_Connect_IPAddress_DualMode_Data = {
+            new object[] { IPAddress.Loopback, false },
+            new object[] { IPAddress.IPv6Loopback, false },
+            new object[] { IPAddress.IPv6Any, true },
+        };
 
         private class SocketServer : IDisposable
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
+++ b/src/System.Net.Sockets/tests/FunctionalTests/System.Net.Sockets.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" DefaultTargets="Build">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
@@ -26,6 +26,7 @@
     <Compile Include="IPPacketInformationTest.cs" />
     <Compile Include="NetworkStreamTest.cs" />
     <Compile Include="SendReceive.cs" />
+    <Compile Include="TcpClientTest.cs" />
     <Compile Include="Shutdown.cs" />
     <Compile Include="SocketAsyncExtensions.cs" />
     <Compile Include="SocketOptionNameTest.cs" />
@@ -59,6 +60,9 @@
     </Compile>
 
     <!-- Common test files -->
+    <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers.cs">
+      <Link>Common\System\Net\HttpTestServers.cs</Link>
+    </Compile>
     <Compile Include="$(CommonTestPath)\System\Net\TestLogging.cs">
       <Link>Common\System\Net\TestLogging.cs</Link>
     </Compile>

--- a/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
@@ -29,19 +29,20 @@ namespace System.Net.Sockets.Tests
             using (TcpClient client = new TcpClient())
             {
                 Assert.False(client.Connected);
-                
-                IPAddress[] addresses = await Dns.GetHostAddressesAsync(HttpTestServers.Host);
-                switch (mode)
+
+                string host = HttpTestServers.Host;
+                const int port = 80;
+
+                if (mode == 0)
                 {
-                    case 0:
-                        await client.ConnectAsync(HttpTestServers.Host, 80);
-                        break;
-                    case 1:
-                        await client.ConnectAsync(addresses[0], 80);
-                        break;
-                    case 2:
-                        await client.ConnectAsync(addresses, 80);
-                        break;
+                    await client.ConnectAsync(host, port);
+                }
+                else
+                {
+                    IPAddress[] addresses = await Dns.GetHostAddressesAsync(host);
+                    await (mode == 1 ?
+                        client.ConnectAsync(addresses[0], port) :
+                        client.ConnectAsync(addresses, port));
                 }
 
                 Assert.True(client.Connected);
@@ -58,45 +59,94 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
-        public void Roundtrip_Properties()
+        public void ConnectedAvailable_InitialValues_Default()
         {
             using (TcpClient client = new TcpClient())
             {
                 Assert.False(client.Connected);
                 Assert.Equal(0, client.Available);
+            }
+        }
 
+        [Fact]
+        public void Roundtrip_ExclusiveAddressUse_GetEqualsSet()
+        {
+            using (TcpClient client = new TcpClient())
+            {
                 client.ExclusiveAddressUse = true;
                 Assert.True(client.ExclusiveAddressUse);
                 client.ExclusiveAddressUse = false;
                 Assert.False(client.ExclusiveAddressUse);
+            }
+        }
 
+        [Fact]
+        public void Roundtrip_LingerOption_GetEqualsSet()
+        {
+            using (TcpClient client = new TcpClient())
+            {
                 client.LingerState = new LingerOption(true, 42);
                 Assert.True(client.LingerState.Enabled);
                 Assert.Equal(42, client.LingerState.LingerTime);
                 client.LingerState = new LingerOption(false, 0);
                 Assert.False(client.LingerState.Enabled);
                 Assert.Equal(0, client.LingerState.LingerTime);
+            }
+        }
 
+        [Fact]
+        public void Roundtrip_NoDelay_GetEqualsSet()
+        {
+            using (TcpClient client = new TcpClient())
+            {
                 client.NoDelay = true;
                 Assert.True(client.NoDelay);
                 client.NoDelay = false;
                 Assert.False(client.NoDelay);
+            }
+        }
 
+        [Fact]
+        public void Roundtrip_ReceiveBufferSize_GetEqualsSet()
+        {
+            using (TcpClient client = new TcpClient())
+            {
                 client.ReceiveBufferSize = 4096;
                 Assert.Equal(4096, client.ReceiveBufferSize);
                 client.ReceiveBufferSize = 8192;
                 Assert.Equal(8192, client.ReceiveBufferSize);
+            }
+        }
 
+        [Fact]
+        public void Roundtrip_SendBufferSize_GetEqualsSet()
+        {
+            using (TcpClient client = new TcpClient())
+            {
                 client.SendBufferSize = 4096;
                 Assert.Equal(4096, client.SendBufferSize);
                 client.SendBufferSize = 8192;
                 Assert.Equal(8192, client.SendBufferSize);
+            }
+        }
 
+        [Fact]
+        public void Roundtrip_ReceiveTimeout_GetEqualsSet()
+        {
+            using (TcpClient client = new TcpClient())
+            {
                 client.ReceiveTimeout = 1;
                 Assert.Equal(1, client.ReceiveTimeout);
                 client.ReceiveTimeout = 0;
                 Assert.Equal(0, client.ReceiveTimeout);
+            }
+        }
 
+        [Fact]
+        public void Roundtrip_SendTimeout_GetEqualsSet()
+        {
+            using (TcpClient client = new TcpClient())
+            {
                 client.SendTimeout = 1;
                 Assert.Equal(1, client.SendTimeout);
                 client.SendTimeout = 0;
@@ -121,8 +171,12 @@ namespace System.Net.Sockets.Tests
                 Assert.Equal(1, client.LingerState.LingerTime);
                 Assert.Equal(42, client.ReceiveTimeout);
                 Assert.Equal(84, client.SendTimeout);
+
+                // Note: not all properties can be tested for this on all OSes, as some
+                // properties are modified by the OS, e.g. Linux will double whatever
+                // buffer size you set and return that double value.  OSes may also enforce
+                // minimums and maximums, silently capping to those amounts.
             }
         }
-
     }
 }

--- a/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
@@ -1,0 +1,128 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+using Xunit.Abstractions;
+
+using System.Threading.Tasks;
+using System.Net.Tests;
+using System.Text;
+
+namespace System.Net.Sockets.Tests
+{
+    public class TcpClientTest
+    {
+        private readonly ITestOutputHelper _log;
+
+        public TcpClientTest(ITestOutputHelper output)
+        {
+            _log = output;
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        public async Task Connect_DnsEndPoint_Success(int mode)
+        {
+            using (TcpClient client = new TcpClient())
+            {
+                Assert.False(client.Connected);
+                
+                IPAddress[] addresses = await Dns.GetHostAddressesAsync(HttpTestServers.Host);
+                switch (mode)
+                {
+                    case 0:
+                        await client.ConnectAsync(HttpTestServers.Host, 80);
+                        break;
+                    case 1:
+                        await client.ConnectAsync(addresses[0], 80);
+                        break;
+                    case 2:
+                        await client.ConnectAsync(addresses, 80);
+                        break;
+                }
+
+                Assert.True(client.Connected);
+                Assert.NotNull(client.Client);
+                Assert.Same(client.Client, client.Client);
+
+                using (NetworkStream s = client.GetStream())
+                {
+                    byte[] getRequest = Encoding.ASCII.GetBytes("GET / HTTP/1.1\r\n\r\n");
+                    await s.WriteAsync(getRequest, 0, getRequest.Length);
+                    Assert.NotEqual(-1, s.ReadByte()); // just verify we successfully get any data back
+                }
+            }
+        }
+
+        [Fact]
+        public void Roundtrip_Properties()
+        {
+            using (TcpClient client = new TcpClient())
+            {
+                Assert.False(client.Connected);
+                Assert.Equal(0, client.Available);
+
+                client.ExclusiveAddressUse = true;
+                Assert.True(client.ExclusiveAddressUse);
+                client.ExclusiveAddressUse = false;
+                Assert.False(client.ExclusiveAddressUse);
+
+                client.LingerState = new LingerOption(true, 42);
+                Assert.True(client.LingerState.Enabled);
+                Assert.Equal(42, client.LingerState.LingerTime);
+                client.LingerState = new LingerOption(false, 0);
+                Assert.False(client.LingerState.Enabled);
+                Assert.Equal(0, client.LingerState.LingerTime);
+
+                client.NoDelay = true;
+                Assert.True(client.NoDelay);
+                client.NoDelay = false;
+                Assert.False(client.NoDelay);
+
+                client.ReceiveBufferSize = 4096;
+                Assert.Equal(4096, client.ReceiveBufferSize);
+                client.ReceiveBufferSize = 8192;
+                Assert.Equal(8192, client.ReceiveBufferSize);
+
+                client.SendBufferSize = 4096;
+                Assert.Equal(4096, client.SendBufferSize);
+                client.SendBufferSize = 8192;
+                Assert.Equal(8192, client.SendBufferSize);
+
+                client.ReceiveTimeout = 1;
+                Assert.Equal(1, client.ReceiveTimeout);
+                client.ReceiveTimeout = 0;
+                Assert.Equal(0, client.ReceiveTimeout);
+
+                client.SendTimeout = 1;
+                Assert.Equal(1, client.SendTimeout);
+                client.SendTimeout = 0;
+                Assert.Equal(0, client.SendTimeout);
+            }
+        }
+
+        [Fact]
+        public async Task Properties_PersistAfterConnect()
+        {
+            using (TcpClient client = new TcpClient())
+            {
+                // Set a few properties
+                client.LingerState = new LingerOption(true, 1);
+                client.ReceiveTimeout = 42;
+                client.SendTimeout = 84;
+
+                await client.ConnectAsync(HttpTestServers.Host, 80);
+
+                // Verify their values remain as were set before connecting
+                Assert.True(client.LingerState.Enabled);
+                Assert.Equal(1, client.LingerState.LingerTime);
+                Assert.Equal(42, client.ReceiveTimeout);
+                Assert.Equal(84, client.SendTimeout);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
On unix, once connect fails on a socket, that socket becomes unusable for further operations, including additional connect attempts.  This is at direct odds with Socket's instance Connect methods, some of which allow for multiple connect attempts, either due to multiple IPAddresses being provided or due to a string hostname / DnsEndPoint being provided that could then result in multiple IPAddresses to be tried.

We've explored multiple workarounds for this, all of which have problems.  The workaround still in the code involves creating a temporary socket for each address, connecting to it, and if that's successful then immediately disconnecting and connecting with the actual socket.  But that causes mayhem for a server not expecting that pattern, e.g. that fails if the client disconnects and attempts a reconnect, e.g. #5436.

This leaves us with a few choices, none of which are great:
1. Remove the offending Connect instance methods.  Ideally they'd be replaced with static methods, which can be implemented with POSIX-compliant behavior.  But these methods are heavily used and work on Windows.
2. Always throw from the instance Connect methods when there's a possibility that multiple addresses will be tried, e.g. from Connect(IPAddress[], ...) but also from Connect(EndPoint) if a DnsEndPoint is specified.  This will break existing code that tries to run on unix, but it's also predictable in that usage of these APIs will always fail, and developers will know quickly when using a problematic API and move away from it to supported patterns.
3. Throw from the Connect methods only if multiple addresses are actually supplied, e.g. calling Connect(IPAddress[]) with an array of length 1 would work but an array of length 2 would throw. This will allow a lot more existing code to work, but it's also very unpredictable, e.g. if a string host is provided and gets mapped by DNS to a single IPAddress in the test environment but then multiple IPAddresses in the production environment, everything will work fine in test but then fail in production.

I'm torn between (2) and (3).  This commit implements the more conservative (2), as I expect (3) would actually cause serious problems for deployments, but we can loosen from (2) to (3) if that turns out to be better.  In the meantime, we should also seriously explore adding static methods for v1 for the same functionality (developers can also write such code themselves), and write guidance and helpers folks can use in the meantime, e.g. pseudo-code:
```C#
public static async Task<Socket> Connect(
    AddressFamily addressFamily, SocketType socketType, ProtocolType protocolType,
    IPAddress[] addresses, int port)
{
    Exception lastExc = null;
    foreach (IPAddress address in addresses)
    {
        Socket s = new Socket(addressFamily, socketType, protocolType);
        try
        {
            await s.ConnectAsync(address, port).ConfigureAwait(false);
            return s;
        }
        catch (Exception exc)
        {
            lastExc = exc;
        }
    }

    if (lastExc != null) throw lastExc;
    throw new ArgumentException("No addresses provided", "addresses");
}
```

cc: @ericeil, @pgavlin, @davidsh, @CIPop 
Fixes #5829 
Fixes #5436 