### PR TITLE
Clean stale [ActiveIssue]s from X509Certificates tests

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/StorePal.cs
@@ -42,8 +42,8 @@ namespace Internal.Cryptography.Pal
 
                 return ListToStorePal(certPals);
             }
-            
-            return null;
+
+            throw Interop.Crypto.CreateOpenSslCryptographicException();
         }
 
         public static IStorePal FromFile(string fileName, string password, X509KeyStorageFlags keyStorageFlags)

--- a/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CertTests.cs
@@ -48,7 +48,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(3893, PlatformID.AnyUnix)]
         public static void X509Cert2Test()
         {
             string certName = @"E=admin@digsigtrust.com, CN=ABA.ECOM Root CA, O=""ABA.ECOM, INC."", L=Washington, S=DC, C=US";
@@ -73,37 +72,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 Assert.Equal("1.2.840.113549.1.1.5", cert2.SignatureAlgorithm.Value);
                 Assert.Equal("7A74410FB0CD5C972A364B71BF031D88A6510E9E", cert2.Thumbprint);
                 Assert.Equal(3, cert2.Version);
-            }
-        }
-
-        /// <summary>
-        /// This test is for excerising X509Store and X509Chain code without actually installing any certificate 
-        /// </summary>
-        [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
-        public static void X509CertStoreChain()
-        {
-            X509Store store = new X509Store("My", StoreLocation.LocalMachine);
-            store.Open(OpenFlags.ReadOnly);
-            // can't guarantee there is a certificate in store
-            if (store.Certificates.Count > 0)
-            {
-                X509Chain chain = new X509Chain();
-                Assert.NotNull(chain.SafeHandle);
-                Assert.Same(chain.SafeHandle, chain.SafeHandle);
-                Assert.True(chain.SafeHandle.IsInvalid);
-
-                foreach (X509Certificate2 c in store.Certificates)
-                {
-                    // can't guarantee success, so no Assert 
-                    if (chain.Build(c))
-                    {
-                        foreach (X509ChainElement k in chain.ChainElements)
-                        {
-                            Assert.NotNull(k.Certificate.IssuerName.Name);
-                        }
-                    }
-                }
             }
         }
 
@@ -132,7 +100,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void X509Cert2ToStringVerbose()
         {
             using (X509Store store = new X509Store("My", StoreLocation.CurrentUser))

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -565,6 +565,13 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        public static void ImportInvalidData()
+        {
+            X509Certificate2Collection cc2 = new X509Certificate2Collection();
+            Assert.ThrowsAny<CryptographicException>(() => cc2.Import(new byte[] { 0, 1, 1, 2, 3, 5, 8, 13, 21 }));
+        }
+
+        [Fact]
         public static void ImportFromFileTests()
         {
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))

--- a/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CollectionTests.cs
@@ -473,7 +473,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ImportStoreSavedAsCerData()
         {
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
@@ -495,8 +494,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
-        public static void ImportStoreSavedAsSerializedCerData()
+        [PlatformSpecific(PlatformID.Windows)]
+        public static void ImportStoreSavedAsSerializedCerData_Windows()
         {
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
             {
@@ -517,8 +516,17 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
-        public static void ImportStoreSavedAsSerializedStoreData()
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public static void ImportStoreSavedAsSerializedCerData_Unix()
+        {
+            X509Certificate2Collection cc2 = new X509Certificate2Collection();
+            Assert.ThrowsAny<CryptographicException>(() => cc2.Import(TestData.StoreSavedAsSerializedCerData));
+            Assert.Equal(0, cc2.Count);
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public static void ImportStoreSavedAsSerializedStoreData_Windows()
         {
             using (var msCer = new X509Certificate2(TestData.MsCertificate))
             using (var pfxCer = new X509Certificate2(TestData.PfxData, TestData.PfxDataPassword))
@@ -542,7 +550,15 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public static void ImportStoreSavedAsSerializedStoreData_Unix()
+        {
+            X509Certificate2Collection cc2 = new X509Certificate2Collection();
+            Assert.ThrowsAny<CryptographicException>(() => cc2.Import(TestData.StoreSavedAsSerializedStoreData));
+            Assert.Equal(0, cc2.Count);
+        }
+
+        [Fact]
         public static void ImportStoreSavedAsPfxData()
         {
             using (var msCer = new X509Certificate2(TestData.MsCertificate))
@@ -615,16 +631,40 @@ namespace System.Security.Cryptography.X509Certificates.Tests
 
         [Fact]
         [PlatformSpecific(PlatformID.Windows)]
-        public static void ExportSerializedCert()
+        public static void ExportSerializedCert_Windows()
         {
             TestExportSingleCert(X509ContentType.SerializedCert);
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public static void ExportSerializedCert_Unix()
+        {
+            using (var msCer = new X509Certificate2(TestData.MsCertificate))
+            using (var ecdsa256Cer = new X509Certificate2(TestData.ECDsa256Certificate))
+            {
+                X509Certificate2Collection cc = new X509Certificate2Collection(new[] { msCer, ecdsa256Cer });
+                Assert.Throws<PlatformNotSupportedException>(() => cc.Export(X509ContentType.SerializedCert));
+            }
+        }
+
+        [Fact]
         [PlatformSpecific(PlatformID.Windows)]
-        public static void ExportSerializedStore()
+        public static void ExportSerializedStore_Windows()
         {
             TestExportStore(X509ContentType.SerializedStore);
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public static void ExportSerializedStore_Unix()
+        {
+            using (var msCer = new X509Certificate2(TestData.MsCertificate))
+            using (var ecdsa256Cer = new X509Certificate2(TestData.ECDsa256Certificate))
+            {
+                X509Certificate2Collection cc = new X509Certificate2Collection(new[] { msCer, ecdsa256Cer });
+                Assert.Throws<PlatformNotSupportedException>(() => cc.Export(X509ContentType.SerializedStore));
+            }
         }
 
         [Fact]
@@ -661,7 +701,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
             Assert.NotNull(exported);
         }
 
-        [ActiveIssue(2893, PlatformID.OSX)]
         [Fact]
         public static void ExportUnrelatedPfx()
         {

--- a/src/System.Security.Cryptography.X509Certificates/tests/CtorTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/CtorTests.cs
@@ -77,6 +77,27 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public static void TestByteArrayConstructor_SerializedCert_Windows()
+        {
+            const string ExpectedThumbPrint = "71CB4E2B02738AD44F8B382C93BD17BA665F9914";
+
+            using (X509Certificate2 cert = new X509Certificate2(TestData.StoreSavedAsSerializedCerData))
+            {
+                IntPtr h = cert.Handle;
+                Assert.NotEqual(IntPtr.Zero, h);
+                Assert.Equal(ExpectedThumbPrint, cert.Thumbprint);
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public static void TestByteArrayConstructor_SerializedCert_Unix()
+        {
+            Assert.ThrowsAny<CryptographicException>(() => new X509Certificate2(TestData.StoreSavedAsSerializedCerData));
+        }
+
+        [Fact]
         public static void TestNullConstructorArguments()
         {
             Assert.Throws<ArgumentException>(() => new X509Certificate2((byte[])null, (String)null));

--- a/src/System.Security.Cryptography.X509Certificates/tests/ExportTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ExportTests.cs
@@ -9,7 +9,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
     public static class ExportTests
     {
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ExportAsCert()
         {
             using (X509Certificate2 c1 = new X509Certificate2(TestData.MsCertificate))
@@ -21,8 +20,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
-        public static void ExportAsSerializedCert()
+        [PlatformSpecific(PlatformID.Windows)]
+        public static void ExportAsSerializedCert_Windows()
         {
             using (X509Certificate2 c1 = new X509Certificate2(TestData.MsCertificate))
             {
@@ -39,7 +38,16 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public static void ExportAsSerializedCert_Unix()
+        {
+            using (X509Certificate2 c1 = new X509Certificate2(TestData.MsCertificate))
+            {
+                Assert.Throws<PlatformNotSupportedException>(() => c1.Export(X509ContentType.SerializedCert));
+            }
+        }
+
+        [Fact]
         public static void ExportAsPfx()
         {
             using (X509Certificate2 c1 = new X509Certificate2(TestData.MsCertificate))
@@ -56,7 +64,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ExportAsPfxWithPassword()
         {
             const string password = "Cotton";
@@ -75,7 +82,6 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
         public static void ExportAsPfxVerifyPassword()
         {
             const string password = "Cotton";

--- a/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/LoadFromFileTests.cs
@@ -116,7 +116,7 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
+        [ActiveIssue(2910, PlatformID.AnyUnix)]
         [ActiveIssue(2667, PlatformID.Windows)]
         public static void TestLoadSignedFile()
         {

--- a/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/PropsTests.cs
@@ -204,8 +204,8 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
-        public static void TestArchive()
+        [PlatformSpecific(PlatformID.Windows)]
+        public static void TestArchive_Windows()
         {
             using (var c = new X509Certificate2(TestData.MsCertificate))
             {
@@ -220,18 +220,53 @@ namespace System.Security.Cryptography.X509Certificates.Tests
         }
 
         [Fact]
-        [ActiveIssue(1993, PlatformID.AnyUnix)]
-        public static void TestFriendlyName()
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public static void TestArchive_Unix()
         {
             using (var c = new X509Certificate2(TestData.MsCertificate))
             {
-                Assert.Equal(String.Empty, c.FriendlyName);
+                Assert.False(c.Archived);
+
+                Assert.Throws<PlatformNotSupportedException>(() => c.Archived = true);
+                Assert.False(c.Archived);
+
+                Assert.Throws<PlatformNotSupportedException>(() => c.Archived = false);
+                Assert.False(c.Archived);
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)]
+        public static void TestFriendlyName_Windows()
+        {
+            using (var c = new X509Certificate2(TestData.MsCertificate))
+            {
+                Assert.Equal(string.Empty, c.FriendlyName);
 
                 c.FriendlyName = "This is a friendly name.";
                 Assert.Equal("This is a friendly name.", c.FriendlyName);
 
                 c.FriendlyName = null;
-                Assert.Equal(String.Empty, c.FriendlyName);
+                Assert.Equal(string.Empty, c.FriendlyName);
+            }
+        }
+
+        [Fact]
+        [PlatformSpecific(PlatformID.AnyUnix)]
+        public static void TestFriendlyName_Unix()
+        {
+            using (var c = new X509Certificate2(TestData.MsCertificate))
+            {
+                Assert.Equal(string.Empty, c.FriendlyName);
+
+                Assert.Throws<PlatformNotSupportedException>(() => c.FriendlyName = "This is a friendly name.");
+                Assert.Equal(string.Empty, c.FriendlyName);
+                
+                Assert.Throws<PlatformNotSupportedException>(() => c.FriendlyName = null);
+                Assert.Equal(string.Empty, c.FriendlyName);
+
+                Assert.Throws<PlatformNotSupportedException>(() => c.FriendlyName = string.Empty);
+                Assert.Equal(string.Empty, c.FriendlyName);
             }
         }
 


### PR DESCRIPTION
One product bug was found, which is fixed (and a test added) in a standalone commit.

The goal was just to search through the [ActiveIssue] attributes and remove any identifying issues that were no longer open.

* 7 tests were enabled and are passing
* 7 tests were split to verify known/accepted differences between Windows and Unix
* 1 test had its ActiveIssue value updated to the correct one
* 1 test was deleted
* 1 new test was added to PlatformID.Any
* 1 new test was added to verify an untested difference between Windows and Unix

Net delta:
Windows: +1 test (+2 behaviors validated)
Unix: +15 tests (+16 behaviors validated)