### PR TITLE
Fixed a Stress issue in Serialization ObjectToIdCache.

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ObjectToIdCache.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ObjectToIdCache.cs
@@ -15,60 +15,64 @@ namespace System.Runtime.Serialization
         internal int m_currentCount;
         internal int[] m_ids;
         internal Object[] m_objs;
+        internal bool[] m_isWrapped;
 
         public ObjectToIdCache()
         {
             m_currentCount = 1;
             m_ids = new int[GetPrime(1)];
             m_objs = new Object[m_ids.Length];
+            m_isWrapped = new bool[m_ids.Length];
         }
 
         public int GetId(object obj, ref bool newId)
         {
-            bool isEmpty;
-            int pos = FindElement(obj, out isEmpty);
+            bool isEmpty, isWrapped;
+            int position = FindElement(obj, out isEmpty, out isWrapped);
             if (!isEmpty)
             {
                 newId = false;
-                return m_ids[pos];
+                return m_ids[position];
             }
             if (!newId)
                 return -1;
+
             int id = m_currentCount++;
-            m_objs[pos] = obj;
-            m_ids[pos] = id;
+            m_objs[position] = obj;
+            m_ids[position] = id;
+            m_isWrapped[position] = isWrapped;
             if (m_currentCount >= (m_objs.Length - 1))
                 Rehash();
             return id;
         }
 
-
         // (oldObjId, oldObj-id, newObj-newObjId) => (oldObj-oldObjId, newObj-id, newObjId )
         public int ReassignId(int oldObjId, object oldObj, object newObj)
         {
-            bool isEmpty;
-            int pos = FindElement(oldObj, out isEmpty);
+            bool isEmpty, isWrapped;
+            int position = FindElement(oldObj, out isEmpty, out isWrapped);
             if (isEmpty)
                 return 0;
-            int id = m_ids[pos];
+            int id = m_ids[position];
             if (oldObjId > 0)
-                m_ids[pos] = oldObjId;
+                m_ids[position] = oldObjId;
             else
-                RemoveAt(pos);
-            pos = FindElement(newObj, out isEmpty);
+                RemoveAt(position);
+            position = FindElement(newObj, out isEmpty, out isWrapped);
             int newObjId = 0;
             if (!isEmpty)
-                newObjId = m_ids[pos];
-            m_objs[pos] = newObj;
-            m_ids[pos] = id;
+                newObjId = m_ids[position];
+            m_objs[position] = newObj;
+            m_ids[position] = id;
+            m_isWrapped[position] = isWrapped;
             return newObjId;
         }
 
-        private int FindElement(object obj, out bool isEmpty)
+        private int FindElement(object obj, out bool isEmpty, out bool isWrapped)
         {
-            int hashcode = RuntimeHelpers.GetHashCode(obj);
-            int pos = ((hashcode & 0x7FFFFFFF) % m_objs.Length);
-            for (int i = pos; i != (pos - 1); i++)
+            isWrapped = false;
+            int position = ComputeStartPosition(obj);
+            for (int i = position; i != (position - 1); i++)
             {
                 if (m_objs[i] == null)
                 {
@@ -81,31 +85,58 @@ namespace System.Runtime.Serialization
                     return i;
                 }
                 if (i == (m_objs.Length - 1))
+                {
+                    isWrapped = true;
                     i = -1;
+                }
             }
             // m_obj must ALWAYS have atleast one slot empty (null).
             DiagnosticUtility.DebugAssert("Object table overflow");
             throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.ObjectTableOverflow)));
         }
 
