### PR TITLE
Validation call IsGenericMethodDefinition after ContainsGenericParameters

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -816,10 +816,8 @@ namespace System.Linq.Expressions
 
         private static void ValidateMethodInfo(MethodInfo method)
         {
-            if (method.IsGenericMethodDefinition)
-                throw Error.MethodIsGeneric(method);
             if (method.ContainsGenericParameters)
-                throw Error.MethodContainsGenericParameters(method);
+                throw method.IsGenericMethodDefinition ? Error.MethodIsGeneric(method) : Error.MethodContainsGenericParameters(method);
         }
 
 


### PR DESCRIPTION
While IsGenericMethodDefinition is cheaper, the normal path would have both these return false. Since ContainsGenericParameters entails IsGenericMethodDefinition we can leave testing it until ContainsGenericParameters has returned true, to decide on the error message. Hence skipping one virtual call and one branch from most method validation checks .