### PR TITLE
Remove some unnecessary checks and dead code from Linq.Expressions

### DIFF
--- a/src/System.Linq.Expressions/src/Resources/Strings.resx
+++ b/src/System.Linq.Expressions/src/Resources/Strings.resx
@@ -150,12 +150,6 @@
   <data name="TypeDoesNotHaveConstructorForTheSignature" xml:space="preserve">
     <value>Type doesn't have constructor with a given signature</value>
   </data>
-  <data name="CountCannotBeNegative" xml:space="preserve">
-    <value>Count must be non-negative.</value>
-  </data>
-  <data name="ArrayTypeMustBeArray" xml:space="preserve">
-    <value>arrayType must be an array type</value>
-  </data>
   <data name="SetterMustBeVoid" xml:space="preserve">
     <value>Setter should have void type.</value>
   </data>
@@ -497,9 +491,6 @@
   </data>
   <data name="OutOfRange" xml:space="preserve">
     <value>{0} must be greater than or equal to {1}</value>
-  </data>
-  <data name="QueueEmpty" xml:space="preserve">
-    <value>Queue empty.</value>
   </data>
   <data name="LabelTargetAlreadyDefined" xml:space="preserve">
     <value>Cannot redefine label '{0}' in an inner block.</value>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -1072,7 +1072,7 @@ namespace System.Linq.Expressions.Compiler
         {
             ContractUtils.RequiresNotNull(elementType, "elementType");
             ContractUtils.RequiresNotNull(emit, "emit");
-            if (count < 0) throw Error.CountCannotBeNegative();
+            Debug.Assert(count >= 0);
 
             il.EmitInt(count);
             il.Emit(OpCodes.Newarr, elementType);
@@ -1095,7 +1095,7 @@ namespace System.Linq.Expressions.Compiler
         internal static void EmitArray(this ILGenerator il, Type arrayType)
         {
             ContractUtils.RequiresNotNull(arrayType, "arrayType");
-            if (!arrayType.IsArray) throw Error.ArrayTypeMustBeArray();
+            Debug.Assert(arrayType.IsArray);
 
             if (arrayType.IsVector())
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/KeyedQueue.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/KeyedQueue.cs
@@ -29,21 +29,6 @@ namespace System.Linq.Expressions.Compiler
             queue.Enqueue(value);
         }
 
-        internal V Dequeue(K key)
-        {
-            Queue<V> queue;
-            if (!_data.TryGetValue(key, out queue))
-            {
-                throw Error.QueueEmpty();
-            }
-            V result = queue.Dequeue();
-            if (queue.Count == 0)
-            {
-                _data.Remove(key);
-            }
-            return result;
-        }
-
         internal bool TryDequeue(K key, out V value)
         {
             Queue<V> queue;
@@ -58,31 +43,6 @@ namespace System.Linq.Expressions.Compiler
             }
             value = default(V);
             return false;
-        }
-
-        internal V Peek(K key)
-        {
-            Queue<V> queue;
-            if (!_data.TryGetValue(key, out queue))
-            {
-                throw Error.QueueEmpty();
-            }
-            return queue.Peek();
-        }
-
-        internal int GetCount(K key)
-        {
-            Queue<V> queue;
-            if (!_data.TryGetValue(key, out queue))
-            {
-                return 0;
-            }
-            return queue.Count;
-        }
-
-        internal void Clear()
-        {
-            _data.Clear();
         }
     }
 }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Error.cs
@@ -89,20 +89,6 @@ namespace System.Linq.Expressions
             return new ArgumentException(Strings.TypeDoesNotHaveConstructorForTheSignature);
         }
         /// <summary>
