### PR TITLE
Split S.R.Metadata v1.2 and v1.3

### DIFF
--- a/src/System.Reflection.Metadata/System.Reflection.Metadata.sln
+++ b/src/System.Reflection.Metadata/System.Reflection.Metadata.sln
@@ -13,16 +13,26 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{5C5F1F
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug_Future|Any CPU = Debug_Future|Any CPU
 		Debug|Any CPU = Debug|Any CPU
+		Release_Future|Any CPU = Release_Future|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F3E433C8-352F-4944-BF7F-765CE435370D}.Debug_Future|Any CPU.ActiveCfg = Debug_Future|Any CPU
+		{F3E433C8-352F-4944-BF7F-765CE435370D}.Debug_Future|Any CPU.Build.0 = Debug_Future|Any CPU
 		{F3E433C8-352F-4944-BF7F-765CE435370D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F3E433C8-352F-4944-BF7F-765CE435370D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F3E433C8-352F-4944-BF7F-765CE435370D}.Release_Future|Any CPU.ActiveCfg = Release_Future|Any CPU
+		{F3E433C8-352F-4944-BF7F-765CE435370D}.Release_Future|Any CPU.Build.0 = Release_Future|Any CPU
 		{F3E433C8-352F-4944-BF7F-765CE435370D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F3E433C8-352F-4944-BF7F-765CE435370D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7061832A-E8CF-4AB6-A8DC-44D2F5A43A13}.Debug_Future|Any CPU.ActiveCfg = Debug|Any CPU
+		{7061832A-E8CF-4AB6-A8DC-44D2F5A43A13}.Debug_Future|Any CPU.Build.0 = Debug|Any CPU
 		{7061832A-E8CF-4AB6-A8DC-44D2F5A43A13}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7061832A-E8CF-4AB6-A8DC-44D2F5A43A13}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7061832A-E8CF-4AB6-A8DC-44D2F5A43A13}.Release_Future|Any CPU.ActiveCfg = Release|Any CPU
+		{7061832A-E8CF-4AB6-A8DC-44D2F5A43A13}.Release_Future|Any CPU.Build.0 = Release|Any CPU
 		{7061832A-E8CF-4AB6-A8DC-44D2F5A43A13}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7061832A-E8CF-4AB6-A8DC-44D2F5A43A13}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/src/System.Reflection.Metadata/pkg/System.Reflection.Metadata.builds
+++ b/src/System.Reflection.Metadata/pkg/System.Reflection.Metadata.builds
@@ -3,6 +3,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Reflection.Metadata.pkgproj"/>
+    <Project Include="future\System.Reflection.Metadata.pkgproj"/>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Reflection.Metadata/pkg/future/System.Reflection.Metadata.pkgproj
+++ b/src/System.Reflection.Metadata/pkg/future/System.Reflection.Metadata.pkgproj
@@ -4,14 +4,18 @@
   <PropertyGroup>
     <!-- we need to be supported on pre-nuget-3 platforms (Dev12, Dev11, etc) -->
     <MinClientVersion>2.8.6</MinClientVersion>
+    <!-- This is the .pkgproj for the "future" build which is not on the same release cadence as corefx -->
+    <PreReleaseLabel>beta</PreReleaseLabel>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\src\System.Reflection.Metadata.csproj">
+    <ProjectReference Include="..\..\src\System.Reflection.Metadata.csproj">
+      <AdditionalProperties>future=true</AdditionalProperties>
       <SupportedFramework>net45;netcore45;dnxcore50;wpa81</SupportedFramework>
     </ProjectReference>
     <!-- Support targets that were supported in previous package versions -->
-    <ProjectReference Include="..\src\System.Reflection.Metadata.csproj">
+    <ProjectReference Include="..\..\src\System.Reflection.Metadata.csproj">
+      <AdditionalProperties>future=true</AdditionalProperties>
       <PackageTargetPath>lib/portable-net45+win8</PackageTargetPath>
       <PackageTargetFramework>portable-net45+win8</PackageTargetFramework>
     </ProjectReference>

--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.builds
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.builds
@@ -3,6 +3,9 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
     <Project Include="System.Reflection.Metadata.csproj" />
