### PR TITLE
Use partitioning on list-based select iterators.

### DIFF
--- a/src/System.Linq/src/System/Linq/ElementAt.cs
+++ b/src/System.Linq/src/System/Linq/ElementAt.cs
@@ -13,17 +13,25 @@ namespace System.Linq
         {
             if (source == null) throw Error.ArgumentNull("source");
             IPartition<TSource> partition = source as IPartition<TSource>;
-            if (partition != null) return partition.ElementAt(index);
-            IList<TSource> list = source as IList<TSource>;
-            if (list != null) return list[index];
-            if (index >= 0)
+            if (partition != null)
             {
-                using (IEnumerator<TSource> e = source.GetEnumerator())
+                bool found;
+                TSource element = partition.TryGetElementAt(index, out found);
+                if (found) return element;
+            }
+            else
+            {
+                IList<TSource> list = source as IList<TSource>;
+                if (list != null) return list[index];
+                if (index >= 0)
                 {
-                    while (e.MoveNext())
+                    using (IEnumerator<TSource> e = source.GetEnumerator())
                     {
-                        if (index == 0) return e.Current;
-                        index--;
+                        while (e.MoveNext())
+                        {
+                            if (index == 0) return e.Current;
+                            index--;
+                        }
                     }
                 }
             }
@@ -34,7 +42,11 @@ namespace System.Linq
         {
             if (source == null) throw Error.ArgumentNull("source");
             IPartition<TSource> partition = source as IPartition<TSource>;
-            if (partition != null) return partition.ElementAtOrDefault(index);
+            if (partition != null)
+            {
+                bool found;
+                return partition.TryGetElementAt(index, out found);
+            }
             if (index >= 0)
             {
                 IList<TSource> list = source as IList<TSource>;

--- a/src/System.Linq/src/System/Linq/First.cs
+++ b/src/System.Linq/src/System/Linq/First.cs
@@ -13,17 +13,25 @@ namespace System.Linq
         {
             if (source == null) throw Error.ArgumentNull("source");
             IPartition<TSource> partition = source as IPartition<TSource>;
-            if (partition != null) return partition.First();
-            IList<TSource> list = source as IList<TSource>;
-            if (list != null)
+            if (partition != null)
             {
-                if (list.Count > 0) return list[0];
+                bool found;
+                TSource first = partition.TryGetFirst(out found);
+                if (found) return first;
             }
             else
             {
-                using (IEnumerator<TSource> e = source.GetEnumerator())
+                IList<TSource> list = source as IList<TSource>;
+                if (list != null)
                 {
-                    if (e.MoveNext()) return e.Current;
+                    if (list.Count > 0) return list[0];
+                }
+                else
+                {
+                    using (IEnumerator<TSource> e = source.GetEnumerator())
+                    {
+                        if (e.MoveNext()) return e.Current;
+                    }
                 }
             }
             throw Error.NoElements();
@@ -46,7 +54,12 @@ namespace System.Linq
         {
             if (source == null) throw Error.ArgumentNull("source");
             IPartition<TSource> partition = source as IPartition<TSource>;
-            if (partition != null) return partition.FirstOrDefault();
+            if (partition != null)
+            {
+                bool found;
+                return partition.TryGetFirst(out found);
+            }
+
             IList<TSource> list = source as IList<TSource>;
             if (list != null)
             {

--- a/src/System.Linq/src/System/Linq/Last.cs
+++ b/src/System.Linq/src/System/Linq/Last.cs
@@ -13,25 +13,33 @@ namespace System.Linq
         {
             if (source == null) throw Error.ArgumentNull("source");
             IPartition<TSource> partition = source as IPartition<TSource>;
-            if (partition != null) return partition.Last();
-            IList<TSource> list = source as IList<TSource>;
-            if (list != null)
+            if (partition != null)
             {
-                int count = list.Count;
-                if (count > 0) return list[count - 1];
+                bool found;
+                TSource last = partition.TryGetLast(out found);
+                if (found) return last;
             }
             else
             {
-                using (IEnumerator<TSource> e = source.GetEnumerator())
+                IList<TSource> list = source as IList<TSource>;
+                if (list != null)
                 {
-                    if (e.MoveNext())
+                    int count = list.Count;
+                    if (count > 0) return list[count - 1];
+                }
+                else
+                {
+                    using (IEnumerator<TSource> e = source.GetEnumerator())
                     {
-                        TSource result;
-                        do
+                        if (e.MoveNext())
                         {
-                            result = e.Current;
-                        } while (e.MoveNext());
-                        return result;
+                            TSource result;
+                            do
+                            {
+                                result = e.Current;
+                            } while (e.MoveNext());
+                            return result;
+                        }
                     }
                 }
             }
@@ -79,7 +87,12 @@ namespace System.Linq
         {
             if (source == null) throw Error.ArgumentNull("source");
             IPartition<TSource> partition = source as IPartition<TSource>;
-            if (partition != null) return partition.LastOrDefault();
+            if (partition != null)
+            {
+                bool found;
+                return partition.TryGetLast(out found);
+            }
+
             IList<TSource> list = source as IList<TSource>;
             if (list != null)
             {

--- a/src/System.Linq/src/System/Linq/Range.cs
+++ b/src/System.Linq/src/System/Linq/Range.cs
@@ -14,7 +14,7 @@ namespace System.Linq
         {
             long max = ((long)start) + count - 1;
             if (count < 0 || max > Int32.MaxValue) throw Error.ArgumentOutOfRange("count");
-            if (count == 0) return new EmptyPartition<int>();
+            if (count == 0) return EmptyPartition<int>.Instance;
             return new RangeIterator(start, count);
         }
 
@@ -57,6 +57,11 @@ namespace System.Linq
                 state = -1; // Don't reset current
             }
 
+            public override IEnumerable<TResult> Select<TResult>(Func<int, TResult> selector)
+            {
+                return new SelectIPartitionIterator<int, TResult>(this, selector);
+            }
+
             public int[] ToArray()
             {
                 int[] array = new int[_end - _start];
@@ -88,7 +93,7 @@ namespace System.Linq
 
             public IPartition<int> Skip(int count)
             {
-                if (count >= _end - _start) return new EmptyPartition<int>();
+                if (count >= _end - _start) return EmptyPartition<int>.Instance;
                 return new RangeIterator(_start + count, _end - _start - count);
             }
 
@@ -99,34 +104,27 @@ namespace System.Linq
                 return new RangeIterator(_start, count);
             }
 
-            public int ElementAt(int index)
+            public int TryGetElementAt(int index, out bool found)
             {
-                if ((uint)index >= (uint)(_end - _start)) throw Error.ArgumentOutOfRange("index");
-                return _start + index;
+                if ((uint)index < (uint)(_end - _start))
+                {
+                    found = true;
+                    return _start + index;
+                }
+
+                found = false;
+                return 0;
             }
 
-            public int ElementAtOrDefault(int index)
+            public int TryGetFirst(out bool found)
             {
-                return (uint)index >= (uint)(_end - _start) ? 0 : _start + index;
-            }
-
-            public int First()
-            {
+                found = true;
                 return _start;
             }
 
-            public int FirstOrDefault()
+            public int TryGetLast(out bool found)
             {
-                return _start;
-            }
-
-            public int Last()
-            {
-                return _end - 1;
-            }
-
-            public int LastOrDefault()
-            {
+                found = true;
                 return _end - 1;
             }
         }

--- a/src/System.Linq/src/System/Linq/Repeat.cs
+++ b/src/System.Linq/src/System/Linq/Repeat.cs
@@ -13,7 +13,7 @@ namespace System.Linq
         public static IEnumerable<TResult> Repeat<TResult>(TResult element, int count)
         {
             if (count < 0) throw Error.ArgumentOutOfRange("count");
-            if (count == 0) return new EmptyPartition<TResult>();
+            if (count == 0) return EmptyPartition<TResult>.Instance;
             return new RepeatIterator<TResult>(element, count);
         }
 
@@ -51,6 +51,11 @@ namespace System.Linq
                 return false;
             }
 
+            public override IEnumerable<TResult2> Select<TResult2>(Func<TResult, TResult2> selector)
+            {
+                return new SelectIPartitionIterator<TResult, TResult2>(this, selector);
+            }
+
             public TResult[] ToArray()
             {
                 TResult[] array = new TResult[_count];
@@ -77,7 +82,7 @@ namespace System.Linq
 
             public IPartition<TResult> Skip(int count)
             {
-                if (count >= _count) return new EmptyPartition<TResult>();
+                if (count >= _count) return EmptyPartition<TResult>.Instance;
                 return new RepeatIterator<TResult>(current, _count - count);
             }
 
@@ -87,34 +92,27 @@ namespace System.Linq
                 return new RepeatIterator<TResult>(current, count);
             }
 
-            public TResult ElementAt(int index)
+            public TResult TryGetElementAt(int index, out bool found)
             {
-                if ((uint)index >= (uint)_count) throw Error.ArgumentOutOfRange("index");
+                if ((uint)index < (uint)_count)
+                {
+                    found = true;
+                    return current;
+                }
+
+                found = false;
+                return default(TResult);
+            }
+
+            public TResult TryGetFirst(out bool found)
+            {
+                found = true;
                 return current;
             }
 
-            public TResult ElementAtOrDefault(int index)
+            public TResult TryGetLast(out bool found)
             {
-                return (uint)index >= (uint)_count ? default(TResult) : current;
-            }
-
-            public TResult First()
-            {
-                return current;
-            }
-
-            public TResult FirstOrDefault()
-            {
-                return current;
-            }
-
-            public TResult Last()
-            {
-                return current;
-            }
-
-            public TResult LastOrDefault()
-            {
+                found = true;
                 return current;
             }
         }

--- a/src/System.Linq/src/System/Linq/Select.cs
+++ b/src/System.Linq/src/System/Linq/Select.cs
@@ -25,6 +25,8 @@ namespace System.Linq
                 if (list != null) return new SelectListIterator<TSource, TResult>(list, selector);
                 return new SelectIListIterator<TSource, TResult>(ilist, selector);
             }
+            IPartition<TSource> partition = source as IPartition<TSource>;
+            if (partition != null) return new SelectIPartitionIterator<TSource, TResult>(partition, selector);
             return new SelectEnumerableIterator<TSource, TResult>(source, selector);
         }
 
@@ -105,7 +107,7 @@ namespace System.Linq
             }
         }
 
