### PR TITLE
Improve coverage of the S.S.Cryptography.Csp package

### DIFF
--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
@@ -894,6 +894,7 @@ namespace Internal.NativeCrypto
                 throw hr.ToCryptographicException();
             }
 
+            hKey.PublicOnly = isPublic;
             safeKeyHandle = hKey;
 
             return;

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
@@ -412,7 +412,10 @@ namespace Internal.NativeCrypto
                         impTypeReturn = GetProviderParameterWorker(safeProvHandle, pb, ref cb, CryptGetProvParamFlags.PP_UNIQUE_CONTAINER);
                         pb = new byte[cb];
                         impTypeReturn = GetProviderParameterWorker(safeProvHandle, pb, ref cb, CryptGetProvParamFlags.PP_UNIQUE_CONTAINER);
-                        retStr = Encoding.ASCII.GetString(pb);
+                        // GetProviderParameterWorker allocated the null character, we want to not interpret that.
+                        Debug.Assert(cb > 0);
+                        Debug.Assert(pb[cb - 1] == 0);
+                        retStr = Encoding.ASCII.GetString(pb, 0, cb - 1);
                     }
                     break;
                 default:

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
@@ -244,6 +244,7 @@ namespace Internal.NativeCrypto
             else //Get the default provider name
             {
                 providerName = GetDefaultProvider(providerType);
+                cspParameters.ProviderName = providerName;
                 safeProvHandle.ReleaseProvider = false;
             }
             // look to see if the user specified that we should pass

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/CapiHelper.cs
@@ -357,9 +357,11 @@ namespace Internal.NativeCrypto
             bool retVal = false;
             string retStr = null;
 
