### PR TITLE
Enable EventSource logging in CurlHandler

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Easy.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Easy.cs
@@ -48,6 +48,8 @@ internal static partial class Interop
 
         public delegate CURLcode SslCtxCallback(IntPtr curl, IntPtr sslCtx, IntPtr userPointer);
 
+        public delegate void DebugCallback(IntPtr curl, CurlInfoType type, IntPtr data, ulong size, IntPtr userPointer);
+
         [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_RegisterSeekCallback")]
         public static extern void RegisterSeekCallback(
             SafeCurlHandle curl,
@@ -67,6 +69,13 @@ internal static partial class Interop
         public static extern CURLcode RegisterSslCtxCallback(
             SafeCurlHandle curl,
             SslCtxCallback callback,
+            IntPtr userPointer,
+            ref SafeCallbackHandle callbackHandle);
+
+        [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_RegisterDebugCallback")]
+        public static extern int RegisterDebugCallback(
+            SafeCurlHandle curl,
+            DebugCallback callback,
             IntPtr userPointer,
             ref SafeCallbackHandle callbackHandle);
 
@@ -166,6 +175,17 @@ internal static partial class Interop
             CURL_SEEKFUNC_FAIL = 1,
             CURL_SEEKFUNC_CANTSEEK = 2,
         }
+
+        internal enum CurlInfoType : int
+        {
+            CURLINFO_TEXT = 0,
+            CURLINFO_HEADER_IN = 1,
+            CURLINFO_HEADER_OUT = 2,
+            CURLINFO_DATA_IN = 3,
+            CURLINFO_DATA_OUT = 4,
+            CURLINFO_SSL_DATA_IN = 5,
+            CURLINFO_SSL_DATA_OUT = 6,
+        };
 
         // constants defined for the results of a CURL_READ or CURL_WRITE function
         internal const ulong CURL_READFUNC_ABORT = 0x10000000;

--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Easy.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Easy.cs
@@ -73,7 +73,7 @@ internal static partial class Interop
             ref SafeCallbackHandle callbackHandle);
 
         [DllImport(Libraries.HttpNative, EntryPoint = "HttpNative_RegisterDebugCallback")]
-        public static extern int RegisterDebugCallback(
+        public static extern CURLcode RegisterDebugCallback(
             SafeCurlHandle curl,
             DebugCallback callback,
             IntPtr userPointer,

--- a/src/Common/src/System/Net/Logging/HttpEventSource.cs
+++ b/src/Common/src/System/Net/Logging/HttpEventSource.cs
@@ -164,6 +164,16 @@ namespace System.Net
         [Event(HandlerMessageId, Keywords = Keywords.Debug, Level = EventLevel.Verbose)]
         internal unsafe void HandlerMessage(int workerId, int requestId, string memberName, string message)
         {
+            if (memberName == null)
+            {
+                memberName = string.Empty;
+            }
+
+            if (message == null)
+            {
+                message = string.Empty;
+            }
+
             const int SizeData = 4;
             fixed (char* memberNamePtr = memberName)
             fixed (char* messagePtr = message)

--- a/src/Common/src/System/Net/Logging/HttpEventSource.cs
+++ b/src/Common/src/System/Net/Logging/HttpEventSource.cs
@@ -19,6 +19,7 @@ namespace System.Net
         private const int ContentNullId = 3;
         private const int ClientSendCompletedId = 4;
         private const int HeadersInvalidValueId = 5;
+        private const int HandlerMessageId = 6;
 
         private readonly static HttpEventSource s_log = new HttpEventSource();
         private HttpEventSource() { }
@@ -158,6 +159,31 @@ namespace System.Net
         internal void HeadersInvalidValue(string name, string rawValue)
         {
             WriteEvent(HeadersInvalidValueId, name, rawValue);
+        }
+
+        [Event(HandlerMessageId, Keywords = Keywords.Debug, Level = EventLevel.Verbose)]
+        internal unsafe void HandlerMessage(int workerId, int requestId, string memberName, string message)
+        {
+            const int SizeData = 4;
+            fixed (char* memberNamePtr = memberName)
+            fixed (char* messagePtr = message)
+            {
+                EventData* dataDesc = stackalloc EventSource.EventData[SizeData];
+
+                dataDesc[0].DataPointer = (IntPtr)(&workerId);
+                dataDesc[0].Size = sizeof(int);
+
+                dataDesc[1].DataPointer = (IntPtr)(&requestId);
+                dataDesc[1].Size = sizeof(int);
+
+                dataDesc[2].DataPointer = (IntPtr)(memberNamePtr);
+                dataDesc[2].Size = (memberName.Length + 1) * sizeof(char);
+
+                dataDesc[3].DataPointer = (IntPtr)(messagePtr);
+                dataDesc[3].Size = (message.Length + 1) * sizeof(char);
+
+                WriteEventCore(HandlerMessageId, SizeData, dataDesc);
+            }
         }
 
         public class Keywords

--- a/src/Native/System.Net.Http.Native/pal_easy.cpp
+++ b/src/Native/System.Net.Http.Native/pal_easy.cpp
@@ -267,7 +267,7 @@ extern "C" int32_t HttpNative_RegisterSslCtxCallback(CURL* curl,
     return curl_easy_setopt(curl, CURLOPT_SSL_CTX_FUNCTION, &ssl_ctx_callback);
 }
 
-static int debug_callback(CURL* curl, curl_infotype type, char *data, size_t size, void *userPointer)
+static int debug_callback(CURL* curl, curl_infotype type, char* data, size_t size, void* userPointer)
 {
     assert(userPointer != nullptr);
     CallbackHandle* handle = static_cast<CallbackHandle*>(userPointer);

--- a/src/Native/System.Net.Http.Native/pal_easy.cpp
+++ b/src/Native/System.Net.Http.Native/pal_easy.cpp
@@ -70,6 +70,14 @@ static_assert(PAL_CURL_READFUNC_ABORT == CURL_READFUNC_ABORT, "");
 static_assert(PAL_CURL_READFUNC_PAUSE == CURL_READFUNC_PAUSE, "");
 static_assert(PAL_CURL_WRITEFUNC_PAUSE == CURL_WRITEFUNC_PAUSE, "");
 
+static_assert(PAL_CURLINFO_TEXT == CURLINFO_TEXT, "");
+static_assert(PAL_CURLINFO_HEADER_IN == CURLINFO_HEADER_IN, "");
+static_assert(PAL_CURLINFO_HEADER_OUT == CURLINFO_HEADER_OUT, "");
+static_assert(PAL_CURLINFO_DATA_IN == CURLINFO_DATA_IN, "");
+static_assert(PAL_CURLINFO_DATA_OUT == CURLINFO_DATA_OUT, "");
+static_assert(PAL_CURLINFO_SSL_DATA_IN == CURLINFO_SSL_DATA_IN, "");
+static_assert(PAL_CURLINFO_SSL_DATA_OUT == CURLINFO_SSL_DATA_OUT, "");
+
 extern "C" CURL* HttpNative_EasyCreate()
 {
     return curl_easy_init();
@@ -146,6 +154,9 @@ struct CallbackHandle
 
     SslCtxCallback sslCtxCallback;
     void* sslUserPointer;
+
+    DebugCallback debugCallback;
+    void* debugUserPointer;
 };
 
 static inline void EnsureCallbackHandle(CallbackHandle** callbackHandle)
@@ -254,6 +265,31 @@ extern "C" int32_t HttpNative_RegisterSslCtxCallback(CURL* curl,
 
     curl_easy_setopt(curl, CURLOPT_SSL_CTX_DATA, handle);
     return curl_easy_setopt(curl, CURLOPT_SSL_CTX_FUNCTION, &ssl_ctx_callback);
+}
+
+static int debug_callback(CURL* curl, curl_infotype type, char *data, size_t size, void *userPointer)
+{
+    assert(userPointer != nullptr);
+    CallbackHandle* handle = static_cast<CallbackHandle*>(userPointer);
+    handle->debugCallback(curl, static_cast<PAL_CurlInfoType>(type), data, size, handle->debugUserPointer);
+    return 0;
+}
+
+extern "C" int32_t HttpNative_RegisterDebugCallback(CURL* curl, 
+                                                    DebugCallback callback, 
+                                                    void* userPointer, 
+                                                    CallbackHandle** callbackHandle)
+{
+    EnsureCallbackHandle(callbackHandle);
+
+    CallbackHandle* handle = *callbackHandle;
+    handle->debugCallback = callback;
+    handle->debugUserPointer = userPointer;
+
+    CURLcode rv = curl_easy_setopt(curl, CURLOPT_DEBUGDATA, handle);
+    return rv == CURLE_OK ? 
+        curl_easy_setopt(curl, CURLOPT_DEBUGFUNCTION, &debug_callback) : 
+        rv;
 }
 
 extern "C" void HttpNative_FreeCallbackHandle(CallbackHandle* callbackHandle)

--- a/src/Native/System.Net.Http.Native/pal_easy.h
+++ b/src/Native/System.Net.Http.Native/pal_easy.h
@@ -108,6 +108,17 @@ enum PAL_CurlSeekResult : int32_t
     PAL_CURL_SEEKFUNC_CANTSEEK = 2,
 };
 
+enum PAL_CurlInfoType : int32_t 
+{
+    PAL_CURLINFO_TEXT = 0,
+    PAL_CURLINFO_HEADER_IN = 1,
+    PAL_CURLINFO_HEADER_OUT = 2,
+    PAL_CURLINFO_DATA_IN = 3,
+    PAL_CURLINFO_DATA_OUT = 4,
+    PAL_CURLINFO_SSL_DATA_IN = 5,
+    PAL_CURLINFO_SSL_DATA_OUT = 6,
+};
+
 const uint64_t PAL_CURL_READFUNC_ABORT = 0x10000000;
 const uint64_t PAL_CURL_READFUNC_PAUSE = 0x10000001;
 const uint64_t PAL_CURL_WRITEFUNC_PAUSE = 0x10000001;
@@ -171,6 +182,9 @@ typedef uint64_t (*ReadWriteCallback)(uint8_t* buffer, uint64_t bufferSize, uint
 // the function pointer definition for the callback used in RegisterSslCtxCallback
 typedef int32_t (*SslCtxCallback)(CURL* curl, void* sslCtx, void* userPointer);
 
+// the function pointer definition for the callback used for debugging callbacks
+typedef void(*DebugCallback)(CURL* curl, PAL_CurlInfoType type, char* data, uint64_t size, void* userPointer);
+
 /*
 The object that is returned from RegisterXXXCallback functions.
 This holds the data necessary to know what managed callback to invoke and with what args.
@@ -208,6 +222,18 @@ extern "C" int32_t HttpNative_RegisterSslCtxCallback(CURL* curl,
                                                      SslCtxCallback callback,
                                                      void* userPointer,
                                                      CallbackHandle** callbackHandle);
+
+/*
+Registers a callback in libcurl for outputting debug information.
+
+This callback function gets called by libcurl each time it has debug information to report.
+
+Returns a CURLcode that describes whether registering the callback was successful or not.
+*/
+extern "C" int32_t HttpNative_RegisterDebugCallback(CURL* curl, 
+                                                    DebugCallback callback,
+                                                    void* userPointer,
+                                                    CallbackHandle** callbackHandle);
 
 /*
 Frees the CallbackHandle created by a RegisterXXXCallback function.

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.ClientCertificateProvider.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.ClientCertificateProvider.cs
@@ -35,14 +35,13 @@ namespace System.Net.Http
                 {
                     certHandle = IntPtr.Zero;
                     privateKeyHandle = IntPtr.Zero;
-                    VerboseTrace("libssl's client certificate callback");
 
                     ISet<string> issuerNames = GetRequestCertificateAuthorities(sslHandle);
                     X509Certificate2 certificate;
                     X509Chain chain;
                     if (!GetClientCertificate(issuerNames, out certificate, out chain))
                     {
-                        VerboseTrace("no cert or chain");
+                        EventSourceTrace("No certificate or chain");
                         return 0;
                     }
 
@@ -52,6 +51,7 @@ namespace System.Net.Http
                         if (rsa != null)
                         {
                             _privateKeyHandle = rsa.DuplicateKeyHandle();
+                            EventSourceTrace("RSA key");
                         }
                         else
                         {
@@ -60,6 +60,7 @@ namespace System.Net.Http
                                 if (ecdsa != null)
                                 {
                                     _privateKeyHandle = ecdsa.DuplicateKeyHandle();
+                                    EventSourceTrace("ECDsa key");
                                 }
                             }
                         }
@@ -67,7 +68,7 @@ namespace System.Net.Http
 
                     if (_privateKeyHandle == null || _privateKeyHandle.IsInvalid)
                     {
-                        VerboseTrace("invalid private key");
+                        EventSourceTrace("Invalid private key");
                         return 0;
                     }
 
@@ -81,7 +82,7 @@ namespace System.Net.Http
                             Interop.Crypto.CheckValidOpenSslHandle(dupCertHandle);
                             if (!Interop.Ssl.SslAddExtraChainCert(sslHandle, dupCertHandle))
                             {
-                                VerboseTrace("failed to add extra chain cert");
+                                EventSourceTrace("Failed to add extra chain certificate");
                                 return -1;
                             }
                         }
@@ -105,7 +106,6 @@ namespace System.Net.Http
                 {
                     _certHandle.Dispose();
                 }
-                VerboseTrace("Disposed client cert provider");
             }
 
             private static ISet<string> GetRequestCertificateAuthorities(SafeSslHandle sslHandle)

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
@@ -162,7 +162,7 @@ namespace System.Net.Http
             {
                 Debug.Assert(pointer != IntPtr.Zero, "Expected a non-null pointer");
                 Debug.Assert(length >= 0, "Expected a non-negative length");
-                VerboseTrace("length: " + length);
+                EventSourceTrace("Length: {0}", length);
 
                 CheckDisposed();
 
@@ -178,9 +178,14 @@ namespace System.Net.Http
 
                     // If there's existing data in the remaining data buffer, or if there's no pending read request, 
                     // we need to pause until the existing data is consumed or until there's a waiting read.
-                    if (_remainingDataCount > 0 || _pendingReadRequest == null)
+                    if (_remainingDataCount > 0)
                     {
-                        VerboseTrace("Pausing due to _remainingDataCount: " + _remainingDataCount + ", _pendingReadRequest: " + (_pendingReadRequest != null));
+                        EventSourceTrace("Pausing. Remaining bytes: {0}", _remainingDataCount);
+                        return Interop.Http.CURL_WRITEFUNC_PAUSE;
+                    }
+                    else if (_pendingReadRequest == null)
+                    {
+                        EventSourceTrace("Pausing. No pending read request");
                         return Interop.Http.CURL_WRITEFUNC_PAUSE;
                     }
 
@@ -191,7 +196,7 @@ namespace System.Net.Http
                     Marshal.Copy(pointer, _pendingReadRequest._buffer, _pendingReadRequest._offset, numBytesForTask);
                     _pendingReadRequest.SetResult(numBytesForTask);
                     ClearPendingReadRequest();
-                    VerboseTrace("Copied to task: " + numBytesForTask);
+                    EventSourceTrace("Bytes copied to task: {0}", numBytesForTask);
 
                     // If there's any data left, transfer it to our remaining buffer. libcurl does not support
                     // partial transfers of data, so since we just took some of it to satisfy the read request
@@ -213,11 +218,10 @@ namespace System.Net.Http
                         {
                             _remainingData = new byte[Math.Max(_remainingData.Length * 2, _remainingDataCount)];
                         }
-                        VerboseTrace("Allocated new remainingData array of length: " + _remainingData.Length);
 
                         // Copy the remaining data to the buffer
                         Marshal.Copy(remainingPointer, _remainingData, 0, _remainingDataCount);
-                        VerboseTrace("Copied to buffer: " + _remainingDataCount);
+                        EventSourceTrace("Copied to buffer: {0}", _remainingDataCount);
                     }
 
                     // All of the data from libcurl was consumed.
@@ -238,12 +242,12 @@ namespace System.Net.Http
                 if (offset > buffer.Length - count) throw new ArgumentException("buffer");
                 CheckDisposed();
 
-                VerboseTrace("buffer: " + buffer.Length + ", offset: " + offset + ", count: " + count);
+                EventSourceTrace("Buffer: {0}, Offset: {1}, Count: {2}", buffer.Length, offset, count);
 
                 // Check for cancellation
                 if (cancellationToken.IsCancellationRequested)
                 {
-                    VerboseTrace("Canceled");
+                    EventSourceTrace("Canceled");
                     return Task.FromCanceled<int>(cancellationToken);
                 }
 
@@ -254,14 +258,15 @@ namespace System.Net.Http
                     // If there's currently a pending read, fail this read, as we don't support concurrent reads.
                     if (_pendingReadRequest != null)
                     {
-                        VerboseTrace("Existing pending read");
+                        EventSourceTrace("Existing pending read");
                         return Task.FromException<int>(new InvalidOperationException(SR.net_http_content_no_concurrent_reads));
                     }
 
                     // If the stream was already completed with failure, complete the read as a failure.
                     if (_completed != null && _completed != s_completionSentinel)
                     {
-                        VerboseTrace("Failing read with " + _completed);
+                        EventSourceTrace("Failing read with error: {0}", _completed);
+
                         OperationCanceledException oce = _completed as OperationCanceledException;
                         return (oce != null && oce.CancellationToken.IsCancellationRequested) ?
                             Task.FromCanceled<int>(oce.CancellationToken) :
@@ -272,7 +277,7 @@ namespace System.Net.Http
                     // for errors so that we can still fail the read and transfer the exception if we should.
                     if (count == 0)
                     {
-                        VerboseTrace("Zero count");
+                        EventSourceTrace("0 count requested");
                         return s_zeroTask;
                     }
 
@@ -287,14 +292,14 @@ namespace System.Net.Http
                         Debug.Assert(_remainingDataCount >= 0, "The remaining count should never go negative");
                         Debug.Assert(_remainingDataOffset <= _remainingData.Length, "The remaining offset should never exceed the buffer size");
 
-                        VerboseTrace("Copied to task: " + bytesToCopy);
+                        EventSourceTrace("Bytes copied to task: {0}", bytesToCopy);
                         return Task.FromResult(bytesToCopy);
                     }
 
                     // If the stream has already been completed, complete the read immediately.
                     if (_completed == s_completionSentinel)
                     {
-                        VerboseTrace("Completed successfully after stream completion");
+                        EventSourceTrace("Completed successfully after stream completion");
                         return s_zeroTask;
                     }
 
@@ -316,7 +321,7 @@ namespace System.Net.Http
                         var crs = new CancelableReadState(buffer, offset, count, this, cancellationToken);
                         crs._registration = cancellationToken.Register(s1 =>
                         {
-                            ((CancelableReadState)s1)._stream.VerboseTrace("Cancellation invoked. Queueing work item to cancel read state.");
+                            ((CancelableReadState)s1)._stream.EventSourceTrace("Cancellation invoked. Queueing work item to cancel read state");
                             Task.Factory.StartNew(s2 =>
                             {
                                 var crsRef = (CancelableReadState)s2;
@@ -332,13 +337,13 @@ namespace System.Net.Http
                             }, s1, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default);
                         }, crs);
                         _pendingReadRequest = crs;
-                        VerboseTrace("Created pending cancelable read");
+                        EventSourceTrace("Created pending cancelable read");
                     }
                     else
                     {
                         // The token isn't cancelable.  Just create a normal read state.
                         _pendingReadRequest = new ReadState(buffer, offset, count);
-                        VerboseTrace("Created pending read");
+                        EventSourceTrace("Created pending read");
                     }
 
                     _easy._associatedMultiAgent.RequestUnpause(_easy);
@@ -370,12 +375,12 @@ namespace System.Net.Http
                     {
                         if (_completed == s_completionSentinel)
                         {
-                            VerboseTrace("Completed pending read task with 0 bytes.");
+                            EventSourceTrace("Completed pending read task with 0 bytes");
                             _pendingReadRequest.TrySetResult(0);
                         }
                         else
                         {
-                            VerboseTrace("Completed pending read task with " + _completed);
+                            EventSourceTrace("Failing pending read task with error: {0}", _completed);
                             OperationCanceledException oce = _completed as OperationCanceledException;
                             if (oce != null)
                             {
@@ -426,10 +431,25 @@ namespace System.Net.Http
                 }
             }
 
-            [Conditional(VerboseDebuggingConditional)]
-            private void VerboseTrace(string text = null, [CallerMemberName] string memberName = null)
+            private void EventSourceTrace<T>(string formatMessage, T arg0, [CallerMemberName] string memberName = null)
             {
-                CurlHandler.VerboseTrace(text, memberName, _easy);
+                if (EventSourceTracingEnabled)
+                {
+                    EventSourceTrace(string.Format(formatMessage, arg0), memberName);
+                }
+            }
+
+            private void EventSourceTrace<T1, T2, T3>(string formatMessage, T1 arg0, T2 arg1, T3 arg2, [CallerMemberName] string memberName = null)
+            {
+                if (EventSourceTracingEnabled)
+                {
+                    EventSourceTrace(string.Format(formatMessage, arg0, arg1, arg2), memberName);
+                }
+            }
+
+            private void EventSourceTrace(string message = null, [CallerMemberName] string memberName = null)
+            {
+                CurlHandler.EventSourceTrace(message: message, memberName: memberName, easy: _easy);
             }
 
             /// <summary>Verifies various invariants that must be true about our state.</summary>

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -23,6 +23,7 @@ using SeekCallback = Interop.Http.SeekCallback;
 using ReadWriteCallback = Interop.Http.ReadWriteCallback;
 using ReadWriteFunction = Interop.Http.ReadWriteFunction;
 using SslCtxCallback = Interop.Http.SslCtxCallback;
+using DebugCallback = Interop.Http.DebugCallback;
 
 namespace System.Net.Http
 {
@@ -83,7 +84,6 @@ namespace System.Net.Http
 
                 // Configure the handle
                 SetUrl();
-                SetDebugging();
                 SetMultithreading();
                 SetRedirection();
                 SetVerb();
@@ -160,19 +160,9 @@ namespace System.Net.Http
 
             private void SetUrl()
             {
-                VerboseTrace(_requestMessage.RequestUri.AbsoluteUri);
+                EventSourceTrace("Url: {0}", _requestMessage.RequestUri);
                 SetCurlOption(CURLoption.CURLOPT_URL, _requestMessage.RequestUri.AbsoluteUri);
                 SetCurlOption(CURLoption.CURLOPT_PROTOCOLS, (long)(CurlProtocols.CURLPROTO_HTTP | CurlProtocols.CURLPROTO_HTTPS));
-            }
-
-            [Conditional(VerboseDebuggingConditional)]
-            private void SetDebugging()
-            {
-                SetCurlOption(CURLoption.CURLOPT_VERBOSE, 1L);
-
-                // In addition to CURLOPT_VERBOSE, CURLOPT_DEBUGFUNCTION could be used here in the future to:
-                // - Route the verbose output to somewhere other than stderr
-                // - Dump additional data related to CURLINFO_DATA_* and CURLINFO_SSL_DATA_*
             }
 
             private void SetMultithreading()
@@ -187,19 +177,21 @@ namespace System.Net.Http
                     return;
                 }
 
-                VerboseTrace(_handler._maxAutomaticRedirections.ToString());
                 SetCurlOption(CURLoption.CURLOPT_FOLLOWLOCATION, 1L);
+
                 CurlProtocols redirectProtocols = string.Equals(_requestMessage.RequestUri.Scheme, UriSchemeHttps, StringComparison.OrdinalIgnoreCase) ?
                     CurlProtocols.CURLPROTO_HTTPS : // redirect only to another https
                     CurlProtocols.CURLPROTO_HTTP | CurlProtocols.CURLPROTO_HTTPS; // redirect to http or to https
                 SetCurlOption(CURLoption.CURLOPT_REDIR_PROTOCOLS, (long)redirectProtocols);
 
                 SetCurlOption(CURLoption.CURLOPT_MAXREDIRS, _handler._maxAutomaticRedirections);
+                EventSourceTrace("Max automatic redirections: {0}", _handler._maxAutomaticRedirections);
             }
 
             private void SetVerb()
             {
-                VerboseTrace(_requestMessage.Method.Method);
+                EventSourceTrace<string>("Verb: {0}", _requestMessage.Method.Method);
+
                 if (_requestMessage.Method == HttpMethod.Put)
                 {
                     SetCurlOption(CURLoption.CURLOPT_UPLOAD, 1L);
@@ -256,12 +248,12 @@ namespace System.Net.Http
                         if (c == CURLcode.CURLE_OK)
                         {
                             // Success.  The requested version will be used.
-                            VerboseTrace("Set HTTP version to " + v);
+                            EventSourceTrace("HTTP version: {0}", v);
                         }
                         else if (c == CURLcode.CURLE_UNSUPPORTED_PROTOCOL)
                         {
                             // The requested version is unsupported.  Fall back to using the default version chosen by libcurl.
-                            VerboseTrace("Unsupported protocol.");
+                            EventSourceTrace("Unsupported protocol: {0}", v);
                         }
                         else
                         {
@@ -288,7 +280,7 @@ namespace System.Net.Http
                                        gzip ? EncodingNameGzip :
                                        EncodingNameDeflate;
                     SetCurlOption(CURLoption.CURLOPT_ACCEPT_ENCODING, encoding);
-                    VerboseTrace(encoding);
+                    EventSourceTrace<string>("Encoding: {0}", encoding);
                 }
             }
 
@@ -297,14 +289,14 @@ namespace System.Net.Http
                 if (_handler._proxyPolicy == ProxyUsePolicy.DoNotUseProxy)
                 {
                     SetCurlOption(CURLoption.CURLOPT_PROXY, string.Empty);
-                    VerboseTrace("No proxy");
+                    EventSourceTrace("No proxy");
                     return;
                 }
 
                 if ((_handler._proxyPolicy == ProxyUsePolicy.UseDefaultProxy) ||
                     (_handler.Proxy == null))
                 {
-                    VerboseTrace("Default proxy");
+                    EventSourceTrace("Default proxy");
                     return;
                 }
 
@@ -313,26 +305,35 @@ namespace System.Net.Http
                 if (_handler.Proxy.IsBypassed(requestUri))
                 {
                     SetCurlOption(CURLoption.CURLOPT_PROXY, string.Empty);
-                    VerboseTrace("Bypassed proxy");
+                    EventSourceTrace("Bypassed proxy");
                     return;
                 }
 
                 var proxyUri = _handler.Proxy.GetProxy(requestUri);
                 if (proxyUri == null)
                 {
-                    VerboseTrace("No proxy URI");
+                    EventSourceTrace("No proxy URI");
                     return;
                 }
 
                 SetCurlOption(CURLoption.CURLOPT_PROXYTYPE, (long)CURLProxyType.CURLPROXY_HTTP);
                 SetCurlOption(CURLoption.CURLOPT_PROXY, proxyUri.AbsoluteUri);
                 SetCurlOption(CURLoption.CURLOPT_PROXYPORT, proxyUri.Port);
-                VerboseTrace("Set proxy: " + proxyUri.ToString());
+                EventSourceTrace("Proxy: {0}", proxyUri);
 
                 KeyValuePair<NetworkCredential, CURLAUTH> credentialScheme = GetCredentials(_handler.Proxy.Credentials, _requestMessage.RequestUri);
                 NetworkCredential credentials = credentialScheme.Key;
-                if (credentials != null && // no credentials to set
-                    credentials != CredentialCache.DefaultCredentials) // no "default credentials" on Unix; nop just like UseDefaultCredentials
+                if (credentials == null)
+                {
+                    // No credentials; nothing to do.
+                    EventSourceTrace("No proxy credentials");
+                }
+                else if (credentials == CredentialCache.DefaultCredentials)
+                {
+                    // No "default credentials" on Unix; nop just like UseDefaultCredentials.
+                    EventSourceTrace("Default proxy credentials. Skipping.");
+                }
+                else
                 {
                     if (string.IsNullOrEmpty(credentials.UserName))
                     {
@@ -342,8 +343,9 @@ namespace System.Net.Http
                     string credentialText = string.IsNullOrEmpty(credentials.Domain) ?
                         string.Format("{0}:{1}", credentials.UserName, credentials.Password) :
                         string.Format("{2}\\{0}:{1}", credentials.UserName, credentials.Password, credentials.Domain);
+
+                    EventSourceTrace("Proxy credentials set.");
                     SetCurlOption(CURLoption.CURLOPT_PROXYUSERPWD, credentialText);
-                    VerboseTrace("Set proxy credentials");
                 }
             }
 
@@ -368,8 +370,8 @@ namespace System.Net.Http
                     SetCurlOption(CURLoption.CURLOPT_PASSWORD, credentials.Password);
                 }
 
+                EventSourceTrace("Credentials set.");
                 _networkCredential = credentials;
-                VerboseTrace("Set credentials options");
             }
 
             internal void SetCookieOption(Uri uri)
@@ -383,7 +385,7 @@ namespace System.Net.Http
                 if (!string.IsNullOrEmpty(cookieValues))
                 {
                     SetCurlOption(CURLoption.CURLOPT_COOKIE, cookieValues);
-                    VerboseTrace("Set cookies");
+                    EventSourceTrace<string>("Cookies: {0}", cookieValues);
                 }
             }
 
@@ -439,7 +441,7 @@ namespace System.Net.Http
                 {
                     _requestHeaders = slist;
                     SetCurlOption(CURLoption.CURLOPT_HTTPHEADER, slist);
-                    VerboseTrace("Set headers");
+                    EventSourceTrace();
                 }
                 else
                 {
@@ -463,7 +465,8 @@ namespace System.Net.Http
                 ReadWriteCallback receiveHeadersCallback,
                 ReadWriteCallback sendCallback,
                 SeekCallback seekCallback,
-                ReadWriteCallback receiveBodyCallback)
+                ReadWriteCallback receiveBodyCallback,
+                DebugCallback debugCallback)
             {
                 if (_callbackHandle == null)
                 {
@@ -502,6 +505,16 @@ namespace System.Net.Http
                         _easyHandle,
                         ReadWriteFunction.Write,
                         receiveBodyCallback,
+                        easyGCHandle,
+                        ref _callbackHandle);
+                }
+
+                if (EventSourceTracingEnabled)
+                {
+                    SetCurlOption(CURLoption.CURLOPT_VERBOSE, 1L);
+                    Interop.Http.RegisterDebugCallback(
+                        _easyHandle, 
+                        debugCallback,
                         easyGCHandle,
                         ref _callbackHandle);
                 }
@@ -578,10 +591,17 @@ namespace System.Net.Http
                 _requestMessage.RequestUri = redirectUri;
             }
 
-            [Conditional(VerboseDebuggingConditional)]
-            private void VerboseTrace(string text = null, [CallerMemberName] string memberName = null)
+            private void EventSourceTrace<TArg0>(string formatMessage, TArg0 arg0, [CallerMemberName] string memberName = null)
             {
-                CurlHandler.VerboseTrace(text, memberName, easy: this, agent: null);
+                if (EventSourceTracingEnabled)
+                {
+                    EventSourceTrace(string.Format(formatMessage, arg0), memberName);
+                }
+            }
+
+            private void EventSourceTrace(string message = null, [CallerMemberName] string memberName = null)
+            {
+                CurlHandler.EventSourceTrace(message: message, easy: this, agent: null, memberName: memberName);
             }
         }
     }

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.HttpContentAsyncStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.HttpContentAsyncStream.cs
@@ -128,7 +128,6 @@ namespace System.Net.Http
                     int bytesToCopy = Math.Min(_count, count);
                     Debug.Assert(bytesToCopy > 0, "Expected to be copying at least 1 byte");
                     Buffer.BlockCopy(_buffer, _offset, buffer, offset, bytesToCopy);
-                    EventSourceTrace("Read {0} bytes from writer", bytesToCopy);
 
                     if (bytesToCopy == _count)
                     {
@@ -206,7 +205,6 @@ namespace System.Net.Http
                     _cancellationRegistration.Dispose();
                     bool completed = _asyncOp.TrySetResult(bytesToCopy);
                     Debug.Assert(completed, "No one else should have completed the reader");
-                    EventSourceTrace("Writer transferred {0} bytes to reader", bytesToCopy);
 
                     if (bytesToCopy < count)
                     {
@@ -297,7 +295,7 @@ namespace System.Net.Http
                     }
                 }
 
-                EventSourceTrace("TryReset failed");
+                EventSourceTrace("TryReset failed due to existing copy task.");
                 return false;
             }
 
@@ -334,7 +332,7 @@ namespace System.Net.Http
                 Debug.Assert(!Monitor.IsEntered(_syncObj), "Should not be invoked while holding the lock");
                 lock (_syncObj)
                 {
-                    EventSourceTrace("CopyToAsync completed: {0}", completedCopy.Status);
+                    EventSourceTrace("Status: {0}", completedCopy.Status);
 
                     // We're done transferring, but a reader doesn't know that until they successfully
                     // read 0 bytes, which won't happen until either a) we complete an already waiting

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.SslProvider.cs
@@ -51,7 +51,7 @@ namespace System.Net.Http
                     case CURLcode.CURLE_UNKNOWN_OPTION:
                     // Curl 7.39 and later
                     case CURLcode.CURLE_NOT_BUILT_IN:
-                        VerboseTrace("CURLOPT_SSL_CTX_FUNCTION is not supported, platform default https chain building in use");
+                        EventSourceTrace("CURLOPT_SSL_CTX_FUNCTION not supported. Platform default HTTPS chain building in use");
                         if (clientCertOption == ClientCertificateOption.Automatic)
                         {
                             throw new PlatformNotSupportedException(SR.net_http_unix_invalid_client_cert_option);
@@ -75,7 +75,7 @@ namespace System.Net.Http
 
                     if (userPointer == IntPtr.Zero)
                     {
-                        VerboseTrace("Not using client Certificate callback ");
+                        EventSourceTrace("Not using client certificate callback");
                     }
                     else
                     {

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -19,7 +19,6 @@ namespace System.Net.Http
     {
         #region Constants
 
-        private const string VerboseDebuggingConditional = "CURLHANDLER_VERBOSE";
         private const char SpaceChar = ' ';
         private const int StatusCodeLength = 3;
 
@@ -413,11 +412,9 @@ namespace System.Net.Http
             }
             catch (CookieException e)
             {
-                string msg = string.Format("Malformed cookie: SetCookies Failed with {0}, server: {1}, cookie:{2}",
-                                           e.Message,
-                                           state._requestMessage.RequestUri,
-                                           cookieHeader);
-                VerboseTrace(msg);
+                EventSourceTrace(
+                    "Malformed cookie parsing failed: {0}, server: {1}, cookie: {2}", 
+                    e.Message, state._requestMessage.RequestUri, cookieHeader);
             }
         }
 
@@ -449,7 +446,7 @@ namespace System.Net.Http
                 }
             }
 
-            VerboseTrace("curlAuthScheme = " + curlAuthScheme);
+            EventSourceTrace("Authentication scheme: {0}", curlAuthScheme);
             return new KeyValuePair<NetworkCredential, CURLAUTH>(nc, curlAuthScheme); ;
         }
 
@@ -475,7 +472,7 @@ namespace System.Net.Http
             if (error != CURLcode.CURLE_OK)
             {
                 var inner = new CurlException((int)error, isMulti: false);
-                VerboseTrace(inner.Message);
+                EventSourceTrace(inner.Message);
                 throw inner;
             }
         }
@@ -485,7 +482,7 @@ namespace System.Net.Http
             if (error != CURLMcode.CURLM_OK)
             {
                 string msg = CurlException.GetCurlErrorString((int)error, true);
-                VerboseTrace(msg);
+                EventSourceTrace(msg);
                 switch (error)
                 {
                     case CURLMcode.CURLM_ADDED_ALREADY:
@@ -512,39 +509,51 @@ namespace System.Net.Http
                 string.Equals(credential1.Password, credential2.Password, StringComparison.Ordinal);
         }
 
-        [Conditional(VerboseDebuggingConditional)]
-        private static void VerboseTrace(string text = null, [CallerMemberName] string memberName = null, EasyRequest easy = null, MultiAgent agent = null)
+        private static bool EventSourceTracingEnabled { get { return HttpEventSource.Log.IsEnabled(); } }
+
+        private static void EventSourceTrace<TArg0>(
+            string formatMessage, TArg0 arg0,
+            MultiAgent agent = null, EasyRequest easy = null, [CallerMemberName] string memberName = null)
+        {
+            if (EventSourceTracingEnabled)
+            {
+                EventSourceTraceCore(string.Format(formatMessage, arg0), agent, easy, memberName);
+            }
+        }
+
+        private static void EventSourceTrace<TArg0, TArg1, TArg2>
+            (string formatMessage, TArg0 arg0, TArg1 arg1, TArg2 arg2,
+            MultiAgent agent = null, EasyRequest easy = null, [CallerMemberName] string memberName = null)
+        {
+            if (EventSourceTracingEnabled)
+            {
+                EventSourceTraceCore(string.Format(formatMessage, arg0, arg1, arg2), agent, easy, memberName);
+            }
+        }
+
+        private static void EventSourceTrace(
+            string message = null, 
+            MultiAgent agent = null, EasyRequest easy = null, [CallerMemberName] string memberName = null)
+        {
+            if (EventSourceTracingEnabled)
+            {
+                EventSourceTraceCore(message, agent, easy, memberName);
+            }
+        }
+
+        private static void EventSourceTraceCore(string message, MultiAgent agent, EasyRequest easy, string memberName)
         {
             // If we weren't handed a multi agent, see if we can get one from the EasyRequest
             if (agent == null && easy != null && easy._associatedMultiAgent != null)
             {
                 agent = easy._associatedMultiAgent;
             }
-            int? agentId = agent != null ? agent.RunningWorkerId : null;
 
-            // Get an ID string that provides info about which MultiAgent worker and which EasyRequest this trace is about
-            string ids = "";
-            if (agentId != null || easy != null)
-            {
-                ids = "(" +
-                    (agentId != null ? "M#" + agentId : "") +
-                    (agentId != null && easy != null ? ", " : "") +
-                    (easy != null ? "E#" + easy.Task.Id : "") +
-                    ")";
-            }
-
-            // Create the message and trace it out
-            string msg = string.Format("[{0, -30}]{1, -16}: {2}", memberName, ids, text);
-            Interop.Sys.PrintF("%s\n", msg);
-        }
-
-        [Conditional(VerboseDebuggingConditional)]
-        private static void VerboseTraceIf(bool condition, string text = null, [CallerMemberName] string memberName = null, EasyRequest easy = null)
-        {
-            if (condition)
-            {
-                VerboseTrace(text, memberName, easy, agent: null);
-            }
+            HttpEventSource.Log.HandlerMessage(
+                agent != null && agent.RunningWorkerId.HasValue ? agent.RunningWorkerId.GetValueOrDefault() : 0,
+                easy != null ? easy.Task.Id : 0,
+                memberName ?? string.Empty,
+                message ?? string.Empty);
         }
 
         private static Exception CreateHttpRequestException(Exception inner = null)


### PR DESCRIPTION
We currently have a bunch of tracing in CurlHandler, but it's all guarded behind compile-time flags, making it difficult to use to diagnose issues.  This converts that to all be EventSource-based logging.  It also enables libcurl to provide its debug info via a callback, which is then routed to the EventSource as well, and mapped to the easy handles with which the info is associated.

cc: @kapilash, @davidsh, @josguil, @eerhardt 