### PR TITLE
Adding the interface to the contracts

### DIFF
--- a/src/System.Data.Common/ref/System.Data.Common.Manual.cs
+++ b/src/System.Data.Common/ref/System.Data.Common.Manual.cs
@@ -79,4 +79,8 @@ namespace System.Data.Common
         }
     }
 
+    public partial interface IDbColumnSchemaGenerator
+    {
+        System.Collections.ObjectModel.ReadOnlyCollection<DbColumn> GetColumnSchema();
+    }
 }


### PR DESCRIPTION
Adding the interface IDbColumnSchemaGenerator to the contract for the DbDataReader schema 