### PR TITLE
Fix two issues with ListInitExpression [WIP]

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ElementInit.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ElementInit.cs
@@ -106,7 +106,6 @@ namespace System.Linq.Expressions
 
             var argumentsRO = arguments.ToReadOnly();
 
-            RequiresCanRead(argumentsRO, "arguments");
             ValidateElementInitAddMethodInfo(addMethod);
             ValidateArgumentTypes(addMethod, ExpressionType.Call, ref argumentsRO);
             return new ElementInit(addMethod, argumentsRO);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2656,7 +2656,10 @@ namespace System.Linq.Expressions.Interpreter
                 {
                     Compile(arg);
                 }
-                _instructions.EmitCall(initializers[i].AddMethod);
+                var add = initializers[i].AddMethod;
+                _instructions.EmitCall(add);
+                if (add.ReturnType != typeof(void))
+                    _instructions.EmitPop();
             }
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
@@ -126,9 +126,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="ListInitExpression"/> that has the <see cref="P:ListInitExpression.NodeType"/> property equal to ListInit and the <see cref="P:ListInitExpression.NewExpression"/> property set to the specified value.</returns>
         public static ListInitExpression ListInit(NewExpression newExpression, params Expression[] initializers)
         {
-            ContractUtils.RequiresNotNull(newExpression, "newExpression");
-            ContractUtils.RequiresNotNull(initializers, "initializers");
-            return ListInit(newExpression, initializers as IEnumerable<Expression>);
+            return ListInit(newExpression, (IEnumerable<Expression>)initializers);
         }
 
         /// <summary>
@@ -187,13 +185,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="ListInitExpression"/> that has the <see cref="P:ListInitExpression.NodeType"/> property equal to ListInit and the <see cref="P:ListInitExpression.NewExpression"/> property set to the specified value.</returns>
         public static ListInitExpression ListInit(NewExpression newExpression, MethodInfo addMethod, params Expression[] initializers)
         {
-            if (addMethod == null)
-            {
-                return ListInit(newExpression, initializers as IEnumerable<Expression>);
-            }
-            ContractUtils.RequiresNotNull(newExpression, "newExpression");
-            ContractUtils.RequiresNotNull(initializers, "initializers");
-            return ListInit(newExpression, addMethod, initializers as IEnumerable<Expression>);
+            return ListInit(newExpression, addMethod, (IEnumerable<Expression>)initializers);
         }
 
         /// <summary>
@@ -217,12 +209,21 @@ namespace System.Linq.Expressions
             {
                 throw Error.ListInitializerWithZeroMembers();
             }
+
+            Type newType = newExpression.Type;
+            if (!typeof(IEnumerable).IsAssignableFrom(newType))
+            {
+                throw Error.TypeNotIEnumerable(newType);
+            }
+
+            ValidateCallInstanceType(newType, addMethod);
+
             ElementInit[] initList = new ElementInit[initializerlist.Count];
             for (int i = 0; i < initializerlist.Count; i++)
             {
                 initList[i] = ElementInit(addMethod, initializerlist[i]);
             }
-            return ListInit(newExpression, new TrueReadOnlyCollection<ElementInit>(initList));
+            return new ListInitExpression(newExpression, new TrueReadOnlyCollection<ElementInit>(initList));
         }
 
         /// <summary>

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
@@ -146,6 +146,7 @@ namespace System.Linq.Expressions
             {
                 throw Error.ListInitializerWithZeroMembers();
             }
+            ContractUtils.RequiresNotNullItems(initializerlist, "initializers");
 
             Type newType = newExpression.Type;
             if (!typeof(IEnumerable).IsAssignableFrom(newType))
@@ -209,6 +210,7 @@ namespace System.Linq.Expressions
             {
                 throw Error.ListInitializerWithZeroMembers();
             }
+            ContractUtils.RequiresNotNullItems(initializerlist, "initializers");
 
             Type newType = newExpression.Type;
             if (!typeof(IEnumerable).IsAssignableFrom(newType))

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberListBinding.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberListBinding.cs
@@ -123,11 +123,10 @@ namespace System.Linq.Expressions
             {
                 throw Error.TypeNotIEnumerable(listType);
             }
