### PR TITLE
Remove active issue tests for 1561

### DIFF
--- a/src/System.Linq/tests/EnumerableTests.cs
+++ b/src/System.Linq/tests/EnumerableTests.cs
@@ -253,26 +253,6 @@ namespace System.Linq.Tests
             }
         }
 
-        /// <summary>
-        /// Emulation of async collection change.
-        /// It adds a new element to the sequence each time the Count property touched,
-        /// so the further call of CopyTo method will fail.
-        /// </summary>
-        protected class GrowingAfterCountReadCollection : TestCollection<int>
-        {
-            public GrowingAfterCountReadCollection(int[] items) : base(items) { }
-
-            public override int Count
-            {
-                get
-                {
-                    var result = base.Count;
-                    Array.Resize(ref Items, Items.Length + 1);
-                    return result;
-                }
-            }
-        }
-
         protected static IEnumerable<T> ForceNotCollection<T>(IEnumerable<T> source)
         {
             foreach (T item in source) yield return item;

--- a/src/System.Linq/tests/ToArrayTests.cs
+++ b/src/System.Linq/tests/ToArrayTests.cs
@@ -107,10 +107,8 @@ namespace System.Linq.Tests
             Assert.Throws<ArgumentNullException>("source", () => source.ToArray());
         }
 
-
-        // Later this behaviour can be changed
+        // Generally the optimal approach. Anything that breaks this should be confirmed as not harming performance.
         [Fact]
-        [ActiveIssue(1561)]
         public void ToArray_UseCopyToWithICollection()
         {
             TestCollection<int> source = new TestCollection<int>(new int[] { 1, 2, 3, 4 });
@@ -118,21 +116,6 @@ namespace System.Linq.Tests
 
             Assert.Equal(source, resultArray);
             Assert.Equal(1, source.CopyToTouched);
-        }
-
-
-        [Fact]
-        [ActiveIssue(1561)]
-        public void ToArray_WorkWhenCountChangedAsynchronously()
-        {
-            GrowingAfterCountReadCollection source = new GrowingAfterCountReadCollection(new int[] { 1, 2, 3, 4 });
-            var resultArray = source.ToArray();
-
-            Assert.True(resultArray.Length >= 4);
-            Assert.Equal(1, resultArray[0]);
-            Assert.Equal(2, resultArray[0]);
-            Assert.Equal(3, resultArray[0]);
-            Assert.Equal(4, resultArray[0]);
         }
 
         [Fact]

--- a/src/System.Linq/tests/ToListTests.cs
+++ b/src/System.Linq/tests/ToListTests.cs
@@ -86,10 +86,8 @@ namespace System.Linq.Tests
             Assert.Throws<ArgumentNullException>("source", () => source.ToList());
         }
 
-
-        // Later this behaviour can be changed
+        // Generally the optimal approach. Anything that breaks this should be confirmed as not harming performance.
         [Fact]
-        [ActiveIssue(1561)]
         public void ToList_UseCopyToWithICollection()
         {
             TestCollection<int> source = new TestCollection<int>(new int[] { 1, 2, 3, 4 });
@@ -97,21 +95,6 @@ namespace System.Linq.Tests
 
             Assert.Equal(source, resultList);
             Assert.Equal(1, source.CopyToTouched);
-        }
-
-
-        [Fact]
-        [ActiveIssue(1561)]
-        public void ToList_WorkWhenCountChangedAsynchronously()
-        {
-            GrowingAfterCountReadCollection source = new GrowingAfterCountReadCollection(new int[] { 1, 2, 3, 4 });
-            var resultList = source.ToList();
-
-            Assert.True(resultList.Count >= 4);
-            Assert.Equal(1, resultList[0]);
-            Assert.Equal(2, resultList[0]);
-            Assert.Equal(3, resultList[0]);
-            Assert.Equal(4, resultList[0]);
         }
 
         [Theory]


### PR DESCRIPTION
#1561 has been closed, with a decision to keep the behaviour as-is.

Two active issue tests were designed to fail due to this issue. Remove them.

Two active issue tests reflect the behaviour this issue commented on. Since they still work, and since there is a performance benefit to the behaviour they depend upon, remove the `ActiveIssueAttribute`, and change the comment above them.