### PR TITLE
Escaping Workspace property in Groovy script, and re-adding configuration group for outeloop runs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -125,7 +125,7 @@ branchList.each { branchName ->
                     // Jobs run as a service in unix, which means that HOME variable is not set, and it is required for restoring packages
                     // so we set it first, and then call build.sh
                     steps {
-                        shell('HOME=$WORKSPACE/tempHome ./build.sh /p:ConfigurationGroup=${configurationGroup} /p:WithCategories=\"InnerLoop;OuterLoop\" /p:TestWithLocalLibraries=true')
+                        shell("HOME=\$WORKSPACE/tempHome ./build.sh /p:ConfigurationGroup=${configurationGroup} /p:WithCategories=\"InnerLoop;OuterLoop\" /p:TestWithLocalLibraries=true")
                     }
                 }
             }


### PR DESCRIPTION
Escaping Workspace property in Groovy script, and re-adding configuration group for outeloop runs

FYI: @mmitche 