### PR TITLE
Optimise Grouping and Lookup

### DIFF
--- a/src/System.Linq/src/System/Linq/Grouping.cs
+++ b/src/System.Linq/src/System/Linq/Grouping.cs
@@ -12,12 +12,12 @@ namespace System.Linq
     {
         public static IEnumerable<IGrouping<TKey, TSource>> GroupBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
         {
-            return new GroupedEnumerable<TSource, TKey, TSource>(source, keySelector, IdentityFunction<TSource>.Instance, null);
+            return new GroupedEnumerable<TSource, TKey>(source, keySelector, null);
         }
 
         public static IEnumerable<IGrouping<TKey, TSource>> GroupBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
         {
-            return new GroupedEnumerable<TSource, TKey, TSource>(source, keySelector, IdentityFunction<TSource>.Instance, comparer);
+            return new GroupedEnumerable<TSource, TKey>(source, keySelector, comparer);
         }
 
         public static IEnumerable<IGrouping<TKey, TElement>> GroupBy<TSource, TKey, TElement>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
@@ -32,30 +32,22 @@ namespace System.Linq
 
         public static IEnumerable<TResult> GroupBy<TSource, TKey, TResult>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TKey, IEnumerable<TSource>, TResult> resultSelector)
         {
-            return new GroupedEnumerable<TSource, TKey, TSource, TResult>(source, keySelector, IdentityFunction<TSource>.Instance, resultSelector, null);
+            return new GroupedResultEnumerable<TSource, TKey, TResult>(source, keySelector, resultSelector, null);
         }
 
         public static IEnumerable<TResult> GroupBy<TSource, TKey, TElement, TResult>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<TKey, IEnumerable<TElement>, TResult> resultSelector)
         {
-            return new GroupedEnumerable<TSource, TKey, TElement, TResult>(source, keySelector, elementSelector, resultSelector, null);
+            return new GroupedResultEnumerable<TSource, TKey, TElement, TResult>(source, keySelector, elementSelector, resultSelector, null);
         }
 
         public static IEnumerable<TResult> GroupBy<TSource, TKey, TResult>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TKey, IEnumerable<TSource>, TResult> resultSelector, IEqualityComparer<TKey> comparer)
         {
-            return new GroupedEnumerable<TSource, TKey, TSource, TResult>(source, keySelector, IdentityFunction<TSource>.Instance, resultSelector, comparer);
+            return new GroupedResultEnumerable<TSource, TKey, TResult>(source, keySelector, resultSelector, comparer);
         }
 
         public static IEnumerable<TResult> GroupBy<TSource, TKey, TElement, TResult>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<TKey, IEnumerable<TElement>, TResult> resultSelector, IEqualityComparer<TKey> comparer)
         {
-            return new GroupedEnumerable<TSource, TKey, TElement, TResult>(source, keySelector, elementSelector, resultSelector, comparer);
-        }
-    }
-
-    internal class IdentityFunction<TElement>
-    {
-        public static Func<TElement, TElement> Instance
-        {
-            get { return x => x; }
+            return new GroupedResultEnumerable<TSource, TKey, TElement, TResult>(source, keySelector, elementSelector, resultSelector, comparer);
         }
     }
 
@@ -172,15 +164,15 @@ namespace System.Linq
         }
     }
 
