### PR TITLE
Remove Client property from TcpClient and UdpClient

### DIFF
--- a/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientAsyncAuthenticateTest.cs
@@ -142,9 +142,8 @@ namespace System.Net.Security.Tests
                     Assert.True(((IAsyncResult)async).AsyncWaitHandle.WaitOne(TestConfiguration.PassingTestTimeoutMilliseconds), "Timed Out");
                     async.GetAwaiter().GetResult();
 
-                    _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
-                        client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
-                        sslStream.CipherAlgorithm, sslStream.CipherStrength);
+                    _log.WriteLine("Client authenticated to server({0}) with encryption cipher: {1} {2}-bit strength",
+                        server.RemoteEndPoint, sslStream.CipherAlgorithm, sslStream.CipherStrength);
                     Assert.True(sslStream.CipherAlgorithm != CipherAlgorithmType.Null, "Cipher algorithm should not be NULL");
                     Assert.True(sslStream.CipherStrength > 0, "Cipher strength should be greater than 0");
                 }

--- a/src/System.Net.Security/tests/FunctionalTests/ClientDefaultEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ClientDefaultEncryptionTest.cs
@@ -45,9 +45,8 @@ namespace System.Net.Security.Tests
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null))
                 {
                     await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
-                    _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
-                        client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
-                        sslStream.CipherAlgorithm, sslStream.CipherStrength);
+                    _log.WriteLine("Client authenticated to server({0}) with encryption cipher: {1} {2}-bit strength",
+                        serverRequireEncryption.RemoteEndPoint, sslStream.CipherAlgorithm, sslStream.CipherStrength);
                     Assert.True(sslStream.CipherAlgorithm != CipherAlgorithmType.Null, "Cipher algorithm should not be NULL");
                     Assert.True(sslStream.CipherStrength > 0, "Cipher strength should be greater than 0");
                 }
@@ -66,9 +65,8 @@ namespace System.Net.Security.Tests
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null))
                 {
                     await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
-                    _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
-                        client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
-                        sslStream.CipherAlgorithm, sslStream.CipherStrength);
+                    _log.WriteLine("Client authenticated to server({0}) with encryption cipher: {1} {2}-bit strength",
+                        serverAllowNoEncryption.RemoteEndPoint, sslStream.CipherAlgorithm, sslStream.CipherStrength);
                     Assert.True(sslStream.CipherAlgorithm != CipherAlgorithmType.Null, "Cipher algorithm should not be NULL");
                     Assert.True(sslStream.CipherStrength > 0, "Cipher strength should be greater than 0");
                 }

--- a/src/System.Net.Security/tests/FunctionalTests/DummyTcpServer.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/DummyTcpServer.cs
@@ -96,8 +96,7 @@ namespace System.Net.Security.Tests
             try
             {
                 result.GetAwaiter().GetResult();
-                _log.WriteLine("Server({0}) authenticated to client({1}) with encryption cipher: {2} {3}-bit strength",
-                    state.TcpClient.Client.LocalEndPoint, state.TcpClient.Client.RemoteEndPoint,
+                _log.WriteLine("Server authenticated to client with encryption cipher: {0} {1}-bit strength",
                     sslStream.CipherAlgorithm, sslStream.CipherStrength);
 
                 // Start listening for data from the client connection.
@@ -106,15 +105,13 @@ namespace System.Net.Security.Tests
             catch (AuthenticationException authEx)
             {
                 _log.WriteLine(
-                    "Server({0}) disconnecting from client({1}) during authentication.  No shared SSL/TLS algorithm. ({2})",
-                    state.TcpClient.Client.LocalEndPoint,
-                    state.TcpClient.Client.RemoteEndPoint,
+                    "Server disconnecting from client during authentication.  No shared SSL/TLS algorithm. ({0})",
                     authEx);
             }
             catch (Exception ex)
             {
-                _log.WriteLine("Server({0}) disconnecting from client({1}) during authentication.  Exception: {2}",
-                    state.TcpClient.Client.LocalEndPoint, state.TcpClient.Client.RemoteEndPoint, ex.Message);
+                _log.WriteLine("Server disconnecting from client during authentication.  Exception: {0}",
+                    ex.Message);
             }
             finally
             {

--- a/src/System.Net.Security/tests/FunctionalTests/ServerAllowNoEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerAllowNoEncryptionTest.cs
@@ -44,9 +44,8 @@ namespace System.Net.Security.Tests
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.RequireEncryption))
                 {
                     await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
-                    _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
-                        client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
-                        sslStream.CipherAlgorithm, sslStream.CipherStrength);
+                    _log.WriteLine("Client authenticated to server({0}) with encryption cipher: {1} {2}-bit strength",
+                        serverAllowNoEncryption.RemoteEndPoint, sslStream.CipherAlgorithm, sslStream.CipherStrength);
                     Assert.NotEqual(CipherAlgorithmType.Null, sslStream.CipherAlgorithm);
                     Assert.True(sslStream.CipherStrength > 0);
                 }
