### PR TITLE
Fix build on NetBSD: Retire check for <alloca.h> it's not portable

### DIFF
--- a/src/Native/Common/pal_config.h.in
+++ b/src/Native/Common/pal_config.h.in
@@ -20,7 +20,6 @@
 #cmakedefine01 HAVE_SCHED_SETAFFINITY
 #cmakedefine01 HAVE_FDS_BITS
 #cmakedefine01 HAVE_PRIVATE_FDS_BITS
-#cmakedefine01 HAVE_ALLOCA_H
 #cmakedefine01 HAVE_STATFS
 #cmakedefine01 HAVE_EPOLL
 #cmakedefine01 HAVE_KQUEUE

--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -6,9 +6,7 @@
 #include "pal_networking.h"
 #include "pal_utilities.h"
 
-#if HAVE_ALLOCA_H
-#include <alloca.h>
-#endif
+#include <stdlib.h>
 #include <arpa/inet.h>
 #include <assert.h>
 #if HAVE_EPOLL

--- a/src/Native/configure.cmake
+++ b/src/Native/configure.cmake
@@ -35,10 +35,6 @@ check_type_size(
 set(CMAKE_EXTRA_INCLUDE_FILES) # reset CMAKE_EXTRA_INCLUDE_FILES
 # /in_pktinfo
 
-check_include_files(
-    alloca.h
-    HAVE_ALLOCA_H)
-
 check_function_exists(
     stat64
     HAVE_STAT64)


### PR DESCRIPTION
NetBSD requires `<stdlib.h>` for `alloca`(3).

Other supported operating systems are satisfied with `<stdlib.h>` as well.