### PR TITLE
Temporarily permit install of OpenSSL on windows

### DIFF
--- a/src/System.Security.Cryptography.OpenSsl/pkg/System.Security.Cryptography.OpenSsl.pkgproj
+++ b/src/System.Security.Cryptography.OpenSsl/pkg/System.Security.Cryptography.OpenSsl.pkgproj
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\ref\System.Security.Cryptography.OpenSsl.csproj">
+      <SupportedFramework>dnxcore50</SupportedFramework>
+    </ProjectReference>
+    <ProjectReference Include="..\src\System.Security.Cryptography.OpenSsl.builds">
+      <AdditionalProperties>FilterToOSGroup=Linux</AdditionalProperties>
+    </ProjectReference>
+
+    <ProjectReference Include="$(NativePackagePath)\runtime.native.System.Security.Cryptography\runtime.native.System.Security.Cryptography.pkgproj" />
+
+    <!-- Opt desktop and netcore out of this package.  
+         This can be removed after we add back the RID to restict this to Unix.
+         https://github.com/dotnet/corefx/issues/2953 -->
+    <NotSupportedOnTargetFramework Include="netcore50" />
+    <NotSupportedOnTargetFramework Include="net46" />
+  </ItemGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
+++ b/src/System.Security.Cryptography.OpenSsl/src/System.Security.Cryptography.OpenSsl.csproj
@@ -12,7 +12,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <CLSCompliant>false</CLSCompliant>
     <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
-    <PackageTargetRuntime>unix</PackageTargetRuntime>
+    <!-- Temporarily remove the RID from this package until we have a
+         cross platform API to use RSA https://github.com/dotnet/corefx/issues/2953 -->
+    <!-- PackageTargetRuntime>unix</PackageTargetRuntime -->
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Linux_Release|AnyCPU'" />


### PR DESCRIPTION
We don't currently have a cross-platform API for folks to use to create
and RSA object https://github.com/dotnet/corefx/issues/2953, and dotnet
cli doesn't yet support folks cross compiling by platform
https://github.com/dotnet/cli/issues/465.

As a result, this package was failing to restore when dotnet CLI
switched to NuGet which will detect missing support at build
time instead of allowing a file-not-found at runtime.

Temporarily unblock installation of this package on Windows so that
folks can consume the package until we have an x-plat API.

This change also moves the package authoring for OpenSSL to 
the open from TFS.

/cc @bartonjs @davidfowl 