### PR TITLE
Restore use of generics in System.Linq.Parallel

### DIFF
--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Merging/MergeExecutor.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Merging/MergeExecutor.cs
@@ -110,7 +110,7 @@ namespace System.Linq.Parallel
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return ((IEnumerable<TInputOutput>)this).GetEnumerator();
+            return GetEnumerator();
         }
 
         public IEnumerator<TInputOutput> GetEnumerator()

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Merging/OrderPreservingPipeliningMergeHelper.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Merging/OrderPreservingPipeliningMergeHelper.cs
@@ -134,7 +134,7 @@ namespace System.Linq.Parallel
             if (keyComparer == Util.GetDefaultComparer<int>())
             {
                 Debug.Assert(typeof(TKey) == typeof(int));
-                _producerComparer = (IComparer<Producer<TKey>>)(object)new ProducerComparerInt();
+                _producerComparer = (IComparer<Producer<TKey>>)new ProducerComparerInt();
             }
             else
             {

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/HashRepartitionStream.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/HashRepartitionStream.cs
@@ -32,7 +32,7 @@ namespace System.Linq.Parallel
     /// <typeparam name="TInputOutput"></typeparam>
     /// <typeparam name="THashKey"></typeparam>
     /// <typeparam name="TOrderKey"></typeparam>
-    internal abstract class HashRepartitionStream<TInputOutput, THashKey, TOrderKey> : PartitionedStream<Pair, TOrderKey>
+    internal abstract class HashRepartitionStream<TInputOutput, THashKey, TOrderKey> : PartitionedStream<Pair<TInputOutput,THashKey>, TOrderKey>
     {
         private readonly IEqualityComparer<THashKey> _keyComparer; // The optional key comparison routine.
         private readonly IEqualityComparer<TInputOutput> _elementComparer; // The optional element comparison routine.

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/OrderedHashRepartitionEnumerator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/OrderedHashRepartitionEnumerator.cs
@@ -22,7 +22,7 @@ namespace System.Linq.Parallel
     /// <typeparam name="TInputOutput">The kind of elements.</typeparam>
     /// <typeparam name="THashKey">The key used to distribute elements.</typeparam>
     /// <typeparam name="TOrderKey">The kind of keys found in the source.</typeparam>
-    internal class OrderedHashRepartitionEnumerator<TInputOutput, THashKey, TOrderKey> : QueryOperatorEnumerator<Pair, TOrderKey>
+    internal class OrderedHashRepartitionEnumerator<TInputOutput, THashKey, TOrderKey> : QueryOperatorEnumerator<Pair<TInputOutput,THashKey>, TOrderKey>
     {
         private const int ENUMERATION_NOT_STARTED = -1; // Sentinel to note we haven't begun enumerating yet.
 
@@ -30,7 +30,7 @@ namespace System.Linq.Parallel
         private readonly int _partitionIndex; // Our unique partition index.
         private readonly Func<TInputOutput, THashKey> _keySelector; // A key-selector function.
         private readonly HashRepartitionStream<TInputOutput, THashKey, TOrderKey> _repartitionStream; // A repartitioning stream.
-        private readonly ListChunk<Pair>[][] _valueExchangeMatrix; // Matrix to do inter-task communication of values.
+        private readonly ListChunk<Pair<TInputOutput,THashKey>>[][] _valueExchangeMatrix; // Matrix to do inter-task communication of values.
         private readonly ListChunk<TOrderKey>[][] _keyExchangeMatrix; // Matrix to do inter-task communication of order keys.
         private readonly QueryOperatorEnumerator<TInputOutput, TOrderKey> _source; // The immediate source of data.
         private CountdownEvent _barrier; // Used to signal and wait for repartitions to complete.
@@ -40,7 +40,7 @@ namespace System.Linq.Parallel
         class Mutables
         {
             internal int _currentBufferIndex; // Current buffer index.
-            internal ListChunk<Pair> _currentBuffer; // The buffer we're currently enumerating.
+            internal ListChunk<Pair<TInputOutput, THashKey>> _currentBuffer; // The buffer we're currently enumerating.
             internal ListChunk<TOrderKey> _currentKeyBuffer; // The buffer we're currently enumerating.
             internal int _currentIndex; // Current index into the buffer.
 
@@ -66,7 +66,7 @@ namespace System.Linq.Parallel
         internal OrderedHashRepartitionEnumerator(
             QueryOperatorEnumerator<TInputOutput, TOrderKey> source, int partitionCount, int partitionIndex,
             Func<TInputOutput, THashKey> keySelector, OrderedHashRepartitionStream<TInputOutput, THashKey, TOrderKey> repartitionStream, CountdownEvent barrier,
-            ListChunk<Pair>[][] valueExchangeMatrix, ListChunk<TOrderKey>[][] keyExchangeMatrix, CancellationToken cancellationToken)
+            ListChunk<Pair<TInputOutput, THashKey>>[][] valueExchangeMatrix, ListChunk<TOrderKey>[][] keyExchangeMatrix, CancellationToken cancellationToken)
         {
             Debug.Assert(source != null);
             Debug.Assert(keySelector != null || typeof(THashKey) == typeof(NoKeyMemoizationRequired));
@@ -104,7 +104,7 @@ namespace System.Linq.Parallel
         // anyway, so having the repartitioning operator do so isn't complicating matters much at all.
         //
 
-        internal override bool MoveNext(ref Pair currentElement, ref TOrderKey currentKey)
+        internal override bool MoveNext(ref Pair<TInputOutput, THashKey> currentElement, ref TOrderKey currentKey)
         {
             if (_partitionCount == 1)
             {
@@ -113,7 +113,7 @@ namespace System.Linq.Parallel
                 // If there's only one partition, no need to do any sort of exchanges.
                 if (_source.MoveNext(ref current, ref currentKey))
                 {
-                    currentElement = new Pair(
+                    currentElement = new Pair<TInputOutput, THashKey>(
                         current, _keySelector == null ? default(THashKey) : _keySelector(current));
                     return true;
                 }
@@ -207,7 +207,7 @@ namespace System.Linq.Parallel
             Mutables mutables = _mutables;
             Debug.Assert(mutables != null);
 
-            ListChunk<Pair>[] privateBuffers = new ListChunk<Pair>[_partitionCount];
+            ListChunk<Pair<TInputOutput, THashKey>>[] privateBuffers = new ListChunk<Pair<TInputOutput, THashKey>>[_partitionCount];
             ListChunk<TOrderKey>[] privateKeyBuffers = new ListChunk<TOrderKey>[_partitionCount];
 
             TInputOutput element = default(TInputOutput);
@@ -241,17 +241,17 @@ namespace System.Linq.Parallel
                 // too much.  In the original implementation, we'd access the buffer in the matrix ([N,M],
                 // where N is the current partition and M is the destination), but some rudimentary
                 // performance profiling indicates copying at the end performs better.
-                ListChunk<Pair> buffer = privateBuffers[destinationIndex];
+                ListChunk<Pair<TInputOutput, THashKey>> buffer = privateBuffers[destinationIndex];
                 ListChunk<TOrderKey> keyBuffer = privateKeyBuffers[destinationIndex];
                 if (buffer == null)
                 {
                     const int INITIAL_PRIVATE_BUFFER_SIZE = 128;
                     Debug.Assert(keyBuffer == null);
-                    privateBuffers[destinationIndex] = buffer = new ListChunk<Pair>(INITIAL_PRIVATE_BUFFER_SIZE);
+                    privateBuffers[destinationIndex] = buffer = new ListChunk<Pair<TInputOutput, THashKey>>(INITIAL_PRIVATE_BUFFER_SIZE);
                     privateKeyBuffers[destinationIndex] = keyBuffer = new ListChunk<TOrderKey>(INITIAL_PRIVATE_BUFFER_SIZE);
                 }
 
-                buffer.Add(new Pair(element, elementHashKey));
+                buffer.Add(new Pair<TInputOutput, THashKey>(element, elementHashKey));
                 keyBuffer.Add(key);
             }
 

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/OrderedHashRepartitionStream.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/OrderedHashRepartitionStream.cs
@@ -26,8 +26,8 @@ namespace System.Linq.Parallel
             // Initialize state shared among the partitions. A latch and a matrix of buffers. Note that
             // the actual elements in the buffer array are lazily allocated if needed.
             CountdownEvent barrier = new CountdownEvent(inputStream.PartitionCount);
-            ListChunk<Pair>[][] valueExchangeMatrix =
-                JaggedArray<ListChunk<Pair>>.Allocate(inputStream.PartitionCount, inputStream.PartitionCount);
+            ListChunk<Pair<TInputOutput, THashKey>>[][] valueExchangeMatrix =
+                JaggedArray<ListChunk<Pair<TInputOutput, THashKey>>>.Allocate(inputStream.PartitionCount, inputStream.PartitionCount);
             ListChunk<TOrderKey>[][] keyExchangeMatrix =
                 JaggedArray<ListChunk<TOrderKey>>.Allocate(inputStream.PartitionCount, inputStream.PartitionCount);
 

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/UnorderedHashRepartitionStream.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Partitioning/UnorderedHashRepartitionStream.cs
@@ -31,8 +31,8 @@ namespace System.Linq.Parallel
             // Initialize state shared among the partitions. A latch and a matrix of buffers. Note that
             // the actual elements in the buffer array are lazily allocated if needed.
             CountdownEvent barrier = new CountdownEvent(inputStream.PartitionCount);
-            ListChunk<Pair>[][] valueExchangeMatrix =
-                JaggedArray<ListChunk<Pair>>.Allocate(inputStream.PartitionCount, inputStream.PartitionCount);
+            ListChunk<Pair<TInputOutput, THashKey>>[][] valueExchangeMatrix =
+                JaggedArray<ListChunk<Pair<TInputOutput, THashKey>>>.Allocate(inputStream.PartitionCount, inputStream.PartitionCount);
 
             // Now construct each partition object.
             for (int i = 0; i < inputStream.PartitionCount; i++)

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/GroupJoinQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/GroupJoinQueryOperator.cs
@@ -96,10 +96,10 @@ namespace System.Linq.Parallel
         //
 
         private void WrapPartitionedStreamHelper<TLeftKey, TRightKey>(
-            PartitionedStream<Pair, TLeftKey> leftHashStream, PartitionedStream<TRightInput, TRightKey> rightPartitionedStream,
+            PartitionedStream<Pair<TLeftInput,TKey>, TLeftKey> leftHashStream, PartitionedStream<TRightInput, TRightKey> rightPartitionedStream,
             IPartitionedStreamRecipient<TOutput> outputRecipient, int partitionCount, CancellationToken cancellationToken)
         {
-            PartitionedStream<Pair, int> rightHashStream = ExchangeUtilities.HashRepartition(
+            PartitionedStream<Pair<TRightInput,TKey>, int> rightHashStream = ExchangeUtilities.HashRepartition(
                 rightPartitionedStream, _rightKeySelector, _keyComparer, null, cancellationToken);
 
             PartitionedStream<TOutput, TLeftKey> outputStream = new PartitionedStream<TOutput, TLeftKey>(

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/JoinQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/JoinQueryOperator.cs
@@ -98,11 +98,11 @@ namespace System.Linq.Parallel
         //
 
         private void WrapPartitionedStreamHelper<TLeftKey, TRightKey>(
-            PartitionedStream<Pair, TLeftKey> leftHashStream, PartitionedStream<TRightInput, TRightKey> rightPartitionedStream,
+            PartitionedStream<Pair<TLeftInput, TKey>, TLeftKey> leftHashStream, PartitionedStream<TRightInput, TRightKey> rightPartitionedStream,
             IPartitionedStreamRecipient<TOutput> outputRecipient, CancellationToken cancellationToken)
         {
             int partitionCount = leftHashStream.PartitionCount;
-            PartitionedStream<Pair, int> rightHashStream = ExchangeUtilities.HashRepartition(
+            PartitionedStream<Pair<TRightInput, TKey>, int> rightHashStream = ExchangeUtilities.HashRepartition(
                 rightPartitionedStream, _rightKeySelector, _keyComparer, null, cancellationToken);
 
             PartitionedStream<TOutput, TLeftKey> outputStream = new PartitionedStream<TOutput, TLeftKey>(

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/UnionQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Binary/UnionQueryOperator.cs
@@ -64,7 +64,7 @@ namespace System.Linq.Parallel
 
             if (LeftChild.OutputOrdered)
             {
-                PartitionedStream<Pair, TLeftKey> leftHashStream =
+                PartitionedStream<Pair<TInputOutput, NoKeyMemoizationRequired>, TLeftKey> leftHashStream =
                     ExchangeUtilities.HashRepartitionOrdered<TInputOutput, NoKeyMemoizationRequired, TLeftKey>(
                         leftStream, null, null, _comparer, settings.CancellationState.MergedCancellationToken);
 
@@ -73,7 +73,7 @@ namespace System.Linq.Parallel
             }
             else
             {
-                PartitionedStream<Pair, int> leftHashStream =
+                PartitionedStream<Pair<TInputOutput, NoKeyMemoizationRequired>, int> leftHashStream =
                     ExchangeUtilities.HashRepartition<TInputOutput, NoKeyMemoizationRequired, TLeftKey>(
                         leftStream, null, null, _comparer, settings.CancellationState.MergedCancellationToken);
 
@@ -87,12 +87,12 @@ namespace System.Linq.Parallel
         //
 
         private void WrapPartitionedStreamFixedLeftType<TLeftKey, TRightKey>(
-            PartitionedStream<Pair, TLeftKey> leftHashStream, PartitionedStream<TInputOutput, TRightKey> rightStream,
+            PartitionedStream<Pair<TInputOutput, NoKeyMemoizationRequired>, TLeftKey> leftHashStream, PartitionedStream<TInputOutput, TRightKey> rightStream,
             IPartitionedStreamRecipient<TInputOutput> outputRecipient, int partitionCount, CancellationToken cancellationToken)
         {
             if (RightChild.OutputOrdered)
             {
-                PartitionedStream<Pair, TRightKey> rightHashStream =
+                PartitionedStream<Pair<TInputOutput, NoKeyMemoizationRequired>, TRightKey> rightHashStream =
                     ExchangeUtilities.HashRepartitionOrdered<TInputOutput, NoKeyMemoizationRequired, TRightKey>(
                         rightStream, null, null, _comparer, cancellationToken);
 
@@ -101,7 +101,7 @@ namespace System.Linq.Parallel
             }
             else
             {
-                PartitionedStream<Pair, int> rightHashStream =
+                PartitionedStream<Pair<TInputOutput, NoKeyMemoizationRequired>, int> rightHashStream =
                     ExchangeUtilities.HashRepartition<TInputOutput, NoKeyMemoizationRequired, TRightKey>(
                         rightStream, null, null, _comparer, cancellationToken);
 
@@ -115,18 +115,18 @@ namespace System.Linq.Parallel
         //
 
         private void WrapPartitionedStreamFixedBothTypes<TLeftKey, TRightKey>(
-            PartitionedStream<Pair, TLeftKey> leftHashStream,
-            PartitionedStream<Pair, TRightKey> rightHashStream,
+            PartitionedStream<Pair<TInputOutput, NoKeyMemoizationRequired>, TLeftKey> leftHashStream,
+            PartitionedStream<Pair<TInputOutput, NoKeyMemoizationRequired>, TRightKey> rightHashStream,
             IPartitionedStreamRecipient<TInputOutput> outputRecipient, int partitionCount,
             CancellationToken cancellationToken)
         {
             if (LeftChild.OutputOrdered || RightChild.OutputOrdered)
             {
-                IComparer<ConcatKey> compoundKeyComparer =
-                    ConcatKey.MakeComparer(leftHashStream.KeyComparer, rightHashStream.KeyComparer);
+                IComparer<ConcatKey<TLeftKey, TRightKey>> compoundKeyComparer =
+                    ConcatKey<TLeftKey, TRightKey>.MakeComparer(leftHashStream.KeyComparer, rightHashStream.KeyComparer);
 
-                PartitionedStream<TInputOutput, ConcatKey> outputStream =
-                    new PartitionedStream<TInputOutput, ConcatKey>(partitionCount, compoundKeyComparer, OrdinalIndexState.Shuffled);
+                PartitionedStream<TInputOutput, ConcatKey<TLeftKey, TRightKey>> outputStream =
+                    new PartitionedStream<TInputOutput, ConcatKey<TLeftKey, TRightKey>>(partitionCount, compoundKeyComparer, OrdinalIndexState.Shuffled);
 
                 for (int i = 0; i < partitionCount; i++)
                 {
@@ -182,8 +182,8 @@ namespace System.Linq.Parallel
 
         class UnionQueryOperatorEnumerator<TLeftKey, TRightKey> : QueryOperatorEnumerator<TInputOutput, int>
         {
-            private QueryOperatorEnumerator<Pair, TLeftKey> _leftSource; // Left data source.
-            private QueryOperatorEnumerator<Pair, TRightKey> _rightSource; // Right data source.
+            private QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, TLeftKey> _leftSource; // Left data source.
+            private QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, TRightKey> _rightSource; // Right data source.
             private readonly int _partitionIndex; // The current partition.
             private Set<TInputOutput> _hashLookup; // The hash lookup, used to produce the union.
             private CancellationToken _cancellationToken;
@@ -195,8 +195,8 @@ namespace System.Linq.Parallel
             //
 
             internal UnionQueryOperatorEnumerator(
-                QueryOperatorEnumerator<Pair, TLeftKey> leftSource,
-                QueryOperatorEnumerator<Pair, TRightKey> rightSource,
+                QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, TLeftKey> leftSource,
+                QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, TRightKey> rightSource,
                 int partitionIndex, IEqualityComparer<TInputOutput> comparer,
                 CancellationToken cancellationToken)
             {
@@ -230,7 +230,7 @@ namespace System.Linq.Parallel
                 {
                     // Iterate over this set's elements until we find a unique element.
                     TLeftKey keyUnused = default(TLeftKey);
-                    Pair currentLeftElement = new Pair(default(TInputOutput), default(NoKeyMemoizationRequired));
+                    Pair<TInputOutput, NoKeyMemoizationRequired> currentLeftElement = default(Pair<TInputOutput, NoKeyMemoizationRequired>);
 
                     int i = 0;
                     while (_leftSource.MoveNext(ref currentLeftElement, ref keyUnused))
@@ -239,12 +239,12 @@ namespace System.Linq.Parallel
                             CancellationState.ThrowIfCanceled(_cancellationToken);
 
                         // We ensure we never return duplicates by tracking them in our set.
-                        if (_hashLookup.Add((TInputOutput)currentLeftElement.First))
+                        if (_hashLookup.Add(currentLeftElement.First))
                         {
 #if DEBUG
                             currentKey = unchecked((int)0xdeadbeef);
 #endif
-                            currentElement = (TInputOutput)currentLeftElement.First;
+                            currentElement = currentLeftElement.First;
                             return true;
                         }
                     }
@@ -258,7 +258,7 @@ namespace System.Linq.Parallel
                 {
                     // Iterate over this set's elements until we find a unique element.
                     TRightKey keyUnused = default(TRightKey);
-                    Pair currentRightElement = new Pair(default(TInputOutput), default(NoKeyMemoizationRequired));
+                    Pair<TInputOutput, NoKeyMemoizationRequired> currentRightElement = default(Pair<TInputOutput, NoKeyMemoizationRequired>);
 
                     while (_rightSource.MoveNext(ref currentRightElement, ref keyUnused))
                     {
@@ -266,12 +266,12 @@ namespace System.Linq.Parallel
                             CancellationState.ThrowIfCanceled(_cancellationToken);
 
                         // We ensure we never return duplicates by tracking them in our set.
-                        if (_hashLookup.Add((TInputOutput)currentRightElement.First))
+                        if (_hashLookup.Add(currentRightElement.First))
                         {
 #if DEBUG
                             currentKey = unchecked((int)0xdeadbeef);
 #endif
-                            currentElement = (TInputOutput)currentRightElement.First;
+                            currentElement = currentRightElement.First;
                             return true;
                         }
                     }
@@ -296,12 +296,12 @@ namespace System.Linq.Parallel
             }
         }
 
-        class OrderedUnionQueryOperatorEnumerator<TLeftKey, TRightKey> : QueryOperatorEnumerator<TInputOutput, ConcatKey>
+        class OrderedUnionQueryOperatorEnumerator<TLeftKey, TRightKey> : QueryOperatorEnumerator<TInputOutput, ConcatKey<TLeftKey, TRightKey>>
         {
-            private QueryOperatorEnumerator<Pair, TLeftKey> _leftSource; // Left data source.
-            private QueryOperatorEnumerator<Pair, TRightKey> _rightSource; // Right data source.
-            private IComparer<ConcatKey> _keyComparer; // Comparer for compound order keys.
-            private IEnumerator<KeyValuePair<Wrapper<TInputOutput>, Pair>> _outputEnumerator; // Enumerator over the output of the union.
+            private QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, TLeftKey> _leftSource; // Left data source.
+            private QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, TRightKey> _rightSource; // Right data source.
+            private IComparer<ConcatKey<TLeftKey, TRightKey>> _keyComparer; // Comparer for compound order keys.
+            private IEnumerator<KeyValuePair<Wrapper<TInputOutput>, Pair<TInputOutput, ConcatKey<TLeftKey, TRightKey>>>> _outputEnumerator; // Enumerator over the output of the union.
             private bool _leftOrdered; // Whether the left data source is ordered.
             private bool _rightOrdered; // Whether the right data source is ordered.
             private IEqualityComparer<TInputOutput> _comparer; // Comparer for the elements.
@@ -312,9 +312,9 @@ namespace System.Linq.Parallel
             //
 
             internal OrderedUnionQueryOperatorEnumerator(
-                QueryOperatorEnumerator<Pair, TLeftKey> leftSource,
-                QueryOperatorEnumerator<Pair, TRightKey> rightSource,
-                bool leftOrdered, bool rightOrdered, IEqualityComparer<TInputOutput> comparer, IComparer<ConcatKey> keyComparer,
+                QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, TLeftKey> leftSource,
+                QueryOperatorEnumerator<Pair<TInputOutput, NoKeyMemoizationRequired>, TRightKey> rightSource,
+                bool leftOrdered, bool rightOrdered, IEqualityComparer<TInputOutput> comparer, IComparer<ConcatKey<TLeftKey, TRightKey>> keyComparer,
                 CancellationToken cancellationToken)
             {
                 Debug.Assert(leftSource != null);
@@ -340,7 +340,7 @@ namespace System.Linq.Parallel
             // Walks the two data sources, left and then right, to produce the union.
             //
 
-            internal override bool MoveNext(ref TInputOutput currentElement, ref ConcatKey currentKey)
+            internal override bool MoveNext(ref TInputOutput currentElement, ref ConcatKey<TLeftKey, TRightKey> currentKey)
             {
                 Debug.Assert(_leftSource != null);
                 Debug.Assert(_rightSource != null);
@@ -348,10 +348,10 @@ namespace System.Linq.Parallel
                 if (_outputEnumerator == null)
                 {
                     IEqualityComparer<Wrapper<TInputOutput>> wrapperComparer = new WrapperEqualityComparer<TInputOutput>(_comparer);
-                    Dictionary<Wrapper<TInputOutput>, Pair> union =
-                        new Dictionary<Wrapper<TInputOutput>, Pair>(wrapperComparer);
+                    Dictionary<Wrapper<TInputOutput>, Pair<TInputOutput, ConcatKey<TLeftKey, TRightKey>>> union =
+                        new Dictionary<Wrapper<TInputOutput>, Pair<TInputOutput, ConcatKey<TLeftKey, TRightKey>>>(wrapperComparer);
 
-                    Pair elem = new Pair(default(TInputOutput), default(NoKeyMemoizationRequired));
+                    Pair<TInputOutput, NoKeyMemoizationRequired> elem = default(Pair<TInputOutput, NoKeyMemoizationRequired>);
                     TLeftKey leftKey = default(TLeftKey);
 
                     int i = 0;
@@ -360,14 +360,14 @@ namespace System.Linq.Parallel
                         if ((i++ & CancellationState.POLL_INTERVAL) == 0)
                             CancellationState.ThrowIfCanceled(_cancellationToken);
 
-                        ConcatKey key =
-                            ConcatKey.MakeLeft<TLeftKey, TRightKey>(_leftOrdered ? leftKey : default(TLeftKey));
-                        Pair oldEntry;
-                        Wrapper<TInputOutput> wrappedElem = new Wrapper<TInputOutput>((TInputOutput)elem.First);
+                        ConcatKey<TLeftKey, TRightKey> key =
+                            ConcatKey<TLeftKey, TRightKey>.MakeLeft(_leftOrdered ? leftKey : default(TLeftKey));
+                        Pair<TInputOutput, ConcatKey<TLeftKey, TRightKey>> oldEntry;
+                        Wrapper<TInputOutput> wrappedElem = new Wrapper<TInputOutput>(elem.First);
 
-                        if (!union.TryGetValue(wrappedElem, out oldEntry) || _keyComparer.Compare(key, (ConcatKey)oldEntry.Second) < 0)
+                        if (!union.TryGetValue(wrappedElem, out oldEntry) || _keyComparer.Compare(key, oldEntry.Second) < 0)
                         {
-                            union[wrappedElem] = new Pair(elem.First, key);
+                            union[wrappedElem] = new Pair<TInputOutput, ConcatKey<TLeftKey, TRightKey>>(elem.First, key);
                         }
                     }
 
@@ -377,14 +377,14 @@ namespace System.Linq.Parallel
                         if ((i++ & CancellationState.POLL_INTERVAL) == 0)
                             CancellationState.ThrowIfCanceled(_cancellationToken);
 
-                        ConcatKey key =
-                            ConcatKey.MakeRight<TLeftKey, TRightKey>(_rightOrdered ? rightKey : default(TRightKey));
-                        Pair oldEntry;
-                        Wrapper<TInputOutput> wrappedElem = new Wrapper<TInputOutput>((TInputOutput)elem.First);
+                        ConcatKey<TLeftKey, TRightKey> key =
+                            ConcatKey<TLeftKey, TRightKey>.MakeRight(_rightOrdered ? rightKey : default(TRightKey));
+                        Pair<TInputOutput, ConcatKey<TLeftKey, TRightKey>> oldEntry;
+                        Wrapper<TInputOutput> wrappedElem = new Wrapper<TInputOutput>(elem.First);
 
-                        if (!union.TryGetValue(wrappedElem, out oldEntry) || _keyComparer.Compare(key, (ConcatKey)oldEntry.Second) < 0)
+                        if (!union.TryGetValue(wrappedElem, out oldEntry) || _keyComparer.Compare(key, oldEntry.Second) < 0)
                         {
-                            union[wrappedElem] = new Pair(elem.First, key); ;
+                            union[wrappedElem] = new Pair<TInputOutput, ConcatKey<TLeftKey, TRightKey>>(elem.First, key);
                         }
                     }
 
@@ -393,9 +393,9 @@ namespace System.Linq.Parallel
 
                 if (_outputEnumerator.MoveNext())
                 {
-                    Pair current = _outputEnumerator.Current.Value;
-                    currentElement = (TInputOutput)current.First;
-                    currentKey = (ConcatKey)current.Second;
+                    Pair<TInputOutput, ConcatKey<TLeftKey, TRightKey>> current = _outputEnumerator.Current.Value;
+                    currentElement = current.First;
+                    currentKey = current.Second;
                     return true;
                 }
 

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/SortQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/SortQueryOperator.cs
@@ -69,11 +69,11 @@ namespace System.Linq.Parallel
                 key2Comparer = new ReverseComparer<TKey2>(key2Comparer);
             }
 
-            IComparer<Pair> pairComparer = new PairComparer<TSortKey, TKey2>(_comparer, key2Comparer);
-            Func<TInputOutput, Pair> pairKeySelector =
-                (TInputOutput elem) => new Pair(_keySelector(elem), key2Selector(elem));
+            IComparer<Pair<TSortKey, TKey2>> pairComparer = new PairComparer<TSortKey, TKey2>(_comparer, key2Comparer);
+            Func<TInputOutput, Pair<TSortKey, TKey2>> pairKeySelector =
+                (TInputOutput elem) => new Pair<TSortKey, TKey2>(_keySelector(elem), key2Selector(elem));
 
-            return new SortQueryOperator<TInputOutput, Pair>(Child, pairKeySelector, pairComparer, false);
+            return new SortQueryOperator<TInputOutput, Pair<TSortKey, TKey2>>(Child, pairKeySelector, pairComparer, false);
         }
 
         //---------------------------------------------------------------------------------------

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/TakeOrSkipQueryOperator.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/QueryOperators/Unary/TakeOrSkipQueryOperator.cs
@@ -157,7 +157,7 @@ namespace System.Linq.Parallel
             private readonly CountdownEvent _sharedBarrier; // To separate the search/yield phases.
             private readonly CancellationToken _cancellationToken; // Indicates that cancellation has occurred.
 
-            private List<Pair> _buffer; // Our buffer.
+            private List<Pair<TResult, TKey>> _buffer; // Our buffer.
             private Shared<int> _bufferIndex; // Our current index within the buffer. [allocate in moveNext to avoid false-sharing]
 
             //---------------------------------------------------------------------------------------
@@ -195,7 +195,7 @@ namespace System.Linq.Parallel
                 if (_buffer == null && _count > 0)
                 {
                     // Create a buffer, but don't publish it yet (in case of exception).
-                    List<Pair> buffer = new List<Pair>();
+                    List<Pair<TResult, TKey>> buffer = new List<Pair<TResult, TKey>>();
 
                     // Enter the search phase. In this phase, all partitions race to populate
                     // the shared indices with their first 'count' contiguous elements.
@@ -208,7 +208,7 @@ namespace System.Linq.Parallel
                             CancellationState.ThrowIfCanceled(_cancellationToken);
 
                         // Add the current element to our buffer.
-                        buffer.Add(new Pair(current, index));
+                        buffer.Add(new Pair<TResult, TKey>(current, index));
 
                         // Now we will try to insert our index into the shared indices list, quitting if
                         // our index is greater than all of the indices already inside it.
@@ -244,12 +244,12 @@ namespace System.Linq.Parallel
 
                     // Increment the index, and remember the values.
                     ++_bufferIndex.Value;
-                    currentElement = (TResult)_buffer[_bufferIndex.Value].First;
-                    currentKey = (TKey)_buffer[_bufferIndex.Value].Second;
+                    currentElement = _buffer[_bufferIndex.Value].First;
+                    currentKey = _buffer[_bufferIndex.Value].Second;
 
                     // Only yield the element if its index is less than or equal to the max index.
                     return _sharedIndices.Count == 0
-                        || _keyComparer.Compare((TKey)_buffer[_bufferIndex.Value].Second, _sharedIndices.MaxValue) <= 0;
+                        || _keyComparer.Compare(_buffer[_bufferIndex.Value].Second, _sharedIndices.MaxValue) <= 0;
                 }
                 else
                 {
@@ -275,10 +275,10 @@ namespace System.Linq.Parallel
                             {
                                 // If the current buffered element's index is greater than the 'count'-th index,
                                 // we will yield it as a result.
-                                if (_keyComparer.Compare((TKey)_buffer[_bufferIndex.Value].Second, minKey) > 0)
+                                if (_keyComparer.Compare(_buffer[_bufferIndex.Value].Second, minKey) > 0)
                                 {
-                                    currentElement = (TResult)_buffer[_bufferIndex.Value].First;
-                                    currentKey = (TKey)_buffer[_bufferIndex.Value].Second;
+                                    currentElement = _buffer[_bufferIndex.Value].First;
+                                    currentKey = _buffer[_bufferIndex.Value].Second;
                                     return true;
                                 }
                             }

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Utils/ExchangeUtilities.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Utils/ExchangeUtilities.cs
@@ -88,7 +88,7 @@ namespace System.Linq.Parallel
         //    keyComparer                 - equality comparer for the keys
         //
 
-        internal static PartitionedStream<Pair, int> HashRepartition<TElement, THashKey, TIgnoreKey>(
+        internal static PartitionedStream<Pair<TElement, THashKey>, int> HashRepartition<TElement, THashKey, TIgnoreKey>(
             PartitionedStream<TElement, TIgnoreKey> source, Func<TElement, THashKey> keySelector, IEqualityComparer<THashKey> keyComparer,
             IEqualityComparer<TElement> elementComparer, CancellationToken cancellationToken)
         {
@@ -96,7 +96,7 @@ namespace System.Linq.Parallel
             return new UnorderedHashRepartitionStream<TElement, THashKey, TIgnoreKey>(source, keySelector, keyComparer, elementComparer, cancellationToken);
         }
 
-        internal static PartitionedStream<Pair, TOrderKey> HashRepartitionOrdered<TElement, THashKey, TOrderKey>(
+        internal static PartitionedStream<Pair<TElement, THashKey>, TOrderKey> HashRepartitionOrdered<TElement, THashKey, TOrderKey>(
             PartitionedStream<TElement, TOrderKey> source, Func<TElement, THashKey> keySelector, IEqualityComparer<THashKey> keyComparer,
             IEqualityComparer<TElement> elementComparer, CancellationToken cancellationToken)
         {

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Utils/Pair.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Utils/Pair.cs
@@ -49,38 +49,4 @@ namespace System.Linq.Parallel
             set { _second = value; }
         }
     }
-
-    //Non-generic version to avoid cycles when doing static analysis in NUTC.
-    internal struct Pair
-    {
-        // The first and second bits of data.
-        internal object _first;
-        internal object _second;
-
-        //-----------------------------------------------------------------------------------
-        // A simple constructor that initializes the first/second fields.
-        //
-
-        public Pair(object first, object second)
-        {
-            _first = first;
-            _second = second;
-        }
-
-        //-----------------------------------------------------------------------------------
-        // Accessors for the left and right data.
-        //
-
-        public object First
-        {
-            get { return _first; }
-            set { _first = value; }
-        }
-
-        public object Second
-        {
-            get { return _second; }
-            set { _second = value; }
-        }
-    }
 }

--- a/src/System.Linq.Parallel/src/System/Linq/Parallel/Utils/PairComparer.cs
+++ b/src/System.Linq.Parallel/src/System/Linq/Parallel/Utils/PairComparer.cs
@@ -18,26 +18,15 @@ namespace System.Linq.Parallel
     /// </summary>
     /// <typeparam name="T"></typeparam>
     /// <typeparam name="U"></typeparam>
-    internal class PairComparer<T, U> : IComparer<Pair>, IComparer<Pair<T, U>>
+    internal sealed class PairComparer<T, U> : IComparer<Pair<T, U>>
     {
-        private IComparer<T> _comparer1;
-        private IComparer<U> _comparer2;
+        private readonly IComparer<T> _comparer1;
+        private readonly IComparer<U> _comparer2;
 
         public PairComparer(IComparer<T> comparer1, IComparer<U> comparer2)
         {
             _comparer1 = comparer1;
             _comparer2 = comparer2;
-        }
-
-        public int Compare(Pair x, Pair y)
-        {
-            int result1 = _comparer1.Compare((T)x.First, (T)y.First);
-            if (result1 != 0)
-            {
-                return result1;
-            }
-
-            return _comparer2.Compare((U)x.Second, (U)y.Second);
         }
 
         public int Compare(Pair<T, U> x, Pair<T, U> y)


### PR DESCRIPTION
PLINQ makes fairly heavy use of generics.  During .NET Native bring-up, some of this generic usage was reduced due to initial limitations of the stack.  Now that those have been addressed, I'm restoring the use of generics to its original extent, helping to avoid a huge number of allocations, lots of casting, etc.

This has a significant impact in the overhead of certain operators.  For example, consider this little test app:
```C#
using System;
using System.Diagnostics;
using System.Linq;

class Test
{
    public static void Main()
    {
        var sw = new Stopwatch();
        int[] data = Enumerable.Range(0, 10000000).ToArray();
        while (true)
        {
            int gen0 = GC.CollectionCount(0);
            sw.Restart();
            int[] results = data.AsParallel().Select(i => i).Distinct().ToArray();
            sw.Stop();
            Console.WriteLine($"{GC.CollectionCount(0) - gen0}: {sw.Elapsed}");
        }
    }
}
```
On my machine, prior to this commit, this produces output like the following:
```
303: 00:00:02.6805895
305: 00:00:03.3609698
308: 00:00:03.8779080
298: 00:00:03.6718290
291: 00:00:05.0167444
```
After this commit, this produces output like the following:
```
  3: 00:00:00.5949436
  4: 00:00:00.5434885
  2: 00:00:00.5391528
  3: 00:00:00.5602570
  3: 00:00:00.4982133
```

The strong-typing provided also helps to avoid issues like that fixed in https://github.com/dotnet/corefx/pull/585.

cc: @AlfredoMS