### PR TITLE
Temporary removing Microsoft.VisualBasic.Tests.csproj from the tests builds

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-1.0.25-prerelease-00167
+1.0.25-prerelease-00169

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/FileUtil.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/FileUtil.cs
@@ -3,17 +3,18 @@
 // See the LICENSE file in the project root for more information.
 
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace System.Net.NetworkInformation.Tests
 {
     internal static class FileUtil
     {
+        /// <summary>
+        /// I'm storing the test text assets with their original line endings ('\n').
+        /// The parsing logic depends on Environment.NewLine, so we normalize beforehand.
+        /// </summary>
         public static void NormalizeLineEndings(string source, string normalizedDest)
         {
-            // I'm storing the test text assets with their original line endings ('\n').
-            // The parsing logic depends on Environment.NewLine, so we normalize beforehand.
-            string contents = File.ReadAllText(source);
+            string contents = File.ReadAllText(TestFile(source));
             if (Environment.NewLine == "\r\n")
             {
                 if (!contents.Contains(Environment.NewLine))
@@ -30,6 +31,15 @@ namespace System.Net.NetworkInformation.Tests
             }
 
             File.WriteAllText(normalizedDest, contents);
+        }
+
+        /// <summary>
+        /// Gets a path to the desired test file
+        /// </summary>
+        /// <returns>The correct path to a valid test file</returns>
+        public static string TestFile(string source)
+        {
+            return Path.Combine("NetworkFiles", source);
         }
     }
 }

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/MiscParsingTests.cs
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/MiscParsingTests.cs
@@ -27,27 +27,27 @@ namespace System.Net.NetworkInformation.Tests
         [Fact]
         public static void RawIntFileParsing()
         {
-            int val = StringParsingHelpers.ParseRawIntFile("rawint");
+            int val = StringParsingHelpers.ParseRawIntFile(FileUtil.TestFile("rawint"));
             Assert.Equal(12, val);
 
-            int max = StringParsingHelpers.ParseRawIntFile("rawint_maxvalue");
+            int max = StringParsingHelpers.ParseRawIntFile(FileUtil.TestFile("rawint_maxvalue"));
             Assert.Equal(int.MaxValue, max);
         }
 
         [Fact]
         public static void RawLongFileParsing()
         {
-            long val = StringParsingHelpers.ParseRawLongFile("rawlong");
+            long val = StringParsingHelpers.ParseRawLongFile(FileUtil.TestFile("rawlong"));
             Assert.Equal(3147483647L, val);
 
-            long max = StringParsingHelpers.ParseRawLongFile("rawlong_maxvalue");
+            long max = StringParsingHelpers.ParseRawLongFile(FileUtil.TestFile("rawlong_maxvalue"));
             Assert.Equal(long.MaxValue, max);
         }
 
         [Fact]
         public static void RawHexIntParsing()
         {
-            int val = StringParsingHelpers.ParseRawHexFileAsInt("rawhexint");
+            int val = StringParsingHelpers.ParseRawHexFileAsInt(FileUtil.TestFile("rawhexint"));
             Assert.Equal(10, val);
         }
     }

--- a/src/System.Net.NetworkInformation/tests/FunctionalTests/System.Net.NetworkInformation.Functional.Tests.csproj
+++ b/src/System.Net.NetworkInformation/tests/FunctionalTests/System.Net.NetworkInformation.Functional.Tests.csproj
@@ -91,66 +91,64 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="NetworkFiles\rawhexint">
+    <Content Include="NetworkFiles\rawint">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="NetworkFiles\rawlong">
+    </Content>
+    <Content Include="NetworkFiles\rawhexint">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="NetworkFiles\rawint_maxvalue">
+    </Content>
+    <Content Include="NetworkFiles\rawlong">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="NetworkFiles\rawlong_maxvalue">
+    </Content>
+    <Content Include="NetworkFiles\rawint_maxvalue">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="NetworkFiles\resolv.conf">
+    </Content>
+    <Content Include="NetworkFiles\rawlong_maxvalue">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="NetworkFiles\smb.conf">
+    </Content>
+    <Content Include="NetworkFiles\resolv.conf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="NetworkFiles\dev">
+    </Content>
+    <Content Include="NetworkFiles\smb.conf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="NetworkFiles\ipv6_route">
+    </Content>
+    <Content Include="NetworkFiles\dev">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="NetworkFiles\route">
+    </Content>
+    <Content Include="NetworkFiles\ipv6_route">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="NetworkFiles\snmp">
+    </Content>
+    <Content Include="NetworkFiles\route">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="NetworkFiles\snmp6">
+    </Content>
+    <Content Include="NetworkFiles\snmp">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="NetworkFiles\sockstat">
+    </Content>
+    <Content Include="NetworkFiles\snmp6">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="NetworkFiles\sockstat6">
+    </Content>
+    <Content Include="NetworkFiles\sockstat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="NetworkFiles\tcp">
+    </Content>
+    <Content Include="NetworkFiles\sockstat6">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="NetworkFiles\tcp6">
+    </Content>
+    <Content Include="NetworkFiles\tcp">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="NetworkFiles\udp">
+    </Content>
+    <Content Include="NetworkFiles\tcp6">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="NetworkFiles\udp6">
+    </Content>
+    <Content Include="NetworkFiles\udp">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="NetworkFiles\dhclient.leases">
+    </Content>
+    <Content Include="NetworkFiles\udp6">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    </Content>
+    <Content Include="NetworkFiles\dhclient.leases">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <None Include="project.json" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="NetworkFiles\rawint">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Reflection.TypeExtensions/tests/CoreCLR/System.Reflection.TypeExtensions.CoreCLR.Tests.csproj
+++ b/src/System.Reflection.TypeExtensions/tests/CoreCLR/System.Reflection.TypeExtensions.CoreCLR.Tests.csproj
@@ -15,9 +15,10 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="..\..\..\Common\tests\Data\TinyAssembly.dll">
+    <None Include="..\..\..\Common\tests\Data\TinyAssembly.dll">
       <Link>Module\TinyAssembly.dll</Link>
-    </Content>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/tests.builds
+++ b/src/tests.builds
@@ -2,7 +2,8 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <ItemGroup>
-    <Project Include="*\test*\**\*.csproj">
+    <ExcludeProjects Condition="'$(OSEnvironment)'!='Windows_NT'" Include="**\Microsoft.VisualBasic.Tests.csproj" />
+    <Project Include="*\test*\**\*.csproj" Exclude="@(ExcludeProjects)">
       <OSGroup Condition="'$(FilterToOSGroup)'!=''">$(FilterToOSGroup)</OSGroup>
     </Project>
     <Project Include="*\test*\**\*.vbproj" Condition="'$(IncludeVbProjects)'!='false'">


### PR DESCRIPTION
Because of Microsoft/MSBuild#137 Microsoft.VisualBasic.vbproj can't be built in Unix so it has been disabled for some time. Now we have a build break because even though the product side project build is being disabled, the test build is trying to build the project again, causing the build to fail. This change temporarily disables the VisualBasic test project from building.

cc: @weshaggard @sokket 