### PR TITLE
Http request/response DiagnosticSource logging.

### DIFF
--- a/src/Common/src/System/Net/Http/HttpHandlerDiagnosticListenerExtensions.cs
+++ b/src/Common/src/System/Net/Http/HttpHandlerDiagnosticListenerExtensions.cs
@@ -1,0 +1,89 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace System.Net.Http
+{
+    /// <summary>
+    /// Defines default values for http handler properties which is meant to be re-used across WinHttp and UnixHttp Handlers
+    /// </summary>
+    internal static class HttpHandlerDiagnosticListenerExtensions
+    {
+        public static Guid LogHttpRequest(this DiagnosticListener @this, HttpRequestMessage request)
+        {
+            return @this.IsEnabled(HttpHandlerLoggingStrings.RequestWriteName) ?
+                LogHttpRequestCore(@this, request) :
+                Guid.Empty;
+        }
+
+        public static void LogHttpResponse(this DiagnosticListener @this, HttpResponseMessage response, Guid loggingRequestId)
+        {
+            if (@this.IsEnabled(HttpHandlerLoggingStrings.ResponseWriteName))
+            {
+                LogHttpResponseCore(@this, response, loggingRequestId);
+            }
+        }
+
+        public static void LogHttpResponse(this DiagnosticListener @this, Task<HttpResponseMessage> responseTask, Guid loggingRequestId)
+        {
+            if (@this.IsEnabled(HttpHandlerLoggingStrings.ResponseWriteName))
+            {
+                ScheduleLogResponse(@this, responseTask, loggingRequestId);
+            }
+        }
+
+        private static void ScheduleLogResponse(DiagnosticListener diagnosticListener, Task<HttpResponseMessage> responseTask, Guid loggingRequestId)
+        {
+            responseTask.ContinueWith(
+                t =>
+                {
+                    if (!t.IsFaulted &&
+                        !t.IsCanceled)
+                    {
+                        LogHttpResponseCore(diagnosticListener, t.Result, loggingRequestId);
+                    }
+                },
+                TaskScheduler.Default);
+        }
+
+        private static Guid LogHttpRequestCore(DiagnosticListener diagnosticListener, HttpRequestMessage request)
+        {
+            Guid loggingRequestId = Guid.NewGuid();
+            long timestamp = Stopwatch.GetTimestamp();
+
+            diagnosticListener.Write(
+                HttpHandlerLoggingStrings.RequestWriteName,
+                new
+                {
+                    Request = request,
+                    LoggingRequestId = loggingRequestId,
+                    Timestamp = timestamp
+                }
+            );
+
+            return loggingRequestId;
+        }
+
+        private static void LogHttpResponseCore(DiagnosticListener diagnosticListener, HttpResponseMessage response, Guid loggingRequestId)
+        {
+            // An empty loggingRequestId signifies that the request was not logged, so do
+            // not attempt to log response.
+            if (loggingRequestId != Guid.Empty)
+            {
+                long timestamp = Stopwatch.GetTimestamp();
+
+                diagnosticListener.Write(
+                    HttpHandlerLoggingStrings.ResponseWriteName,
+                    new
+                    {
+                        Response = response,
+                        LoggingRequestId = loggingRequestId,
+                        TimeStamp = timestamp
+                    }
+                );
+            }
+        }
+    }
+}

--- a/src/Common/src/System/Net/Http/HttpHandlerLoggingStrings.cs
+++ b/src/Common/src/System/Net/Http/HttpHandlerLoggingStrings.cs
@@ -1,0 +1,16 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.Net.Http
+{
+    /// <summary>
+    /// Defines names of DiagnosticListener and Write events for WinHttpHandler, CurlHandler, and HttpHandlerToFilter.
+    /// </summary>
+    internal static class HttpHandlerLoggingStrings
+    {
+        public const string DiagnosticListenerName = "HttpHandlerDiagnosticListener";
+        public const string RequestWriteName = "System.Net.Http.Request";
+        public const string ResponseWriteName = "System.Net.Http.Response";
+    }
+}

