### PR TITLE
Reenable Aes InPlaceDecryption test.

### DIFF
--- a/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesCipherTests.cs
+++ b/src/Common/tests/System/Security/Cryptography/AlgorithmImplementations/AES/AesCipherTests.cs
@@ -161,7 +161,6 @@ namespace System.Security.Cryptography.Encryption.Aes.Tests
         }
 
         [Fact]
-        [ActiveIssue(3952, PlatformID.AnyUnix)]
         public static void VerifyInPlaceDecryption()
         {
             byte[] key = "1ed2f625c187b993256a8b3ccf9dcbfa5b44b4795c731012f70e4e64732efd5d".HexToByteArray();


### PR DESCRIPTION
Fix issue #3952

Actually, it's not clear what the issue was or if it's been fixed. The new test (VerifyInPlaceDecryption) that was supposed to repro this no longer fails on Debian.

So I'm removing the ActiveIssue tag and seeing what CI says.
