### PR TITLE
Allow CurlHandler to opt-in to NTLM via CredentialCache

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Easy.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Http.Native/Interop.Easy.cs
@@ -153,6 +153,7 @@ internal static partial class Interop
             Basic = 1 << 0,
             Digest = 1 << 1,
             Negotiate = 1 << 2,
+            NTLM = 1 << 3,
         }
 
         // Enum for constants defined for the enum curl_proxytype in curl.h

--- a/src/Native/System.Net.Http.Native/pal_easy.cpp
+++ b/src/Native/System.Net.Http.Native/pal_easy.cpp
@@ -56,6 +56,7 @@ static_assert(PAL_CURLAUTH_None == CURLAUTH_NONE, "");
 static_assert(PAL_CURLAUTH_Basic == CURLAUTH_BASIC, "");
 static_assert(PAL_CURLAUTH_Digest == CURLAUTH_DIGEST, "");
 static_assert(PAL_CURLAUTH_Negotiate == CURLAUTH_GSSNEGOTIATE, "");
+static_assert(PAL_CURLAUTH_NTLM == CURLAUTH_NTLM, "");
 
 static_assert(PAL_CURLPROXY_HTTP == CURLPROXY_HTTP, "");
 

--- a/src/Native/System.Net.Http.Native/pal_easy.h
+++ b/src/Native/System.Net.Http.Native/pal_easy.h
@@ -88,6 +88,7 @@ enum PAL_CURLAUTH : int64_t
     PAL_CURLAUTH_Basic = 1 << 0,
     PAL_CURLAUTH_Digest = 1 << 1,
     PAL_CURLAUTH_Negotiate = 1 << 2,
+    PAL_CURLAUTH_NTLM = 1 << 3,
 };
 
 enum PAL_CURLPROXYTYPE : int32_t

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.EasyRequest.cs
@@ -40,8 +40,6 @@ namespace System.Net.Http
             internal SafeCurlHandle _easyHandle;
             private SafeCurlSListHandle _requestHeaders;
 
-            internal NetworkCredential _networkCredential;
-
             internal MultiAgent _associatedMultiAgent;
             internal SendTransferState _sendTransferState;
             internal bool _isRedirect = false;
@@ -90,7 +88,7 @@ namespace System.Net.Http
                 SetVersion();
                 SetDecompressionOptions();
                 SetProxyOptions(_requestMessage.RequestUri);
-                SetCredentialsOptions(_handler.GetNetworkCredentials(_handler._serverCredentials, _requestMessage.RequestUri));
+                SetCredentialsOptions(_handler.GetCredentials(_requestMessage.RequestUri));
                 SetCookieOption(_requestMessage.RequestUri);
                 SetRequestHeaders();
                 SetSslOptions();
@@ -320,7 +318,7 @@ namespace System.Net.Http
                 SetCurlOption(CURLoption.CURLOPT_PROXYPORT, proxyUri.Port);
                 EventSourceTrace("Proxy: {0}", proxyUri);
 
-                KeyValuePair<NetworkCredential, CURLAUTH> credentialScheme = GetCredentials(_handler.Proxy.Credentials, _requestMessage.RequestUri);
+                KeyValuePair<NetworkCredential, CURLAUTH> credentialScheme = GetCredentials(_requestMessage.RequestUri, _handler.Proxy.Credentials, AuthTypesPermittedByCredentialKind(_handler.Proxy.Credentials));
                 NetworkCredential credentials = credentialScheme.Key;
                 if (credentials == CredentialCache.DefaultCredentials)
                 {
@@ -347,7 +345,6 @@ namespace System.Net.Http
             {
                 if (credentialSchemePair.Key == null)
                 {
-                    _networkCredential = null;
                     return;
                 }
 
@@ -365,7 +362,6 @@ namespace System.Net.Http
                 }
 
                 EventSourceTrace("Credentials set.");
-                _networkCredential = credentials;
             }
 
             internal void SetCookieOption(Uri uri)

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.MultiAgent.cs
@@ -518,13 +518,16 @@ namespace System.Net.Http
 
                 if (completedOperation._responseMessage.StatusCode != HttpStatusCode.Unauthorized)
                 {
+                    // If preauthentication is enabled, then we want to transfer credentials to the handler's credential cache.
+                    // That entails asking the easy operation which auth types are supported, and then giving that info to the
+                    // handler, which along with the request URI and its server credentials will populate the cache appropriately.
                     if (completedOperation._handler.PreAuthenticate)
                     {
                         long authAvailable;
                         if (Interop.Http.EasyGetInfoLong(completedOperation._easyHandle, CURLINFO.CURLINFO_HTTPAUTH_AVAIL, out authAvailable) == CURLcode.CURLE_OK)
                         {
-                            completedOperation._handler.AddCredentialToCache(
-                               completedOperation._requestMessage.RequestUri, (CURLAUTH)authAvailable, completedOperation._networkCredential);
+                            completedOperation._handler.TransferCredentialsToCache(
+                                completedOperation._requestMessage.RequestUri, (CURLAUTH)authAvailable);
                         }
                         // Ignore errors: no need to fail for the sake of putting the credentials into the cache
                     }


### PR DESCRIPTION
libcurl supports four auth types (Negotiate, NTLM, Digest, and Basic), but today our CurlHandler implementation only enables three (Negotiate, Digest, and Basic), with NTLM explicitly disabled to match what was done in WinHttpHandler in corefx (the full framework enables it).

However, there are a few key differences that need to be taken into account for CurlHandler. For example, popular implementations of gssapi and Negotiate on Unix do not include implementations for fallback to NTLM.  So whereas including “Negotiate” in WinHttpHandler often allows code on Windows to use NTLM if Kerberos is not available, the current state of CurlHandler often does not.  And although NTLM has some known issues, if it's the only option for a scenario where a Unix front-end needs to communicate with a Windows back-end (say because the front-end doesn't have Kerberos infrastructure available and the back-end only has Windows authentication enabled), we still want it to be possible for a developer to write an app that communicates with that back-end: the underlying platform supports it, so if the developer explicitly wants it, CurlHandler sitting in the middle shouldn't get in the way.

As such, this commit enables NTLM to be used, essentially removing the blocking of it that was previously done.  However, it's not enabled by default for arbitrary credentials; rather, it's only enabled when a credential added to a CredentialCache explicitly specifies "NTLM".  That way, it's available for a dev to opt-in to if desired, but just providing a NetworkCredential to CurlHandler will not use NTLM.

cc: @bartonjs, @davidsh, @cipop, @kapilash, @chrisrpatterson, @ericeil 