### PR TITLE
Add clarifying comments and asserts in Unix SSL Disconnect

### DIFF
--- a/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
@@ -61,6 +61,13 @@ internal static partial class Interop
 
                 Ssl.SetProtocolOptions(innerContext, protocols);
 
+                // The logic in SafeSslHandle.Disconnect is simple because we are doing a quiet
+                // shutdown (we aren't negotating for session close to enable later session
+                // restoration).
+                //
+                // If you find yourself wanting to remove this line to enable bidirectional
+                // close-notify, you'll probably need to rewrite SafeSslHandle.Disconnect().
+                // https://www.openssl.org/docs/manmaster/ssl/SSL_shutdown.html
                 Ssl.SslCtxSetQuietShutdown(innerContext);
 
                 Ssl.SetEncryptionPolicy(innerContext, policy);


### PR DESCRIPTION
The code could be written like

```C#
ret = SslShutdown();

while (ret != 1)
{
    if (ret != 0)
    {
        errorCode = SslGetError();

        switch (errorCode)
        {
            case WANT_READ:
            case WANT_WRITE:
            case WANT_ASYNC:
                // the answer is just "try again".
                break;
            default:
                throw new SslException();
        }
    }

    ret = SslShutdown();
}
```

But that would all be untestable code, because we set quiet shutdown unconditionally, so it always returns 1 on the first call.

Instead, just added comments, removed the error handling stub, and added an assert that it wasn't needed.

Fixes #4031.
cc: @eerhardt 
fyi: @ericeil 