### PR TITLE
Use fcntl with FD_CLOEXEC to better implement HandleInheritability

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.Fcntl.SetCloseOnExec.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Fcntl.SetCloseOnExec.cs
@@ -1,0 +1,19 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        internal static class Fcntl
+        {
+            [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FcntlSetCloseOnExec", SetLastError=true)]
+            internal static extern int SetCloseOnExec(SafeFileHandle fd);
+        }
+    }
+}

--- a/src/Native/System.Native/pal_io.h
+++ b/src/Native/System.Native/pal_io.h
@@ -377,6 +377,13 @@ extern "C" int32_t SystemNative_Pipe(int32_t pipefd[2], // [out] pipefds[0] gets
 // complexity around converting command codes.
 
 /**
+ * Sets the O_CLOEXEC flag on a file descriptor.
+ *
+ * Returns 0 for success; -1 for failure. Sets errno for failure.
+ */
+extern "C" int32_t SystemNative_FcntlSetCloseOnExec(intptr_t fd);
+
+/**
  * Determines if the current platform supports getting and setting pipe capacity.
  *
  * Returns true (non-zero) if supported, false (zero) if not.

--- a/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
+++ b/src/System.IO.MemoryMappedFiles/src/System.IO.MemoryMappedFiles.csproj
@@ -127,6 +127,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Errors.cs">
       <Link>Common\Interop\Unix\Interop.Errors.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Fcntl.SetCloseOnExec.cs">
+      <Link>Common\Interop\Unix\Interop.Fcntl.SetCloseOnExec.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.IOErrors.cs">
       <Link>Common\Interop\Unix\Interop.IOErrors.cs</Link>
     </Compile>

--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.Unix.cs
@@ -70,6 +70,12 @@ namespace System.IO.MemoryMappedFiles
                 {
                     ownsFileStream = true;
                     fileStream = CreateSharedBackingObject(protections, capacity);
+
+                    // If the MMF handle should not be inherited, mark the backing object fd as O_CLOEXEC.
+                    if (inheritability == HandleInheritability.None)
+                    {
+                        Interop.CheckIo(Interop.Sys.Fcntl.SetCloseOnExec(fileStream.SafeFileHandle));
+                    }
                 }
             }
 


### PR DESCRIPTION
In System.IO.Pipes, we use pipe2 on Linux to support HandleInheritability.None, but on other platforms we just ignore the flag.  And in System.IO.MemoryMappedFiles, when creating a backing object, we also ignore the flag.  This commit augments the implementations to use fcntl(fd, F_SETFD, FD_CLOEXEC) to address those gaps.

cc: @ellismg, @eerhardt 