### PR TITLE
Add System.IO.* tests missing from Open

### DIFF
--- a/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
+++ b/src/System.IO.Compression/tests/System.IO.Compression.Tests.csproj
@@ -58,7 +58,9 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
-    <SupplementalTestData Include="$(PackagesDir)System.IO.Compression.TestData\1.0.2-prerelease\content\**\*.*" />
+    <SupplementalTestData Include="$(PackagesDir)System.IO.Compression.TestData\1.0.2-prerelease\content\**\*.*">
+      <Link>%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </SupplementalTestData>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Windows.Tests.cs
+++ b/src/System.IO.FileSystem.DriveInfo/tests/DriveInfo.Windows.Tests.cs
@@ -19,7 +19,7 @@ namespace System.IO.FileSystem.DriveInfoTests
         [PlatformSpecific(PlatformID.Windows)]
         public void TestConstructor()
         {
-            string[] invalidInput = { ":", "://", @":\", ":/", @":\\", "Az", "1", "a1", @"\\share", @"\\", "c ", string.Empty, " c" };
+            string[] invalidInput = { ":\0", ":", "://", @":\", ":/", @":\\", "Az", "1", "a1", @"\\share", @"\\", "c ", string.Empty, " c" };
             string[] variableInput = { "{0}", "{0}", "{0}:", "{0}:", @"{0}:\", @"{0}:\\", "{0}://" };
 
             // Test Invalid input

--- a/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.CreateServer.cs
+++ b/src/System.IO.Pipes/tests/AnonymousPipeTests/AnonymousPipeTest.CreateServer.cs
@@ -78,6 +78,7 @@ namespace System.IO.Pipes.Tests
             new AnonymousPipeServerStream().Dispose();
             new AnonymousPipeServerStream(PipeDirection.Out).Dispose();
             new AnonymousPipeServerStream(PipeDirection.Out, HandleInheritability.None).Dispose();
+            new AnonymousPipeServerStream(PipeDirection.Out, HandleInheritability.Inheritable).Dispose();
             new AnonymousPipeServerStream(PipeDirection.Out, HandleInheritability.None, 0).Dispose();
         }
     }

--- a/src/System.IO.Pipes/tests/PipeTest.Read.cs
+++ b/src/System.IO.Pipes/tests/PipeTest.Read.cs
@@ -124,6 +124,7 @@ namespace System.IO.Pipes.Tests
                 PipeStream pipe = pair.readablePipe;
                 Assert.True(pipe.IsConnected);
                 Assert.False(pipe.CanWrite);
+                Assert.False(pipe.CanSeek);
 
                 Assert.Throws<NotSupportedException>(() => pipe.Write(new byte[5], 0, 5));
 

--- a/src/System.IO.Pipes/tests/PipeTest.Write.cs
+++ b/src/System.IO.Pipes/tests/PipeTest.Write.cs
@@ -45,6 +45,7 @@ namespace System.IO.Pipes.Tests
                 PipeStream pipe = pair.writeablePipe;
                 Assert.True(pipe.IsConnected);
                 Assert.True(pipe.CanWrite);
+                Assert.False(pipe.CanSeek);
 
                 // Offset must be nonnegative
                 Assert.Throws<ArgumentOutOfRangeException>("offset", () => pipe.Write(new byte[5], -1, 1));


### PR DESCRIPTION
As part of disabling the ToF tests, we're raising coverage in Open where there are gaps that are covered by the ToF tests.

This commit gets us to parity with ToF for:
- System.IO.Compression
- System.IO.Compression.ZipFile
- System.IO.FileSystem.DriveInfo
- System.IO.FileSystem.Watcher
- System.IO.MemoryMappedFiles
- System.IO.Pipes
- System.IO.UnmanagedMemoryStream