### PR TITLE
Add the GetColumnSchema API to SqlDataReader

### DIFF
--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -47,6 +47,7 @@
     <Compile Include="System\Data\OperationAbortedException.cs" />
     <Compile Include="System\Data\RecordsAffectedEventArgs.cs" />
     <Compile Include="System\Data\RecordsAffectedEventHandler.cs" />
+    <Compile Include="System\Data\SqlClient\SqlDbColumn.cs" />
     <Compile Include="System\Data\SqlDbType.cs" />
     <Compile Include="System\Data\Common\ActivityCorrelator.cs" />
     <Compile Include="System\Data\Common\AdapterUtil.cs" />
@@ -173,6 +174,11 @@
   <ItemGroup Condition="'$(TargetGroup)' == 'net45'">
     <TargetingPackReference Include="mscorlib" />
     <TargetingPackReference Include="System.Data" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\System.Data.Common\src\System.Data.Common.csproj">
+      <Name>System.Data.Common</Name>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.csproj
@@ -176,11 +176,6 @@
     <TargetingPackReference Include="System.Data" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\System.Data.Common\src\System.Data.Common.csproj">
-      <Name>System.Data.Common</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
@@ -4620,7 +4620,7 @@ namespace System.Data.SqlClient
             for (int i = 0; i < md.Length; i++)
             {
                 _SqlMetaData col = md[i];
-                SqlDbColumn dbColumn = new SqlDbColumn(md[i], _browseModeInfoConsumed);
+                SqlDbColumn dbColumn = new SqlDbColumn(md[i]);
                 
                 if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && col.IsNewKatmaiDateTimeType)
                 {
@@ -4633,6 +4633,14 @@ namespace System.Data.SqlClient
                 else
                 {
                     dbColumn.SqlNumericScale = col.metaType.Scale;
+                }
+
+                if (_browseModeInfoConsumed)
+                {
+                    dbColumn.SqlIsAliased = col.isDifferentName;
+                    dbColumn.SqlIsKey = col.isKey;
+                    dbColumn.SqlIsHidden = col.isHidden;
+                    dbColumn.SqlIsExpression = col.isExpression;
                 }
 
                 dbColumn.SqlDataType = GetFieldTypeInternal(col);

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
@@ -18,10 +18,12 @@ using System.Xml;
 
 using Microsoft.SqlServer.Server;
 using System.Threading.Tasks;
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
 
 namespace System.Data.SqlClient
 {
-    public class SqlDataReader : DbDataReader
+    public class SqlDataReader : DbDataReader, IDbColumnSchemaGenerator
     {
         private enum ALTROWSTATUS
         {
@@ -68,6 +70,7 @@ namespace System.Data.SqlClient
         private CommandBehavior _commandBehavior;
 
         private static int s_objectTypeCount; // Bid counter
+        private readonly static ReadOnlyCollection<DbColumn> s_emptySchema = new ReadOnlyCollection<DbColumn>(Array.Empty<DbColumn>());
         internal readonly int ObjectID = System.Threading.Interlocked.Increment(ref s_objectTypeCount);
 
         // metadata (no explicit table, use 'Table')
@@ -4580,6 +4583,66 @@ namespace System.Data.SqlClient
         {
             Debug.Assert(false, "TdsParser should have thrown on UDT");
             return SQL.UnsupportedFeatureAndToken(_parser.Connection, SqlDbType.Udt.ToString());
+        }
+
+        public ReadOnlyCollection<DbColumn> GetColumnSchema()
+        {
+            SqlStatistics statistics = null;
+            try
+            {
+                statistics = SqlStatistics.StartTimer(Statistics);
+                if (null == _metaData || null == _metaData.dbColumnSchema)
+                {
+                    if (null != this.MetaData)
+                    {
+
+                        _metaData.dbColumnSchema = BuildColumnSchema();
+                        Debug.Assert(null != _metaData.dbColumnSchema, "No schema information yet!");
+                        // filter table?
+                    }
+                }
+                if (null != _metaData)
+                {
+                    return _metaData.dbColumnSchema;
+                }
+                return s_emptySchema;
+            }
+            finally
+            {
+                SqlStatistics.StopTimer(statistics);
+            }
+        }
+
+        private ReadOnlyCollection<DbColumn> BuildColumnSchema()
+        {
+            _SqlMetaDataSet md = MetaData;
+            DbColumn[] columnSchema = new DbColumn[md.Length];
+            for (int i = 0; i < md.Length; i++)
+            {
+                _SqlMetaData col = md[i];
+                SqlDbColumn dbColumn = new SqlDbColumn(md[i], _browseModeInfoConsumed);
+                
+                if (_typeSystem <= SqlConnectionString.TypeSystem.SQLServer2005 && col.IsNewKatmaiDateTimeType)
+                {
+                    dbColumn.SqlNumericScale = MetaType.MetaNVarChar.Scale;
+                }
+                else if (TdsEnums.UNKNOWN_PRECISION_SCALE != col.scale)
+                {
+                    dbColumn.SqlNumericScale = col.scale;
+                }
+                else
+                {
+                    dbColumn.SqlNumericScale = col.metaType.Scale;
+                }
+
+                dbColumn.SqlDataType = GetFieldTypeInternal(col);
+
+                dbColumn.SqlDataTypeName = GetDataTypeNameInternal(col);
+
+                columnSchema[i] = dbColumn;
+            }
+
+            return new ReadOnlyCollection<DbColumn>(columnSchema);
         }
     }// SqlDataReader
 }// namespace

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDbColumn.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDbColumn.cs
@@ -1,0 +1,95 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+
+using System.Data.Common;
+
+namespace System.Data.SqlClient
+{
+    internal class SqlDbColumn : DbColumn
+    {
+        private readonly bool _isBrowseModeInfoConsumed;
+        private readonly _SqlMetaData _metadata;
+
+        internal SqlDbColumn(_SqlMetaData md, bool isBrowseModeInfoConsumed)
+        {
+            _metadata = md;
+            _isBrowseModeInfoConsumed = isBrowseModeInfoConsumed;
+            Populate();
+        }
+
+        private void Populate()
+        {
+            AllowDBNull = _metadata.isNullable;
+            BaseCatalogName = _metadata.catalogName;
+            BaseColumnName = _metadata.baseColumn;
+            BaseSchemaName = _metadata.schemaName;
+            BaseServerName = _metadata.serverName;
+            BaseTableName = _metadata.tableName;
+            ColumnName = _metadata.column;
+            ColumnOrdinal = _metadata.ordinal;
+            ColumnSize = (_metadata.metaType.IsSizeInCharacters && (_metadata.length != 0x7fffffff)) ? (_metadata.length / 2) : _metadata.length;
+
+            if (_isBrowseModeInfoConsumed)
+            {
+                IsAliased = _metadata.isDifferentName;
+                IsKey = _metadata.isKey;
+                IsHidden = _metadata.isHidden;
+                IsExpression = _metadata.isExpression;
+            }
+
+            IsAutoIncrement = _metadata.isIdentity;
+            IsIdentity = _metadata.isIdentity;
+            IsLong = _metadata.metaType.IsLong;
+
+            if (SqlDbType.Timestamp == _metadata.type)
+            {
+                IsUnique = true;
+            }
+            else
+            {
+                IsUnique = false;
+            }
+
+            if (TdsEnums.UNKNOWN_PRECISION_SCALE != _metadata.precision)
+            {
+                NumericPrecision = _metadata.precision;
+            }
+            else
+            {
+                NumericPrecision = _metadata.metaType.Precision;
+            }
+
+            IsReadOnly = (0 == _metadata.updatability);
+
+            UdtAssemblyQualifiedName = null;
+
+        }
+
+        internal Type SqlDataType
+        {
+            set
+            {
+                DataType = value;
+            }
+        }
+
+        internal string SqlDataTypeName
+        {
+            set
+            {
+                DataTypeName = value;
+            }
+        }
+
+        internal int? SqlNumericScale
+        {
+            set
+            {
+                NumericScale = value;
+            }
+        }
+
+    }
+}

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDbColumn.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDbColumn.cs
@@ -9,13 +9,11 @@ namespace System.Data.SqlClient
 {
     internal class SqlDbColumn : DbColumn
     {
-        private readonly bool _isBrowseModeInfoConsumed;
         private readonly _SqlMetaData _metadata;
 
-        internal SqlDbColumn(_SqlMetaData md, bool isBrowseModeInfoConsumed)
+        internal SqlDbColumn(_SqlMetaData md)
         {
             _metadata = md;
-            _isBrowseModeInfoConsumed = isBrowseModeInfoConsumed;
             Populate();
         }
 
@@ -30,15 +28,6 @@ namespace System.Data.SqlClient
             ColumnName = _metadata.column;
             ColumnOrdinal = _metadata.ordinal;
             ColumnSize = (_metadata.metaType.IsSizeInCharacters && (_metadata.length != 0x7fffffff)) ? (_metadata.length / 2) : _metadata.length;
-
-            if (_isBrowseModeInfoConsumed)
-            {
-                IsAliased = _metadata.isDifferentName;
-                IsKey = _metadata.isKey;
-                IsHidden = _metadata.isHidden;
-                IsExpression = _metadata.isExpression;
-            }
-
             IsAutoIncrement = _metadata.isIdentity;
             IsIdentity = _metadata.isIdentity;
             IsLong = _metadata.metaType.IsLong;
@@ -65,6 +54,38 @@ namespace System.Data.SqlClient
 
             UdtAssemblyQualifiedName = null;
 
+        }
+
+        internal bool? SqlIsAliased
+        {
+            set
+            {
+                IsAliased = value;
+            }
+        }
+
+        internal bool? SqlIsKey
+        {
+            set
+            {
+                IsKey = value;
+            }
+        }
+
+        internal bool? SqlIsHidden
+        {
+            set
+            {
+                IsHidden = value;
+            }
+        }
+
+        internal bool? SqlIsExpression
+        {
+            set
+            {
+                IsExpression = value;
+            }
         }
 
         internal Type SqlDataType

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -3955,7 +3955,7 @@ namespace System.Data.SqlClient
                     {
                         return false;
                     }
-                    if (!stateObj.TrySkipBytes(len * ADP.CharSize))
+                    if (!stateObj.TryReadString(len, out col.baseColumn))
                     {
                         return false;
                     }

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserHelperClasses.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParserHelperClasses.cs
@@ -7,6 +7,7 @@
 //------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Data.Common;
 using System.Data.SqlTypes;
 using System.Diagnostics;
@@ -275,6 +276,7 @@ namespace System.Data.SqlClient
         internal bool isHidden;
         internal bool isExpression;
         internal bool isIdentity;
+        internal string baseColumn;
         internal _SqlMetaData(int ordinal) : base()
         {
             this.ordinal = ordinal;
@@ -346,6 +348,7 @@ namespace System.Data.SqlClient
         internal int[] indexMap;
         internal int visibleColumns;
         private readonly _SqlMetaData[] _metaDataArray;
+        internal ReadOnlyCollection<DbColumn> dbColumnSchema;
 
         internal _SqlMetaDataSet(int count)
         {
@@ -362,6 +365,7 @@ namespace System.Data.SqlClient
             // although indexMap is not immutable, in practice it is initialized once and then passed around
             this.indexMap = original.indexMap;
             this.visibleColumns = original.visibleColumns;
+            this.dbColumnSchema = original.dbColumnSchema;
             if (original._metaDataArray == null)
             {
                 _metaDataArray = null;


### PR DESCRIPTION
The change contains the implementation of IDbDolumnSchemaGenerator on SqlDataReader to get the columns as the API to retrieve the Columns metadata. 


This change contains the reference to System.Data.Common via the Project Reference in csproj 
Sending this PR out for Code Review and this will be complete with another commit to remove the Project Reference once System.Data.Common Nuget packages are updated.