### PR TITLE
Correctly interpret void TryExpressions with non-void components

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -1996,9 +1996,10 @@ namespace System.Linq.Expressions.Interpreter
             Debug.Assert(enterTryInstr != null);
 
             PushLabelBlock(LabelScopeKind.Try);
-            Compile(node.Body);
+            bool hasValue = node.Type != typeof(void);
 
-            bool hasValue = node.Body.Type != typeof(void);
+            Compile(node.Body, !hasValue);
+
             int tryEnd = _instructions.Count;
 
             // handlers jump here:
@@ -2072,12 +2073,11 @@ namespace System.Linq.Expressions.Interpreter
                     int handlerStart = _instructions.Count;
 
                     CompileSetVariable(parameter, true);
-                    Compile(handler.Body);
+                    Compile(handler.Body, !hasValue);
 
                     _exceptionForRethrowStack.Pop();
 
                     // keep the value of the body on the stack:
-                    Debug.Assert(hasValue == (handler.Body.Type != typeof(void)));
                     _instructions.EmitLeaveExceptionHandler(hasValue, gotoEnd);
 
                     exHandlers.Add(new ExceptionHandler(tryStart, tryEnd, handlerLabel, handlerStart, _instructions.Count, handler.Test));


### PR DESCRIPTION
Don't leave a value behind on the stack in such cases.

Fixes #5908

cc @VSadov @bartdesmet 