+    <Project Include="System.Reflection.Metadata.csproj">
+      <AdditionalProperties>Future=true</AdditionalProperties>
+    </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
 </Project>

--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -27,6 +27,25 @@
     <Optimize>true</Optimize>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug_Future|AnyCPU'">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <Optimize>false</Optimize>
+    <ErrorReport>prompt</ErrorReport>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <Future>true</Future>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release_Future|AnyCPU'">
+    <Future>true</Future>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <Optimize>true</Optimize>
+    <ErrorReport>prompt</ErrorReport>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Future)' == 'true'">
+    <AssemblyVersion>1.3.0.0</AssemblyVersion>
+    <OutputPath>$(BaseOutputPath)$(OSPlatformConfig)/$(MSBuildProjectName)/future</OutputPath>
+    <IntermediateOutputPath>$(IntermediateOutputRootPath)$(MSBuildProjectName)/future</IntermediateOutputPath>
+    <DefineConstants>$(DefineConstants);FUTURE</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="System\Reflection\Blob.cs" />
     <Compile Include="System\Reflection\BlobWriter.cs" />

--- a/src/System.Reflection.Metadata/src/System/Reflection/Blob.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Blob.cs
@@ -10,7 +10,7 @@ namespace System.Reflection
 namespace Roslyn.Reflection
 #endif
 {
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct Blob

--- a/src/System.Reflection.Metadata/src/System/Reflection/BlobBuilder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/BlobBuilder.cs
@@ -25,7 +25,7 @@ namespace Roslyn.Reflection
 #endif
 {
     [DebuggerDisplay("{GetDebuggerDisplay(),nq}")]
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     unsafe partial class BlobBuilder

--- a/src/System.Reflection.Metadata/src/System/Reflection/BlobWriter.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/BlobWriter.cs
@@ -24,7 +24,7 @@ namespace Roslyn.Reflection
 #endif
 {
     // TODO: argument checking
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     unsafe struct BlobWriter

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ArrayShape.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ArrayShape.cs
@@ -4,12 +4,19 @@
 
 using System.Collections.Immutable;
 
+#if SRM
 namespace System.Reflection.Metadata.Decoding
+#else
+namespace Roslyn.Reflection.Metadata.Decoding
+#endif
 {
     /// <summary>
     /// Represents the shape of an array type.
     /// </summary>
-    public struct ArrayShape
+#if SRM && FUTURE
+    public
+#endif
+    struct ArrayShape
     {
         private readonly int _rank;
         private readonly ImmutableArray<int> _sizes;

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/IConstructedTypeProvider.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/IConstructedTypeProvider.cs
@@ -4,9 +4,16 @@
 
 using System.Collections.Immutable;
 
+#if SRM
 namespace System.Reflection.Metadata.Decoding
+#else
+namespace Roslyn.Reflection.Metadata.Decoding
+#endif
 {
-    public interface IConstructedTypeProvider<TType> : ISZArrayTypeProvider<TType>
+#if SRM && FUTURE
+    public
+#endif
+    interface IConstructedTypeProvider<TType> : ISZArrayTypeProvider<TType>
     {
         /// <summary>
         /// Gets the type symbol for a generic instantiation of the given generic type with the given type arguments.

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/IPrimitiveTypeProvider.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/IPrimitiveTypeProvider.cs
@@ -2,9 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if SRM
 namespace System.Reflection.Metadata.Decoding
+#else
+namespace Roslyn.Reflection.Metadata.Decoding
+#endif
 {
-    public interface IPrimitiveTypeProvider<TType>
+#if SRM && FUTURE
+    public
+#endif
+    interface IPrimitiveTypeProvider<TType>
     {
         /// <summary>
         /// Gets the type symbol for a primitive type.

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ISZArrayTypeProvider.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ISZArrayTypeProvider.cs
@@ -2,9 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if SRM
 namespace System.Reflection.Metadata.Decoding
+#else
+namespace Roslyn.Reflection.Metadata.Decoding
+#endif
 {
-    public interface ISZArrayTypeProvider<TType>
+#if SRM && FUTURE
+    public
+#endif
+    interface ISZArrayTypeProvider<TType>
     {
         /// <summary>
         /// Gets the type symbol for a single-dimensional array with zero lower bounds of the given element type.

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ISignatureTypeProvider.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ISignatureTypeProvider.cs
@@ -2,9 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if SRM
 namespace System.Reflection.Metadata.Decoding
+#else
+namespace Roslyn.Reflection.Metadata.Decoding
+#endif
 {
-    public interface ISignatureTypeProvider<TType> : IPrimitiveTypeProvider<TType>, ITypeProvider<TType>, IConstructedTypeProvider<TType>
+#if SRM && FUTURE
+    public
+#endif
+    interface ISignatureTypeProvider<TType> : IPrimitiveTypeProvider<TType>, ITypeProvider<TType>, IConstructedTypeProvider<TType>
     {
         /// <summary>
         /// Gets the a type symbol for the function pointer type of the given method signature.

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ITypeProvider.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ITypeProvider.cs
@@ -2,9 +2,16 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if SRM
 namespace System.Reflection.Metadata.Decoding
+#else
+namespace Roslyn.Reflection.Metadata.Decoding
+#endif
 {
-    public interface ITypeProvider<TType>
+#if SRM && FUTURE
+    public
+#endif
+    interface ITypeProvider<TType>
     {
         /// <summary>
         /// Gets the type symbol for a type definition.

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/MethodSignature.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/MethodSignature.cs
@@ -4,13 +4,20 @@
 
 using System.Collections.Immutable;
 
+#if SRM
 namespace System.Reflection.Metadata.Decoding
+#else
+namespace Roslyn.Reflection.Metadata.Decoding
+#endif
 {
     /// <summary>
     /// Represents a method (definition, reference, or standalone) or property signature.
     /// In the case of properties, the signature matches that of a getter with a distinguishing <see cref="SignatureHeader"/>.
     /// </summary>
-    public struct MethodSignature<TType>
+#if SRM && FUTURE
+    public
+#endif
+    struct MethodSignature<TType>
     {
         private readonly SignatureHeader _header;
         private readonly TType _returnType;

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/PrimitiveTypeCode.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/PrimitiveTypeCode.cs
@@ -2,12 +2,19 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if SRM
 namespace System.Reflection.Metadata.Decoding
+#else
+namespace Roslyn.Reflection.Metadata.Decoding
+#endif
 {
     /// <summary>
     /// Represents a primitive type found in metadata signatures.
     /// </summary>
-    public enum PrimitiveTypeCode : byte
+#if SRM && FUTURE
+    public
+#endif
+    enum PrimitiveTypeCode : byte
     {
         Boolean = SignatureTypeCode.Boolean,
         Byte = SignatureTypeCode.Byte,

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/SignatureDecoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/SignatureDecoder.cs
@@ -6,13 +6,20 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reflection.Metadata.Ecma335;
 
+#if SRM
 namespace System.Reflection.Metadata.Decoding
+#else
+namespace Roslyn.Reflection.Metadata.Decoding
+#endif
 {
     /// <summary>
     /// Decodes signature blobs.
     /// See Metadata Specification section II.23.2: Blobs and signatures.
     /// </summary>
-    public struct SignatureDecoder<TType>
+#if SRM && FUTURE
+    public
+#endif
+    struct SignatureDecoder<TType>
     {
         private readonly ISignatureTypeProvider<TType> _provider;
         private readonly MetadataReader _metadataReaderOpt;

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/SignatureDecoderOptions.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/SignatureDecoderOptions.cs
@@ -2,10 +2,17 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+#if SRM
 namespace System.Reflection.Metadata.Decoding
+#else
+namespace Roslyn.Reflection.Metadata.Decoding
+#endif
 {
     [Flags]
-    public enum SignatureDecoderOptions
+#if SRM && FUTURE
+    public
+#endif
+    enum SignatureDecoderOptions
     {
         /// <summary>
         /// Disable all options (default when no options are passed).

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/SignatureTypeHandleCode.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/SignatureTypeHandleCode.cs
@@ -4,9 +4,16 @@
 
 using System.Reflection.Metadata.Ecma335;
 
+#if SRM
 namespace System.Reflection.Metadata.Decoding
+#else
+namespace Roslyn.Reflection.Metadata.Decoding
+#endif
 {
-    public enum SignatureTypeHandleCode : byte
+#if SRM && FUTURE
+    public
+#endif
+    enum SignatureTypeHandleCode : byte
     {
         /// <summary>
         /// It is not known in the current context if the type reference or definition is a class or value type.

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Blobs/BlobEncoders.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Blobs/BlobEncoders.cs
@@ -32,7 +32,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
     //[EditorBrowsable(EditorBrowsableState.Never)]
     //public override string ToString() => base.ToString();
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct BlobEncoder
@@ -128,7 +128,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct MethodSignatureEncoder
@@ -151,7 +151,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct LocalVariablesEncoder
@@ -173,7 +173,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct LocalVariableTypeEncoder
@@ -211,7 +211,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct ParameterTypeEncoder
@@ -244,7 +244,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct PermissionSetEncoder
@@ -269,7 +269,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct GenericTypeArgumentsEncoder
@@ -291,7 +291,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct FixedArgumentsEncoder
@@ -313,7 +313,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct LiteralEncoder
@@ -348,7 +348,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct ScalarEncoder
@@ -389,7 +389,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct LiteralsEncoder
@@ -411,7 +411,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct VectorEncoder
@@ -430,7 +430,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct NameEncoder
@@ -448,7 +448,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct CustomAttributeNamedArgumentsEncoder
@@ -472,7 +472,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct NamedArgumentsEncoder
@@ -497,7 +497,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct NamedArgumentTypeEncoder
@@ -525,7 +525,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct CustomAttributeArrayTypeEncoder
@@ -550,7 +550,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct CustomAttributeElementTypeEncoder
@@ -621,7 +621,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     enum FunctionPointerAttributes
@@ -631,7 +631,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         HasExplicitThis = SignatureAttributes.Instance | SignatureAttributes.ExplicitThis
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct SignatureTypeEncoder
@@ -778,7 +778,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct CustomModifiersEncoder
@@ -810,7 +810,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct ArrayShapeEncoder
@@ -850,7 +850,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct ReturnTypeEncoder
@@ -888,7 +888,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct ParametersEncoder

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Blobs/ExceptionRegionEncoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Blobs/ExceptionRegionEncoder.cs
@@ -13,7 +13,7 @@ namespace System.Reflection.Metadata.Ecma335.Blobs
 namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
 #endif
 {
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct ExceptionRegionEncoder

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Blobs/InstructionEncoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Blobs/InstructionEncoder.cs
@@ -15,7 +15,7 @@ namespace System.Reflection.Metadata.Ecma335.Blobs
 namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
 #endif
 {
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct InstructionEncoder

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Blobs/MethodBodyEncoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Blobs/MethodBodyEncoder.cs
@@ -14,7 +14,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
 #endif
 {
     [Flags]
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     enum MethodBodyAttributes
@@ -24,7 +24,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         LargeExceptionRegions = 2,
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct MethodBodiesEncoder
@@ -71,7 +71,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct MethodBodyEncoder

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/CodedIndex.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/CodedIndex.cs
@@ -12,7 +12,7 @@ namespace System.Reflection.Metadata.Ecma335
 namespace Roslyn.Reflection.Metadata.Ecma335
 #endif
 {
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     static class CodedIndex

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataBuilder.Heaps.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataBuilder.Heaps.cs
@@ -24,7 +24,7 @@ namespace System.Reflection.Metadata.Ecma335
 namespace Roslyn.Reflection.Metadata.Ecma335
 #endif
 {
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     sealed partial class MetadataBuilder

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataSerializer.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataSerializer.cs
@@ -21,7 +21,7 @@ namespace System.Reflection.Metadata.Ecma335
 namespace Roslyn.Reflection.Metadata.Ecma335
 #endif
 {
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     sealed class StandaloneDebugMetadataSerializer : MetadataSerializer
@@ -74,7 +74,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     sealed class TypeSystemMetadataSerializer : MetadataSerializer
@@ -101,7 +101,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335
         }
     }
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     abstract class MetadataSerializer

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataSizes.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/MetadataSizes.cs
@@ -19,7 +19,7 @@ namespace System.Reflection.Metadata.Ecma335
 namespace Roslyn.Reflection.Metadata.Ecma335
 #endif
 {
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     sealed class MetadataSizes

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/FieldDefinition.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/FieldDefinition.cs
@@ -78,7 +78,12 @@ namespace System.Reflection.Metadata
             }
         }
 
-        public TType DecodeSignature<TType>(ISignatureTypeProvider<TType> provider, SignatureDecoderOptions options = SignatureDecoderOptions.None)
+#if FUTURE
+        public 
+#else
+        internal
+#endif
+        TType DecodeSignature<TType>(ISignatureTypeProvider<TType> provider, SignatureDecoderOptions options = SignatureDecoderOptions.None)
         {
             var decoder = new SignatureDecoder<TType>(provider, _reader, options);
             var blob = _reader.GetBlobReader(Signature);
@@ -147,7 +152,7 @@ namespace System.Reflection.Metadata
             return new CustomAttributeHandleCollection(_reader, Handle);
         }
 
-        #region Projections
+#region Projections
 
         private StringHandle GetProjectedName()
         {
@@ -171,6 +176,6 @@ namespace System.Reflection.Metadata
         {
             return _reader.FieldTable.GetSignature(Handle);
         }
-        #endregion
+#endregion
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/ILOpCode.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/ILOpCode.cs
@@ -8,7 +8,7 @@ namespace System.Reflection.Metadata
 namespace Microsoft.CodeAnalysis.CodeGen
 #endif
 {
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     enum ILOpCode : ushort

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MemberReference.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MemberReference.cs
@@ -70,9 +70,6 @@ namespace System.Reflection.Metadata
 
         /// <summary>
         /// Gets a handle to the signature blob.
-        ///
-        /// Decode using <see cref="DecodeMethodSignature"/> if <see cref="GetKind"/> returns <see cref="MemberReferenceKind.Method"/>
-        /// Decode using <see cref="DecodeFieldSignature"/> if <see cref="GetKind"/> returns <see cref="MemberReferenceKind.Field"/>
         /// </summary>
         public BlobHandle Signature
         {
@@ -87,14 +84,24 @@ namespace System.Reflection.Metadata
             }
         }
 
-        public TType DecodeFieldSignature<TType>(ISignatureTypeProvider<TType> provider, SignatureDecoderOptions options = SignatureDecoderOptions.None)
+#if FUTURE
+        public
+#else
+        internal
+#endif
+        TType DecodeFieldSignature<TType>(ISignatureTypeProvider<TType> provider, SignatureDecoderOptions options = SignatureDecoderOptions.None)
         {
             var decoder = new SignatureDecoder<TType>(provider, _reader, options);
             var blobReader = _reader.GetBlobReader(Signature);
             return decoder.DecodeFieldSignature(ref blobReader);
         }
 
-        public MethodSignature<TType> DecodeMethodSignature<TType>(ISignatureTypeProvider<TType> provider, SignatureDecoderOptions options = SignatureDecoderOptions.None)
+#if FUTURE
+        public 
+#else
+        internal
+#endif
+        MethodSignature<TType> DecodeMethodSignature<TType>(ISignatureTypeProvider<TType> provider, SignatureDecoderOptions options = SignatureDecoderOptions.None)
         {
             var decoder = new SignatureDecoder<TType>(provider, _reader, options);
             var blobReader = _reader.GetBlobReader(Signature);
@@ -128,7 +135,7 @@ namespace System.Reflection.Metadata
             return new CustomAttributeHandleCollection(_reader, Handle);
         }
 
-        #region Projections
+#region Projections
 
         private EntityHandle GetProjectedParent()
         {
@@ -151,6 +158,6 @@ namespace System.Reflection.Metadata
             // no change
             return _reader.MemberRefTable.GetSignature(Handle);
         }
-        #endregion
+#endregion
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MethodDefinition.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MethodDefinition.cs
@@ -65,7 +65,12 @@ namespace System.Reflection.Metadata
             }
         }
 
-        public MethodSignature<TType> DecodeSignature<TType>(ISignatureTypeProvider<TType> provider, SignatureDecoderOptions options = SignatureDecoderOptions.None)
+#if FUTURE
+        public 
+#else
+        internal
+#endif
+        MethodSignature<TType> DecodeSignature<TType>(ISignatureTypeProvider<TType> provider, SignatureDecoderOptions options = SignatureDecoderOptions.None)
         {
             var decoder = new SignatureDecoder<TType>(provider, _reader, options);
             var blobReader = _reader.GetBlobReader(Signature);
@@ -147,7 +152,7 @@ namespace System.Reflection.Metadata
             return new DeclarativeSecurityAttributeHandleCollection(_reader, Handle);
         }
 
-        #region Projections
+#region Projections
 
         private StringHandle GetProjectedName()
         {
@@ -214,6 +219,6 @@ namespace System.Reflection.Metadata
         {
             return 0;
         }
-        #endregion
+#endregion
     }
 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MethodSpecification.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/MethodSpecification.cs
@@ -43,8 +43,6 @@ namespace System.Reflection.Metadata
 
         /// <summary>
         /// Gets a handle to the signature blob.
-        ///
-        /// Decode using <see cref="DecodeSignature"/>.
         /// </summary>
         public BlobHandle Signature
         {
@@ -54,12 +52,14 @@ namespace System.Reflection.Metadata
             }
         }
 
+#if FUTURE
         public ImmutableArray<TType> DecodeSignature<TType>(ISignatureTypeProvider<TType> provider, SignatureDecoderOptions options = SignatureDecoderOptions.None)
         {
             var decoder = new SignatureDecoder<TType>(provider, _reader, options);
             var blobReader = _reader.GetBlobReader(Signature);
             return decoder.DecodeMethodSpecificationSignature(ref blobReader);
         }
+#endif
 
         public CustomAttributeHandleCollection GetCustomAttributes()
         {

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PropertyDefinition.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/PropertyDefinition.cs
@@ -53,7 +53,12 @@ namespace System.Reflection.Metadata
             }
         }
 
-        public MethodSignature<TType> DecodeSignature<TType>(ISignatureTypeProvider<TType> provider, SignatureDecoderOptions options = SignatureDecoderOptions.None)
+#if FUTURE
+        public 
+#else
+        internal
+#endif
+        MethodSignature<TType> DecodeSignature<TType>(ISignatureTypeProvider<TType> provider, SignatureDecoderOptions options = SignatureDecoderOptions.None)
         {
             var decoder = new SignatureDecoder<TType>(provider, _reader, options);
             var blobReader = _reader.GetBlobReader(Signature);

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/StandaloneSignature.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/StandaloneSignature.cs
@@ -31,23 +31,30 @@ namespace System.Reflection.Metadata
 
         /// <summary>
         /// Gets a handle to the signature blob.
-        ///
-        /// Decode using <see cref="DecodeMethodSignature"/> if <see cref="GetKind"/> returns <see cref="StandaloneSignatureKind.Method"/>
-        /// Decode using <see cref="DecodeLocalSignature"/> if <see cref="GetKind"/> returns <see cref="StandaloneSignatureKind.LocalVariables"/>
         /// </summary>
         public BlobHandle Signature
         {
             get { return _reader.StandAloneSigTable.GetSignature(_rowId); }
         }
 
-        public MethodSignature<TType> DecodeMethodSignature<TType>(ISignatureTypeProvider<TType> provider, SignatureDecoderOptions options = SignatureDecoderOptions.None)
+#if FUTURE
+        public 
+#else
+        internal
+#endif
+        MethodSignature<TType> DecodeMethodSignature<TType>(ISignatureTypeProvider<TType> provider, SignatureDecoderOptions options = SignatureDecoderOptions.None)
         {
             var decoder = new SignatureDecoder<TType>(provider, _reader, options);
             var blobReader = _reader.GetBlobReader(Signature);
             return decoder.DecodeMethodSignature(ref blobReader);
         }
 
-        public ImmutableArray<TType> DecodeLocalSignature<TType>(ISignatureTypeProvider<TType> provider, SignatureDecoderOptions options = SignatureDecoderOptions.None)
+#if FUTURE
+        public 
+#else
+        internal
+#endif
+        ImmutableArray<TType> DecodeLocalSignature<TType>(ISignatureTypeProvider<TType> provider, SignatureDecoderOptions options = SignatureDecoderOptions.None)
         {
             var decoder = new SignatureDecoder<TType>(provider, _reader, options);
             var blobReader = _reader.GetBlobReader(Signature);

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSpecification.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/TypeSpecification.cs
@@ -33,7 +33,12 @@ namespace System.Reflection.Metadata
             get { return _reader.TypeSpecTable.GetSignature(Handle); }
         }
 
-        public TType DecodeSignature<TType>(ISignatureTypeProvider<TType> provider, SignatureDecoderOptions options = SignatureDecoderOptions.None)
+#if FUTURE
+        public 
+#else
+        internal
+#endif
+        TType DecodeSignature<TType>(ISignatureTypeProvider<TType> provider, SignatureDecoderOptions options = SignatureDecoderOptions.None)
         {
             var decoder = new SignatureDecoder<TType>(provider, _reader, options);
             var blobReader = _reader.GetBlobReader(Signature);

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/ContentId.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/ContentId.cs
@@ -12,7 +12,7 @@ namespace System.Reflection.PortableExecutable
 namespace Roslyn.Reflection.PortableExecutable
 #endif
 {
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct ContentId

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/ManagedPEBuilder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/ManagedPEBuilder.cs
@@ -18,7 +18,7 @@ namespace Roslyn.Reflection.PortableExecutable
     using Roslyn.Reflection.Metadata.Ecma335;
 #endif
 
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     static class ManagedPEBuilder

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/ManagedTextSection.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/ManagedTextSection.cs
@@ -36,7 +36,7 @@ namespace Roslyn.Reflection.PortableExecutable
     /// - Runtime Startup Stub
     /// - Mapped Field Data
     /// </remarks>
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     sealed class ManagedTextSection

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEBuilder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEBuilder.cs
@@ -21,7 +21,7 @@ namespace System.Reflection.PortableExecutable
 namespace Roslyn.Reflection.PortableExecutable
 #endif
 {
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     sealed class PEBuilder

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEDirectoriesBuilder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEDirectoriesBuilder.cs
@@ -10,7 +10,7 @@ namespace System.Reflection.PortableExecutable
 namespace Roslyn.Reflection.PortableExecutable
 #endif
 {
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     sealed class PEDirectoriesBuilder

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PESectionLocation.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PESectionLocation.cs
@@ -8,7 +8,7 @@ namespace System.Reflection.PortableExecutable
 namespace Roslyn.Reflection.PortableExecutable
 #endif
 {
-#if SRM
+#if SRM && FUTURE
     public
 #endif
     struct PESectionLocation

--- a/src/System.Reflection.Metadata/tests/Metadata/Decoding/DisassemblingTypeProvider.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/Decoding/DisassemblingTypeProvider.cs
@@ -10,7 +10,7 @@ namespace System.Reflection.Metadata.Decoding.Tests
 {
     // Test implementation of ISignatureTypeProvider<TType> that uses strings in ilasm syntax as TType.
     // A real provider in any sort of perf constraints would not want to allocate strings freely like this, but it keeps test code simple.
-    public class DisassemblingTypeProvider : ISignatureTypeProvider<string>
+    internal class DisassemblingTypeProvider : ISignatureTypeProvider<string>
     {
         public virtual string GetPrimitiveType(PrimitiveTypeCode typeCode)
         {

--- a/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -95,7 +95,7 @@
     <None Include="Resources\NetModule\ModuleCS01.cs" />
     <EmbeddedResource Include="Resources\NetModule\ModuleCS01.mod" />
     <EmbeddedResource Include="Resources\NetModule\ModuleVB01.mod" />
-    <None Include="Resources\NetModule\ModuleVB01.vb" />    
+    <None Include="Resources\NetModule\ModuleVB01.vb" />
     <EmbeddedResource Include="Resources\WinRT\Lib.winmd" />
     <None Include="Resources\WinRT\Lib.cs" />
   </ItemGroup>


### PR DESCRIPTION
We have to lock down a v1.2 S.R.Metadata now, but there are features
(metadata writer, signature decoder) that we're pushing out to a v1.3.

Set up the build to produce both packages and configure the project
such that the default configurations are v1.2 and the *_Future
configurations are v1.3.

Currently, v1.2 just internalizes the features of v1.3, but we can
consider stripping them out entirely.

cc @ericstj @tmat