@@ -65,9 +64,8 @@ namespace System.Net.Security.Tests
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.AllowNoEncryption))
                 {
                     await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
-                    _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
-                        client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
-                        sslStream.CipherAlgorithm, sslStream.CipherStrength);
+                    _log.WriteLine("Client authenticated to server({0}) with encryption cipher: {1} {2}-bit strength",
+                        serverAllowNoEncryption.RemoteEndPoint, sslStream.CipherAlgorithm, sslStream.CipherStrength);
                     Assert.NotEqual(CipherAlgorithmType.Null, sslStream.CipherAlgorithm);
                     Assert.True(sslStream.CipherStrength > 0, "Cipher strength should be greater than 0");
                 }
@@ -87,9 +85,8 @@ namespace System.Net.Security.Tests
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.NoEncryption))
                 {
                     await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
-                    _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
-                        client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
-                        sslStream.CipherAlgorithm, sslStream.CipherStrength);
+                    _log.WriteLine("Client authenticated to server({0}) with encryption cipher: {1} {2}-bit strength",
+                        serverAllowNoEncryption.RemoteEndPoint, sslStream.CipherAlgorithm, sslStream.CipherStrength);
 
                     CipherAlgorithmType expected = CipherAlgorithmType.Null;
                     Assert.Equal(expected, sslStream.CipherAlgorithm);

--- a/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerAsyncAuthenticateTest.cs
@@ -171,9 +171,8 @@ namespace System.Net.Security.Tests
                     }
 
                     _log.WriteLine(
-                        "Server({0}) authenticated client({1}) with encryption cipher: {2} {3}-bit strength",
-                        serverConnection.Client.LocalEndPoint,
-                        serverConnection.Client.RemoteEndPoint,
+                        "Server({0}) authenticated with encryption cipher: {1} {2}-bit strength",
+                        serverEndPoint,
                         sslServerStream.CipherAlgorithm,
                         sslServerStream.CipherStrength);
 

--- a/src/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerNoEncryptionTest.cs
@@ -63,9 +63,8 @@ namespace System.Net.Security.Tests
                 {
                     await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
 
-                    _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
-                        client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
-                        sslStream.CipherAlgorithm, sslStream.CipherStrength);
+                    _log.WriteLine("Client authenticated to server({0}) with encryption cipher: {1} {2}-bit strength",
+                        serverNoEncryption.RemoteEndPoint, sslStream.CipherAlgorithm, sslStream.CipherStrength);
 
                     CipherAlgorithmType expected = CipherAlgorithmType.Null;
                     Assert.Equal(expected, sslStream.CipherAlgorithm);
@@ -87,9 +86,8 @@ namespace System.Net.Security.Tests
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.NoEncryption))
                 {
                     await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
-                    _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
-                        client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
-                        sslStream.CipherAlgorithm, sslStream.CipherStrength);
+                    _log.WriteLine("Client authenticated to server({0}) with encryption cipher: {1} {2}-bit strength",
+                        serverNoEncryption.RemoteEndPoint, sslStream.CipherAlgorithm, sslStream.CipherStrength);
 
                     CipherAlgorithmType expected = CipherAlgorithmType.Null;
                     Assert.Equal(expected, sslStream.CipherAlgorithm);

