### PR TITLE
Add ip_mreq support for NetBSD

### DIFF
--- a/src/Native/Common/pal_config.h.in
+++ b/src/Native/Common/pal_config.h.in
@@ -34,6 +34,7 @@
 #cmakedefine01 HAVE_ICANON
 #cmakedefine01 HAVE_TCSANOW
 #cmakedefine01 HAVE_IN_PKTINFO
+#cmakedefine01 HAVE_IP_MREQN
 #cmakedefine01 HAVE_TCP_VAR_H
 #cmakedefine01 HAVE_RT_MSGHDR
 #cmakedefine01 HAVE_LINUX_RTNETLINK_H

--- a/src/Native/configure.cmake
+++ b/src/Native/configure.cmake
@@ -27,6 +27,11 @@ check_type_size(
     "struct in_pktinfo"
     HAVE_IN_PKTINFO
     BUILTIN_TYPES_ONLY)
+
+check_type_size(
+    "struct ip_mreqn"
+    HAVE_IP_MREQN
+    BUILTIN_TYPES_ONLY)
 set(CMAKE_EXTRA_INCLUDE_FILES) # reset CMAKE_EXTRA_INCLUDE_FILES
 # /in_pktinfo
 


### PR DESCRIPTION
NetBSD supports `struct ip_mreq` for multicast requests instead of
`ip_mreqn`. This change feature detects this reality and adds modifies
the related code.