### PR TITLE
Improve performance and metadata copying of File.Copy on Unix

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.CopyFile.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.CopyFile.cs
@@ -1,0 +1,16 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CopyFile", SetLastError = true)]
+        internal static extern int CopyFile(SafeFileHandle source, SafeFileHandle destination);
+    }
+}

--- a/src/Native/Common/pal_config.h.in
+++ b/src/Native/Common/pal_config.h.in
@@ -25,6 +25,8 @@
 #cmakedefine01 HAVE_STATFS
 #cmakedefine01 HAVE_EPOLL
 #cmakedefine01 HAVE_KQUEUE
+#cmakedefine01 HAVE_SENDFILE
+#cmakedefine01 HAVE_FCOPYFILE
 #cmakedefine01 HAVE_GETHOSTBYNAME_R
 #cmakedefine01 HAVE_GETHOSTBYADDR_R
 #cmakedefine01 HAVE_SUPPORT_FOR_DUAL_MODE_IPV4_PACKET_INFO

--- a/src/Native/System.Native/pal_io.h
+++ b/src/Native/System.Native/pal_io.h
@@ -633,6 +633,13 @@ extern "C" void SystemNative_Sync();
 extern "C" int32_t SystemNative_Write(intptr_t fd, const void* buffer, int32_t bufferSize);
 
 /**
+ * Copies all data from the source file descriptor to the destination file descriptor.
+ *
+ * Returns 0 on success; otherwise, returns -1 and sets errno.
+ */
+extern "C" int32_t SystemNative_CopyFile(intptr_t sourceFd, intptr_t destinationFd);
+
+/**
 * Initializes a new inotify instance and returns a file
 * descriptor associated with a new inotify event queue.
 *

--- a/src/Native/configure.cmake
+++ b/src/Native/configure.cmake
@@ -177,6 +177,17 @@ check_struct_has_member(
     "sys/select.h"
     HAVE_PRIVATE_FDS_BITS)
 
+check_cxx_source_compiles(
+    "
+    #include <sys/sendfile.h>
+    int main() { int i = sendfile(0, 0, 0, 0); }
+    "
+    HAVE_SENDFILE)
+
+check_function_exists(
+    fcopyfile
+    HAVE_FCOPYFILE)
+
 check_function_exists(
     epoll_create1
     HAVE_EPOLL)

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -277,6 +277,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Close.cs">
       <Link>Common\Interop\Unix\Interop.Close.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.CopyFile.cs">
+      <Link>Common\Interop\Unix\Interop.CopyFile.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.FTruncate.cs">
       <Link>Common\Interop\Unix\Interop.FTruncate.cs</Link>
     </Compile>

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -32,20 +32,11 @@ namespace System.IO
             }
 
             // Copy the contents of the file from the source to the destination, creating the destination in the process
-            const int bufferSize = FileStream.DefaultBufferSize;
-            const bool useAsync = false;
-            using (var src = new FileStream(sourceFullPath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize, useAsync))
-            using (var dst = new FileStream(destFullPath, overwrite ? FileMode.Create : FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, bufferSize, useAsync))
+            using (var src = new FileStream(sourceFullPath, FileMode.Open, FileAccess.Read, FileShare.Read, FileStream.DefaultBufferSize, FileOptions.None))
+            using (var dst = new FileStream(destFullPath, overwrite ? FileMode.Create : FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, FileStream.DefaultBufferSize, FileOptions.None))
             {
                 Interop.CheckIo(Interop.Sys.CopyFile(src.SafeFileHandle, dst.SafeFileHandle));
             }
-
-            // Now copy over relevant read/write/execute permissions from the source to the destination
-            // Use Stat (not LStat) since permissions for symbolic links are meaninless and defer to permissions on the target
-            Interop.Sys.FileStatus status;
-            Interop.CheckIo(Interop.Sys.Stat(sourceFullPath, out status), sourceFullPath);
-            int newMode = status.Mode & (int)Interop.Sys.Permissions.Mask;
-            Interop.CheckIo(Interop.Sys.ChMod(destFullPath, newMode), destFullPath);
         }
 
         public override void MoveFile(string sourceFullPath, string destFullPath)

--- a/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/UnixFileSystem.cs
@@ -24,9 +24,6 @@ namespace System.IO
 
         public override void CopyFile(string sourceFullPath, string destFullPath, bool overwrite)
         {
-            // Note: we could consider using sendfile here, but it isn't part of the POSIX spec, and
-            // has varying degrees of support on different systems.
-
             // The destination path may just be a directory into which the file should be copied.
             // If it is, append the filename from the source onto the destination directory
             if (DirectoryExists(destFullPath))
@@ -37,10 +34,10 @@ namespace System.IO
             // Copy the contents of the file from the source to the destination, creating the destination in the process
             const int bufferSize = FileStream.DefaultBufferSize;
             const bool useAsync = false;
-            using (Stream src = new FileStream(sourceFullPath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize, useAsync))
-            using (Stream dst = new FileStream(destFullPath, overwrite ? FileMode.Create : FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, bufferSize, useAsync))
+            using (var src = new FileStream(sourceFullPath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize, useAsync))
+            using (var dst = new FileStream(destFullPath, overwrite ? FileMode.Create : FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, bufferSize, useAsync))
             {
-                src.CopyTo(dst);
+                Interop.CheckIo(Interop.Sys.CopyFile(src.SafeFileHandle, dst.SafeFileHandle));
             }
 
             // Now copy over relevant read/write/execute permissions from the source to the destination

--- a/src/System.IO.FileSystem/tests/File/Copy.cs
+++ b/src/System.IO.FileSystem/tests/File/Copy.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
 using Xunit;
@@ -102,19 +103,33 @@ namespace System.IO.Tests
             Assert.Throws<ArgumentException>(() => Copy("\0", testFile));
         }
 
-        [Fact]
-        public void CopyFileWithData()
+        public static IEnumerable<object[]> CopyFileWithData_MemberData()
+        {
+            var rand = new Random();
+            foreach (int length in new[] { 0, 1, 3, 4096, 1024 * 80, 1024 * 1024 * 10 })
+            {
+                char[] data = new char[length];
+                for (int i = 0; i < data.Length; i++)
+                {
+                    data[i] = (char)rand.Next(0, 256);
+                }
+                yield return new object[] { data };
+            }
+        }
+
+        [Theory]
+        [MemberData("CopyFileWithData_MemberData")]
+        public void CopyFileWithData_MemberData(char[] data)
         {
             string testFileSource = GetTestFilePath();
             string testFileDest = GetTestFilePath();
-            char[] data = { 'a', 'A', 'b' };
 
             // Write and copy file
             using (StreamWriter stream = new StreamWriter(File.Create(testFileSource)))
             {
                 stream.Write(data, 0, data.Length);
-                stream.Flush();
             }
+
             Copy(testFileSource, testFileDest);
 
             // Ensure copy transferred written data


### PR DESCRIPTION
Adds a CopyFile function to the shim that, if possible, uses fcopyfile on OS X, sendfile on Linux, and elsewhere a manual read/write copy as we do today.

In my local tests on Linux, this often resulted in greater than 10% throughput improvements.

cc: @ellismg, @ianhays, @eerhardt 
Fixes #6083 