### PR TITLE
Use Buffer.BlockCopy with byte[]s

### DIFF
--- a/src/Common/src/System/Net/Logging/GlobalLog.cs
+++ b/src/Common/src/System/Net/Logging/GlobalLog.cs
@@ -248,7 +248,7 @@ namespace System.Net
             }
 
             var bufferSegment = new byte[length];
-            Array.Copy(buffer, offset, bufferSegment, 0, length);
+            Buffer.BlockCopy(buffer, offset, bufferSegment, 0, length);
             EventSourceLogging.Log.DebugDumpArray(bufferSegment);
         }
 

--- a/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
+++ b/src/Common/src/System/Security/Cryptography/RSAOpenSsl.cs
@@ -108,7 +108,7 @@ namespace System.Security.Cryptography
             }
 
             byte[] plainBytes = new byte[returnValue];
-            Array.Copy(buf, 0, plainBytes, 0, returnValue);
+            Buffer.BlockCopy(buf, 0, plainBytes, 0, returnValue);
             return plainBytes;
         }
 

--- a/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
+++ b/src/Microsoft.CSharp/src/Microsoft/CSharp/RuntimeBinder/Semantics/Symbols/SymbolManagerBase.cs
@@ -400,7 +400,7 @@ namespace Microsoft.CSharp.RuntimeBinder.Semantics
         public TypeArray ConcatParams(CType[] prgtype1, CType[] prgtype2)
         {
             CType[] combined = new CType[prgtype1.Length + prgtype2.Length];
-            Array.Copy(prgtype1, combined, prgtype1.Length);
+            Array.Copy(prgtype1, 0, combined, 0, prgtype1.Length);
             Array.Copy(prgtype2, 0, combined, prgtype1.Length, prgtype2.Length);
             return AllocParams(combined);
         }

--- a/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/UIHintAttribute.cs
+++ b/src/System.ComponentModel.Annotations/src/System/ComponentModel/DataAnnotations/UIHintAttribute.cs
@@ -100,7 +100,7 @@ namespace System.ComponentModel.DataAnnotations
                 if (controlParameters != null)
                 {
                     _inputControlParameters = new object[controlParameters.Length];
-                    Array.Copy(controlParameters, _inputControlParameters, controlParameters.Length);
+                    Array.Copy(controlParameters, 0, _inputControlParameters, 0, controlParameters.Length);
                 }
             }
 

--- a/src/System.Data.SqlClient/src/System/Data/Common/DataRecordInternal.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Common/DataRecordInternal.cs
@@ -143,7 +143,7 @@ namespace System.Data.Common
                 }
 
                 // until arrays are 64 bit, we have to do these casts
