### PR TITLE
Improve coverage in X509Certificates library

### DIFF
--- a/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/Internal/Cryptography/Pal.Unix/OpenSslX509ChainProcessor.cs
@@ -267,7 +267,7 @@ namespace Internal.Cryptography.Pal
 
                     X509ChainStatus chainStatus = new X509ChainStatus
                     {
-                        Status = X509ChainStatusFlags.InvalidPolicyConstraints,
+                        Status = X509ChainStatusFlags.NotValidForUsage,
                         StatusInformation = SR.Chain_NoPolicyMatch,
                     };
 

--- a/src/System.Security.Cryptography.X509Certificates/tests/ExtensionsTests.cs
+++ b/src/System.Security.Cryptography.X509Certificates/tests/ExtensionsTests.cs
@@ -388,6 +388,15 @@ namespace System.Security.Cryptography.X509Certificates.Tests
                 "A260A870BE1145ED71E2BB5AA19463A4FE9DCC41");
         }
 
+        [Fact]
+        public static void ReadInvalidExtension_KeyUsage()
+        {
+            X509KeyUsageExtension keyUsageExtension =
+                new X509KeyUsageExtension(new AsnEncodedData(Array.Empty<byte>()), false);
+
+            Assert.ThrowsAny<CryptographicException>(() => keyUsageExtension.KeyUsages);
+        }
+
         private static void TestKeyUsageExtension(X509KeyUsageFlags flags, bool critical, byte[] expectedDer)
         {
             X509KeyUsageExtension ext = new X509KeyUsageExtension(flags, critical);


### PR DESCRIPTION
I did a pass through the X509Certificates code coverage.  One goal was to not have the tests be missing coverage that the legacy internal test system had, but another was to find completely untested chunks of code.

To that end:
* X509ExtensionsCollection string indexer now has tests
* X509Chain now has ApplicationPolicy-verifying tests
* X509Chain now has CertificatePolicy-verifying tests
* Added tests to X509ChainElementCollection's enumerator

The X509Chain tests found a bug in the Unix implementation, and that is addressed in this change.