--- a/src/System.Net.Security/tests/FunctionalTests/ServerRequireEncryptionTest.cs
+++ b/src/System.Net.Security/tests/FunctionalTests/ServerRequireEncryptionTest.cs
@@ -44,9 +44,8 @@ namespace System.Net.Security.Tests
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.RequireEncryption))
                 {
                     await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
-                    _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
-                        client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
-                        sslStream.CipherAlgorithm, sslStream.CipherStrength);
+                    _log.WriteLine("Client authenticated to server({0}) with encryption cipher: {1} {2}-bit strength",
+                        serverRequireEncryption.RemoteEndPoint, sslStream.CipherAlgorithm, sslStream.CipherStrength);
                     Assert.True(sslStream.CipherAlgorithm != CipherAlgorithmType.Null, "Cipher algorithm should not be NULL");
                     Assert.True(sslStream.CipherStrength > 0, "Cipher strength should be greater than 0");
                 }
@@ -65,9 +64,8 @@ namespace System.Net.Security.Tests
                 using (var sslStream = new SslStream(client.GetStream(), false, AllowAnyServerCertificate, null, EncryptionPolicy.AllowNoEncryption))
                 {
                     await sslStream.AuthenticateAsClientAsync("localhost", null, SslProtocolSupport.DefaultSslProtocols, false);
-                    _log.WriteLine("Client({0}) authenticated to server({1}) with encryption cipher: {2} {3}-bit strength",
-                        client.Client.LocalEndPoint, client.Client.RemoteEndPoint,
-                        sslStream.CipherAlgorithm, sslStream.CipherStrength);
+                    _log.WriteLine("Client authenticated to server({0}) with encryption cipher: {1} {2}-bit strength",
+                        serverRequireEncryption.RemoteEndPoint, sslStream.CipherAlgorithm, sslStream.CipherStrength);
                     Assert.True(sslStream.CipherAlgorithm != CipherAlgorithmType.Null, "Cipher algorithm should not be NULL");
                     Assert.True(sslStream.CipherStrength > 0, "Cipher strength should be greater than 0");
                 }

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/AgnosticListenerTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/AgnosticListenerTest.cs
@@ -73,8 +73,6 @@ namespace System.Net.Sockets.Tests
             v6Client.ConnectAsync(IPAddress.IPv6Loopback, port).GetAwaiter().GetResult();
 
             TcpClient acceptedV6Client = listener.EndAcceptTcpClient(asyncResult);
-            Assert.Equal(AddressFamily.InterNetworkV6, acceptedV6Client.Client.RemoteEndPoint.AddressFamily);
-            Assert.Equal(AddressFamily.InterNetworkV6, v6Client.Client.RemoteEndPoint.AddressFamily);
 
             asyncResult = listener.BeginAcceptTcpClient(null, null);
 
@@ -82,8 +80,6 @@ namespace System.Net.Sockets.Tests
             v4Client.ConnectAsync(IPAddress.Loopback, port).GetAwaiter().GetResult();
 
             TcpClient acceptedV4Client = listener.EndAcceptTcpClient(asyncResult);
-            Assert.Equal(AddressFamily.InterNetworkV6, acceptedV4Client.Client.RemoteEndPoint.AddressFamily);
-            Assert.Equal(AddressFamily.InterNetwork, v4Client.Client.RemoteEndPoint.AddressFamily);
 
             v6Client.Dispose();
             acceptedV6Client.Dispose();

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/UdpClientTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/UdpClientTest.cs
@@ -55,14 +55,6 @@ namespace System.Net.Sockets.Tests
             Assert.True(_waitHandle.WaitOne(Configuration.PassingTestTimeout), "Timed out while waiting for connection");
         }
 
