### PR TITLE
Improve performance of ImmutableArray in version resilient code

### DIFF
--- a/src/Common/src/System/Runtime/Versioning/NonVersionableAttribute.cs
+++ b/src/Common/src/System/Runtime/Versioning/NonVersionableAttribute.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+/*============================================================
+**
+** Class:  NonVersionableAttribute
+**
+**
+** The [NonVersionable] attribute is applied to indicate that the implementation 
+** of a particular member or layout of a struct cannot be changed for given platform in incompatible way.
+** This allows cross-module inlining of methods and data structures whose implementation 
+** is never changed in ReadyToRun native images. Any changes to such members or types would be 
+** breaking changes for ReadyToRun.
+**
+===========================================================*/
+using System;
+using System.Diagnostics;
+
+namespace System.Runtime.Versioning
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Method | AttributeTargets.Constructor, 
+                    AllowMultiple = false, Inherited = false)]
+    sealed internal class NonVersionableAttribute : Attribute
+    {
+        public NonVersionableAttribute()
+        {
+        }
+    }
+}

--- a/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -96,6 +96,9 @@
     <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
       <Link>Common\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\Runtime\Versioning\NonVersionableAttribute.cs">
+      <Link>Common\System\Runtime\Versioning\NonVersionableAttribute.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Interfaces.cd" />

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -8,6 +8,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.Versioning;
 
 namespace System.Collections.Immutable
 {
@@ -32,6 +33,7 @@ namespace System.Collections.Immutable
     /// it is insulated from other threads.
     /// </devremarks>
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
+    [NonVersionable] // Applies to field layout
     public partial struct ImmutableArray<T> : IReadOnlyList<T>, IList<T>, IEquatable<ImmutableArray<T>>, IImmutableList<T>, IList, IImmutableArray, IStructuralComparable, IStructuralEquatable
     {
         /// <summary>
@@ -66,6 +68,7 @@ namespace System.Collections.Immutable
         /// <param name="left">The instance to the left of the operator.</param>
         /// <param name="right">The instance to the right of the operator.</param>
         /// <returns><c>true</c> if the values' underlying arrays are reference equal; <c>false</c> otherwise.</returns>
+        [NonVersionable]
         public static bool operator ==(ImmutableArray<T> left, ImmutableArray<T> right)
         {
             return left.Equals(right);
@@ -77,6 +80,7 @@ namespace System.Collections.Immutable
         /// <param name="left">The instance to the left of the operator.</param>
         /// <param name="right">The instance to the right of the operator.</param>
         /// <returns><c>true</c> if the values' underlying arrays are reference not equal; <c>false</c> otherwise.</returns>
+        [NonVersionable]
         public static bool operator !=(ImmutableArray<T> left, ImmutableArray<T> right)
         {
             return !left.Equals(right);
@@ -113,6 +117,7 @@ namespace System.Collections.Immutable
         /// <returns>The element at the specified index in the read-only list.</returns>
         public T this[int index]
         {
+            [NonVersionable]
             get
             {
                 // We intentionally do not check this.array != null, and throw NullReferenceException
@@ -160,6 +165,7 @@ namespace System.Collections.Immutable
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public bool IsEmpty
         {
+            [NonVersionable]
             get { return this.Length == 0; }
         }
 
@@ -169,6 +175,7 @@ namespace System.Collections.Immutable
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public int Length
         {
+            [NonVersionable]
             get
             {
                 // We intentionally do not check this.array != null, and throw NullReferenceException
@@ -1066,6 +1073,7 @@ namespace System.Collections.Immutable
         /// true if the current object is equal to the <paramref name="other"/> parameter; otherwise, false.
         /// </returns>
         [Pure]
+        [NonVersionable]
         public bool Equals(ImmutableArray<T> other)
         {
             return this.array == other.array;


### PR DESCRIPTION
Marked a few performance critical trivial wrappers in ImmutableArray with NonVersionableAttribute. It allows them to be inlined in version resilient (readytorun) images.