### PR TITLE
Improve X509Chain.Build perf on Unix

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/ChainPal.cs
@@ -44,11 +44,11 @@ namespace Internal.Cryptography.Pal
             }
 
             TimeSpan remainingDownloadTime = timeout;
-            X509Certificate2 leaf = new X509Certificate2(cert.Handle);
-            List<X509Certificate2> downloaded = new List<X509Certificate2>();
-            List<X509Certificate2> systemTrusted = new List<X509Certificate2>();
+            var leaf = new X509Certificate2(cert.Handle);
+            var downloaded = new HashSet<X509Certificate2>();
+            var systemTrusted = new HashSet<X509Certificate2>();
 
-            List<X509Certificate2> candidates = OpenSslX509ChainProcessor.FindCandidates(
+            HashSet<X509Certificate2> candidates = OpenSslX509ChainProcessor.FindCandidates(
                 leaf,
                 extraStore,
                 downloaded,
@@ -77,7 +77,7 @@ namespace Internal.Cryptography.Pal
 
         private static void SaveIntermediateCertificates(
             X509ChainElement[] chainElements,
-            List<X509Certificate2> downloaded)
+            HashSet<X509Certificate2> downloaded)
         {
             List<X509Certificate2> chainDownloaded = new List<X509Certificate2>(chainElements.Length);
 
@@ -110,11 +110,11 @@ namespace Internal.Cryptography.Pal
                     return;
                 }
 
-                for (int i = 0; i < chainDownloaded.Count; i++)
+                foreach (X509Certificate2 cert in chainDownloaded)
                 {
                     try
                     {
-                        userIntermediate.Add(downloaded[i]);
+                        userIntermediate.Add(cert);
                     }
                     catch (CryptographicException)
                     {

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509Certificate.cs
@@ -144,8 +144,9 @@ namespace System.Security.Cryptography.X509Certificates
             if (!Issuer.Equals(other.Issuer))
                 return false;
 
-            byte[] thisSerialNumber = GetSerialNumber();
-            byte[] otherSerialNumber = other.GetSerialNumber();
+            byte[] thisSerialNumber = GetRawSerialNumber();
+            byte[] otherSerialNumber = other.GetRawSerialNumber();
+
             if (thisSerialNumber.Length != otherSerialNumber.Length)
                 return false;
             for (int i = 0; i < thisSerialNumber.Length; i++)
@@ -179,12 +180,13 @@ namespace System.Security.Cryptography.X509Certificates
         public virtual byte[] GetCertHash()
         {
             ThrowIfInvalid();
+            return GetRawCertHash().CloneByteArray();
+        }
 
-            byte[] certHash = _lazyCertHash;
-            if (certHash == null)
-                _lazyCertHash = certHash = Pal.Thumbprint;
-
-            return certHash.CloneByteArray();
+        // Only use for internal purposes when the returned byte[] will not be mutated
+        private byte[] GetRawCertHash()
+        {
+            return _lazyCertHash ?? (_lazyCertHash = Pal.Thumbprint);
         }
 
         public virtual string GetFormat()
@@ -197,7 +199,7 @@ namespace System.Security.Cryptography.X509Certificates
             if (Pal == null)
                 return 0;
 
-            byte[] thumbPrint = GetCertHash();
+            byte[] thumbPrint = GetRawCertHash();
             int value = 0;
             for (int i = 0; i < thumbPrint.Length && i < 4; ++i)
             {
@@ -248,10 +250,13 @@ namespace System.Security.Cryptography.X509Certificates
         {
             ThrowIfInvalid();
 
-            byte[] serialNumber = _lazySerialNumber;
-            if (serialNumber == null)
-                serialNumber = _lazySerialNumber = Pal.SerialNumber;
-            return serialNumber.CloneByteArray();
+            return GetRawSerialNumber().CloneByteArray();
+        }
+
+        // Only use for internal purposes when the returned byte[] will not be mutated
+        private byte[] GetRawSerialNumber()
+        {
+            return _lazySerialNumber ?? (_lazySerialNumber = Pal.SerialNumber);
         }
 
         public override string ToString()
@@ -302,7 +307,7 @@ namespace System.Security.Cryptography.X509Certificates
             sb.AppendLine();
             sb.AppendLine("[Thumbprint]");
             sb.Append("  ");
-            sb.Append(GetCertHash().ToHexArrayUpper());
+            sb.Append(GetRawCertHash().ToHexArrayUpper());
             sb.AppendLine();
 
             return sb.ToString();


### PR DESCRIPTION
The implementation is doing a bunch of calls to ```List<X509Certificate>.Contains```.  This is incurring both lots of O(N) lookups and non-trivial costs in X509Certificate.Equals.  By avoiding some work in Equals and by changing to ```HashSet<X509Certificate>``` for these cases, throughput improved by more than 30% on my machine with ~160 certs in the root store.

cc: @bartonjs