--- a/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
+++ b/src/System.Net.Http.WinHttpHandler/src/System.Net.Http.WinHttpHandler.msbuild
@@ -19,6 +19,8 @@
     <CompileItem Include="$(CommonPath)\System\Net\UriScheme.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\SecurityProtocol.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\Http\HttpHandlerDefaults.cs" />
+    <CompileItem Include="$(CommonPath)\System\Net\Http\HttpHandlerDiagnosticListenerExtensions.cs" />
+    <CompileItem Include="$(CommonPath)\System\Net\Http\HttpHandlerLoggingStrings.cs" />
     <CompileItem Include="$(CommonPath)\System\Net\Http\WinHttpException.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpAuthHelper.cs" />
     <CompileItem Include="$(MSBuildThisFileDirectory)\System\Net\Http\WinHttpCertificateHelper.cs" />

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -83,6 +83,7 @@ namespace System.Net.Http
         private volatile bool _disposed;
         private SafeWinHttpHandle _sessionHandle;
         private WinHttpAuthHelper _authHelper = new WinHttpAuthHelper();
+        private static readonly DiagnosticListener s_diagnosticListener = new DiagnosticListener(HttpHandlerLoggingStrings.DiagnosticListenerName);
 
         public WinHttpHandler()
         {
@@ -526,6 +527,8 @@ namespace System.Net.Http
 
             CheckDisposed();
 
+            Guid loggingRequestId = s_diagnosticListener.LogHttpRequest(request);
+
             SetOperationStarted();
 
             TaskCompletionSource<HttpResponseMessage> tcs = new TaskCompletionSource<HttpResponseMessage>();
@@ -549,7 +552,9 @@ namespace System.Net.Http
                 state,
                 CancellationToken.None,
                 TaskCreationOptions.DenyChildAttach,
-                TaskScheduler.Default);                
+                TaskScheduler.Default);
+
+            s_diagnosticListener.LogHttpResponse(tcs.Task, loggingRequestId);
 
             return tcs.Task;
         }

--- a/src/System.Net.Http.WinHttpHandler/src/project.json
+++ b/src/System.Net.Http.WinHttpHandler/src/project.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23808",
     "Microsoft.Win32.Primitives": "4.0.0",
+    "System.Diagnostics.DiagnosticSource": "4.0.0-rc3-23808",
     "System.Globalization": "4.0.10",
     "System.IO": "4.0.10",
     "System.Net.Http": "4.0.0",

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/System.Net.Http.WinHttpHandler.Unit.Tests.csproj
@@ -56,6 +56,12 @@
     <Compile Include="$(CommonPath)\System\Net\Http\HttpHandlerDefaults.cs">
       <Link>Common\System\Net\Http\HttpHandlerDefaults.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Http\HttpHandlerDiagnosticListenerExtensions.cs">
+      <Link>Common\System\Net\Http\HttpHandlerDiagnosticListenerExtensions.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Http\HttpHandlerLoggingStrings.cs">
+      <Link>Common\System\Net\Http\HttpHandlerLoggingStrings.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\Http\WinHttpException.cs">
       <Link>Common\System\Net\Http\WinHttpException.cs</Link>
     </Compile>

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/project.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23808",
     "Microsoft.Win32.Primitives": "4.0.0",
+    "System.Diagnostics.DiagnosticSource": "4.0.0-rc3-23808",
     "System.Globalization": "4.0.10",
     "System.IO": "4.0.10",
     "System.Net.Http": "4.0.0",

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -224,6 +224,12 @@
     <Compile Include="$(CommonPath)\System\Net\Http\HttpHandlerDefaults.cs">
       <Link>Common\System\Net\Http\HttpHandlerDefaults.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Http\HttpHandlerDiagnosticListenerExtensions.cs">
+      <Link>Common\System\Net\Http\HttpHandlerDiagnosticListenerExtensions.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Http\HttpHandlerLoggingStrings.cs">
+      <Link>Common\System\Net\Http\HttpHandlerLoggingStrings.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\Http\TlsCertificateExtensions.cs">
         <Link>Common\System\Net\Http\TlsCertificateExtensions</Link>
     </Compile>
