### PR TITLE
Sync Microsoft.VisualBasic changes from TFS

### DIFF
--- a/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/IDOBinder.vb
+++ b/src/Microsoft.VisualBasic/src/Microsoft/VisualBasic/CompilerServices/IDOBinder.vb
@@ -1050,6 +1050,15 @@ Namespace Microsoft.VisualBasic.CompilerServices
         End Function
     End Class
 
+    Public Delegate Function SiteDelegate0(ByVal site As CallSite, ByVal instance As Object) As Object
+    Public Delegate Function SiteDelegate1(ByVal site As CallSite, ByVal instance As Object, ByRef arg0 As Object) As Object
+    Public Delegate Function SiteDelegate2(ByVal site As CallSite, ByVal instance As Object, ByRef arg0 As Object, ByRef arg1 As Object) As Object
+    Public Delegate Function SiteDelegate3(ByVal site As CallSite, ByVal instance As Object, ByRef arg0 As Object, ByRef arg1 As Object, ByRef arg2 As Object) As Object
+    Public Delegate Function SiteDelegate4(ByVal site As CallSite, ByVal instance As Object, ByRef arg0 As Object, ByRef arg1 As Object, ByRef arg2 As Object, ByRef arg3 As Object) As Object
+    Public Delegate Function SiteDelegate5(ByVal site As CallSite, ByVal instance As Object, ByRef arg0 As Object, ByRef arg1 As Object, ByRef arg2 As Object, ByRef arg3 As Object, ByRef arg4 As Object) As Object
+    Public Delegate Function SiteDelegate6(ByVal site As CallSite, ByVal instance As Object, ByRef arg0 As Object, ByRef arg1 As Object, ByRef arg2 As Object, ByRef arg3 As Object, ByRef arg4 As Object, ByRef arg5 As Object) As Object
+    Public Delegate Function SiteDelegate7(ByVal site As CallSite, ByVal instance As Object, ByRef arg0 As Object, ByRef arg1 As Object, ByRef arg2 As Object, ByRef arg3 As Object, ByRef arg4 As Object, ByRef arg5 As Object, ByRef arg6 As Object) As Object
+
     Friend Class IDOUtils
 
         Private Sub New()
@@ -1271,15 +1280,6 @@ Namespace Microsoft.VisualBasic.CompilerServices
         Public Shared Function ConvertToObject(ByVal valueExpression As Expression) As Expression
             Return If(valueExpression.Type.Equals(GetType(Object)), valueExpression, Expression.Convert(valueExpression, GetType(Object)))
         End Function
-
-        Friend Delegate Function SiteDelegate0(ByVal site As CallSite, ByVal instance As Object) As Object
-        Friend Delegate Function SiteDelegate1(ByVal site As CallSite, ByVal instance As Object, ByRef arg0 As Object) As Object
-        Friend Delegate Function SiteDelegate2(ByVal site As CallSite, ByVal instance As Object, ByRef arg0 As Object, ByRef arg1 As Object) As Object
-        Friend Delegate Function SiteDelegate3(ByVal site As CallSite, ByVal instance As Object, ByRef arg0 As Object, ByRef arg1 As Object, ByRef arg2 As Object) As Object
-        Friend Delegate Function SiteDelegate4(ByVal site As CallSite, ByVal instance As Object, ByRef arg0 As Object, ByRef arg1 As Object, ByRef arg2 As Object, ByRef arg3 As Object) As Object
-        Friend Delegate Function SiteDelegate5(ByVal site As CallSite, ByVal instance As Object, ByRef arg0 As Object, ByRef arg1 As Object, ByRef arg2 As Object, ByRef arg3 As Object, ByRef arg4 As Object) As Object
-        Friend Delegate Function SiteDelegate6(ByVal site As CallSite, ByVal instance As Object, ByRef arg0 As Object, ByRef arg1 As Object, ByRef arg2 As Object, ByRef arg3 As Object, ByRef arg4 As Object, ByRef arg5 As Object) As Object
-        Friend Delegate Function SiteDelegate7(ByVal site As CallSite, ByVal instance As Object, ByRef arg0 As Object, ByRef arg1 As Object, ByRef arg2 As Object, ByRef arg3 As Object, ByRef arg4 As Object, ByRef arg5 As Object, ByRef arg6 As Object) As Object
 
         Public Shared Function CreateRefCallSiteAndInvoke(
                 ByVal action As CallSiteBinder,


### PR DESCRIPTION
These changes were made on the closed version of our library. Before deleting that copy, I'm making sure the source code is in sync with the open version. Most of these changes are parallels to what was already made in the Microsoft.CSharp project here. We've already deleted the duplicated Microsoft.CSharp project in TFS, so there's nothing out of sync there.

Includes three TFS changes:

Changeset 1491194:
  Enable latebound calls to DynamicObjects in VB.

Changeset 1461633:
  Adjust implementation of HasSameMetadataDefinitionAs to be resilient to
  failures of Expression.Compile.

Changeset 1478798:
  Implementing the fix for more robust MetadataToken probing for VB

@VSadov , @AlekseyTs 

To be clear, the goal here is to get the code in sync, delete the duplicate version in TFS, and then turn that into a wrapper project of this open-source version.