### PR TITLE
Fixing bug #5949 in System.Buffers

### DIFF
--- a/src/System.Buffers/src/Resources/Strings.resx
+++ b/src/System.Buffers/src/Resources/Strings.resx
@@ -129,4 +129,7 @@
   <data name="event_BucketExhausted" xml:space="preserve">
     <value>Bucket {0}, with {2} maximum buffers, exhausted of all Buffers of size {1} in Pool {3}</value>
   </data>
+  <data name="ArgumentException_BufferNotFromPool" xml:space="preserve">
+    <value>The buffer is not associated with this pool and may not be returned to it.</value>
+  </data>
 </root>

--- a/src/System.Buffers/src/System/Buffers/DefaultArrayPoolBucket.cs
+++ b/src/System.Buffers/src/System/Buffers/DefaultArrayPoolBucket.cs
@@ -88,6 +88,10 @@ namespace System.Buffers
         /// </summary>
         internal void Return(T[] buffer)
         {
+            // Check to see if the buffer is the correct size for this bucket
+            if (buffer.Length != _bufferLength)
+                throw new ArgumentException(SR.ArgumentException_BufferNotFromPool, "buffer");
+
             // Use a SpinLock since it is super lightweight
             // and our lock is very short lived. Wrap in try-finally
             // to protect against thread-aborts

--- a/src/System.Buffers/tests/ArrayPool/UnitTests.cs
+++ b/src/System.Buffers/tests/ArrayPool/UnitTests.cs
@@ -371,5 +371,15 @@ namespace System.Buffers.ArrayPool.Tests
                 Assert.True(are.WaitOne(MaxEventWaitTimeoutInMs));
             }, 4, are);
         }
+
+        [Fact]
+        public static void ReturningANonPooledBufferOfDifferentSizeToThePoolThrows()
+        {
+            ArrayPool<byte> pool = ArrayPool<byte>.Create(maxArrayLength: 16, maxArraysPerBucket: 1);
+            byte[] buffer = pool.Rent(15);
+            Assert.Throws<ArgumentException>("buffer", () => pool.Return(new byte[1]));
+            buffer = pool.Rent(15);
+            Assert.Equal(buffer.Length, 16);
+        }
     }
 }


### PR DESCRIPTION
Fixing bug #5949 in System.Buffers where we would accept invalid sized arrays and return them back to the user incorrectly. Also adding a UT to validate and prevent regressions of this scenario

@stephentoub 