+            ContractUtils.RequiresNotNullItems(initializers, "initializers");
             for (int i = 0, n = initializers.Count; i < n; i++)
             {
-                ElementInit element = initializers[i];
-                ContractUtils.RequiresNotNull(element, "initializers");
-                ValidateCallInstanceType(listType, element.AddMethod);
+                ValidateCallInstanceType(listType, initializers[i].AddMethod);
             }
         }
     }

--- a/src/System.Linq.Expressions/tests/ListInit/ElementInitTests.cs
+++ b/src/System.Linq.Expressions/tests/ListInit/ElementInitTests.cs
@@ -1,0 +1,199 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public class ElementInitTests
+    {
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        private class ParameterlessAdd
+        {
+            public void Add()
+            {
+            }
+        }
+
+        private class StaticAdd
+        {
+            public static void Add(int value)
+            {
+            }
+        }
+
+        private class ByRefAdd
+        {
+            public static void Add(ref int value)
+            {
+            }
+        }
+
+        private class GenericAdd
+        {
+            public static void Add<T>(T value)
+            {
+            }
+        }
+
+        [Fact]
+        public void NullAddMethod()
+        {
+            Assert.Throws<ArgumentNullException>("addMethod", () => Expression.ElementInit(null, Expression.Constant(0)));
+            Assert.Throws<ArgumentNullException>("addMethod", () => Expression.ElementInit(null, Enumerable.Repeat(Expression.Constant(0), 1)));
+        }
+
+        [Fact]
+        public void NullArguments()
+        {
+            Assert.Throws<ArgumentNullException>("arguments", () => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), default(Expression[])));
+            Assert.Throws<ArgumentNullException>("arguments", () => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), default(Expression[])));
+        }
+
+        [Fact]
+        public void NoArguments()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add")));
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Enumerable.Empty<Expression>()));
+        }
+
+        [Fact]
+        public void ArgumentCountWrong()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant(0), Expression.Constant(1)));
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 2)));
+        }
+
+        [Fact]
+        public void ArgumentTypeMisMatch()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant("Hello")));
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Enumerable.Repeat(Expression.Constant("Hello"), 1)));
+        }
+
+        [Fact]
+        public void UnreadableArgument()
+        {
+            Expression argument = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), argument));
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Enumerable.Repeat(argument, 1)));
+        }
+
+        [Fact]
+        public void ParameterlessAddProhibited()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(ParameterlessAdd).GetMethod("Add"), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(ParameterlessAdd).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 1)));
+        }
+
+        [Fact]
+        public void StaticAddProhibited()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(StaticAdd).GetMethod("Add"), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(StaticAdd).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 1)));
+        }
+
+        [Fact]
+        public void ByRefAddProhibited()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(ByRefAdd).GetMethod("Add"), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(ByRefAdd).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 1)));
+        }
+
+        [Fact]
+        public void GenericAddProhibited()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(GenericAdd).GetMethod("Add"), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(GenericAdd).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 1)));
+        }
+
+        [Fact]
+        public void GenericParameterAddProhibited()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<>).GetMethod("Add"), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<>).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 1)));
+        }
+
+        [Fact]
+        public void AddMethodNotCalledAdd()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Remove"), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Remove"), Enumerable.Repeat(Expression.Constant(0), 1)));
+        }
+
+        [Fact]
+        public void UpdateSameArgumentsSameInstanceReturned()
+        {
+            ElementInit init = Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant(0));
+            IEnumerable<Expression> arguments = init.Arguments;
+            Assert.Same(init, init.Update(arguments));
+        }
+
+        [Fact]
+        public void UpdateDifferentArgumentsDifferetInstanceReturned()
+        {
+            ElementInit init = Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant(0));
+            Assert.NotSame(init, init.Update(Enumerable.Repeat(Expression.Constant(1), 1)));
+        }
+
+        [Fact]
+        public void UpdateDifferentNumberArgumentsDifferetInstanceReturned()
+        {
+            ElementInit init = Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant(0));
+            Assert.NotSame(init, init.Update(Enumerable.Repeat(Expression.Constant(1), 1)));
+        }
+
+        [Fact]
+        public void CanRetrieveMethod()
+        {
+            ElementInit init = Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant(0));
+            Assert.Equal(typeof(List<int>).GetMethod("Add"), init.AddMethod);
+        }
+
+        [Fact]
+        public void CanAccessArguments()
+        {
+            Expression key = Expression.Constant("Key");
+            Expression value = Expression.Constant(42);
+            ElementInit init = Expression.ElementInit(typeof(Dictionary<string, int>).GetMethod("Add"), key, value);
+            Assert.Equal(2, init.ArgumentCount);
+            Assert.Same(key, init.GetArgument(0));
+            Assert.Same(value, init.GetArgument(1));
+            Assert.Equal(new[] { key, value }, init.Arguments);
+        }
+
+        [Fact]
+        public void InvalidArgumentIndex()
+        {
+            Expression key = Expression.Constant("Key");
+            Expression value = Expression.Constant(42);
+            ElementInit init = Expression.ElementInit(typeof(Dictionary<string, int>).GetMethod("Add"), key, value);
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => init.GetArgument(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => init.GetArgument(2));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => init.GetArgument(3));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => init.GetArgument(int.MaxValue));
+        }
+
+        [Fact]
+        public void ToStringShowsArguments()
+        {
+            ElementInit init = Expression.ElementInit(
+                typeof(Dictionary<string, int>).GetMethod("Add"),
+                Expression.Constant("Key"),
+                Expression.Constant(42)
+                );
+            Assert.Equal(typeof(Dictionary<string, int>).GetMethod("Add").ToString() + "(\"Key\", 42)", init.ToString());
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
@@ -80,6 +80,23 @@ namespace System.Linq.Expressions.Tests
         }
 
         [Fact]
