### PR TITLE
Keep accepted sockets open until the tests are done with them.

### DIFF
--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
@@ -95,7 +95,6 @@ namespace System.Net.Sockets.Tests
             });
         }
 
-        [ActiveIssue(3494, PlatformID.AnyUnix)]
         [Fact] // Base Case
         public void ConnectV4MappedIPAddressToV4Host_Success()
         {
@@ -225,7 +224,6 @@ namespace System.Net.Sockets.Tests
             DualModeConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
         }
 
-        [ActiveIssue(3494, PlatformID.AnyUnix)]
         [Fact]
         public void ConnectV6IPEndPointToDualHost_Success()
         {
@@ -789,7 +787,6 @@ namespace System.Net.Sockets.Tests
             });
         }
 
-        [ActiveIssue(3682, PlatformID.AnyUnix)]
         [Fact]
         public void ConnectAsyncV4IPEndPointToDualHost_Success()
         {

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
@@ -177,7 +177,6 @@ namespace System.Net.Sockets.Tests
             });
         }
 
-        [ActiveIssue(3744, PlatformID.AnyUnix)]
         [Fact] // Base case
         public void ConnectV4MappedIPEndPointToV4Host_Success()
         {
@@ -2496,6 +2495,7 @@ namespace System.Net.Sockets.Tests
         {
             private readonly ITestOutputHelper _log;
             private TcpListener _server;
+            private Socket _acceptedSocket;
 
             public SocketServer(ITestOutputHelper log, IPAddress address, bool dualMode, out int port)
             {
@@ -2516,8 +2516,8 @@ namespace System.Net.Sockets.Tests
             {
                 try
                 {
-                    Socket socket = _server.EndAcceptSocket(ar);
-                    _log.WriteLine("Accepted Socket: " + socket.RemoteEndPoint);
+                    _acceptedSocket = _server.EndAcceptSocket(ar);
+                    _log.WriteLine("Accepted Socket: " + _acceptedSocket.RemoteEndPoint);
                 }
                 catch (SocketException) { }
                 catch (ObjectDisposedException) { }
@@ -2528,6 +2528,8 @@ namespace System.Net.Sockets.Tests
                 try
                 {
                     _server.Stop();
+                    if (_acceptedSocket != null)
+                        _acceptedSocket.Dispose();
                 }
                 catch (Exception) { }
             }

--- a/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -68,7 +68,6 @@ namespace System.Net.Sockets.Tests
             DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
         }
 
-        [ActiveIssue(5291, PlatformID.AnyUnix)]
         [Fact]
         public void ConnectAsyncV6IPEndPointToV6Host_Success()
         {
@@ -636,6 +635,7 @@ namespace System.Net.Sockets.Tests
         {
             private readonly ITestOutputHelper _output;
             private Socket _server;
+            private Socket _acceptedSocket;
             private EventWaitHandle _waitHandle = new AutoResetEvent(false);
 
             public EventWaitHandle WaitHandle
@@ -676,6 +676,8 @@ namespace System.Net.Sockets.Tests
                     "Accepted: " + e.GetHashCode() + " SocketAsyncEventArgs with manual event " +
                     handle.GetHashCode() + " error: " + e.SocketError);
 
+                _acceptedSocket = e.AcceptSocket;
+
                 handle.Set();
             }
 
@@ -684,6 +686,8 @@ namespace System.Net.Sockets.Tests
                 try
                 {
                     _server.Dispose();
+                    if (_acceptedSocket != null)
+                        _acceptedSocket.Dispose();
                 }
                 catch (Exception) { }
             }


### PR DESCRIPTION
Prior to this change, a GC triggered at the wrong time could cause a newly-accepted Socket to be collected and finalized, closing the connection before the other end of the socket was done.  To avoid this, we keep a reference to the new socket until the test is done with the connection.

Fixes #5291, #3748, #3744, #3682, #3494.

@stephentoub, @pgavlin, @CIPop 