### PR TITLE
Update System.Runtime.InteropServices.PInvoke.Tests.csproj

### DIFF
--- a/src/System.Runtime.InteropServices.PInvoke/tests/System.Runtime.InteropServices.PInvoke.Tests.csproj
+++ b/src/System.Runtime.InteropServices.PInvoke/tests/System.Runtime.InteropServices.PInvoke.Tests.csproj
@@ -9,7 +9,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
     <RootNamespace>System.Runtime.InteropServices</RootNamespace>
-    <AssemblyName>System.Runtime.InteropServices.Tests</AssemblyName>
+    <AssemblyName>System.Runtime.InteropServices.PInvoke.Tests</AssemblyName>
     <ProjectGuid>{A824F4CD-935B-4496-A1B2-C3664936DA7B}</ProjectGuid>
     <UnsupportedPlatforms>Linux;OSX</UnsupportedPlatforms>
   </PropertyGroup>


### PR DESCRIPTION
Fix assembly name.  The .NET Helix System assumes, like the other tests in this repo, that the assembly name will match csproj name.