### PR TITLE
Add arm64 native support

### DIFF
--- a/src/Native/CMakeLists.txt
+++ b/src/Native/CMakeLists.txt
@@ -26,10 +26,19 @@ endif ()
 
 if (CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 OR CMAKE_SYSTEM_PROCESSOR STREQUAL amd64)
     add_definitions(-DBIT64=1)
-    add_definitions(-DX64=1)
+    add_definitions(-D_AMD64_)
+elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL x86)
+    add_definitions(-DBIT32=1)
+    add_definitions(-D_X86_)
+elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64)
+    add_definitions(-DBIT64=1)
+    add_definitions(-D_ARM64_)
+    # Because we don't use CMAKE_C_COMPILER/CMAKE_CXX_COMPILER to use clang
+    # we have to set the triple by adding a compiler argument
+    add_compile_options(-target aarch64-linux-gnu)
 elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l)
     add_definitions(-DBIT32=1)
-    add_definitions(-DARM=1)
+    add_definitions(-D_ARM_)
     add_definitions(-D_FILE_OFFSET_BITS=64)
     # Because we don't use CMAKE_C_COMPILER/CMAKE_CXX_COMPILER to use clang
     # we have to set the triple by adding a compiler argument

--- a/src/Native/System.Native/pal_runtimeinformation.cpp
+++ b/src/Native/System.Native/pal_runtimeinformation.cpp
@@ -26,14 +26,17 @@ extern "C" int32_t SystemNative_GetUnixVersion(char* version, int* capacity)
 /* Returns an int representing the OS Architecture:
  0 - x86
  1 - x64
- 2 - ARM */
+ 2 - ARM
+ 3 - ARM64 */
 extern "C" int32_t SystemNative_GetUnixArchitecture()
 {
-#if defined(ARM)
+#if defined(_ARM_)
     return ARCH_ARM;
-#elif defined(X64)
+#elif defined(_ARM64_)
+    return ARCH_ARM64;
+#elif defined(_AMD64_)
     return ARCH_X64;
-#elif defined(X86)
+#elif defined(_X86_)
     return ARCH_X86;
 #error Unidentified Architecture
 #endif

--- a/src/Native/System.Native/pal_runtimeinformation.h
+++ b/src/Native/System.Native/pal_runtimeinformation.h
@@ -14,5 +14,6 @@ enum
 {
     ARCH_X86,
     ARCH_X64,
-    ARCH_ARM
+    ARCH_ARM,
+    ARCH_ARM64
 };


### PR DESCRIPTION
Add arm64 support for native code in runtimeinformation.cpp/h

This is a native only version of PR #6197 