### PR TITLE
Improve LINQ perf of chained Concats

### DIFF
--- a/src/System.Linq/src/System/Linq/Concatenate.cs
+++ b/src/System.Linq/src/System/Linq/Concatenate.cs
@@ -2,26 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace System.Linq
 {
     public static partial class Enumerable
     {
-        public static IEnumerable<TSource> Concat<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second)
-        {
-            if (first == null) throw Error.ArgumentNull("first");
-            if (second == null) throw Error.ArgumentNull("second");
-            return ConcatIterator(first, second);
-        }
-
-        private static IEnumerable<TSource> ConcatIterator<TSource>(IEnumerable<TSource> first, IEnumerable<TSource> second)
-        {
-            foreach (TSource element in first) yield return element;
-            foreach (TSource element in second) yield return element;
-        }
-
         public static IEnumerable<TSource> Append<TSource>(this IEnumerable<TSource> source, TSource element)
         {
             if (source == null) throw Error.ArgumentNull("source");
@@ -44,6 +31,228 @@ namespace System.Linq
         {
             yield return element;
             foreach (TSource e1 in source) yield return e1;
+        }
+
+        public static IEnumerable<TSource> Concat<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second)
+        {
+            if (first == null) throw Error.ArgumentNull("first");
+            if (second == null) throw Error.ArgumentNull("second");
+
+            var concatFirst = first as ConcatIterator<TSource>;
+            return concatFirst != null ?
+                UpgradeConcatIterator(concatFirst, second) :
+                new Concat2Iterator<TSource>(first, second);
+        }
+
+        private static ConcatIterator<TSource> UpgradeConcatIterator<TSource>(ConcatIterator<TSource> first, IEnumerable<TSource> second)
+        {
+            Debug.Assert(first is Concat2Iterator<TSource> || first is Concat3Iterator<TSource> || first is ConcatNIterator<TSource>);
+            Debug.Assert(second != null);
+
+            // Are we upgrading from two sources to three?
+            Concat2Iterator<TSource> two = first as Concat2Iterator<TSource>;
+            if (two != null)
+            {
+                return new Concat3Iterator<TSource>(two._first, two._second, second);
+            }
+
+            // From three to four?
+            Concat3Iterator<TSource> three = first as Concat3Iterator<TSource>;
+            if (three != null)
+            {
+                return new ConcatNIterator<TSource>(three._first, three._second, three._third, second);
+            }
+
+            // From four+ to one more
+            const int MaxLengthForConcatArray = 64; // arbitrary limit on array size to avoid lots of large array allocations
+            ConcatNIterator<TSource> n = (ConcatNIterator<TSource>)first;
+            if (n._sources.Length < MaxLengthForConcatArray)
+            {
+                var sources = new IEnumerable<TSource>[n._sources.Length + 1];
+                Array.Copy(n._sources, 0, sources, 0, n._sources.Length);
+                sources[n._sources.Length] = second;
+                return new ConcatNIterator<TSource>(sources);
+            }
+
+            // Fall back to using the normal two-source concat
+            return new Concat2Iterator<TSource>(first, second);
+        }
+
+        private sealed class Concat2Iterator<TSource> : ConcatIterator<TSource>
+        {
+            internal readonly IEnumerable<TSource> _first;
+            internal readonly IEnumerable<TSource> _second;
+
+            internal Concat2Iterator(IEnumerable<TSource> first, IEnumerable<TSource> second)
+            {
+                Debug.Assert(first != null && second != null);
+                _first = first;
+                _second = second;
+            }
+
+            public override Iterator<TSource> Clone()
+            {
+                return new Concat2Iterator<TSource>(_first, _second);
+            }
+
+            protected override IEnumerable<TSource> GetEnumerable(int index)
+            {
+                switch (index)
+                {
+                    case 0: return _first;
+                    case 1: return _second;
+                    default: return null;
+                }
+            }
+        }
+
+        private sealed class Concat3Iterator<TSource> : ConcatIterator<TSource>
+        {
+            internal readonly IEnumerable<TSource> _first;
+            internal readonly IEnumerable<TSource> _second;
+            internal readonly IEnumerable<TSource> _third;
+
+            internal Concat3Iterator(IEnumerable<TSource> first, IEnumerable<TSource> second, IEnumerable<TSource> third)
+            {
+                Debug.Assert(first != null && second != null && third != null);
+                _first = first;
+                _second = second;
+                _third = third;
+            }
+
+            public override Iterator<TSource> Clone()
+            {
+                return new Concat3Iterator<TSource>(_first, _second, _third);
+            }
+
+            protected override IEnumerable<TSource> GetEnumerable(int index)
+            {
+                switch (index)
+                {
+                    case 0: return _first;
+                    case 1: return _second;
+                    case 2: return _third;
+                    default: return null;
+                }
+            }
+        }
+
+        private sealed class ConcatNIterator<TSource> : ConcatIterator<TSource>
+        {
+            internal readonly IEnumerable<TSource>[] _sources;
+
+            internal ConcatNIterator(params IEnumerable<TSource>[] sources)
+            {
+                Debug.Assert(sources != null);
+                Debug.Assert(sources.All(s => s != null));
+                Debug.Assert(sources.Length > 3, "Should be using Concat2Iterator or Concat3Iterator");
+                _sources = sources;
+            }
+
+            public override Iterator<TSource> Clone()
+            {
+                return new ConcatNIterator<TSource>(_sources);
+            }
+
+            protected override IEnumerable<TSource> GetEnumerable(int index)
+            {
+                return index < _sources.Length ? _sources[index] : null;
+            }
+        }
+
+        private abstract class ConcatIterator<TSource> : Iterator<TSource>, IIListProvider<TSource>
+        {
+            private IEnumerator<TSource> _enumerator;
+
+            public override void Dispose()
+            {
+                if (_enumerator != null)
+                {
+                    _enumerator.Dispose();
+                    _enumerator = null;
+                }
+                base.Dispose();
+            }
+
+            protected abstract IEnumerable<TSource> GetEnumerable(int index);
+
+            public override bool MoveNext()
+            {
+                if (state == 1)
+                {
+                    _enumerator = GetEnumerable(0).GetEnumerator();
+                    state = 2;
+                }
+
+                if (state > 1)
+                {
+                    while (true)
+                    {
+                        if (_enumerator.MoveNext())
+                        {
+                            current = _enumerator.Current;
+                            return true;
+                        }
+
+                        Debug.Assert(state < int.MaxValue);
+                        IEnumerable<TSource> next = GetEnumerable(state++ - 1);
+                        if (next != null)
+                        {
+                            _enumerator.Dispose();
+                            _enumerator = next.GetEnumerator();
+                            continue;
+                        }
+
+                        Dispose();
+                        break;
+                    }
+                }
+
+                return false;
+            }
+
+            public TSource[] ToArray()
+            {
+                return EnumerableHelpers.ToArray(this);
+            }
+
+            public List<TSource> ToList()
+            {
+                var list = new List<TSource>();
+                for (int i = 0; ; i++)
+                {
+                    IEnumerable<TSource> source = GetEnumerable(i);
+                    if (source == null) break;
+
+                    list.AddRange(source);
+                }
+                return list;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                int count = 0;
+                for (int i = 0; ; i++)
+                {
+                    IEnumerable<TSource> source = GetEnumerable(i);
+                    if (source == null) break;
+
+                    ICollection<TSource> c = source as ICollection<TSource>;
+                    checked
+                    {
+                        if (c == null)
+                        {
+                            if (onlyIfCheap) return -1;
+                            count += source.Count();
+                        }
+                        else
+                        {
+                            count += c.Count;
+                        }
+                    }
+                }
+                return count;
+            }
         }
     }
 }