-        /// ArgumentException with message like "Count must be non-negative."
-        /// </summary>
-        internal static Exception CountCannotBeNegative()
-        {
-            return new ArgumentException(Strings.CountCannotBeNegative);
-        }
-        /// <summary>
-        /// ArgumentException with message like "arrayType must be an array type"
-        /// </summary>
-        internal static Exception ArrayTypeMustBeArray()
-        {
-            return new ArgumentException(Strings.ArrayTypeMustBeArray);
-        }
-        /// <summary>
         /// ArgumentException with message like "Setter should have void type."
         /// </summary>
         internal static Exception SetterMustBeVoid()
@@ -865,13 +851,6 @@ namespace System.Linq.Expressions
         internal static Exception OutOfRange(object p0, object p1)
         {
             return new ArgumentOutOfRangeException(Strings.OutOfRange(p0, p1));
-        }
-        /// <summary>
-        /// InvalidOperationException with message like "Queue empty."
-        /// </summary>
-        internal static Exception QueueEmpty()
-        {
-            return new InvalidOperationException(Strings.QueueEmpty);
         }
         /// <summary>
         /// InvalidOperationException with message like "Cannot redefine label '{0}' in an inner block."

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/TypeOperations.cs
@@ -2339,26 +2339,6 @@ namespace System.Linq.Expressions.Interpreter
         }
     }
 