-        private void RemoveAt(int pos)
+        private void RemoveAt(int position)
         {
-            int hashcode = RuntimeHelpers.GetHashCode(m_objs[pos]);
-            for (int i = pos, j; i != (pos - 1); i = j)
+            int cacheSize = m_objs.Length;
+            int lastVacantPosition = position;
+            for (int next = (position == cacheSize - 1) ? 0 : position + 1; next != position; next++)
             {
-                j = (i + 1) % m_objs.Length;
-                if (m_objs[j] == null || RuntimeHelpers.GetHashCode(m_objs[j]) != hashcode)
+                if (m_objs[next] == null)
                 {
-                    m_objs[pos] = m_objs[i];
-                    m_ids[pos] = m_ids[i];
-                    m_objs[i] = null;
-                    m_ids[i] = 0;
+                    m_objs[lastVacantPosition] = null;
+                    m_ids[lastVacantPosition] = 0;
+                    m_isWrapped[lastVacantPosition] = false;
                     return;
+                }
+                int nextStartPosition = ComputeStartPosition(m_objs[next]);
+                // If we wrapped while placing an object, then it must be that the start position wasn't wrapped to begin with
+                bool isNextStartPositionWrapped = next < position && !m_isWrapped[next];
+                bool isLastVacantPositionWrapped = lastVacantPosition < position;
+
+                // We want to avoid moving objects in the cache if the next bucket position is wrapped, but the last vacant position isn't
+                // and we want to make sure to move objects in the cache when the last vacant position is wrapped but the next bucket position isn't
+                if ((nextStartPosition <= lastVacantPosition && !(isNextStartPositionWrapped && !isLastVacantPositionWrapped)) ||
+                    (isLastVacantPositionWrapped && !isNextStartPositionWrapped))
+                {
+                    m_objs[lastVacantPosition] = m_objs[next];
+                    m_ids[lastVacantPosition] = m_ids[next];
+                    // A wrapped object might become unwrapped if it moves from the front of the array to the end of the array
+                    m_isWrapped[lastVacantPosition] = m_isWrapped[next] && next > lastVacantPosition;
+                    lastVacantPosition = next;
+                }
+                if (next == (cacheSize - 1))
+                {
+                    next = -1;
                 }
             }
             // m_obj must ALWAYS have atleast one slot empty (null).
             DiagnosticUtility.DebugAssert("Object table overflow");
             throw System.Runtime.Serialization.DiagnosticUtility.ExceptionUtility.ThrowHelperError(XmlObjectSerializer.CreateSerializationException(SR.Format(SR.ObjectTableOverflow)));
+        }
+
+        private int ComputeStartPosition(object o)
+        {
+            return (RuntimeHelpers.GetHashCode(o) & 0x7FFFFFFF) % m_objs.Length;
         }
 
         private void Rehash()
@@ -115,16 +146,18 @@ namespace System.Runtime.Serialization
             object[] oldObjs = m_objs;
             m_ids = new int[size];
             m_objs = new Object[size];
+            m_isWrapped = new bool[size];
 
             for (int j = 0; j < oldObjs.Length; j++)
             {
                 object obj = oldObjs[j];
                 if (obj != null)
                 {
-                    bool found;
-                    int pos = FindElement(obj, out found);
-                    m_objs[pos] = obj;
-                    m_ids[pos] = oldIds[j];
+                    bool found, isWrapped;
+                    int position = FindElement(obj, out found, out isWrapped);
+                    m_objs[position] = obj;
+                    m_ids[position] = oldIds[j];
+                    m_isWrapped[position] = isWrapped;
                 }
             }
         }
@@ -155,4 +188,3 @@ namespace System.Runtime.Serialization
         };
     }
 }
-

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializerStressTests.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializerStressTests.cs
@@ -1,0 +1,65 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.IO;
+using System.Runtime.Serialization;
+using Xunit;
+
+
+public static partial class DataContractSerializerTests
+{
+    [Fact]
+    public static void DCS_MyPersonSurrogate_Stress()
+    {
+        // This test is to verify a bug fix made in ObjectToIdCache.cs.
+        // There was a bug with ObjectToIdCache.RemoveAt() method which might cause
+        // one item be added into the cache more than once.
+        // The issue could happen in the following scenario,
+        // 1) ObjectToIdCache is used. ObjectToIdCache is used for DataContract types 
+        //    marked with [DataContract(IsReference = true)].
+        // 2) ObjectToIdCache.RemoveAt() is called. The method is called only when one uses
+        //    DataContract Surrogate.
+        // 3) There's hash-key collision in the cache and elements are deletes at certain position.
+        //
+        // The reason that I used multi-iterations here is because the issue does not always repro.
+        // It was a matter of odds. The more iterations we run here the more likely we repro the issue. 
+        for (int iterations = 0; iterations < 5; iterations++)
+        {
+            int length = 2000;
+            DataContractSerializer dcs = new DataContractSerializer(typeof(FamilyForStress));
+            dcs.SetSerializationSurrogateProvider(new MyPersonSurrogateProvider());
+            var members = new NonSerializablePersonForStress[2 * length];
+            for (int i = 0; i < length; i++)
+            {
+                var m = new NonSerializablePersonForStress("name", 30);
+
+                // We put the same object at two different slots. Because the DataContract type
+                // is marked with [DataContract(IsReference = true)], after serialization-deserialization,
+                // the objects at this two places should be the same object to each other.
+                members[i] = m;
+                members[i + length] = m;
+            }
+
+            MemoryStream ms = new MemoryStream();
+            FamilyForStress myFamily = new FamilyForStress
+            {
+                Members = members
+            };
+            dcs.WriteObject(ms, myFamily);
+            ms.Position = 0;
+            var newFamily = (FamilyForStress)dcs.ReadObject(ms);
+            Assert.StrictEqual(myFamily.Members.Length, newFamily.Members.Length);
+            for (int i = 0; i < myFamily.Members.Length; ++i)
+            {
+                Assert.StrictEqual(myFamily.Members[i].Name, newFamily.Members[i].Name);
+            }
+
+            var resultMembers = newFamily.Members;
+            for (int i = 0; i < length; i++)
+            {
+                Assert.Equal(resultMembers[i], resultMembers[i + length]);
+            }
+        }
+    }
+}

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -2515,9 +2515,43 @@ public class NonSerializablePerson
     }
 }
 
