### PR TITLE
Use System.Buffers in System.IO.FileSystem

### DIFF
--- a/src/Common/src/System/IO/StreamHelpers.cs
+++ b/src/Common/src/System/IO/StreamHelpers.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Buffers;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.IO
+{
+    /// <summary>Provides methods to help in the implementation of Stream-derived types.</summary>
+    internal static class StreamHelpers
+    {
+        /// <summary>
+        /// Provides an implementation usable as an override of Stream.CopyToAsync but that uses the shared
+        /// ArrayPool for the intermediate buffer rather than allocating a new buffer each time.
+        /// </summary>
+        /// <remarks>
+        /// If/when the base CopyToAsync implementation is changed to use a pooled buffer, 
+        /// this will no longer be necessary.
+        /// </remarks>
+        public static Task ArrayPoolCopyToAsync(Stream source, Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            Debug.Assert(source != null);
+
+            if (destination == null)
+            {
+                throw new ArgumentNullException("destination");
+            }
+            if (bufferSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException("bufferSize", bufferSize, SR.ArgumentOutOfRange_NeedPosNum);
+            }
+
+            if (!source.CanRead)
+            {
+                throw source.CanWrite ?
+                    (Exception)new NotSupportedException(SR.NotSupported_UnreadableStream) :
+                    new ObjectDisposedException(null); // passing null as this is used as part of an instance Stream.CopyToAsync override
+            }
+
+            if (!destination.CanWrite)
+            {
+                throw destination.CanRead ?
+                    (Exception)new NotSupportedException(SR.NotSupported_UnwritableStream) :
+                    new ObjectDisposedException("destination");
+            }
+
+            return ArrayPoolCopyToAsyncInternal(source, destination, bufferSize, cancellationToken);
+        }
+
+        private static async Task ArrayPoolCopyToAsyncInternal(Stream source, Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+            try
+            {
+                int bytesRead;
+                while ((bytesRead = await source.ReadAsync(buffer, 0, bufferSize, cancellationToken).ConfigureAwait(false)) != 0)
+                {
+                    await destination.WriteAsync(buffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer, clearArray: true); // TODO: When an overload is available, pass bufferSize so we only clear the used part of the array
+            }
+        }
+    }
+}

--- a/src/System.IO.Compression/src/Resources/Strings.resx
+++ b/src/System.IO.Compression/src/Resources/Strings.resx
@@ -120,6 +120,9 @@
   <data name="ArgumentOutOfRange_Enum" xml:space="preserve">
     <value>Enum value was out of legal range.</value>
   </data>
+  <data name="ArgumentOutOfRange_NeedPosNum" xml:space="preserve">
+    <value>Positive number required.</value>
+  </data>
   <data name="CannotReadFromDeflateStream" xml:space="preserve">
     <value>Reading from the compression stream is not supported.</value>
   </data>
@@ -141,14 +144,14 @@
   <data name="InvalidHuffmanData" xml:space="preserve">
     <value>Failed to construct a huffman tree using the length array. The stream might be corrupted.</value>
   </data>
-  <data name="NotReadableStream" xml:space="preserve">
-    <value>The base stream is not readable.</value>
-  </data>
   <data name="NotSupported" xml:space="preserve">
     <value>This operation is not supported.</value>
   </data>
-  <data name="NotWriteableStream" xml:space="preserve">
-    <value>The base stream is not writeable.</value>
+  <data name="NotSupported_UnreadableStream" xml:space="preserve">
+    <value>Stream does not support reading.</value>
+  </data>
+  <data name="NotSupported_UnwritableStream" xml:space="preserve">
+    <value>Stream does not support writing.</value>
   </data>
   <data name="ObjectDisposed_StreamClosed" xml:space="preserve">
     <value>Can not access a closed Stream.</value>

--- a/src/System.IO.Compression/src/System.IO.Compression.csproj
+++ b/src/System.IO.Compression/src/System.IO.Compression.csproj
@@ -38,6 +38,9 @@
     <Compile Include="$(CommonPath)\System\IO\PathInternal.cs">
       <Link>Common\System\IO\PathInternal.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\IO\StreamHelpers.cs">
+      <Link>Common\System\IO\StreamHelpers.cs</Link>
+    </Compile>
   </ItemGroup>
   <!-- Files exclusive to Core -->
   <ItemGroup Condition="'$(TargetGroup)' != 'net46'">

--- a/src/System.IO.Compression/src/System/IO/Compression/DeflateStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/DeflateStream.cs
@@ -90,7 +90,7 @@ namespace System.IO.Compression
         {
             Debug.Assert(stream != null);
             if (!stream.CanRead)
-                throw new ArgumentException(SR.NotReadableStream, "stream");
+                throw new ArgumentException(SR.NotSupported_UnreadableStream, "stream");
 
             _inflater = new Inflater(windowBits);
 
@@ -107,7 +107,7 @@ namespace System.IO.Compression
         {
             Debug.Assert(stream != null);
             if (!stream.CanWrite)
-                throw new ArgumentException(SR.NotWriteableStream, "stream");
+                throw new ArgumentException(SR.NotSupported_UnwritableStream, "stream");
 
             _deflater = new Deflater(compressionLevel, windowBits);
 
@@ -333,6 +333,11 @@ namespace System.IO.Compression
             throw new InvalidOperationException(SR.CannotWriteToDeflateStream);
         }
 
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            return StreamHelpers.ArrayPoolCopyToAsync(this, destination, bufferSize, cancellationToken);
+        }
+
         public override Task<int> ReadAsync(Byte[] array, int offset, int count, CancellationToken cancellationToken)
         {
             EnsureDecompressionMode();
@@ -373,7 +378,7 @@ namespace System.IO.Compression
                 readTask = _stream.ReadAsync(_buffer, 0, _buffer.Length, cancellationToken);
                 if (readTask == null)
                 {
-                    throw new InvalidOperationException(SR.NotReadableStream);
+                    throw new InvalidOperationException(SR.NotSupported_UnreadableStream);
                 }
 
                 return ReadAsyncCore(readTask, array, offset, count, cancellationToken);
@@ -422,7 +427,7 @@ namespace System.IO.Compression
                         readTask = _stream.ReadAsync(_buffer, 0, _buffer.Length, cancellationToken);
                         if (readTask == null)
                         {
-                            throw new InvalidOperationException(SR.NotReadableStream);
+                            throw new InvalidOperationException(SR.NotSupported_UnreadableStream);
                         }
                     }
                     else

--- a/src/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
+++ b/src/System.IO.Compression/src/System/IO/Compression/GZipStream.cs
@@ -159,6 +159,11 @@ namespace System.IO.Compression
             }
         }
 
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            return StreamHelpers.ArrayPoolCopyToAsync(this, destination, bufferSize, cancellationToken);
+        }
+
         public override Task<int> ReadAsync(Byte[] array, int offset, int count, CancellationToken cancellationToken)
         {
             CheckDeflateStream();

--- a/src/System.IO.Compression/tests/DeflateStreamTests.cs
+++ b/src/System.IO.Compression/tests/DeflateStreamTests.cs
@@ -459,6 +459,23 @@ namespace System.IO.Compression.Tests
         }
 
         [Fact]
