### PR TITLE
Remove duplicate validation calls in Expression.

### DIFF
--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
@@ -125,8 +125,6 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="ListInitExpression"/> that has the <see cref="P:ListInitExpression.NodeType"/> property equal to ListInit and the <see cref="P:ListInitExpression.NewExpression"/> property set to the specified value.</returns>
         public static ListInitExpression ListInit(NewExpression newExpression, params Expression[] initializers)
         {
-            ContractUtils.RequiresNotNull(newExpression, "newExpression");
-            ContractUtils.RequiresNotNull(initializers, "initializers");
             return ListInit(newExpression, initializers as IEnumerable<Expression>);
         }
 
@@ -160,12 +158,6 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="ListInitExpression"/> that has the <see cref="P:ListInitExpression.NodeType"/> property equal to ListInit and the <see cref="P:ListInitExpression.NewExpression"/> property set to the specified value.</returns>
         public static ListInitExpression ListInit(NewExpression newExpression, MethodInfo addMethod, params Expression[] initializers)
         {
-            if (addMethod == null)
-            {
-                return ListInit(newExpression, initializers as IEnumerable<Expression>);
-            }
-            ContractUtils.RequiresNotNull(newExpression, "newExpression");
-            ContractUtils.RequiresNotNull(initializers, "initializers");
             return ListInit(newExpression, addMethod, initializers as IEnumerable<Expression>);
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberListBinding.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberListBinding.cs
@@ -63,8 +63,6 @@ namespace System.Linq.Expressions
         ///<paramref name="member" /> does not represent a field or property.-or-The <see cref="P:System.Reflection.FieldInfo.FieldType" /> or <see cref="P:System.Reflection.PropertyInfo.PropertyType" /> of the field or property that <paramref name="member" /> represents does not implement <see cref="T:System.Collections.IEnumerable" />.</exception>
         public static MemberListBinding ListBind(MemberInfo member, params ElementInit[] initializers)
         {
-            ContractUtils.RequiresNotNull(member, "member");
-            ContractUtils.RequiresNotNull(initializers, "initializers");
             return ListBind(member, (IEnumerable<ElementInit>)initializers);
         }
 
@@ -97,8 +95,6 @@ namespace System.Linq.Expressions
         ///<paramref name="propertyAccessor" /> does not represent a property accessor method.-or-The <see cref="P:System.Reflection.PropertyInfo.PropertyType" /> of the property that the method represented by <paramref name="propertyAccessor" /> accesses does not implement <see cref="T:System.Collections.IEnumerable" />.</exception>  
         public static MemberListBinding ListBind(MethodInfo propertyAccessor, params ElementInit[] initializers)
         {
-            ContractUtils.RequiresNotNull(propertyAccessor, "propertyAccessor");
-            ContractUtils.RequiresNotNull(initializers, "initializers");
             return ListBind(propertyAccessor, (IEnumerable<ElementInit>)initializers);
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberMemberBinding.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberMemberBinding.cs
@@ -64,8 +64,6 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="MemberMemberBinding"/> that has the <see cref="P:MemberBinding.BindingType"/> property equal to <see cref="MemberBinding"/> and the <see cref="P:MemberBinding.Member"/> and <see cref="P:MemberMemberBindings.Bindings"/> properties set to the specified values.</returns>
         public static MemberMemberBinding MemberBind(MemberInfo member, params MemberBinding[] bindings)
         {
-            ContractUtils.RequiresNotNull(member, "member");
-            ContractUtils.RequiresNotNull(bindings, "bindings");
             return MemberBind(member, (IEnumerable<MemberBinding>)bindings);
         }
 
@@ -98,8 +96,7 @@ namespace System.Linq.Expressions
         /// </returns>
         public static MemberMemberBinding MemberBind(MethodInfo propertyAccessor, params MemberBinding[] bindings)
         {
-            ContractUtils.RequiresNotNull(propertyAccessor, "propertyAccessor");
-            return MemberBind(GetProperty(propertyAccessor), bindings);
+            return MemberBind(propertyAccessor, (IEnumerable<MemberBinding>)bindings);
         }
 
         /// <summary>


### PR DESCRIPTION
Some methods validate arguments before calling an overload that does the exact same validation. Remove the first validation.

There are some similar cases, but I restricted this to the simplest cases that won't even change which exception is thrown in the case of multiple validation failures so there should be zero observable change in behaviour.

cc: @VSadov 