### PR TITLE
Remove ~20 explicit static cctors across corefx

### DIFF
--- a/src/Common/src/Interop/Unix/libssl/StreamSizes.cs
+++ b/src/Common/src/Interop/Unix/libssl/StreamSizes.cs
@@ -6,27 +6,16 @@ namespace System.Net
 {
     internal class StreamSizes
     {
-        private static readonly int s_header;
-        private static readonly int s_trailer;
-        private static readonly int s_maximumMessage;
-
-        public int header;
-        public int trailer;
-        public int maximumMessage;
-
-        static StreamSizes()
-        {
-            Interop.Ssl.GetStreamSizes(
-                out s_header,
-                out s_trailer,
-                out s_maximumMessage);
-        }
+        public readonly int header;
+        public readonly int trailer;
+        public readonly int maximumMessage;
 
         internal StreamSizes()
         {
-            header = s_header;
-            trailer = s_trailer;
-            maximumMessage = s_maximumMessage;
+            Interop.Ssl.GetStreamSizes(
+                out header,
+                out trailer,
+                out maximumMessage);
         }
     }
 }

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/PredefinedTypes.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Types/PredefinedTypes.cs
@@ -427,22 +427,6 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             }
         }
 
-        static PredefinedTypeFacts()
-        {
-#if DEBUG
-            for (int i = 0; i < (int)PredefinedType.PT_COUNT; i++)
-            {
-                System.Diagnostics.Debug.Assert(s_pdTypes[i].type == (PredefinedType)i);
-            }
-#endif
-            for (int i = 0; i < (int)PredefinedType.PT_COUNT; i++)
-            {
-                s_pdTypeNames.Add(s_pdTypes[i].name, (PredefinedType)i);
-            }
-        }
-
-        private static readonly Dictionary<string, PredefinedType> s_pdTypeNames = new Dictionary<string, PredefinedType>();
-
         private static readonly PredefinedTypeInfo[] s_pdTypes = new PredefinedTypeInfo[] {
             new PredefinedTypeInfo(PredefinedType.PT_BYTE,   typeof(System.Byte), "System.Byte", true, 0, AggKindEnum.Struct, FUNDTYPE.FT_U1, true),
             new PredefinedTypeInfo(PredefinedType.PT_SHORT,  typeof(System.Int16), "System.Int16", true, 0, AggKindEnum.Struct, FUNDTYPE.FT_I2, true),
@@ -571,5 +555,23 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
             new PredefinedTypeInfo(PredefinedType.PT_G_IREADONLYLIST, typeof(System.Collections.Generic.IReadOnlyList<>), "System.Collections.Generic.IReadOnlyList`1", false, 1, AggKindEnum.Interface, FUNDTYPE.FT_REF, false),
             new PredefinedTypeInfo(PredefinedType.PT_G_IREADONLYCOLLECTION, typeof(System.Collections.Generic.IReadOnlyCollection<>), "System.Collections.Generic.IReadOnlyCollection`1", false, 1, AggKindEnum.Interface, FUNDTYPE.FT_REF, false),
         };
+
+        private static readonly Dictionary<string, PredefinedType> s_pdTypeNames = CreatePredefinedTypeFacts();
+
+        private static Dictionary<string, PredefinedType> CreatePredefinedTypeFacts()
+        {
+            var pdTypeNames = new Dictionary<string, PredefinedType>((int)PredefinedType.PT_COUNT);
+#if DEBUG
+            for (int i = 0; i < (int)PredefinedType.PT_COUNT; i++)
+            {
+                System.Diagnostics.Debug.Assert(s_pdTypes[i].type == (PredefinedType)i);
+            }
+#endif
+            for (int i = 0; i < (int)PredefinedType.PT_COUNT; i++)
+            {
+                pdTypeNames.Add(s_pdTypes[i].name, (PredefinedType)i);
+            }
+            return pdTypeNames;
+        }
     }
 }