@@ -296,6 +302,12 @@
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>
     <!-- TODO: reconcile with Open\src\Common, see issue #5525 -->
+    <Compile Include="$(CommonPath)\System\Net\Http\HttpHandlerDiagnosticListenerExtensions.cs">
+      <Link>Common\System\Net\Http\HttpHandlerDiagnosticListenerExtensions.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\System\Net\Http\HttpHandlerLoggingStrings.cs">
+      <Link>Common\System\Net\Http\HttpHandlerLoggingStrings.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\Net\HttpVersion.cs">
       <Link>Common\System\Net\HttpVersion.cs</Link>
     </Compile>

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -60,6 +60,8 @@ namespace System.Net.Http
         private readonly static bool s_supportsSSL;
         private readonly static bool s_supportsHttp2Multiplexing;
 
+        private readonly static DiagnosticListener s_diagnosticListener = new DiagnosticListener(HttpHandlerLoggingStrings.DiagnosticListenerName);
+
         private readonly MultiAgent _agent = new MultiAgent();
         private volatile bool _anyOperationStarted;
         private volatile bool _disposed;
@@ -331,6 +333,8 @@ namespace System.Net.Http
                 throw new InvalidOperationException(SR.net_http_invalid_cookiecontainer);
             }
 
+            Guid loggingRequestId = s_diagnosticListener.LogHttpRequest(request);
+
             CheckDisposed();
             SetOperationStarted();
 
@@ -361,6 +365,9 @@ namespace System.Net.Http
                 easy.FailRequest(exc);
                 easy.Cleanup(); // no active processing remains, so we can cleanup
             }
+
+            s_diagnosticListener.LogHttpResponse(easy.Task, loggingRequestId);
+
             return easy.Task;
         }
 

--- a/src/System.Net.Http/src/netcore50/System/Net/HttpHandlerToFilter.cs
+++ b/src/System.Net.Http/src/netcore50/System/Net/HttpHandlerToFilter.cs
@@ -25,6 +25,8 @@ namespace System.Net.Http
 {
     internal class HttpHandlerToFilter : HttpMessageHandler
     {
+        private readonly static DiagnosticListener s_diagnosticListener = new DiagnosticListener(HttpHandlerLoggingStrings.DiagnosticListenerName);
+
         private readonly RTHttpBaseProtocolFilter _next;
         private int _filterMaxVersionSet;
 
@@ -47,6 +49,8 @@ namespace System.Net.Http
             }
             cancel.ThrowIfCancellationRequested();
 
+            Guid loggingRequestId = s_diagnosticListener.LogHttpRequest(request);
+
             RTHttpRequestMessage rtRequest = await ConvertRequestAsync(request).ConfigureAwait(false);
             RTHttpResponseMessage rtResponse = await _next.SendRequestAsync(rtRequest).AsTask(cancel).ConfigureAwait(false);
 
@@ -55,6 +59,9 @@ namespace System.Net.Http
 
             HttpResponseMessage response = ConvertResponse(rtResponse);
             response.RequestMessage = request;
+
+            s_diagnosticListener.LogHttpResponse(response, loggingRequestId);
+
             return response;
         }
 

