### PR TITLE
Remove the _customValues Dictionary.

### DIFF
--- a/src/System.Data.Common/src/System/Data/Common/DbColumn.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbColumn.cs
@@ -79,10 +79,10 @@ namespace System.Data.Common
                         return NumericScale;
                     case "UdtAssemblyQualifiedName":
                         return UdtAssemblyQualifiedName;
-                    case "Data":
-                        return Data;
-                    case "DataName":
-                        return DataName;
+                    case "DataType":
+                        return DataType;
+                    case "DataTypeName":
+                        return DataTypeName;
                     default:
                         return null;
                 }

--- a/src/System.Data.Common/src/System/Data/Common/DbColumn.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbColumn.cs
@@ -83,8 +83,9 @@ namespace System.Data.Common
                         return Data;
                     case "DataName":
                         return DataName;
+                    default:
+                        return null;
                 }
-                return null;
             }
         }
 

--- a/src/System.Data.Common/src/System/Data/Common/DbColumn.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbColumn.cs
@@ -8,7 +8,6 @@ namespace System.Data.Common
 {
     public class DbColumn
     {
-        private readonly Dictionary<string, object> _customValues = new Dictionary<string, object>();
         public virtual bool AllowDBNull { get; set; }
         public virtual string BaseCatalogName { get; set; }
         public virtual string BaseColumnName { get; set; }
@@ -36,13 +35,56 @@ namespace System.Data.Common
         {
             get
             {
-                object value;
-                _customValues.TryGetValue(property, out value);
-                return value;
-            }
-            set
-            {
-                _customValues[property] = value;
+                switch (property)
+                {
+                    case "AllowDBNull":
+                        return AllowDBNull;
+                    case "BaseCatalogName":
+                        return BaseCatalogName;
+                    case "BaseColumnName":
+                        return BaseColumnName;
+                    case "BaseSchemaName":
+                        return BaseSchemaName;
+                    case "BaseServerName":
+                        return BaseServerName;
+                    case "BaseTableName":
+                        return BaseTableName;
+                    case "ColumnName":
+                        return ColumnName;
+                    case "ColumnOrdinal":
+                        return ColumnOrdinal;
+                    case "ColumnSize":
+                        return ColumnSize;
+                    case "IsAliased":
+                        return IsAliased;
+                    case "IsAutoIncrement":
+                        return IsAutoIncrement;
+                    case "IsExpression":
+                        return IsExpression;
+                    case "IsHidden":
+                        return IsHidden;
+                    case "IsIdentity":
+                        return IsIdentity;
+                    case "IsKey":
+                        return IsKey;
+                    case "IsLong":
+                        return IsLong;
+                    case "IsReadOnly":
+                        return IsReadOnly;
+                    case "IsUnique":
+                        return IsUnique;
+                    case "NumericPrecision":
+                        return NumericPrecision;
+                    case "NumericScale":
+                        return NumericScale;
+                    case "UdtAssemblyQualifiedName":
+                        return UdtAssemblyQualifiedName;
+                    case "Data":
+                        return Data;
+                    case "DataName":
+                        return DataName;
+                }
+                return null;
             }
         }
 


### PR DESCRIPTION
The change is meant for the issue #5611 

1. Remove the setter from the indexer.
2. Remove the dictionary from DbColumn
3. Allow the attributes being expsoed by the DbColumn to be retrieved using the names of the attributes as the default implementation.

The indexer in the DbColumn is supposed to allow access to the properties
being exposed by the DbColumn and its subclasses. The setter and the
storage is being removed from the DbColumn. The DbColumn will expose its
default properties using the indexer. However if a subclass of the
DbColumn needs to expose its properties via the indexer, then need to
implement their own mechanisms

