### PR TITLE
Remove an unused file

### DIFF
--- a/override.targets
+++ b/override.targets
@@ -1,5 +1,0 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <!--
-    Overrides for all other targets (including build tools) can go in this file.
-  -->
-</Project>

--- a/src/dir.targets
+++ b/src/dir.targets
@@ -15,8 +15,6 @@
   <Target Name="GetDocumentationFile"
           Returns="$(DocumentationFile)"/>
 
-  <Import Project="..\override.targets" Condition="Exists('..\override.targets')"/>
-
   <Target Name="DumpTargets" BeforeTargets="ResolveProjectReferences">
     <Message Text="DumpTargets> $(OutputPath), C=[$(Configuration)], CG=[$(ConfigurationGroup)], OG=[$(OSGroup)], TG=[$(TargetGroup)]" Importance="Low" />
   </Target>


### PR DESCRIPTION
With #5905, `override.targets` was rendered unused as pointed out by @weshaggard: https://github.com/dotnet/corefx/pull/5905#discussion_r51952029.

cc @mellinoe