### PR TITLE
Respond to feedback on PR #6130

### DIFF
--- a/src/System.Linq/src/System/Linq/Grouping.cs
+++ b/src/System.Linq/src/System/Linq/Grouping.cs
@@ -226,8 +226,8 @@ namespace System.Linq
             if (resultSelector == null) throw Error.ArgumentNull("resultSelector");
             _source = source;
             _keySelector = keySelector;
-            _comparer = comparer;
             _resultSelector = resultSelector;
+            _comparer = comparer;
         }
 
         public IEnumerator<TResult> GetEnumerator()

--- a/src/System.Linq/src/System/Linq/Join.cs
+++ b/src/System.Linq/src/System/Linq/Join.cs
@@ -41,7 +41,7 @@ namespace System.Linq
                         do
                         {
                             TOuter item = e.Current;
-                            Grouping<TKey, TInner> g = lookup.GetGrouping(outerKeySelector(item), false);
+                            Grouping<TKey, TInner> g = lookup.GetGrouping(outerKeySelector(item), create: false);
                             if (g != null)
                             {
                                 int count = g.count;

--- a/src/System.Linq/src/System/Linq/Lookup.cs
+++ b/src/System.Linq/src/System/Linq/Lookup.cs
@@ -59,7 +59,7 @@ namespace System.Linq
             Lookup<TKey, TElement> lookup = new Lookup<TKey, TElement>(comparer);
             foreach (TSource item in source)
             {
-                lookup.GetGrouping(keySelector(item), true).Add(elementSelector(item));
+                lookup.GetGrouping(keySelector(item), create: true).Add(elementSelector(item));
             }
             return lookup;
         }
@@ -71,7 +71,7 @@ namespace System.Linq
             Lookup<TKey, TElement> lookup = new Lookup<TKey, TElement>(comparer);
             foreach (TElement item in source)
             {
-                lookup.GetGrouping(keySelector(item), true).Add(item);
+                lookup.GetGrouping(keySelector(item), create: true).Add(item);
             }
             return lookup;
         }
@@ -82,7 +82,7 @@ namespace System.Linq
             foreach (TElement item in source)
             {
                 TKey key = keySelector(item);
-                if (key != null) lookup.GetGrouping(key, true).Add(item);
+                if (key != null) lookup.GetGrouping(key, create: true).Add(item);
             }
             return lookup;
         }
@@ -103,7 +103,7 @@ namespace System.Linq
         {
             get
             {
-                Grouping<TKey, TElement> grouping = GetGrouping(key, false);
+                Grouping<TKey, TElement> grouping = GetGrouping(key, create: false);
                 if (grouping != null) return grouping;
                 return Array.Empty<TElement>();
             }
@@ -111,7 +111,7 @@ namespace System.Linq
 
         public bool Contains(TKey key)
         {
-            return GetGrouping(key, false) != null;
+            return GetGrouping(key, create: false) != null;
         }
 
         public IEnumerator<IGrouping<TKey, TElement>> GetEnumerator()


### PR DESCRIPTION
Two nits @stephentoub found with #6130 that were still un-picked when it was merged.

1. Order of assignments in GroupedResultEnumerable constructor.

2. Name boolean arg in call to GetGrouping. (Have applied this across the board).