### PR TITLE
Fix file casing in System.Collections.NonGeneric.Tests.csproj

### DIFF
--- a/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
+++ b/src/System.Collections.NonGeneric/tests/System.Collections.NonGeneric.Tests.csproj
@@ -32,7 +32,7 @@
       <Link>Common\System\Diagnostics\DebuggerAttributes.cs</Link>
     </Compile>
     <!-- Performance Tests -->
-    <Compile Include="Performance\Perf.Hashtable.cs" />
+    <Compile Include="Performance\Perf.HashTable.cs" />
     <Compile Include="$(CommonTestPath)\System\PerfUtils.cs">
       <Link>Common\System\PerfUtils.cs</Link>
     </Compile>


### PR DESCRIPTION
A recent commit changed the casing of this file. The actual file is named "Perf.HashTable.cs". This causes cast-sensitive systems to fail to build this project.