### PR TITLE
Work around xplat nuget restore race condition by fixing capitalization

### DIFF
--- a/src/System.Diagnostics.Contracts/src/netcore50aot/project.json
+++ b/src/System.Diagnostics.Contracts/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816"
       }
     }
   }

--- a/src/System.Diagnostics.Debug/src/project.json
+++ b/src/System.Diagnostics.Debug/src/project.json
@@ -7,7 +7,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816"
       }
     },
     "net46": {

--- a/src/System.Diagnostics.StackTrace/src/project.json
+++ b/src/System.Diagnostics.StackTrace/src/project.json
@@ -7,7 +7,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816"
       }
     },
     "net46": {

--- a/src/System.Diagnostics.Tools/src/project.json
+++ b/src/System.Diagnostics.Tools/src/project.json
@@ -12,7 +12,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816"
       }
     }
   }

--- a/src/System.Globalization.Calendars/src/netcore50aot/project.json
+++ b/src/System.Globalization.Calendars/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816"
       }
     }
   }

--- a/src/System.Globalization/src/netcore50aot/project.json
+++ b/src/System.Globalization/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816"
       }
     }
   }

--- a/src/System.IO.FileSystem/src/netcore50/project.json
+++ b/src/System.IO.FileSystem/src/netcore50/project.json
@@ -22,7 +22,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1",
         "System.Globalization": "4.0.10",
         "System.Reflection": "4.0.10",

--- a/src/System.IO.IsolatedStorage/src/project.json
+++ b/src/System.IO.IsolatedStorage/src/project.json
@@ -3,7 +3,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-23816",
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1",
         "System.Collections": "4.0.0.0",
         "System.Diagnostics.Contracts": "4.0.0.0",

--- a/src/System.IO/src/project.json
+++ b/src/System.IO/src/project.json
@@ -9,7 +9,7 @@
     "netcore50": {
       "dependencies": {
         "Microsoft.NETCore.Platforms": "1.0.1-rc3-23816",
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816",
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816",
         "System.Diagnostics.Contracts": "4.0.0",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",

--- a/src/System.Linq.Expressions/src/netcore50/project.json
+++ b/src/System.Linq.Expressions/src/netcore50/project.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23816",
-    "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816",
+    "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816",
     "System.Collections": "4.0.10",
     "System.Diagnostics.Contracts": "4.0.0",
     "System.Diagnostics.Debug": "4.0.10",

--- a/src/System.Private.Uri/src/project.json
+++ b/src/System.Private.Uri/src/project.json
@@ -7,7 +7,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816"
       }
     }
   }

--- a/src/System.Reflection.DispatchProxy/src/facade/project.json
+++ b/src/System.Reflection.DispatchProxy/src/facade/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816"
       }
     }
   }

--- a/src/System.Reflection/src/netcore50aot/project.json
+++ b/src/System.Reflection/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816"
       }
     }
   }

--- a/src/System.Runtime.Handles/src/project.json
+++ b/src/System.Runtime.Handles/src/project.json
@@ -7,7 +7,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816"
       }
     },
     "net46": {

--- a/src/System.Runtime.InteropServices.PInvoke/src/project.json
+++ b/src/System.Runtime.InteropServices.PInvoke/src/project.json
@@ -7,7 +7,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816"
       }
     },
     "net46": {

--- a/src/System.Runtime.InteropServices.WindowsRuntime/src/project.json
+++ b/src/System.Runtime.InteropServices.WindowsRuntime/src/project.json
@@ -7,7 +7,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816"
       }
     },
     "net46": {

--- a/src/System.Runtime.InteropServices/src/project.json
+++ b/src/System.Runtime.InteropServices/src/project.json
@@ -7,7 +7,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816"
       }
     },
     "net46": {

--- a/src/System.Runtime.Serialization.Json/src/netcore50aot/project.json
+++ b/src/System.Runtime.Serialization.Json/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816"
       }
     }
   }

--- a/src/System.Runtime.Serialization.Xml/src/netcore50aot/project.json
+++ b/src/System.Runtime.Serialization.Xml/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816"
       }
     }
   }

--- a/src/System.Runtime/src/project.json
+++ b/src/System.Runtime/src/project.json
@@ -7,7 +7,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816"
       }
     },
     "net46": {

--- a/src/System.Text.Encoding.Extensions/src/netcore50aot/project.json
+++ b/src/System.Text.Encoding.Extensions/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816"
       }
     }
   }

--- a/src/System.Text.Encoding/src/netcore50aot/project.json
+++ b/src/System.Text.Encoding/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816"
       }
     }
   }

--- a/src/System.Threading.Timer/src/netcore50aot/project.json
+++ b/src/System.Threading.Timer/src/netcore50aot/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816"
       }
     }
   }

--- a/src/System.Threading/src/project.json
+++ b/src/System.Threading/src/project.json
@@ -7,7 +7,7 @@
     },
     "netcore50": {
       "dependencies": {
-        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23816"
+        "Microsoft.TargetingPack.Private.NETNative": "1.0.0-rc3-23816"
       }
     },
     "net46": {


### PR DESCRIPTION
Put capitalization fixes back in place after some merge conflicts removed them. These fixes work around a xplat nuget restore race condition (https://github.com/NuGet/Home/issues/2102) that happens when there are multiple capitalizations of the same package ID in one restore command.

Basically, change `NetNative` to `NETNative`.

If the race condition isn't fixed soon in xplat nuget I have some tooling I could add to buildtools to check for this issue. (Inside the existing validation task.) I used it to generate the changes in this PR.

/cc @weshaggard @ericstj 