### PR TITLE
Misc Web encoders fixes

### DIFF
--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/HtmlEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/HtmlEncoder.cs
@@ -94,7 +94,7 @@ namespace System.Text.Encodings.Web
 
         public override int MaxOutputCharactersPerInputCharacter
         {
-            get { return 8; } // "&#xFFFF;" is the longest encoded form 
+            get { return 9; } // "&#xFFFFF;" is the longest encoded form
         }
 
         static readonly char[] s_quote = "&quot;".ToCharArray();

--- a/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptEncoder.cs
+++ b/src/System.Text.Encodings.Web/src/System/Text/Encodings/Web/JavaScriptEncoder.cs
@@ -73,6 +73,9 @@ namespace System.Text.Encodings.Web
 
             _allowedCharacters.ForbidCharacter('\\');
             _allowedCharacters.ForbidCharacter('/');
+            
+            // Forbid GRAVE ACCENT \u0060 character.
+            _allowedCharacters.ForbidCharacter('`'); 
         }
 
         public DefaultJavaScriptEncoder(params UnicodeRange[] allowedRanges) : this(new TextEncoderSettings(allowedRanges))
@@ -100,7 +103,7 @@ namespace System.Text.Encodings.Web
         // surrogate pairs in the output.
         public override int MaxOutputCharactersPerInputCharacter
         {
-            get { return 6; } // "\uFFFF" is the longest encoded form 
+            get { return 12; } // "\uFFFF\uFFFF" is the longest encoded form 
         }
 
         static readonly char[] s_b = new char[] { '\\', 'b' };

--- a/src/System.Text.Encodings.Web/tests/HtmlEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/HtmlEncoderTests.cs
@@ -14,6 +14,18 @@ namespace Microsoft.Framework.WebEncoders
     public class HtmlEncoderTests
     {
         [Fact]
+        public void TestSurrogate()
+        {
+            Assert.Equal("&#x1F4A9;", System.Text.Encodings.Web.HtmlEncoder.Default.Encode("\U0001f4a9"));
+            
+            using (var writer = new StringWriter())
+            {
+                System.Text.Encodings.Web.HtmlEncoder.Default.Encode(writer, "\U0001f4a9");
+                Assert.Equal("&#x1F4A9;", writer.GetStringBuilder().ToString());
+            }
+        }
+        
+        [Fact]
         public void Ctor_WithTextEncoderSettings()
         {
             // Arrange

--- a/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/JavaScriptStringEncoderTests.cs
@@ -14,6 +14,17 @@ namespace Microsoft.Framework.WebEncoders
     public class JavaScriptStringEncoderTests
     {
         [Fact]
+        public void TestSurrogate()
+        {
+            Assert.Equal("\\uD83D\\uDCA9", System.Text.Encodings.Web.JavaScriptEncoder.Default.Encode("\U0001f4a9"));
+            using (var writer = new StringWriter())
+            {
+                System.Text.Encodings.Web.JavaScriptEncoder.Default.Encode(writer, "\U0001f4a9");
+                Assert.Equal("\\uD83D\\uDCA9", writer.GetStringBuilder().ToString());
+            }
+        }
+
+        [Fact]
         public void Ctor_WithTextEncoderSettings()
         {
             // Arrange
@@ -133,6 +144,7 @@ namespace Microsoft.Framework.WebEncoders
                     else if (input == "\r") { expected = @"\r"; }
                     else if (input == "\\") { expected = @"\\"; }
                     else if (input == "/") { expected = @"\/"; }
+                    else if (input == "`") { expected = @"\u0060"; }
                     else
                     {
                         bool mustEncode = false;

--- a/src/System.Text.Encodings.Web/tests/UrlEncoderTests.cs
+++ b/src/System.Text.Encodings.Web/tests/UrlEncoderTests.cs
@@ -18,6 +18,17 @@ namespace Microsoft.Framework.WebEncoders
         private static UTF8Encoding _utf8EncodingThrowOnInvalidBytes = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
 
         [Fact]
+        public void TestSurrogate()
+        {
+            Assert.Equal("%F0%9F%92%A9", System.Text.Encodings.Web.UrlEncoder.Default.Encode("\U0001f4a9"));
+            using (var writer = new StringWriter())
+            {
+                System.Text.Encodings.Web.UrlEncoder.Default.Encode(writer, "\U0001f4a9");
+                Assert.Equal("%F0%9F%92%A9", writer.GetStringBuilder().ToString());
+            }
+        }
+        
+        [Fact]
         public void Ctor_WithTextEncoderSettings()
         {
             // Arrange


### PR DESCRIPTION
This change to fix the MaxOutputCharactersPerInputCharacter for JavaScript, Url,
and Html encoders to allow encoding the surrogate characters correctly.
Also EcmaScript v6 support Grave Accent character (\u0060 `) so we'll let
JavaScript encoder to start encoding this character