-                Array.Copy(data, ndataIndex, buffer, bufferIndex, (int)cbytes);
+                Buffer.BlockCopy(data, ndataIndex, buffer, bufferIndex, (int)cbytes);
             }
             catch (Exception e)
             {

--- a/src/System.Data.SqlClient/src/System/Data/Sql/SqlMetaData.cs
+++ b/src/System.Data.SqlClient/src/System/Data/Sql/SqlMetaData.cs
@@ -942,7 +942,7 @@ namespace Microsoft.SqlServer.Server
                     {
                         byte[] rgbValue = value.Value;
                         byte[] rgbNewValue = new byte[MaxLength];
-                        Array.Copy(rgbValue, 0, rgbNewValue, 0, rgbValue.Length);
+                        Buffer.BlockCopy(rgbValue, 0, rgbNewValue, 0, rgbValue.Length);
                         Array.Clear(rgbNewValue, rgbValue.Length, rgbNewValue.Length - rgbValue.Length);
                         return new SqlBinary(rgbNewValue);
                     }
@@ -963,7 +963,7 @@ namespace Microsoft.SqlServer.Server
             {
                 byte[] rgbValue = value.Value;
                 byte[] rgbNewValue = new byte[MaxLength];
-                Array.Copy(rgbValue, 0, rgbNewValue, 0, (int)MaxLength);
+                Buffer.BlockCopy(rgbValue, 0, rgbNewValue, 0, (int)MaxLength);
                 value = new SqlBinary(rgbNewValue);
             }
 
@@ -1040,7 +1040,7 @@ namespace Microsoft.SqlServer.Server
                         if (value.MaxLength < MaxLength)
                         {
                             byte[] rgbNew = new byte[MaxLength];
-                            Array.Copy(value.Buffer, 0, rgbNew, 0, (int)oldLength);
+                            Buffer.BlockCopy(value.Buffer, 0, rgbNew, 0, (int)oldLength);
                             value = new SqlBytes(rgbNew);
                         }
 
@@ -1380,7 +1380,7 @@ namespace Microsoft.SqlServer.Server
                     if (value.Length < MaxLength)
                     {
                         byte[] rgbNewValue = new byte[MaxLength];
-                        Array.Copy(value, 0, rgbNewValue, 0, value.Length);
+                        Buffer.BlockCopy(value, 0, rgbNewValue, 0, value.Length);
                         Array.Clear(rgbNewValue, value.Length, (int)rgbNewValue.Length - value.Length);
                         return rgbNewValue;
                     }
@@ -1400,7 +1400,7 @@ namespace Microsoft.SqlServer.Server
             if (value.Length > MaxLength && Max != MaxLength)
             {
                 byte[] rgbNewValue = new byte[MaxLength];
-                Array.Copy(value, 0, rgbNewValue, 0, (int)MaxLength);
+                Buffer.BlockCopy(value, 0, rgbNewValue, 0, (int)MaxLength);
                 value = rgbNewValue;
             }
 

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SNI/SNIPacket.cs
@@ -124,7 +124,7 @@ namespace System.Data.SqlClient.SNI
         {
             SNIPacket packet = new SNIPacket(null);
             packet._data = new byte[_length];
-            Array.Copy(_data, 0, packet._data, 0, _length);
+            Buffer.BlockCopy(_data, 0, packet._data, 0, _length);
             packet._length = _length;
 
             return packet;

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlDataReader.cs
@@ -1374,7 +1374,7 @@ namespace System.Data.SqlClient
                         cbytes = length;
                 }
 
-                Array.Copy(data, ndataIndex, buffer, bufferIndex, cbytes);
+                Buffer.BlockCopy(data, ndataIndex, buffer, bufferIndex, cbytes);
             }
             catch (Exception e)
             {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlSequentialTextReader.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlSequentialTextReader.cs
@@ -371,7 +371,7 @@ namespace System.Data.SqlClient
                     {
                         // Otherwise, copy over the leftover buffer
                         byteBuffer = new byte[byteBufferSize];
-                        Array.Copy(_leftOverBytes, byteBuffer, _leftOverBytes.Length);
+                        Buffer.BlockCopy(_leftOverBytes, 0, byteBuffer, 0, _leftOverBytes.Length);
                         byteBufferUsed = _leftOverBytes.Length;
                     }
                 }
@@ -410,7 +410,7 @@ namespace System.Data.SqlClient
             if ((!completed) && (bytesUsed < inBufferCount))
             {
                 _leftOverBytes = new byte[inBufferCount - bytesUsed];
-                Array.Copy(inBuffer, bytesUsed, _leftOverBytes, 0, _leftOverBytes.Length);
+                Buffer.BlockCopy(inBuffer, bytesUsed, _leftOverBytes, 0, _leftOverBytes.Length);
             }
             else
             {

--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlStream.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlStream.cs
@@ -452,7 +452,7 @@ namespace System.Data.SqlClient
                 cb = _cachedBytes[_currentArrayIndex].Length - _currentPosition;
                 if (cb > count)
                     cb = count;
-                Array.Copy(_cachedBytes[_currentArrayIndex], _currentPosition, buffer, offset, cb);
+                Buffer.BlockCopy(_cachedBytes[_currentArrayIndex], _currentPosition, buffer, offset, cb);
 
                 _currentPosition += cb;
                 count -= (int)cb;

--- a/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLBytes.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLBytes.cs
@@ -194,7 +194,7 @@ namespace System.Data.SqlTypes
 
                     default:
                         buffer = new byte[_lCurLen];
-                        Array.Copy(m_rgbBuf, buffer, (int)_lCurLen);
+                        System.Buffer.BlockCopy(m_rgbBuf, 0, buffer, 0, (int)_lCurLen);
                         break;
                 }
 
@@ -343,7 +343,7 @@ namespace System.Data.SqlTypes
                     default:
                         // ProjectK\Core doesn't support long-typed array indexers
                         Debug.Assert(offset < int.MaxValue);
-                        Array.Copy(m_rgbBuf, checked((int)offset), buffer, offsetInBuffer, count);
+                        System.Buffer.BlockCopy(m_rgbBuf, checked((int)offset), buffer, offsetInBuffer, count);
                         break;
                 }
             }