+        public void CopyToAsyncArgumentValidation()
+        {
+            using (DeflateStream ds = new DeflateStream(new MemoryStream(), CompressionMode.Decompress))
+            {
+                Assert.Throws<ArgumentNullException>("destination", () => { ds.CopyToAsync(null); });
+                Assert.Throws<ArgumentOutOfRangeException>("bufferSize", () => { ds.CopyToAsync(new MemoryStream(), 0); });
+                Assert.Throws<NotSupportedException>(() => { ds.CopyToAsync(new MemoryStream(new byte[1], writable: false)); });
+                ds.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => { ds.CopyToAsync(new MemoryStream()); });
+            }
+            using (DeflateStream ds = new DeflateStream(new MemoryStream(), CompressionMode.Compress))
+            {
+                Assert.Throws<NotSupportedException>(() => { ds.CopyToAsync(new MemoryStream()); });
+            }
+        }
+
+        [Fact]
         public void Precancellation()
         {
             var ms = new MemoryStream();

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -55,6 +55,9 @@
     <Compile Include="$(CommonPath)\System\Collections\Generic\EnumerableHelpers.cs">
       <Link>Common\System\Collections\Generic\EnumerableHelpers.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\System\IO\StreamHelpers.cs">
+      <Link>Common\System\IO\StreamHelpers.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\System\IO\StringBuilderCache.cs">
       <Link>Common\System\IO\StringBuilderCache.cs</Link>
     </Compile>

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileStream.cs
@@ -764,6 +764,19 @@ namespace System.IO
         }
 
         /// <summary>
