### PR TITLE
Add support for statvfs

### DIFF
--- a/src/Native/Common/pal_config.h.in
+++ b/src/Native/Common/pal_config.h.in
@@ -7,6 +7,7 @@
 #cmakedefine01 HAVE_DIRENT_NAME_LEN
 #cmakedefine01 HAVE_MNTINFO
 #cmakedefine01 HAVE_STATFS_FSTYPENAME
+#cmakedefine01 HAVE_STATVFS_FSTYPENAME
 #cmakedefine01 HAVE_STRCPY_S
 #cmakedefine01 HAVE_STRLCPY
 #cmakedefine01 HAVE_SHM_OPEN_THAT_WORKS_WELL_ENOUGH_WITH_MMAP
@@ -20,6 +21,7 @@
 #cmakedefine01 HAVE_FDS_BITS
 #cmakedefine01 HAVE_PRIVATE_FDS_BITS
 #cmakedefine01 HAVE_ALLOCA_H
+#cmakedefine01 HAVE_STATFS
 #cmakedefine01 HAVE_EPOLL
 #cmakedefine01 HAVE_KQUEUE
 #cmakedefine01 HAVE_GETHOSTBYNAME_R

--- a/src/Native/System.Native/pal_mount.cpp
+++ b/src/Native/System.Native/pal_mount.cpp
@@ -22,7 +22,11 @@ static int32_t GetMountInfo(MountPointFound onFound)
 {
 #if HAVE_MNTINFO
     // getmntinfo returns pointers to OS-internal structs, so we don't need to worry about free'ing the object
+#if HAVE_STATFS
     struct statfs* mounts = nullptr;
+#else
+    struct statvfs* mounts = nullptr;
+#endif
     int count = getmntinfo(&mounts, 0);
     for (int32_t i = 0; i < count; i++)
     {
@@ -68,8 +72,13 @@ extern "C" int32_t SystemNative_GetSpaceInfoForMountPoint(const char* name, Moun
     assert(name != nullptr);
     assert(mpi != nullptr);
 
+#if HAVE_STATFS
     struct statfs stats = {};
     int result = statfs(name, &stats);
+#else
+    struct statvfs stats = {};
+    int result = statvfs(name, &stats);
+#endif
     if (result == 0)
     {
         // Note that these have signed integer types on some platforms but musn't be negative.
@@ -98,12 +107,17 @@ SystemNative_GetFormatInfoForMountPoint(const char* name, char* formatNameBuffer
     assert((formatNameBuffer != nullptr) && (formatType != nullptr));
     assert(bufferLength > 0);
 
+#if HAVE_STATFS
     struct statfs stats;
     int result = statfs(name, &stats);
+#else
+    struct statvfs stats;
+    int result = statvfs(name, &stats);
+#endif
     if (result == 0)
     {
 
-#if HAVE_STATFS_FSTYPENAME
+#if HAVE_STATFS_FSTYPENAME || HAVE_STATVFS_FSTYPENAME
 #ifdef VFS_NAMELEN
         if (bufferLength < VFS_NAMELEN)
 #else

--- a/src/Native/configure.cmake
+++ b/src/Native/configure.cmake
@@ -117,6 +117,27 @@ check_struct_has_member(
     HAVE_STATFS_FSTYPENAME)
 
 check_struct_has_member(
+    "struct statvfs"
+    f_fstypename
+    "sys/mount.h"
+    HAVE_STATVFS_FSTYPENAME)
+
+# statfs: Find whether this struct exists
+if (HAVE_STATFS_FSTYPENAME OR HAVE_STATVFS_FSTYPENAME)
+    set (STATFS_INCLUDES sys/mount.h)
+else ()
+    set (STATFS_INCLUDES sys/statfs.h)
+endif ()
+
+set(CMAKE_EXTRA_INCLUDE_FILES ${STATFS_INCLUDES})
+check_type_size(
+    "struct statfs"
+    HAVE_STATFS
+    BUILTIN_TYPES_ONLY)
+set(CMAKE_EXTRA_INCLUDE_FILES) # reset CMAKE_EXTRA_INCLUDE_FILES
+# /statfs
+
+check_struct_has_member(
     "struct in6_addr"
     __in6_u
     "netdb.h"


### PR DESCRIPTION
statfs is unavailable on NetBSD. This delta adds support for statvfs,
which is the supported alternative.