### PR TITLE
Misplaced Assert() is useless

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/TdsParser.cs
@@ -1109,6 +1109,7 @@ namespace System.Data.SqlClient
             // can be deleted)
             SqlErrorCollection temp = stateObj.GetFullErrorAndWarningCollection(out breakConnection);
 
+            Debug.Assert(temp != null, "TdsParser::ThrowExceptionAndWarning: null errors collection!");
             Debug.Assert(temp.Count > 0, "TdsParser::ThrowExceptionAndWarning called with no exceptions or warnings!");
             Debug.Assert(_connHandler != null, "TdsParser::ThrowExceptionAndWarning called with null connectionHandler!");
 
@@ -1129,7 +1130,6 @@ namespace System.Data.SqlClient
                 }
             }
 
-            Debug.Assert(temp != null, "TdsParser::ThrowExceptionAndWarning: 0 errors in collection");
             if (temp != null && temp.Count > 0)
             {
                 // Construct the exception now that we've collected all the errors


### PR DESCRIPTION
The original code would never have this `Assert()` firing - if `temp` is null then there's a `NullReferenceException` on `Assert(temp.Count>0)`.