### PR TITLE
Re-enable WaitForPeerProcess test

### DIFF
--- a/src/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
+++ b/src/System.Diagnostics.Process/tests/ProcessWaitingTests.cs
@@ -122,7 +122,6 @@ namespace System.Diagnostics.Tests
             }
         }
 
-        [ActiveIssue(5780, PlatformID.AnyUnix)]
         [Fact]
         public void WaitForPeerProcess()
         {


### PR DESCRIPTION
Closes https://github.com/dotnet/corefx/issues/5780
Fixed by https://github.com/dotnet/coreclr/pull/3110