### PR TITLE
Fix gchandle leak in WebSockets.Client

### DIFF
--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocketCallback.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocketCallback.cs
@@ -134,6 +134,12 @@ namespace System.Net.WebSockets
 
             state.RequestHandle.DetachCallback();
             state.RequestHandle = null;
+            
+            // Unpin the operation object if there is no WebSocket handle. This will happen in error cases.
+            if (state.WebSocketHandle == null)
+            {
+                state.Unpin();
+            }
         }
 
         private static void OnRequestError(
@@ -290,6 +296,9 @@ namespace System.Net.WebSockets
 
             state.WebSocketHandle.DetachCallback();
             state.WebSocketHandle = null;
+
+            // Unpin the operation object since all handles that would use a callback are now closed.
+            state.Unpin();
         }
 
         private static void OnWebSocketError(

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocketState.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocketState.cs
@@ -61,14 +61,17 @@ namespace System.Net.WebSockets
             }
         }
 
-        public int IncrementHandlesOpenWithCallback()
+        public void IncrementHandlesOpenWithCallback()
         {
-            return Interlocked.Increment(ref _handlesOpenWithCallback);
+            Interlocked.Increment(ref _handlesOpenWithCallback);
         }
 
         public int DecrementHandlesOpenWithCallback()
         {
-            return Interlocked.Decrement(ref _handlesOpenWithCallback);
+            int count = Interlocked.Decrement(ref _handlesOpenWithCallback);
+            Debug.Assert(count >= 0);
+            
+            return count;
         }
 
         public WebSocketState State

--- a/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocketState.cs
+++ b/src/System.Net.WebSockets.Client/src/System/Net/WebSockets/WinHttpWebSocketState.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -43,6 +44,7 @@ namespace System.Net.WebSockets
 
         public void Pin()
         {
+            Debug.Assert(!_operationHandle.IsAllocated);
             _operationHandle = GCHandle.Alloc(this);
         }
 
@@ -51,6 +53,7 @@ namespace System.Net.WebSockets
             if (_operationHandle.IsAllocated)
             {
                 _operationHandle.Free();
+                _operationHandle = default(GCHandle);
             }
         }
 


### PR DESCRIPTION
The Windows implementation of WebSockets.Client leaks the WinHttpWebSocketState object. This object was being pinned by `GCHandle.Alloc(this)` in the contructor. And it was never freed.

This object needs to be pinned during the WebSocket lifecycle because the address of the object is passed to native WinHTTP and used as the context value during callbacks. However, it needs to be manually freed at the proper time after all WinHTTP callbacks are done via closing down the handles.

This fix adds Pin() and Unpin() methods to WinHttpWebSocketState and calls them at appropriate times. While fixing this I discovered other places where the object might be left as pinned. The current logic relies on WinHTTP calling the callback with HANDLE_CLOSING before the object would get unpinned. But since the object is pinned very early on, it's possible due to unexpected errors, that the wiring of the WinHTTP callback never gets done. And thus, the object would never have been unpinned.  This fix delays the pinning of the object until the right time where it is assured that the WinHTTP callback wiring has been completed.

This logic is now similar to the state handling in WinHttpHandler. There is still a work item #2501 to merge these design implementations and share code in the future.

Fixes #3256.