### PR TITLE
Fixed a bug in XmlUTF8NodeWriter which caused EncoderFallbackException

### DIFF
--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlUTF8TextWriter.cs
@@ -101,7 +101,7 @@ namespace System.Xml
         new public void SetOutput(Stream stream, bool ownsStream, Encoding encoding)
         {
             Encoding utf8Encoding = null;
-            if (encoding != null && encoding == Encoding.UTF8)
+            if (encoding != null && encoding.CodePage == Encoding.UTF8.CodePage)
             {
                 utf8Encoding = encoding;
                 encoding = null;

--- a/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/XmlDictionaryWriterTest.cs
@@ -115,6 +115,26 @@ public static class XmlDictionaryWriterTest
         }
     }
 
+    [Fact]
+    public static void XmlDictionaryWriter_InvalidUnicodeChar()
+    {
+        using (var ms = new MemoryStream())
+        {
+            var writer = XmlDictionaryWriter.CreateTextWriter(ms);
+            writer.WriteStartDocument();
+            writer.WriteStartElement("data");
+
+            // This is an invalid char. Writing this char shouldn't
+            // throw exception.
+            writer.WriteString("\uDB1B");
+
+            writer.WriteEndElement();
+            writer.WriteEndDocument();
+            writer.Flush();
+            ms.Position = 0;            
+        }
+    }
+
     private static byte[] GetByteArray(int byteSize)
     {
         var bytes = new byte[byteSize];


### PR DESCRIPTION
The fix is ported form Desktop. Most of the fix had already been ported, but there still is a bug in the current code.

Fixed #6076