### PR TITLE
Allow IPv4 Loopback for DualModeConnect_AcceptAsync sockets tests

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -22,6 +22,12 @@ namespace System.Net.Sockets.Tests
 
         private readonly ITestOutputHelper _log;
 
+        private static IPAddress[] ValidIPv6Loopbacks = new IPAddress[] {
+            new IPAddress(new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 127, 0, 0, 1 }, 0),  // ::127.0.0.1
+            IPAddress.Loopback.MapToIPv6(),                                                     // ::ffff:127.0.0.1
+            IPAddress.IPv6Loopback                                                              // ::1
+        };
+
         public DualMode(ITestOutputHelper output)
         {
             _log = TestLogging.GetInstance();
@@ -336,7 +342,10 @@ namespace System.Net.Sockets.Tests
                 Assert.NotNull(clientSocket);
                 Assert.True(clientSocket.Connected);
                 Assert.Equal(AddressFamily.InterNetworkV6, clientSocket.AddressFamily);
-                Assert.Equal(connectTo.MapToIPv6(), ((IPEndPoint)clientSocket.LocalEndPoint).Address);
+                if (connectTo == IPAddress.Loopback)
+                    Assert.Contains(((IPEndPoint)clientSocket.LocalEndPoint).Address, ValidIPv6Loopbacks);
+                else
+                    Assert.Equal(connectTo.MapToIPv6(), ((IPEndPoint)clientSocket.LocalEndPoint).Address);
                 clientSocket.Dispose();
             }
         }


### PR DESCRIPTION
Some sockets tests were connecting with the IPv4 loopback address and asserting that the connected IPv6 address was equivalent to the IPv4 loopback mapped to IPv6 (ffff:127.0.0.1). However, a non-mapped IPv4 loopback (127.0.01) is still supported on some platforms so the test needs to accommodate that case as it is still a valid loopback address.

resolves #4829 

@ericeil 