--- a/src/System.Linq/tests/ConcatTests.cs
+++ b/src/System.Linq/tests/ConcatTests.cs
@@ -106,6 +106,22 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void TwoArraySelectSources()
+        {
+            VerifyEquals(
+                Enumerable.Range(0, 7),
+                Enumerable.Range(0, 3).ToArray().Select(i => i).Concat(Enumerable.Range(3, 4).ToArray().Select(i => i)));
+        }
+
+        [Fact]
+        public void TwoNonCollectionSources()
+        {
+            VerifyEquals(
+                Enumerable.Range(0, 7),
+                NumberRangeGuaranteedNotCollectionType(0, 3).Concat(NumberRangeGuaranteedNotCollectionType(3, 4).ToArray().Select(i => i)));
+        }
+
+        [Fact]
         public void ThreeEnumerableSources()
         {
             VerifyEquals(
@@ -130,6 +146,18 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void FiveNonCollectionSources()
+        {
+            VerifyEquals(
+                Enumerable.Range(0, 25),
+                NumberRangeGuaranteedNotCollectionType(0, 3)
+                .Concat(NumberRangeGuaranteedNotCollectionType(3, 4))
+                .Concat(NumberRangeGuaranteedNotCollectionType(7, 5))
+                .Concat(NumberRangeGuaranteedNotCollectionType(12, 6))
+                .Concat(NumberRangeGuaranteedNotCollectionType(18, 7)));
+        }
+
+        [Fact]
         public void FiveListSources()
         {
             VerifyEquals(
@@ -141,14 +169,37 @@ namespace System.Linq.Tests
                           .Concat(Enumerable.Range(18, 7).ToList()));
         }
 
+        [Fact]
+        public void ConcatOfConcats()
+        {
+            VerifyEquals(
+                Enumerable.Range(0, 20),
+                Enumerable.Concat(
+                    Enumerable.Concat(
+                        Enumerable.Range(0, 4),
+                        Enumerable.Range(4, 6)),
+                    Enumerable.Concat(
+                        Enumerable.Range(10, 3),
+                        Enumerable.Range(13, 7))));
+        }
+
+        [Fact]
+        public void ConcatWithSelf()
+        {
+            IEnumerable<int> source = Enumerable.Repeat(1, 4).Concat(Enumerable.Repeat(1, 5));
+            source = source.Concat(source);
+            VerifyEquals(Enumerable.Repeat(1, 18), source);
+        }
+
         private void VerifyEquals(IEnumerable<int> expected, IEnumerable<int> actual)
         {
             Assert.Equal(expected, actual);
             Assert.Equal(expected, actual.ToArray());
+            Assert.Equal(expected, actual.ToList());
             Assert.Equal(expected, actual.Select(i => i).ToArray());
             Assert.Equal(expected, actual.Where(i => true).ToArray());
-            Assert.Equal(expected, actual.ToList());
             Assert.Equal(expected, actual.OrderBy(i => i));
+            Assert.Equal(expected, Enumerable.Empty<int>().Concat(actual));
             Assert.Equal(expected.Count(), actual.Count());
         }
 

--- a/src/System.Linq/tests/ConcatTests.cs
+++ b/src/System.Linq/tests/ConcatTests.cs
@@ -17,7 +17,7 @@ namespace System.Linq.Tests
                      select x1;
             var q2 = from x2 in new int?[] { 1, 9, null, 4 }
                      select x2;
-                     
+
             Assert.Equal(q1.Concat(q2), q1.Concat(q2));
         }
 
@@ -87,6 +87,93 @@ namespace System.Linq.Tests
         public void SecondNull()
         {
             Assert.Throws<ArgumentNullException>("second", () => Enumerable.Range(0, 0).Concat(null));
+        }
+
+        [Fact]
+        public void TwoEnumerableSources()
+        {
+            VerifyEquals(
+                Enumerable.Range(0, 7),
+                Enumerable.Range(0, 3).Concat(Enumerable.Range(3, 4)));
+        }
+
+        [Fact]
+        public void TwoArraySources()
+        {
+            VerifyEquals(
+                Enumerable.Range(0, 7),
+                Enumerable.Range(0, 3).ToArray().Concat(Enumerable.Range(3, 4).ToArray()));
+        }
+
+        [Fact]
+        public void ThreeEnumerableSources()
+        {
+            VerifyEquals(
+                Enumerable.Range(0, 12),
+                Enumerable.Range(0, 3).Concat(Enumerable.Range(3, 4)).Concat(Enumerable.Range(7, 5)));
+        }
+
+        [Fact]
+        public void FourEnumerableSources()
+        {
+            VerifyEquals(
+                Enumerable.Range(0, 18),
+                Enumerable.Range(0, 3).Concat(Enumerable.Range(3, 4)).Concat(Enumerable.Range(7, 5)).Concat(Enumerable.Range(12, 6)));
+        }
+
+        [Fact]
+        public void FiveEnumerableSources()
+        {
+            VerifyEquals(
+                Enumerable.Range(0, 25),
+                Enumerable.Range(0, 3).Concat(Enumerable.Range(3, 4)).Concat(Enumerable.Range(7, 5)).Concat(Enumerable.Range(12, 6)).Concat(Enumerable.Range(18, 7)));
+        }
+
+        [Fact]
+        public void FiveListSources()
+        {
+            VerifyEquals(
+                Enumerable.Range(0, 25),
+                Enumerable.Range(0, 3).ToList()
+                          .Concat(Enumerable.Range(3, 4).ToList())
+                          .Concat(Enumerable.Range(7, 5).ToList())
+                          .Concat(Enumerable.Range(12, 6).ToList())
+                          .Concat(Enumerable.Range(18, 7).ToList()));
+        }
+
+        private void VerifyEquals(IEnumerable<int> expected, IEnumerable<int> actual)
+        {
+            Assert.Equal(expected, actual);
+            Assert.Equal(expected, actual.ToArray());
+            Assert.Equal(expected, actual.Select(i => i).ToArray());
+            Assert.Equal(expected, actual.Where(i => true).ToArray());
+            Assert.Equal(expected, actual.ToList());
+            Assert.Equal(expected, actual.OrderBy(i => i));
+            Assert.Equal(expected.Count(), actual.Count());
+        }
+
+        [Fact]
+        public void ManyEmptyConcats()
+        {
+            IEnumerable<int> source = Enumerable.Empty<int>();
+            for (int i = 0; i < 256; i++)
+            {
+                source = source.Concat(Enumerable.Empty<int>());
+            }
+            Assert.Equal(0, source.Count());
+            Assert.Equal(Enumerable.Empty<int>(), source);
+        }
+
+        [Fact]
+        public void ManyNonEmptyConcats()
+        {
+            IEnumerable<int> source = Enumerable.Empty<int>();
+            for (int i = 0; i < 256; i++)
+            {
+                source = source.Concat(Enumerable.Repeat(i, 1));
+            }
+            Assert.Equal(256, source.Count());
+            Assert.Equal(Enumerable.Range(0, 256), source);
         }
     }
 }


