### PR TITLE
Retry package restore twice before failing

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -57,17 +57,41 @@
               ItemName="ExpandedDnuRestoreDir" />
     </GatherDirectoriesToRestore>
 
-    <Exec Command="$(DnuRestoreCommand) &quot;%(ExpandedDnuRestoreDir.Identity)&quot;"
-          StandardOutputImportance="Low"
-          CustomErrorRegularExpression="(^Unable to locate .*)|(^Updating the invalid lock file with .*)"
-          ContinueOnError="ErrorAndContinue"
-          Condition="'$(SkipGatherRestoreDirs)' != 'true'" />
+    <PropertyGroup>
+      <PackageRestoreCommandWithDirs Condition="'$(SkipGatherRestoreDirs)' != 'true'">$(DnuRestoreCommand) &quot;%(ExpandedDnuRestoreDir.Identity)&quot;</PackageRestoreCommandWithDirs>
+      <PackageRestoreCommandWithDirs Condition="'$(SkipGatherRestoreDirs)' == 'true'">$(DnuRestoreCommand) @(DnuRestoreDir->'&quot;%(Identity)&quot;', ' ')</PackageRestoreCommandWithDirs>
+      
+      <RestoreErrorRegularExpression>(^Unable to locate .%2A)|(^Updating the invalid lock file with .%2A)</RestoreErrorRegularExpression>
+    </PropertyGroup>
 
-    <Exec Command="$(DnuRestoreCommand) @(DnuRestoreDir->'&quot;%(Identity)&quot;', ' ')"
+    <Exec Command="$(PackageRestoreCommandWithDirs)"
           StandardOutputImportance="Low"
-          CustomErrorRegularExpression="(^Unable to locate .*)|(^Updating the invalid lock file with .*)"
+          CustomErrorRegularExpression="$(RestoreErrorRegularExpression)"
+          ContinueOnError="WarnAndContinue">
+      <Output TaskParameter="ExitCode" PropertyName="RestoreErrorCode" />
+    </Exec>
+
+    <Message Importance="High"
+             Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Encountered error during restore. Retry 1..."
+             Condition="'$(RestoreErrorCode)'!='0'" />
+
+    <Exec Command="$(PackageRestoreCommandWithDirs)"
+          StandardOutputImportance="Low"
+          CustomErrorRegularExpression="$(RestoreErrorRegularExpression)"
+          ContinueOnError="WarnAndContinue"
+          Condition="'$(RestoreErrorCode)'!='0'">
+      <Output TaskParameter="ExitCode" PropertyName="RestoreErrorCode" />
+    </Exec>
+
+    <Message Importance="High"
+             Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Encountered error during restore. Final retry..."
+             Condition="'$(RestoreErrorCode)'!='0'" />
+
+    <Exec Command="$(PackageRestoreCommandWithDirs)"
+          StandardOutputImportance="Low"
+          CustomErrorRegularExpression="$(RestoreErrorRegularExpression)"
           ContinueOnError="ErrorAndContinue"
-          Condition="'$(SkipGatherRestoreDirs)' == 'true'" />
+          Condition="'$(RestoreErrorCode)'!='0'" />
 
     <Message Importance="High" Text="[$([System.DateTime]::Now.ToString('HH:mm:ss.ff'))] Restoring all packages...Done." />
   </Target>


### PR DESCRIPTION
Also refactors the two restore tasks down to one by applying the conditions on a property rather than on the Exec tasks. This means the code ends up with 3 execs for 2 retries, not 6.

This is mainly to help the automated official build when there are network issues, but anyone (or any other CI) hitting rare network issues should benefit. The downside is that non-network issues will show up as two warnings and an error, and take three times as long to settle. The logs should make it clear what's going on in that case, though.

This will also need to be applied to WCF to really help the official build restore reliability.

/cc @weshaggard 