--- a/src/System.Net.Http/src/netcore50/project.json
+++ b/src/System.Net.Http/src/netcore50/project.json
@@ -1,4 +1,7 @@
 {
+  "dependencies": {
+    "System.Diagnostics.DiagnosticSource": "4.0.0-rc3-23808"
+  },
   "frameworks": {
     "netcore50": {
       "dependencies": {

--- a/src/System.Net.Http/src/project.json
+++ b/src/System.Net.Http/src/project.json
@@ -1,4 +1,7 @@
 {
+  "dependencies": {
+    "System.Diagnostics.DiagnosticSource": "4.0.0-rc3-23808"
+  },
   "frameworks": {
     "dnxcore50": {
       "dependencies": {

--- a/src/System.Net.Http/src/unix/project.json
+++ b/src/System.Net.Http/src/unix/project.json
@@ -1,4 +1,7 @@
 {
+  "dependencies": {
+    "System.Diagnostics.DiagnosticSource": "4.0.0-rc3-23808"
+  },
   "frameworks": {
     "dnxcore50": {
       "dependencies": {

--- a/src/System.Net.Http/tests/FunctionalTests/FakeDiagnosticSourceListenerObserver.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/FakeDiagnosticSourceListenerObserver.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public sealed class FakeDiagnosticListenerObserver : IObserver<DiagnosticListener>
+    {
+        private class FakeDiagnosticSourceWriteObserver : IObserver<KeyValuePair<string, object>>
+        {
+            private readonly Action<KeyValuePair<string, object>> _writeCallback;
+
+            public FakeDiagnosticSourceWriteObserver(Action<KeyValuePair<string, object>> writeCallback)
+            {
+                _writeCallback = writeCallback;
+            }
+
+            public void OnCompleted()
+            {
+            }
+
+            public void OnError(Exception error)
+            {
+            }
+
+            public void OnNext(KeyValuePair<string, object> value)
+            {
+                _writeCallback(value);
+            }
+        }
+
+        private readonly Action<KeyValuePair<string, object>> _writeCallback;
+
+        private bool _writeObserverEnabled;
+
+        public FakeDiagnosticListenerObserver(Action<KeyValuePair<string, object>> writeCallback)
+        {
+            _writeCallback = writeCallback;
+        }
+
+        public void OnCompleted()
+        {
+        }
+
+        public void OnError(Exception error)
+        {
+        }
+
+        public void OnNext(DiagnosticListener value)
+        {
+            if (value.Name.Equals("HttpHandlerDiagnosticListener"))
+            {
+                value.Subscribe(new FakeDiagnosticSourceWriteObserver(_writeCallback), IsEnabled);
+            }
+        }
+
+        public void Enable()
+        {
+            _writeObserverEnabled = true;
+        }
+
+        public void Disable()
+        {
+            _writeObserverEnabled = false;
+        }
+
+        private bool IsEnabled(string s)
+        {
+            return _writeObserverEnabled;
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/HttpClientTest.cs
@@ -3,9 +3,11 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
 using System.Net.Test.Common;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -29,6 +31,116 @@ namespace System.Net.Http.Functional.Tests
                 var response = client.GetAsync(SlowServer).GetAwaiter().GetResult();
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             }
+        }
+
+        /// <remarks>
+        /// This test must be in the same test collection as any others testing HttpClient/WinHttpHandler
+        /// DiagnosticSources, since the global logging mechanism makes them conflict inherently.
+        /// </remarks>
+        [Fact]
+        public void SendAsync_ExpectedDiagnosticSourceLogging()
+        {
+            bool requestLogged = false;
+            Guid requestGuid = Guid.Empty;
+            bool responseLogged = false;
+            Guid responseGuid = Guid.Empty;
+
+            var diagnosticListenerObserver = new FakeDiagnosticListenerObserver(
+                kvp =>
+                {
+                    if (kvp.Key.Equals("System.Net.Http.Request"))
+                    {
+                        Assert.NotNull(kvp.Value);
+                        GetPropertyValueFromAnonymousTypeInstance<HttpRequestMessage>(kvp.Value, "Request");
+                        requestGuid = GetPropertyValueFromAnonymousTypeInstance<Guid>(kvp.Value, "LoggingRequestId");
+
+                        requestLogged = true;
+                    }
+                    else if (kvp.Key.Equals("System.Net.Http.Response"))
+                    {
+                        Assert.NotNull(kvp.Value);
+
+                        GetPropertyValueFromAnonymousTypeInstance<HttpResponseMessage>(kvp.Value, "Response");
+                        responseGuid = GetPropertyValueFromAnonymousTypeInstance<Guid>(kvp.Value, "LoggingRequestId");
+
+                        responseLogged = true;
+                    }
+                });
+            diagnosticListenerObserver.Enable();
+
+            DiagnosticListener.AllListeners.Subscribe(diagnosticListenerObserver);
+
+            using (var client = new HttpClient())
+            {
+                var response = client.GetAsync(HttpTestServers.RemoteEchoServer).Result;
+            }
+
+            Assert.True(requestLogged, "Request was not logged.");
+            // Poll with a timeout since logging response is not synchronized with returning a response.
+            WaitForTrue(() => responseLogged, TimeSpan.FromSeconds(1), "Response was not logged within 1 second timeout.");
+            Assert.Equal(requestGuid, responseGuid);
+
+            // No way to unsubscribe, so turn it off so that it doesn't interfere with other tests.
+            diagnosticListenerObserver.Disable(); 
+        }
+
+        /// <remarks>
+        /// This test must be in the same test collection as any others testing HttpClient/WinHttpHandler
+        /// DiagnosticSources, since the global logging mechanism makes them conflict inherently.
+        /// </remarks>
+        [Fact]
+        public void SendAsync_ExpectedDiagnosticSourceNoLogging()
+        {
+            bool requestLogged = false;
+            bool responseLogged = false;
+
+            DiagnosticListener.AllListeners.Subscribe(new FakeDiagnosticListenerObserver(
+                kvp =>
+                {
+                    if (kvp.Key.Equals("System.Net.Http.Request"))
+                    {
+                        requestLogged = true;
+                    }
+                    else if (kvp.Key.Equals("System.Net.Http.Response"))
+                    {
+                        responseLogged = true;
+                    }
+                }));
+
+            using (var client = new HttpClient())
+            {
+                var response = client.GetAsync(HttpTestServers.RemoteEchoServer).Result;
+            }
+
+            Assert.False(requestLogged, "Request was logged while logging disabled.");
+            // TODO: Waiting for one second is not ideal, but how else be reasonably sure that
+            // some logging message hasn't slipped through?
+            WaitForFalse(() => responseLogged, TimeSpan.FromSeconds(1), "Response was logged while logging disabled.");
+        }
+
+        private void WaitForTrue(Func<bool> p, TimeSpan timeout, string message)
+        {
+            // Assert that spin doesn't time out.
+            Assert.True(System.Threading.SpinWait.SpinUntil(p, timeout), message);
+        }
+
+        private void WaitForFalse(Func<bool> p, TimeSpan timeout, string message)
+        {
+            // Assert that spin times out.
+            Assert.False(System.Threading.SpinWait.SpinUntil(p, timeout), message);
+        }
+
+        private T GetPropertyValueFromAnonymousTypeInstance<T>(object obj, string propertyName)
+        {
+            Type t = obj.GetType();
+
+            PropertyInfo p = t.GetRuntimeProperty(propertyName);
+
+            object propertyValue = p.GetValue(obj);
+            Assert.NotNull(propertyValue);
+            Assert.IsType<T>(propertyValue);
+
+            return (T)propertyValue;
         }
     }
 }

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition="'$(Configuration)'==''">Windows_Debug</Configuration>
@@ -19,7 +19,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'OSX_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'OSX_Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />  
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Windows_Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="$(CommonTestPath)\System\Net\HttpTestServers.cs">
       <Link>Common\System\Net\HttpTestServers.cs</Link>
@@ -31,6 +31,7 @@
     <Compile Include="ChannelBindingAwareContent.cs" />
     <Compile Include="CustomContent.cs" />
     <Compile Include="DelegatingHandlerTest.cs" />
+    <Compile Include="FakeDiagnosticSourceListenerObserver.cs" />
     <Compile Include="FormUrlEncodedContentTest.cs" />
     <Compile Include="HttpClientHandlerTest.cs" />
     <Compile Include="HttpClientTest.cs" />
@@ -56,7 +57,8 @@
       <Project>{1D422B1D-D7C4-41B9-862D-EB3D98DF37DE}</Project>
       <Name>System.Net.Http</Name>
     </ProjectReference>
-  </ItemGroup>  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Net.Http/tests/FunctionalTests/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23808",
+    "System.Diagnostics.DiagnosticSource": "4.0.0-rc3-23808",
     "System.Globalization": "4.0.10",
     "System.IO": "4.0.10",
     "System.IO.FileSystem": "4.0.0",


### PR DESCRIPTION
- Added logging to WinHttpHandler, CurlHandler, and HttpHandlerToFilter
  for HTTP request/response.
- Added functional tests for HttpClient and WinHttpHandler.

@davidsh @cipop @stephentoub