### PR TITLE
#2727 Removed unnecessary IsPrime function after expanding table.

### DIFF
--- a/src/Common/src/System/Collections/HashHelpers.cs
+++ b/src/Common/src/System/Collections/HashHelpers.cs
@@ -23,8 +23,6 @@ namespace System.Collections
 {
     internal static class HashHelpers
     {
-        private const Int32 HashPrime = 101;
-
         // Table of prime numbers to use as hash table sizes. 
         // A typical resize algorithm would pick the smallest prime number in this array
         // that is larger than twice the previous capacity. 
@@ -41,23 +39,12 @@ namespace System.Collections
             1103, 1327, 1597, 1931, 2333, 2801, 3371, 4049, 4861, 5839, 7013, 8419, 10103, 12143, 14591,
             17519, 21023, 25229, 30293, 36353, 43627, 52361, 62851, 75431, 90523, 108631, 130363, 156437,
             187751, 225307, 270371, 324449, 389357, 467237, 560689, 672827, 807403, 968897, 1162687, 1395263,
-            1674319, 2009191, 2411033, 2893249, 3471899, 4166287, 4999559, 5999471, 7199369 };
-
-        public static bool IsPrime(int candidate)
-        {
-            if ((candidate & 1) != 0)
-            {
-                int limit = (int)Math.Sqrt(candidate);
-                for (int divisor = 3; divisor <= limit; divisor += 2)
-                {
-                    if ((candidate % divisor) == 0)
-                        return false;
-                }
-                return true;
-            }
-            return (candidate == 2);
-        }
-
+            1674319, 2009191, 2411033, 2893249, 3471899, 4166287, 4999559, 5999471, 7199369, 8639249, 10367101,
+            12440537, 14928671, 17914409, 21497293, 25796759, 30956117, 37147349, 44576837, 53492207, 64190669,
+            77028803, 92434613, 110921543, 133105859, 159727031, 191672443, 230006941, 276008387, 331210079,
+            397452101, 476942527, 572331049, 686797261, 824156741, 988988137, 1186785773, 1424142949, 1708971541,
+            2050765853, MaxPrimeArrayLength };
+        
         public static int GetPrime(int min)
         {
             if (min < 0)
@@ -70,13 +57,6 @@ namespace System.Collections
                 if (prime >= min) return prime;
             }
 
-            //outside of our predefined table. 
-            //compute the hard way. 
-            for (int i = (min | 1); i < Int32.MaxValue; i += 2)
-            {
-                if (IsPrime(i) && ((i - 1) % HashPrime != 0))
-                    return i;
-            }
             return min;
         }
 

--- a/src/System.Collections/src/System/Collections/Generic/HashSet.cs
+++ b/src/System.Collections/src/System/Collections/Generic/HashSet.cs
@@ -1013,8 +1013,6 @@ namespace System.Collections.Generic
         /// </summary>
         private void SetCapacity(int newSize, bool forceNewHashCodes)
         {
-            Debug.Assert(HashHelpers.IsPrime(newSize), "New size is not prime!");
-
             Debug.Assert(_buckets != null, "SetCapacity called on a set with no elements");
 
             Slot[] newSlots = new Slot[newSize];


### PR DESCRIPTION
The IsPrime function is only used when the table does not have enough values. This change expands the number of values up to the maximum and removes the, now unneeded, IsPrime function. 

Suggest exploring alternative bucket sizes and ways to get the bucket size be deferred till another time.