### PR TITLE
Remove unnecessary array copy before calling CheckMagicValueOfKey

### DIFF
--- a/src/Common/src/System/Security/Cryptography/RSACng.ImportExport.cs
+++ b/src/Common/src/System/Security/Cryptography/RSACng.ImportExport.cs
@@ -145,9 +145,7 @@ namespace System.Security.Cryptography
             //     byte[cbPrime1]       coefficient         - InverseQ
             //     byte[cbModulus]      privateExponent     - D
             //
-            byte[] tempMagic = new byte[4];
-            tempMagic[0] = rsaBlob[0]; tempMagic[1] = rsaBlob[1]; tempMagic[2] = rsaBlob[2]; tempMagic[3] = rsaBlob[3];
-            KeyBlobMagicNumber magic = (KeyBlobMagicNumber)BitConverter.ToInt32(tempMagic, 0);
+            KeyBlobMagicNumber magic = (KeyBlobMagicNumber)BitConverter.ToInt32(rsaBlob, 0);
 
             // Check the magic value in the key blob header. If the blob does not have the required magic,
             // then throw a CryptographicException.


### PR DESCRIPTION
RSACng.ExportParameters was copying the first 4 bytes of the key blob to a
second array.  But since it didn't change the byte ordering this is the same as
just calling BitConverter with the original array.

One allocation and 5 assignments that were just simply not needed.

Good eye, @justinvp.
cc: @stephentoub @AtsushiKan 