### PR TITLE
Change MMF.CreateFromFile sharing setting from None to Read

### DIFF
--- a/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.cs
+++ b/src/System.IO.MemoryMappedFiles/src/System/IO/MemoryMappedFiles/MemoryMappedFile.cs
@@ -147,7 +147,7 @@ namespace System.IO.MemoryMappedFiles
             }
 
             bool existed = File.Exists(path);
-            FileStream fileStream = new FileStream(path, mode, GetFileAccess(access), FileShare.None, 0x1000, FileOptions.None);
+            FileStream fileStream = new FileStream(path, mode, GetFileAccess(access), FileShare.Read, 0x1000, FileOptions.None);
 
             if (capacity == 0 && fileStream.Length == 0)
             {

--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
@@ -575,10 +575,11 @@ namespace System.IO.MemoryMappedFiles.Tests
         }
 
         /// <summary>
-        /// Test exceptional behavior when trying to create a map for a file that's currently in use.
+        /// Test exceptional behavior when trying to create a map for a read-write file that's currently in use.
         /// </summary>
         [Fact]
-        public void FileInUse()
+        [PlatformSpecific(PlatformID.Windows)] // FileShare is limited on Unix, with None == exclusive, everything else == concurrent
+        public void FileInUse_CreateFromFile_FailsWithExistingReadWriteFile()
         {
             // Already opened with a FileStream
             using (TempFile file = new TempFile(GetTestFilePath(), 4096))
@@ -586,12 +587,51 @@ namespace System.IO.MemoryMappedFiles.Tests
             {
                 Assert.Throws<IOException>(() => MemoryMappedFile.CreateFromFile(file.Path));
             }
+        }
 
-            // Already opened with another map
+        /// <summary>
+        /// Test exceptional behavior when trying to create a map for a non-shared file that's currently in use.
+        /// </summary>
+        [Fact]
+        [PlatformSpecific(PlatformID.Windows)] // FileShare is limited on Unix, with None == exclusive, everything else == concurrent
+        public void FileInUse_CreateFromFile_FailsWithExistingReadWriteMap()
+        {
+            // Already opened with another read-write map
             using (TempFile file = new TempFile(GetTestFilePath(), 4096))
             using (MemoryMappedFile mmf = MemoryMappedFile.CreateFromFile(file.Path))
             {
                 Assert.Throws<IOException>(() => MemoryMappedFile.CreateFromFile(file.Path));
+            }
+        }
+
+        /// <summary>
+        /// Test exceptional behavior when trying to create a map for a non-shared file that's currently in use.
+        /// </summary>
+        [Fact]
+        public void FileInUse_CreateFromFile_FailsWithExistingNoShareFile()
+        {
+            // Already opened with a FileStream
+            using (TempFile file = new TempFile(GetTestFilePath(), 4096))
+            using (FileStream fs = File.Open(file.Path, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+            {
+                Assert.Throws<IOException>(() => MemoryMappedFile.CreateFromFile(file.Path));
+            }
+        }
+
+        /// <summary>
+        /// Test to validate we can create multiple concurrent read-only maps from the same file path.
+        /// </summary>
+        [Fact]
+        public void FileInUse_CreateFromFile_SucceedsWithReadOnly()
+        {
+            const int Capacity = 4096;
+            using (TempFile file = new TempFile(GetTestFilePath(), Capacity))
+            using (MemoryMappedFile mmf1 = MemoryMappedFile.CreateFromFile(file.Path, FileMode.Open, null, Capacity, MemoryMappedFileAccess.Read))
+            using (MemoryMappedFile mmf2 = MemoryMappedFile.CreateFromFile(file.Path, FileMode.Open, null, Capacity, MemoryMappedFileAccess.Read))
+            using (MemoryMappedViewAccessor acc1 = mmf1.CreateViewAccessor(0, Capacity, MemoryMappedFileAccess.Read))
+            using (MemoryMappedViewAccessor acc2 = mmf2.CreateViewAccessor(0, Capacity, MemoryMappedFileAccess.Read))
+            {
+                Assert.Equal(acc1.Capacity, acc2.Capacity);
             }
         }
 


### PR DESCRIPTION
When calling MemoryMappedFile.CreateFromFile(string path, ...), it creates an underlying FileStream using FileShare.None.  This means that these convenience functions aren't very useful for a common case of needing shared read-access to some file.  This changes the default from None to Read, changing a situation that previously threw an exception to one that doesn't.

One-word product change, plus some test changes.
Fixes https://github.com/dotnet/corefx/issues/6092
cc: @schellap, @jkotas, @weshaggard, @ericstj 