### PR TITLE
Implement IIListProvider on Reverse and DefaultIfEmpty

### DIFF
--- a/src/System.Linq/src/System/Linq/DefaultIfEmpty.cs
+++ b/src/System.Linq/src/System/Linq/DefaultIfEmpty.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace System.Linq
 {
@@ -17,24 +19,95 @@ namespace System.Linq
         public static IEnumerable<TSource> DefaultIfEmpty<TSource>(this IEnumerable<TSource> source, TSource defaultValue)
         {
             if (source == null) throw Error.ArgumentNull("source");
-            return DefaultIfEmptyIterator(source, defaultValue);
+            return new DefaultIfEmptyIterator<TSource>(source, defaultValue);
         }
 
-        private static IEnumerable<TSource> DefaultIfEmptyIterator<TSource>(IEnumerable<TSource> source, TSource defaultValue)
+        private sealed class DefaultIfEmptyIterator<TSource> : Iterator<TSource>, IIListProvider<TSource>
         {
-            using (IEnumerator<TSource> e = source.GetEnumerator())
+            private readonly IEnumerable<TSource> _source;
+            private readonly TSource _default;
+            private IEnumerator<TSource> _enumerator;
+
+            public DefaultIfEmptyIterator(IEnumerable<TSource> source, TSource defaultValue)
             {
-                if (e.MoveNext())
+                Debug.Assert(source != null);
+                _source = source;
+                _default = defaultValue;
+            }
+
+            public override Iterator<TSource> Clone()
+            {
+                return new DefaultIfEmptyIterator<TSource>(_source, _default);
+            }
+
+            public override bool MoveNext()
+            {
+                switch (state)
                 {
-                    do
-                    {
-                        yield return e.Current;
-                    } while (e.MoveNext());
+                    case 1:
+                        _enumerator = _source.GetEnumerator();
+                        if (_enumerator.MoveNext())
+                        {
+                            current = _enumerator.Current;
+                            state = 2;
+                        }
+                        else
+                        {
+                            current = _default;
+                            state = -1;
+                        }
+                        return true;
+                    case 2:
+                        if (_enumerator.MoveNext())
+                        {
+                            current = _enumerator.Current;
+                            return true;
+                        }
+                        break;
+                }
+
+                Dispose();
+                return false;
+            }
+
+            public override void Dispose()
+            {
+                if (_enumerator != null)
+                {
+                    _enumerator.Dispose();
+                    _enumerator = null;
+                }
+
+                base.Dispose();
+            }
+
+            public TSource[] ToArray()
+            {
+                TSource[] array = _source.ToArray();
+                return array.Length == 0 ? new[] { _default } : array;
+            }
+
+            public List<TSource> ToList()
+            {
+                List<TSource> list = _source.ToList();
+                if (list.Count == 0)
+                    list.Add(_default);
+                return list;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                int count;
+                if (!onlyIfCheap || _source is ICollection<TSource> || _source is ICollection)
+                {
+                    count = _source.Count();
                 }
                 else
                 {
-                    yield return defaultValue;
+                    IIListProvider<TSource> listProv = _source as IIListProvider<TSource>;
+                    count = listProv == null ? -1 : listProv.GetCount(onlyIfCheap: true);
                 }
+                return count == 0 ? 1 : count;
             }
         }
     }

--- a/src/System.Linq/src/System/Linq/Reverse.cs
+++ b/src/System.Linq/src/System/Linq/Reverse.cs
@@ -3,7 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace System.Linq
 {
@@ -12,13 +14,88 @@ namespace System.Linq
         public static IEnumerable<TSource> Reverse<TSource>(this IEnumerable<TSource> source)
         {
             if (source == null) throw Error.ArgumentNull("source");
-            return ReverseIterator(source);
+            return new ReverseIterator<TSource>(source);
         }
 
-        private static IEnumerable<TSource> ReverseIterator<TSource>(IEnumerable<TSource> source)
+        private sealed class ReverseIterator<TSource> : Iterator<TSource>, IIListProvider<TSource>
         {
-            Buffer<TSource> buffer = new Buffer<TSource>(source);
-            for (int i = buffer.count - 1; i >= 0; i--) yield return buffer.items[i];
+            private readonly IEnumerable<TSource> _source;
+            private TSource[] _buffer;
+            private int _index;
+
+            public ReverseIterator(IEnumerable<TSource> source)
+            {
+                Debug.Assert(source != null);
+                _source = source;
+            }
+
+            public override Iterator<TSource> Clone()
+            {
+                return new ReverseIterator<TSource>(_source);
+            }
+
+            public override bool MoveNext()
+            {
+                switch (state)
+                {
+                    case 1:
+                        Buffer<TSource> buffer = new Buffer<TSource>(_source);
+                        _buffer = buffer.items;
+                        _index = buffer.count - 1;
+                        state = 2;
+                        goto case 2;
+                    case 2:
+                        if (_index != -1)
+                        {
+                            current = _buffer[_index];
+                            --_index;
+                            return true;
+                        }
+                        break;
+                }
+
+                Dispose();
+                return false;
+            }
+
+            public override void Dispose()
+            {
+                _buffer = null; // Just in case this ends up being long-lived, allow the memory to be reclaimed.
+                base.Dispose();
+            }
+
+            public TSource[] ToArray()
+            {
+                TSource[] array = _source.ToArray();
+                // Array.Reverse() involves boxing for non-primitive value types, but
+                // checking that has its own cost, so just use this approach for all types.
+                for (int i = 0, j = array.Length - 1; i < j; ++i, --j)
+                {
+                    TSource temp = array[i];
+                    array[i] = array[j];
+                    array[j] = temp;
+                }
+                return array;
+            }
+
+            public List<TSource> ToList()
+            {
+                List<TSource> list = _source.ToList();
+                list.Reverse();
+                return list;
+            }
+
+            public int GetCount(bool onlyIfCheap)
+            {
+                if (onlyIfCheap)
+                {
+                    IIListProvider<TSource> listProv = _source as IIListProvider<TSource>;
+                    if (listProv != null) return listProv.GetCount(onlyIfCheap: true);
+                    if (!(_source is ICollection<TSource>) && !(_source is ICollection)) return -1;
+                }
+
+                return _source.Count();
+            }
         }
     }
 }