--- a/src/Microsoft.Win32.Registry/src/Microsoft/Win32/Registry.cs
+++ b/src/Microsoft.Win32.Registry/src/Microsoft/Win32/Registry.cs
@@ -17,11 +17,6 @@ namespace Microsoft.Win32
     //This class contains only static members and does not need to be serializable.
     public static class Registry
     {
-        [System.Security.SecuritySafeCritical]  
-        static Registry()
-        {
-        }
-
         /**
          * Current User Key.
          * 

--- a/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/MetadataUtilsSmi.cs
+++ b/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/MetadataUtilsSmi.cs
@@ -79,10 +79,9 @@ namespace Microsoft.SqlServer.Server
 
         // Hash table to map from clr type object to ExtendedClrTypeCodeMap enum
         // this HashTable should only be accessed from DetermineExtendedTypeCode and class ctor for setup.
-        private static readonly Hashtable s_typeToExtendedTypeCodeMap;
+        private static readonly Hashtable s_typeToExtendedTypeCodeMap = CreateTypeToExtendedTypeCodeMap();
 
-
-        static MetaDataUtilsSmi()
+        private static Hashtable CreateTypeToExtendedTypeCodeMap()
         {
             // Set up type mapping hash table
             // Keep this initialization list in the same order as ExtendedClrTypeCode for ease in validating!
@@ -128,9 +127,8 @@ namespace Microsoft.SqlServer.Server
             ht.Add(typeof(IEnumerable<SqlDataRecord>), ExtendedClrTypeCode.IEnumerableOfSqlDataRecord);
             ht.Add(typeof(System.TimeSpan), ExtendedClrTypeCode.TimeSpan);
             ht.Add(typeof(System.DateTimeOffset), ExtendedClrTypeCode.DateTimeOffset);
-            s_typeToExtendedTypeCodeMap = ht;
+            return ht;
         }
-
 
         internal static bool IsCharOrXmlType(SqlDbType type)
         {

--- a/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SmiMetaDataProperty.cs
+++ b/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SmiMetaDataProperty.cs
@@ -35,18 +35,19 @@ namespace Microsoft.SqlServer.Server
         private SmiMetaDataProperty[] _properties;
         private bool _isReadOnly;
 
-        internal static readonly SmiMetaDataPropertyCollection EmptyInstance;
+        internal static readonly SmiMetaDataPropertyCollection EmptyInstance = CreateEmptyInstance();
+
+        private static SmiMetaDataPropertyCollection CreateEmptyInstance()
+        {
+            var emptyInstance = new SmiMetaDataPropertyCollection();
+            emptyInstance.SetReadOnly();
+            return emptyInstance;
+        }
 
         // Singleton empty instances to ensure each property is always non-null
         private static readonly SmiDefaultFieldsProperty s_emptyDefaultFields = new SmiDefaultFieldsProperty(new List<bool>());
         private static readonly SmiOrderProperty s_emptySortOrder = new SmiOrderProperty(new List<SmiOrderProperty.SmiColumnOrder>());
         private static readonly SmiUniqueKeyProperty s_emptyUniqueKey = new SmiUniqueKeyProperty(new List<bool>());
-
-        static SmiMetaDataPropertyCollection()
-        {
-            EmptyInstance = new SmiMetaDataPropertyCollection();
-            EmptyInstance.SetReadOnly();
-        }
 
         internal SmiMetaDataPropertyCollection()
         {

--- a/src/System.Data.SqlClient/src/System/Data/Locale/LocaleMapper.Unix.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Locale/LocaleMapper.Unix.cs
@@ -12,26 +12,7 @@ namespace System.Data
     /// </summary>
     internal class LocaleMapper
     {
-        private static readonly Dictionary<int, LocaleCodePage> _mapper;
-        public static string LcidToLocaleNameInternal(int lcid)
-        {
-            return _mapper[lcid].LocaleName;
-        }
-
-        public static int LocaleNameToAnsiCodePage(string localeName)
-        {
-            return _mapper.FirstOrDefault(t => t.Value.LocaleName == localeName).Value.CodePage;
-        }
-
-        public static int GetLcidForLocaleName(string localeName)
-        {
-            return _mapper.FirstOrDefault(t => t.Value.LocaleName == localeName).Key;
-        }
-
-        static LocaleMapper()
-        {
-            _mapper = new Dictionary<int, LocaleCodePage>
-            {
+        private static readonly Dictionary<int, LocaleCodePage> s_mapper = new Dictionary<int, LocaleCodePage>(431) {
             #region <<Locale Mapper>>
                 {1, new LocaleCodePage("ar", 1256)},
                 {2, new LocaleCodePage("bg", 1251)},
@@ -466,6 +447,20 @@ namespace System.Data
                 {267268, new LocaleCodePage("zh-MO", 950)}
             #endregion
         };
+
+        public static string LcidToLocaleNameInternal(int lcid)
+        {
+            return s_mapper[lcid].LocaleName;
+        }
+
+        public static int LocaleNameToAnsiCodePage(string localeName)
+        {
+            return s_mapper.FirstOrDefault(t => t.Value.LocaleName == localeName).Value.CodePage;
+        }
+
+        public static int GetLcidForLocaleName(string localeName)
+        {
+            return s_mapper.FirstOrDefault(t => t.Value.LocaleName == localeName).Key;
         }
     }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionStringBuilder.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionStringBuilder.cs
@@ -67,8 +67,8 @@ namespace System.Data.SqlClient
         internal const int KeywordsCount = (int)Keywords.KeywordsCount;
         internal const int DeprecatedKeywordsCount = 6;
 
-        private static readonly string[] s_validKeywords;
-        private static readonly Dictionary<string, Keywords> s_keywords;
+        private static readonly string[] s_validKeywords = CreateValidKeywords();
+        private static readonly Dictionary<string, Keywords> s_keywords = CreateKeywordsDictionary();
 
         private ApplicationIntent _applicationIntent = DbConnectionStringDefaults.ApplicationIntent;
         private string _applicationName = DbConnectionStringDefaults.ApplicationName;
@@ -101,8 +101,7 @@ namespace System.Data.SqlClient
         private bool _replication = DbConnectionStringDefaults.Replication;
         private bool _userInstance = DbConnectionStringDefaults.UserInstance;
 
-
-        static SqlConnectionStringBuilder()
+        private static string[] CreateValidKeywords()
         {
             string[] validKeywords = new string[KeywordsCount];
             validKeywords[(int)Keywords.ApplicationIntent] = DbConnectionStringKeywords.ApplicationIntent;
@@ -133,8 +132,11 @@ namespace System.Data.SqlClient
             validKeywords[(int)Keywords.WorkstationID] = DbConnectionStringKeywords.WorkstationID;
             validKeywords[(int)Keywords.ConnectRetryCount] = DbConnectionStringKeywords.ConnectRetryCount;
             validKeywords[(int)Keywords.ConnectRetryInterval] = DbConnectionStringKeywords.ConnectRetryInterval;
-            s_validKeywords = validKeywords;
+            return validKeywords;
+        }
 
+        private static Dictionary<string, Keywords> CreateKeywordsDictionary()
+        {
             Dictionary<string, Keywords> hash = new Dictionary<string, Keywords>(KeywordsCount + SqlConnectionString.SynonymCount, StringComparer.OrdinalIgnoreCase);
             hash.Add(DbConnectionStringKeywords.ApplicationIntent, Keywords.ApplicationIntent);
             hash.Add(DbConnectionStringKeywords.ApplicationName, Keywords.ApplicationName);
@@ -184,7 +186,7 @@ namespace System.Data.SqlClient
             hash.Add(DbConnectionStringSynonyms.User, Keywords.UserID);
             hash.Add(DbConnectionStringSynonyms.WSID, Keywords.WorkstationID);
             Debug.Assert((KeywordsCount + SqlConnectionString.SynonymCount) == hash.Count, "initial expected size is incorrect");
-            s_keywords = hash;
+            return hash;
         }
 
         public SqlConnectionStringBuilder() : this((string)null)

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Windows.cs
@@ -225,31 +225,28 @@ namespace System.Diagnostics
         private const string PerfCounterQueryString = "230 232";
         internal const int IdleProcessID = 0;
 
-        private static Dictionary<String, ValueId> s_valueIds;
-
-        static NtProcessManager()
+        private static readonly Dictionary<String, ValueId> s_valueIds = new Dictionary<string, ValueId>(19)
         {
-            s_valueIds = new Dictionary<String, ValueId>();
-            s_valueIds.Add("Pool Paged Bytes", ValueId.PoolPagedBytes);
-            s_valueIds.Add("Pool Nonpaged Bytes", ValueId.PoolNonpagedBytes);
-            s_valueIds.Add("Elapsed Time", ValueId.ElapsedTime);
-            s_valueIds.Add("Virtual Bytes Peak", ValueId.VirtualBytesPeak);
-            s_valueIds.Add("Virtual Bytes", ValueId.VirtualBytes);
-            s_valueIds.Add("Private Bytes", ValueId.PrivateBytes);
-            s_valueIds.Add("Page File Bytes", ValueId.PageFileBytes);
-            s_valueIds.Add("Page File Bytes Peak", ValueId.PageFileBytesPeak);
-            s_valueIds.Add("Working Set Peak", ValueId.WorkingSetPeak);
-            s_valueIds.Add("Working Set", ValueId.WorkingSet);
-            s_valueIds.Add("ID Thread", ValueId.ThreadId);
-            s_valueIds.Add("ID Process", ValueId.ProcessId);
-            s_valueIds.Add("Priority Base", ValueId.BasePriority);
-            s_valueIds.Add("Priority Current", ValueId.CurrentPriority);
-            s_valueIds.Add("% User Time", ValueId.UserTime);
-            s_valueIds.Add("% Privileged Time", ValueId.PrivilegedTime);
-            s_valueIds.Add("Start Address", ValueId.StartAddress);
-            s_valueIds.Add("Thread State", ValueId.ThreadState);
-            s_valueIds.Add("Thread Wait Reason", ValueId.ThreadWaitReason);
-        }
+            { "Pool Paged Bytes", ValueId.PoolPagedBytes },
+            { "Pool Nonpaged Bytes", ValueId.PoolNonpagedBytes },
+            { "Elapsed Time", ValueId.ElapsedTime },
+            { "Virtual Bytes Peak", ValueId.VirtualBytesPeak },
+            { "Virtual Bytes", ValueId.VirtualBytes },
+            { "Private Bytes", ValueId.PrivateBytes },
+            { "Page File Bytes", ValueId.PageFileBytes },
+            { "Page File Bytes Peak", ValueId.PageFileBytesPeak },
+            { "Working Set Peak", ValueId.WorkingSetPeak },
+            { "Working Set", ValueId.WorkingSet },
+            { "ID Thread", ValueId.ThreadId },
+            { "ID Process", ValueId.ProcessId },
+            { "Priority Base", ValueId.BasePriority },
+            { "Priority Current", ValueId.CurrentPriority },
+            { "% User Time", ValueId.UserTime },
+            { "% Privileged Time", ValueId.PrivilegedTime },
+            { "Start Address", ValueId.StartAddress },
+            { "Thread State", ValueId.ThreadState },
+            { "Thread Wait Reason", ValueId.ThreadWaitReason }
+        };
 
         internal static int SystemProcessID
         {

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpTraceHelper.cs
@@ -11,9 +11,9 @@ namespace System.Net.Http
     internal static class WinHttpTraceHelper
     {
         private const string WinHtpTraceEnvironmentVariable = "WINHTTPHANDLER_TRACE";
-        private static bool s_TraceEnabled;
+        private static readonly bool s_traceEnabled = IsTraceEnabledViaEnvironmentVariable();
 
-        static WinHttpTraceHelper()
+        private static bool IsTraceEnabledViaEnvironmentVariable()
         {
             string env;
             try
@@ -25,13 +25,13 @@ namespace System.Net.Http
                 env = null;
             }
 
-            s_TraceEnabled = !string.IsNullOrEmpty(env);
+            return !string.IsNullOrEmpty(env);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsTraceEnabled()
         {
-            return s_TraceEnabled;
+            return s_traceEnabled;
         }
 
         public static void Trace(string message)

--- a/src/System.Net.Http/src/Internal/Mail/MailBnfHelper.cs
+++ b/src/System.Net.Http/src/Internal/Mail/MailBnfHelper.cs
@@ -14,22 +14,22 @@ namespace System.Net.Mime
     internal static class MailBnfHelper
     {
         // characters allowed in atoms
-        internal static bool[] Atext = new bool[128];
+        internal static readonly bool[] Atext = CreateCharactersAllowedInAtoms();
 
         // characters allowed in quoted strings (not including unicode)
-        internal static bool[] Qtext = new bool[128];
+        internal static readonly bool[] Qtext = CreateCharactersAllowedInQuotedStrings();
 
         // characters allowed in domain literals
-        internal static bool[] Dtext = new bool[128];
+        internal static readonly bool[] Dtext = CreateCharactersAllowedInDomainLiterals();
 
         // characters allowed in header names
-        internal static bool[] Ftext = new bool[128];
+        internal static readonly bool[] Ftext = CreateCharactersAllowedInHeaderNames();
 
         // characters allowed in tokens
-        internal static bool[] Ttext = new bool[128];
+        internal static readonly bool[] Ttext = CreateCharactersAllowedInTokens();
 
         // characters allowed inside of comments
-        internal static bool[] Ctext = new bool[128];
+        internal static readonly bool[] Ctext = CreateCharactersAllowedInComments();
 
         internal static readonly int Ascii7bitMaxValue = 127;
         internal static readonly char Quote = '\"';
@@ -47,91 +47,122 @@ namespace System.Net.Mime
         internal static readonly char EndSquareBracket = ']';
         internal static readonly char Comma = ',';
         internal static readonly char Dot = '.';
-        internal static readonly IList<char> Whitespace;
+        internal static readonly IList<char> Whitespace = CreateAllowedWhitespace();
 
-        static MailBnfHelper()
+        private static List<char> CreateAllowedWhitespace()
         {
-            // NOTE: See RFC 2822 for more detail.  By default, every value in the array is false and only
-            // those values which are allowed in that particular set are then set to true.  The numbers
-            // annotating each definition below are the range of ASCII values which are allowed in that definition.
-
             // all allowed whitespace characters
-            Whitespace = new List<char>();
-            Whitespace.Add(Tab);
-            Whitespace.Add(Space);
-            Whitespace.Add(CR);
-            Whitespace.Add(LF);
+            var whitespace = new List<char>(4);
+            whitespace.Add(Tab);
+            whitespace.Add(Space);
+            whitespace.Add(CR);
+            whitespace.Add(LF);
+            return whitespace;
+        }
 
+        // NOTE: See RFC 2822 for more detail.  By default, every value in the array is false and only
+        // those values which are allowed in that particular set are then set to true.  The numbers
+        // annotating each definition below are the range of ASCII values which are allowed in that definition.
+
+        private static bool[] CreateCharactersAllowedInAtoms()
+        {
             // atext = ALPHA / DIGIT / "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "/" / "=" / "?" / "^" / "_" / "`" / "{" / "|" / "}" / "~"
-            for (int i = '0'; i <= '9'; i++) { Atext[i] = true; }
-            for (int i = 'A'; i <= 'Z'; i++) { Atext[i] = true; }
-            for (int i = 'a'; i <= 'z'; i++) { Atext[i] = true; }
-            Atext['!'] = true;
-            Atext['#'] = true;
-            Atext['$'] = true;
-            Atext['%'] = true;
-            Atext['&'] = true;
-            Atext['\''] = true;
-            Atext['*'] = true;
-            Atext['+'] = true;
-            Atext['-'] = true;
-            Atext['/'] = true;
-            Atext['='] = true;
-            Atext['?'] = true;
-            Atext['^'] = true;
-            Atext['_'] = true;
-            Atext['`'] = true;
-            Atext['{'] = true;
-            Atext['|'] = true;
-            Atext['}'] = true;
-            Atext['~'] = true;
+            var atext = new bool[128];
+            for (int i = '0'; i <= '9'; i++) { atext[i] = true; }
+            for (int i = 'A'; i <= 'Z'; i++) { atext[i] = true; }
+            for (int i = 'a'; i <= 'z'; i++) { atext[i] = true; }
+            atext['!'] = true;
+            atext['#'] = true;
+            atext['$'] = true;
+            atext['%'] = true;
+            atext['&'] = true;
+            atext['\''] = true;
+            atext['*'] = true;
+            atext['+'] = true;
+            atext['-'] = true;
+            atext['/'] = true;
+            atext['='] = true;
+            atext['?'] = true;
+            atext['^'] = true;
+            atext['_'] = true;
+            atext['`'] = true;
+            atext['{'] = true;
+            atext['|'] = true;
+            atext['}'] = true;
+            atext['~'] = true;
+            return atext;
+        }
 
+        private static bool[] CreateCharactersAllowedInQuotedStrings()
+        {
             // fqtext = %d1-9 / %d11 / %d12 / %d14-33 / %d35-91 / %d93-127
-            for (int i = 1; i <= 9; i++) { Qtext[i] = true; }
-            Qtext[11] = true;
-            Qtext[12] = true;
-            for (int i = 14; i <= 33; i++) { Qtext[i] = true; }
-            for (int i = 35; i <= 91; i++) { Qtext[i] = true; }
-            for (int i = 93; i <= 127; i++) { Qtext[i] = true; }
+            var qtext = new bool[128];
+            for (int i = 1; i <= 9; i++) { qtext[i] = true; }
+            qtext[11] = true;
+            qtext[12] = true;
+            for (int i = 14; i <= 33; i++) { qtext[i] = true; }
+            for (int i = 35; i <= 91; i++) { qtext[i] = true; }
+            for (int i = 93; i <= 127; i++) { qtext[i] = true; }
+            return qtext;
+        }
 
+        private static bool[] CreateCharactersAllowedInDomainLiterals()
+        {
             // fdtext = %d1-8 / %d11 / %d12 / %d14-31 / %d33-90 / %d94-127
-            for (int i = 1; i <= 8; i++) { Dtext[i] = true; }
-            Dtext[11] = true;
-            Dtext[12] = true;
-            for (int i = 14; i <= 31; i++) { Dtext[i] = true; }
-            for (int i = 33; i <= 90; i++) { Dtext[i] = true; }
-            for (int i = 94; i <= 127; i++) { Dtext[i] = true; }
+            var dtext = new bool[128];
+            for (int i = 1; i <= 8; i++) { dtext[i] = true; }
+            dtext[11] = true;
+            dtext[12] = true;
+            for (int i = 14; i <= 31; i++) { dtext[i] = true; }
+            for (int i = 33; i <= 90; i++) { dtext[i] = true; }
+            for (int i = 94; i <= 127; i++) { dtext[i] = true; }
+            return dtext;
+        }
 
+        private static bool[] CreateCharactersAllowedInHeaderNames()
+        {
             // ftext = %d33-57 / %d59-126
-            for (int i = 33; i <= 57; i++) { Ftext[i] = true; }
-            for (int i = 59; i <= 126; i++) { Ftext[i] = true; }
+            var ftext = new bool[128];
+            for (int i = 33; i <= 57; i++) { ftext[i] = true; }
+            for (int i = 59; i <= 126; i++) { ftext[i] = true; }
+            return ftext;
+        }
 
+        private static bool[] CreateCharactersAllowedInTokens()
+        {
             // ttext = %d33-126 except '()<>@,;:\"/[]?='
-            for (int i = 33; i <= 126; i++) { Ttext[i] = true; }
-            Ttext['('] = false;
-            Ttext[')'] = false;
-            Ttext['<'] = false;
-            Ttext['>'] = false;
-            Ttext['@'] = false;
-            Ttext[','] = false;
-            Ttext[';'] = false;
-            Ttext[':'] = false;
-            Ttext['\\'] = false;
-            Ttext['"'] = false;
-            Ttext['/'] = false;
-            Ttext['['] = false;
-            Ttext[']'] = false;
-            Ttext['?'] = false;
-            Ttext['='] = false;
+            var ttext = new bool[128];
+            for (int i = 33; i <= 126; i++) { ttext[i] = true; }
+            ttext['('] = false;
+            ttext[')'] = false;
+            ttext['<'] = false;
+            ttext['>'] = false;
+            ttext['@'] = false;
+            ttext[','] = false;
+            ttext[';'] = false;
+            ttext[':'] = false;
+            ttext['\\'] = false;
+            ttext['"'] = false;
+            ttext['/'] = false;
+            ttext['['] = false;
+            ttext[']'] = false;
+            ttext['?'] = false;
+            ttext['='] = false;
+            return ttext;
+        }
 
+        private static bool[] CreateCharactersAllowedInComments()
+        {
             // ctext- %d1-8 / %d11 / %d12 / %d14-31 / %33-39 / %42-91 / %93-127
-            for (int i = 1; i <= 8; i++) { Ctext[i] = true; }
-            Ctext[11] = true;
-            Ctext[12] = true;
-            for (int i = 14; i <= 31; i++) { Ctext[i] = true; }
-            for (int i = 33; i <= 39; i++) { Ctext[i] = true; }
-            for (int i = 42; i <= 91; i++) { Ctext[i] = true; }
-            for (int i = 93; i <= 127; i++) { Ctext[i] = true; }
+            var ctext = new bool[128];
+            for (int i = 1; i <= 8; i++) { ctext[i] = true; }
+            ctext[11] = true;
+            ctext[12] = true;
+            for (int i = 14; i <= 31; i++) { ctext[i] = true; }
+            for (int i = 33; i <= 39; i++) { ctext[i] = true; }
+            for (int i = 42; i <= 91; i++) { ctext[i] = true; }
+            for (int i = 93; i <= 127; i++) { ctext[i] = true; }
+            return ctext;
         }
 
         internal static bool SkipCFWS(string data, ref int offset)

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpContentHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpContentHeaders.cs
@@ -12,8 +12,8 @@ namespace System.Net.Http.Headers
         Justification = "This is not a collection")]
     public sealed class HttpContentHeaders : HttpHeaders
     {
-        private static readonly Dictionary<string, HttpHeaderParser> s_parserStore;
-        private static readonly HashSet<string> s_invalidHeaders;
+        private static readonly Dictionary<string, HttpHeaderParser> s_parserStore = CreateParserStore();
+        private static readonly HashSet<string> s_invalidHeaders = CreateInvalidHeaders();
 
         private Func<long?> _calculateLengthFunc;
         private bool _contentLengthSet;
@@ -153,26 +153,34 @@ namespace System.Net.Http.Headers
             SetConfiguration(s_parserStore, s_invalidHeaders);
         }
 
-        static HttpContentHeaders()
+        private static Dictionary<string, HttpHeaderParser> CreateParserStore()
         {
-            s_parserStore = new Dictionary<string, HttpHeaderParser>(StringComparer.OrdinalIgnoreCase);
+            var parserStore = new Dictionary<string, HttpHeaderParser>(11, StringComparer.OrdinalIgnoreCase);
 
-            s_parserStore.Add(HttpKnownHeaderNames.Allow, GenericHeaderParser.TokenListParser);
-            s_parserStore.Add(HttpKnownHeaderNames.ContentDisposition, GenericHeaderParser.ContentDispositionParser);
-            s_parserStore.Add(HttpKnownHeaderNames.ContentEncoding, GenericHeaderParser.TokenListParser);
-            s_parserStore.Add(HttpKnownHeaderNames.ContentLanguage, GenericHeaderParser.TokenListParser);
-            s_parserStore.Add(HttpKnownHeaderNames.ContentLength, Int64NumberHeaderParser.Parser);
-            s_parserStore.Add(HttpKnownHeaderNames.ContentLocation, UriHeaderParser.RelativeOrAbsoluteUriParser);
-            s_parserStore.Add(HttpKnownHeaderNames.ContentMD5, ByteArrayHeaderParser.Parser);
-            s_parserStore.Add(HttpKnownHeaderNames.ContentRange, GenericHeaderParser.ContentRangeParser);
-            s_parserStore.Add(HttpKnownHeaderNames.ContentType, MediaTypeHeaderParser.SingleValueParser);
-            s_parserStore.Add(HttpKnownHeaderNames.Expires, DateHeaderParser.Parser);
-            s_parserStore.Add(HttpKnownHeaderNames.LastModified, DateHeaderParser.Parser);
+            parserStore.Add(HttpKnownHeaderNames.Allow, GenericHeaderParser.TokenListParser);
+            parserStore.Add(HttpKnownHeaderNames.ContentDisposition, GenericHeaderParser.ContentDispositionParser);
+            parserStore.Add(HttpKnownHeaderNames.ContentEncoding, GenericHeaderParser.TokenListParser);
+            parserStore.Add(HttpKnownHeaderNames.ContentLanguage, GenericHeaderParser.TokenListParser);
+            parserStore.Add(HttpKnownHeaderNames.ContentLength, Int64NumberHeaderParser.Parser);
+            parserStore.Add(HttpKnownHeaderNames.ContentLocation, UriHeaderParser.RelativeOrAbsoluteUriParser);
+            parserStore.Add(HttpKnownHeaderNames.ContentMD5, ByteArrayHeaderParser.Parser);
+            parserStore.Add(HttpKnownHeaderNames.ContentRange, GenericHeaderParser.ContentRangeParser);
+            parserStore.Add(HttpKnownHeaderNames.ContentType, MediaTypeHeaderParser.SingleValueParser);
+            parserStore.Add(HttpKnownHeaderNames.Expires, DateHeaderParser.Parser);
+            parserStore.Add(HttpKnownHeaderNames.LastModified, DateHeaderParser.Parser);
 
-            s_invalidHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            HttpRequestHeaders.AddKnownHeaders(s_invalidHeaders);
-            HttpResponseHeaders.AddKnownHeaders(s_invalidHeaders);
-            HttpGeneralHeaders.AddKnownHeaders(s_invalidHeaders);
+            return parserStore;
+        }
+
+        private static HashSet<string> CreateInvalidHeaders()
+        {
+            var invalidHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            HttpRequestHeaders.AddKnownHeaders(invalidHeaders);
+            HttpResponseHeaders.AddKnownHeaders(invalidHeaders);
+            HttpGeneralHeaders.AddKnownHeaders(invalidHeaders);
+
+            return invalidHeaders;
         }
 
         internal static void AddKnownHeaders(HashSet<string> headerSet)

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpRequestHeaders.cs
@@ -13,8 +13,8 @@ namespace System.Net.Http.Headers
         Justification = "This is not a collection")]
     public sealed class HttpRequestHeaders : HttpHeaders
     {
-        private static readonly Dictionary<string, HttpHeaderParser> s_parserStore;
-        private static readonly HashSet<string> s_invalidHeaders;
+        private static readonly Dictionary<string, HttpHeaderParser> s_parserStore = CreateParserStore();
+        private static readonly HashSet<string> s_invalidHeaders = CreateInvalidHeaders();
 
         private HttpGeneralHeaders _generalHeaders;
         private HttpHeaderValueCollection<MediaTypeWithQualityHeaderValue> _accept;
@@ -351,34 +351,41 @@ namespace System.Net.Http.Headers
             base.SetConfiguration(s_parserStore, s_invalidHeaders);
         }
 
-        static HttpRequestHeaders()
+        private static Dictionary<string, HttpHeaderParser> CreateParserStore()
         {
-            s_parserStore = new Dictionary<string, HttpHeaderParser>(StringComparer.OrdinalIgnoreCase);
+            var parserStore = new Dictionary<string, HttpHeaderParser>(StringComparer.OrdinalIgnoreCase);
 
-            s_parserStore.Add(HttpKnownHeaderNames.Accept, MediaTypeHeaderParser.MultipleValuesParser);
-            s_parserStore.Add(HttpKnownHeaderNames.AcceptCharset, GenericHeaderParser.MultipleValueStringWithQualityParser);
-            s_parserStore.Add(HttpKnownHeaderNames.AcceptEncoding, GenericHeaderParser.MultipleValueStringWithQualityParser);
-            s_parserStore.Add(HttpKnownHeaderNames.AcceptLanguage, GenericHeaderParser.MultipleValueStringWithQualityParser);
-            s_parserStore.Add(HttpKnownHeaderNames.Authorization, GenericHeaderParser.SingleValueAuthenticationParser);
-            s_parserStore.Add(HttpKnownHeaderNames.Expect, GenericHeaderParser.MultipleValueNameValueWithParametersParser);
-            s_parserStore.Add(HttpKnownHeaderNames.From, GenericHeaderParser.MailAddressParser);
-            s_parserStore.Add(HttpKnownHeaderNames.Host, GenericHeaderParser.HostParser);
-            s_parserStore.Add(HttpKnownHeaderNames.IfMatch, GenericHeaderParser.MultipleValueEntityTagParser);
-            s_parserStore.Add(HttpKnownHeaderNames.IfModifiedSince, DateHeaderParser.Parser);
-            s_parserStore.Add(HttpKnownHeaderNames.IfNoneMatch, GenericHeaderParser.MultipleValueEntityTagParser);
-            s_parserStore.Add(HttpKnownHeaderNames.IfRange, GenericHeaderParser.RangeConditionParser);
-            s_parserStore.Add(HttpKnownHeaderNames.IfUnmodifiedSince, DateHeaderParser.Parser);
-            s_parserStore.Add(HttpKnownHeaderNames.MaxForwards, Int32NumberHeaderParser.Parser);
-            s_parserStore.Add(HttpKnownHeaderNames.ProxyAuthorization, GenericHeaderParser.SingleValueAuthenticationParser);
-            s_parserStore.Add(HttpKnownHeaderNames.Range, GenericHeaderParser.RangeParser);
-            s_parserStore.Add(HttpKnownHeaderNames.Referer, UriHeaderParser.RelativeOrAbsoluteUriParser);
-            s_parserStore.Add(HttpKnownHeaderNames.TE, TransferCodingHeaderParser.MultipleValueWithQualityParser);
-            s_parserStore.Add(HttpKnownHeaderNames.UserAgent, ProductInfoHeaderParser.MultipleValueParser);
+            parserStore.Add(HttpKnownHeaderNames.Accept, MediaTypeHeaderParser.MultipleValuesParser);
+            parserStore.Add(HttpKnownHeaderNames.AcceptCharset, GenericHeaderParser.MultipleValueStringWithQualityParser);
+            parserStore.Add(HttpKnownHeaderNames.AcceptEncoding, GenericHeaderParser.MultipleValueStringWithQualityParser);
+            parserStore.Add(HttpKnownHeaderNames.AcceptLanguage, GenericHeaderParser.MultipleValueStringWithQualityParser);
+            parserStore.Add(HttpKnownHeaderNames.Authorization, GenericHeaderParser.SingleValueAuthenticationParser);
+            parserStore.Add(HttpKnownHeaderNames.Expect, GenericHeaderParser.MultipleValueNameValueWithParametersParser);
+            parserStore.Add(HttpKnownHeaderNames.From, GenericHeaderParser.MailAddressParser);
+            parserStore.Add(HttpKnownHeaderNames.Host, GenericHeaderParser.HostParser);
+            parserStore.Add(HttpKnownHeaderNames.IfMatch, GenericHeaderParser.MultipleValueEntityTagParser);
+            parserStore.Add(HttpKnownHeaderNames.IfModifiedSince, DateHeaderParser.Parser);
+            parserStore.Add(HttpKnownHeaderNames.IfNoneMatch, GenericHeaderParser.MultipleValueEntityTagParser);
+            parserStore.Add(HttpKnownHeaderNames.IfRange, GenericHeaderParser.RangeConditionParser);
+            parserStore.Add(HttpKnownHeaderNames.IfUnmodifiedSince, DateHeaderParser.Parser);
+            parserStore.Add(HttpKnownHeaderNames.MaxForwards, Int32NumberHeaderParser.Parser);
+            parserStore.Add(HttpKnownHeaderNames.ProxyAuthorization, GenericHeaderParser.SingleValueAuthenticationParser);
+            parserStore.Add(HttpKnownHeaderNames.Range, GenericHeaderParser.RangeParser);
+            parserStore.Add(HttpKnownHeaderNames.Referer, UriHeaderParser.RelativeOrAbsoluteUriParser);
+            parserStore.Add(HttpKnownHeaderNames.TE, TransferCodingHeaderParser.MultipleValueWithQualityParser);
+            parserStore.Add(HttpKnownHeaderNames.UserAgent, ProductInfoHeaderParser.MultipleValueParser);
 
-            HttpGeneralHeaders.AddParsers(s_parserStore);
+            HttpGeneralHeaders.AddParsers(parserStore);
 
-            s_invalidHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            HttpContentHeaders.AddKnownHeaders(s_invalidHeaders);
+            return parserStore;
+        }
+
+        private static HashSet<string> CreateInvalidHeaders()
+        {
+            var invalidHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            HttpContentHeaders.AddKnownHeaders(invalidHeaders);
+            return invalidHeaders;
+
             // Note: Reserved response header names are allowed as custom request header names.  Reserved response
             // headers have no defined meaning or format when used on a request.  This enables a server to accept
             // any headers sent from the client as either content headers or request headers.

--- a/src/System.Net.Http/src/System/Net/Http/Headers/HttpResponseHeaders.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Headers/HttpResponseHeaders.cs
@@ -13,8 +13,8 @@ namespace System.Net.Http.Headers
         Justification = "This is not a collection")]
     public sealed class HttpResponseHeaders : HttpHeaders
     {
-        private static readonly Dictionary<string, HttpHeaderParser> s_parserStore;
-        private static readonly HashSet<string> s_invalidHeaders;
+        private static readonly Dictionary<string, HttpHeaderParser> s_parserStore = CreateParserStore();
+        private static readonly HashSet<string> s_invalidHeaders = CreateInvalidHeaders();
 
         private HttpGeneralHeaders _generalHeaders;
         private HttpHeaderValueCollection<string> _acceptRanges;
@@ -185,24 +185,31 @@ namespace System.Net.Http.Headers
             base.SetConfiguration(s_parserStore, s_invalidHeaders);
         }
 
-        static HttpResponseHeaders()
+        private static Dictionary<string, HttpHeaderParser> CreateParserStore()
         {
-            s_parserStore = new Dictionary<string, HttpHeaderParser>(StringComparer.OrdinalIgnoreCase);
+            var parserStore = new Dictionary<string, HttpHeaderParser>(StringComparer.OrdinalIgnoreCase);
 
-            s_parserStore.Add(HttpKnownHeaderNames.AcceptRanges, GenericHeaderParser.TokenListParser);
-            s_parserStore.Add(HttpKnownHeaderNames.Age, TimeSpanHeaderParser.Parser);
-            s_parserStore.Add(HttpKnownHeaderNames.ETag, GenericHeaderParser.SingleValueEntityTagParser);
-            s_parserStore.Add(HttpKnownHeaderNames.Location, UriHeaderParser.RelativeOrAbsoluteUriParser);
-            s_parserStore.Add(HttpKnownHeaderNames.ProxyAuthenticate, GenericHeaderParser.MultipleValueAuthenticationParser);
-            s_parserStore.Add(HttpKnownHeaderNames.RetryAfter, GenericHeaderParser.RetryConditionParser);
-            s_parserStore.Add(HttpKnownHeaderNames.Server, ProductInfoHeaderParser.MultipleValueParser);
-            s_parserStore.Add(HttpKnownHeaderNames.Vary, GenericHeaderParser.TokenListParser);
-            s_parserStore.Add(HttpKnownHeaderNames.WWWAuthenticate, GenericHeaderParser.MultipleValueAuthenticationParser);
+            parserStore.Add(HttpKnownHeaderNames.AcceptRanges, GenericHeaderParser.TokenListParser);
+            parserStore.Add(HttpKnownHeaderNames.Age, TimeSpanHeaderParser.Parser);
+            parserStore.Add(HttpKnownHeaderNames.ETag, GenericHeaderParser.SingleValueEntityTagParser);
+            parserStore.Add(HttpKnownHeaderNames.Location, UriHeaderParser.RelativeOrAbsoluteUriParser);
+            parserStore.Add(HttpKnownHeaderNames.ProxyAuthenticate, GenericHeaderParser.MultipleValueAuthenticationParser);
+            parserStore.Add(HttpKnownHeaderNames.RetryAfter, GenericHeaderParser.RetryConditionParser);
+            parserStore.Add(HttpKnownHeaderNames.Server, ProductInfoHeaderParser.MultipleValueParser);
+            parserStore.Add(HttpKnownHeaderNames.Vary, GenericHeaderParser.TokenListParser);
+            parserStore.Add(HttpKnownHeaderNames.WWWAuthenticate, GenericHeaderParser.MultipleValueAuthenticationParser);
 
-            HttpGeneralHeaders.AddParsers(s_parserStore);
+            HttpGeneralHeaders.AddParsers(parserStore);
 
-            s_invalidHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            HttpContentHeaders.AddKnownHeaders(s_invalidHeaders);
+            return parserStore;
+        }
+
+        private static HashSet<string> CreateInvalidHeaders()
+        {
+            var invalidHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            HttpContentHeaders.AddKnownHeaders(invalidHeaders);
+            return invalidHeaders;
+
             // Note: Reserved request header names are allowed as custom response header names.  Reserved request
             // headers have no defined meaning or format when used on a response. This enables a client to accept
             // any headers sent from the server as either content headers or response headers.

--- a/src/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs
+++ b/src/System.Net.Http/src/System/Net/Http/HttpRuleParser.cs
@@ -11,7 +11,7 @@ namespace System.Net.Http
 {
     internal static class HttpRuleParser
     {
-        private static readonly bool[] s_tokenChars;
+        private static readonly bool[] s_tokenChars = CreateTokenChars();
         private const int maxNestedCount = 5;
         private static readonly string[] s_dateFormats = new string[] {
             // "r", // RFC 1123, required output format but too strict for input
@@ -46,36 +46,38 @@ namespace System.Net.Http
         internal static readonly Encoding DefaultHttpEncoding = Encoding.GetEncoding(28591);
 #endif
 
-        static HttpRuleParser()
+        private static bool[] CreateTokenChars()
         {
             // token = 1*<any CHAR except CTLs or separators>
             // CTL = <any US-ASCII control character (octets 0 - 31) and DEL (127)>
 
-            s_tokenChars = new bool[128]; // All elements default to "false".
+            var tokenChars = new bool[128]; // All elements default to "false".
 
             for (int i = 33; i < 127; i++) // Skip Space (32) & DEL (127).
             {
-                s_tokenChars[i] = true;
+                tokenChars[i] = true;
             }
 
             // Remove separators: these are not valid token characters.
-            s_tokenChars[(byte)'('] = false;
-            s_tokenChars[(byte)')'] = false;
-            s_tokenChars[(byte)'<'] = false;
-            s_tokenChars[(byte)'>'] = false;
-            s_tokenChars[(byte)'@'] = false;
-            s_tokenChars[(byte)','] = false;
-            s_tokenChars[(byte)';'] = false;
-            s_tokenChars[(byte)':'] = false;
-            s_tokenChars[(byte)'\\'] = false;
-            s_tokenChars[(byte)'"'] = false;
-            s_tokenChars[(byte)'/'] = false;
-            s_tokenChars[(byte)'['] = false;
-            s_tokenChars[(byte)']'] = false;
-            s_tokenChars[(byte)'?'] = false;
-            s_tokenChars[(byte)'='] = false;
-            s_tokenChars[(byte)'{'] = false;
-            s_tokenChars[(byte)'}'] = false;
+            tokenChars[(byte)'('] = false;
+            tokenChars[(byte)')'] = false;
+            tokenChars[(byte)'<'] = false;
+            tokenChars[(byte)'>'] = false;
+            tokenChars[(byte)'@'] = false;
+            tokenChars[(byte)','] = false;
+            tokenChars[(byte)';'] = false;
+            tokenChars[(byte)':'] = false;
+            tokenChars[(byte)'\\'] = false;
+            tokenChars[(byte)'"'] = false;
+            tokenChars[(byte)'/'] = false;
+            tokenChars[(byte)'['] = false;
+            tokenChars[(byte)']'] = false;
+            tokenChars[(byte)'?'] = false;
+            tokenChars[(byte)'='] = false;
+            tokenChars[(byte)'{'] = false;
+            tokenChars[(byte)'}'] = false;
+
+            return tokenChars;
         }
 
         internal static bool IsTokenChar(char character)

--- a/src/System.Net.Security/src/System/Net/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/SslStreamPal.Unix.cs
@@ -14,6 +14,8 @@ namespace System.Net
 {
     internal static class SslStreamPal
     {
+        private static readonly StreamSizes s_streamSizes = new StreamSizes();
+
         public static Exception GetException(SecurityStatusPal status)
         {
             return new Interop.OpenSsl.SslException((int)status);
@@ -76,7 +78,7 @@ namespace System.Net
 
         public static void QueryContextStreamSizes(SafeDeleteContext securityContext, out StreamSizes streamSizes)
         {
-            streamSizes = new StreamSizes();
+            streamSizes = s_streamSizes;
         }
 
         public static void QueryContextConnectionInfo(SafeDeleteContext securityContext, out SslConnectionInfo connectionInfo)

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/DataContract.cs
@@ -505,8 +505,8 @@ namespace System.Runtime.Serialization
         [SecurityCritical]
         internal class DataContractCriticalHelper
         {
-            private static Dictionary<TypeHandleRef, IntRef> s_typeToIDCache;
-            private static DataContract[] s_dataContractCache;
+            private static Dictionary<TypeHandleRef, IntRef> s_typeToIDCache = new Dictionary<TypeHandleRef, IntRef>(new TypeHandleRefEqualityComparer());
+            private static DataContract[] s_dataContractCache = new DataContract[32];
             private static int s_dataContractID;
             private static Dictionary<Type, DataContract> s_typeToBuiltInContract;
             private static Dictionary<XmlQualifiedName, DataContract> s_nameToBuiltInContract;
@@ -537,13 +537,6 @@ namespace System.Runtime.Serialization
             /// Critical - in deserialization, we initialize an object instance passing this Type to GetUninitializedObject method
             /// </SecurityNote>
             private Type _typeForInitialization;
-
-            static DataContractCriticalHelper()
-            {
-                s_typeToIDCache = new Dictionary<TypeHandleRef, IntRef>(new TypeHandleRefEqualityComparer());
-                s_dataContractCache = new DataContract[32];
-                s_dataContractID = 0;
-            }
 
             internal static DataContract GetDataContractSkipValidation(int id, RuntimeTypeHandle typeHandle, Type type)
             {

--- a/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExceptionDataContract.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Runtime/Serialization/ExceptionDataContract.cs
@@ -111,9 +111,11 @@ namespace System.Runtime.Serialization
             private List<DataMember> _members;
             private bool _hasDataContract;
             private Dictionary<XmlQualifiedName, DataContract> _knownDataContracts;
-            private static readonly Dictionary<string, string> s_essentialExceptionFields; //Contains the essential fields to serialize an Exception. Not all fields are serialized in an Exception. Some private fields
-                                                                                           //need to be serialized, but then again some need to be left out. This will  keep track of which ones need to be serialized
-                                                                                           //And also their display name for serialization which differs from their declared name.
+
+            //Contains the essential fields to serialize an Exception. Not all fields are serialized in an Exception. Some private fields
+            //need to be serialized, but then again some need to be left out. This will  keep track of which ones need to be serialized
+            //And also their display name for serialization which differs from their declared name.
+            private static readonly Dictionary<string, string> s_essentialExceptionFields = CreateExceptionFields();
 
             /*
              * The ordering of this dictionary is important due to the nature of the ClassDataContract that ExceptionDataContract depends on.
@@ -124,21 +126,22 @@ namespace System.Runtime.Serialization
              * This dictionary is in the order that the Full Framework declares System.Exceptions members. This order is established
              * in the Full Framework version of System.Exception's Iserializable interface.
              */
-            static ExceptionDataContractCriticalHelper()
+            private static Dictionary<string, string> CreateExceptionFields()
             {
-                s_essentialExceptionFields = new Dictionary<string, string>();
-                s_essentialExceptionFields.Add("_className", "ClassName");
-                s_essentialExceptionFields.Add("_message", "Message");
-                s_essentialExceptionFields.Add("_data", "Data");
-                s_essentialExceptionFields.Add("_innerException", "InnerException");
-                s_essentialExceptionFields.Add("_helpURL", "HelpURL");
-                s_essentialExceptionFields.Add("_stackTraceString", "StackTraceString");
-                s_essentialExceptionFields.Add("_remoteStackTraceString", "RemoteStackTraceString");
-                s_essentialExceptionFields.Add("_remoteStackIndex", "RemoteStackIndex");
-                s_essentialExceptionFields.Add("_exceptionMethodString", "ExceptionMethod");
-                s_essentialExceptionFields.Add("_HResult", "HResult");
-                s_essentialExceptionFields.Add("_source", "Source");
-                s_essentialExceptionFields.Add("_watsonBuckets", "WatsonBuckets");
+                var essentialExceptionFields = new Dictionary<string, string>(12);
+                essentialExceptionFields.Add("_className", "ClassName");
+                essentialExceptionFields.Add("_message", "Message");
+                essentialExceptionFields.Add("_data", "Data");
+                essentialExceptionFields.Add("_innerException", "InnerException");
+                essentialExceptionFields.Add("_helpURL", "HelpURL");
+                essentialExceptionFields.Add("_stackTraceString", "StackTraceString");
+                essentialExceptionFields.Add("_remoteStackTraceString", "RemoteStackTraceString");
+                essentialExceptionFields.Add("_remoteStackIndex", "RemoteStackIndex");
+                essentialExceptionFields.Add("_exceptionMethodString", "ExceptionMethod");
+                essentialExceptionFields.Add("_HResult", "HResult");
+                essentialExceptionFields.Add("_source", "Source");
+                essentialExceptionFields.Add("_watsonBuckets", "WatsonBuckets");
+                return essentialExceptionFields;
             }
 
             public ExceptionDataContractCriticalHelper()

--- a/src/System.Security.AccessControl/src/System/Security/AccessControl/Privilege.cs
+++ b/src/System.Security.AccessControl/src/System/Security/AccessControl/Privilege.cs
@@ -171,10 +171,6 @@ namespace System.Security.AccessControl
 
             #region Constructor and Finalizer
 
-            static TlsContents()
-            {
-            }
-
             public TlsContents()
             {
                 int error = 0;

--- a/src/System.Text.Encoding.CodePages/src/System/Text/BaseCodePageEncoding.cs
+++ b/src/System.Text.Encoding.CodePages/src/System/Text/BaseCodePageEncoding.cs
@@ -54,11 +54,6 @@ namespace System.Text
         protected char[] arrayUnicodeBestFit = null;
         protected char[] arrayBytesBestFit = null;
 
-        [System.Security.SecuritySafeCritical] // static constructors should be safe to call
-        static BaseCodePageEncoding()
-        {
-        }
-
         [System.Security.SecurityCritical]  // auto-generated
         internal BaseCodePageEncoding(int codepage)
             : this(codepage, codepage)

--- a/src/System.Xml.ReaderWriter/src/System/Xml/Schema/DtdParser.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Schema/DtdParser.cs
@@ -182,9 +182,9 @@ namespace System.Xml
         // Constructor
         //
 
+#if DEBUG
         static DtdParser()
         {
-#if DEBUG
             //  The absolute numbering is utilized in attribute type parsing
             Debug.Assert((int)Token.CDATA == (int)XmlTokenizedType.CDATA && (int)XmlTokenizedType.CDATA == 0);
             Debug.Assert((int)Token.ID == (int)XmlTokenizedType.ID && (int)XmlTokenizedType.ID == 1);
@@ -195,8 +195,8 @@ namespace System.Xml
             Debug.Assert((int)Token.NMTOKEN == (int)XmlTokenizedType.NMTOKEN && (int)XmlTokenizedType.NMTOKEN == 6);
             Debug.Assert((int)Token.NMTOKENS == (int)XmlTokenizedType.NMTOKENS && (int)XmlTokenizedType.NMTOKENS == 7);
             Debug.Assert((int)Token.NOTATION == (int)XmlTokenizedType.NOTATION && (int)XmlTokenizedType.NOTATION == 8);
+    }
 #endif
-        }
 
         private DtdParser()
         {

--- a/src/System.Xml.ReaderWriter/src/System/Xml/XmlCharType.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/XmlCharType.cs
@@ -1029,15 +1029,9 @@ namespace System.Xml
                         0x700 , 0x700 , 0x700 , 0x700 , 0x700 , 0x700 , 0x700 , 0x1B00
         };
 
-        private static byte** s_CharProperties;
+        private static readonly IntPtr[] s_PageIndexes = new IntPtr[256];
+        private static readonly byte** s_CharProperties = InitializeCharProperties();
         private byte** _charProperties;
-        private static IntPtr[] s_PageIndexes;
-
-        static XmlCharType()
-        {
-            s_PageIndexes = new IntPtr[256];
-            s_CharProperties = InitializeCharProperties();
-        }
 
         private static byte** InitializeCharProperties()
         {


### PR DESCRIPTION
Explicit static cctors cause the C# compiler to not mark types as beforefieldinit, which in turn means that the backend compiler needs to add checks to static methods to ensure that the type has been initialized.  We have a bunch of such cctors across corefx that can be easily removed; this commit does so.  (See https://msdn.microsoft.com/en-us/library/ms182275.aspx for some background.)

The changes are all minor and basically boil down to converting the static cctor to one or more static methods which are then just called in the field initializer(s).

cc: 
@davidsh for networking
@saurabh500 for data
@bartonjs for security
@khdang for serialization/xml
@jkotas 