### PR TITLE
Apply OS filtering mechanism to post-build project.

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -18,7 +18,10 @@
       <!-- For the root traversal default filter the OSGroup to the OSEnvironment which is the OS we are running on -->
       <FilterToOSGroup Condition="'$(BuildAllOSGroups)' != 'true'">$(OSEnvironment)</FilterToOSGroup>
     </Project>
-    <Project Include="src\post.msbuild" />
+    <Project Include="src\post.builds">
+      <!-- For the root traversal default filter the OSGroup to the OSEnvironment which is the OS we are running on -->
+      <FilterToOSGroup Condition="'$(BuildAllOSGroups)' != 'true'">$(OSEnvironment)</FilterToOSGroup>
+    </Project>
   </ItemGroup>
 
   <Import Project="dir.targets" />

--- a/src/post.builds
+++ b/src/post.builds
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup>
+    <OSGroup Condition="'$(FilterToOSGroup)'!=''">$(FilterToOSGroup)</OSGroup>
+  </PropertyGroup>
+
   <Import Project="dir.props" />
   <Import Project="..\dir.targets" />
   <Import Project="$(ToolsDir)Build.Post.targets" Condition="Exists('$(ToolsDir)Build.Post.targets')" />


### PR DESCRIPTION
The OS filtering properties weren't added to the post-build project
causing their dependencies to calculate the incorrect value for
OSPlatformConfig; e.g. instead of Windows_NT.AnyCPU.Release one would get
AnyOS.AnyCPU.Release.
The rename of post.msbuild is to follow suit with the other build projects
and to prevent some properties from being dropped during the traversal
build (see dir.traversal.targets).