### PR TITLE
Using Full Framework roslyn compilers for Windows builds.

### DIFF
--- a/BuildToolsVersion.txt
+++ b/BuildToolsVersion.txt
@@ -1,1 +1,1 @@
-1.0.25-prerelease-00169
+1.0.25-prerelease-00170

--- a/dir.props
+++ b/dir.props
@@ -52,7 +52,14 @@
     <ToolsDir Condition="'$(ToolsDir)'==''">$(ProjectDir)Tools/</ToolsDir>
     <DotnetCliPath Condition="'$(DotnetCliPath)'==''">$(ToolRuntimePath)dotnetcli/bin/</DotnetCliPath>
     <BuildToolsTaskDir Condition="'$(BuildToolsTargets45)' == 'true'">$(ToolsDir)net45/</BuildToolsTaskDir>
+    <UseRoslynCompilers Condition="'$(UseRoslynCompilers)'=='' and '$(OSEnvironment)'!='Windows_NT'">false</UseRoslynCompilers>
   </PropertyGroup>
+
+  <!-- Use Roslyn Compilers to build -->
+  <PropertyGroup Condition="'$(UseRoslynCompilers)'!='false'">
+    <UseSharedCompilation>true</UseSharedCompilation>
+  </PropertyGroup>
+  <Import Project="$(ToolRuntimePath)/net45/roslyn/build/Microsoft.Net.Compilers.props" Condition="'$(UseRoslynCompilers)'!='false'" />
 
   <!-- Import packaging props -->
   <Import Project="$(MSBuildThisFileDirectory)Packaging.props"/>
@@ -364,11 +371,6 @@
   <PropertyGroup>
     <WarningLevel>4</WarningLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
-
-  <!-- Temporary until build/CI system is upgraded to C# 6: disable C# 6 features -->
-  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj' OR '$(Language)' == 'C#'">
-    <LangVersion>5</LangVersion>
   </PropertyGroup>
 
   <!-- Set up some common paths -->

--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -12,7 +12,6 @@
     <NoWarn>1591</NoWarn>
     <CLSCompliant>false</CLSCompliant>
     <AssemblyVersion>1.2.0.0</AssemblyVersion>
-    <LangVersion>6</LangVersion>
     <DefineConstants>$(DefineConstants);SRM</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -13,7 +13,6 @@
     <ExternallyShipping>false</ExternallyShipping>
     <NuGetPackageImportStamp>83230753</NuGetPackageImportStamp>
     <CLSCompliant>false</CLSCompliant>
-    <LangVersion>6</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/System.Runtime.Numerics/tests/BigInteger/cast_from.cs
+++ b/src/System.Runtime.Numerics/tests/BigInteger/cast_from.cs
@@ -479,7 +479,7 @@ namespace System.Numerics.Tests
             VerifySingleExplicitCastFromBigInteger(Single.MaxValue, bigInteger);
 
             // Single Explicit Cast from BigInteger: Random value > Single.MaxValue
-            bigInteger = GenerateRandomBigIntegerGreaterThan(Single.MaxValue * 2, s_random);
+            bigInteger = GenerateRandomBigIntegerGreaterThan((double)Single.MaxValue * 2, s_random);
             VerifySingleExplicitCastFromBigInteger(Single.PositiveInfinity, bigInteger);
 
             // Single Explicit Cast from BigInteger: value < Single.MaxValue but can not be accurately represented in a Single


### PR DESCRIPTION
In order to be able to use C#6 features and also to ensure that we close the gap between the compilers used in x-plat and Windows, we want to enable using the roslyn compilers for our builds in Windows.

In order for this PR to be merged, we depend on dotnet/buildtools#453 to be merged first, and a new package is generated since that is the version that contains the compilers. Once that buildtools package is available, I'll update this PR to consume that new version of buildtools.

cc: @weshaggard 
fyi: @agocke @jaredpar 