### PR TITLE
Change socket test to stop sending data only when we've sent all the data, or an error occurs.

### DIFF
--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendReceive.cs
@@ -445,7 +445,7 @@ namespace System.Net.Sockets.Tests
                             sentChecksum.Add(sendBuffer, 0, sent);
 
                             remaining -= sent;
-                            if (remaining <= 0 || sent == 0)
+                            if (remaining <= 0)
                             {
                                 client.LingerState = new LingerOption(true, LingerTime);
                                 client.Dispose();
@@ -484,7 +484,7 @@ namespace System.Net.Sockets.Tests
                             }
 
                             remaining -= sent;
-                            if (remaining <= 0 || sent == 0)
+                            if (remaining <= 0)
                             {
                                 client.LingerState = new LingerOption(true, LingerTime);
                                 client.Dispose();
@@ -507,7 +507,7 @@ namespace System.Net.Sockets.Tests
                 sendHandler(0);
             });
 
-            Assert.True(serverFinished.Task.Wait(TestTimeout));
+            Assert.True(serverFinished.Task.Wait(TestTimeout), "Timed out");
 
             Assert.Equal(bytesSent, bytesReceived);
             Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/SendReceive.cs
@@ -285,7 +285,6 @@ namespace System.Net.Sockets.Tests
                         random.NextBytes(sendBuffer);
 
                         sent = client.Send(sendBuffer, 0, Math.Min(sendBuffer.Length, remaining), SocketFlags.None);
-                        Assert.NotEqual(0, sent);
                         bytesSent += sent;
                         sentChecksum.Add(sendBuffer, 0, sent);
                     }
@@ -307,10 +306,6 @@ namespace System.Net.Sockets.Tests
                         }
 
                         sent = client.Send(sendBuffers, SocketFlags.None);
-                        if (sent == 0)
-                        {
-                            break;
-                        }
 
                         bytesSent += sent;
                         for (int i = 0, remaining = sent; i < sendBuffers.Count && remaining > 0; i++)
@@ -326,7 +321,7 @@ namespace System.Net.Sockets.Tests
                 client.LingerState = new LingerOption(true, LingerTime);
             }
 
-            Assert.True(serverThread.Join(TestTimeout));
+            Assert.True(serverThread.Join(TestTimeout), "Completed within allowed time");
 
             Assert.Equal(bytesSent, bytesReceived);
             Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);
@@ -507,7 +502,7 @@ namespace System.Net.Sockets.Tests
                 sendHandler(0);
             });
 
-            Assert.True(serverFinished.Task.Wait(TestTimeout), "Timed out");
+            Assert.True(serverFinished.Task.Wait(TestTimeout), "Completed within allowed time");
 
             Assert.Equal(bytesSent, bytesReceived);
             Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);

--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -313,7 +313,7 @@ namespace System.Net.Sockets.Tests
 
                             remaining -= sent;
                             Assert.True(remaining >= 0);
-                            if (remaining == 0 || sent == 0)
+                            if (remaining == 0)
                             {
                                 client.LingerState = new LingerOption(true, LingerTime);
                                 client.Dispose();
@@ -352,7 +352,7 @@ namespace System.Net.Sockets.Tests
                             }
 
                             remaining -= sent;
-                            if (remaining <= 0 || sent == 0)
+                            if (remaining <= 0)
                             {
                                 client.LingerState = new LingerOption(true, LingerTime);
                                 client.Dispose();
@@ -376,7 +376,7 @@ namespace System.Net.Sockets.Tests
                 sendHandler(0);
             });
 
-            Assert.True(serverFinished.Task.Wait(TestTimeout));
+            Assert.True(serverFinished.Task.Wait(TestTimeout), "Completed within allowed time");
 
             Assert.Equal(bytesSent, bytesReceived);
             Assert.Equal(sentChecksum.Sum, receivedChecksum.Sum);


### PR DESCRIPTION
If send returns zero, that does not necessarily mean we are done.

Fixes #5739
Fixes #4817

@stephentoub, @pgavlin , @CIPop 