@@ -409,7 +409,7 @@ namespace System.Data.SqlTypes
                 {
                     // ProjectK\Core doesn't support long-typed array indexers
                     Debug.Assert(offset < int.MaxValue);
-                    Array.Copy(buffer, offsetInBuffer, m_rgbBuf, checked((int)offset), count);
+                    System.Buffer.BlockCopy(buffer, offsetInBuffer, m_rgbBuf, checked((int)offset), count);
 
                     // If the last position that has been written is after
                     // the current data length, reset the length

--- a/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLChars.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlTypes/SQLChars.cs
@@ -186,7 +186,7 @@ namespace System.Data.SqlTypes
 
                     default:
                         buffer = new char[_lCurLen];
-                        Array.Copy(m_rgchBuf, buffer, (int)_lCurLen);
+                        Array.Copy(m_rgchBuf, 0, buffer, 0, (int)_lCurLen);
                         break;
                 }
 

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventCounter.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventCounter.cs
@@ -285,7 +285,7 @@ namespace System.Diagnostics.Tracing
             else if (eventSourceIndex >= EventCounterGroup.s_eventCounterGroups.Length)
             {
                 EventCounterGroup[] newEventCounterGroups = new EventCounterGroup[eventSourceIndex + 1];
-                Array.Copy(EventCounterGroup.s_eventCounterGroups, newEventCounterGroups, EventCounterGroup.s_eventCounterGroups.Length);
+                Array.Copy(EventCounterGroup.s_eventCounterGroups, 0, newEventCounterGroups, 0, EventCounterGroup.s_eventCounterGroups.Length);
                 EventCounterGroup.s_eventCounterGroups = newEventCounterGroups;
             }
         }

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventSource.cs
@@ -3645,7 +3645,7 @@ namespace System.Diagnostics.Tracing
             if (eventData == null || eventData.Length <= eventAttribute.EventId)
             {
                 EventMetadata[] newValues = new EventMetadata[Math.Max(eventData.Length + 16, eventAttribute.EventId + 1)];
-                Array.Copy(eventData, newValues, eventData.Length);
+                Array.Copy(eventData, 0, newValues, 0, eventData.Length);
                 eventData = newValues;
             }
 
@@ -3684,7 +3684,7 @@ namespace System.Diagnostics.Tracing
             if (eventData.Length - idx > 2)      // allow one wasted slot. 
             {
                 EventMetadata[] newValues = new EventMetadata[idx + 1];
-                Array.Copy(eventData, newValues, newValues.Length);
+                Array.Copy(eventData, 0, newValues, 0, newValues.Length);
                 eventData = newValues;
             }
         }

--- a/src/System.IO/src/System/IO/BufferedStream.cs
+++ b/src/System.IO/src/System/IO/BufferedStream.cs
@@ -134,7 +134,7 @@ namespace System.IO
                 return;
 
             byte[] shadowBuffer = new byte[Math.Min(_bufferSize + _bufferSize, MaxShadowBufferSize)];
-            Array.Copy(_buffer, 0, shadowBuffer, 0, _writePos);
+            Buffer.BlockCopy(_buffer, 0, shadowBuffer, 0, _writePos);
             _buffer = shadowBuffer;
         }
 
@@ -416,7 +416,7 @@ namespace System.IO
 
             if (readbytes > count)
                 readbytes = count;
-            Array.Copy(_buffer, _readPos, array, offset, readbytes);
+            Buffer.BlockCopy(_buffer, _readPos, array, offset, readbytes);
             _readPos += readbytes;
 
             return readbytes;
@@ -683,7 +683,7 @@ namespace System.IO
                 return;
 
             EnsureBufferAllocated();
-            Array.Copy(array, offset, _buffer, _writePos, bytesToWrite);
+            Buffer.BlockCopy(array, offset, _buffer, _writePos, bytesToWrite);
 
             _writePos += bytesToWrite;
             count -= bytesToWrite;
