### PR TITLE
Add check for HAVE_VFS_NAMELEN

### DIFF
--- a/src/Native/System.Native/pal_mount.cpp
+++ b/src/Native/System.Native/pal_mount.cpp
@@ -104,7 +104,11 @@ SystemNative_GetFormatInfoForMountPoint(const char* name, char* formatNameBuffer
     {
 
 #if HAVE_STATFS_FSTYPENAME
+#ifdef VFS_NAMELEN
+        if (bufferLength < VFS_NAMELEN)
+#else
         if (bufferLength < MFSNAMELEN)
+#endif
         {
             result = ERANGE;
             *formatType = 0;


### PR DESCRIPTION
`MFSNAMELEN` is not defined in NetBSD. The suitable alternative is
`VFS_NAMELEN`, which this change adds support for.