-            switch (keyParam)
+            try
             {
-                case Constants.CLR_EXPORTABLE:
+                switch (keyParam)
+                {
+                    case Constants.CLR_EXPORTABLE:
                     {
                         impTypeReturn = GetProviderParameterWorker(safeProvHandle, impType, ref cb, CryptGetProvParamFlags.PP_IMPTYPE);
                         //If implementation type is not HW
@@ -385,27 +387,28 @@ namespace Internal.NativeCrypto
                             //Assumption HW keys are not exportable.
                             retVal = false;
                         }
+
+                        break;
                     }
-                    break;
-                case Constants.CLR_REMOVABLE:
+                    case Constants.CLR_REMOVABLE:
                     {
                         impTypeReturn = GetProviderParameterWorker(safeProvHandle, impType, ref cb, CryptGetProvParamFlags.PP_IMPTYPE);
                         retVal = IsFlagBitSet((uint)impTypeReturn, (uint)CryptGetProvParamPPImpTypeFlags.CRYPT_IMPL_REMOVABLE);
+                        break;
                     }
-                    break;
-                case Constants.CLR_HARDWARE:
-                case Constants.CLR_PROTECTED:
+                    case Constants.CLR_HARDWARE:
+                    case Constants.CLR_PROTECTED:
                     {
                         impTypeReturn = GetProviderParameterWorker(safeProvHandle, impType, ref cb, CryptGetProvParamFlags.PP_IMPTYPE);
                         retVal = IsFlagBitSet((uint)impTypeReturn, (uint)CryptGetProvParamPPImpTypeFlags.CRYPT_IMPL_HARDWARE);
+                        break;
                     }
-                    break;
-                case Constants.CLR_ACCESSIBLE:
+                    case Constants.CLR_ACCESSIBLE:
                     {
                         retVal = Interop.CryptGetUserKey(safeProvHandle, keyNumber, ref safeKeyHandle) ? true : false;
+                        break;
                     }
-                    break;
-                case Constants.CLR_UNIQUE_CONTAINER:
+                    case Constants.CLR_UNIQUE_CONTAINER:
                     {
                         returnType = 1;
                         byte[] pb = null;
@@ -416,13 +419,18 @@ namespace Internal.NativeCrypto
                         Debug.Assert(cb > 0);
                         Debug.Assert(pb[cb - 1] == 0);
                         retStr = Encoding.ASCII.GetString(pb, 0, cb - 1);
+                        break;
                     }
-                    break;
-                default:
+                    default:
                     {
                         Debug.Assert(false);
                         break;
                     }
+                }
+            }
+            finally
+            {
+                safeKeyHandle.Dispose();
             }
             if (returnType == 0)
             {
@@ -442,7 +450,6 @@ namespace Internal.NativeCrypto
         {
             int hr = S_OK;
             VerifyValidHandle(safeProvHandle);
-            safeKeyHandle = SafeKeyHandle.InvalidHandle;
             if (!Interop.CryptGetUserKey(safeProvHandle, keySpec, ref safeKeyHandle))
             {
                 hr = GetErrorCode();

--- a/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SafeCryptoHandles.cs
+++ b/src/System.Security.Cryptography.Csp/src/System/Security/Cryptography/SafeCryptoHandles.cs
@@ -3,9 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
-using System.Runtime.InteropServices;
-using System.Runtime.CompilerServices;
-using System.Runtime.Versioning;
 
 using Internal.NativeCrypto;
 using Microsoft.Win32.SafeHandles;
@@ -30,17 +27,6 @@ namespace System.Security.Cryptography
         private SafeProvHandle() : base(true)
         {
             SetHandle(IntPtr.Zero);
-            _containerName = null;
-            _providerName = null;
-            _type = 0;
-            _flags = 0;
-            _fPersistKeyInCsp = true;
-            _fReleaseProvider = true;
-        }
-
-        private SafeProvHandle(IntPtr handle) : base(true)
-        {
-            SetHandle(handle);
             _containerName = null;
             _providerName = null;
             _type = 0;
@@ -163,19 +149,11 @@ namespace System.Security.Cryptography
     [SecurityCritical]  // auto-generated
     internal sealed class SafeKeyHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        //SafeProvHandle safeProvHandle;
         private int _keySpec;
         private bool _fPublicOnly;
         private SafeKeyHandle() : base(true)
         {
             SetHandle(IntPtr.Zero);
-            _keySpec = 0;
-            _fPublicOnly = false;
-        }
-
-        private SafeKeyHandle(IntPtr handle) : base(true)
-        {
-            SetHandle(handle);
             _keySpec = 0;
             _fPublicOnly = false;
         }
@@ -209,12 +187,6 @@ namespace System.Security.Cryptography
             get { return new SafeKeyHandle(); }
         }
 
-        //[DllImport(JitHelpers.QCall, CharSet = CharSet.Unicode)]
-        //[ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-        //[ResourceExposure(ResourceScope.None)]
-        //[SuppressUnmanagedCodeSecurity]
-        //private static extern void FreeKey(IntPtr pKeyCotext);
-
         [SecurityCritical]
         protected override bool ReleaseHandle()
         {
@@ -235,17 +207,10 @@ namespace System.Security.Cryptography
             SetHandle(IntPtr.Zero);
         }
 
-        private SafeHashHandle(IntPtr handle) : base(true)
-        {
-            SetHandle(handle);
-        }
-
         internal static SafeHashHandle InvalidHandle
         {
             get { return new SafeHashHandle(); }
         }
-
-        //private static extern void FreeHash(IntPtr pHashContext);
 
         [SecurityCritical]
         protected override bool ReleaseHandle()

--- a/src/System.Security.Cryptography.Csp/tests/CspParametersTests.cs
+++ b/src/System.Security.Cryptography.Csp/tests/CspParametersTests.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Xunit;
+
+namespace System.Security.Cryptography.Csp.Tests
+{
+    public static class CspParametersTests
+    {
+        [Fact]
+        public static void DefaultProvider()
+        {
+            const int PROV_RSA_AES = 24;
+
+            CspParameters cspParameters = new CspParameters();
+
+            // An awful lot of work goes into this calculation in the product code,
+            // but on all supported operating systems PROV_RSA_AES should be the
+            // conclusion:
+            Assert.Equal(PROV_RSA_AES, cspParameters.ProviderType);
+        }
+
+        [Fact]
+        public static void SetFlags_ValidatesInput()
+        {
+            CspParameters cspParameters = new CspParameters();
+
+            // Unmapped values (> 0xFF) throw
+            Assert.Throws<ArgumentException>(() => cspParameters.Flags = (CspProviderFlags)0x0100);
+
+            // Unmapped values (> 0xFF) throw, even when combined with known values.
+            Assert.Throws<ArgumentException>(
+                () => cspParameters.Flags = (CspProviderFlags)0x0100 | CspProviderFlags.NoPrompt);
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Csp/tests/ImportExportCspBlob.cs
+++ b/src/System.Security.Cryptography.Csp/tests/ImportExportCspBlob.cs
@@ -80,5 +80,63 @@ namespace System.Security.Cryptography.Rsa.Tests
                 Assert.Equal<byte>(exported, exported2);
             }
         }
+
+        [Fact]
+        public static void RSAParametersToBlob_PublicOnly()
+        {
+            byte[] blob;
+
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                rsa.ImportParameters(TestData.RSA1024Params);
+                blob = rsa.ExportCspBlob(false);
+            }
+
+            RSAParameters exported;
+
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                rsa.ImportCspBlob(blob);
+
+                Assert.True(rsa.PublicOnly);
+
+                exported = rsa.ExportParameters(false);
+            }
+
+            RSAParameters expected = new RSAParameters
+            {
+                Modulus = TestData.RSA1024Params.Modulus,
+                Exponent = TestData.RSA1024Params.Exponent,
+            };
+
+            ImportExport.AssertKeyEquals(ref expected, ref exported);
+        }
+
+        [Fact]
+        public static void RSAParametersToBlob_PublicPrivate()
+        {
+            byte[] blob;
+
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                rsa.ImportParameters(TestData.RSA1024Params);
+                blob = rsa.ExportCspBlob(true);
+            }
+
+            RSAParameters exported;
+
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                rsa.ImportCspBlob(blob);
+
+                Assert.False(rsa.PublicOnly);
+
+                exported = rsa.ExportParameters(true);
+            }
+
+            RSAParameters expected = TestData.RSA1024Params;
+
+            ImportExport.AssertKeyEquals(ref expected, ref exported);
+        }
     }
 }