@@ -825,7 +825,7 @@ namespace System.IO
                     if (totalUserbytes <= (_bufferSize + _bufferSize) && totalUserbytes <= MaxShadowBufferSize)
                     {
                         EnsureShadowBufferAllocated();
-                        Array.Copy(array, offset, _buffer, _writePos, count);
+                        Buffer.BlockCopy(array, offset, _buffer, _writePos, count);
                         _stream.Write(_buffer, 0, totalUserbytes);
                         _writePos = 0;
                         return;
@@ -977,7 +977,7 @@ namespace System.IO
                         if (totalUserBytes <= (_bufferSize + _bufferSize) && totalUserBytes <= MaxShadowBufferSize)
                         {
                             EnsureShadowBufferAllocated();
-                            Array.Copy(array, offset, _buffer, _writePos, count);
+                            Buffer.BlockCopy(array, offset, _buffer, _writePos, count);
 
                             await _stream.WriteAsync(_buffer, 0, totalUserBytes, cancellationToken).ConfigureAwait(false);
                             _writePos = 0;

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
@@ -282,7 +282,7 @@ namespace System.Net.Http
                     if (_remainingDataCount > 0)
                     {
                         int bytesToCopy = Math.Min(count, _remainingDataCount);
-                        Array.Copy(_remainingData, _remainingDataOffset, buffer, offset, bytesToCopy);
+                        Buffer.BlockCopy(_remainingData, _remainingDataOffset, buffer, offset, bytesToCopy);
 
                         _remainingDataOffset += bytesToCopy;
                         _remainingDataCount -= bytesToCopy;

--- a/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemNetworkInterface.cs
+++ b/src/System.Net.NetworkInformation/src/System/Net/NetworkInformation/SystemNetworkInterface.cs
@@ -173,9 +173,9 @@ namespace System.Net.NetworkInformation
         {
             byte[] newAddr = new byte[_addressLength];
 
-            // Array.Copy only supports int and long while addressLength is uint (see IpAdapterAddresses).
+            // Buffer.BlockCopy only supports int while addressLength is uint (see IpAdapterAddresses).
             // Will throw OverflowException if addressLength > Int32.MaxValue.
-            Array.Copy(_physicalAddress, 0, newAddr, 0, checked((int)_addressLength));
+            Buffer.BlockCopy(_physicalAddress, 0, newAddr, 0, checked((int)_addressLength));
             return new PhysicalAddress(newAddr);
         }
 

--- a/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
+++ b/src/System.Net.Ping/src/System/Net/NetworkInformation/Ping.Unix.cs
@@ -113,7 +113,7 @@ namespace System.Net.NetworkInformation
                     int dataOffset = ipHeaderLength + IcmpHeaderLengthInBytes;
                     // We want to return a buffer with the actual data we sent out, not including the header data.
                     byte[] dataBuffer = new byte[bytesReceived - dataOffset];
-                    Array.Copy(receiveBuffer, dataOffset, dataBuffer, 0, dataBuffer.Length);
+                    Buffer.BlockCopy(receiveBuffer, dataOffset, dataBuffer, 0, dataBuffer.Length);
 
                     IPStatus status = isIpv4
                                         ? IcmpV4MessageConstants.MapV4TypeToIPStatus(type, code)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -4116,7 +4116,7 @@ namespace System.Net.Sockets
 
             Socket socket = EndAccept(out innerBuffer, out bytesTransferred, asyncResult);
             buffer = new byte[bytesTransferred];
-            Array.Copy(innerBuffer, 0, buffer, 0, bytesTransferred);
+            Buffer.BlockCopy(innerBuffer, 0, buffer, 0, bytesTransferred);
             return socket;
         }
 

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlBaseReader.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlBaseReader.cs
@@ -1370,9 +1370,9 @@ namespace System.Xml
             if (_trailByteCount > 0)
             {
                 int actual = Math.Min(_trailByteCount, byteCount);
-                Array.Copy(_trailBytes, 0, buffer, offset, actual);
+                Buffer.BlockCopy(_trailBytes, 0, buffer, offset, actual);
                 _trailByteCount -= actual;
-                Array.Copy(_trailBytes, actual, _trailBytes, 0, _trailByteCount);
+                Buffer.BlockCopy(_trailBytes, actual, _trailBytes, 0, _trailByteCount);
                 return actual;
             }
             XmlNodeType nodeType = _node.NodeType;
@@ -1440,9 +1440,9 @@ namespace System.Xml
                             _trailBytes = new byte[3];
                         _trailByteCount = encoding.GetBytes(chars, 0, charCount, _trailBytes, 0);
                         int actual = Math.Min(_trailByteCount, byteCount);
-                        Array.Copy(_trailBytes, 0, buffer, offset, actual);
+                        Buffer.BlockCopy(_trailBytes, 0, buffer, offset, actual);
                         _trailByteCount -= actual;
-                        Array.Copy(_trailBytes, actual, _trailBytes, 0, _trailByteCount);
+                        Buffer.BlockCopy(_trailBytes, actual, _trailBytes, 0, _trailByteCount);
                         return actual;
                     }
                     else

--- a/src/System.Private.DataContractSerialization/src/System/Xml/XmlStreamNodeWriter.cs
+++ b/src/System.Private.DataContractSerialization/src/System/Xml/XmlStreamNodeWriter.cs
@@ -467,7 +467,7 @@ namespace System.Xml
                         string tmp = new string(charsStart, 0, (int)(chars - charsStart));
                         byte[] newBytes = _encoding != null ? _encoding.GetBytes(tmp) : s_UTF8Encoding.GetBytes(tmp);
                         int toCopy = Math.Min(newBytes.Length, (int)(bytesMax - bytes));
-                        Array.Copy(newBytes, 0, buffer, (int)(bytes - _bytes) + offset, toCopy);
+                        Buffer.BlockCopy(newBytes, 0, buffer, (int)(bytes - _bytes) + offset, toCopy);
 
                         bytes += toCopy;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/BlobBuilder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/BlobBuilder.cs
@@ -305,7 +305,7 @@ namespace Roslyn.Reflection
                         break;
                     }
 