+        /// Asynchronously reads the bytes from the current stream and writes them to another
+        /// stream, using a specified buffer size.
+        /// </summary>
+        /// <param name="destination">The stream to which the contents of the current stream will be copied.</param>
+        /// <param name="bufferSize">The size, in bytes, of the buffer. This value must be greater than zero.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous copy operation.</returns>
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            return StreamHelpers.ArrayPoolCopyToAsync(this, destination, bufferSize, cancellationToken);
+        }
+
+        /// <summary>
         /// Asynchronously reads a sequence of bytes from the current stream and advances
         /// the position within the stream by the number of bytes read.
         /// </summary>

--- a/src/System.IO.FileSystem/src/System/IO/Win32FileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/Win32FileStream.cs
@@ -905,7 +905,7 @@ namespace System.IO
             Debug.Assert(_buffer == null);
             Debug.Assert(_preallocatedOverlapped == null);
 
-            _buffer = new byte[_bufferSize]; // TODO: Issue #5598: Use ArrayPool.
+            _buffer = new byte[_bufferSize];
             if (_isAsync)
             {
                 _preallocatedOverlapped = new PreAllocatedOverlapped(s_ioCallback, this, _buffer);
@@ -1687,6 +1687,11 @@ namespace System.IO
             }
 
             return errorCode;
+        }
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            return StreamHelpers.ArrayPoolCopyToAsync(this, destination, bufferSize, cancellationToken);
         }
 
         [System.Security.SecuritySafeCritical]

--- a/src/System.IO.FileSystem/src/project.json
+++ b/src/System.IO.FileSystem/src/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "System.Buffers": "4.0.0-rc3-23808",
     "System.Collections": "4.0.10",
     "System.Diagnostics.Contracts": "4.0.0",
     "System.Diagnostics.Debug": "4.0.10",

--- a/src/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
+++ b/src/System.IO.FileSystem/tests/FileStream/WriteAsync.cs
@@ -396,6 +396,23 @@ namespace System.IO.Tests
                 numWrites: 10);
         }
 
+        [Fact]
+        public void CopyToAsync_InvalidArgs_Throws()
+        {
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create))
+            {
+                Assert.Throws<ArgumentNullException>("destination", () => { fs.CopyToAsync(null); });
+                Assert.Throws<ArgumentOutOfRangeException>("bufferSize", () => { fs.CopyToAsync(new MemoryStream(), 0); });
+                Assert.Throws<NotSupportedException>(() => { fs.CopyToAsync(new MemoryStream(new byte[1], writable: false)); });
+                fs.Dispose();
+                Assert.Throws<ObjectDisposedException>(() => { fs.CopyToAsync(new MemoryStream()); });
+            }
+            using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.Create, FileAccess.Write))
+            {
+                Assert.Throws<NotSupportedException>(() => { fs.CopyToAsync(new MemoryStream()); });
+            }
+        }
+
         [Theory]
         [MemberData("MemberData_FileStreamAsyncWriting")]
         [OuterLoop] // many combinations: we test just one in inner loop and the rest outer

--- a/src/System.IO.Pipes/src/Resources/Strings.resx
+++ b/src/System.IO.Pipes/src/Resources/Strings.resx
@@ -168,6 +168,9 @@
   <data name="ArgumentOutOfRange_MaxNumServerInstances" xml:space="preserve">
     <value>maxNumberOfServerInstances must either be a value between 1 and 254, or NamedPipeServerStream.MaxAllowedServerInstances (to obtain the maximum number allowed by system resources).</value>
   </data>
+  <data name="ArgumentOutOfRange_NeedPosNum" xml:space="preserve">
+    <value>Positive number required.</value>
+  </data>
   <data name="InvalidOperation_PipeNotYetConnected" xml:space="preserve">
     <value>Pipe hasn't been connected yet.</value>
   </data>

--- a/src/System.IO.Pipes/src/System.IO.Pipes.csproj
+++ b/src/System.IO.Pipes/src/System.IO.Pipes.csproj
@@ -36,6 +36,9 @@
     <Compile Include="System\IO\Pipes\NamedPipeServerStream.cs" />
     <Compile Include="System\IO\Pipes\PipeState.cs" />
     <Compile Include="System\IO\Pipes\PipeStream.cs" />
+    <Compile Include="$(CommonPath)\System\IO\StreamHelpers.cs">
+      <Link>Common\System\IO\StreamHelpers.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsWindows)' == 'true' ">
     <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs
