### PR TITLE
Improve performance of chained Union operations.

### DIFF
--- a/src/System.Linq/src/System/Linq/Concatenate.cs
+++ b/src/System.Linq/src/System/Linq/Concatenate.cs
@@ -143,7 +143,14 @@ namespace System.Linq
 
             internal override ConcatIterator<TSource> Concat(IEnumerable<TSource> next)
             {
-                return new ConcatNIterator<TSource>(this, next, checked(_nextIndex + 1));
+                if (_nextIndex == int.MaxValue - 2)
+                {
+                    // In the unlikely case of this many concatenations, if we produced a ConcatNIterator
+                    // with int.MaxValue then state would overflow before it matched it's index.
+                    // So we use the naïve approach of just having a left and right sequence.
+                    return new Concat2Iterator<TSource>(this, next);
+                }
+                return new ConcatNIterator<TSource>(this, next, _nextIndex + 1);
             }
 
             internal override IEnumerable<TSource> GetEnumerable(int index)

--- a/src/System.Linq/tests/UnionTests.cs
+++ b/src/System.Linq/tests/UnionTests.cs
@@ -9,7 +9,33 @@ using Xunit;
 namespace System.Linq.Tests
 {
     public class UnionTests : EnumerableTests
-    {        
+    {
+        private sealed class Modulo100EqualityComparer : IEqualityComparer<int?>
+        {
+            public bool Equals(int? x, int? y)
+            {
+                if (!x.HasValue) return !y.HasValue;
+                if (!y.HasValue) return false;
+                return x.GetValueOrDefault() % 100 == y.GetValueOrDefault() % 100;
+            }
+
+            public int GetHashCode(int? obj)
+            {
+                return obj.HasValue ? obj.GetValueOrDefault() % 100 + 1 : 0;
+            }
+
+            public override bool Equals(object obj)
+            {
+                // Equal to all other instances.
+                return obj is Modulo100EqualityComparer;
+            }
+
+            public override int GetHashCode()
+            {
+                return 0xAFFAB1E; // Any number as long as it's constant.
+            }
+        }
+
         [Fact]
         public void SameResultsRepeatCallsIntQuery()
         {
@@ -17,10 +43,10 @@ namespace System.Linq.Tests
                      select x1;
             var q2 = from x2 in new int?[] { 1, 9, null, 4 }
                      select x2;
-                     
+
             Assert.Equal(q1.Union(q2), q1.Union(q2));
         }
-        
+
         [Fact]
         public void SameResultsRepeatCallsStringQuery()
         {
@@ -28,8 +54,21 @@ namespace System.Linq.Tests
                      select x1;
             var q2 = from x2 in new[] { "!@#$%^", "C", "AAA", "", "Calling Twice", "SoS" }
                      select x2;
-                     
+
             Assert.Equal(q1.Union(q2), q1.Union(q2));
+        }
+
+        [Fact]
+        public void SameResultsRepeatCallsMultipleUnions()
+        {
+            var q1 = from x1 in new int?[] { 2, 3, null, 2, null, 4, 5 }
+                     select x1;
+            var q2 = from x2 in new int?[] { 1, 9, null, 4 }
+                     select x2;
+            var q3 = from x3 in new int?[] { null, 8, 2, 2, 3 }
+                     select x3;
+
+            Assert.Equal(q1.Union(q2).Union(q3), q1.Union(q2).Union(q3));
         }
 
         [Fact]
@@ -41,12 +80,22 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void ManyEmpty()
+        {
+            int[] first = { };
+            int[] second = { };
+            int[] third = { };
+            int[] fourth = { };
+            Assert.Empty(first.Union(second).Union(third).Union(fourth));
+        }
+
+        [Fact]
         public void CustomComparer()
         {
             string[] first = { "Bob", "Robert", "Tim", "Matt", "miT" };
             string[] second = { "ttaM", "Charlie", "Bbo" };
             string[] expected = { "Bob", "Robert", "Tim", "Matt", "Charlie" };
-            
+
             var comparer = new AnagramEqualityComparer();
 
             Assert.Equal(expected, first.Union(second, comparer), comparer);
@@ -57,7 +106,7 @@ namespace System.Linq.Tests
         {
             string[] first = null;
             string[] second = { "ttaM", "Charlie", "Bbo" };
-            
+
             var ane = Assert.Throws<ArgumentNullException>("first", () => first.Union(second, new AnagramEqualityComparer()));
         }
 
@@ -94,7 +143,7 @@ namespace System.Linq.Tests
             string[] first = { null };
             string[] second = new string[0];
             string[] expected = { null };
-            
+
             Assert.Equal(expected, first.Union(second, EqualityComparer<string>.Default));
         }
 
@@ -189,6 +238,44 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void EachHasRepeatsBetweenAndAmongstThemselvesMultipleUnions()
+        {
+            int?[] first = { 1, 2, 3, 4, null, 5, 1 };
+            int?[] second = { 6, 2, 3, 4, 5, 6 };
+            int?[] third = { 2, 8, 2, 3, 2, 8 };
+            int?[] fourth = { null, 1, 7, 2, 7 };
+            int?[] expected = { 1, 2, 3, 4, null, 5, 6, 8, 7 };
+
+            Assert.Equal(expected, first.Union(second).Union(third).Union(fourth));
+        }
+
+        [Fact]
+        public void MultipleUnionsCustomComparer()
+        {
+            int?[] first = { 1, 102, 903, 204, null, 5, 601 };
+            int?[] second = { 6, 202, 903, 204, 5, 106 };
+            int?[] third = { 2, 308, 2, 103, 802, 308 };
+            int?[] fourth = { null, 101, 207, 202, 207 };
+            int?[] expected = { 1, 102, 903, 204, null, 5, 6, 308, 207 };
+
+            Assert.Equal(expected, first.Union(second, new Modulo100EqualityComparer()).Union(third, new Modulo100EqualityComparer()).Union(fourth, new Modulo100EqualityComparer()));
+        }
+
+        [Fact]
+        public void MultipleUnionsDifferentComparers()
+        {
+            string[] first = { "Alpha", "Bravo", "Charlie", "Bravo", "Delta", "atleD", "ovarB" };
+            string[] second = { "Charlie", "Delta", "Echo", "Foxtrot", "Foxtrot", "choE" };
+            string[] third = { "trotFox", "Golf", "Alpha", "choE", "Tango" };
+
+            string[] plainThenAnagram = { "Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "Golf", "Tango" };
+            string[] anagramThenPlain = { "Alpha", "Bravo", "Charlie", "Delta", "Echo", "Foxtrot", "trotFox", "Golf", "choE", "Tango" };
+
+            Assert.Equal(plainThenAnagram, first.Union(second).Union(third, new AnagramEqualityComparer()));
+            Assert.Equal(anagramThenPlain, first.Union(second, new AnagramEqualityComparer()).Union(third));
+        }
+
+        [Fact]
         public void NullEqualityComparer()
         {
             string[] first = { "Bob", "Robert", "Tim", "Matt", "miT" };
@@ -208,6 +295,15 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void ForcedToEnumeratorDoesntEnumerateMultipleUnions()
+        {
+            var iterator = NumberRangeGuaranteedNotCollectionType(0, 3).Union(Enumerable.Range(0, 3)).Union(Enumerable.Range(2, 4)).Union(new[] { 9, 2, 4 });
+            // Don't insist on this behaviour, but check its correct if it happens
+            var en = iterator as IEnumerator<int>;
+            Assert.False(en != null && en.MoveNext());
+        }
+
+        [Fact]
         public void ToArray()
         {
             string[] first = { "Bob", "Robert", "Tim", "Matt", "miT" };
@@ -215,6 +311,17 @@ namespace System.Linq.Tests
             string[] expected = { "Bob", "Robert", "Tim", "Matt", "miT", "ttaM", "Charlie", "Bbo" };
 
             Assert.Equal(expected, first.Union(second).ToArray());
+        }
+
+        [Fact]
+        public void ToArrayMultipleUnion()
+        {
+            string[] first = { "Bob", "Robert", "Tim", "Matt", "miT" };
+            string[] second = { "ttaM", "Charlie", "Bbo" };
+            string[] third = { "Bob", "Albert", "Tim" };
+            string[] expected = { "Bob", "Robert", "Tim", "Matt", "miT", "ttaM", "Charlie", "Bbo", "Albert" };
+
+            Assert.Equal(expected, first.Union(second).Union(third).ToArray());
         }
 
         [Fact]
@@ -228,12 +335,32 @@ namespace System.Linq.Tests
         }
 
         [Fact]
+        public void ToListMultipleUnion()
+        {
+            string[] first = { "Bob", "Robert", "Tim", "Matt", "miT" };
+            string[] second = { "ttaM", "Charlie", "Bbo" };
+            string[] third = { "Bob", "Albert", "Tim" };
+            string[] expected = { "Bob", "Robert", "Tim", "Matt", "miT", "ttaM", "Charlie", "Bbo", "Albert" };
+
+            Assert.Equal(expected, first.Union(second).Union(third).ToList());
+        }
+
+        [Fact]
         public void Count()
         {
             string[] first = { "Bob", "Robert", "Tim", "Matt", "miT" };
             string[] second = { "ttaM", "Charlie", "Bbo" };
 
             Assert.Equal(8, first.Union(second).Count());
+        }
+        [Fact]
+        public void CountMultipleUnion()
+        {
+            string[] first = { "Bob", "Robert", "Tim", "Matt", "miT" };
+            string[] second = { "ttaM", "Charlie", "Bbo" };
+            string[] third = { "Bob", "Albert", "Tim" };
+
+            Assert.Equal(9, first.Union(second).Union(third).Count());
         }
 
         [Fact]
@@ -243,6 +370,18 @@ namespace System.Linq.Tests
             string[] second = { "ttaM", "Charlie", "Bbo" };
 
             var result = first.Union(second);
+
+            Assert.Equal(result, result);
+        }
+
+        [Fact]
+        public void RepeatEnumeratingMultipleUnions()
+        {
+            string[] first = { "Bob", "Robert", "Tim", "Matt", "miT" };
+            string[] second = { "ttaM", "Charlie", "Bbo" };
+            string[] third = { "Matt", "Albert", "Ichabod" };
+
+            var result = first.Union(second).Union(third);
 
             Assert.Equal(result, result);
         }


### PR DESCRIPTION
While not as common as chained Concat, chained Union operations are sometimes needed when combining different sources. This applies a cut-down version of the improvements made to concat in this regard, though only considering the 2-source union (first call) and n-source unions (all subsequent calls) rather than specialising further.

Acting on the union now requires only one hash set to be created and filled, rather than allocating and filling one for each call to `Union()`.