--- a/src/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderBackCompat.cs
+++ b/src/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderBackCompat.cs
@@ -4,26 +4,115 @@
 
 using System.Collections.Generic;
 using System.Security.Cryptography.Rsa.Tests;
+using Test.IO.Streams;
 using Xunit;
 
 namespace System.Security.Cryptography.Csp.Tests
 {
     public class RSACryptoServiceProviderBackCompat
     {
+        private static readonly byte[] s_dataToSign = { 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+
         [Theory]
         [MemberData("AlgorithmIdentifiers")]
         public static void AlgorithmLookups(string primaryId, object halg)
         {
-            byte[] data = { 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
-
             using (var rsa = new RSACryptoServiceProvider())
             {
                 rsa.ImportParameters(TestData.RSA2048Params);
 
-                byte[] primary = rsa.SignData(data, primaryId);
-                byte[] lookup = rsa.SignData(data, halg);
+                byte[] primary = rsa.SignData(s_dataToSign, primaryId);
+                byte[] lookup = rsa.SignData(s_dataToSign, halg);
 
                 Assert.Equal(primary, lookup);
+            }
+        }
+
+        [Fact]
+        public static void ApiInterop_OldToNew()
+        {
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                byte[] oldSignature = rsa.SignData(s_dataToSign, "SHA384");
+                Assert.True(rsa.VerifyData(s_dataToSign, oldSignature, HashAlgorithmName.SHA384, RSASignaturePadding.Pkcs1));
+            }
+        }
+
+        [Fact]
+        public static void ApiInterop_OldToNew_Positional()
+        {
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                byte[] oldSignature = rsa.SignData(s_dataToSign, 3, 2, "SHA384");
+                Assert.True(rsa.VerifyData(s_dataToSign, 3, 2, oldSignature, HashAlgorithmName.SHA384, RSASignaturePadding.Pkcs1));
+            }
+        }
+
+        [Fact]
+        public static void ApiInterop_OldToNew_Stream()
+        {
+            const int TotalCount = 10;
+
+            using (var rsa = new RSACryptoServiceProvider())
+            using (PositionValueStream stream1 = new PositionValueStream(TotalCount))
+            using (PositionValueStream stream2 = new PositionValueStream(TotalCount))
+            {
+                byte[] oldSignature = rsa.SignData(stream1, "SHA384");
+                Assert.True(rsa.VerifyData(stream2, oldSignature, HashAlgorithmName.SHA384, RSASignaturePadding.Pkcs1));
+            }
+        }
+
+        [Fact]
+        public static void ApiInterop_NewToOld()
+        {
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                byte[] newSignature = rsa.SignData(s_dataToSign, HashAlgorithmName.SHA384, RSASignaturePadding.Pkcs1);
+                Assert.True(rsa.VerifyData(s_dataToSign, "SHA384", newSignature));
+            }
+        }
+
+        [Fact]
+        public static void SignHash_NullArray()
+        {
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                Assert.Throws<ArgumentNullException>(() => rsa.SignHash(null, "SHA384"));
+            }
+        }
+
+        [Fact]
+        public static void SignHash_BadAlgorithm()
+        {
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                Assert.Throws<CryptographicException>(() => rsa.SignHash(Array.Empty<byte>(), "SHA384-9000"));
+            }
+        }
+
+        [Fact]
+        public static void SignHash_WrongSizeHash()
+        {
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                Assert.ThrowsAny<CryptographicException>(() => rsa.SignHash(Array.Empty<byte>(), "SHA384"));
+            }
+        }
+
+        [Fact]
+        public static void SignHash_PublicKey()
+        {
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                RSAParameters publicParams = new RSAParameters
+                {
+                    Modulus = TestData.RSA1024Params.Modulus,
+                    Exponent = TestData.RSA1024Params.Exponent,
+                };
+
+                rsa.ImportParameters(publicParams);
+
+                Assert.Throws<CryptographicException>(() => rsa.SignHash(Array.Empty<byte>(), "SHA384"));
             }
         }
 

