### PR TITLE
Fix race in SocketAsyncEngine

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.SocketEvent.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SocketEvent.cs
@@ -29,13 +29,13 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CreateSocketEventPort")]
-        internal static extern unsafe Error CreateSocketEventPort(int* port);
+        internal static extern unsafe Error CreateSocketEventPort(out int port);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CloseSocketEventPort")]
         internal static extern Error CloseSocketEventPort(int port);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CreateSocketEventBuffer")]
-        internal static extern unsafe Error CreateSocketEventBuffer(int count, SocketEvent** buffer);
+        internal static extern unsafe Error CreateSocketEventBuffer(int count, out SocketEvent* buffer);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FreeSocketEventBuffer")]
         internal static extern unsafe Error FreeSocketEventBuffer(SocketEvent* buffer);

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Write.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Write.cs
@@ -20,5 +20,8 @@ internal static partial class Interop
         /// </returns>
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Write", SetLastError = true)]
         internal static unsafe extern int Write(SafeFileHandle fd, byte* buffer, int bufferSize);
+
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Write", SetLastError = true)]
+        internal static unsafe extern int Write(int fd, byte* buffer, int bufferSize);
     }
 }

--- a/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
@@ -28,7 +28,7 @@ namespace System.Net.Sockets
             {
                 if (Volatile.Read(ref _asyncContext) == null)
                 {
-                    Interlocked.CompareExchange(ref _asyncContext, new SocketAsyncContext(this, SocketAsyncEngine.Instance), null);
+                    Interlocked.CompareExchange(ref _asyncContext, new SocketAsyncContext(this), null);
                 }
 
                 return _asyncContext;

--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -461,6 +461,12 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SocketAddress.cs">
       <Link>Interop\Unix\System.Native\Interop.SocketAddress.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Pipe.cs">
+      <Link>Interop\Unix\System.Native\Interop.Pipe.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Write.cs">
+      <Link>Interop\Unix\System.Native\Interop.Write.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetGroup)' == 'net46'">

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -12,99 +13,322 @@ namespace System.Net.Sockets
 {
     internal sealed unsafe class SocketAsyncEngine
     {
+        //
+        // Encapsulates a particular SocketAsyncContext object's access to a SocketAsyncEngine.  
+        //
+        public struct Token
+        {
+            private readonly SocketAsyncEngine _engine;
+            private readonly IntPtr _handle;
+
+            public Token(SocketAsyncContext context)
+            {
+                AllocateToken(context, out _engine, out _handle);
+            }
+
+            public bool IsAllocated
+            {
+                get { return _engine != null; }
+            }
+
+            public void Free()
+            {
+                if (IsAllocated)
+                    _engine.FreeHandle(_handle);
+            }
+
+            public bool TryRegister(SafeCloseSocket socket, Interop.Sys.SocketEvents current, Interop.Sys.SocketEvents events, out Interop.Error error)
+            {
+                Debug.Assert(IsAllocated);
+                return _engine.TryRegister(socket, current, events, _handle, out error);
+            }
+        }
+
         private const int EventBufferCount = 64;
 
-        private static SocketAsyncEngine _engine;
-        private static readonly object _initLock = new object();
+        private static readonly object _lock = new object();
+
+        //
+        // The current engine.  We replace this with a new engine when we run out of "handle" values for the current
+        // engine.
+        // Must be accessed under _lock.
+        //
+        private static SocketAsyncEngine _currentEngine;
 
         private readonly int _port;
         private readonly Interop.Sys.SocketEvent* _buffer;
 
-        public static SocketAsyncEngine Instance
+        //
+        // The read and write ends of a native pipe, used to signal that this instance's event loop should stop 
+        // processing events.
+        // 
+        private readonly int _shutdownReadPipe;
+        private readonly int _shutdownWritePipe;
+
+        //
+        // Each SocketAsyncContext is associated with a particular "handle" value, used to identify that 
+        // SocketAsyncContext when events are raised.  These handle values are never resused, because we do not have
+        // a way to ensure that we will never see an event for a socket/handle that has been freed.  Instead, we
+        // allocate monotonically increasing handle values up to some limit; when we would exceed that limit,
+        // we allocate a new SocketAsyncEngine (and thus a new event port) and start the handle values over at zero.
+        // Thus we can uniquely identify a given SocketAsyncContext by the *pair* {SocketAsyncEngine, handle},
+        // and avoid any issues with misidentifying the target of an event we read from the port.
+        //
+#if DEBUG
+        //
+        // In debug builds, force rollover to new SocketAsyncEngine instances so that code doesn't go untested, since
+        // it's very unlikely that the "real" limits will ever be reached in test code.
+        //
+        private readonly IntPtr MaxHandles = (IntPtr)(EventBufferCount * 2);
+#else
+        //
+        // In release builds, we use *very* high limits.  No 64-bit process running on release builds should ever
+        // reach the handle limit for a single event port, and even 32-bit processes should see this only very rarely.
+        //
+        private readonly IntPtr MaxHandles = IntPtr.Size == 4 ? (IntPtr)int.MaxValue : (IntPtr)long.MaxValue;
+#endif
+
+        //
+        // Sentinel handle value to identify events from the "shutdown pipe," used to signal an event loop to stop
+        // processing events.
+        //
+        private readonly IntPtr ShutdownHandle = (IntPtr)(-1);
+
+        //
+        // The next handle value to be allocated for this event port.
+        // Must be accessed under _lock.
+        //
+        private IntPtr _nextHandle;
+
+        //
+        // Count of handles that have been allocated for this event port, but not yet freed.
+        // Must be accessed under _lock.
+        // 
+        private IntPtr _outstandingHandles;
+
+        //
+        // Maps handle values to SocketAsyncContext instances.
+        // Must be accessed under _lock.
+        //
+        private readonly Dictionary<IntPtr, SocketAsyncContext> _handleToContextMap = new Dictionary<IntPtr, SocketAsyncContext>();
+
+        //
+        // True if we've reached the handle value limit for this event port, and thus must allocate a new event port
+        // on the next handle allocation.
+        //
+        private bool IsFull { get { return _nextHandle == MaxHandles; } }
+
+        //
+        // Allocates a new {SocketAsyncEngine, handle} pair.
+        //
+        private static void AllocateToken(SocketAsyncContext context, out SocketAsyncEngine engine, out IntPtr handle)
         {
-            get
+            lock (_lock)
             {
-                if (Volatile.Read(ref _engine) == null)
+                if (_currentEngine == null || _currentEngine.IsFull)
                 {
-                    lock (_initLock)
-                    {
-                        if (_engine == null)
-                        {
-                            int port;
-                            Interop.Error err = Interop.Sys.CreateSocketEventPort(&port);
-                            if (err != Interop.Error.SUCCESS)
-                            {
-                                throw new InternalException();
-                            }
-
-                            Interop.Sys.SocketEvent* buffer;
-                            err = Interop.Sys.CreateSocketEventBuffer(EventBufferCount, &buffer);
-                            if (err != Interop.Error.SUCCESS)
-                            {
-                                Interop.Sys.CloseSocketEventPort(port);
-                                throw new InternalException();
-                            }
-
-                            var engine = new SocketAsyncEngine(port, buffer);
-                            Task.Factory.StartNew(o =>
-                            {
-                                var eng = (SocketAsyncEngine)o;
-                                for (;;)
-                                {
-                                    try
-                                    {
-                                        eng.EventLoop();
-                                    }
-                                    catch (Exception e)
-                                    {
-                                        Debug.Fail(string.Format("Exception thrown from event loop: {0}", e.Message));
-                                    }
-                                }
-                            }, engine, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
-
-                            Volatile.Write(ref _engine, engine);
-                        }
-                    }
+                    _currentEngine = new SocketAsyncEngine();
                 }
 
-                return _engine;
+                engine = _currentEngine;
+                handle = _currentEngine.AllocateHandle(context);
             }
         }
 
-        private SocketAsyncEngine(int port, Interop.Sys.SocketEvent* buffer)
+        private IntPtr AllocateHandle(SocketAsyncContext context)
         {
-            _port = port;
-            _buffer = buffer;
+            Debug.Assert(Monitor.IsEntered(_lock));
+            Debug.Assert(!IsFull);
+
+            IntPtr handle = _nextHandle;
+            _handleToContextMap.Add(handle, context);
+
+            _nextHandle = IntPtr.Add(_nextHandle, 1);
+            _outstandingHandles = IntPtr.Add(_outstandingHandles, 1);
+
+            Debug.Assert(handle != ShutdownHandle);
+            return handle;
         }
 
-        private void EventLoop()
+        private void FreeHandle(IntPtr handle)
         {
-            for (;;)
+            Debug.Assert(handle != ShutdownHandle);
+
+            bool shutdownNeeded = false;
+
+            lock (_lock)
             {
-                int numEvents = EventBufferCount;
-                Interop.Error err = Interop.Sys.WaitForSocketEvents(_port, _buffer, &numEvents);
-                if (err != Interop.Error.SUCCESS)
+                if (_handleToContextMap.Remove(handle))
+                {
+                    _outstandingHandles = IntPtr.Subtract(_outstandingHandles, 1);
+
+                    Debug.Assert(_outstandingHandles.ToInt64() >= 0);
+
+                    //
+                    // If we've allocated all possible handles for this instance, and freed them all, then 
+                    // we don't need the event loop any more, and can reclaim resources.
+                    //
+                    if (IsFull && _outstandingHandles == IntPtr.Zero)
+                        shutdownNeeded = true;
+                }
+            }
+
+            //
+            // Signal shutdown outside of the lock to reduce contention.  
+            //
+            if (shutdownNeeded)
+            {
+                BeginShutdown();
+            }
+        }
+
+        private SocketAsyncContext GetContextFromHandle(IntPtr handle)
+        {
+            Debug.Assert(handle != ShutdownHandle);
+            Debug.Assert(handle.ToInt64() < MaxHandles.ToInt64());
+            lock (_lock)
+            {
+                SocketAsyncContext context;
+                _handleToContextMap.TryGetValue(handle, out context);
+                return context;
+            }
+        }
+
+        private SocketAsyncEngine()
+        {
+            _port = -1;
+            _shutdownReadPipe = -1;
+            _shutdownWritePipe = -1;
+            try
+            {
+                //
+                // Create the event port and buffer
+                //
+                if (Interop.Sys.CreateSocketEventPort(out _port) != Interop.Error.SUCCESS)
+                {
+                    throw new InternalException();
+                }
+                if (Interop.Sys.CreateSocketEventBuffer(EventBufferCount, out _buffer) != Interop.Error.SUCCESS)
                 {
                     throw new InternalException();
                 }
 
-                // The native shim is responsible for ensuring this condition.
-                Debug.Assert(numEvents > 0);
-
-                for (int i = 0; i < numEvents; i++)
+                //
+                // Create the pipe for signalling shutdown, and register for "read" events for the pipe.  Now writing
+                // to the pipe will send an event to the event loop.
+                //
+                int* pipeFds = stackalloc int[2];
+                if (Interop.Sys.Pipe(pipeFds, Interop.Sys.PipeFlags.O_CLOEXEC) != 0)
                 {
-                    var handle = (GCHandle)(IntPtr)_buffer[i].Data;
-                    var context = (SocketAsyncContext)handle.Target;
-
-                    if (context != null)
-                    {
-                        context.HandleEvents(_buffer[i].Events);
-                    }
+                    throw new InternalException();
                 }
+                _shutdownReadPipe = pipeFds[Interop.Sys.ReadEndOfPipe];
+                _shutdownWritePipe = pipeFds[Interop.Sys.WriteEndOfPipe];
+
+                if (Interop.Sys.DangerousTryChangeSocketEventRegistration(_port, _shutdownReadPipe, Interop.Sys.SocketEvents.None, Interop.Sys.SocketEvents.Read, ShutdownHandle) != Interop.Error.SUCCESS)
+                {
+                    throw new InternalException();
+                }
+
+                //
+                // Start the event loop on its own thread.
+                //
+                Task.Factory.StartNew(
+                    EventLoop,
+                    CancellationToken.None,
+                    TaskCreationOptions.LongRunning,
+                    TaskScheduler.Default);
+            }
+            catch
+            {
+                if (_shutdownReadPipe != -1)
+                {
+                    Interop.Sys.Close((IntPtr)_shutdownReadPipe);
+                }
+                if (_shutdownWritePipe != -1)
+                {
+                    Interop.Sys.Close((IntPtr)_shutdownWritePipe);
+                }
+                if (_buffer != null)
+                {
+                    Interop.Sys.FreeSocketEventBuffer(_buffer);
+                }
+                if (_port != -1)
+                {
+                    Interop.Sys.CloseSocketEventPort(_port);
+                }
+                throw;
             }
         }
 
-        public bool TryRegister(SafeCloseSocket socket, Interop.Sys.SocketEvents current, Interop.Sys.SocketEvents events, GCHandle handle, out Interop.Error error)
+        private void EventLoop()
+        {
+            try
+            {
+                bool shutdown = false;
+                while (!shutdown)
+                {
+                    int numEvents = EventBufferCount;
+                    Interop.Error err = Interop.Sys.WaitForSocketEvents(_port, _buffer, &numEvents);
+                    if (err != Interop.Error.SUCCESS)
+                    {
+                        throw new InternalException();
+                    }
+
+                    // The native shim is responsible for ensuring this condition.
+                    Debug.Assert(numEvents > 0);
+
+                    for (int i = 0; i < numEvents; i++)
+                    {
+                        IntPtr handle = _buffer[i].Data;
+                        if (handle == ShutdownHandle)
+                        {
+                            shutdown = true;
+                        }
+                        else
+                        {
+                            SocketAsyncContext context = GetContextFromHandle(handle);
+                            if (context != null)
+                            {
+                                context.HandleEvents(_buffer[i].Events);
+                            }
+                        }
+                    }
+                }
+
+                EndShutdown();
+            }
+            catch (Exception e)
+            {
+                Environment.FailFast("Exception thrown from SocketAsyncEngine event loop", e);
+            }
+        }
+
+        private void BeginShutdown()
+        {
+            //
+            // Write to the pipe, which will wake up the event loop and cause it to exit.
+            //
+            byte* buf = stackalloc byte[1];
+            int bytesWritten = Interop.Sys.Write(_shutdownWritePipe, buf, 1);
+            if (bytesWritten != 1)
+            {
+                throw new InternalException();
+            }
+        }
+
+        private void EndShutdown()
+        {
+            //
+            // The event loop is exiting, so we can free all native resources.
+            //
+            Interop.Sys.Close((IntPtr)_shutdownReadPipe);
+            Interop.Sys.Close((IntPtr)_shutdownWritePipe);
+            Interop.Sys.CloseSocketEventPort(_port);
+            Interop.Sys.FreeSocketEventBuffer(_buffer);
+        }
+
+        private bool TryRegister(SafeCloseSocket socket, Interop.Sys.SocketEvents current, Interop.Sys.SocketEvents events, IntPtr handle, out Interop.Error error)
         {
             if (current == events)
             {
@@ -112,13 +336,7 @@ namespace System.Net.Sockets
                 return true;
             }
 
-            //
-            // @TODO: work out a better way to handle this.  For now, just do the "dangerous" thing; this is called
-            // from SafeCloseSocket.ReleaseHandle, so it can't access the file descriptor in the normal way.
-            // 
-            int fd = (int)socket.DangerousGetHandle();
-
-            error = Interop.Sys.DangerousTryChangeSocketEventRegistration(_port, fd, current, events, (IntPtr)handle);
+            error = Interop.Sys.TryChangeSocketEventRegistration(_port, socket, current, events, handle);
             return error == Interop.Error.SUCCESS;
         }
     }


### PR DESCRIPTION
In `SocketAsyncEngine.EventLoop`, there is a window where `WaitForSocketEvents` has returned an event for a socket, but we have not yet dereferenced the event's 'GCHandle' to obtain the socket's `SocketAsyncContext`. In that window, another thread may close the socket and free the `GCHandle`. This can lead to some problems, depending on what else happens in this window. The most egregious of these is probably as follows:

If another `GCHandle` with the same value is allocated for another `SocketAsyncContext`, then we will misattribute the events to the new socket. For the most part this won't matter, as it will simply mean that we have to retry some operation again. But if the new socket has a pending "connect" operation, and we receive a "write" event, we'll think the new socket is connected, and there is likely no way we can recover from this.

This change switches to a new handle allocation strategy that does not permit re-use of a given handle with a given event port.  Handle values increase monotonically until we reach the handle's maximum size; at that point, we allocate a new event port, and start allocating handle values from zero.  The old port will be freed once all of the handles associated with that port have been freed.

On 64-bit platforms, the maximum handle value is `long.MaxValue`, which effectively means that we will never need to allocate a new event port.  On 32-bit platforms, we top out at `int.MaxValue`, and so a long-running process may occasionally need to allocate a new port.  Since this limit is reachable on 32-bit, but is in any case hard to reach, we artificially impose a very low limit in "debug" builds, so we can be sure to exercise the rollover to the new event port.

Fixes #6173.

@pgavlin, @stephentoub