@@ -373,18 +373,16 @@ namespace System.IO.Pipes
 
                             if (signaledFdCount != 0)
                             {
-                                // Our pipe is ready.  Break out of the loop to read from it.
-                                Debug.Assert((events[0].TriggeredEvents & Interop.Sys.PollEvents.POLLIN) != 0, "Expected revents on read fd to have POLLIN set");
+                                // Our pipe is ready.  Break out of the loop to read from it.  The fd may have been signaled due to 
+                                // POLLIN (data available), POLLHUP (hang-up), POLLERR (some error on the stream), etc... any such
+                                // data will be propagated to us when we do the actual read.
                                 break;
                             }
                         }
 
                         // Read it.
-                        Debug.Assert((events[0].TriggeredEvents & Interop.Sys.PollEvents.POLLIN) != 0);
                         int result = CheckPipeCall(Interop.Sys.Read(_handle, bufPtr + offset, count));
-                        Debug.Assert(result <= count);
-
-                        Debug.Assert(result >= 0);
+                        Debug.Assert(result >= 0 && result <= count, "Expected 0 <= result <= count bytes, got " + result);
 
                         // return what we read.
                         return result;

--- a/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
+++ b/src/System.IO.Pipes/src/System/IO/Pipes/PipeStream.cs
@@ -110,6 +110,11 @@ namespace System.IO.Pipes
             _isFromExistingHandle = isExposed;
         }
 
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            return StreamHelpers.ArrayPoolCopyToAsync(this, destination, bufferSize, cancellationToken);
+        }
+
         [SecurityCritical]
         public override int Read([In, Out] byte[] buffer, int offset, int count)
         {

--- a/src/System.IO.Pipes/src/project.json
+++ b/src/System.IO.Pipes/src/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "System.Buffers": "4.0.0-rc3-23808",
     "System.Diagnostics.Contracts": "4.0.0",
     "System.Diagnostics.Debug": "4.0.10",
     "System.Diagnostics.Tools": "4.0.0",

--- a/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.Read.cs
+++ b/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.Read.cs
@@ -2,11 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace System.IO.Pipes.Tests
 {
-    public class AnonymousPipeTest_Read_ServerIn_ClientOut : PipeTest_Read
+    public class AnonymousPipeTest_Read_ServerIn_ClientOut : AnonymousPipeTest_Read
     {
         protected override ServerClientPair CreateServerClientPair()
         {
@@ -17,7 +19,7 @@ namespace System.IO.Pipes.Tests
         }
     }
 
-    public class AnonymousPipeTest_Read_ServerOut_ClientIn : PipeTest_Read
+    public class AnonymousPipeTest_Read_ServerOut_ClientIn : AnonymousPipeTest_Read
     {
         protected override ServerClientPair CreateServerClientPair()
         {
@@ -27,4 +29,33 @@ namespace System.IO.Pipes.Tests
             return ret;
         }
     }
+
+    public abstract class AnonymousPipeTest_Read : PipeTest_Read
+    {
+        [Theory]
+        [MemberData("AsyncReadWriteChain_MemberData")]
+        public async Task AsyncReadWriteChain_CopyToAsync(int iterations, int writeBufferSize, int readBufferSize, bool cancelableToken)
+        {
+            var writeBuffer = new byte[writeBufferSize * iterations];
+            new Random().NextBytes(writeBuffer);
+            var cancellationToken = cancelableToken ? new CancellationTokenSource().Token : CancellationToken.None;
+
+            using (ServerClientPair pair = CreateServerClientPair())
+            {
+                var readData = new MemoryStream();
+                Task copyTask = pair.readablePipe.CopyToAsync(readData, readBufferSize, cancellationToken);
+
+                for (int iter = 0; iter < iterations; iter++)
+                {
+                    await pair.writeablePipe.WriteAsync(writeBuffer, iter * writeBufferSize, writeBufferSize, cancellationToken);
+                }
+                pair.writeablePipe.Dispose();
+
+                await copyTask;
+                Assert.Equal(writeBuffer.Length, readData.Length);
+                Assert.Equal(writeBuffer, readData.ToArray());
+            }
+        }
+    }
+
 }

--- a/src/System.IO.Pipes/tests/PipeTest.Read.cs
+++ b/src/System.IO.Pipes/tests/PipeTest.Read.cs
@@ -192,6 +192,21 @@ namespace System.IO.Pipes.Tests
         }
 
         [Fact]
