### PR TITLE
Fix build on NetBSD: Add missing include <sys/types.h>

### DIFF
--- a/src/Native/System.Native/pal_interfaceaddresses.cpp
+++ b/src/Native/System.Native/pal_interfaceaddresses.cpp
@@ -7,6 +7,7 @@
 #include "pal_maphardwaretype.h"
 #include "pal_utilities.h"
 
+#include <sys/types.h>
 #include <assert.h>
 #include <ifaddrs.h>
 #include <net/if.h>


### PR DESCRIPTION
```
In file included from /tmp/pkgsrc-tmp/wip/corefx-git/work/corefx/src/Native/System.Native/pal_interfaceaddresses.cpp:11:
/usr/include/ifaddrs.h:34:2: error: unknown type name 'u_int'
        u_int            ifa_flags;
        ^
```

Original solution by Peter Jas.