-                    Array.Copy(chunk._buffer, Math.Max(start - chunkStartPosition, 0), result, resultOffset, bytesToCopy);
+                    Buffer.BlockCopy(chunk._buffer, Math.Max(start - chunkStartPosition, 0), result, resultOffset, bytesToCopy);
 
                     resultOffset += bytesToCopy;
                 }

--- a/src/System.Reflection.Metadata/src/System/Reflection/BlobWriter.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/BlobWriter.cs
@@ -108,7 +108,7 @@ namespace Roslyn.Reflection
             BlobUtilities.ValidateRange(Length, start, byteCount);
 
             var result = new byte[byteCount];
-            Array.Copy(_buffer, _start + start, result, 0, byteCount);
+            Buffer.BlockCopy(_buffer, _start + start, result, 0, byteCount);
             return result;
         }
 

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/BufferedStream.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/BufferedStream.cs
@@ -170,7 +170,7 @@ namespace System.IO
                 return;
 
             Byte[] shadowBuffer = new Byte[Math.Min(_bufferSize + _bufferSize, MaxShadowBufferSize)];
-            Array.Copy(_buffer, 0, shadowBuffer, 0, _writePos);
+            Buffer.BlockCopy(_buffer, 0, shadowBuffer, 0, _writePos);
             _buffer = shadowBuffer;
         }
 
@@ -485,7 +485,7 @@ namespace System.IO
 
             if (readBytes > count)
                 readBytes = count;
-            Array.Copy(_buffer, _readPos, array, offset, readBytes);
+            Buffer.BlockCopy(_buffer, _readPos, array, offset, readBytes);
             _readPos += readBytes;
 
             return readBytes;
@@ -842,7 +842,7 @@ namespace System.IO
                 return;
 
             EnsureBufferAllocated();
-            Array.Copy(array, offset, _buffer, _writePos, bytesToWrite);
+            Buffer.BlockCopy(array, offset, _buffer, _writePos, bytesToWrite);
 
             _writePos += bytesToWrite;
             count -= bytesToWrite;
@@ -986,7 +986,7 @@ namespace System.IO
                     if (totalUserBytes <= (_bufferSize + _bufferSize) && totalUserBytes <= MaxShadowBufferSize)
                     {
                         EnsureShadowBufferAllocated();
-                        Array.Copy(array, offset, _buffer, _writePos, count);
+                        Buffer.BlockCopy(array, offset, _buffer, _writePos, count);
                         _stream.Write(_buffer, 0, totalUserBytes);
                         _writePos = 0;
                         return;

--- a/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeBuffer.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeBuffer.cs
@@ -65,7 +65,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             Contract.EndContractBlock();
 
             Byte[] underlyingData = new Byte[capacity];
-            Array.Copy(data, offset, underlyingData, 0, length);
+            Buffer.BlockCopy(data, offset, underlyingData, 0, length);
             return new WindowsRuntimeBuffer(underlyingData, 0, length, capacity);
         }
 

