### PR TITLE
Add finalizers to Process and Ping

### DIFF
--- a/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/Process.cs
@@ -93,6 +93,15 @@ namespace System.Diagnostics
         /// </devdoc>
         public Process()
         {
+            // This class once inherited a finalizer. For backward compatibility it has one so that 
+            // any derived class that depends on it will see the behaviour expected. Since it is
+            // not used by this class itself, suppress it immediately if this is not an instance
+            // of a derived class it doesn't suffer the GC burden of finalization.
+            if (GetType() == typeof(Process))
+            {
+                GC.SuppressFinalize(this);
+            }
+
             _machineName = ".";
             _outputStreamReadMode = StreamReadMode.Undefined;
             _errorStreamReadMode = StreamReadMode.Undefined;
@@ -100,6 +109,7 @@ namespace System.Diagnostics
 
         private Process(string machineName, bool isRemoteMachine, int processId, ProcessInfo processInfo)
         {
+            GC.SuppressFinalize(this);
             _processInfo = processInfo;
             _machineName = machineName;
             _isRemoteMachine = isRemoteMachine;
@@ -107,6 +117,11 @@ namespace System.Diagnostics
             _haveProcessId = true;
             _outputStreamReadMode = StreamReadMode.Undefined;
             _errorStreamReadMode = StreamReadMode.Undefined;
+        }
+
+        ~Process()
+        {
+            Dispose(false);
         }
 
         public SafeProcessHandle SafeHandle
@@ -1348,6 +1363,7 @@ namespace System.Diagnostics
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessModule.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessModule.cs
@@ -25,7 +25,6 @@ namespace System.Diagnostics
         internal ProcessModule(ModuleInfo moduleInfo)
         {
             _moduleInfo = moduleInfo;
-            GC.SuppressFinalize(this);
         }
 
         /// <devdoc>

--- a/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
+++ b/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.cs
@@ -25,6 +25,23 @@ namespace System.Net.NetworkInformation
         private const int Disposed = 2;
         private int _status = Free;
 
+        public Ping()
+        {
+            // This class once inherited a finalizer. For backward compatibility it has one so that 
+            // any derived class that depends on it will see the behaviour expected. Since it is
+            // not used by this class itself, suppress it immediately if this is not an instance
+            // of a derived class it doesn't suffer the GC burden of finalization.
+            if (GetType() == typeof(Ping))
+            {
+                GC.SuppressFinalize(this);
+            }
+        }
+
+        ~Ping()
+        {
+            Dispose(false);
+        }
+
         private void CheckStart()
         {
             if (_disposeRequested)
@@ -71,6 +88,7 @@ namespace System.Net.NetworkInformation
         public void Dispose()
         {
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         protected virtual void Dispose(bool disposing)


### PR DESCRIPTION
Have them call `Dispose(false)`.

`SuppressFinalize(this)` in constructors if they are not a derived type to lessen the possible negative impact on collection.

Remove unnecessary `SuppressFinalize(this)` from `ProcessModule`.

Fixes #5886