### PR TITLE
Avoid buffer overrun when calling gethostname

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetHostName.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetHostName.cs
@@ -31,6 +31,9 @@ internal static partial class Interop
                 throw new InvalidOperationException(string.Format("gethostname returned {0}", err));
             }
 
+            // If the hostname is truncated, it is unspecified whether the returned buffer includes a terminating null byte.
+            name[ArrLength - 1] = 0;
+
             return Marshal.PtrToStringAnsi((IntPtr)name);
         }
     }


### PR DESCRIPTION
gethostname can truncate the returned host name up to the buffer size.
in that case the null termination will not be stored.
the change here is to force null termination