### PR TITLE
Fix some race conditions in the build

### DIFF
--- a/src/System.Reflection.Context/tests/System.Reflection.Context.Tests.csproj
+++ b/src/System.Reflection.Context/tests/System.Reflection.Context.Tests.csproj
@@ -15,6 +15,7 @@
     <ProjectReference Include="..\src\System.Reflection.Context.csproj">
       <Project>{96AA2060-C846-4E56-9509-E8CB9C114C8F}</Project>
       <Name>System.Reflection.Context</Name>
+      <TargetGroup>netcore50</TargetGroup>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Reflection.TypeExtensions/tests/CoreCLR/System.Reflection.TypeExtensions.CoreCLR.Tests.csproj
+++ b/src/System.Reflection.TypeExtensions/tests/CoreCLR/System.Reflection.TypeExtensions.CoreCLR.Tests.csproj
@@ -28,6 +28,7 @@
       <Name>System.Reflection.TypeExtensions</Name>
       <!-- Don't deploy reference assembly -->
       <Private>false</Private>
+      <UndefineProperties>OSGroup</UndefineProperties>
     </ProjectReference>
     <ProjectReference Include="..\..\src\System.Reflection.TypeExtensions.csproj">
       <Project>{1e689c1b-690c-4799-bde9-6e7990585894}</Project>

--- a/src/System.Reflection.TypeExtensions/tests/System.Reflection.TypeExtensions.Tests.csproj
+++ b/src/System.Reflection.TypeExtensions/tests/System.Reflection.TypeExtensions.Tests.csproj
@@ -81,6 +81,7 @@
       <Name>System.Reflection.TypeExtensions</Name>
       <!-- Don't deploy reference assembly -->
       <Private>false</Private>
+      <UndefineProperties>OSGroup</UndefineProperties>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Reflection.TypeExtensions.csproj">
       <Project>{1e689c1b-690c-4799-bde9-6e7990585894}</Project>

--- a/src/System.Reflection/tests/CoreCLR/System.Reflection.CoreCLR.Tests.csproj
+++ b/src/System.Reflection/tests/CoreCLR/System.Reflection.CoreCLR.Tests.csproj
@@ -32,6 +32,7 @@
       <Name>System.Reflection</Name>
       <!-- Don't copy the reference assembly to output -->
       <Private>false</Private>
+      <UndefineProperties>OSGroup</UndefineProperties>
     </ProjectReference>
     <ProjectReference Include="..\TestExe\System.Reflection.Tests.TestExe.csproj">
       <Project>{8c19b991-41e9-4b38-9602-e19375397f1d}</Project>

--- a/src/System.Reflection/tests/System.Reflection.Tests.csproj
+++ b/src/System.Reflection/tests/System.Reflection.Tests.csproj
@@ -102,6 +102,7 @@
       <Name>System.Reflection</Name>
       <!-- Don't copy the reference assembly to output -->
       <Private>false</Private>
+      <UndefineProperties>OSGroup</UndefineProperties>
     </ProjectReference>
     <ProjectReference Include="TestExe\System.Reflection.Tests.TestExe.csproj">
       <Project>{8c19b991-41e9-4b38-9602-e19375397f1d}</Project>

--- a/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
+++ b/src/System.Runtime.Extensions/tests/System.Runtime.Extensions.Tests.csproj
@@ -95,6 +95,7 @@
       <Name>System.Runtime.Extensions</Name>
       <!-- Don't deploy reference assembly -->
       <Private>false</Private>
+      <UndefineProperties>OSGroup</UndefineProperties>
     </ProjectReference>
     <ProjectReference Include="..\src\System.Runtime.Extensions.csproj">
       <Project>{1e689c1b-690c-4799-bde9-6e7990585894}</Project>


### PR DESCRIPTION
These projects were all being built multiple times to the same output
path with different global configuration.  If those builds happen at
the same time it causes a race condition which fill fail the build

I detected these with an msbuild logger that I wrote which will soon be
integrated  with buildtools.