### PR TITLE
Fixing #2279 to make the Linux FSW ignore root folder changes

### DIFF
--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
@@ -572,6 +572,13 @@ namespace System.IO
                             expandedName = associatedDirectoryEntry.GetPath(true, nextEvent.name);
                         }
 
+                        // To match Windows, ignore all changes that happen on the root folder itself
+                        if (string.IsNullOrEmpty(expandedName))
+                        {
+                            watcher = null;
+                            continue;
+                        }
+
                         // Determine whether the affected object is a directory (rather than a file).
                         // If it is, we may need to do special processing, such as adding a watch for new 
                         // directories if IncludeSubdirectories is enabled.  Since we're only watching

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Changed.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Changed.cs
@@ -250,4 +250,22 @@ public class ChangedTests
             Utility.ExpectNoEvent(are, "symlink'd file change");
         }
     }
+
+    [Fact]
+    public static void FileSystemWatcher_Changed_RootFolderChangeDoesNotFireEvent()
+    {
+       using (var dir = Utility.CreateTestDirectory())
+       using (var watcher = new FileSystemWatcher())
+       {
+          AutoResetEvent are = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);
+
+          // Setup the watcher
+          watcher.Path = Path.GetFullPath(dir.Path);
+          watcher.Filter = "*";
+          watcher.EnableRaisingEvents = true;
+
+          Directory.SetLastWriteTime(dir.Path, DateTime.Now.AddSeconds(10));
+          Utility.ExpectNoEvent(are, "Root Directory Change");
+       }
+    }          
 }


### PR DESCRIPTION
Fixing #2279 to make the Linux FSW ignore root folder changes. The Windows FSW does not send change notifications about the root folder due to API limitations; #4781 brought parity to the OS X FSW and this PR will fix the Linux FSW. 

@stephentoub 