-    internal class GroupedEnumerable<TSource, TKey, TElement, TResult> : IIListProvider<TResult>
+    internal sealed class GroupedResultEnumerable<TSource, TKey, TElement, TResult> : IIListProvider<TResult>
     {
-        private IEnumerable<TSource> _source;
-        private Func<TSource, TKey> _keySelector;
-        private Func<TSource, TElement> _elementSelector;
-        private IEqualityComparer<TKey> _comparer;
-        private Func<TKey, IEnumerable<TElement>, TResult> _resultSelector;
+        private readonly IEnumerable<TSource> _source;
+        private readonly Func<TSource, TKey> _keySelector;
+        private readonly Func<TSource, TElement> _elementSelector;
+        private readonly IEqualityComparer<TKey> _comparer;
+        private readonly Func<TKey, IEnumerable<TElement>, TResult> _resultSelector;
 
-        public GroupedEnumerable(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<TKey, IEnumerable<TElement>, TResult> resultSelector, IEqualityComparer<TKey> comparer)
+        public GroupedResultEnumerable(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<TKey, IEnumerable<TElement>, TResult> resultSelector, IEqualityComparer<TKey> comparer)
         {
             if (source == null) throw Error.ArgumentNull("source");
             if (keySelector == null) throw Error.ArgumentNull("keySelector");
@@ -196,7 +188,7 @@ namespace System.Linq
         public IEnumerator<TResult> GetEnumerator()
         {
             Lookup<TKey, TElement> lookup = Lookup<TKey, TElement>.Create(_source, _keySelector, _elementSelector, _comparer);
-            return lookup.ApplyResultSelector(_resultSelector).GetEnumerator();
+            return lookup.ApplyResultSelector(_resultSelector);
         }
 
         IEnumerator IEnumerable.GetEnumerator()
@@ -220,12 +212,57 @@ namespace System.Linq
         }
     }
 
