### PR TITLE
Making the class DbCommandTests public for test execution

### DIFF
--- a/src/System.Data.Common/tests/DbCommandTests.cs
+++ b/src/System.Data.Common/tests/DbCommandTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.Data.Common.Tests
 {
-    class DbCommandTests
+    public class DbCommandTests
     {
         private static volatile bool _wasFinalized;
 


### PR DESCRIPTION
Making the `class DbCommandTests` public so that it can be visible for test execution.

