### PR TITLE
Two perf tweaks to ArrayPool

### DIFF
--- a/src/System.Buffers/src/System/Buffers/DefaultArrayPoolBucket.cs
+++ b/src/System.Buffers/src/System/Buffers/DefaultArrayPoolBucket.cs
@@ -15,7 +15,7 @@ namespace System.Buffers
     {
         private int _index;
         private readonly T[][] _data;
-        private readonly int _bufferLength;
+        internal readonly int _bufferLength;
         private SpinLock _lock;
         private bool _exhaustedEventSent;
         private readonly int _poolId;

--- a/src/System.Buffers/src/System/Buffers/Utilities.cs
+++ b/src/System.Buffers/src/System/Buffers/Utilities.cs
@@ -8,19 +8,37 @@ namespace System.Buffers
 {
     internal static class Utilities
     {
+        private static readonly int[] s_logTable256 = new int[256] {
+           -1, 0, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3,
+            4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+            5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+            5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+            6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+            6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+            6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+            6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6,
+            7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+            7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+            7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+            7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+            7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+            7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+            7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+            7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+        };
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static int SelectBucketIndex(int bufferSize)
         {
-            uint bitsRemaining = ((uint)bufferSize - 1) >> 4;
-            int poolIndex = 0;
+            uint input = ((uint)bufferSize - 1) >> 4;
 
-            while (bitsRemaining > 0)
-            {
-                bitsRemaining >>= 1;
-                poolIndex++;
-            }
-
-            return poolIndex;
+            // Based on bit twiddling examples from http://graphics.stanford.edu/~seander/bithacks.html
+            int[] table = s_logTable256;
+            uint t, tt;
+            return 1 +
+                ((tt = input >> 16) != 0 ?
+                    (((t = tt >> 8) != 0 ? 24 + table[t] : 16 + table[tt])) :
+                    (((t = input >> 8) != 0 ? 8 + table[t] : table[input])));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/System.Buffers/tests/ArrayPool/UnitTests.cs
+++ b/src/System.Buffers/tests/ArrayPool/UnitTests.cs
@@ -235,9 +235,21 @@ namespace System.Buffers.ArrayPool.Tests
             for (int i = 1; i < 10000; i++)
             {
                 byte[] buffer = pool.Rent(i);
-                Assert.InRange(buffer.Length, i, int.MaxValue);
+                Assert.Equal(i <= 16 ? 16 : RoundUpToPowerOf2(i), buffer.Length);
                 pool.Return(buffer);
             }
+        }
+
+        private static int RoundUpToPowerOf2(int i)
+        {
+            // http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+            --i;
+            i |= i >> 1;
+            i |= i >> 2;
+            i |= i >> 4;
+            i |= i >> 8;
+            i |= i >> 16;
+            return i + 1;
         }
 
         [Theory]


### PR DESCRIPTION
1. SelectBucketIndex is consuming ~10-15% of the time of Rent and Return.  I've changed it to use a different algorithm for log2.  For very small sizes (e.g. 16 elements), the existing algorithm is slightly faster (e.g.  ~5%), but for sizes commonly used with ArrayPool (e.g. 1K, 4K, 8K, 80K, etc.) the new algorithm is in my measurements upwards of 2x faster.  It's also relatively constant in its cost, whereas the existing algorithm gets more expensive proportional to the number of bits set in the buffer size. Repeatedly renting and returning a 4K buffer is now ~6% faster than before. The crossover point where the old and new algorithms have the same speed is ~64 elements.

2. When requesting buffers larger than the pool can store, the pool is still rounding up to the next power of 2, e.g. asking for a buffer of size ```1024*1024+1``` allocates a buffer of size ```1024*1024*2```, even though there is no corresponding bucket to eventually return it to, resulting in more memory allocated than is needed. I've fixed that.

cc: @sokket, @KrzysztofCwalina, @benaadams