### PR DESCRIPTION
The Concat operator today is very simple: it iterats through the first source yielding all items, then does the same for the second.  This works great in isolation, but when chained, the cost grows as yielding each item from the Nth source results in calling through the MoveNext/Current interface methods of the previous N-1 concats.  While this is the nature of LINQ operators in general, it's particular pernicious with Concat, which is often used to assembly data from many sources.

This commit introduces a special concat iterator that avoids that recursive cost.  This comes at the small expense of N+1 interface calls per iteration, where N is the number of sources involved in the concatenation chain.  Chains of two sources and three sources are special-cased, after which an array is allocated and used to hold all of the sources (this could be tweaked in the future to have specializations for more sources if, for example, we found that four was a very common number).  Other benefits include the size of the concat iterator being a bit smaller than it was previously when generated by the compiler, and it now taking part in the IIListProvider interface, so that for example ToList operations are faster when any of the sources are ILists.

Example results on my machine:
- Enumerating a Concat of 2 Range(0, 10) enumerables: ~15% faster
- Enumerating a Concat of 3 Range(0, 10) enumerables: ~30% faster
- Enumerating a Concat of 10 Range(0, 100) enumerables: ~4x faster
- Enumerating a Concat of 100 Range(0, 1) enumerables: ~2x faster

cc: @VSadov, @JonHanna 
Related to https://github.com/dotnet/corefx/issues/2075