--- a/src/System.Linq/tests/DefaultIfEmptyTests.cs
+++ b/src/System.Linq/tests/DefaultIfEmptyTests.cs
@@ -117,5 +117,55 @@ namespace System.Linq.Tests
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
         }
+
+        [Fact]
+        public void RepeatEnumeration()
+        {
+            var q = Enumerable.Range(0, 3).DefaultIfEmpty(9);
+
+            Assert.Equal(q, q);
+        }
+
+        [Fact]
+        public void ToArray()
+        {
+            int[] source = { 3, -1, 0, 10, 15 };
+
+            Assert.Equal(source, source.DefaultIfEmpty(9).ToArray());
+        }
+
+        [Fact]
+        public void EmptyToArray()
+        {
+            Assert.Equal(new[] { 9 }, Enumerable.Empty<int>().DefaultIfEmpty(9).ToArray());
+        }
+
+        [Fact]
+        public void ToList()
+        {
+            int[] source = { 3, -1, 0, 10, 15 };
+
+            Assert.Equal(source, source.DefaultIfEmpty(9).ToList());
+        }
+
+        [Fact]
+        public void EmptyToList()
+        {
+            Assert.Equal(new[] { 9 }, Enumerable.Empty<int>().DefaultIfEmpty(9).ToList());
+        }
+
+        [Fact]
+        public void Count()
+        {
+            int[] source = { 3, -1, 0, 10, 15 };
+
+            Assert.Equal(5, source.DefaultIfEmpty().Count());
+        }
+
+        [Fact]
+        public void EmptyCount()
+        {
+            Assert.Equal(1, Enumerable.Empty<int>().DefaultIfEmpty().Count());
+        }
     }
 }

--- a/src/System.Linq/tests/ReverseTests.cs
+++ b/src/System.Linq/tests/ReverseTests.cs
@@ -60,14 +60,40 @@ namespace System.Linq.Tests
 
             Assert.Equal(q.Reverse(), q.Reverse());
         }
-        
+
         [Fact]
         public void SomeRepeatedElements()
         {
             int?[] source = new int?[] { -10, 0, 5, null, 0, 9, 100, null, 9 };
             int?[] expected = new int?[] { 9, null, 100, 9, 0, null, 5, 0, -10 };
-            
+
             Assert.Equal(expected, source.Reverse());
+        }
+
+        [Fact]
+        public void ToArray()
+        {
+            int?[] source = new int?[] { -10, 0, 5, null, 0, 9, 100, null, 9 };
+            int?[] expected = new int?[] { 9, null, 100, 9, 0, null, 5, 0, -10 };
+
+            Assert.Equal(expected, source.Reverse().ToArray());
+        }
+
+        [Fact]
+        public void ToList()
+        {
+            int?[] source = new int?[] { -10, 0, 5, null, 0, 9, 100, null, 9 };
+            int?[] expected = new int?[] { 9, null, 100, 9, 0, null, 5, 0, -10 };
+
+            Assert.Equal(expected, source.Reverse().ToList());
+        }
+
+        [Fact]
+        public void Count()
+        {
+            int?[] source = new int?[] { -10, 0, 5, null, 0, 9, 100, null, 9 };
+
+            Assert.Equal(9, source.Reverse().Count());
         }
 
         [Fact]
@@ -77,6 +103,14 @@ namespace System.Linq.Tests
             // Don't insist on this behaviour, but check its correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
+        }
+
+        [Fact]
+        public void RepeatEnumerating()
+        {
+            var reverse = new int?[] { -10, 0, 5, null, 0, 9, 100, null, 9 }.Reverse();
+
+            Assert.Equal(reverse, reverse);
         }
     }
 }


### PR DESCRIPTION
Both of these cases allow the work of `ToList()` and `ToArray()` to be passed to their source.

In the worse case this removes a level of `MoveNext()` and `Current` indirection.

In the best case the underlying source has optimized handling itself, and the benefits accrue.