-#if DEBUG
-    internal class LogInstruction : Instruction
-    {
-        private readonly string _message;
-        public LogInstruction(string message)
-        {
-            _message = message;
-        }
-        public override string InstructionName
-        {
-            get { return "Log"; }
-        }
-        public override int Run(InterpretedFrame frame)
-        {
-            //Console.WriteLine(_message);
-            return +1;
-        }
-    }
-#endif
-
     internal class QuoteInstruction : Instruction
     {
         private readonly Expression _operand;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
@@ -28,6 +28,7 @@ namespace System.Linq.Expressions
 
         internal static NewArrayExpression Make(ExpressionType nodeType, Type type, ReadOnlyCollection<Expression> expressions)
         {
+            Debug.Assert(type.IsArray);
             if (nodeType == ExpressionType.NewArrayInit)
             {
                 return new NewArrayInitExpression(type, expressions);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Strings.cs
@@ -133,28 +133,6 @@ namespace System.Linq.Expressions
         }
 
         /// <summary>
-        /// A string like "Count must be non-negative."
-        /// </summary>
-        internal static string CountCannotBeNegative
-        {
-            get
-            {
-                return SR.CountCannotBeNegative;
-            }
-        }
-
-        /// <summary>
-        /// A string like "arrayType must be an array type"
-        /// </summary>
-        internal static string ArrayTypeMustBeArray
-        {
-            get
-            {
-                return SR.ArrayTypeMustBeArray;
-            }
-        }
-
-        /// <summary>
         /// A string like "Setter should have void type."
         /// </summary>
         internal static string SetterMustBeVoid
@@ -1161,17 +1139,6 @@ namespace System.Linq.Expressions
         internal static string OutOfRange(object p0, object p1)
         {
             return SR.Format(SR.OutOfRange, p0, p1);
-        }
-
-        /// <summary>
-        /// A string like "Queue empty."
-        /// </summary>
-        internal static string QueueEmpty
-        {
-            get
-            {
-                return SR.QueueEmpty;
-            }
         }
 
         /// <summary>

--- a/src/System.Linq.Expressions/tests/Array/ArrayBoundsTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/ArrayBoundsTests.cs
@@ -3,12 +3,93 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
 {
     public static class ArrayBoundsTests
     {
+        private class BogusCollection<T> : IList<T>
+        {
+            public T this[int index]
+            {
+                get { return default(T); }
+
+                set { throw new NotSupportedException(); }
+            }
+
+            public int Count
+            {
+                get { return -1; }
+            }
+
+            public bool IsReadOnly
+            {
+                get { return true; }
+            }
+
+            public void Add(T item)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void Clear()
+            {
+                throw new NotSupportedException();
+            }
+
+            public bool Contains(T item)
+            {
+                return false;
+            }
+
+            public void CopyTo(T[] array, int arrayIndex)
+            {
+            }
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                return Enumerable.Empty<T>().GetEnumerator();
+            }
+
+            public int IndexOf(T item)
+            {
+                return -1;
+            }
+
+            public void Insert(int index, T item)
+            {
+                throw new NotSupportedException();
+            }
+
+            public bool Remove(T item)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void RemoveAt(int index)
+            {
+                throw new NotSupportedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+
+        private class BogusReadOnlyCollection<T> : ReadOnlyCollection<T>
+        {
+            public BogusReadOnlyCollection()
+                : base(new BogusCollection<T>())
+            {
+
+            }
+        }
+
         #region Test methods
 
         #region Byte sized arrays
@@ -1338,6 +1419,15 @@ namespace System.Linq.Expressions.Tests
         }
 
         #endregion
+
+        [Fact]
+        public static void ThrowOnNegativeSizedCollection()
+        {
+            // This is an obscure case, and it doesn't much matter what is thrown, as long as is thrown before such
+            // an edge case could cause more obscure damage. A class derived from ReadOnlyCollection is used to catch
+            // assumptions that such a type is safe.
+            Assert.ThrowsAny<Exception>(() => Expression.NewArrayBounds(typeof(int), new BogusReadOnlyCollection<Expression>()));
+        }
 
         #endregion
 

--- a/src/System.Linq.Expressions/tests/Array/NewArrayListTests.cs
+++ b/src/System.Linq.Expressions/tests/Array/NewArrayListTests.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using Xunit;
 
 namespace System.Linq.Expressions.Tests
@@ -849,9 +852,96 @@ namespace System.Linq.Expressions.Tests
             CheckGenericWithStructRestrictionArrayListHelper<Scs>();
         }
 
+        [Fact]
+        public static void ThrowOnNegativeSizedCollection()
+        {
+            // This is an obscure case, and it doesn't much matter what is thrown, as long as is thrown before such
+            // an edge case could cause more obscure damage. A class derived from ReadOnlyCollection is used to catch
+            // assumptions that such a type is safe.
+            Assert.ThrowsAny<Exception>(() => Expression.NewArrayInit(typeof(int), new BogusReadOnlyCollection<Expression>()));
+        }
+
         #endregion
 
         #region Helper methods
+
+        private class BogusCollection<T> : IList<T>
+        {
+            public T this[int index]
+            {
+                get { return default(T); }
+
+                set { throw new NotSupportedException(); }
+            }
+
+            public int Count
+            {
+                get { return -1; }
+            }
+
+            public bool IsReadOnly
+            {
+                get { return true; }
+            }
+
+            public void Add(T item)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void Clear()
+            {
+                throw new NotSupportedException();
+            }
+
+            public bool Contains(T item)
+            {
+                return false;
+            }
+
+            public void CopyTo(T[] array, int arrayIndex)
+            {
+            }
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                return Enumerable.Empty<T>().GetEnumerator();
+            }
+
+            public int IndexOf(T item)
+            {
+                return -1;
+            }
+
+            public void Insert(int index, T item)
+            {
+                throw new NotSupportedException();
+            }
+
+            public bool Remove(T item)
+            {
+                throw new NotSupportedException();
+            }
+
+            public void RemoveAt(int index)
+            {
+                throw new NotSupportedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+
+        private class BogusReadOnlyCollection<T> : ReadOnlyCollection<T>
+        {
+            public BogusReadOnlyCollection()
+                :base(new BogusCollection<T>())
+            {
+
+            }
+        }
 
         private static void CheckGenericArrayListHelper<T>()
         {


### PR DESCRIPTION
Remove dead code from KeyedQueue helper class.

Replace run-time check on impossible condition into assert.

ReadOnlyCollection is tested for condition of count < 0 though getting here would pass through paths that would either fail or produce an empty collection en route.

Include tests attepting all possible routes for getting such a bogus collection into an expression.

Turn run-time check on array creation expression having array type with assert, both at the point where the run-time check was, and at the point where the expressions are given that type.