### PR TITLE
Removed sealed from PhoneAttribute.cs

### DIFF
--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/PhoneAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/PhoneAttribute.cs
@@ -7,7 +7,7 @@ namespace System.ComponentModel.DataAnnotations
 {
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter,
         AllowMultiple = false)]
-    public sealed class PhoneAttribute : DataTypeAttribute
+    public class PhoneAttribute : DataTypeAttribute
     {
         // see unit tests for examples
         private static readonly Regex _regex =

--- a/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
+++ b/src/System.Diagnostics.Process/src/System/Diagnostics/ProcessManager.Linux.cs
@@ -67,11 +67,6 @@ namespace System.Diagnostics
             }
 
             // Return the set of modules found
-            if (modules.Count == 0)
-            {
-                // Match Windows behavior when failing to enumerate modules
-                throw new Win32Exception(SR.EnumProcessModuleFailed);
-            }
             return modules.ToArray();
         }
 


### PR DESCRIPTION
Removed sealed from PhoneAttribute.cs and the class can be inherited now.