--- a/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeBufferExtensions.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Runtime/InteropServices/WindowsRuntime/WindowsRuntimeBufferExtensions.cs
@@ -118,7 +118,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             Int32 destDataOffs;
             if (destination.TryGetUnderlyingData(out destDataArr, out destDataOffs))
             {
-                Array.Copy(source, sourceIndex, destDataArr, (int)(destDataOffs + destinationIndex), count);
+                Buffer.BlockCopy(source, sourceIndex, destDataArr, (int)(destDataOffs + destinationIndex), count);
                 return;
             }
 
@@ -194,7 +194,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
             Int32 srcDataOffs;
             if (source.TryGetUnderlyingData(out srcDataArr, out srcDataOffs))
             {
-                Array.Copy(srcDataArr, (int)(srcDataOffs + sourceIndex), destination, destinationIndex, count);
+                Buffer.BlockCopy(srcDataArr, (int)(srcDataOffs + sourceIndex), destination, destinationIndex, count);
                 return;
             }
 
@@ -245,7 +245,7 @@ namespace System.Runtime.InteropServices.WindowsRuntime
                 Debug.Assert(sourceIndex <= Int32.MaxValue);
                 Debug.Assert(destinationIndex <= Int32.MaxValue);
 
-                Array.Copy(srcDataArr, srcDataOffs + (Int32)sourceIndex, destDataArr, destDataOffs + (Int32)destinationIndex, (Int32)count);
+                Buffer.BlockCopy(srcDataArr, srcDataOffs + (Int32)sourceIndex, destDataArr, destDataOffs + (Int32)destinationIndex, (Int32)count);
                 return;
             }
 

--- a/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
+++ b/src/System.Security.Cryptography.Algorithms/src/System/Security/Cryptography/Rfc2898DeriveBytes.cs
@@ -125,13 +125,13 @@ namespace System.Security.Cryptography
             {
                 if (cb >= size)
                 {
-                    Array.Copy(_buffer, _startIndex, password, 0, size);
+                    Buffer.BlockCopy(_buffer, _startIndex, password, 0, size);
                     _startIndex = _endIndex = 0;
                     offset += size;
                 }
                 else
                 {
-                    Array.Copy(_buffer, _startIndex, password, 0, cb);
+                    Buffer.BlockCopy(_buffer, _startIndex, password, 0, cb);
                     _startIndex += cb;
                     return password;
                 }
@@ -145,14 +145,14 @@ namespace System.Security.Cryptography
                 int remainder = cb - offset;
                 if (remainder > BlockSize)
                 {
-                    Array.Copy(T_block, 0, password, offset, BlockSize);
+                    Buffer.BlockCopy(T_block, 0, password, offset, BlockSize);
                     offset += BlockSize;
                 }
                 else
                 {
-                    Array.Copy(T_block, 0, password, offset, remainder);
+                    Buffer.BlockCopy(T_block, 0, password, offset, remainder);
                     offset += remainder;
-                    Array.Copy(T_block, remainder, _buffer, _startIndex, BlockSize - remainder);
+                    Buffer.BlockCopy(T_block, remainder, _buffer, _startIndex, BlockSize - remainder);
                     _endIndex += (BlockSize - remainder);
                     return password;
                 }

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
@@ -781,7 +781,7 @@ namespace Internal.NativeCrypto
                 throw new CryptographicException(SR.Format(SR.Argument_InvalidValue, "Encrypted data length is less than 0"));
             }
             byte[] dataTobeDecrypted = new byte[encryptedDataLength];
-            Array.Copy(encryptedData, 0, dataTobeDecrypted, 0, encryptedDataLength);
+            Buffer.BlockCopy(encryptedData, 0, dataTobeDecrypted, 0, encryptedDataLength);
             Array.Reverse(dataTobeDecrypted); //ToDO: Check is this is really needed? To be confirmed with tests
 
             int dwFlags = fOAEP ? (int)CryptDecryptFlags.CRYPT_OAEP : 0;
@@ -814,7 +814,7 @@ namespace Internal.NativeCrypto
 
 
             decryptedData = new byte[decryptedDataLength];
-            Array.Copy(dataTobeDecrypted, 0, decryptedData, 0, decryptedDataLength);
+            Buffer.BlockCopy(dataTobeDecrypted, 0, decryptedData, 0, decryptedDataLength);
             return;
         }
 
@@ -857,7 +857,7 @@ namespace Internal.NativeCrypto
             // key should always be larger than the plaintext key, so use that to determine the buffer size.
             Debug.Assert(cbEncryptedKey >= cbKey);
             pbEncryptedKey = new byte[cbEncryptedKey];
