### PR TITLE
Remove the uncommon errno symbols

### DIFF
--- a/src/Common/src/Interop/Unix/Interop.Errors.cs
+++ b/src/Common/src/Interop/Unix/Interop.Errors.cs
@@ -75,13 +75,11 @@ internal static partial class Interop
         ENOTCONN         = 0x10038,           // The socket is not connected.
         ENOTDIR          = 0x10039,           // Not a directory or a symbolic link to a directory.
         ENOTEMPTY        = 0x1003A,           // Directory not empty.
-        ENOTRECOVERABLE  = 0x1003B,           // State not recoverable.
         ENOTSOCK         = 0x1003C,           // Not a socket.
         ENOTSUP          = 0x1003D,           // Not supported (same value as EOPNOTSUP).
         ENOTTY           = 0x1003E,           // Inappropriate I/O control operation.
         ENXIO            = 0x1003F,           // No such device or address.
         EOVERFLOW        = 0x10040,           // Value too large to be stored in data type.
-        EOWNERDEAD       = 0x10041,           // Previous owner died.
         EPERM            = 0x10042,           // Operation not permitted.
         EPIPE            = 0x10043,           // Broken pipe.
         EPROTO           = 0x10044,           // Protocol error.

--- a/src/Native/System.Native/pal_errno.cpp
+++ b/src/Native/System.Native/pal_errno.cpp
@@ -126,8 +126,6 @@ extern "C" Error SystemNative_ConvertErrorPlatformToPal(int32_t platformErrno)
             return PAL_ENOTDIR;
         case ENOTEMPTY:
             return PAL_ENOTEMPTY;
-        case ENOTRECOVERABLE:
-            return PAL_ENOTRECOVERABLE;
         case ENOTSOCK:
             return PAL_ENOTSOCK;
         case ENOTSUP:
@@ -138,8 +136,6 @@ extern "C" Error SystemNative_ConvertErrorPlatformToPal(int32_t platformErrno)
             return PAL_ENXIO;
         case EOVERFLOW:
             return PAL_EOVERFLOW;
-        case EOWNERDEAD:
-            return PAL_EOWNERDEAD;
         case EPERM:
             return PAL_EPERM;
         case EPIPE:
@@ -298,8 +294,6 @@ extern "C" int32_t SystemNative_ConvertErrorPalToPlatform(Error error)
             return ENOTDIR;
         case PAL_ENOTEMPTY:
             return ENOTEMPTY;
-        case PAL_ENOTRECOVERABLE:
-            return ENOTRECOVERABLE;
         case PAL_ENOTSOCK:
             return ENOTSOCK;
         case PAL_ENOTSUP:
@@ -310,8 +304,6 @@ extern "C" int32_t SystemNative_ConvertErrorPalToPlatform(Error error)
             return ENXIO;
         case PAL_EOVERFLOW:
             return EOVERFLOW;
-        case PAL_EOWNERDEAD:
-            return EOWNERDEAD;
         case PAL_EPERM:
             return EPERM;
         case PAL_EPIPE:

--- a/src/Native/System.Native/pal_errno.h
+++ b/src/Native/System.Native/pal_errno.h
@@ -84,13 +84,11 @@ enum Error : int32_t
     PAL_ENOTCONN = 0x10038,        // The socket is not connected.
     PAL_ENOTDIR = 0x10039,         // Not a directory or a symbolic link to a directory.
     PAL_ENOTEMPTY = 0x1003A,       // Directory not empty.
-    PAL_ENOTRECOVERABLE = 0x1003B, // State not recoverable.
     PAL_ENOTSOCK = 0x1003C,        // Not a socket.
     PAL_ENOTSUP = 0x1003D,         // Not supported (same value as EOPNOTSUP).
     PAL_ENOTTY = 0x1003E,          // Inappropriate I/O control operation.
     PAL_ENXIO = 0x1003F,           // No such device or address.
     PAL_EOVERFLOW = 0x10040,       // Value too large to be stored in data type.
-    PAL_EOWNERDEAD = 0x10041,      // Previous owner died.
     PAL_EPERM = 0x10042,           // Operation not permitted.
     PAL_EPIPE = 0x10043,           // Broken pipe.
     PAL_EPROTO = 0x10044,          // Protocol error.


### PR DESCRIPTION
`ENOTRECOVERABLE` and `EOWNERDEAD` are not available in NetBSD. Due to
this lack of availability in all Unices, they are removed.