### PR TITLE
Fix S.R.Metadata v1.2 vs v1.3 nuspec path clash

### DIFF
--- a/src/System.Reflection.Metadata/pkg/future/System.Reflection.Metadata.pkgproj
+++ b/src/System.Reflection.Metadata/pkg/future/System.Reflection.Metadata.pkgproj
@@ -6,6 +6,7 @@
     <MinClientVersion>2.8.6</MinClientVersion>
     <!-- This is the .pkgproj for the "future" build which is not on the same release cadence as corefx -->
     <PreReleaseLabel>beta</PreReleaseLabel>
+    <NuspecSuffix>-future</NuspecSuffix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The nuspec files were clobbering each other and preventing both packages from being produced and uploaded correctly. 

@ericstj @tmat