+public class NonSerializablePersonForStress
+{
+    public string Name { get; private set; }
+    public int Age { get; private set; }
+
+    public NonSerializablePersonForStress(string name, int age)
+    {
+        this.Name = name;
+        this.Age = age;
+    }
+
+    public override string ToString()
+    {
+        return string.Format("Person[Name={0},Age={1}]", this.Name, this.Age);
+    }
+}
+
 public class Family
 {
     public NonSerializablePerson[] Members;
+
+    public override string ToString()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.AppendLine("Family members:");
+        foreach (var member in this.Members)
+        {
+            sb.AppendLine("  " + member);
+        }
+
+        return sb.ToString();
+    }
+}
+
+public class FamilyForStress
+{
+    public NonSerializablePersonForStress[] Members;
 
     public override string ToString()
     {
@@ -2541,6 +2575,16 @@ public class NonSerializablePersonSurrogate
     public int Age { get; set; }
 }
 
+// Note that DataContractAttribute.IsReference is set to true.
+[DataContract(IsReference = true)]
+public class NonSerializablePersonForStressSurrogate
+{
+    [DataMember(Name = "PersonName")]
+    public string Name { get; set; }
+    [DataMember(Name = "PersonAge")]
+    public int Age { get; set; }
+}
+
 public class MyPersonSurrogateProvider : ISerializationSurrogateProvider
 {
     public Type GetSurrogateType(Type type)
@@ -2548,6 +2592,10 @@ public class MyPersonSurrogateProvider : ISerializationSurrogateProvider
         if (type == typeof(NonSerializablePerson))
         {
             return typeof(NonSerializablePersonSurrogate);
+        }
+        else if (type == typeof(NonSerializablePersonForStress))
+        {
+            return typeof(NonSerializablePersonForStressSurrogate);
         }
         else
         {
@@ -2562,6 +2610,11 @@ public class MyPersonSurrogateProvider : ISerializationSurrogateProvider
             NonSerializablePersonSurrogate person = (NonSerializablePersonSurrogate)obj;
             return new NonSerializablePerson(person.Name, person.Age);
         }
+        else if (obj is NonSerializablePersonForStressSurrogate)
+        {
+            NonSerializablePersonForStressSurrogate person = (NonSerializablePersonForStressSurrogate)obj;
+            return new NonSerializablePersonForStress(person.Name, person.Age);
+        }
 
         return obj;
     }
@@ -2572,6 +2625,17 @@ public class MyPersonSurrogateProvider : ISerializationSurrogateProvider
         {
             NonSerializablePerson nsp = (NonSerializablePerson)obj;
             NonSerializablePersonSurrogate serializablePerson = new NonSerializablePersonSurrogate
+            {
+                Name = nsp.Name,
+                Age = nsp.Age,
+            };
+
+            return serializablePerson;
+        }
+        else if (obj is NonSerializablePersonForStress)
+        {
+            NonSerializablePersonForStress nsp = (NonSerializablePersonForStress)obj;
+            NonSerializablePersonForStressSurrogate serializablePerson = new NonSerializablePersonForStressSurrogate
             {
                 Name = nsp.Name,
                 Age = nsp.Age,

--- a/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
@@ -19,6 +19,7 @@
     <Compile Include="Utils.cs" />
     <Compile Include="SerializationTypes.cs" />
     <Compile Include="DataContractSerializer.cs" />
+    <Compile Include="DataContractSerializerStressTests.cs" />
     <Compile Include="DataContractSerializerTestData.cs" />
     <Compile Include="MyResolver.cs" />
     <Compile Include="XmlDictionaryReaderTests.cs" />


### PR DESCRIPTION
The fix was ported from Desktop. 

The root cause of the issue is that the RemoveAt() method doesn't remove item correctly, which causes one item can be re-added to the cache.

Fix #5912