### PR TITLE
Allow libcurl to use CURLAUTH_NTLM

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Easy.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Easy.cs
@@ -144,6 +144,7 @@ internal static partial class Interop
             Basic = 1 << 0,
             Digest = 1 << 1,
             Negotiate = 1 << 2,
+            NTLM = 1 << 3,
         }
 
         // Enum for constants defined for the enum curl_proxytype in curl.h

--- a/src/Native/System.Net.Http.Native/pal_easy.cpp
+++ b/src/Native/System.Net.Http.Native/pal_easy.cpp
@@ -56,6 +56,7 @@ static_assert(PAL_CURLAUTH_None == CURLAUTH_NONE, "");
 static_assert(PAL_CURLAUTH_Basic == CURLAUTH_BASIC, "");
 static_assert(PAL_CURLAUTH_Digest == CURLAUTH_DIGEST, "");
 static_assert(PAL_CURLAUTH_Negotiate == CURLAUTH_GSSNEGOTIATE, "");
+static_assert(PAL_CURLAUTH_NTLM == CURLAUTH_NTLM, "");
 
 static_assert(PAL_CURLPROXY_HTTP == CURLPROXY_HTTP, "");
 

--- a/src/Native/System.Net.Http.Native/pal_easy.h
+++ b/src/Native/System.Net.Http.Native/pal_easy.h
@@ -88,6 +88,7 @@ enum PAL_CURLAUTH : int64_t
     PAL_CURLAUTH_Basic = 1 << 0,
     PAL_CURLAUTH_Digest = 1 << 1,
     PAL_CURLAUTH_Negotiate = 1 << 2,
+    PAL_CURLAUTH_NTLM = 1 << 3,
 };
 
 enum PAL_CURLPROXYTYPE : int32_t

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -39,8 +39,8 @@ namespace System.Net.Http
         #region Fields
 
         private readonly static char[] s_newLineCharArray = new char[] { HttpRuleParser.CR, HttpRuleParser.LF };
-        private readonly static string[] s_authenticationSchemes = { "Negotiate", "Digest", "Basic" }; // the order in which libcurl goes over authentication schemes
-        private readonly static CURLAUTH[] s_authSchemePriorityOrder = { CURLAUTH.Negotiate, CURLAUTH.Digest, CURLAUTH.Basic };
+        private readonly static string[] s_authenticationSchemes = { "Negotiate", "NTLM", "Digest", "Basic" }; // the order in which libcurl goes over authentication schemes
+        private readonly static CURLAUTH[] s_authSchemePriorityOrder = { CURLAUTH.Negotiate, CURLAUTH.NTLM, CURLAUTH.Digest, CURLAUTH.Basic };
 
         private readonly static bool s_supportsAutomaticDecompression;
         private readonly static bool s_supportsSSL;


### PR DESCRIPTION
We already have Negotiate, Digest, and Basic... adding NTLM.

@kapilash, @vijaykota, why wasn't this done initially?  Is there something important I'm missing? I just tested it, and it appears to work fine (using libcurl4-openssl-dev), and the docs for CURLAUTH_NTLM state it should work with multiple backends.  Seems like worst case is there's some platform where it's simply not available but the other auth protocols continue to work as they would...?

cc: @kapilash, @vijaykota, @ericeil 