### PR TITLE
Enable Console.CursorTop/Left even when terminfo missing CPR string

### DIFF
--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -311,9 +311,7 @@ namespace System
                 return;
 
             // Get the cursor position request format string.
-            string cpr = TerminalFormatStrings.Instance.CursorPositionRequest;
-            if (string.IsNullOrEmpty(cpr))
-                return;
+            Debug.Assert(!string.IsNullOrEmpty(TerminalFormatStrings.CursorPositionReport));
 
             // Synchronize with all other stdin readers.  We need to do this in case multiple threads are
             // trying to read/write concurrently, and to minimize the chances of resulting conflicts.
@@ -322,8 +320,8 @@ namespace System
             // one thread's get_CursorLeft/Top from providing input to the other's Console.Read*.
             lock (StdInReader) 
             {
-                // Write out the cursor position request.
-                WriteStdoutAnsiString(cpr);
+                // Write out the cursor position report request.
+                WriteStdoutAnsiString(TerminalFormatStrings.CursorPositionReport);
 
                 // Read the response.  There's a race condition here if the user is typing,
                 // or if other threads are accessing the console; there's relatively little
@@ -658,14 +656,15 @@ namespace System
             public readonly string CursorAddress;
             /// <summary>The format string to use to move the cursor to the left.</summary>
             public readonly string CursorLeft;
-            /// <summary>The format string for "user string 7", interpreted to be a cursor position request.</summary>
+            /// <summary>The ANSI-compatible string for the Cursor Position report request.</summary>
             /// <remarks>
-            /// This should be <see cref="KnownCursorPositionRequest"/>, but we use the format string as a way to 
-            /// guess whether the terminal will actually support the request/response protocol.
+            /// This should really be in user string 7 in the terminfo file, but some terminfo databases
+            /// are missing it.  As this is defined to be supported by any ANSI-compatible terminal,
+            /// we assume it's available; doing so means CursorTop/Left will work even if the terminfo database
+            /// doesn't contain it (as appears to be the case with e.g. screen and tmux on Ubuntu), at the risk
+            /// of outputting the sequence on some terminal that's not compatible.
             /// </remarks>
-            public readonly string CursorPositionRequest;
-            /// <summary>Well-known CPR format.</summary>
-            private const string KnownCursorPositionRequest = "\x1B[6n";
+            public const string CursorPositionReport = "\x1B[6n";
             /// <summary>
             /// The dictionary of keystring to ConsoleKeyInfo.
             /// Only some members of the ConsoleKeyInfo are used; in particular, the actual char is ignored.
@@ -698,9 +697,9 @@ namespace System
 
                 Title = GetTitle(db);
 
-                CursorPositionRequest = db.GetString(TermInfo.WellKnownStrings.CursorPositionRequest) == KnownCursorPositionRequest ?
-                    KnownCursorPositionRequest :
-                    string.Empty;
+                Debug.WriteLineIf(db.GetString(TermInfo.WellKnownStrings.CursorPositionReport) != CursorPositionReport,
+                    "Getting the cursor position will only work if the terminal supports the CPR sequence," +
+                    "but the terminfo database does not contain an entry for it.");
 
                 int maxColors = db.GetNumber(TermInfo.WellKnownNumbers.MaxColors);
                 MaxColors = // normalize to either the full range of all ANSI colors, just the dark ones, or none

--- a/src/System.Console/src/System/TermInfo.cs
+++ b/src/System.Console/src/System/TermInfo.cs
@@ -26,7 +26,7 @@ namespace System
             Clear = 5,
             CursorAddress = 10,
             CursorLeft = 14,
-            CursorPositionRequest = 294,
+            CursorPositionReport = 294,
             OrigPairs = 297,
             OrigColors = 298,
             SetAnsiForeground = 359,


### PR DESCRIPTION
We currently require the terminfo database to have the cursor position report string in order for Console.CursorTop/Left to work correctly.  However, some terminfo database files don't contain the relevant string even though they support the sequence.  Since it's meant to be supported by any ANSI-compatible terminal, this commit simply changes it to assume it'll work.

Fixes #6091 
cc: @pallavit, @andschwa 