### PR TITLE
Increase the System.ServiceProcess.ServiceController tests timeout

### DIFF
--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/ServiceControllerTests.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/ServiceControllerTests.cs
@@ -22,7 +22,7 @@ namespace System.ServiceProcess.Tests
         public ServiceProvider()
         {
             TestMachineName = ".";
-            ControlTimeout = TimeSpan.FromSeconds(5);
+            ControlTimeout = TimeSpan.FromSeconds(10);
             TestServiceName = Guid.NewGuid().ToString();
             TestServiceDisplayName = "Test Service " + TestServiceName;
             DependentTestServiceNamePrefix = TestServiceName + ".Dependent";

--- a/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/ServiceControllerTests.cs
+++ b/src/System.ServiceProcess.ServiceController/tests/System.ServiceProcess.ServiceController.Tests/ServiceControllerTests.cs
@@ -22,7 +22,7 @@ namespace System.ServiceProcess.Tests
         public ServiceProvider()
         {
             TestMachineName = ".";
-            ControlTimeout = TimeSpan.FromSeconds(3);
+            ControlTimeout = TimeSpan.FromSeconds(5);
             TestServiceName = Guid.NewGuid().ToString();
             TestServiceDisplayName = "Test Service " + TestServiceName;
             DependentTestServiceNamePrefix = TestServiceName + ".Dependent";


### PR DESCRIPTION
System.ServiceProcess.ServiceController tests currently waits for 3 seconds for the service to transition from one state to the other, which might not always be sufficient. Increasing the time a little to make it more resilient to a machine that is slow or working on other things in parallel.

Fixes Issue #6029