### PR TITLE
Remove unnecessary LINQ Concat3Iterator

### DIFF
--- a/src/System.Linq/src/System/Linq/Concatenate.cs
+++ b/src/System.Linq/src/System/Linq/Concatenate.cs
@@ -63,7 +63,7 @@ namespace System.Linq
 
             internal override ConcatIterator<TSource> Concat(IEnumerable<TSource> next)
             {
-                return new Concat3Iterator<TSource>(_first, _second, next);
+                return new ConcatNIterator<TSource>(this, next, 2);
             }
 
             internal override IEnumerable<TSource> GetEnumerable(int index)
@@ -72,42 +72,6 @@ namespace System.Linq
                 {
                     case 0: return _first;
                     case 1: return _second;
-                    default: return null;
-                }
-            }
-        }
-
-        private sealed class Concat3Iterator<TSource> : ConcatIterator<TSource>
-        {
-            private readonly IEnumerable<TSource> _first;
-            private readonly IEnumerable<TSource> _second;
-            private readonly IEnumerable<TSource> _third;
-
-            internal Concat3Iterator(IEnumerable<TSource> first, IEnumerable<TSource> second, IEnumerable<TSource> third)
-            {
-                Debug.Assert(first != null && second != null && third != null);
-                _first = first;
-                _second = second;
-                _third = third;
-            }
-
-            public override Iterator<TSource> Clone()
-            {
-                return new Concat3Iterator<TSource>(_first, _second, _third);
-            }
-
-            internal override ConcatIterator<TSource> Concat(IEnumerable<TSource> next)
-            {
-                return new ConcatNIterator<TSource>(this, next, 3);
-            }
-
-            internal override IEnumerable<TSource> GetEnumerable(int index)
-            {
-                switch (index)
-                {
-                    case 0: return _first;
-                    case 1: return _second;
-                    case 2: return _third;
                     default: return null;
                 }
             }
@@ -115,7 +79,7 @@ namespace System.Linq
 
         private sealed class ConcatNIterator<TSource> : ConcatIterator<TSource>
         {
-            // To handle chains of >= 4 sources, we chain the concat iterators together and allow
+            // To handle chains of >= 3 sources, we chain the concat iterators together and allow
             // GetEnumerable to fetch enumerables from the previous sources.  This means that rather
             // than each MoveNext/Current calls having to traverse all of the previous sources, we
             // only have to traverse all of the previous sources once per chained enumerable.  An
@@ -130,7 +94,7 @@ namespace System.Linq
             {
                 Debug.Assert(previousConcat != null);
                 Debug.Assert(next != null);
-                Debug.Assert(nextIndex > 0);
+                Debug.Assert(nextIndex >= 2);
                 _previousConcat = previousConcat;
                 _next = next;
                 _nextIndex = nextIndex;
@@ -156,7 +120,7 @@ namespace System.Linq
                 // Walk back through the chain of ConcatNIterators looking for the one
                 // that has its _nextIndex equal to index.  If we don't find one, then it
                 // must be prior to any of them, so call GetEnumerable on the previous
-                // Concat3/2Iterator.  This avoids a deep recursive call chain.
+                // Concat2Iterator.  This avoids a deep recursive call chain.
                 ConcatNIterator<TSource> current = this;
                 while (true)
                 {
@@ -172,6 +136,8 @@ namespace System.Linq
                         continue;
                     }
 
+                    Debug.Assert(current._previousConcat is Concat2Iterator<TSource>);
+                    Debug.Assert(index == 0 || index == 1);
                     return current._previousConcat.GetEnumerable(index);
                 }
             }


### PR DESCRIPTION
When I reimplemented Concat yesterday, I initially did so where longer chains of concats would end up using an allocated array to store all of the enumerables.  Since short chains of 1 and 2 concats (2 and 3 sources, respectively) are relatively common, I special cased those to not need the array.  I then changed the implementation to use a linked list of the concat iterators instead of the array, at which point while 2 sources still needed to be special cased, 3 didn't, but I neglected to remove the special 3 case.  This removes it, as it adds some code without commensurate benefit.

cc: @VSadov, @JonHanna 