-    internal class GroupedEnumerable<TSource, TKey, TElement> : IIListProvider<IGrouping<TKey, TElement>>
+    internal sealed class GroupedResultEnumerable<TSource, TKey, TResult> : IIListProvider<TResult>
     {
-        private IEnumerable<TSource> _source;
-        private Func<TSource, TKey> _keySelector;
-        private Func<TSource, TElement> _elementSelector;
-        private IEqualityComparer<TKey> _comparer;
+        private readonly IEnumerable<TSource> _source;
+        private readonly Func<TSource, TKey> _keySelector;
+        private readonly IEqualityComparer<TKey> _comparer;
+        private readonly Func<TKey, IEnumerable<TSource>, TResult> _resultSelector;
+
+        public GroupedResultEnumerable(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TKey, IEnumerable<TSource>, TResult> resultSelector, IEqualityComparer<TKey> comparer)
+        {
+            if (source == null) throw Error.ArgumentNull("source");
+            if (keySelector == null) throw Error.ArgumentNull("keySelector");
+            if (resultSelector == null) throw Error.ArgumentNull("resultSelector");
+            _source = source;
+            _keySelector = keySelector;
+            _comparer = comparer;
+            _resultSelector = resultSelector;
+        }
+
+        public IEnumerator<TResult> GetEnumerator()
+        {
+            Lookup<TKey, TSource> lookup = Lookup<TKey, TSource>.Create(_source, _keySelector, _comparer);
+            return lookup.ApplyResultSelector(_resultSelector);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public TResult[] ToArray()
+        {
+            return Lookup<TKey, TSource>.Create(_source, _keySelector, _comparer).ToArray(_resultSelector);
+        }
+
+        public List<TResult> ToList()
+        {
+            return Lookup<TKey, TSource>.Create(_source, _keySelector, _comparer).ToList(_resultSelector);
+        }
+
+        public int GetCount(bool onlyIfCheap)
+        {
+            return onlyIfCheap ? -1 : Lookup<TKey, TSource>.Create(_source, _keySelector, _comparer).Count;
+        }
+    }
+
+    internal sealed class GroupedEnumerable<TSource, TKey, TElement> : IIListProvider<IGrouping<TKey, TElement>>
+    {
+        private readonly IEnumerable<TSource> _source;
+        private readonly Func<TSource, TKey> _keySelector;
+        private readonly Func<TSource, TElement> _elementSelector;
+        private readonly IEqualityComparer<TKey> _comparer;
 
         public GroupedEnumerable(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
         {
@@ -263,6 +300,49 @@ namespace System.Linq
         public int GetCount(bool onlyIfCheap)
         {
             return onlyIfCheap ? -1 : Lookup<TKey, TElement>.Create(_source, _keySelector, _elementSelector, _comparer).Count;
+        }
+    }
+
+    internal sealed class GroupedEnumerable<TSource, TKey> : IIListProvider<IGrouping<TKey, TSource>>
+    {
+        private readonly IEnumerable<TSource> _source;
+        private readonly Func<TSource, TKey> _keySelector;
+        private readonly IEqualityComparer<TKey> _comparer;
+
+        public GroupedEnumerable(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            if (source == null) throw Error.ArgumentNull("source");
+            if (keySelector == null) throw Error.ArgumentNull("keySelector");
+            _source = source;
+            _keySelector = keySelector;
+            _comparer = comparer;
+        }
+
+        public IEnumerator<IGrouping<TKey, TSource>> GetEnumerator()
+        {
+            return Lookup<TKey, TSource>.Create(_source, _keySelector, _comparer).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public IGrouping<TKey, TSource>[] ToArray()
+        {
+            IIListProvider<IGrouping<TKey, TSource>> lookup = Lookup<TKey, TSource>.Create(_source, _keySelector, _comparer);
+            return lookup.ToArray();
+        }
+
+        public List<IGrouping<TKey, TSource>> ToList()
+        {
+            IIListProvider<IGrouping<TKey, TSource>> lookup = Lookup<TKey, TSource>.Create(_source, _keySelector, _comparer);
+            return lookup.ToList();
+        }
+
+        public int GetCount(bool onlyIfCheap)
+        {
+            return onlyIfCheap ? -1 : Lookup<TKey, TSource>.Create(_source, _keySelector, _comparer).Count;
         }
     }
 }

--- a/src/System.Linq/tests/GroupByTests.cs
+++ b/src/System.Linq/tests/GroupByTests.cs
@@ -215,6 +215,7 @@ namespace System.Linq.Tests
         {
             Record[] source = null;
             Assert.Throws<ArgumentNullException>("source", () => source.GroupBy(e => e.Name, e => e.Score, new AnagramEqualityComparer()));
+            Assert.Throws<ArgumentNullException>("source", () => source.GroupBy(e => e.Name, new AnagramEqualityComparer()));
         }
 
         [Fact]
@@ -252,6 +253,7 @@ namespace System.Linq.Tests
             };
 
             Assert.Throws<ArgumentNullException>("keySelector", () => source.GroupBy(null, e => e.Score, new AnagramEqualityComparer()));
+            Assert.Throws<ArgumentNullException>("keySelector", () => source.GroupBy(null, new AnagramEqualityComparer()));
         }
 
         [Fact]
@@ -579,6 +581,24 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void GroupingWithElementSelectorToArray()
+        {
+            Record[] source = new Record[]
+            {
+                new Record{ Name = "Tim", Score = 55 },
+                new Record{ Name = "Chris", Score = 49 },
+                new Record{ Name = "Robert", Score = -100 },
+                new Record{ Name = "Chris", Score = 24 },
+                new Record{ Name = "Prakash", Score = 9 },
+                new Record{ Name = "Tim", Score = 25 }
+            };
+
+            IGrouping<string, int>[] groupedArray = source.GroupBy(r => r.Name, e => e.Score).ToArray();
+            Assert.Equal(4, groupedArray.Length);
+            Assert.Equal(source.GroupBy(r => r.Name, e => e.Score), groupedArray);
+        }
+
+        [Fact]
         public void GroupingWithResultsToArray()
         {
             Record[] source = new Record[]
@@ -594,6 +614,24 @@ namespace System.Linq.Tests
             IEnumerable<Record>[] groupedArray = source.GroupBy(r => r.Name, (r, e) => e).ToArray();
             Assert.Equal(4, groupedArray.Length);
             Assert.Equal(source.GroupBy(r => r.Name, (r, e) => e), groupedArray);
+        }
+
+        [Fact]
+        public void GroupingWithElementSelectorAndResultsToArray()
+        {
+            Record[] source = new Record[]
+            {
+                new Record{ Name = "Tim", Score = 55 },
+                new Record{ Name = "Chris", Score = 49 },
+                new Record{ Name = "Robert", Score = -100 },
+                new Record{ Name = "Chris", Score = 24 },
+                new Record{ Name = "Prakash", Score = 9 },
+                new Record{ Name = "Tim", Score = 25 }
+            };
+
+            IEnumerable<Record>[] groupedArray = source.GroupBy(r => r.Name, e => e, (r, e) => e).ToArray();
+            Assert.Equal(4, groupedArray.Length);
+            Assert.Equal(source.GroupBy(r => r.Name, e => e, (r, e) => e), groupedArray);
         }
 
         [Fact]
@@ -615,6 +653,24 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void GroupingWithElementSelectorToList()
+        {
+            Record[] source = new Record[]
+            {
+                new Record { Name = "Tim", Score = 55 },
+                new Record { Name = "Chris", Score = 49 },
+                new Record { Name = "Robert", Score = -100 },
+                new Record { Name = "Chris", Score = 24 },
+                new Record { Name = "Prakash", Score = 9 },
+                new Record { Name = "Tim", Score = 25 }
+            };
+
+            List<IGrouping<string, int>> groupedList = source.GroupBy(r => r.Name, e => e.Score).ToList();
+            Assert.Equal(4, groupedList.Count);
+            Assert.Equal(source.GroupBy(r => r.Name, e => e.Score), groupedList);
+        }
+
+        [Fact]
         public void GroupingWithResultsToList()
         {
             Record[] source = new Record[]
@@ -630,6 +686,24 @@ namespace System.Linq.Tests
             List<IEnumerable<Record>> groupedList = source.GroupBy(r => r.Name, (r, e) => e).ToList();
             Assert.Equal(4, groupedList.Count);
             Assert.Equal(source.GroupBy(r => r.Name, (r, e) => e), groupedList);
+        }
+
+        [Fact]
+        public void GroupingWithElementSelectorAndResultsToList()
+        {
+            Record[] source = new Record[]
+            {
+                new Record { Name = "Tim", Score = 55 },
+                new Record { Name = "Chris", Score = 49 },
+                new Record { Name = "Robert", Score = -100 },
+                new Record { Name = "Chris", Score = 24 },
+                new Record { Name = "Prakash", Score = 9 },
+                new Record { Name = "Tim", Score = 25 }
+            };
+
+            List<IEnumerable<Record>> groupedList = source.GroupBy(r => r.Name, e => e, (r, e) => e).ToList();
+            Assert.Equal(4, groupedList.Count);
+            Assert.Equal(source.GroupBy(r => r.Name, e => e, (r, e) => e), groupedList);
         }
 
         [Fact]
@@ -649,6 +723,22 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void GroupingWithElementSelectorCount()
+        {
+            Record[] source = new Record[]
+            {
+                new Record { Name = "Tim", Score = 55 },
+                new Record { Name = "Chris", Score = 49 },
+                new Record { Name = "Robert", Score = -100 },
+                new Record { Name = "Chris", Score = 24 },
+                new Record { Name = "Prakash", Score = 9 },
+                new Record { Name = "Tim", Score = 25 }
+            };
+
+            Assert.Equal(4, source.GroupBy(r => r.Name, e => e.Score).Count());
+        }
+
+        [Fact]
         public void GroupingWithResultsCount()
         {
             Record[] source = new Record[]
@@ -662,6 +752,22 @@ namespace System.Linq.Tests
             };
 
             Assert.Equal(4, source.GroupBy(r => r.Name, (r, e) => e).Count());
+        }
+
+        [Fact]
+        public void GroupingWithElementSelectorAndResultsCount()
+        {
+            Record[] source = new Record[]
+            {
+                new Record { Name = "Tim", Score = 55 },
+                new Record { Name = "Chris", Score = 49 },
+                new Record { Name = "Robert", Score = -100 },
+                new Record { Name = "Chris", Score = 24 },
+                new Record { Name = "Prakash", Score = 9 },
+                new Record { Name = "Tim", Score = 25 }
+            };
+
+            Assert.Equal(4, source.GroupBy(r => r.Name, e=> e, (r, e) => e).Count());
         }
 
         [Fact]


### PR DESCRIPTION
Have separate implementations for when there is no element selector, to avoid going through an identity function delegate.

Have `ApplyResultSelector` return an enumerator, rather than an enumerable that is only ever used to immediately obtain its enumerator.

Create `Lookup` without element selector when none is needed.

Found to have a small but consistent improvement of around 3-5%, and no cases where it slows things.

cc: @stephentoub @VSadov 