### PR TITLE
Move CoreCLR-only serialization tests to a separate file

### DIFF
--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.CoreCLR.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.CoreCLR.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using SerializationTypes.CoreCLR;
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+using Xunit;
+
+public static partial class DataContractJsonSerializerTests
+{
+    [Fact]
+    public static void DCJS_DifferentCollectionsOfSameTypeAsKnownTypes()
+    {
+        Assert.Throws<InvalidOperationException>(() => {
+            (new DataContractSerializer(typeof(TypeWithKnownTypesOfCollectionsWithConflictingXmlName))).WriteObject(new MemoryStream(), new TypeWithKnownTypesOfCollectionsWithConflictingXmlName());
+        });
+    }
+}

--- a/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
+++ b/src/System.Runtime.Serialization.Json/tests/DataContractJsonSerializer.cs
@@ -1771,14 +1771,6 @@ public static partial class DataContractJsonSerializerTests
         });
     }
 
-    [Fact]
-    public static void DCJS_DifferentCollectionsOfSameTypeAsKnownTypes()
-    {
-        Assert.Throws<InvalidOperationException>(() => {
-            (new DataContractSerializer(typeof(TypeWithKnownTypesOfCollectionsWithConflictingXmlName))).WriteObject(new MemoryStream(), new TypeWithKnownTypesOfCollectionsWithConflictingXmlName());
-        });
-    }
-
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractJsonSerializerSettings settings = null, Func<DataContractJsonSerializer> serializerFactory = null, bool skipStringCompare = false)
     {
         DataContractJsonSerializer dcjs;

--- a/src/System.Runtime.Serialization.Json/tests/System.Runtime.Serialization.Json.Tests.csproj
+++ b/src/System.Runtime.Serialization.Json/tests/System.Runtime.Serialization.Json.Tests.csproj
@@ -14,7 +14,9 @@
   <ItemGroup>
     <Compile Include="..\..\System.Runtime.Serialization.Xml\tests\Utils.cs" />
     <Compile Include="..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.cs" />
+    <Compile Include="..\..\System.Runtime.Serialization.Xml\tests\SerializationTypes.CoreCLR.cs" />
     <Compile Include="DataContractJsonSerializer.cs" />
+    <Compile Include="DataContractJsonSerializer.CoreCLR.cs" />
     <Compile Include="Performance\DcjsDeserializationTests.cs" />
     <Compile Include="Performance\DcjsSerializationTests.cs" />
   </ItemGroup>

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.CoreCLR.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.CoreCLR.cs
@@ -1,0 +1,20 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using SerializationTypes.CoreCLR;
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+using Xunit;
+
+public static partial class DataContractSerializerTests
+{
+    [Fact]
+    public static void DCS_DifferentCollectionsOfSameTypeAsKnownTypes()
+    {
+        Assert.Throws<InvalidOperationException>(() => {
+            (new DataContractSerializer(typeof(TypeWithKnownTypesOfCollectionsWithConflictingXmlName))).WriteObject(new MemoryStream(), new TypeWithKnownTypesOfCollectionsWithConflictingXmlName());
+        });
+    }
+}

--- a/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/DataContractSerializer.cs
@@ -2023,14 +2023,6 @@ public static partial class DataContractSerializerTests
         }
     }
 
-    [Fact]
-    public static void DCS_DifferentCollectionsOfSameTypeAsKnownTypes()
-    {
-        Assert.Throws<InvalidOperationException>(() => { 
-            (new DataContractSerializer(typeof(TypeWithKnownTypesOfCollectionsWithConflictingXmlName))).WriteObject(new MemoryStream(), new TypeWithKnownTypesOfCollectionsWithConflictingXmlName());
-        });
-    }
-
     private static T SerializeAndDeserialize<T>(T value, string baseline, DataContractSerializerSettings settings = null, Func<DataContractSerializer> serializerFactory = null, bool skipStringCompare = false)
     {
         DataContractSerializer dcs;

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.CoreCLR.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.CoreCLR.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace SerializationTypes.CoreCLR
+{
+    [KnownType(typeof(List<SimpleType>))]
+    [KnownType(typeof(SimpleType[]))]
+    [DataContract]
+    public class TypeWithKnownTypesOfCollectionsWithConflictingXmlName
+    {
+        [DataMember]
+        public object Value1 = new List<SimpleType>();
+
+        [DataMember]
+        public object Value2 = new SimpleType[1];
+
+    }
+}

--- a/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
+++ b/src/System.Runtime.Serialization.Xml/tests/SerializationTypes.cs
@@ -2369,19 +2369,6 @@ namespace SerializationTypes
     {
         public string Name { get; set; }
     }
-
-    [KnownType(typeof(List<SimpleType>))]
-    [KnownType(typeof(SimpleType[]))]
-    [DataContract]
-    public class TypeWithKnownTypesOfCollectionsWithConflictingXmlName
-    {
-        [DataMember]
-        public object Value1 = new List<SimpleType>();
-
-        [DataMember]
-        public object Value2 = new SimpleType[1];
-
-    }
 }
 
 namespace DuplicateTypeNamesTest.ns1

--- a/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
+++ b/src/System.Runtime.Serialization.Xml/tests/System.Runtime.Serialization.Xml.Tests.csproj
@@ -18,7 +18,9 @@
     <Compile Include="Performance\XmlUTF8TextReaderTests.cs" />
     <Compile Include="Utils.cs" />
     <Compile Include="SerializationTypes.cs" />
+    <Compile Include="SerializationTypes.CoreCLR.cs" />
     <Compile Include="DataContractSerializer.cs" />
+    <Compile Include="DataContractSerializer.CoreCLR.cs" />
     <Compile Include="DataContractSerializerStressTests.cs" />
     <Compile Include="DataContractSerializerTestData.cs" />
     <Compile Include="MyResolver.cs" />


### PR DESCRIPTION
We have internal lab run of serialization tests on corefx for NetNative which involve these tests affecting other tests because of compilation failure so this is to move them out to a separate file until that issue is fixed.

@SGuyGe @shmao @zhenlan 