--- a/src/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderTests.cs
+++ b/src/System.Security.Cryptography.Csp/tests/RSACryptoServiceProviderTests.cs
@@ -1,0 +1,308 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Security.Cryptography.Rsa.Tests;
+using Xunit;
+
+namespace System.Security.Cryptography.Csp.Tests
+{
+    public class RSACryptoServiceProviderTests
+    {
+        const int PROV_RSA_FULL = 1;
+        const int PROV_RSA_AES = 24;
+
+        [Fact]
+        public static void DefaultKeySize()
+        {
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                Assert.Equal(1024, rsa.KeySize);
+            }
+        }
+
+        [Fact]
+        public static void PublicOnly_DefaultKey()
+        {
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                // This will call the key into being, which should create a public/private pair,
+                // therefore it should not be public-only.
+                Assert.False(rsa.PublicOnly);
+            }
+        }
+
+        [Fact]
+        public static void PublicOnly_WithPrivateKey()
+        {
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                rsa.ImportParameters(TestData.RSA1024Params);
+
+                Assert.False(rsa.PublicOnly);
+            }
+        }
+
+        [Fact]
+        public static void PublicOnly_WithNoPrivate()
+        {
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                RSAParameters publicParams = new RSAParameters
+                {
+                    Modulus = TestData.RSA1024Params.Modulus,
+                    Exponent = TestData.RSA1024Params.Exponent,
+                };
+
+                rsa.ImportParameters(publicParams);
+                Assert.True(rsa.PublicOnly);
+            }
+        }
+
+        [Fact]
+        public static void CreateKey_LegacyProvider()
+        {
+            CspParameters cspParameters = new CspParameters(PROV_RSA_FULL);
+
+            using (var rsa = new RSACryptoServiceProvider(cspParameters))
+            {
+                CspKeyContainerInfo containerInfo = rsa.CspKeyContainerInfo;
+                Assert.Equal(PROV_RSA_FULL, containerInfo.ProviderType);
+            }
+        }
+
+        [Fact]
+        public static void CreateKey_LegacyProvider_RoundtripBlob()
+        {
+            const int KeySize = 512;
+
+            CspParameters cspParameters = new CspParameters(PROV_RSA_FULL);
+            byte[] blob;
+
+            using (var rsa = new RSACryptoServiceProvider(KeySize, cspParameters))
+            {
+                CspKeyContainerInfo containerInfo = rsa.CspKeyContainerInfo;
+                Assert.Equal(PROV_RSA_FULL, containerInfo.ProviderType);
+                Assert.Equal(KeySize, rsa.KeySize);
+
+                blob = rsa.ExportCspBlob(true);
+            }
+
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                rsa.ImportCspBlob(blob);
+
+                CspKeyContainerInfo containerInfo = rsa.CspKeyContainerInfo;
+
+                // The provider information is not persisted in the blob
+                Assert.Equal(PROV_RSA_AES, containerInfo.ProviderType);
+                Assert.Equal(KeySize, rsa.KeySize);
+            }
+        }
+
+        [Fact]
+        public static void DefaultKey_Parameters()
+        {
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                CspKeyContainerInfo keyContainerInfo = rsa.CspKeyContainerInfo;
+
+                Assert.NotNull(keyContainerInfo);
+                Assert.Equal(PROV_RSA_AES, keyContainerInfo.ProviderType);
+
+                // This shouldn't be localized, so it should be safe to test on all cultures
+                Assert.Equal("Microsoft Enhanced RSA and AES Cryptographic Provider", keyContainerInfo.ProviderName);
+
+                Assert.Null(keyContainerInfo.KeyContainerName);
+                Assert.Equal(string.Empty, keyContainerInfo.UniqueKeyContainerName);
+
+                Assert.False(keyContainerInfo.HardwareDevice, "HardwareDevice");
+                Assert.False(keyContainerInfo.MachineKeyStore, "MachineKeyStore");
+                Assert.False(keyContainerInfo.Protected, "Protected");
+                Assert.False(keyContainerInfo.Removable, "Removable");
+
+                // Ephemeral keys don't successfully request the exportable bit.
+                Assert.ThrowsAny<CryptographicException>(() => keyContainerInfo.Exportable);
+
+                Assert.True(keyContainerInfo.RandomlyGenerated, "RandomlyGenerated");
+
+                Assert.Equal(KeyNumber.Exchange, keyContainerInfo.KeyNumber);
+            }
+        }
+
+        [Fact]
+        public static void DefaultKey_NotPersisted()
+        {
+            using (var rsa = new RSACryptoServiceProvider())
+            {
+                Assert.False(rsa.PersistKeyInCsp);
+            }
+        }
+
+        [Fact]
+        public static void NamedKey_DefaultProvider()
+        {
+            const int KeySize = 2048;
+
+            CspParameters cspParameters = new CspParameters
+            {
+                KeyContainerName = Guid.NewGuid().ToString(),
+            };
+
+            using (new RsaKeyLifetime(cspParameters))
+            {
+                byte[] privateBlob;
+                string uniqueKeyContainerName;
+
+                using (var rsa = new RSACryptoServiceProvider(KeySize, cspParameters))
+                {
+                    Assert.True(rsa.PersistKeyInCsp, "rsa.PersistKeyInCsp");
+                    Assert.Equal(cspParameters.KeyContainerName, rsa.CspKeyContainerInfo.KeyContainerName);
+
+                    uniqueKeyContainerName = rsa.CspKeyContainerInfo.UniqueKeyContainerName;
+                    Assert.NotNull(uniqueKeyContainerName);
+                    Assert.NotEqual(string.Empty, uniqueKeyContainerName);
+
+                    privateBlob = rsa.ExportCspBlob(true);
+                    Assert.True(rsa.CspKeyContainerInfo.Exportable, "rsa.CspKeyContainerInfo.Exportable");
+                }
+
+                // Fail if the key didn't persist
+                cspParameters.Flags |= CspProviderFlags.UseExistingKey;
+
+                using (var rsa = new RSACryptoServiceProvider(cspParameters))
+                {
+                    Assert.True(rsa.PersistKeyInCsp);
+                    Assert.Equal(KeySize, rsa.KeySize);
+
+                    Assert.Equal(uniqueKeyContainerName, rsa.CspKeyContainerInfo.UniqueKeyContainerName);
+
+                    byte[] blob2 = rsa.ExportCspBlob(true);
+                    Assert.Equal(privateBlob, blob2);
+                }
+            }
+        }
+
+        [Fact]
+        public static void NamedKey_AlternateProvider()
+        {
+            const int KeySize = 512;
+
+            CspParameters cspParameters = new CspParameters(PROV_RSA_FULL)
+            {
+                KeyContainerName = Guid.NewGuid().ToString(),
+            };
+
+            using (new RsaKeyLifetime(cspParameters))
+            {
+                byte[] privateBlob;
+                string uniqueKeyContainerName;
+
+                using (var rsa = new RSACryptoServiceProvider(KeySize, cspParameters))
+                {
+                    Assert.True(rsa.PersistKeyInCsp);
+                    Assert.Equal(PROV_RSA_FULL, rsa.CspKeyContainerInfo.ProviderType);
+
+                    privateBlob = rsa.ExportCspBlob(true);
+
+                    Assert.Equal(cspParameters.KeyContainerName, rsa.CspKeyContainerInfo.KeyContainerName);
+
+                    uniqueKeyContainerName = rsa.CspKeyContainerInfo.UniqueKeyContainerName;
+                    Assert.NotNull(uniqueKeyContainerName);
+                    Assert.NotEqual(string.Empty, uniqueKeyContainerName);
+                }
+
+                // Fail if the key didn't persist
+                cspParameters.Flags |= CspProviderFlags.UseExistingKey;
+
+                using (var rsa = new RSACryptoServiceProvider(cspParameters))
+                {
+                    Assert.True(rsa.PersistKeyInCsp);
+                    Assert.Equal(KeySize, rsa.KeySize);
+
+                    // Since we're specifying the provider explicitly it should still match.
+                    Assert.Equal(PROV_RSA_FULL, rsa.CspKeyContainerInfo.ProviderType);
+
+                    Assert.Equal(uniqueKeyContainerName, rsa.CspKeyContainerInfo.UniqueKeyContainerName);
+
+                    byte[] blob2 = rsa.ExportCspBlob(true);
+                    Assert.Equal(privateBlob, blob2);
+                }
+            }
+        }
+
+        [Fact]
+        public static void NonExportable_Ephemeral()
+        {
+            CspParameters cspParameters = new CspParameters
+            {
+                Flags = CspProviderFlags.UseNonExportableKey,
+            };
+
+            using (var rsa = new RSACryptoServiceProvider(cspParameters))
+            {
+                // Ephemeral keys don't successfully request the exportable bit.
+                Assert.ThrowsAny<CryptographicException>(() => rsa.CspKeyContainerInfo.Exportable);
+
+                Assert.Throws<CryptographicException>(() => rsa.ExportCspBlob(true));
+                Assert.Throws<CryptographicException>(() => rsa.ExportParameters(true));
+            }
+        }
+
+        [Fact]
+        public static void NonExportable_Persisted()
+        {
+            CspParameters cspParameters = new CspParameters
+            {
+                KeyContainerName = Guid.NewGuid().ToString(),
+                Flags = CspProviderFlags.UseNonExportableKey,
+            };
+
+            using (new RsaKeyLifetime(cspParameters))
+            {
+                using (var rsa = new RSACryptoServiceProvider(cspParameters))
+                {
+                    Assert.False(rsa.CspKeyContainerInfo.Exportable, "rsa.CspKeyContainerInfo.Exportable");
+
+                    Assert.Throws<CryptographicException>(() => rsa.ExportCspBlob(true));
+                    Assert.Throws<CryptographicException>(() => rsa.ExportParameters(true));
+                }
+            }
+        }
+
+        private sealed class RsaKeyLifetime : IDisposable
+        {
+            private readonly CspParameters _cspParameters;
+
+            internal RsaKeyLifetime(CspParameters cspParameters)
+            {
+                const CspProviderFlags CopyableFlags =
+                    CspProviderFlags.UseMachineKeyStore;
+
+                _cspParameters = new CspParameters(
+                    cspParameters.ProviderType,
+                    cspParameters.ProviderName,
+                    cspParameters.KeyContainerName)
+                {
+                    // If the test failed before creating the key, don't bother recreating it.
+                    Flags = (cspParameters.Flags & CopyableFlags) | CspProviderFlags.UseExistingKey,
+                };
+            }
+
+            public void Dispose()
+            {
+                try
+                {
+                    using (var rsa = new RSACryptoServiceProvider(_cspParameters))
+                    {
+                        // Delete the key at the end of this using
+                        rsa.PersistKeyInCsp = false;
+                    }
+                }
+                catch (CryptographicException)
+                {
+                }
+            }
+        }
+    }
+}