+        public void NullInitializerInList()
+        {
+            var validNew = Expression.New(typeof(List<int>));
+            Assert.Throws<ArgumentNullException>("initializers[0]", () => Expression.ListInit(validNew, default(Expression)));
+            Assert.Throws<ArgumentNullException>("initializers[0]", () => Expression.ListInit(validNew, Enumerable.Repeat(default(Expression), 1)));
+            Assert.Throws<ArgumentNullException>("initializers[0]", () => Expression.ListInit(validNew, default(ElementInit)));
+            Assert.Throws<ArgumentNullException>("initializers[0]", () => Expression.ListInit(validNew, Enumerable.Repeat(default(ElementInit), 1)));
+
+            var validMethod = typeof(List<int>).GetMethod("Add");
+            Assert.Throws<ArgumentNullException>("initializers[0]", () => Expression.ListInit(validNew, validMethod, default(Expression)));
+            Assert.Throws<ArgumentNullException>("initializers[0]", () => Expression.ListInit(validNew, validMethod, Enumerable.Repeat(default(Expression), 1)));
+
+            Assert.Throws<ArgumentNullException>("initializers[0]", () => Expression.ListInit(validNew, default(MethodInfo), default(Expression)));
+            Assert.Throws<ArgumentNullException>("initializers[0]", () => Expression.ListInit(validNew, null, Enumerable.Repeat(default(Expression), 1)));
+        }
+
+        [Fact]
         public void ZeroInitializers()
         {
             var validNew = Expression.New(typeof(List<int>));

--- a/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
@@ -1,0 +1,240 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public class ListInitExpressionTests
+    {
+        private class NonEnumerableAddable
+        {
+            public readonly List<int> Store = new List<int>();
+
+            public void Add(int value)
+            {
+                Store.Add(value);
+            }
+        }
+
+        private class MixedAddable : IEnumerable
+        {
+            private readonly List<string> _strings = new List<string>();
+            private readonly List<int> _ints = new List<int>();
+
+            public void Add(string value)
+            {
+                _strings.Add(value);
+            }
+
+            public void Add(int value)
+            {
+                _ints.Add(value);
+            }
+
+            public IEnumerator GetEnumerator()
+            {
+                return _strings.Concat(_ints.Select(i => i.ToString())).GetEnumerator();
+            }
+        }
+
+        [Fact]
+        public void NullNewMethod()
+        {
+            var validExpression = Expression.Constant(1);
+            Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, validExpression));
+            Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, Enumerable.Repeat(validExpression, 1)));
+
+            var validMethod = typeof(List<int>).GetMethod("Add");
+            Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, validMethod, validExpression));
+            Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, validMethod, Enumerable.Repeat(validExpression, 1)));
+
+            Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, default(MethodInfo), validExpression));
+            Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, null, Enumerable.Repeat(validExpression, 1)));
+
+            var validElementInit = Expression.ElementInit(validMethod, validExpression);
+            Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, validElementInit));
+            Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, Enumerable.Repeat(validElementInit, 1)));
+        }
+
+        [Fact]
+        public void NullInitializers()
+        {
+            var validNew = Expression.New(typeof(List<int>));
+            Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, default(Expression[])));
+            Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, default(IEnumerable<Expression>)));
+            Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, default(ElementInit[])));
+            Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, default(IEnumerable<ElementInit>)));
+
+            var validMethod = typeof(List<int>).GetMethod("Add");
+            Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, validMethod, default(Expression[])));
+            Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, validMethod, default(IEnumerable<Expression>)));
+
+            Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, null, default(Expression[])));
+            Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, null, default(IEnumerable<Expression>)));
+        }
+
+        [Fact]
+        public void ZeroInitializers()
+        {
+            var validNew = Expression.New(typeof(List<int>));
+            Assert.Throws<ArgumentException>(null, () => Expression.ListInit(validNew, new Expression[0]));
+            Assert.Throws<ArgumentException>(null, () => Expression.ListInit(validNew, Enumerable.Empty<Expression>()));
+            Assert.Throws<ArgumentException>(null, () => Expression.ListInit(validNew, new ElementInit[0]));
+            Assert.Throws<ArgumentException>(null, () => Expression.ListInit(validNew, Enumerable.Empty<ElementInit>()));
+
+            var validMethod = typeof(List<int>).GetMethod("Add");
+            Assert.Throws<ArgumentException>(null, () => Expression.ListInit(validNew, validMethod, new Expression[0]));
+            Assert.Throws<ArgumentException>(null, () => Expression.ListInit(validNew, validMethod, Enumerable.Empty<Expression>()));
+
+            Assert.Throws<ArgumentException>(null, () => Expression.ListInit(validNew, null, new Expression[0]));
+            Assert.Throws<ArgumentException>(null, () => Expression.ListInit(validNew, null, Enumerable.Empty<Expression>()));
+        }
+
+        [Fact]
+        public void TypeWithoutAdd()
+        {
+            var newExp = Expression.New(typeof(string).GetConstructor(new[] { typeof(char[]) }), Expression.Constant("aaaa".ToCharArray()));
+            Assert.Throws<InvalidOperationException>(() => Expression.ListInit(newExp, Expression.Constant('a')));
+            Assert.Throws<InvalidOperationException>(() => Expression.ListInit(newExp, Enumerable.Repeat(Expression.Constant('a'), 1)));
+            Assert.Throws<InvalidOperationException>(() => Expression.ListInit(newExp, default(MethodInfo), Expression.Constant('a')));
+            Assert.Throws<InvalidOperationException>(() => Expression.ListInit(newExp, default(MethodInfo), Enumerable.Repeat(Expression.Constant('a'), 1)));
+        }
+
+        [Fact]
+        public void InitializeNonEnumerable()
+        {
+            // () => new NonEnumerableAddable { 1, 2, 4, 16, 42 } isn't allowed because list initialization
+            // is allowed only with enumerable types.
+            Assert.Throws<ArgumentException>(null, () => Expression.ListInit(Expression.New(typeof(NonEnumerableAddable)), Expression.Constant(1)));
+        }
+
+        [Fact]
+        public void InitializersWrappedExactly()
+        {
+            var newExp = Expression.New(typeof(List<int>));
+            var expressions = new[] { Expression.Constant(1), Expression.Constant(2), Expression.Constant(int.MaxValue) };
+            var listInit = Expression.ListInit(newExp, expressions);
+            Assert.Equal(expressions, listInit.Initializers.Select(i => i.GetArgument(0)));
+        }
+
+        [Fact]
+        public void CanReduce()
+        {
+            var listInit = Expression.ListInit(
+                Expression.New(typeof(List<int>)),
+                Expression.Constant(0)
+                );
+            Assert.True(listInit.CanReduce);
+            Assert.NotSame(listInit, listInit.ReduceAndCheck());
+        }
+
+        [Fact]
+        public void InitializeVoidAddCompiler()
+        {
+            Expression<Func<List<int>>> listInit = () => new List<int> { 1, 2, 4, 16, 42 };
+            Func<List<int>> func = listInit.Compile(false);
+            Assert.Equal(new[] { 1, 2, 4, 16, 42 }, func());
+        }
+
+        [Fact]
+        public void InitializeVoidAddInterpreter()
+        {
+            Expression<Func<List<int>>> listInit = () => new List<int> { 1, 2, 4, 16, 42 };
+            Func<List<int>> func = listInit.Compile(true);
+            Assert.Equal(new[] { 1, 2, 4, 16, 42 }, func());
+        }
+
+        [Fact]
+        public void InitializeNonVoidAddCompiler()
+        {
+            Expression<Func<HashSet<int>>> hashInit = () => new HashSet<int> { 1, 2, 4, 16, 42 };
+            Func<HashSet<int>> func = hashInit.Compile(false);
+            Assert.Equal(new[] { 1, 2, 4, 16, 42 }, func().OrderBy(i => i));
+        }
+
+        [Fact]
+        public void InitializeNonVoidAddInterpreter()
+        {
+            Expression<Func<HashSet<int>>> hashInit = () => new HashSet<int> { 1, 2, 4, 16, 42 };
+            Func<HashSet<int>> func = hashInit.Compile(true);
+            Assert.Equal(new[] { 1, 2, 4, 16, 42 }, func().OrderBy(i => i));
+        }
+
+        [Fact]
+        public void InitializeTwoParameterAddCompiler()
+        {
+            Expression<Func<Dictionary<string, int>>> dictInit = () => new Dictionary<string, int>
+            {
+                { "a", 1 }, {"b", 2 }, {"c", 3 }
+            };
+            Func<Dictionary<string, int>> func = dictInit.Compile(false);
+            var expected = new Dictionary<string, int>
+            {
+                { "a", 1 }, {"b", 2 }, {"c", 3 }
+            };
+            Assert.Equal(expected.OrderBy(kvp => kvp.Key), func().OrderBy(kvp => kvp.Key));
+        }
+
+        [Fact]
+        public void InitializeTwoParameterAddInterpreter()
+        {
+            Expression<Func<Dictionary<string, int>>> dictInit = () => new Dictionary<string, int>
+            {
+                { "a", 1 }, {"b", 2 }, {"c", 3 }
+            };
+            Func<Dictionary<string, int>> func = dictInit.Compile(true);
+            var expected = new Dictionary<string, int>
+            {
+                { "a", 1 }, {"b", 2 }, {"c", 3 }
+            };
+            Assert.Equal(expected.OrderBy(kvp => kvp.Key), func().OrderBy(kvp => kvp.Key));
+        }
+
+        public static IEnumerable<object[]> MixedAddableExpressions()
+        {
+            yield return new object[] { new[] { "0" }, Expression.ListInit(Expression.New(typeof(MixedAddable)), Expression.Constant(0)) };
+            yield return new object[] { new[] { "0" }, Expression.ListInit(Expression.New(typeof(MixedAddable)), Enumerable.Repeat(Expression.Constant(0), 1)) };
+            yield return new object[] { new[] { "a" }, Expression.ListInit(Expression.New(typeof(MixedAddable)), Expression.Constant("a")) };
+            yield return new object[] { new[] { "a" }, Expression.ListInit(Expression.New(typeof(MixedAddable)), Enumerable.Repeat(Expression.Constant("a"), 1)) };
+            yield return new object[] { new[] { "a", "0" }, Expression.ListInit(Expression.New(typeof(MixedAddable)), Expression.Constant(0), Expression.Constant("a")) };
+            yield return new object[] { new[] { "a", "0" }, Expression.ListInit(Expression.New(typeof(MixedAddable)), new List<Expression> { Expression.Constant(0), Expression.Constant("a") }) };
+
+            yield return new object[] { new[] { "0" }, Expression.ListInit(Expression.New(typeof(MixedAddable)), default(MethodInfo), Expression.Constant(0)) };
+            yield return new object[] { new[] { "0" }, Expression.ListInit(Expression.New(typeof(MixedAddable)), default(MethodInfo), Enumerable.Repeat(Expression.Constant(0), 1)) };
+            yield return new object[] { new[] { "a" }, Expression.ListInit(Expression.New(typeof(MixedAddable)), default(MethodInfo), Expression.Constant("a")) };
+            yield return new object[] { new[] { "a" }, Expression.ListInit(Expression.New(typeof(MixedAddable)), default(MethodInfo), Enumerable.Repeat(Expression.Constant("a"), 1)) };
+            yield return new object[] { new[] { "a", "0" }, Expression.ListInit(Expression.New(typeof(MixedAddable)), default(MethodInfo), Expression.Constant(0), Expression.Constant("a")) };
+            yield return new object[] { new[] { "a", "0" }, Expression.ListInit(Expression.New(typeof(MixedAddable)), default(MethodInfo), new List<Expression> { Expression.Constant(0), Expression.Constant("a") }) };
+        }
+
+        [Theory]
+        [MemberData("MixedAddableExpressions")]
+        public void MixedAddableFromExpressions(string[] expected, ListInitExpression expression)
+        {
+            Func<MixedAddable> func = Expression.Lambda<Func<MixedAddable>>(expression).Compile();
+            Assert.Equal(expected, func().Cast<string>());
+        }
+
+        [Fact]
+        public void MixedAddableCompiler()
+        {
+            Expression<Func<MixedAddable>> mixedInit = () => new MixedAddable { 1, "a", 2, "b" };
+            Func<MixedAddable> func = mixedInit.Compile(false);
+            Assert.Equal(new[] { "a", "b", "1", "2" }, func().Cast<string>());
+        }
+
+        [Fact]
+        public void MixedAddableInterpreter()
+        {
+            Expression<Func<MixedAddable>> mixedInit = () => new MixedAddable { 1, "a", 2, "b" };
+            Func<MixedAddable> func = mixedInit.Compile(true);
+            Assert.Equal(new[] { "a", "b", "1", "2" }, func().Cast<string>());
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
+++ b/src/System.Linq.Expressions/tests/SequenceTests/SequenceTests.cs
@@ -650,19 +650,6 @@ namespace System.Linq.Expressions.Tests
             Assert.NotNull(v);
         }
 
