### PR TITLE
Interpret ListInitExpression with non-void Add methods correctly.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/LightCompiler.cs
@@ -2656,7 +2656,10 @@ namespace System.Linq.Expressions.Interpreter
                 {
                     Compile(arg);
                 }
-                _instructions.EmitCall(initializers[i].AddMethod);
+                var add = initializers[i].AddMethod;
+                _instructions.EmitCall(add);
+                if (add.ReturnType != typeof(void))
+                    _instructions.EmitPop();
             }
         }
 

--- a/src/System.Linq.Expressions/tests/ListInit/ElementInitTests.cs
+++ b/src/System.Linq.Expressions/tests/ListInit/ElementInitTests.cs
@@ -1,0 +1,199 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public class ElementInitTests
+    {
+        private static class Unreadable<T>
+        {
+            public static T WriteOnly
+            {
+                set { }
+            }
+        }
+
+        private class ParameterlessAdd
+        {
+            public void Add()
+            {
+            }
+        }
+
+        private class StaticAdd
+        {
+            public static void Add(int value)
+            {
+            }
+        }
+
+        private class ByRefAdd
+        {
+            public static void Add(ref int value)
+            {
+            }
+        }
+
+        private class GenericAdd
+        {
+            public static void Add<T>(T value)
+            {
+            }
+        }
+
+        [Fact]
+        public void NullAddMethod()
+        {
+            Assert.Throws<ArgumentNullException>("addMethod", () => Expression.ElementInit(null, Expression.Constant(0)));
+            Assert.Throws<ArgumentNullException>("addMethod", () => Expression.ElementInit(null, Enumerable.Repeat(Expression.Constant(0), 1)));
+        }
+
+        [Fact]
+        public void NullArguments()
+        {
+            Assert.Throws<ArgumentNullException>("arguments", () => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), default(Expression[])));
+            Assert.Throws<ArgumentNullException>("arguments", () => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), default(Expression[])));
+        }
+
+        [Fact]
+        public void NoArguments()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add")));
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Enumerable.Empty<Expression>()));
+        }
+
+        [Fact]
+        public void ArgumentCountWrong()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant(0), Expression.Constant(1)));
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 2)));
+        }
+
+        [Fact]
+        public void ArgumentTypeMisMatch()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant("Hello")));
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Enumerable.Repeat(Expression.Constant("Hello"), 1)));
+        }
+
+        [Fact]
+        public void UnreadableArgument()
+        {
+            Expression argument = Expression.Property(null, typeof(Unreadable<int>), "WriteOnly");
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), argument));
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Enumerable.Repeat(argument, 1)));
+        }
+
+        [Fact]
+        public void ParameterlessAddProhibited()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(ParameterlessAdd).GetMethod("Add"), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(ParameterlessAdd).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 1)));
+        }
+
+        [Fact]
+        public void StaticAddProhibited()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(StaticAdd).GetMethod("Add"), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(StaticAdd).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 1)));
+        }
+
+        [Fact]
+        public void ByRefAddProhibited()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(ByRefAdd).GetMethod("Add"), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(ByRefAdd).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 1)));
+        }
+
+        [Fact]
+        public void GenericAddProhibited()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(GenericAdd).GetMethod("Add"), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(GenericAdd).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 1)));
+        }
+
+        [Fact]
+        public void GenericParameterAddProhibited()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<>).GetMethod("Add"), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<>).GetMethod("Add"), Enumerable.Repeat(Expression.Constant(0), 1)));
+        }
+
+        [Fact]
+        public void AddMethodNotCalledAdd()
+        {
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Remove"), Expression.Constant(0)));
+            Assert.Throws<ArgumentException>(() => Expression.ElementInit(typeof(List<int>).GetMethod("Remove"), Enumerable.Repeat(Expression.Constant(0), 1)));
+        }
+
+        [Fact]
+        public void UpdateSameArgumentsSameInstanceReturned()
+        {
+            ElementInit init = Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant(0));
+            IEnumerable<Expression> arguments = init.Arguments;
+            Assert.Same(init, init.Update(arguments));
+        }
+
+        [Fact]
+        public void UpdateDifferentArgumentsDifferetInstanceReturned()
+        {
+            ElementInit init = Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant(0));
+            Assert.NotSame(init, init.Update(Enumerable.Repeat(Expression.Constant(1), 1)));
+        }
+
+        [Fact]
+        public void UpdateDifferentNumberArgumentsDifferetInstanceReturned()
+        {
+            ElementInit init = Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant(0));
+            Assert.NotSame(init, init.Update(Enumerable.Repeat(Expression.Constant(1), 1)));
+        }
+
+        [Fact]
+        public void CanRetrieveMethod()
+        {
+            ElementInit init = Expression.ElementInit(typeof(List<int>).GetMethod("Add"), Expression.Constant(0));
+            Assert.Equal(typeof(List<int>).GetMethod("Add"), init.AddMethod);
+        }
+
+        [Fact]
+        public void CanAccessArguments()
+        {
+            Expression key = Expression.Constant("Key");
+            Expression value = Expression.Constant(42);
+            ElementInit init = Expression.ElementInit(typeof(Dictionary<string, int>).GetMethod("Add"), key, value);
+            Assert.Equal(2, init.ArgumentCount);
+            Assert.Same(key, init.GetArgument(0));
+            Assert.Same(value, init.GetArgument(1));
+            Assert.Equal(new[] { key, value }, init.Arguments);
+        }
+
+        [Fact]
+        public void InvalidArgumentIndex()
+        {
+            Expression key = Expression.Constant("Key");
+            Expression value = Expression.Constant(42);
+            ElementInit init = Expression.ElementInit(typeof(Dictionary<string, int>).GetMethod("Add"), key, value);
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => init.GetArgument(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => init.GetArgument(2));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => init.GetArgument(3));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => init.GetArgument(int.MaxValue));
+        }
+
+        [Fact]
+        public void ToStringShowsArguments()
+        {
+            ElementInit init = Expression.ElementInit(
+                typeof(Dictionary<string, int>).GetMethod("Add"),
+                Expression.Constant("Key"),
+                Expression.Constant(42)
+                );
+            Assert.Equal(typeof(Dictionary<string, int>).GetMethod("Add").ToString() + "(\"Key\", 42)", init.ToString());
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
+++ b/src/System.Linq.Expressions/tests/ListInit/ListInitExpressionTests.cs
@@ -1,0 +1,178 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using Xunit;
+
+namespace System.Linq.Expressions.Tests
+{
+    public class ListInitExpressionTests
+    {
+        private class NonEnumerableAddable
+        {
+            public readonly List<int> Store = new List<int>();
+
+            public void Add(int value)
+            {
+                Store.Add(value);
+            }
+        }
+
+        [Fact]
+        public void NullNewMethod()
+        {
+            var validExpression = Expression.Constant(1);
+            Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, validExpression));
+            Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, Enumerable.Repeat(validExpression, 1)));
+
+            var validMethod = typeof(List<int>).GetMethod("Add");
+            Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, validMethod, validExpression));
+            Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, validMethod, Enumerable.Repeat(validExpression, 1)));
+
+            Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, default(MethodInfo), validExpression));
+            Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, null, Enumerable.Repeat(validExpression, 1)));
+
+            var validElementInit = Expression.ElementInit(validMethod, validExpression);
+            Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, validElementInit));
+            Assert.Throws<ArgumentNullException>("newExpression", () => Expression.ListInit(null, Enumerable.Repeat(validElementInit, 1)));
+        }
+
+        [Fact]
+        public void NullInitializers()
+        {
+            var validNew = Expression.New(typeof(List<int>));
+            Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, default(Expression[])));
+            Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, default(IEnumerable<Expression>)));
+            Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, default(ElementInit[])));
+            Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, default(IEnumerable<ElementInit>)));
+
+            var validMethod = typeof(List<int>).GetMethod("Add");
+            Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, validMethod, default(Expression[])));
+            Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, validMethod, default(IEnumerable<Expression>)));
+
+            Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, null, default(Expression[])));
+            Assert.Throws<ArgumentNullException>("initializers", () => Expression.ListInit(validNew, null, default(IEnumerable<Expression>)));
+        }
+
+        [Fact]
+        public void ZeroInitializers()
+        {
+            var validNew = Expression.New(typeof(List<int>));
+            Assert.Throws<ArgumentException>(null, () => Expression.ListInit(validNew, new Expression[0]));
+            Assert.Throws<ArgumentException>(null, () => Expression.ListInit(validNew, Enumerable.Empty<Expression>()));
+            Assert.Throws<ArgumentException>(null, () => Expression.ListInit(validNew, new ElementInit[0]));
+            Assert.Throws<ArgumentException>(null, () => Expression.ListInit(validNew, Enumerable.Empty<ElementInit>()));
+
+            var validMethod = typeof(List<int>).GetMethod("Add");
+            Assert.Throws<ArgumentException>(null, () => Expression.ListInit(validNew, validMethod, new Expression[0]));
+            Assert.Throws<ArgumentException>(null, () => Expression.ListInit(validNew, validMethod, Enumerable.Empty<Expression>()));
+
+            Assert.Throws<ArgumentException>(null, () => Expression.ListInit(validNew, null, new Expression[0]));
+            Assert.Throws<ArgumentException>(null, () => Expression.ListInit(validNew, null, Enumerable.Empty<Expression>()));
+        }
+
+        [Fact]
+        public void TypeWithoutAdd()
+        {
+            var newExp = Expression.New(typeof(string).GetConstructor(new[] { typeof(char[]) }), Expression.Constant("aaaa".ToCharArray()));
+            Assert.Throws<InvalidOperationException>(() => Expression.ListInit(newExp, Expression.Constant('a')));
+            Assert.Throws<InvalidOperationException>(() => Expression.ListInit(newExp, Enumerable.Repeat(Expression.Constant('a'), 1)));
+            Assert.Throws<InvalidOperationException>(() => Expression.ListInit(newExp, default(MethodInfo), Expression.Constant('a')));
+            Assert.Throws<InvalidOperationException>(() => Expression.ListInit(newExp, default(MethodInfo), Enumerable.Repeat(Expression.Constant('a'), 1)));
+        }
+
+        [Fact]
+        public void InitializeNonEnumerable()
+        {
+            // () => new NonEnumerableAddable { 1, 2, 4, 16, 42 } isn't allowed because list initialization
+            // is allowed only with enumerable types.
+            Assert.Throws<ArgumentException>(null, () => Expression.ListInit(Expression.New(typeof(NonEnumerableAddable)), Expression.Constant(1)));
+        }
+
+        [Fact]
+        public void InitializersWrappedExactly()
+        {
+            var newExp = Expression.New(typeof(List<int>));
+            var expressions = new[] { Expression.Constant(1), Expression.Constant(2), Expression.Constant(int.MaxValue) };
+            var listInit = Expression.ListInit(newExp, expressions);
+            Assert.Equal(expressions, listInit.Initializers.Select(i => i.GetArgument(0)));
+        }
+
+        [Fact]
+        public void CanReduce()
+        {
+            var listInit = Expression.ListInit(
+                Expression.New(typeof(List<int>)),
+                Expression.Constant(0)
+                );
+            Assert.True(listInit.CanReduce);
+            Assert.NotSame(listInit, listInit.ReduceAndCheck());
+        }
+
+        [Fact]
+        public void InitializeVoidAddCompiler()
+        {
+            Expression<Func<List<int>>> listInit = () => new List<int> { 1, 2, 4, 16, 42 };
+            Func<List<int>> func = listInit.Compile(false);
+            Assert.Equal(new[] { 1, 2, 4, 16, 42 }, func());
+        }
+
+        [Fact]
+        public void InitializeVoidAddInterpreter()
+        {
+            Expression<Func<List<int>>> listInit = () => new List<int> { 1, 2, 4, 16, 42 };
+            Func<List<int>> func = listInit.Compile(true);
+            Assert.Equal(new[] { 1, 2, 4, 16, 42 }, func());
+        }
+
+        [Fact]
+        public void InitializeNonVoidAddCompiler()
+        {
+            Expression<Func<HashSet<int>>> hashInit = () => new HashSet<int> { 1, 2, 4, 16, 42 };
+            Func<HashSet<int>> func = hashInit.Compile(false);
+            Assert.Equal(new[] { 1, 2, 4, 16, 42 }, func().OrderBy(i => i));
+        }
+
+        [Fact]
+        public void InitializeNonVoidAddInterpreter()
+        {
+            Expression<Func<HashSet<int>>> hashInit = () => new HashSet<int> { 1, 2, 4, 16, 42 };
+            Func<HashSet<int>> func = hashInit.Compile(true);
+            Assert.Equal(new[] { 1, 2, 4, 16, 42 }, func().OrderBy(i => i));
+        }
+
+        [Fact]
+        public void InitializeTwoParameterAddCompiler()
+        {
+            Expression<Func<Dictionary<string, int>>> dictInit = () => new Dictionary<string, int>
+            {
+                { "a", 1 }, {"b", 2 }, {"c", 3 }
+            };
+            Func<Dictionary<string, int>> func = dictInit.Compile(false);
+            var expected = new Dictionary<string, int>
+            {
+                { "a", 1 }, {"b", 2 }, {"c", 3 }
+            };
+            Assert.Equal(expected.OrderBy(kvp => kvp.Key), func().OrderBy(kvp => kvp.Key));
+        }
+
+        [Fact]
+        public void InitializeTwoParameterAddInterpreter()
+        {
+            Expression<Func<Dictionary<string, int>>> dictInit = () => new Dictionary<string, int>
+            {
+                { "a", 1 }, {"b", 2 }, {"c", 3 }
+            };
+            Func<Dictionary<string, int>> func = dictInit.Compile(true);
+            var expected = new Dictionary<string, int>
+            {
+                { "a", 1 }, {"b", 2 }, {"c", 3 }
+            };
+            Assert.Equal(expected.OrderBy(kvp => kvp.Key), func().OrderBy(kvp => kvp.Key));
+        }
+    }
+}

--- a/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
+++ b/src/System.Linq.Expressions/tests/System.Linq.Expressions.Tests.csproj
@@ -180,6 +180,8 @@
     <Compile Include="Lifted\NonLiftedComparisonLessThanNullableTests.cs" />
     <Compile Include="Lifted\NonLiftedComparisonLessThanOrEqualNullableTests.cs" />
     <Compile Include="Lifted\NonLiftedComparisonNotEqualNullableTests.cs" />
+    <Compile Include="ListInit\ElementInitTests.cs" />
+    <Compile Include="ListInit\ListInitExpressionTests.cs" />
     <Compile Include="MemberInit\MemberInitTests.cs" />
     <Compile Include="Member\MemberAccessTests.cs" />
     <Compile Include="New\NewTests.cs" />


### PR DESCRIPTION
Fixes #5945

Also add List Initialization Expression Tests beyond those needed
to verify this fix.

cc: @stephentoub @VSadov @bartdesmet 