--- a/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
+++ b/src/System.Security.Cryptography.Csp/tests/System.Security.Cryptography.Csp.Tests.csproj
@@ -17,9 +17,11 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CspParametersTests.cs" />
     <Compile Include="ImportExportCspBlob.cs" />
     <Compile Include="RSACryptoServiceProviderBackCompat.cs" />
     <Compile Include="RSACryptoServiceProviderProvider.cs" />
+    <Compile Include="RSACryptoServiceProviderTests.cs" />
     <Compile Include="$(CommonTestPath)\System\Security\Cryptography\ByteUtils.cs">
       <Link>CommonTest\System\Security\Cryptography\ByteUtils.cs</Link>
     </Compile>


### PR DESCRIPTION
This was originally motivated by a report that said that our internal test suite had marginally better (30 blocks, 1.9% line coverage) coverage results.  But we only have 53.3% line coverage... so I went ahead and just did a full coverage-improvement pass.

* Added tests to validate the PublicOnly property
* Added tests to validate the CspKeyContainerInfo population
* Added tests for the RSACryptoServiceProvider-specific Sign and Verify methods
* Added tests which verify persistent key support

This additional coverage turned up a few bugs that happened while porting from the desktop code (largely errors that happened when porting the CSP support from within the VM to just using managed code)
* RSACryptoServiceProvider.PublicOnly was always false
* RSACryptoServiceProvider.CspKeyContainerInfo.UniqueKeyContainerName had trailing null characters
* RSACryptoServiceProvider.CspKeyContainerInfo.ProviderName didn't populate the value when only a ProviderType was set

I also got "lucky" and started hitting an assert in SafeKeyHandle.ReleaseHandle, it turned out to be that SafeKeyHandles need to be freed before their allocating SafeProvHandles, and the increased coverage showed that GetProviderParameter (in particular, reading the Exportable property) was causing SafeKeyHandles to be finalized, and there's a race condition against the SafeProvHandle.  This specific problem was fixed in this PR, but opened #6210 and #6211 to track the overall problems discovered with these handles.

cc: @AtsushiKan @morganbr @stephentoub 