### PR TITLE
Enable portable PDB generation for x-plat builds

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-1.0.25-prerelease-00157
+1.0.25-prerelease-00161

--- a/dir.props
+++ b/dir.props
@@ -175,11 +175,9 @@
     <RoslynPropsFile>$(RoslynPackageDir)build/Microsoft.Net.ToolsetCompilers.props</RoslynPropsFile>
 
     <!--
-      PDB support isn't implemented yet. https://github.com/dotnet/roslyn/issues/2449
-      Note that both DebugSymbols and DebugType need set or project references will assume they need to copy pdbs and fail.
+      Portable PDBs are now supported in Linux and OSX with .Net Core MSBuild.
     -->
-    <DebugSymbols>false</DebugSymbols>
-    <DebugType>none</DebugType>
+    <DebugType>Portable</DebugType>
 
     <!--
       Delay signing with the ECMA key currently doesn't work.


### PR DESCRIPTION
Enable portable PDB generation for x-plat builds.

cc: @weshaggard 