### PR TITLE
Fix inconsistent ToString() implementations in System.Drawing.Primitives

### DIFF
--- a/src/System.Drawing.Primitives/src/System/Drawing/PointF.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/PointF.cs
@@ -200,7 +200,7 @@ namespace System.Drawing
 
         public override string ToString()
         {
-            return "{X=" + _x.ToString() + ", Y=" + _y.ToString() + "}";
+            return "{X=" + _x.ToString() + ",Y=" + _y.ToString() + "}";
         }
     }
 }

--- a/src/System.Drawing.Primitives/src/System/Drawing/Size.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/Size.cs
@@ -239,7 +239,7 @@ namespace System.Drawing
         /// </summary>
         public override string ToString()
         {
-            return "{Width=" + _width.ToString() + ", Height=" + _height.ToString() + "}";
+            return "{Width=" + _width.ToString() + ",Height=" + _height.ToString() + "}";
         }
     }
 

--- a/src/System.Drawing.Primitives/src/System/Drawing/SizeF.cs
+++ b/src/System.Drawing.Primitives/src/System/Drawing/SizeF.cs
@@ -232,7 +232,7 @@ namespace System.Drawing
         /// </summary>
         public override string ToString()
         {
-            return "{Width=" + _width.ToString() + ", Height=" + _height.ToString() + "}";
+            return "{Width=" + _width.ToString() + ",Height=" + _height.ToString() + "}";
         }
     }
 }

--- a/src/System.Drawing.Primitives/tests/PointFTests.cs
+++ b/src/System.Drawing.Primitives/tests/PointFTests.cs
@@ -148,7 +148,7 @@ namespace System.Drawing.PrimitivesTests
         public void ToStringTest(float x, float y)
         {
             PointF p = new PointF(x, y);
-            Assert.Equal(string.Format(CultureInfo.CurrentCulture, "{{X={0}, Y={1}}}", p.X, p.Y), p.ToString());
+            Assert.Equal(string.Format(CultureInfo.CurrentCulture, "{{X={0},Y={1}}}", p.X, p.Y), p.ToString());
         }
     }
 }

--- a/src/System.Drawing.Primitives/tests/SizeFTests.cs
+++ b/src/System.Drawing.Primitives/tests/SizeFTests.cs
@@ -138,7 +138,7 @@ namespace System.Drawing.PrimitivesTest
         public void ToStringTest()
         {
             SizeF s = new SizeF(0, 0);
-            Assert.Equal(string.Format(CultureInfo.CurrentCulture, "{{Width={0}, Height={1}}}", s.Width, s.Height), s.ToString());
+            Assert.Equal(string.Format(CultureInfo.CurrentCulture, "{{Width={0},Height={1}}}", s.Width, s.Height), s.ToString());
         }
     }
 }

--- a/src/System.Drawing.Primitives/tests/SizeTests.cs
+++ b/src/System.Drawing.Primitives/tests/SizeTests.cs
@@ -165,7 +165,7 @@ namespace System.Drawing.PrimitivesTests
         public void ToStringTest()
         {
             Size sz = new Size(0, 0);
-            Assert.Equal(string.Format(CultureInfo.CurrentCulture, "{{Width={0}, Height={1}}}", sz.Width, sz.Height), sz.ToString());
+            Assert.Equal(string.Format(CultureInfo.CurrentCulture, "{{Width={0},Height={1}}}", sz.Width, sz.Height), sz.ToString());
         }
     }
 }


### PR DESCRIPTION
Some ToString() methods were {x,y} and others were {x, y}. Let's make this more consistent

The split between space and no space between members was 3:5, so I went for
removing a space between commas and members in the library.