### PR TITLE
InnerSafeCloseSocket.SetNonBlocking should access the AsyncContext property

### DIFF
--- a/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
@@ -118,7 +118,7 @@ namespace System.Net.Sockets
 
             public void SetNonBlocking()
             {
-                _asyncContext.SetNonBlocking();
+                AsyncContext.SetNonBlocking();
             }
 
             public SocketAsyncContext AsyncContext


### PR DESCRIPTION
InnerSafeCloseSocket.SetNonBlocking should access the AsyncContext property, rather than using _asyncContext directly.  _asyncContext might not be initialized yet.  This causes a NullReferenceException if setting the socket to non-blocking before some other operation has initialized the AsyncContext.