-            Array.Copy(pbKey, 0, pbEncryptedKey, 0, cbKey);
+            Buffer.BlockCopy(pbKey, 0, pbEncryptedKey, 0, cbKey);
 
             // Encrypt for real - the last parameter is the total size of the in/out buffer, while the second to last
             // parameter specifies the size of the plaintext to encrypt.

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/FindPal.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/FindPal.cs
@@ -262,7 +262,7 @@ namespace Internal.Cryptography.Pal
             // Since the sign bit is set, put a new 0x00 on the end to move that bit from
             // the sign bit to a data bit.
             byte[] newBytes = new byte[bytes.Length + 1];
-            Array.Copy(bytes, 0, newBytes, 0, bytes.Length);
+            Buffer.BlockCopy(bytes, 0, newBytes, 0, bytes.Length);
             return new BigInteger(newBytes);
         }
 

--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.CustomExtensions.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Windows/X509Pal.CustomExtensions.cs
@@ -238,7 +238,7 @@ namespace Internal.Cryptography.Pal
                             if (cb < buffer.Length)
                             {
                                 byte[] newBuffer = new byte[cb];
-                                Array.Copy(buffer, 0, newBuffer, 0, cb);
+                                Buffer.BlockCopy(buffer, 0, newBuffer, 0, cb);
                                 buffer = newBuffer;
                             }
                             return buffer;

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509SubjectKeyIdentifierExtension.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509SubjectKeyIdentifierExtension.cs
@@ -112,7 +112,7 @@ namespace System.Security.Cryptography.X509Certificates
                         //  SHA-1 hash of the value of the BIT STRING subjectPublicKey 
                         // (excluding the tag, length, and number of unused bit string bits)
                         byte[] shortSha1 = new byte[8];
-                        Array.Copy(sha1, sha1.Length - 8, shortSha1, 0, shortSha1.Length);
+                        Buffer.BlockCopy(sha1, sha1.Length - 8, shortSha1, 0, shortSha1.Length);
                         shortSha1[0] &= 0x0f;
                         shortSha1[0] |= 0x40;
                         return shortSha1;

--- a/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
+++ b/src/System.Security.Principal.Windows/src/System/Security/Principal/WindowsIdentity.cs
@@ -75,7 +75,7 @@ namespace System.Security.Principal
                 if (!Interop.SecurityBase.AllocateLocallyUniqueId(out sourceContext.SourceIdentifier))
                     throw new SecurityException(new Win32Exception().Message);
                 sourceContext.SourceName = new byte[TOKEN_SOURCE.TOKEN_SOURCE_LENGTH];
-                Array.Copy(sourceName, 0, sourceContext.SourceName, 0, sourceName.Length);
+                Buffer.BlockCopy(sourceName, 0, sourceContext.SourceName, 0, sourceName.Length);
 
                 // Desktop compat: Desktop never null-checks sUserPrincipalName. Actual behavior is that the null makes it down to Encoding.Unicode.GetBytes() which then throws
                 // the ArgumentNullException (provided that the prior LSA calls didn't fail first.) To make this compat decision explicit, we'll null check ourselves 

--- a/src/System.Xml.ReaderWriter/src/System/Xml/BinHexDecoder.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/BinHexDecoder.cs
@@ -176,7 +176,7 @@ namespace System.Xml
             if (bytesDecoded < bytes.Length)
             {
                 byte[] tmp = new byte[bytesDecoded];
-                Array.Copy(bytes, 0, tmp, 0, bytesDecoded);
+                Buffer.BlockCopy(bytes, 0, tmp, 0, bytesDecoded);
                 bytes = tmp;
             }
 


### PR DESCRIPTION
In particular after https://github.com/dotnet/coreclr/pull/3118, Buffer.BlockCopy has less overhead than Array.Copy when copying byte[]s, such that there's no benefit to using Array.Copy and potential benefit to using Buffer.BlockCopy (in particular for small arrays).

This commit replaces usage of Array.Copy(byte[], ...) in corefx with Buffer.BlockCopy(byte[], ...).  A lot of places were already using BlockCopy.

(In a few places where we weren't passing lower bounds to Array.Copy with T[] arguments, I added explicit lower bounds as well to avoid the overload needing to call GetLowerBound.)

cc: 
@davidsh for networking
@saurabh500 for data
@bartonjs for security
@ianhays for I/O