### PR TITLE
Modify SNI Provider error messages in Strings.resx to match previous versions of .NET

### DIFF
--- a/src/System.Data.SqlClient/src/Resources/Strings.resx
+++ b/src/System.Data.SqlClient/src/Resources/Strings.resx
@@ -1030,9 +1030,12 @@
     <value>TCP Provider</value>
   </data>
   <data name="SNI_PN8" xml:space="preserve">
-    <value>   </value>
+    <value>VIA Provider</value>
   </data>
   <data name="SNI_PN9" xml:space="preserve">
+    <value></value>
+  </data>
+  <data name="SNI_PN10" xml:space="preserve">
     <value>SQL Network Interfaces</value>
   </data>
   <data name="ADP_FeatureNotSupportedOnNonWindowsPlatform" xml:space="preserve">

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNICommon.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNICommon.cs
@@ -19,11 +19,17 @@ namespace System.Data.SqlClient.SNI
     /// </summary>
     internal enum SNIProviders
     {
-        NP_PROV = 1,        // Named Pipes Provider
-        SMUX_PROV = 5,      // MARS Provider
-        SSL_PROV = 6,       // SSL Provider
-        TCP_PROV = 7,       // TCP Provider
-        INVALID_PROV = 10,  // Invalid Provider
+        HTTP_PROV = 0, // HTTP Provider
+        NP_PROV = 1, // Named Pipes Provider
+        SESSION_PROV = 2, // Session Provider
+        SIGN_PROV = 3, // Sign Provider
+        SM_PROV = 4, // Shared Memory Provider
+        SMUX_PROV = 5, // SMUX Provider
+        SSL_PROV = 6, // SSL Provider
+        TCP_PROV = 7, // TCP Provider
+        VIA_PROV = 8, // VIA Provider
+        MAX_PROVS = 9,
+        INVALID_PROV = 10 // SQL Network Interfaces
     }
 
     /// <summary>


### PR DESCRIPTION
When returning INVALID_PROV errors in managed SNI, an error would be thrown since Strings.resx did not have a mapping for SNI_PN10. This change makes all the SNI_PN* errors identical to those in previous versions of .NET.