-        [Fact]
-        public static void ListInit()
-        {
-            NewExpression newExpr = Expression.New(typeof(List<int>));
-            ConstantExpression init1 = Expression.Constant(4, typeof(int));
-            Expression[] inits = new Expression[] { null, init1 };
-
-            Assert.Throws<ArgumentNullException>("argument", () => Expression.ListInit(newExpr, inits));
-
-            ElementInit[] einits = new ElementInit[] { };
-            Assert.Throws<ArgumentException>(() => Expression.ListInit(newExpr, einits));
-        }
-
         public void Add(ref int i)
         {
         }

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -180,6 +180,8 @@
     <Compile Include="Lifted\NonLiftedComparisonLessThanNullableTests.cs" />
     <Compile Include="Lifted\NonLiftedComparisonLessThanOrEqualNullableTests.cs" />
     <Compile Include="Lifted\NonLiftedComparisonNotEqualNullableTests.cs" />
+    <Compile Include="ListInit\ElementInitTests.cs" />
+    <Compile Include="ListInit\ListInitExpressionTests.cs" />
     <Compile Include="MemberInit\MemberInitTests.cs" />
     <Compile Include="Member\MemberAccessTests.cs" />
     <Compile Include="New\NewTests.cs" />


### PR DESCRIPTION
Interpret `ListInitExpression` with non-`void` `Add` methods correctly.

Fixes #5945

Accept heterogeneous initializer types in `ListInit`

Fixes #5946

Also add tests for `ListInitExpression` and `ElementInit` beyond those needed for that, and remove some duplicated validation.

cc @VSadov @bartdesmet 