### PR TITLE
Fix issue #4337. ECDsaOpenSsl tests failing on CentOS.

### DIFF
--- a/src/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslTests.cs
+++ b/src/System.Security.Cryptography.OpenSsl/tests/EcDsaOpenSslTests.cs
@@ -11,22 +11,40 @@ namespace System.Security.Cryptography.EcDsaOpenSsl.Tests
 {
     public static class EcDsaOpenSslTests
     {
-        // TODO: Issue #4337.  Temporary workaround for tests to pass on CentOS 
-        // where secp224r1 appears to be disabled. 
+        // On CentOS, secp224r1 appears to be disabled. To prevent test failures on that platform, probe for this capability
+        // before depending on it. 
         private static bool ECDsa224Available
         {
             get
             {
-                try
+                using (ECDsaOpenSsl key = new ECDsaOpenSsl())
                 {
-                    using (ECDsaOpenSsl e = new ECDsaOpenSsl(224)) e.Exercise();
-                    return true;
-                }
-                catch (Exception exc)
-                {
-                    return !exc.Message.Contains("unknown group");
+                    KeySizes[] legalKeySizes = key.LegalKeySizes;
+                    return IsLegalSize(224, legalKeySizes);
                 }
             }
+        }
+
+        private static bool IsLegalSize(int size, KeySizes[] legalSizes)
+        {
+            for (int i = 0; i < legalSizes.Length; i++)
+            {
+                // If a cipher has only one valid key size, MinSize == MaxSize and SkipSize will be 0
+                if (legalSizes[i].SkipSize == 0)
+                {
+                    if (legalSizes[i].MinSize == size)
+                        return true;
+                }
+                else
+                {
+                    for (int j = legalSizes[i].MinSize; j <= legalSizes[i].MaxSize; j += legalSizes[i].SkipSize)
+                    {
+                        if (j == size)
+                            return true;
+                    }
+                }
+            }
+            return false;
         }
 
         [Fact]
@@ -40,7 +58,7 @@ namespace System.Security.Cryptography.EcDsaOpenSsl.Tests
             }
         }
 
-        [ConditionalFact("ECDsa224Available")] // Issue #4337
+        [ConditionalFact("ECDsa224Available")]
         public static void Ctor224()
         {
             int expectedKeySize = 224;
@@ -76,7 +94,7 @@ namespace System.Security.Cryptography.EcDsaOpenSsl.Tests
             }
         }
 
-        [ConditionalFact("ECDsa224Available")] // Issue #4337
+        [ConditionalFact("ECDsa224Available")]
         public static void CtorHandle224()
         {
             IntPtr ecKey = Interop.Crypto.EcKeyCreateByCurveName(NID_secp224r1);
@@ -149,7 +167,7 @@ namespace System.Security.Cryptography.EcDsaOpenSsl.Tests
             }
         }
 
-        [ConditionalFact("ECDsa224Available")] // Issue #4337
+        [ConditionalFact("ECDsa224Available")]
         public static void KeySizeProp()
         {
             using (ECDsaOpenSsl e = new ECDsaOpenSsl())


### PR DESCRIPTION
cc @bartonjs 

Gracefully degrade by not advertising 224 (or any other key size not supposed by the underlying OS) as a legal key size.