+        public void CopyToAsync_InvalidArgs_Throws()
+        {
+            using (ServerClientPair pair = CreateServerClientPair())
+            {
+                Assert.Throws<ArgumentNullException>("destination", () => { pair.readablePipe.CopyToAsync(null); });
+                Assert.Throws<ArgumentOutOfRangeException>("bufferSize", () => { pair.readablePipe.CopyToAsync(new MemoryStream(), 0); });
+                Assert.Throws<NotSupportedException>(() => { pair.readablePipe.CopyToAsync(new MemoryStream(new byte[1], writable: false)); });
+                if (!pair.writeablePipe.CanRead)
+                {
+                    Assert.Throws<NotSupportedException>(() => { pair.writeablePipe.CopyToAsync(new MemoryStream()); });
+                }
+            }
+        }
+
+        [Fact]
         public virtual async Task ReadFromPipeWithClosedPartner_ReadNoBytes()
         {
             using (ServerClientPair pair = CreateServerClientPair())
@@ -262,7 +277,7 @@ namespace System.IO.Pipes.Tests
 
         [Theory]
         [MemberData("AsyncReadWriteChain_MemberData")]
-        public async Task AsyncReadWriteChain(int iterations, int writeBufferSize, int readBufferSize, bool cancelableToken)
+        public async Task AsyncReadWriteChain_ReadWrite(int iterations, int writeBufferSize, int readBufferSize, bool cancelableToken)
         {
             var writeBuffer = new byte[writeBufferSize];
             var readBuffer = new byte[readBufferSize];

--- a/src/System.IO.UnmanagedMemoryStream/src/Resources/Strings.resx
+++ b/src/System.IO.UnmanagedMemoryStream/src/Resources/Strings.resx
@@ -153,6 +153,9 @@
   <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
     <value>Non negative number is required.</value>
   </data>
+  <data name="ArgumentOutOfRange_NeedPosNum" xml:space="preserve">
+    <value>Positive number required.</value>
+  </data>
   <data name="ArgumentOutOfRange_PositionLessThanCapacityRequired" xml:space="preserve">
     <value>The position may not be greater or equal to the capacity of the accessor.</value>
   </data>

--- a/src/System.IO.UnmanagedMemoryStream/src/System.IO.UnmanagedMemoryStream.csproj
+++ b/src/System.IO.UnmanagedMemoryStream/src/System.IO.UnmanagedMemoryStream.csproj
@@ -17,6 +17,9 @@
     <Compile Include="Common\Error.cs" />
     <Compile Include="System\IO\UnmanagedMemoryAccessor.cs" />
     <Compile Include="System\IO\UnmanagedMemoryStream.cs" />
+    <Compile Include="$(CommonPath)\System\IO\StreamHelpers.cs">
+      <Link>Common\System\IO\StreamHelpers.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.IO.UnmanagedMemoryStream/src/System/IO/UnmanagedMemoryStream.cs
+++ b/src/System.IO.UnmanagedMemoryStream/src/System/IO/UnmanagedMemoryStream.cs
@@ -492,6 +492,19 @@ namespace System.IO
         }
 
         /// <summary>
+        /// Asynchronously reads the bytes from the current stream and writes them to another
+        /// stream, using a specified buffer size.
+        /// </summary>
+        /// <param name="destination">The stream to which the contents of the current stream will be copied.</param>
+        /// <param name="bufferSize">The size, in bytes, of the buffer. This value must be greater than zero.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>A task that represents the asynchronous copy operation.</returns>
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            return StreamHelpers.ArrayPoolCopyToAsync(this, destination, bufferSize, cancellationToken);
+        }
+
+        /// <summary>
         /// Reads bytes from stream and puts them into the buffer
         /// </summary>
         /// <param name="buffer">Buffer to read the bytes to.</param>

--- a/src/System.IO.UnmanagedMemoryStream/src/project.json
+++ b/src/System.IO.UnmanagedMemoryStream/src/project.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "System.Buffers": "4.0.0-rc3-23808",
     "System.Diagnostics.Contracts": "4.0.0",
     "System.Diagnostics.Debug": "4.0.10",
     "System.Diagnostics.Tools": "4.0.0",


### PR DESCRIPTION
- Change FileStream to use ```ArrayPool<byte>.Shared``` for its internal buffer
- Add to Common a helper implementation of CopyToAsync that uses ```ArrayPool<byte>.Shared``` until such type as the base Stream (in mscorlib) can use a pooled buffer
- Utilize that CopyToAsync helper in FileStream

Having added that:
- Utilize that CopyToAsync helper in DeflateStream/GZipStream, as System.IO.Compression already depends on System.Buffers.

cc: @ericstij, @ianhays, @sokket, @KrzysztofCwalina 
https://github.com/dotnet/corefx/issues/5598