-        [ActiveIssue(4968)]
-        [Fact]
-        public void UdpClient_ConnectAsync_Success()
-        {
-            var c = new UdpClient();
-            c.Client.ConnectAsync("114.114.114.114", 53).Wait();
-        }
-
         private void AsyncCompleted(IAsyncResult ar)
         {
             UdpClient udpService = (UdpClient)ar.AsyncState;

--- a/src/System.Net.Sockets/ref/System.Net.Sockets.cs
+++ b/src/System.Net.Sockets/ref/System.Net.Sockets.cs
@@ -417,7 +417,6 @@ namespace System.Net.Sockets
         public TcpClient(System.Net.Sockets.AddressFamily family) { }
         protected bool Active { get { return default(bool); } set { } }
         public int Available { get { return default(int); } }
-        public System.Net.Sockets.Socket Client { get { return default(System.Net.Sockets.Socket); } set { } }
         public bool Connected { get { return default(bool); } }
         public bool ExclusiveAddressUse { get { return default(bool); } set { } }
         public System.Net.Sockets.LingerOption LingerState { get { return default(System.Net.Sockets.LingerOption); } set { } }
@@ -458,7 +457,6 @@ namespace System.Net.Sockets
         public UdpClient(System.Net.Sockets.AddressFamily family) { }
         protected bool Active { get { return default(bool); } set { } }
         public int Available { get { return default(int); } }
-        public System.Net.Sockets.Socket Client { get { return default(System.Net.Sockets.Socket); } set { } }
         public bool DontFragment { get { return default(bool); } set { } }
         public bool EnableBroadcast { get { return default(bool); } set { } }
         public bool ExclusiveAddressUse { get { return default(bool); } set { } }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Windows.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.Windows.cs
@@ -10,21 +10,10 @@ namespace System.Net.Sockets
     {
         private void InitializeClientSocket()
         {
-            Client = CreateSocket();
+            _clientSocket = CreateSocket();
         }
 
-        // Used by the class to provide the underlying network socket.
-        private Socket ClientCore
-        {
-            get
-            {
-                return _clientSocket;
-            }
-            set
-            {
-                _clientSocket = value;
-            }
-        }
+        private Socket Client { get { return _clientSocket; } }
 
         private int AvailableCore { get { return _clientSocket.Available; } }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/TCPClient.cs
@@ -63,14 +63,6 @@ namespace System.Net.Sockets
             }
         }
 
-        // Used by the class to provide the underlying network socket.
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)] // TODO: Remove once https://github.com/dotnet/corefx/issues/5868 is addressed.
-        public Socket Client
-        {
-            get { return ClientCore; }
-            set { ClientCore = value; }
-        }
-
         // Used by the class to indicate that a connection has been made.
         protected bool Active
         {
@@ -151,14 +143,14 @@ namespace System.Net.Sockets
             {
                 throw new ObjectDisposedException(this.GetType().FullName);
             }
-            if (!Client.Connected)
+            if (!Connected)
             {
                 throw new InvalidOperationException(SR.net_notconnected);
             }
 
             if (_dataStream == null)
             {
-                _dataStream = new NetworkStream(Client, true);
+                _dataStream = new NetworkStream(_clientSocket, true);
             }
 
             if (NetEventSource.Log.IsEnabled())

--- a/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/ArgumentValidationTests.cs
@@ -758,27 +758,5 @@ namespace System.Net.Sockets.Tests
                 Assert.Throws<PlatformNotSupportedException>(() => { s.ConnectAsync(new[] { IPAddress.Loopback }, 12345); });
             }
         }
-
-        [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
-        public void TcpClient_ConnectAsync_StringHost_NotSupportedAfterClientAccess()
-        {
-            using (TcpClient client = new TcpClient())
-            {
-                var tmp = client.Client;
-                Assert.Throws<PlatformNotSupportedException>(() => { client.ConnectAsync("localhost", 12345); });
-            }
-        }
-
-        [Fact]
-        [PlatformSpecific(PlatformID.AnyUnix)]
-        public void TcpClient_ConnectAsync_MultipleAddresses_NotSupportedAfterClientAccess()
-        {
-            using (TcpClient client = new TcpClient())
-            {
-                var tmp = client.Client;
-                Assert.Throws<PlatformNotSupportedException>(() => { client.ConnectAsync(new[] { IPAddress.Loopback }, 12345); });
-            }
-        }
     }
 }

--- a/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/TcpClientTest.cs
@@ -46,8 +46,6 @@ namespace System.Net.Sockets.Tests
                 }
 
                 Assert.True(client.Connected);
-                Assert.NotNull(client.Client);
-                Assert.Same(client.Client, client.Client);
 
                 using (NetworkStream s = client.GetStream())
                 {


### PR DESCRIPTION
The property leaks through the abstraction.  It's rarely used.  And it complicates things on Unix due to exposing the underlying socket instance combined with difficulties with multiple connect calls on a single socket instance.

Until we have good reason to expose it in the contract, we're removing it from the contract before it's stable.

cc: @davidsh, @cipop, @SidharthNabar, @terrajobst, @weshaggard, @saurabh500 
Closes #4968
Closes #5411