### PR TITLE
Exception Format Bug

### DIFF
--- a/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.GssApiException.cs
+++ b/src/Common/src/Interop/Unix/System.Net.Security.Native/Interop.GssApiException.cs
@@ -38,7 +38,7 @@ internal static partial class Interop
 
                 return (majorError != null && minorError != null) ?
                     SR.Format(SR.net_gssapi_operation_failed_detailed, majorError, minorError) :
-                    SR.Format(SR.net_gssapi_operation_failed, majorStatus.ToString("x8"), minorStatus.ToString("x8"));
+                    SR.Format(SR.net_gssapi_operation_failed, majorStatus.ToString("x"), minorStatus.ToString("x"));
             }
 
             private static string GetGssApiDisplayStatus(Status status, bool isMinor)


### PR DESCRIPTION
A bug in the exception formatter results in format exception,  there by giving wrong message in case of exceptions.

This PR attempts to fix the issue.

cc @stephentoub , @vijaykota @shrutigarg 