### PR TITLE
Change the build compile group to net45

### DIFF
--- a/src/System.Data.SqlClient/src/System.Data.SqlClient.builds
+++ b/src/System.Data.SqlClient/src/System.Data.SqlClient.builds
@@ -9,7 +9,7 @@
       <OSGroup>Windows_NT</OSGroup>
     </Project>
     <Project Include="facade\System.Data.SqlClient.csproj">
-      <TargetGroup>net46</TargetGroup>
+      <TargetGroup>net45</TargetGroup>
     </Project>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />

--- a/src/System.Data.SqlClient/src/facade/System.Data.SqlClient.csproj
+++ b/src/System.Data.SqlClient/src/facade/System.Data.SqlClient.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Configuration Condition="'$(Configuration)'==''">net46_Debug</Configuration>
+    <Configuration Condition="'$(Configuration)'==''">net45_Debug</Configuration>
   </PropertyGroup>
 
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
@@ -12,12 +12,12 @@
   </PropertyGroup>
 
   <!-- Help VS understand available configurations -->
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Debug|AnyCPU'" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45_Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net45_Release|AnyCPU'" />
 
   <ItemGroup>
     <TargetingPackReference Include="mscorlib" Condition="'$(TargetGroup)' != 'netcore50aot'" />
-    <TargetingPackReference Include="System.Data" Condition="'$(TargetGroup)' == 'net46'" />
+    <TargetingPackReference Include="System.Data" Condition="'$(TargetGroup)' == 'net45'" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/System.Data.SqlClient/src/facade/project.json
+++ b/src/System.Data.SqlClient/src/facade/project.json
@@ -2,7 +2,7 @@
     "frameworks": {
         "net46": {
             "dependencies": {
-                "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
+                "Microsoft.TargetingPack.NETFramework.v4.5": "1.0.1"
             }
         }
     }

--- a/src/System.Data.SqlClient/src/facade/project.json
+++ b/src/System.Data.SqlClient/src/facade/project.json
@@ -1,6 +1,6 @@
 {
     "frameworks": {
-        "net46": {
+        "net45": {
             "dependencies": {
                 "Microsoft.TargetingPack.NETFramework.v4.5": "1.0.1"
             }


### PR DESCRIPTION
SqlClient should target .Net platform 4.5
This PR contains change to the target group of SqlClient on .Net 4.5
