### PR TITLE
Disable DualMode Socket connect tests on Unix

### DIFF
--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
@@ -845,30 +845,35 @@ namespace System.Net.Sockets.Tests
         #region Accept Begin/End
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginAcceptV4BoundToSpecificV4_Success()
         {
             DualModeConnect_BeginAccept_Helper(IPAddress.Loopback, IPAddress.Loopback);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginAcceptV4BoundToAnyV4_Success()
         {
             DualModeConnect_BeginAccept_Helper(IPAddress.Any, IPAddress.Loopback);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginAcceptV6BoundToSpecificV6_Success()
         {
             DualModeConnect_BeginAccept_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginAcceptV6BoundToAnyV6_Success()
         {
             DualModeConnect_BeginAccept_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginAcceptV6BoundToSpecificV4_CantConnect()
         {
             Assert.Throws<SocketException>(() =>
@@ -878,6 +883,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginAcceptV4BoundToSpecificV6_CantConnect()
         {
             Assert.Throws<SocketException>(() =>
@@ -887,6 +893,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginAcceptV6BoundToAnyV4_CantConnect()
         {
             Assert.Throws<SocketException>(() =>
@@ -896,6 +903,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginAcceptV4BoundToAnyV6_Success()
         {
             DualModeConnect_BeginAccept_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
@@ -1078,18 +1086,21 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void SendToV4IPEndPointToV4Host_Success()
         {
             DualModeSendTo_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void SendToV6IPEndPointToV6Host_Success()
         {
             DualModeSendTo_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void SendToV4IPEndPointToV6Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -1099,6 +1110,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void SendToV6IPEndPointToV4Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -1108,12 +1120,14 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void SendToV4IPEndPointToDualHost_Success()
         {
             DualModeSendTo_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void SendToV6IPEndPointToDualHost_Success()
         {
             DualModeSendTo_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
@@ -1678,6 +1692,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveFromAsyncV4BoundToSpecificV4_Success()
         {
             ReceiveFromAsync_Helper(IPAddress.Loopback, IPAddress.Loopback);
@@ -1685,24 +1700,28 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [ActiveIssue(4004, PlatformID.OSX)]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveFromAsyncV4BoundToAnyV4_Success()
         {
             ReceiveFromAsync_Helper(IPAddress.Any, IPAddress.Loopback);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveFromAsyncV6BoundToSpecificV6_Success()
         {
             ReceiveFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveFromAsyncV6BoundToAnyV6_Success()
         {
             ReceiveFromAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveFromAsyncV6BoundToSpecificV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -1712,6 +1731,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveFromAsyncV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -1721,6 +1741,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveFromAsyncV6BoundToAnyV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -1730,6 +1751,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveFromAsyncV4BoundToAnyV6_Success()
         {
             ReceiveFromAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback);

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
@@ -940,30 +940,35 @@ namespace System.Net.Sockets.Tests
         #region Accept Async/Event
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void AcceptAsyncV4BoundToSpecificV4_Success()
         {
             DualModeConnect_AcceptAsync_Helper(IPAddress.Loopback, IPAddress.Loopback);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void AcceptAsyncV4BoundToAnyV4_Success()
         {
             DualModeConnect_AcceptAsync_Helper(IPAddress.Any, IPAddress.Loopback);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void AcceptAsyncV6BoundToSpecificV6_Success()
         {
             DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void AcceptAsyncV6BoundToAnyV6_Success()
         {
             DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void AcceptAsyncV6BoundToSpecificV4_CantConnect()
         {
             Assert.Throws<SocketException>(() =>
@@ -973,6 +978,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void AcceptAsyncV4BoundToSpecificV6_CantConnect()
         {
             Assert.Throws<SocketException>(() =>
@@ -982,6 +988,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void AcceptAsyncV6BoundToAnyV4_CantConnect()
         {
             Assert.Throws<SocketException>(() =>
@@ -991,6 +998,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void AcceptAsyncV4BoundToAnyV6_Success()
         {
             DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
@@ -1158,18 +1166,21 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginSendToV4IPEndPointToV4Host_Success()
         {
             DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginSendToV6IPEndPointToV6Host_Success()
         {
             DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginSendToV4IPEndPointToV6Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -1179,6 +1190,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginSendToV6IPEndPointToV4Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -1188,12 +1200,14 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginSendToV4IPEndPointToDualHost_Success()
         {
             DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginSendToV6IPEndPointToDualHost_Success()
         {
             DualModeBeginSendTo_EndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
@@ -1255,18 +1269,21 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void SendToAsyncV4IPEndPointToV4Host_Success()
         {
             DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void SendToAsyncV6IPEndPointToV6Host_Success()
         {
             DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void SendToAsyncV4IPEndPointToV6Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -1276,6 +1293,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void SendToAsyncV6IPEndPointToV4Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -1285,12 +1303,14 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void SendToAsyncV4IPEndPointToDualHost_Success()
         {
             DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void SendToAsyncV6IPEndPointToDualHost_Success()
         {
             DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);
@@ -1984,6 +2004,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact] // Base case
         [ActiveIssue(4004, PlatformID.OSX)]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginReceiveMessageFromV4BoundToSpecificMappedV4_Success()
         {
             BeginReceiveMessageFrom_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback);
@@ -1991,6 +2012,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact] // Base case
         [ActiveIssue(4004, PlatformID.OSX)]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginReceiveMessageFromV4BoundToAnyMappedV4_Success()
         {
             BeginReceiveMessageFrom_Helper(IPAddress.Any.MapToIPv6(), IPAddress.Loopback);
@@ -1998,6 +2020,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [ActiveIssue(4004, PlatformID.OSX)]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginReceiveMessageFromV4BoundToSpecificV4_Success()
         {
             BeginReceiveMessageFrom_Helper(IPAddress.Loopback, IPAddress.Loopback);
@@ -2005,6 +2028,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [ActiveIssue(4004, PlatformID.OSX)]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginReceiveMessageFromV4BoundToAnyV4_Success()
         {
             BeginReceiveMessageFrom_Helper(IPAddress.Any, IPAddress.Loopback);
@@ -2012,6 +2036,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [ActiveIssue(4004, PlatformID.OSX)]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginReceiveMessageFromV6BoundToSpecificV6_Success()
         {
             BeginReceiveMessageFrom_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
@@ -2019,12 +2044,14 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [ActiveIssue(4004, PlatformID.OSX)]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginReceiveMessageFromV6BoundToAnyV6_Success()
         {
             BeginReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginReceiveMessageFromV6BoundToSpecificV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -2035,6 +2062,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [PlatformSpecific(~PlatformID.Linux)]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginReceiveMessageFromV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -2052,6 +2080,7 @@ namespace System.Net.Sockets.Tests
         //       be necessary to emulate the Winsock behavior.
         [Fact]
         [PlatformSpecific(PlatformID.Linux)]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginReceiveMessageFromV4BoundToSpecificV6_NotReceived_Linux()
         {
             Assert.Throws<ArgumentException>(() =>
@@ -2061,6 +2090,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginReceiveMessageFromV6BoundToAnyV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -2071,6 +2101,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [ActiveIssue(4004, PlatformID.OSX)]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void BeginReceiveMessageFromV4BoundToAnyV6_Success()
         {
             BeginReceiveMessageFrom_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
@@ -2161,6 +2192,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact] // Base case
         [ActiveIssue(4004, PlatformID.OSX)]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveMessageFromAsyncV4BoundToSpecificMappedV4_Success()
         {
             ReceiveMessageFromAsync_Helper(IPAddress.Loopback.MapToIPv6(), IPAddress.Loopback);
@@ -2168,6 +2200,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact] // Base case
         [ActiveIssue(4004, PlatformID.OSX)]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveMessageFromAsyncV4BoundToAnyMappedV4_Success()
         {
             ReceiveMessageFromAsync_Helper(IPAddress.Any.MapToIPv6(), IPAddress.Loopback);
@@ -2175,6 +2208,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [ActiveIssue(4004, PlatformID.OSX)]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveMessageFromAsyncV4BoundToSpecificV4_Success()
         {
             ReceiveMessageFromAsync_Helper(IPAddress.Loopback, IPAddress.Loopback);
@@ -2182,6 +2216,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [ActiveIssue(4004, PlatformID.OSX)]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveMessageFromAsyncV4BoundToAnyV4_Success()
         {
             ReceiveMessageFromAsync_Helper(IPAddress.Any, IPAddress.Loopback);
@@ -2189,6 +2224,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [ActiveIssue(4004, PlatformID.OSX)]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveMessageFromAsyncV6BoundToSpecificV6_Success()
         {
             ReceiveMessageFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
@@ -2196,12 +2232,14 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [ActiveIssue(4004, PlatformID.OSX)]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveMessageFromAsyncV6BoundToAnyV6_Success()
         {
             ReceiveMessageFromAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveMessageFromAsyncV6BoundToSpecificV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -2212,6 +2250,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [PlatformSpecific(~PlatformID.Linux)]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveMessageFromAsyncV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -2238,6 +2277,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveMessageFromAsyncV6BoundToAnyV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -2248,6 +2288,7 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [ActiveIssue(4004, PlatformID.OSX)]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveMessageFromAsyncV4BoundToAnyV6_Success()
         {
             ReceiveMessageFromAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback);

--- a/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets.Legacy/tests/FunctionalTests/DualModeSocketTest.cs
@@ -342,18 +342,21 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void BeginConnectV4IPAddressToV4Host_Success()
         {
             DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void BeginConnectV6IPAddressToV6Host_Success()
         {
             DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void BeginConnectV4IPAddressToV6Host_Fails()
         {
@@ -363,6 +366,7 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void BeginConnectV6IPAddressToV4Host_Fails()
         {
@@ -372,12 +376,14 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void BeginConnectV4IPAddressToDualHost_Success()
         {
             DualModeBeginConnect_IPAddressToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void BeginConnectV6IPAddressToDualHost_Success()
         {
@@ -412,18 +418,21 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void BeginConnectV4IPEndPointToV4Host_Success()
         {
             DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void BeginConnectV6IPEndPointToV6Host_Success()
         {
             DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void BeginConnectV4IPEndPointToV6Host_Fails()
         {
@@ -433,6 +442,7 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void BeginConnectV6IPEndPointToV4Host_Fails()
         {
@@ -442,12 +452,14 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void BeginConnectV4IPEndPointToDualHost_Success()
         {
             DualModeBeginConnect_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void BeginConnectV6IPEndPointToDualHost_Success()
         {
@@ -545,18 +557,21 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void ConnectAsyncV4IPEndPointToV4Host_Success()
         {
             DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void ConnectAsyncV6IPEndPointToV6Host_Success()
         {
             DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void ConnectAsyncV4IPEndPointToV6Host_Fails()
         {
@@ -566,6 +581,7 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void ConnectAsyncV6IPEndPointToV4Host_Fails()
         {
@@ -575,12 +591,14 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void ConnectAsyncV4IPEndPointToDualHost_Success()
         {
             DualModeConnectAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void ConnectAsyncV6IPEndPointToDualHost_Success()
         {
@@ -1480,30 +1498,35 @@ namespace System.Net.Sockets.Tests
             }
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void BeginReceiveFromV4BoundToSpecificV4_Success()
         {
             BeginReceiveFrom_Helper(IPAddress.Loopback, IPAddress.Loopback);
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void BeginReceiveFromV4BoundToAnyV4_Success()
         {
             BeginReceiveFrom_Helper(IPAddress.Any, IPAddress.Loopback);
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void BeginReceiveFromV6BoundToSpecificV6_Success()
         {
             BeginReceiveFrom_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void BeginReceiveFromV6BoundToAnyV6_Success()
         {
             BeginReceiveFrom_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void BeginReceiveFromV6BoundToSpecificV4_NotReceived()
         {
@@ -1513,6 +1536,7 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         [PlatformSpecific(~PlatformID.Linux)]
         public void BeginReceiveFromV4BoundToSpecificV6_NotReceived()
@@ -1530,6 +1554,7 @@ namespace System.Net.Sockets.Tests
         //       with the socket's address family fail. We've decided that this is
         //       an acceptable difference due to the extra state that would otherwise
         //       be necessary to emulate the Winsock behavior.
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         [PlatformSpecific(PlatformID.Linux)]
         public void BeginReceiveFromV4BoundToSpecificV6_NotReceived_Linux()
@@ -1540,6 +1565,7 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void BeginReceiveFromV6BoundToAnyV4_NotReceived()
         {
@@ -1549,6 +1575,7 @@ namespace System.Net.Sockets.Tests
             });
         }
 
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         [Fact]
         public void BeginReceiveFromV4BoundToAnyV6_Success()
         {

--- a/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -228,30 +228,35 @@ namespace System.Net.Sockets.Tests
         #region Accept Async/Event
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void AcceptAsyncV4BoundToSpecificV4_Success()
         {
             DualModeConnect_AcceptAsync_Helper(IPAddress.Loopback, IPAddress.Loopback);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void AcceptAsyncV4BoundToAnyV4_Success()
         {
             DualModeConnect_AcceptAsync_Helper(IPAddress.Any, IPAddress.Loopback);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void AcceptAsyncV6BoundToSpecificV6_Success()
         {
             DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void AcceptAsyncV6BoundToAnyV6_Success()
         {
             DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void AcceptAsyncV6BoundToSpecificV4_CantConnect()
         {
             Assert.Throws<SocketException>(() =>
@@ -261,6 +266,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void AcceptAsyncV4BoundToSpecificV6_CantConnect()
         {
             Assert.Throws<SocketException>(() =>
@@ -270,6 +276,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void AcceptAsyncV6BoundToAnyV4_CantConnect()
         {
             Assert.Throws<SocketException>(() =>
@@ -279,6 +286,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void AcceptAsyncV4BoundToAnyV6_Success()
         {
             DualModeConnect_AcceptAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback);
@@ -401,18 +409,21 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void SendToAsyncV4IPEndPointToV4Host_Success()
         {
             DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.Loopback, false);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void SendToAsyncV6IPEndPointToV6Host_Success()
         {
             DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback, false);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void SendToAsyncV4IPEndPointToV6Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -422,6 +433,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void SendToAsyncV6IPEndPointToV4Host_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -431,12 +443,14 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void SendToAsyncV4IPEndPointToDualHost_Success()
         {
             DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.Loopback, IPAddress.IPv6Any, true);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void SendToAsyncV6IPEndPointToDualHost_Success()
         {
             DualModeSendToAsync_IPEndPointToHost_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Any, true);

--- a/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/DualModeSocketTest.cs
@@ -526,6 +526,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveFromAsyncV4BoundToSpecificV4_Success()
         {
             ReceiveFromAsync_Helper(IPAddress.Loopback, IPAddress.Loopback);
@@ -533,24 +534,28 @@ namespace System.Net.Sockets.Tests
 
         [Fact]
         [ActiveIssue(4004, PlatformID.OSX)]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveFromAsyncV4BoundToAnyV4_Success()
         {
             ReceiveFromAsync_Helper(IPAddress.Any, IPAddress.Loopback);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveFromAsyncV6BoundToSpecificV6_Success()
         {
             ReceiveFromAsync_Helper(IPAddress.IPv6Loopback, IPAddress.IPv6Loopback);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveFromAsyncV6BoundToAnyV6_Success()
         {
             ReceiveFromAsync_Helper(IPAddress.IPv6Any, IPAddress.IPv6Loopback);
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveFromAsyncV6BoundToSpecificV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -560,6 +565,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveFromAsyncV4BoundToSpecificV6_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -569,6 +575,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveFromAsyncV6BoundToAnyV4_NotReceived()
         {
             Assert.Throws<TimeoutException>(() =>
@@ -578,6 +585,7 @@ namespace System.Net.Sockets.Tests
         }
 
         [Fact]
+        [ActiveIssue(6218, PlatformID.AnyUnix)]
         public void ReceiveFromAsyncV4BoundToAnyV6_Success()
         {
             ReceiveFromAsync_Helper(IPAddress.IPv6Any, IPAddress.Loopback);


### PR DESCRIPTION
These tests are now frequently timing out or hanging, causing failures and significant delays in many PR legs.  I'm disabling them all until we better understand the issue.

cc: @ericeil 
#6218