-        internal sealed class SelectArrayIterator<TSource, TResult> : Iterator<TResult>, IIListProvider<TResult>
+        internal sealed class SelectArrayIterator<TSource, TResult> : Iterator<TResult>, IPartition<TResult>
         {
             private readonly TSource[] _source;
             private readonly Func<TSource, TResult> _selector;
@@ -170,9 +172,58 @@ namespace System.Linq
             {
                 return _source.Length;
             }
+
+            public IPartition<TResult> Skip(int count)
+            {
+                if (count == 0) return (IPartition<TResult>)Clone();
+                if (count >= _source.Length) return EmptyPartition<TResult>.Instance;
+                return new SelectListPartitionIterator<TSource, TResult>(_source, _selector, count, int.MaxValue);
+            }
+
+            public IPartition<TResult> Take(int count)
+            {
+                return count >= _source.Length ? (IPartition<TResult>)Clone() : new SelectListPartitionIterator<TSource, TResult>(_source, _selector, 0, count - 1);
+            }
+
+            public TResult TryGetElementAt(int index, out bool found)
+            {
+                if ((uint)index < (uint)_source.Length)
+                {
+                    found = true;
+                    return _selector(_source[index]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
+
+            public TResult TryGetFirst(out bool found)
+            {
+                if (_source.Length != 0)
+                {
+                    found = true;
+                    return _selector(_source[0]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
+
+            public TResult TryGetLast(out bool found)
+            {
+                int len = _source.Length;
+                if (len != 0)
+                {
+                    found = true;
+                    return _selector(_source[len - 1]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
         }
 
-        internal sealed class SelectListIterator<TSource, TResult> : Iterator<TResult>, IIListProvider<TResult>
+        internal sealed class SelectListIterator<TSource, TResult> : Iterator<TResult>, IPartition<TResult>
         {
             private readonly List<TSource> _source;
             private readonly Func<TSource, TResult> _selector;
@@ -247,9 +298,56 @@ namespace System.Linq
             {
                 return _source.Count;
             }
+
+            public IPartition<TResult> Skip(int count)
+            {
+                return count == 0 ? (IPartition<TResult>)Clone() : new SelectListPartitionIterator<TSource, TResult>(_source, _selector, count, int.MaxValue);
+            }
+
+            public IPartition<TResult> Take(int count)
+            {
+                return new SelectListPartitionIterator<TSource, TResult>(_source, _selector, 0, count - 1);
+            }
+
+            public TResult TryGetElementAt(int index, out bool found)
+            {
+                if ((uint)index < (uint)_source.Count)
+                {
+                    found = true;
+                    return _selector(_source[index]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
+
+            public TResult TryGetFirst(out bool found)
+            {
+                if (_source.Count != 0)
+                {
+                    found = true;
+                    return _selector(_source[0]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
+
+            public TResult TryGetLast(out bool found)
+            {
+                int len = _source.Count;
+                if (len != 0)
+                {
+                    found = true;
+                    return _selector(_source[len - 1]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
         }
 
-        internal sealed class SelectIListIterator<TSource, TResult> : Iterator<TResult>, IIListProvider<TResult>
+        internal sealed class SelectIListIterator<TSource, TResult> : Iterator<TResult>, IPartition<TResult>
         {
             private readonly IList<TSource> _source;
             private readonly Func<TSource, TResult> _selector;
@@ -333,6 +431,318 @@ namespace System.Linq
             public int GetCount(bool onlyIfCheap)
             {
                 return _source.Count;
+            }
+
+            public IPartition<TResult> Skip(int count)
+            {
+                return count == 0 ? (IPartition<TResult>)Clone() : new SelectListPartitionIterator<TSource, TResult>(_source, _selector, count, int.MaxValue);
+            }
+
+            public IPartition<TResult> Take(int count)
+            {
+                return new SelectListPartitionIterator<TSource, TResult>(_source, _selector, 0, count - 1);
+            }
+
+            public TResult TryGetElementAt(int index, out bool found)
+            {
+                if ((uint)index < (uint)_source.Count)
+                {
+                    found = true;
+                    return _selector(_source[index]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
+
+            public TResult TryGetFirst(out bool found)
+            {
+                if (_source.Count != 0)
+                {
+                    found = true;
+                    return _selector(_source[0]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
+
+            public TResult TryGetLast(out bool found)
+            {
+                int len = _source.Count;
+                if (len != 0)
+                {
+                    found = true;
+                    return _selector(_source[len - 1]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
+        }
+
+        internal sealed class SelectIPartitionIterator<TSource, TResult> : Iterator<TResult>, IPartition<TResult>
+        {
+            private readonly IPartition<TSource> _source;
+            private readonly Func<TSource, TResult> _selector;
+            private IEnumerator<TSource> _enumerator;
+
+            public SelectIPartitionIterator(IPartition<TSource> source, Func<TSource, TResult> selector)
+            {
+                Debug.Assert(source != null);
+                Debug.Assert(selector != null);
+                _source = source;
+                _selector = selector;
+            }
+
+            public override Iterator<TResult> Clone()
+            {
+                return new SelectIPartitionIterator<TSource, TResult>(_source, _selector);
+            }
+
+            public override bool MoveNext()
+            {
+                switch (state)
+                {
+                    case 1:
+                        _enumerator = _source.GetEnumerator();
+                        state = 2;
+                        goto case 2;
+                    case 2:
+                        if (_enumerator.MoveNext())
+                        {
+                            current = _selector(_enumerator.Current);
+                            return true;
+                        }
+                        Dispose();
+                        break;
+                }
+                return false;
+            }
+
+            public override void Dispose()
+            {
+                if (_enumerator != null)
+                {
+                    _enumerator.Dispose();
+                    _enumerator = null;
+                }
+                base.Dispose();
+            }
+
+            public override IEnumerable<TResult2> Select<TResult2>(Func<TResult, TResult2> selector)
+            {
+                return new SelectIPartitionIterator<TSource, TResult2>(_source, CombineSelectors(_selector, selector));
+            }
+
+            public IPartition<TResult> Skip(int count)
+            {
+                return count == 0 ? (IPartition<TResult>)Clone() : new SelectIPartitionIterator<TSource, TResult>(_source.Skip(count), _selector);
+            }
+
+            public IPartition<TResult> Take(int count)
+            {
+                return new SelectIPartitionIterator<TSource, TResult>(_source.Take(count), _selector);
+            }
+
+            public TResult TryGetElementAt(int index, out bool found)
+            {
+                bool sourceFound;
+                TSource input = _source.TryGetElementAt(index, out sourceFound);
+                found = sourceFound;
+                return sourceFound ? _selector(input) : default(TResult);
+            }
+
+            public TResult TryGetFirst(out bool found)
+            {
+                bool sourceFound;
+                TSource input = _source.TryGetFirst(out sourceFound);
+                found = sourceFound;
+                return sourceFound ? _selector(input) : default(TResult);
+            }
+
+            public TResult TryGetLast(out bool found)
+            {
+                bool sourceFound;
+                TSource input = _source.TryGetLast(out sourceFound);
+                found = sourceFound;
+                return sourceFound ? _selector(input) : default(TResult);
+            }
+
+            public TResult[] ToArray()
+            {
+                int count = _source.GetCount(onlyIfCheap: true);
+                switch (count)
+                {
+                    case -1:
+                        return EnumerableHelpers.ToArray(this);
+                    case 0:
+                        return Array.Empty<TResult>();
+                    default:
+                        TResult[] array = new TResult[count];
+                        int index = 0;
+                        foreach(TSource input in _source)
+                        {
+                            array[index] = _selector(input);
+                            ++index;
+                        }
+                        return array;
+                }
+            }
+
+            public List<TResult> ToList()
+            {
+                int count = _source.GetCount(onlyIfCheap: true);
+                List<TResult> list;
+                switch (count)
+                {
+                    case -1:
+                        list = new List<TResult>();
+                        break;
+                    case 0:
+                        return new List<TResult>();
+                    default:
+                        list = new List<TResult>(count);
+                        break;
+                }
+                foreach (TSource input in _source)
+                    list.Add(_selector(input));
+
+                return list;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                return _source.GetCount(onlyIfCheap);
+            }
+        }
+
+        private sealed class SelectListPartitionIterator<TSource, TResult> : Iterator<TResult>, IPartition<TResult>
+        {
+            private readonly IList<TSource> _source;
+            private readonly Func<TSource, TResult> _selector;
+            private readonly int _minIndex;
+            private readonly int _maxIndex;
+            private int _index;
+
+            public SelectListPartitionIterator(IList<TSource> source, Func<TSource, TResult> selector, int minIndexInclusive, int maxIndexInclusive)
+            {
+                Debug.Assert(source != null);
+                Debug.Assert(selector != null);
+                Debug.Assert(minIndexInclusive >= 0);
+                Debug.Assert(minIndexInclusive <= maxIndexInclusive);
+                _source = source;
+                _selector = selector;
+                _minIndex = minIndexInclusive;
+                _maxIndex = maxIndexInclusive;
+                _index = minIndexInclusive;
+            }
+
+            public override Iterator<TResult> Clone()
+            {
+                return new SelectListPartitionIterator<TSource, TResult>(_source, _selector, _minIndex, _maxIndex);
+            }
+
+            public override bool MoveNext()
+            {
+                if ((state == 1 & _index <= _maxIndex) && _index < _source.Count)
+                {
+                    current = _selector(_source[_index]);
+                    ++_index;
+                    return true;
+                }
+                Dispose();
+                return false;
+            }
+
+            public override IEnumerable<TResult2> Select<TResult2>(Func<TResult, TResult2> selector)
+            {
+                return new SelectListPartitionIterator<TSource, TResult2>(_source, CombineSelectors(_selector, selector), _minIndex, _maxIndex);
+            }
+
+            public IPartition<TResult> Skip(int count)
+            {
+                int minIndex = _minIndex + count;
+                return minIndex >= _maxIndex ? EmptyPartition<TResult>.Instance : new SelectListPartitionIterator<TSource, TResult>(_source, _selector, minIndex, _maxIndex);
+            }
+
+            public IPartition<TResult> Take(int count)
+            {
+                int maxIndex = _minIndex + count - 1;
+                return new SelectListPartitionIterator<TSource, TResult>(_source, _selector, _minIndex, (uint)maxIndex >= (uint)_maxIndex ? _maxIndex : maxIndex);
+            }
+
+            public TResult TryGetElementAt(int index, out bool found)
+            {
+                if ((uint)index <= (uint)(_maxIndex - _minIndex) && index < _source.Count - _minIndex)
+                {
+                    found = true;
+                    return _selector(_source[_minIndex + index]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
+
+            public TResult TryGetFirst(out bool found)
+            {
+                if (_source.Count > _minIndex)
+                {
+                    found = true;
+                    return _selector(_source[_minIndex]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
+
+            public TResult TryGetLast(out bool found)
+            {
+                int lastIndex = _source.Count - 1;
+                if (lastIndex >= _minIndex)
+                {
+                    found = true;
+                    return _selector(_source[Math.Min(lastIndex, _maxIndex)]);
+                }
+
+                found = false;
+                return default(TResult);
+            }
+
+            private int Count
+            {
+                get
+                {
+                    int count = _source.Count;
+                    if (count <= _minIndex) return 0;
+                    return Math.Min(count - 1, _maxIndex) - _minIndex + 1;
+                }
+            }
+
+            public TResult[] ToArray()
+            {
+                int count = Count;
+                if (count == 0) return Array.Empty<TResult>();
+                TResult[] array = new TResult[count];
+                for (int i = 0, curIdx = _minIndex; i != array.Length; ++i, ++curIdx)
+                    array[i] = _selector(_source[curIdx]);
+                return array;
+            }
+
+            public List<TResult> ToList()
+            {
+                int count = Count;
+                if (count == 0) return new List<TResult>();
+                List<TResult> list = new List<TResult>(count);
+                int end = _minIndex + count;
+                for (int i = _minIndex; i != end; ++i)
+                    list.Add(_selector(_source[i]));
+                return list;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                return Count;
             }
         }
     }

--- a/src/System.Linq/src/System/Linq/Take.cs
+++ b/src/System.Linq/src/System/Linq/Take.cs
@@ -12,7 +12,7 @@ namespace System.Linq
         public static IEnumerable<TSource> Take<TSource>(this IEnumerable<TSource> source, int count)
         {
             if (source == null) throw Error.ArgumentNull("source");
-            if (count <= 0) return new EmptyPartition<TSource>();
+            if (count <= 0) return EmptyPartition<TSource>.Instance;
             IPartition<TSource> partition = source as IPartition<TSource>;
             if (partition != null) return partition.Take(count);
             IList<TSource> sourceList = source as IList<TSource>;

--- a/src/System.Linq/tests/EmptyPartitionTests.cs
+++ b/src/System.Linq/tests/EmptyPartitionTests.cs
@@ -23,23 +23,23 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void NotSingleInstance()
+        public void SingleInstance()
         {
-            Assert.NotSame(GetEmptyPartition<int>(), GetEmptyPartition<int>());
+            Assert.Same(GetEmptyPartition<int>(), GetEmptyPartition<int>());
         }
 
         [Fact]
-        public void SkipNotSame()
+        public void SkipSame()
         {
             var empty = GetEmptyPartition<int>();
-            Assert.NotSame(empty, empty.Skip(2));
+            Assert.Same(empty, empty.Skip(2));
         }
 
         [Fact]
-        public void TakeNotSame()
+        public void TakeSame()
         {
             var empty = GetEmptyPartition<int>();
-            Assert.NotSame(empty, empty.Take(2));
+            Assert.Same(empty, empty.Take(2));
         }
 
         [Fact]

--- a/src/System.Linq/tests/OrderedSubsetting.cs
+++ b/src/System.Linq/tests/OrderedSubsetting.cs
@@ -378,5 +378,75 @@ namespace System.Linq.Tests
             while (enumerator.MoveNext()) { }
             Assert.False(enumerator.MoveNext());
         }
+
+        [Fact]
+        public void Select()
+        {
+            Assert.Equal(new[] { 0, 2, 4, 6, 8 }, Enumerable.Range(-1, 8).Shuffle().OrderBy(i => i).Skip(1).Take(5).Select(i => i * 2));
+        }
+
+        [Fact]
+        public void SelectForcedToEnumeratorDoesntEnumerate()
+        {
+            var iterator = Enumerable.Range(-1, 8).Shuffle().OrderBy(i => i).Skip(1).Take(5).Select(i => i * 2);
+            // Don't insist on this behaviour, but check its correct if it happens
+            var en = iterator as IEnumerator<int>;
+            Assert.False(en != null && en.MoveNext());
+        }
+
+        [Fact]
+        public void SelectElementAt()
+        {
+            var source = Enumerable.Range(0, 9).Shuffle().OrderBy(i => i).Skip(1).Take(5).Select(i => i * 2);
+            Assert.Equal(6, source.ElementAt(2));
+            Assert.Equal(8, source.ElementAtOrDefault(3));
+            Assert.Equal(0, source.ElementAtOrDefault(8));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => source.ElementAt(-2));
+        }
+
+        [Fact]
+        public void SelectFirst()
+        {
+            var source = Enumerable.Range(0, 9).Shuffle().OrderBy(i => i).Skip(1).Take(5).Select(i => i * 2);
+            Assert.Equal(2, source.First());
+            Assert.Equal(2, source.FirstOrDefault());
+            source = source.Skip(20);
+            Assert.Equal(0, source.FirstOrDefault());
+            Assert.Throws<InvalidOperationException>(() => source.First());
+        }
+
+        [Fact]
+        public void SelectLast()
+        {
+            var source = Enumerable.Range(0, 9).Shuffle().OrderBy(i => i).Skip(1).Take(5).Select(i => i * 2);
+            Assert.Equal(10, source.Last());
+            Assert.Equal(10, source.LastOrDefault());
+            source = source.Skip(20);
+            Assert.Equal(0, source.LastOrDefault());
+            Assert.Throws<InvalidOperationException>(() => source.Last());
+        }
+
+        [Fact]
+        public void SelectArray()
+        {
+            var source = Enumerable.Range(0, 9).Shuffle().OrderBy(i => i).Skip(1).Take(5).Select(i => i * 2);
+            Assert.Equal(new[] { 2, 4, 6, 8, 10 }, source.ToArray());
+        }
+
+        [Fact]
+        public void SelectList()
+        {
+            var source = Enumerable.Range(0, 9).Shuffle().OrderBy(i => i).Skip(1).Take(5).Select(i => i * 2);
+            Assert.Equal(new[] { 2, 4, 6, 8, 10 }, source.ToList());
+        }
+
+        [Fact]
+        public void SelectCount()
+        {
+            var source = Enumerable.Range(0, 9).Shuffle().OrderBy(i => i).Skip(1).Take(5).Select(i => i * 2);
+            Assert.Equal(5, source.Count());
+            source = Enumerable.Range(0, 9).Shuffle().OrderBy(i => i).Skip(1).Take(1000).Select(i => i * 2);
+            Assert.Equal(8, source.Count());
+        }
     }
 }

--- a/src/System.Linq/tests/SelectTests.cs
+++ b/src/System.Linq/tests/SelectTests.cs
@@ -769,6 +769,14 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void ForcedToEnumeratorDoesntEnumerateIPartition()
+        {
+            var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).ToList().AsReadOnly().Select(i => i).Skip(1);
+            var en = iterator as IEnumerator<int>;
+            Assert.False(en != null && en.MoveNext());
+        }
+
+        [Fact]
         public void Select_SourceIsArray_Count()
         {
             var source = new[] { 1, 2, 3, 4 };
@@ -787,6 +795,316 @@ namespace System.Linq.Tests
         {
             var souce = new List<int> { 1, 2, 3, 4 }.AsReadOnly();
             Assert.Equal(souce.Count, souce.Select(i => i * 2).Count());
+        }
+
+        [Fact]
+        public void Select_SourceIsArray_Skip()
+        {
+            var source = new[] { 1, 2, 3, 4 }.Select(i => i * 2);
+            Assert.Equal(new[] { 6, 8 }, source.Skip(2));
+            Assert.Equal(new[] { 6, 8 }, source.Skip(2).Skip(-1));
+            Assert.Equal(new[] { 6, 8 }, source.Skip(1).Skip(1));
+            Assert.Equal(new[] { 2, 4, 6, 8 }, source.Skip(-1));
+            Assert.Empty(source.Skip(4));
+            Assert.Empty(source.Skip(20));
+        }
+
+        [Fact]
+        public void Select_SourceIsList_Skip()
+        {
+            var source = new List<int> { 1, 2, 3, 4 }.Select(i => i * 2);
+            Assert.Equal(new[] { 6, 8 }, source.Skip(2));
+            Assert.Equal(new[] { 6, 8 }, source.Skip(2).Skip(-1));
+            Assert.Equal(new[] { 6, 8 }, source.Skip(1).Skip(1));
+            Assert.Equal(new[] { 2, 4, 6, 8 }, source.Skip(-1));
+            Assert.Empty(source.Skip(4));
+            Assert.Empty(source.Skip(20));
+        }
+
+        [Fact]
+        public void Select_SourceIsIList_Skip()
+        {
+            var source = new List<int> { 1, 2, 3, 4 }.AsReadOnly().Select(i => i * 2);
+            Assert.Equal(new[] { 6, 8 }, source.Skip(2));
+            Assert.Equal(new[] { 6, 8 }, source.Skip(2).Skip(-1));
+            Assert.Equal(new[] { 6, 8 }, source.Skip(1).Skip(1));
+            Assert.Equal(new[] { 2, 4, 6, 8 }, source.Skip(-1));
+            Assert.Empty(source.Skip(4));
+            Assert.Empty(source.Skip(20));
+        }
+
+        [Fact]
+        public void Select_SourceIsArray_Take()
+        {
+            var source = new[] { 1, 2, 3, 4 }.Select(i => i * 2);
+            Assert.Equal(new[] { 2, 4 }, source.Take(2));
+            Assert.Equal(new[] { 2, 4 }, source.Take(3).Take(2));
+            Assert.Empty(source.Take(-1));
+            Assert.Equal(new[] { 2, 4, 6, 8 }, source.Take(4));
+            Assert.Equal(new[] { 2, 4, 6, 8 }, source.Take(40));
+        }
+
+        [Fact]
+        public void Select_SourceIsList_Take()
+        {
+            var source = new List<int> { 1, 2, 3, 4 }.Select(i => i * 2);
+            Assert.Equal(new[] { 2, 4 }, source.Take(2));
+            Assert.Equal(new[] { 2, 4 }, source.Take(3).Take(2));
+            Assert.Empty(source.Take(-1));
+            Assert.Equal(new[] { 2, 4, 6, 8 }, source.Take(4));
+            Assert.Equal(new[] { 2, 4, 6, 8 }, source.Take(40));
+        }
+
+        [Fact]
+        public void Select_SourceIsIList_Take()
+        {
+            var source = new List<int> { 1, 2, 3, 4 }.AsReadOnly().Select(i => i * 2);
+            Assert.Equal(new[] { 2, 4 }, source.Take(2));
+            Assert.Equal(new[] { 2, 4 }, source.Take(3).Take(2));
+            Assert.Empty(source.Take(-1));
+            Assert.Equal(new[] { 2, 4, 6, 8 }, source.Take(4));
+            Assert.Equal(new[] { 2, 4, 6, 8 }, source.Take(40));
+        }
+
+        [Fact]
+        public void Select_SourceIsArray_ElementAt()
+        {
+            var source = new[] { 1, 2, 3, 4 }.Select(i => i * 2);
+            for (int i = 0; i != 4; ++i)
+                Assert.Equal(i * 2 + 2, source.ElementAt(i));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => source.ElementAt(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => source.ElementAt(4));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => source.ElementAt(40));
+
+            Assert.Equal(6, source.Skip(1).ElementAt(1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => source.Skip(2).ElementAt(9));
+        }
+
+        [Fact]
+        public void Select_SourceIsList_ElementAt()
+        {
+            var source = new List<int> { 1, 2, 3, 4 }.Select(i => i * 2);
+            for (int i = 0; i != 4; ++i)
+                Assert.Equal(i * 2 + 2, source.ElementAt(i));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => source.ElementAt(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => source.ElementAt(4));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => source.ElementAt(40));
+
+            Assert.Equal(6, source.Skip(1).ElementAt(1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => source.Skip(2).ElementAt(9));
+        }
+
+        [Fact]
+        public void Select_SourceIsIList_ElementAt()
+        {
+            var source = new List<int> { 1, 2, 3, 4 }.AsReadOnly().Select(i => i * 2);
+            for (int i = 0; i != 4; ++i)
+                Assert.Equal(i * 2 + 2, source.ElementAt(i));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => source.ElementAt(-1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => source.ElementAt(4));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => source.ElementAt(40));
+
+            Assert.Equal(6, source.Skip(1).ElementAt(1));
+            Assert.Throws<ArgumentOutOfRangeException>("index", () => source.Skip(2).ElementAt(9));
+        }
+
+        [Fact]
+        public void Select_SourceIsArray_ElementAtOrDefault()
+        {
+            var source = new[] { 1, 2, 3, 4 }.Select(i => i * 2);
+            for (int i = 0; i != 4; ++i)
+                Assert.Equal(i * 2 + 2, source.ElementAtOrDefault(i));
+            Assert.Equal(0, source.ElementAtOrDefault(-1));
+            Assert.Equal(0, source.ElementAtOrDefault(4));
+            Assert.Equal(0, source.ElementAtOrDefault(40));
+
+            Assert.Equal(6, source.Skip(1).ElementAtOrDefault(1));
+            Assert.Equal(0, source.Skip(2).ElementAtOrDefault(9));
+        }
+
+        [Fact]
+        public void Select_SourceIsList_ElementAtOrDefault()
+        {
+            var source = new List<int> { 1, 2, 3, 4 }.Select(i => i * 2);
+            for (int i = 0; i != 4; ++i)
+                Assert.Equal(i * 2 + 2, source.ElementAtOrDefault(i));
+            Assert.Equal(0, source.ElementAtOrDefault(-1));
+            Assert.Equal(0, source.ElementAtOrDefault(4));
+            Assert.Equal(0, source.ElementAtOrDefault(40));
+
+            Assert.Equal(6, source.Skip(1).ElementAtOrDefault(1));
+            Assert.Equal(0, source.Skip(2).ElementAtOrDefault(9));
+        }
+
+        [Fact]
+        public void Select_SourceIsIList_ElementAtOrDefault()
+        {
+            var source = new List<int> { 1, 2, 3, 4 }.AsReadOnly().Select(i => i * 2);
+            for (int i = 0; i != 4; ++i)
+                Assert.Equal(i * 2 + 2, source.ElementAtOrDefault(i));
+            Assert.Equal(0, source.ElementAtOrDefault(-1));
+            Assert.Equal(0, source.ElementAtOrDefault(4));
+            Assert.Equal(0, source.ElementAtOrDefault(40));
+
+            Assert.Equal(6, source.Skip(1).ElementAtOrDefault(1));
+            Assert.Equal(0, source.Skip(2).ElementAtOrDefault(9));
+        }
+
+        [Fact]
+        public void Select_SourceIsArray_First()
+        {
+            var source = new[] { 1, 2, 3, 4 }.Select(i => i * 2);
+            Assert.Equal(2, source.First());
+            Assert.Equal(2, source.FirstOrDefault());
+
+            Assert.Equal(6, source.Skip(2).First());
+            Assert.Equal(6, source.Skip(2).FirstOrDefault());
+            Assert.Throws<InvalidOperationException>(() => source.Skip(4).First());
+            Assert.Throws<InvalidOperationException>(() => source.Skip(14).First());
+            Assert.Equal(0, source.Skip(4).FirstOrDefault());
+            Assert.Equal(0, source.Skip(14).FirstOrDefault());
+
+            var empty = new int[0].Select(i => i * 2);
+            Assert.Throws<InvalidOperationException>(() => empty.First());
+            Assert.Equal(0, empty.FirstOrDefault());
+        }
+
+        [Fact]
+        public void Select_SourceIsList_First()
+        {
+            var source = new List<int> { 1, 2, 3, 4 }.Select(i => i * 2);
+            Assert.Equal(2, source.First());
+            Assert.Equal(2, source.FirstOrDefault());
+
+            Assert.Equal(6, source.Skip(2).First());
+            Assert.Equal(6, source.Skip(2).FirstOrDefault());
+            Assert.Throws<InvalidOperationException>(() => source.Skip(4).First());
+            Assert.Throws<InvalidOperationException>(() => source.Skip(14).First());
+            Assert.Equal(0, source.Skip(4).FirstOrDefault());
+            Assert.Equal(0, source.Skip(14).FirstOrDefault());
+
+            var empty = new List<int>().Select(i => i * 2);
+            Assert.Throws<InvalidOperationException>(() => empty.First());
+            Assert.Equal(0, empty.FirstOrDefault());
+        }
+
+        [Fact]
+        public void Select_SourceIsIList_First()
+        {
+            var source = new List<int> { 1, 2, 3, 4 }.AsReadOnly().Select(i => i * 2);
+            Assert.Equal(2, source.First());
+            Assert.Equal(2, source.FirstOrDefault());
+
+            Assert.Equal(6, source.Skip(2).First());
+            Assert.Equal(6, source.Skip(2).FirstOrDefault());
+            Assert.Throws<InvalidOperationException>(() => source.Skip(4).First());
+            Assert.Throws<InvalidOperationException>(() => source.Skip(14).First());
+            Assert.Equal(0, source.Skip(4).FirstOrDefault());
+            Assert.Equal(0, source.Skip(14).FirstOrDefault());
+
+            var empty = new List<int>().AsReadOnly().Select(i => i * 2);
+            Assert.Throws<InvalidOperationException>(() => empty.First());
+            Assert.Equal(0, empty.FirstOrDefault());
+        }
+
+        [Fact]
+        public void Select_SourceIsArray_Last()
+        {
+            var source = new[] { 1, 2, 3, 4 }.Select(i => i * 2);
+            Assert.Equal(8, source.Last());
+            Assert.Equal(8, source.LastOrDefault());
+
+            Assert.Equal(6, source.Take(3).Last());
+            Assert.Equal(6, source.Take(3).LastOrDefault());
+
+            var empty = new int[0].Select(i => i * 2);
+            Assert.Throws<InvalidOperationException>(() => empty.Last());
+            Assert.Equal(0, empty.LastOrDefault());
+            Assert.Throws<InvalidOperationException>(() => empty.Skip(1).Last());
+            Assert.Equal(0, empty.Skip(1).LastOrDefault());
+        }
+
+        [Fact]
+        public void Select_SourceIsList_Last()
+        {
+            var source = new List<int> { 1, 2, 3, 4 }.Select(i => i * 2);
+            Assert.Equal(8, source.Last());
+            Assert.Equal(8, source.LastOrDefault());
+
+            Assert.Equal(6, source.Take(3).Last());
+            Assert.Equal(6, source.Take(3).LastOrDefault());
+
+            var empty = new List<int>().Select(i => i * 2);
+            Assert.Throws<InvalidOperationException>(() => empty.Last());
+            Assert.Equal(0, empty.LastOrDefault());
+            Assert.Throws<InvalidOperationException>(() => empty.Skip(1).Last());
+            Assert.Equal(0, empty.Skip(1).LastOrDefault());
+        }
+
+        [Fact]
+        public void Select_SourceIsIList_Last()
+        {
+            var source = new List<int> { 1, 2, 3, 4 }.AsReadOnly().Select(i => i * 2);
+            Assert.Equal(8, source.Last());
+            Assert.Equal(8, source.LastOrDefault());
+
+            Assert.Equal(6, source.Take(3).Last());
+            Assert.Equal(6, source.Take(3).LastOrDefault());
+
+            var empty = new List<int>().AsReadOnly().Select(i => i * 2);
+            Assert.Throws<InvalidOperationException>(() => empty.Last());
+            Assert.Equal(0, empty.LastOrDefault());
+            Assert.Throws<InvalidOperationException>(() => empty.Skip(1).Last());
+            Assert.Equal(0, empty.Skip(1).LastOrDefault());
+        }
+
+        [Fact]
+        public void Select_SourceIsArray_SkipRepeatCalls()
+        {
+            var source = new[] { 1, 2, 3, 4 }.Select(i => i * 2).Skip(1);
+            Assert.Equal(source, source);
+        }
+
+        [Fact]
+        public void Select_SourceIsArraySkipSelect()
+        {
+            var source = new[] { 1, 2, 3, 4 }.Select(i => i * 2).Skip(1).Select(i => i + 1);
+            Assert.Equal(new[] { 5, 7, 9 }, source);
+        }
+
+        [Fact]
+        public void Select_SourceIsArrayTakeTake()
+        {
+            var source = new[] { 1, 2, 3, 4 }.Select(i => i * 2).Take(2).Take(1);
+            Assert.Equal(new[] { 2 }, source);
+            Assert.Equal(new[] { 2 }, source.Take(10));
+        }
+
+        [Fact]
+        public void Select_SourceIsListSkipTakeCount()
+        {
+            Assert.Equal(3, new List<int> { 1, 2, 3, 4 }.Select(i => i * 2).Take(3).Count());
+            Assert.Equal(4, new List<int> { 1, 2, 3, 4 }.Select(i => i * 2).Take(9).Count());
+            Assert.Equal(2, new List<int> { 1, 2, 3, 4 }.Select(i => i * 2).Skip(2).Count());
+            Assert.Equal(0, new List<int> { 1, 2, 3, 4 }.Select(i => i * 2).Skip(8).Count());
+        }
+
+        [Fact]
+        public void Select_SourceIsListSkipTakeToArray()
+        {
+            Assert.Equal(new[] { 2, 4, 6 }, new List<int> { 1, 2, 3, 4 }.Select(i => i * 2).Take(3).ToArray());
+            Assert.Equal(new[] { 2, 4, 6, 8 }, new List<int> { 1, 2, 3, 4 }.Select(i => i * 2).Take(9).ToArray());
+            Assert.Equal(new[] { 6, 8 }, new List<int> { 1, 2, 3, 4 }.Select(i => i * 2).Skip(2).ToArray());
+            Assert.Empty(new List<int> { 1, 2, 3, 4 }.Select(i => i * 2).Skip(8).ToArray());
+        }
+
+        [Fact]
+        public void Select_SourceIsListSkipTakeToList()
+        {
+            Assert.Equal(new[] { 2, 4, 6 }, new List<int> { 1, 2, 3, 4 }.Select(i => i * 2).Take(3).ToList());
+            Assert.Equal(new[] { 2, 4, 6, 8 }, new List<int> { 1, 2, 3, 4 }.Select(i => i * 2).Take(9).ToList());
+            Assert.Equal(new[] { 6, 8 }, new List<int> { 1, 2, 3, 4 }.Select(i => i * 2).Skip(2).ToList());
+            Assert.Empty(new List<int> { 1, 2, 3, 4 }.Select(i => i * 2).Skip(8).ToList());
         }
     }
 }

--- a/src/System.Linq/tests/SkipWhileTests.cs
+++ b/src/System.Linq/tests/SkipWhileTests.cs
@@ -54,7 +54,7 @@ namespace System.Linq.Tests
         [Fact]
         public void SkipErrorWhenSourceErrors()
         {
-            var source = Enumerable.Range(-2, 5).Select(i => (decimal)i).Select(m => 1 / m).Skip(4);
+            var source = NumberRangeGuaranteedNotCollectionType(-2, 5).Select(i => (decimal)i).Select(m => 1 / m).Skip(4);
             using(var en = source.GetEnumerator())
             {
                 Assert.Throws<DivideByZeroException>(() => en.MoveNext());

--- a/src/System.Linq/tests/ToArrayTests.cs
+++ b/src/System.Linq/tests/ToArrayTests.cs
@@ -263,5 +263,61 @@ namespace System.Linq.Tests
     
             Assert.Equal(expected, source.ToArray());
         }
+
+        [Fact]
+        public void ConstantTimeCountPartitionSelectSameTypeToArray()
+        {
+            var source = Enumerable.Range(0, 100).Select(i => i * 2).Skip(1).Take(5);
+            Assert.Equal(new[] { 2, 4, 6, 8, 10 }, source.ToArray());
+        }
+
+        [Fact]
+        public void ConstantTimeCountPartitionSelectDiffTypeToArray()
+        {
+            var source = Enumerable.Range(0, 100).Select(i => i.ToString()).Skip(1).Take(5);
+            Assert.Equal(new[] { "1", "2", "3", "4", "5" }, source.ToArray());
+        }
+
+        [Fact]
+        public void ConstantTimeCountEmptyPartitionSelectSameTypeToArray()
+        {
+            var source = Enumerable.Range(0, 100).Select(i => i * 2).Skip(1000);
+            Assert.Empty(source.ToArray());
+        }
+
+        [Fact]
+        public void ConstantTimeCountEmptyPartitionSelectDiffTypeToArray()
+        {
+            var source = Enumerable.Range(0, 100).Select(i => i.ToString()).Skip(1000);
+            Assert.Empty(source.ToArray());
+        }
+
+        [Fact]
+        public void NonConstantTimeCountPartitionSelectSameTypeToArray()
+        {
+            var source = NumberRangeGuaranteedNotCollectionType(0, 100).OrderBy(i => i).Select(i => i * 2).Skip(1).Take(5);
+            Assert.Equal(new[] { 2, 4, 6, 8, 10 }, source.ToArray());
+        }
+
+        [Fact]
+        public void NonConstantTimeCountPartitionSelectDiffTypeToArray()
+        {
+            var source = NumberRangeGuaranteedNotCollectionType(0, 100).OrderBy(i => i).Select(i => i.ToString()).Skip(1).Take(5);
+            Assert.Equal(new[] { "1", "2", "3", "4", "5" }, source.ToArray());
+        }
+
+        [Fact]
+        public void NonConstantTimeCountEmptyPartitionSelectSameTypeToArray()
+        {
+            var source = NumberRangeGuaranteedNotCollectionType(0, 100).OrderBy(i => i).Select(i => i * 2).Skip(1000);
+            Assert.Empty(source.ToArray());
+        }
+
+        [Fact]
+        public void NonConstantTimeCountEmptyPartitionSelectDiffTypeToArray()
+        {
+            var source = NumberRangeGuaranteedNotCollectionType(0, 100).OrderBy(i => i).Select(i => i.ToString()).Skip(1000);
+            Assert.Empty(source.ToArray());
+        }
     }
 }

--- a/src/System.Linq/tests/ToListTests.cs
+++ b/src/System.Linq/tests/ToListTests.cs
@@ -240,5 +240,61 @@ namespace System.Linq.Tests
     
             Assert.Equal(expected, source.ToList());
         }
+
+        [Fact]
+        public void ConstantTimeCountPartitionSelectSameTypeToList()
+        {
+            var source = Enumerable.Range(0, 100).Select(i => i * 2).Skip(1).Take(5);
+            Assert.Equal(new[] { 2, 4, 6, 8, 10 }, source.ToList());
+        }
+
+        [Fact]
+        public void ConstantTimeCountPartitionSelectDiffTypeToList()
+        {
+            var source = Enumerable.Range(0, 100).Select(i => i.ToString()).Skip(1).Take(5);
+            Assert.Equal(new[] { "1", "2", "3", "4", "5" }, source.ToList());
+        }
+
+        [Fact]
+        public void ConstantTimeCountEmptyPartitionSelectSameTypeToList()
+        {
+            var source = Enumerable.Range(0, 100).Select(i => i * 2).Skip(1000);
+            Assert.Empty(source.ToList());
+        }
+
+        [Fact]
+        public void ConstantTimeCountEmptyPartitionSelectDiffTypeToList()
+        {
+            var source = Enumerable.Range(0, 100).Select(i => i.ToString()).Skip(1000);
+            Assert.Empty(source.ToList());
+        }
+
+        [Fact]
+        public void NonConstantTimeCountPartitionSelectSameTypeToList()
+        {
+            var source = NumberRangeGuaranteedNotCollectionType(0, 100).OrderBy(i => i).Select(i => i * 2).Skip(1).Take(5);
+            Assert.Equal(new[] { 2, 4, 6, 8, 10 }, source.ToList());
+        }
+
+        [Fact]
+        public void NonConstantTimeCountPartitionSelectDiffTypeToList()
+        {
+            var source = NumberRangeGuaranteedNotCollectionType(0, 100).OrderBy(i => i).Select(i => i.ToString()).Skip(1).Take(5);
+            Assert.Equal(new[] { "1", "2", "3", "4", "5" }, source.ToList());
+        }
+
+        [Fact]
+        public void NonConstantTimeCountEmptyPartitionSelectSameTypeToList()
+        {
+            var source = NumberRangeGuaranteedNotCollectionType(0, 100).OrderBy(i => i).Select(i => i * 2).Skip(1000);
+            Assert.Empty(source.ToList());
+        }
+
+        [Fact]
+        public void NonConstantTimeCountEmptyPartitionSelectDiffTypeToList()
+        {
+            var source = NumberRangeGuaranteedNotCollectionType(0, 100).OrderBy(i => i).Select(i => i.ToString()).Skip(1000);
+            Assert.Empty(source.ToList());
+        }
     }
 }


### PR DESCRIPTION
The creation of SelectListIterator above allows for partitioning to be used with the list-based Select() iterators, improving some subsequent operations on them.

Closes #2844. While there are still a few cases left, the majority of operations where implementing IList<T> could give a gain now have the same time complexity due to going through `IPartition`.

cc @stephentoub @VSadov 