### PR TITLE
Revert "Use SafeHandles in *nix Sockets implementation"

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.Accept.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Accept.cs
@@ -10,23 +10,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Accept")]
-        private static extern unsafe Error DangerousAccept(int socket, byte* socketAddress, int* socketAddressLen, int* acceptedFd);
-
-        internal static unsafe Error Accept(SafeHandle socket, byte* socketAddress, int* socketAddressLen, int* acceptedFd)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousAccept((int)socket.DangerousGetHandle(), socketAddress, socketAddressLen, acceptedFd);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern unsafe Error Accept(int socket, byte* socketAddress, int* socketAddressLen, int* acceptedFd);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Bind.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Bind.cs
@@ -10,23 +10,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Bind")]
-        private static extern unsafe Error DangerousBind(int socket, byte* socketAddress, int socketAddressLen);
-
-        internal static unsafe Error Bind(SafeHandle socket, byte* socketAddress, int socketAddressLen)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousBind((int)socket.DangerousGetHandle(), socketAddress, socketAddressLen);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern unsafe Error Bind(int socket, byte* socketAddress, int socketAddressLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Connect.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Connect.cs
@@ -10,23 +10,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Connect")]
-        private static extern unsafe Error DangerousConnect(int socket, byte* socketAddress, int socketAddressLen);
-
-        internal static unsafe Error Connect(SafeHandle socket, byte* socketAddress, int socketAddressLen)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousConnect((int)socket.DangerousGetHandle(), socketAddress, socketAddressLen);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern unsafe Error Connect(int socket, byte* socketAddress, int socketAddressLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Fcntl.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Fcntl.cs
@@ -11,11 +11,8 @@ internal static partial class Interop
     {
         internal static class Fcntl
         {
-            [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FcntlSetIsNonBlocking", SetLastError = true)]
-            internal static extern int DangerousSetIsNonBlocking(IntPtr fd, int isNonBlocking);
-
             [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FcntlSetIsNonBlocking", SetLastError=true)]
-            internal static extern int SetIsNonBlocking(SafeHandle fd, int isNonBlocking);
+            internal static extern int SetIsNonBlocking(IntPtr fd, int isNonBlocking);
         }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetBytesAvailable.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetBytesAvailable.cs
@@ -10,23 +10,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetBytesAvailable")]
-        private static extern unsafe Error DangerousGetBytesAvailable(int socket, int* available);
-
-        internal static unsafe Error GetBytesAvailable(SafeHandle socket, int* available)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousGetBytesAvailable((int)socket.DangerousGetHandle(), available);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern unsafe Error GetBytesAvailable(int socket, int* available);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetPeerName.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetPeerName.cs
@@ -10,23 +10,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPeerName")]
-        private static extern unsafe Error DangerousGetPeerName(int socket, byte* socketAddress, int* socketAddressLen);
-
-        internal static unsafe Error GetPeerName(SafeHandle socket, byte* socketAddress, int* socketAddressLen)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousGetPeerName((int)socket.DangerousGetHandle(), socketAddress, socketAddressLen);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern unsafe Error GetPeerName(int socket, byte* socketAddress, int* socketAddressLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetSockName.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetSockName.cs
@@ -10,23 +10,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSockName")]
-        private static extern unsafe Error DangerousGetSockName(int socket, byte* socketAddress, int* socketAddressLen);
-
-        internal static unsafe Error GetSockName(SafeHandle socket, byte* socketAddress, int* socketAddressLen)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousGetSockName((int)socket.DangerousGetHandle(), socketAddress, socketAddressLen);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern unsafe Error GetSockName(int socket, byte* socketAddress, int* socketAddressLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetSockOpt.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetSockOpt.cs
@@ -11,23 +11,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSockOpt")]
-        private static extern unsafe Error DangerousGetSockOpt(int socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int* optionLen);
-
-        internal static unsafe Error GetSockOpt(SafeHandle socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int* optionLen)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousGetSockOpt((int)socket.DangerousGetHandle(), optionLevel, optionName, optionValue, optionLen);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern unsafe Error GetSockOpt(int socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int* optionLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetSocketErrorOption.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetSocketErrorOption.cs
@@ -11,23 +11,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSocketErrorOption")]
-        private static extern unsafe Error DangerousGetSocketErrorOption(int socket, Error* socketError);
-
-        internal static unsafe Error GetSocketErrorOption(SafeHandle socket, Error* socketError)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousGetSocketErrorOption((int)socket.DangerousGetHandle(), socketError);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern unsafe Error GetSocketErrorOption(int socket, Error* socketError);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.LingerOption.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.LingerOption.cs
@@ -17,43 +17,9 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetLingerOption")]
-        private static extern unsafe Error DangerousGetLingerOption(int socket, LingerOption* option);
-
-        internal static unsafe Error GetLingerOption(SafeHandle socket, LingerOption* option)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousGetLingerOption((int)socket.DangerousGetHandle(), option);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern unsafe Error GetLingerOption(int socket, LingerOption* option);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetLingerOption")]
-        internal static extern unsafe Error DangerousSetLingerOption(int socket, LingerOption* option);
-
-        internal static unsafe Error SetLingerOption(SafeHandle socket, LingerOption* option)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousSetLingerOption((int)socket.DangerousGetHandle(), option);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern unsafe Error SetLingerOption(int socket, LingerOption* option);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Listen.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Listen.cs
@@ -10,23 +10,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Listen")]
-        private static extern Error DangerousListen(int socket, int backlog);
-
-        internal static Error Listen(SafeHandle socket, int backlog)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousListen((int)socket.DangerousGetHandle(), backlog);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern Error Listen(int socket, int backlog);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MulticastOption.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MulticastOption.cs
@@ -32,83 +32,15 @@ internal static partial class Interop
         }
        
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv4MulticastOption")]
-        private static extern unsafe Error DangerousGetIPv4MulticastOption(int socket, MulticastOption multicastOption, IPv4MulticastOption* option);
-
-        internal static unsafe Error GetIPv4MulticastOption(SafeHandle socket, MulticastOption multicastOption, IPv4MulticastOption* option)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousGetIPv4MulticastOption((int)socket.DangerousGetHandle(), multicastOption, option);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern unsafe Error GetIPv4MulticastOption(int socket, MulticastOption multicastOption, IPv4MulticastOption* option);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv4MulticastOption")]
-        private static extern unsafe Error DangerousSetIPv4MulticastOption(int socket, MulticastOption multicastOption, IPv4MulticastOption* option);
-
-        internal static unsafe Error SetIPv4MulticastOption(SafeHandle socket, MulticastOption multicastOption, IPv4MulticastOption* option)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousSetIPv4MulticastOption((int)socket.DangerousGetHandle(), multicastOption, option);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern unsafe Error SetIPv4MulticastOption(int socket, MulticastOption multicastOption, IPv4MulticastOption* option);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv6MulticastOption")]
-        private static extern unsafe Error DangerousGetIPv6MulticastOption(int socket, MulticastOption multicastOption, IPv6MulticastOption* option);
-
-        internal static unsafe Error GetIPv6MulticastOption(SafeHandle socket, MulticastOption multicastOption, IPv6MulticastOption* option)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousGetIPv6MulticastOption((int)socket.DangerousGetHandle(), multicastOption, option);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern unsafe Error GetIPv6MulticastOption(int socket, MulticastOption multicastOption, IPv6MulticastOption* option);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv6MulticastOption")]
-        private static extern unsafe Error DangerousSetIPv6MulticastOption(int socket, MulticastOption multicastOption, IPv6MulticastOption* option);
-
-        internal static unsafe Error SetIPv6MulticastOption(SafeHandle socket, MulticastOption multicastOption, IPv6MulticastOption* option)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousSetIPv6MulticastOption((int)socket.DangerousGetHandle(), multicastOption, option);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern unsafe Error SetIPv6MulticastOption(int socket, MulticastOption multicastOption, IPv6MulticastOption* option);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.ReceiveMessage.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ReceiveMessage.cs
@@ -11,23 +11,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReceiveMessage")]
-        private static extern unsafe Error DangerousReceiveMessage(int socket, MessageHeader* messageHeader, SocketFlags flags, long* received);
-
-        internal static unsafe Error ReceiveMessage(SafeHandle socket, MessageHeader* messageHeader, SocketFlags flags, long* received)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousReceiveMessage((int)socket.DangerousGetHandle(), messageHeader, flags, received);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern unsafe Error ReceiveMessage(int socket, MessageHeader* messageHeader, SocketFlags flags, long* received);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SendMessage.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SendMessage.cs
@@ -11,23 +11,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SendMessage")]
-        private static extern unsafe Error DangerousSendMessage(int socket, MessageHeader* messageHeader, SocketFlags flags, long* sent);
-
-        internal static unsafe Error SendMessage(SafeHandle socket, MessageHeader* messageHeader, SocketFlags flags, long* sent)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousSendMessage((int)socket.DangerousGetHandle(), messageHeader, flags, sent);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern unsafe Error SendMessage(int socket, MessageHeader* messageHeader, SocketFlags flags, long* sent);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SetReceiveTimeout.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SetReceiveTimeout.cs
@@ -10,23 +10,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetReceiveTimeout")]
-        private static extern unsafe Error DangerousSetReceiveTimeout(int socket, int millisecondsTimeout);
-
-        internal static unsafe Error SetReceiveTimeout(SafeHandle socket, int millisecondsTimeout)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousSetReceiveTimeout((int)socket.DangerousGetHandle(), millisecondsTimeout);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern unsafe Error SetReceiveTimeout(int socket, int millisecondsTimeout);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SetSendTimeout.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SetSendTimeout.cs
@@ -10,23 +10,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetSendTimeout")]
-        private static extern unsafe Error DangerousSetSendTimeout(int socket, int millisecondsTimeout);
-
-        internal static unsafe Error SetSendTimeout(SafeHandle socket, int millisecondsTimeout)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousSetSendTimeout((int)socket.DangerousGetHandle(), millisecondsTimeout);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern unsafe Error SetSendTimeout(int socket, int millisecondsTimeout);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SetSockOpt.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SetSockOpt.cs
@@ -11,23 +11,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetSockOpt")]
-        internal static extern unsafe Error DangerousSetSockOpt(int socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int optionLen);
-
-        internal static unsafe Error SetSockOpt(SafeHandle socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int optionLen)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousSetSockOpt((int)socket.DangerousGetHandle(), optionLevel, optionName, optionValue, optionLen);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern unsafe Error SetSockOpt(int socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int optionLen);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Shutdown.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Shutdown.cs
@@ -11,23 +11,6 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Shutdown")]
-        private static extern Error DangerousShutdown(int socket, SocketShutdown how);
-
-        internal static Error Shutdown(SafeHandle socket, SocketShutdown how)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousShutdown((int)socket.DangerousGetHandle(), how);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern Error Shutdown(int socket, SocketShutdown how);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SocketEvent.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SocketEvent.cs
@@ -41,24 +41,7 @@ internal static partial class Interop
         internal static extern unsafe Error FreeSocketEventBuffer(SocketEvent* buffer);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_TryChangeSocketEventRegistration")]
-        internal static extern Error DangerousTryChangeSocketEventRegistration(int port, int socket, SocketEvents currentEvents, SocketEvents newEvents, IntPtr data);
-
-        internal static Error TryChangeSocketEventRegistration(int port, SafeHandle socket, SocketEvents currentEvents, SocketEvents newEvents, IntPtr data)
-        {
-            bool release = false;
-            try
-            {
-                socket.DangerousAddRef(ref release);
-                return DangerousTryChangeSocketEventRegistration(port, (int)socket.DangerousGetHandle(), currentEvents, newEvents, data);
-            }
-            finally
-            {
-                if (release)
-                {
-                    socket.DangerousRelease();
-                }
-            }
-        }
+        internal static extern Error TryChangeSocketEventRegistration(int port, int socket, SocketEvents currentEvents, SocketEvents newEvents, IntPtr data);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_WaitForSocketEvents")]
         internal static extern unsafe Error WaitForSocketEvents(int port, SocketEvent* buffer, int* count);

--- a/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
@@ -20,21 +20,24 @@ namespace System.Net.Sockets
         private int _receiveTimeout = -1;
         private int _sendTimeout = -1;
         private bool _nonBlocking;
-        private SocketAsyncContext _asyncContext;
 
         public SocketAsyncContext AsyncContext
         {
             get
             {
-                if (Volatile.Read(ref _asyncContext) == null)
-                {
-                    Interlocked.CompareExchange(ref _asyncContext, new SocketAsyncContext(this, SocketAsyncEngine.Instance), null);
-                }
-
-                return _asyncContext;
+                return _innerSocket == null ?
+                    SocketAsyncContext.ClosedAsyncContext :
+                    _innerSocket.AsyncContext;
             }
         }
 
+        public int FileDescriptor
+        {
+            get
+            {
+                return (int)handle;
+            }
+        }
 
         public bool IsNonBlocking
         {
@@ -54,7 +57,7 @@ namespace System.Net.Sockets
                 //
                 if (value)
                 {
-                    AsyncContext.SetNonBlocking();
+                    _innerSocket.SetNonBlocking();
                 }
             }
         }
@@ -106,17 +109,38 @@ namespace System.Net.Sockets
 
         private void InnerReleaseHandle()
         {
-            if (_asyncContext != null)
-            {
-                _asyncContext.Close();
-            }
+            // No-op for Unix.
         }
 
         internal sealed partial class InnerSafeCloseSocket : SafeHandleMinusOneIsInvalid
         {
+            private SocketAsyncContext _asyncContext;
+
+            public void SetNonBlocking()
+            {
+                AsyncContext.SetNonBlocking();
+            }
+
+            public SocketAsyncContext AsyncContext
+            {
+                get
+                {
+                    if (Volatile.Read(ref _asyncContext) == null)
+                    {
+                        Interlocked.CompareExchange(ref _asyncContext, new SocketAsyncContext((int)handle, SocketAsyncEngine.Instance), null);
+                    }
+                    return _asyncContext;
+                }
+            }
+
             private unsafe SocketError InnerReleaseHandle()
             {
                 int errorCode;
+
+                if (_asyncContext != null)
+                {
+                    _asyncContext.Close();
+                }
 
                 // If _blockable was set in BlockingRelease, it's safe to block here, which means
                 // we can honor the linger options set on the socket.  It also means closesocket() might return WSAEWOULDBLOCK, in which
@@ -146,12 +170,16 @@ namespace System.Net.Sockets
                     // If it's not EWOULDBLOCK, there's no more recourse - we either succeeded or failed.
                     if (errorCode != (int)Interop.Error.EWOULDBLOCK)
                     {
+                        if (errorCode == 0 && _asyncContext != null)
+                        {
+                            _asyncContext.Close();
+                        }
                         return SocketPal.GetSocketErrorForErrorCode((Interop.Error)errorCode);
                     }
 
                     // The socket must be non-blocking with a linger timeout set.
                     // We have to set the socket to blocking.
-                    errorCode = Interop.Sys.Fcntl.DangerousSetIsNonBlocking(handle, 0);
+                    errorCode = Interop.Sys.Fcntl.SetIsNonBlocking(handle, 0);
                     if (errorCode == 0)
                     {
                         // The socket successfully made blocking; retry the close().
@@ -165,6 +193,10 @@ namespace System.Net.Sockets
                         _closeSocketHandle = handle;
                         _closeSocketResult = SocketPal.GetSocketErrorForErrorCode((Interop.Error)errorCode);
 #endif
+                        if (errorCode == 0 && _asyncContext != null)
+                        {
+                            _asyncContext.Close();
+                        }
                         return SocketPal.GetSocketErrorForErrorCode((Interop.Error)errorCode);
                     }
 
@@ -177,7 +209,7 @@ namespace System.Net.Sockets
                     Seconds = 0
                 };
 
-                errorCode = (int)Interop.Sys.DangerousSetLingerOption((int)handle, &linger);
+                errorCode = (int)Interop.Sys.SetLingerOption((int)handle, &linger);
 #if DEBUG
                 _closeSocketLinger = SocketPal.GetSocketErrorForErrorCode((Interop.Error)errorCode);
 #endif
@@ -226,7 +258,7 @@ namespace System.Net.Sockets
                     if (addressFamily == AddressFamily.InterNetworkV6)
                     {
                         int on = 1;
-                        error = Interop.Sys.DangerousSetSockOpt(fd, SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, (byte*)&on, sizeof(int));
+                        error = Interop.Sys.SetSockOpt(fd, SocketOptionLevel.IPv6, SocketOptionName.IPv6Only, (byte*)&on, sizeof(int));
                         if (error != Interop.Error.SUCCESS)
                         {
                             Interop.Sys.Close((IntPtr)fd);
@@ -256,7 +288,7 @@ namespace System.Net.Sockets
                 }
                 else
                 {
-                    SocketPal.TryCompleteAccept(socketHandle, socketAddress, ref socketAddressLen, out acceptedFd, out errorCode);
+                    SocketPal.TryCompleteAccept(socketHandle.FileDescriptor, socketAddress, ref socketAddressLen, out acceptedFd, out errorCode);
                 }
 
                 var res = new InnerSafeCloseSocket();

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Unix.cs
@@ -35,7 +35,7 @@ namespace System.Net.Sockets
                     throw new ArgumentException(SR.Format(SR.net_sockets_select, socketList[i].GetType().FullName, typeof(System.Net.Sockets.Socket).FullName), "socketList");
                 }
 
-                int fd = (int)socket._handle.DangerousGetHandle();
+                int fd = socket._handle.FileDescriptor;
                 Interop.Sys.FD_SET(fd, fdset);
 
                 if (fd > maxFd)
@@ -61,7 +61,7 @@ namespace System.Net.Sockets
                 for (int i = socketList.Count - 1; i >= 0; i--)
                 {
                     var socket = (Socket)socketList[i];
-                    if (!Interop.Sys.FD_ISSET((int)socket._handle.DangerousGetHandle(), fdset))
+                    if (!Interop.Sys.FD_ISSET(socket._handle.FileDescriptor, fdset))
                     {
                         socketList.RemoveAt(i);
                     }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -107,9 +107,9 @@ namespace System.Net.Sockets
                 return TryCompleteOrAbortAsync(context, abort: false);
             }
 
-            public void AbortAsync()
+            public void AbortAsync(SocketAsyncContext context)
             {
-                bool completed = TryCompleteOrAbortAsync(null, abort: true);
+                bool completed = TryCompleteOrAbortAsync(context, abort: true);
                 Debug.Assert(completed);
             }
 
@@ -227,7 +227,7 @@ namespace System.Net.Sockets
         {
             protected override bool DoTryComplete(SocketAsyncContext context)
             {
-                return SocketPal.TryCompleteSendTo(context._socket, Buffer, Buffers, ref BufferIndex, ref Offset, ref Count, Flags, SocketAddress, SocketAddressLen, ref BytesTransferred, out ErrorCode);
+                return SocketPal.TryCompleteSendTo(context._fileDescriptor, Buffer, Buffers, ref BufferIndex, ref Offset, ref Count, Flags, SocketAddress, SocketAddressLen, ref BytesTransferred, out ErrorCode);
             }
         }
 
@@ -235,7 +235,7 @@ namespace System.Net.Sockets
         {
             protected override bool DoTryComplete(SocketAsyncContext context)
             {
-                return SocketPal.TryCompleteReceiveFrom(context._socket, Buffer, Buffers, Offset, Count, Flags, SocketAddress, ref SocketAddressLen, out BytesTransferred, out ReceivedFlags, out ErrorCode);
+                return SocketPal.TryCompleteReceiveFrom(context._fileDescriptor, Buffer, Buffers, Offset, Count, Flags, SocketAddress, ref SocketAddressLen, out BytesTransferred, out ReceivedFlags, out ErrorCode);
             }
         }
 
@@ -253,7 +253,7 @@ namespace System.Net.Sockets
 
             protected override bool DoTryComplete(SocketAsyncContext context)
             {
-                return SocketPal.TryCompleteReceiveMessageFrom(context._socket, Buffer, Offset, Count, Flags, SocketAddress, ref SocketAddressLen, IsIPv4, IsIPv6, out BytesTransferred, out ReceivedFlags, out IPPacketInformation, out ErrorCode);
+                return SocketPal.TryCompleteReceiveMessageFrom(context._fileDescriptor, Buffer, Offset, Count, Flags, SocketAddress, ref SocketAddressLen, IsIPv4, IsIPv6, out BytesTransferred, out ReceivedFlags, out IPPacketInformation, out ErrorCode);
             }
 
             protected override void InvokeCallback()
@@ -283,7 +283,7 @@ namespace System.Net.Sockets
 
             protected override bool DoTryComplete(SocketAsyncContext context)
             {
-                bool completed = SocketPal.TryCompleteAccept(context._socket, SocketAddress, ref SocketAddressLen, out AcceptedFileDescriptor, out ErrorCode);
+                bool completed = SocketPal.TryCompleteAccept(context._fileDescriptor, SocketAddress, ref SocketAddressLen, out AcceptedFileDescriptor, out ErrorCode);
                 Debug.Assert(ErrorCode == SocketError.Success || AcceptedFileDescriptor == -1);
                 return completed;
             }
@@ -306,7 +306,7 @@ namespace System.Net.Sockets
 
             protected override bool DoTryComplete(SocketAsyncContext context)
             {
-                bool result = SocketPal.TryCompleteConnect(context._socket, SocketAddressLen, out ErrorCode);
+                bool result = SocketPal.TryCompleteConnect(context._fileDescriptor, SocketAddressLen, out ErrorCode);
                 context.RegisterConnectResult(ErrorCode);
                 return result;
             }
@@ -389,7 +389,24 @@ namespace System.Net.Sockets
             }
         }
 
-        private SafeCloseSocket _socket;
+        private static SocketAsyncContext s_closedAsyncContext;
+        public static SocketAsyncContext ClosedAsyncContext
+        {
+            get
+            {
+                if (Volatile.Read(ref s_closedAsyncContext) == null)
+                {
+                    var ctx = new SocketAsyncContext(-1, null);
+                    ctx.Close();
+
+                    Volatile.Write(ref s_closedAsyncContext, ctx);
+                }
+
+                return s_closedAsyncContext;
+            }
+        }
+
+        private int _fileDescriptor;
         private GCHandle _handle;
         private OperationQueue<TransferOperation> _receiveQueue;
         private OperationQueue<SendOperation> _sendQueue;
@@ -404,9 +421,9 @@ namespace System.Net.Sockets
         private object _closeLock = new object();
         private object _queueLock = new object();
 
-        public SocketAsyncContext(SafeCloseSocket socket, SocketAsyncEngine engine)
+        public SocketAsyncContext(int fileDescriptor, SocketAsyncEngine engine)
         {
-            _socket = socket;
+            _fileDescriptor = fileDescriptor;
             _engine = engine;
         }
 
@@ -425,7 +442,7 @@ namespace System.Net.Sockets
             events |= _registeredEvents;
 
             Interop.Error errorCode;
-            if (!_engine.TryRegister(_socket, _registeredEvents, events, _handle, out errorCode))
+            if (!_engine.TryRegister(_fileDescriptor, _registeredEvents, events, _handle, out errorCode))
             {
                 if (_registeredEvents == Interop.Sys.SocketEvents.None)
                 {
@@ -452,7 +469,7 @@ namespace System.Net.Sockets
             else
             {
                 Interop.Error errorCode;
-                bool unregistered = _engine.TryRegister(_socket, _registeredEvents, events, _handle, out errorCode);
+                bool unregistered = _engine.TryRegister(_fileDescriptor, _registeredEvents, events, _handle, out errorCode);
                 if (unregistered)
                 {
                     _registeredEvents = events;
@@ -475,7 +492,7 @@ namespace System.Net.Sockets
             }
 
             Interop.Error errorCode;
-            bool unregistered = _engine.TryRegister(_socket, _registeredEvents, Interop.Sys.SocketEvents.None, _handle, out errorCode);
+            bool unregistered = _engine.TryRegister(_fileDescriptor, _registeredEvents, Interop.Sys.SocketEvents.None, _handle, out errorCode);
             _registeredEvents = (Interop.Sys.SocketEvents)(-1);
             if (unregistered)
             {
@@ -517,7 +534,7 @@ namespace System.Net.Sockets
             while (!acceptOrConnectQueue.IsEmpty)
             {
                 AcceptOrConnectOperation op = acceptOrConnectQueue.Head;
-                op.AbortAsync();
+                op.AbortAsync(this);
                 acceptOrConnectQueue.Dequeue();
             }
 
@@ -525,7 +542,7 @@ namespace System.Net.Sockets
             while (!sendQueue.IsEmpty)
             {
                 SendReceiveOperation op = sendQueue.Head;
-                op.AbortAsync();
+                op.AbortAsync(this);
                 sendQueue.Dequeue();
             }
 
@@ -533,7 +550,7 @@ namespace System.Net.Sockets
             while (!receiveQueue.IsEmpty)
             {
                 TransferOperation op = receiveQueue.Head;
-                op.AbortAsync();
+                op.AbortAsync(this);
                 receiveQueue.Dequeue();
             }
         }
@@ -561,7 +578,7 @@ namespace System.Net.Sockets
             //
             if (!_nonBlockingSet)
             {
-                if (Interop.Sys.Fcntl.SetIsNonBlocking(_socket, 1) != 0)
+                if (Interop.Sys.Fcntl.SetIsNonBlocking((IntPtr)_fileDescriptor, 1) != 0)
                 {
                     throw new SocketException((int)SocketPal.GetSocketErrorForErrorCode(Interop.Sys.GetLastError()));
                 }
@@ -635,7 +652,7 @@ namespace System.Net.Sockets
             Debug.Assert(timeout == -1 || timeout > 0);
 
             SocketError errorCode;
-            if (SocketPal.TryCompleteAccept(_socket, socketAddress, ref socketAddressLen, out acceptedFd, out errorCode))
+            if (SocketPal.TryCompleteAccept(_fileDescriptor, socketAddress, ref socketAddressLen, out acceptedFd, out errorCode))
             {
                 Debug.Assert(errorCode == SocketError.Success || acceptedFd == -1);
                 return errorCode;
@@ -688,7 +705,7 @@ namespace System.Net.Sockets
 
             int acceptedFd;
             SocketError errorCode;
-            if (SocketPal.TryCompleteAccept(_socket, socketAddress, ref socketAddressLen, out acceptedFd, out errorCode))
+            if (SocketPal.TryCompleteAccept(_fileDescriptor, socketAddress, ref socketAddressLen, out acceptedFd, out errorCode))
             {
                 Debug.Assert(errorCode == SocketError.Success || acceptedFd == -1);
 
@@ -735,7 +752,7 @@ namespace System.Net.Sockets
             CheckForPriorConnectFailure();
 
             SocketError errorCode;
-            if (SocketPal.TryStartConnect(_socket, socketAddress, socketAddressLen, out errorCode))
+            if (SocketPal.TryStartConnect(_fileDescriptor, socketAddress, socketAddressLen, out errorCode))
             {
                 RegisterConnectResult(errorCode);
                 return errorCode;
@@ -778,7 +795,7 @@ namespace System.Net.Sockets
             SetNonBlocking();
 
             SocketError errorCode;
-            if (SocketPal.TryStartConnect(_socket, socketAddress, socketAddressLen, out errorCode))
+            if (SocketPal.TryStartConnect(_fileDescriptor, socketAddress, socketAddressLen, out errorCode))
             {
                 RegisterConnectResult(errorCode);
 
@@ -830,7 +847,7 @@ namespace System.Net.Sockets
 
             SocketFlags receivedFlags;
             SocketError errorCode;
-            if (SocketPal.TryCompleteReceiveFrom(_socket, buffer, offset, count, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode))
+            if (SocketPal.TryCompleteReceiveFrom(_fileDescriptor, buffer, offset, count, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode))
             {
                 flags = receivedFlags;
                 return errorCode;
@@ -884,7 +901,7 @@ namespace System.Net.Sockets
             int bytesReceived;
             SocketFlags receivedFlags;
             SocketError errorCode;
-            if (SocketPal.TryCompleteReceiveFrom(_socket, buffer, offset, count, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode))
+            if (SocketPal.TryCompleteReceiveFrom(_fileDescriptor, buffer, offset, count, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode))
             {
                 if (errorCode == SocketError.Success)
                 {
@@ -942,7 +959,7 @@ namespace System.Net.Sockets
 
             SocketFlags receivedFlags;
             SocketError errorCode;
-            if (SocketPal.TryCompleteReceiveFrom(_socket, buffers, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode))
+            if (SocketPal.TryCompleteReceiveFrom(_fileDescriptor, buffers, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode))
             {
                 flags = receivedFlags;
                 return errorCode;
@@ -994,7 +1011,7 @@ namespace System.Net.Sockets
             int bytesReceived;
             SocketFlags receivedFlags;
             SocketError errorCode;
-            if (SocketPal.TryCompleteReceiveFrom(_socket, buffers, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode))
+            if (SocketPal.TryCompleteReceiveFrom(_fileDescriptor, buffers, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode))
             {
                 if (errorCode == SocketError.Success)
                 {
@@ -1040,7 +1057,7 @@ namespace System.Net.Sockets
 
             SocketFlags receivedFlags;
             SocketError errorCode;
-            if (SocketPal.TryCompleteReceiveMessageFrom(_socket, buffer, offset, count, flags, socketAddress, ref socketAddressLen, isIPv4, isIPv6, out bytesReceived, out receivedFlags, out ipPacketInformation, out errorCode))
+            if (SocketPal.TryCompleteReceiveMessageFrom(_fileDescriptor, buffer, offset, count, flags, socketAddress, ref socketAddressLen, isIPv4, isIPv6, out bytesReceived, out receivedFlags, out ipPacketInformation, out errorCode))
             {
                 flags = receivedFlags;
                 return errorCode;
@@ -1102,7 +1119,7 @@ namespace System.Net.Sockets
             SocketFlags receivedFlags;
             IPPacketInformation ipPacketInformation;
             SocketError errorCode;
-            if (SocketPal.TryCompleteReceiveMessageFrom(_socket, buffer, offset, count, flags, socketAddress, ref socketAddressLen, isIPv4, isIPv6, out bytesReceived, out receivedFlags, out ipPacketInformation, out errorCode))
+            if (SocketPal.TryCompleteReceiveMessageFrom(_fileDescriptor, buffer, offset, count, flags, socketAddress, ref socketAddressLen, isIPv4, isIPv6, out bytesReceived, out receivedFlags, out ipPacketInformation, out errorCode))
             {
                 if (errorCode == SocketError.Success)
                 {
@@ -1163,7 +1180,7 @@ namespace System.Net.Sockets
 
             bytesSent = 0;
             SocketError errorCode;
-            if (SocketPal.TryCompleteSendTo(_socket, buffer, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode))
+            if (SocketPal.TryCompleteSendTo(_fileDescriptor, buffer, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode))
             {
                 return errorCode;
             }
@@ -1209,7 +1226,7 @@ namespace System.Net.Sockets
 
             int bytesSent = 0;
             SocketError errorCode;
-            if (SocketPal.TryCompleteSendTo(_socket, buffer, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode))
+            if (SocketPal.TryCompleteSendTo(_fileDescriptor, buffer, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode))
             {
                 if (errorCode == SocketError.Success)
                 {
@@ -1268,7 +1285,7 @@ namespace System.Net.Sockets
             int bufferIndex = 0;
             int offset = 0;
             SocketError errorCode;
-            if (SocketPal.TryCompleteSendTo(_socket, buffers, ref bufferIndex, ref offset, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode))
+            if (SocketPal.TryCompleteSendTo(_fileDescriptor, buffers, ref bufferIndex, ref offset, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode))
             {
                 return errorCode;
             }
@@ -1316,7 +1333,7 @@ namespace System.Net.Sockets
             int offset = 0;
             int bytesSent = 0;
             SocketError errorCode;
-            if (SocketPal.TryCompleteSendTo(_socket, buffers, ref bufferIndex, ref offset, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode))
+            if (SocketPal.TryCompleteSendTo(_fileDescriptor, buffers, ref bufferIndex, ref offset, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode))
             {
                 if (errorCode == SocketError.Success)
                 {
@@ -1383,6 +1400,13 @@ namespace System.Net.Sockets
                     // Set the Read and Write flags as well; the processing for these events
                     // will pick up the error.
                     events |= Interop.Sys.SocketEvents.Read | Interop.Sys.SocketEvents.Write;
+                }
+
+                if ((events & Interop.Sys.SocketEvents.Close) != 0)
+                {
+                    // Drain queues and unregister this fd, then return.
+                    CloseInner();
+                    return;
                 }
 
                 if ((events & Interop.Sys.SocketEvents.ReadClose) != 0)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -104,7 +104,7 @@ namespace System.Net.Sockets
             }
         }
 
-        public bool TryRegister(SafeCloseSocket socket, Interop.Sys.SocketEvents current, Interop.Sys.SocketEvents events, GCHandle handle, out Interop.Error error)
+        public bool TryRegister(int fileDescriptor, Interop.Sys.SocketEvents current, Interop.Sys.SocketEvents events, GCHandle handle, out Interop.Error error)
         {
             if (current == events)
             {
@@ -112,13 +112,7 @@ namespace System.Net.Sockets
                 return true;
             }
 
-            //
-            // @TODO: work out a better way to handle this.  For now, just do the "dangerous" thing; this is called
-            // from SafeCloseSocket.ReleaseHandle, so it can't access the file descriptor in the normal way.
-            // 
-            int fd = (int)socket.DangerousGetHandle();
-
-            error = Interop.Sys.DangerousTryChangeSocketEventRegistration(_port, fd, current, events, (IntPtr)handle);
+            error = Interop.Sys.TryChangeSocketEventRegistration(_port, fileDescriptor, current, events, (IntPtr)handle);
             return error == Interop.Error.SUCCESS;
         }
     }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -157,7 +157,7 @@ namespace System.Net.Sockets
             return SafeCloseSocket.CreateSocket(addressFamily, socketType, protocolType, out socket);
         }
 
-        private static unsafe int Receive(SafeCloseSocket socket, SocketFlags flags, int available, byte[] buffer, int offset, int count, byte[] socketAddress, ref int socketAddressLen, out SocketFlags receivedFlags, out Interop.Error errno)
+        private static unsafe int Receive(int fd, SocketFlags flags, int available, byte[] buffer, int offset, int count, byte[] socketAddress, ref int socketAddressLen, out SocketFlags receivedFlags, out Interop.Error errno)
         {
             Debug.Assert(socketAddress != null || socketAddressLen == 0);
 
@@ -184,7 +184,7 @@ namespace System.Net.Sockets
                     IOVectorCount = 1
                 };
 
-                errno = Interop.Sys.ReceiveMessage(socket, &messageHeader, flags, &received);
+                errno = Interop.Sys.ReceiveMessage(fd, &messageHeader, flags, &received);
                 receivedFlags = messageHeader.Flags;
                 sockAddrLen = messageHeader.SocketAddressLen;
             }
@@ -198,7 +198,7 @@ namespace System.Net.Sockets
             return checked((int)received);
         }
 
-        private static unsafe int Send(SafeCloseSocket socket, SocketFlags flags, byte[] buffer, ref int offset, ref int count, byte[] socketAddress, int socketAddressLen, out Interop.Error errno)
+        private static unsafe int Send(int fd, SocketFlags flags, byte[] buffer, ref int offset, ref int count, byte[] socketAddress, int socketAddressLen, out Interop.Error errno)
         {
             int sent;
 
@@ -224,7 +224,7 @@ namespace System.Net.Sockets
                 };
 
                 long bytesSent;
-                errno = Interop.Sys.SendMessage(socket, &messageHeader, flags, &bytesSent);
+                errno = Interop.Sys.SendMessage(fd, &messageHeader, flags, &bytesSent);
 
                 sent = checked((int)bytesSent);
             }
@@ -240,7 +240,7 @@ namespace System.Net.Sockets
             return sent;
         }
 
-        private static unsafe int Send(SafeCloseSocket socket, SocketFlags flags, IList<ArraySegment<byte>> buffers, ref int bufferIndex, ref int offset, byte[] socketAddress, int socketAddressLen, out Interop.Error errno)
+        private static unsafe int Send(int fd, SocketFlags flags, IList<ArraySegment<byte>> buffers, ref int bufferIndex, ref int offset, byte[] socketAddress, int socketAddressLen, out Interop.Error errno)
         {
             // Pin buffers and set up iovecs.
             int startIndex = bufferIndex, startOffset = offset;
@@ -283,7 +283,7 @@ namespace System.Net.Sockets
                     };
 
                     long bytesSent;
-                    errno = Interop.Sys.SendMessage(socket, &messageHeader, flags, &bytesSent);
+                    errno = Interop.Sys.SendMessage(fd, &messageHeader, flags, &bytesSent);
 
                     sent = checked((int)bytesSent);
                 }
@@ -324,7 +324,7 @@ namespace System.Net.Sockets
             return sent;
         }
 
-        private static unsafe int Receive(SafeCloseSocket socket, SocketFlags flags, int available, IList<ArraySegment<byte>> buffers, byte[] socketAddress, ref int socketAddressLen, out SocketFlags receivedFlags, out Interop.Error errno)
+        private static unsafe int Receive(int fd, SocketFlags flags, int available, IList<ArraySegment<byte>> buffers, byte[] socketAddress, ref int socketAddressLen, out SocketFlags receivedFlags, out Interop.Error errno)
         {
             // Pin buffers and set up iovecs.
             int maxBuffers = buffers.Count;
@@ -371,7 +371,7 @@ namespace System.Net.Sockets
                         IOVectorCount = iovCount
                     };
 
-                    errno = Interop.Sys.ReceiveMessage(socket, &messageHeader, flags, &received);
+                    errno = Interop.Sys.ReceiveMessage(fd, &messageHeader, flags, &received);
                     receivedFlags = messageHeader.Flags;
                     sockAddrLen = messageHeader.SocketAddressLen;
                 }
@@ -397,7 +397,7 @@ namespace System.Net.Sockets
             return checked((int)received);
         }
 
-        private static unsafe int ReceiveMessageFrom(SafeCloseSocket socket, SocketFlags flags, int available, byte[] buffer, int offset, int count, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, out Interop.Error errno)
+        private static unsafe int ReceiveMessageFrom(int fd, SocketFlags flags, int available, byte[] buffer, int offset, int count, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, out Interop.Error errno)
         {
             Debug.Assert(socketAddress != null);
 
@@ -428,7 +428,7 @@ namespace System.Net.Sockets
                     ControlBufferLen = cmsgBufferLen
                 };
 
-                errno = Interop.Sys.ReceiveMessage(socket, &messageHeader, flags, &received);
+                errno = Interop.Sys.ReceiveMessage(fd, &messageHeader, flags, &received);
                 receivedFlags = messageHeader.Flags;
                 sockAddrLen = messageHeader.SocketAddressLen;
             }
@@ -444,14 +444,14 @@ namespace System.Net.Sockets
             return checked((int)received);
         }
 
-        public static unsafe bool TryCompleteAccept(SafeCloseSocket socket, byte[] socketAddress, ref int socketAddressLen, out int acceptedFd, out SocketError errorCode)
+        public static unsafe bool TryCompleteAccept(int fileDescriptor, byte[] socketAddress, ref int socketAddressLen, out int acceptedFd, out SocketError errorCode)
         {
             int fd;
             Interop.Error errno;
             int sockAddrLen = socketAddressLen;
             fixed (byte* rawSocketAddress = socketAddress)
             {
-                errno = Interop.Sys.Accept(socket, rawSocketAddress, &sockAddrLen, &fd);
+                errno = Interop.Sys.Accept(fileDescriptor, rawSocketAddress, &sockAddrLen, &fd);
             }
 
             if (errno == Interop.Error.SUCCESS)
@@ -476,7 +476,7 @@ namespace System.Net.Sockets
             return false;
         }
 
-        public static unsafe bool TryStartConnect(SafeCloseSocket socket, byte[] socketAddress, int socketAddressLen, out SocketError errorCode)
+        public static unsafe bool TryStartConnect(int fileDescriptor, byte[] socketAddress, int socketAddressLen, out SocketError errorCode)
         {
             Debug.Assert(socketAddress != null);
             Debug.Assert(socketAddressLen > 0);
@@ -484,7 +484,7 @@ namespace System.Net.Sockets
             Interop.Error err;
             fixed (byte* rawSocketAddress = socketAddress)
             {
-                err = Interop.Sys.Connect(socket, rawSocketAddress, socketAddressLen);
+                err = Interop.Sys.Connect(fileDescriptor, rawSocketAddress, socketAddressLen);
             }
 
             if (err == Interop.Error.SUCCESS)
@@ -503,10 +503,10 @@ namespace System.Net.Sockets
             return false;
         }
 
-        public static unsafe bool TryCompleteConnect(SafeCloseSocket socket, int socketAddressLen, out SocketError errorCode)
+        public static unsafe bool TryCompleteConnect(int fileDescriptor, int socketAddressLen, out SocketError errorCode)
         {
             Interop.Error socketError;
-            Interop.Error err = Interop.Sys.GetSocketErrorOption(socket, &socketError);
+            Interop.Error err = Interop.Sys.GetSocketErrorOption(fileDescriptor, &socketError);
             if (err != Interop.Error.SUCCESS)
             {
                 Debug.Assert(err == Interop.Error.EBADF);
@@ -529,20 +529,20 @@ namespace System.Net.Sockets
             return true;
         }
 
-        public static bool TryCompleteReceiveFrom(SafeCloseSocket socket, byte[] buffer, int offset, int count, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, out SocketError errorCode)
+        public static bool TryCompleteReceiveFrom(int fileDescriptor, byte[] buffer, int offset, int count, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, out SocketError errorCode)
         {
-            return TryCompleteReceiveFrom(socket, buffer, null, offset, count, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode);
+            return TryCompleteReceiveFrom(fileDescriptor, buffer, null, offset, count, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode);
         }
 
-        public static bool TryCompleteReceiveFrom(SafeCloseSocket socket, IList<ArraySegment<byte>> buffers, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, out SocketError errorCode)
+        public static bool TryCompleteReceiveFrom(int fileDescriptor, IList<ArraySegment<byte>> buffers, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, out SocketError errorCode)
         {
-            return TryCompleteReceiveFrom(socket, null, buffers, 0, 0, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode);
+            return TryCompleteReceiveFrom(fileDescriptor, null, buffers, 0, 0, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode);
         }
 
-        public static unsafe bool TryCompleteReceiveFrom(SafeCloseSocket socket, byte[] buffer, IList<ArraySegment<byte>> buffers, int offset, int count, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, out SocketError errorCode)
+        public static unsafe bool TryCompleteReceiveFrom(int fileDescriptor, byte[] buffer, IList<ArraySegment<byte>> buffers, int offset, int count, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, out SocketError errorCode)
         {
             int available;
-            Interop.Error errno = Interop.Sys.GetBytesAvailable(socket, &available);
+            Interop.Error errno = Interop.Sys.GetBytesAvailable(fileDescriptor, &available);
             if (errno != Interop.Error.SUCCESS)
             {
                 bytesReceived = 0;
@@ -559,11 +559,11 @@ namespace System.Net.Sockets
             int received;
             if (buffer != null)
             {
-                received = Receive(socket, flags, available, buffer, offset, count, socketAddress, ref socketAddressLen, out receivedFlags, out errno);
+                received = Receive(fileDescriptor, flags, available, buffer, offset, count, socketAddress, ref socketAddressLen, out receivedFlags, out errno);
             }
             else
             {
-                received = Receive(socket, flags, available, buffers, socketAddress, ref socketAddressLen, out receivedFlags, out errno);
+                received = Receive(fileDescriptor, flags, available, buffers, socketAddress, ref socketAddressLen, out receivedFlags, out errno);
             }
 
             if (received != -1)
@@ -585,10 +585,10 @@ namespace System.Net.Sockets
             return false;
         }
 
-        public static unsafe bool TryCompleteReceiveMessageFrom(SafeCloseSocket socket, byte[] buffer, int offset, int count, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out int bytesReceived, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, out SocketError errorCode)
+        public static unsafe bool TryCompleteReceiveMessageFrom(int fileDescriptor, byte[] buffer, int offset, int count, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out int bytesReceived, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, out SocketError errorCode)
         {
             int available;
-            Interop.Error errno = Interop.Sys.GetBytesAvailable(socket, &available);
+            Interop.Error errno = Interop.Sys.GetBytesAvailable(fileDescriptor, &available);
             if (errno != Interop.Error.SUCCESS)
             {
                 bytesReceived = 0;
@@ -603,7 +603,7 @@ namespace System.Net.Sockets
                 available = 1;
             }
 
-            int received = ReceiveMessageFrom(socket, flags, available, buffer, offset, count, socketAddress, ref socketAddressLen, isIPv4, isIPv6, out receivedFlags, out ipPacketInformation, out errno);
+            int received = ReceiveMessageFrom(fileDescriptor, flags, available, buffer, offset, count, socketAddress, ref socketAddressLen, isIPv4, isIPv6, out receivedFlags, out ipPacketInformation, out errno);
 
             if (received != -1)
             {
@@ -624,19 +624,19 @@ namespace System.Net.Sockets
             return false;
         }
 
-        public static bool TryCompleteSendTo(SafeCloseSocket socket, byte[] buffer, ref int offset, ref int count, SocketFlags flags, byte[] socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
+        public static bool TryCompleteSendTo(int fileDescriptor, byte[] buffer, ref int offset, ref int count, SocketFlags flags, byte[] socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
         {
             int bufferIndex = 0;
-            return TryCompleteSendTo(socket, buffer, null, ref bufferIndex, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode);
+            return TryCompleteSendTo(fileDescriptor, buffer, null, ref bufferIndex, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode);
         }
 
-        public static bool TryCompleteSendTo(SafeCloseSocket socket, IList<ArraySegment<byte>> buffers, ref int bufferIndex, ref int offset, SocketFlags flags, byte[] socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
+        public static bool TryCompleteSendTo(int fileDescriptor, IList<ArraySegment<byte>> buffers, ref int bufferIndex, ref int offset, SocketFlags flags, byte[] socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
         {
             int count = 0;
-            return TryCompleteSendTo(socket, null, buffers, ref bufferIndex, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode);
+            return TryCompleteSendTo(fileDescriptor, null, buffers, ref bufferIndex, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode);
         }
 
-        public static bool TryCompleteSendTo(SafeCloseSocket socket, byte[] buffer, IList<ArraySegment<byte>> buffers, ref int bufferIndex, ref int offset, ref int count, SocketFlags flags, byte[] socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
+        public static bool TryCompleteSendTo(int fileDescriptor, byte[] buffer, IList<ArraySegment<byte>> buffers, ref int bufferIndex, ref int offset, ref int count, SocketFlags flags, byte[] socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
         {
             for (;;)
             {
@@ -644,11 +644,11 @@ namespace System.Net.Sockets
                 Interop.Error errno;
                 if (buffer != null)
                 {
-                    sent = Send(socket, flags, buffer, ref offset, ref count, socketAddress, socketAddressLen, out errno);
+                    sent = Send(fileDescriptor, flags, buffer, ref offset, ref count, socketAddress, socketAddressLen, out errno);
                 }
                 else
                 {
-                    sent = Send(socket, flags, buffers, ref bufferIndex, ref offset, socketAddress, socketAddressLen, out errno);
+                    sent = Send(fileDescriptor, flags, buffers, ref bufferIndex, ref offset, socketAddress, socketAddressLen, out errno);
                 }
 
                 if (sent == -1)
@@ -689,7 +689,7 @@ namespace System.Net.Sockets
             int addrLen = nameLen;
             fixed (byte* rawBuffer = buffer)
             {
-                err = Interop.Sys.GetSockName(handle, rawBuffer, &addrLen);
+                err = Interop.Sys.GetSockName(handle.FileDescriptor, rawBuffer, &addrLen);
             }
 
             nameLen = addrLen;
@@ -699,7 +699,7 @@ namespace System.Net.Sockets
         public static unsafe SocketError GetAvailable(SafeCloseSocket handle, out int available)
         {
             int value = 0;
-            Interop.Error err = Interop.Sys.GetBytesAvailable(handle, &value);
+            Interop.Error err = Interop.Sys.GetBytesAvailable(handle.FileDescriptor, &value);
             available = value;
 
             return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
@@ -711,7 +711,7 @@ namespace System.Net.Sockets
             int addrLen = nameLen;
             fixed (byte* rawBuffer = buffer)
             {
-                err = Interop.Sys.GetPeerName(handle, rawBuffer, &addrLen);
+                err = Interop.Sys.GetPeerName(handle.FileDescriptor, rawBuffer, &addrLen);
             }
 
             nameLen = addrLen;
@@ -723,7 +723,7 @@ namespace System.Net.Sockets
             Interop.Error err;
             fixed (byte* rawBuffer = buffer)
             {
-                err = Interop.Sys.Bind(handle, rawBuffer, nameLen);
+                err = Interop.Sys.Bind(handle.FileDescriptor, rawBuffer, nameLen);
             }
 
             return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
@@ -731,7 +731,7 @@ namespace System.Net.Sockets
 
         public static SocketError Listen(SafeCloseSocket handle, int backlog)
         {
-            Interop.Error err = Interop.Sys.Listen(handle, backlog);
+            Interop.Error err = Interop.Sys.Listen(handle.FileDescriptor, backlog);
             return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
         }
 
@@ -750,7 +750,7 @@ namespace System.Net.Sockets
             handle.AsyncContext.CheckForPriorConnectFailure();
 
             SocketError errorCode;
-            bool completed = TryStartConnect(handle, socketAddress, socketAddressLen, out errorCode);
+            bool completed = TryStartConnect(handle.FileDescriptor, socketAddress, socketAddressLen, out errorCode);
             if (completed)
             {
                 handle.AsyncContext.RegisterConnectResult(errorCode);
@@ -779,7 +779,7 @@ namespace System.Net.Sockets
             int bufferIndex = 0;
             int offset = 0;
             SocketError errorCode;
-            bool completed = TryCompleteSendTo(handle, bufferList, ref bufferIndex, ref offset, socketFlags, null, 0, ref bytesTransferred, out errorCode);
+            bool completed = TryCompleteSendTo(handle.FileDescriptor, bufferList, ref bufferIndex, ref offset, socketFlags, null, 0, ref bytesTransferred, out errorCode);
             return completed ? errorCode : SocketError.WouldBlock;
         }
 
@@ -792,7 +792,7 @@ namespace System.Net.Sockets
 
             bytesTransferred = 0;
             SocketError errorCode;
-            bool completed = TryCompleteSendTo(handle, buffer, ref offset, ref count, socketFlags, null, 0, ref bytesTransferred, out errorCode);
+            bool completed = TryCompleteSendTo(handle.FileDescriptor, buffer, ref offset, ref count, socketFlags, null, 0, ref bytesTransferred, out errorCode);
             return completed ? errorCode : SocketError.WouldBlock;
         }
 
@@ -805,7 +805,7 @@ namespace System.Net.Sockets
 
             bytesTransferred = 0;
             SocketError errorCode;
-            bool completed = TryCompleteSendTo(handle, buffer, ref offset, ref count, socketFlags, socketAddress, socketAddressLen, ref bytesTransferred, out errorCode);
+            bool completed = TryCompleteSendTo(handle.FileDescriptor, buffer, ref offset, ref count, socketFlags, socketAddress, socketAddressLen, ref bytesTransferred, out errorCode);
             return completed ? errorCode : SocketError.WouldBlock;
         }
 
@@ -819,7 +819,7 @@ namespace System.Net.Sockets
             else
             {
                 int socketAddressLen = 0;
-                if (!TryCompleteReceiveFrom(handle, buffers, socketFlags, null, ref socketAddressLen, out bytesTransferred, out socketFlags, out errorCode))
+                if (!TryCompleteReceiveFrom(handle.FileDescriptor, buffers, socketFlags, null, ref socketAddressLen, out bytesTransferred, out socketFlags, out errorCode))
                 {
                     errorCode = SocketError.WouldBlock;
                 }
@@ -837,7 +837,7 @@ namespace System.Net.Sockets
 
             int socketAddressLen = 0;
             SocketError errorCode;
-            bool completed = TryCompleteReceiveFrom(handle, buffer, offset, count, socketFlags, null, ref socketAddressLen, out bytesTransferred, out socketFlags, out errorCode);
+            bool completed = TryCompleteReceiveFrom(handle.FileDescriptor, buffer, offset, count, socketFlags, null, ref socketAddressLen, out bytesTransferred, out socketFlags, out errorCode);
             return completed ? errorCode : SocketError.WouldBlock;
         }
 
@@ -856,7 +856,7 @@ namespace System.Net.Sockets
             }
             else
             {
-                if (!TryCompleteReceiveMessageFrom(handle, buffer, offset, count, socketFlags, socketAddressBuffer, ref socketAddressLen, isIPv4, isIPv6, out bytesTransferred, out socketFlags, out ipPacketInformation, out errorCode))
+                if (!TryCompleteReceiveMessageFrom(handle.FileDescriptor, buffer, offset, count, socketFlags, socketAddressBuffer, ref socketAddressLen, isIPv4, isIPv6, out bytesTransferred, out socketFlags, out ipPacketInformation, out errorCode))
                 {
                     errorCode = SocketError.WouldBlock;
                 }
@@ -875,7 +875,7 @@ namespace System.Net.Sockets
             }
 
             SocketError errorCode;
-            bool completed = TryCompleteReceiveFrom(handle, buffer, offset, count, socketFlags, socketAddress, ref socketAddressLen, out bytesTransferred, out socketFlags, out errorCode);
+            bool completed = TryCompleteReceiveFrom(handle.FileDescriptor, buffer, offset, count, socketFlags, socketAddress, ref socketAddressLen, out bytesTransferred, out socketFlags, out errorCode);
             return completed ? errorCode : SocketError.WouldBlock;
         }
 
@@ -900,18 +900,18 @@ namespace System.Net.Sockets
                 if (optionName == SocketOptionName.ReceiveTimeout)
                 {
                     handle.ReceiveTimeout = optionValue == 0 ? -1 : optionValue;
-                    err = Interop.Sys.SetReceiveTimeout(handle, optionValue);
+                    err = Interop.Sys.SetReceiveTimeout(handle.FileDescriptor, optionValue);
                     return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
                 }
                 else if (optionName == SocketOptionName.SendTimeout)
                 {
                     handle.SendTimeout = optionValue == 0 ? -1 : optionValue;
-                    err = Interop.Sys.SetSendTimeout(handle, optionValue);
+                    err = Interop.Sys.SetSendTimeout(handle.FileDescriptor, optionValue);
                     return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
                 }
             }
 
-            err = Interop.Sys.SetSockOpt(handle, optionLevel, optionName, (byte*)&optionValue, sizeof(int));
+            err = Interop.Sys.SetSockOpt(handle.FileDescriptor, optionLevel, optionName, (byte*)&optionValue, sizeof(int));
             return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
         }
 
@@ -920,13 +920,13 @@ namespace System.Net.Sockets
             Interop.Error err;
             if (optionValue == null || optionValue.Length == 0)
             {
-                err = Interop.Sys.SetSockOpt(handle, optionLevel, optionName, null, 0);
+                err = Interop.Sys.SetSockOpt(handle.FileDescriptor, optionLevel, optionName, null, 0);
             }
             else
             {
                 fixed (byte* pinnedValue = optionValue)
                 {
-                    err = Interop.Sys.SetSockOpt(handle, optionLevel, optionName, pinnedValue, optionValue.Length);
+                    err = Interop.Sys.SetSockOpt(handle.FileDescriptor, optionLevel, optionName, pinnedValue, optionValue.Length);
                 }
             }
 
@@ -947,7 +947,7 @@ namespace System.Net.Sockets
                 InterfaceIndex = optionValue.InterfaceIndex
             };
 
-            Interop.Error err = Interop.Sys.SetIPv4MulticastOption(handle, optName, &opt);
+            Interop.Error err = Interop.Sys.SetIPv4MulticastOption(handle.FileDescriptor, optName, &opt);
             return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
         }
 
@@ -964,7 +964,7 @@ namespace System.Net.Sockets
                 InterfaceIndex = (int)optionValue.InterfaceIndex
             };
 
-            Interop.Error err = Interop.Sys.SetIPv6MulticastOption(handle, optName, &opt);
+            Interop.Error err = Interop.Sys.SetIPv6MulticastOption(handle.FileDescriptor, optName, &opt);
             return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
         }
 
@@ -975,7 +975,7 @@ namespace System.Net.Sockets
                 Seconds = optionValue.LingerTime
             };
 
-            Interop.Error err = Interop.Sys.SetLingerOption(handle, &opt);
+            Interop.Error err = Interop.Sys.SetLingerOption(handle.FileDescriptor, &opt);
             return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
         }
 
@@ -1007,7 +1007,7 @@ namespace System.Net.Sockets
 
             int value = 0;
             int optLen = sizeof(int);
-            Interop.Error err = Interop.Sys.GetSockOpt(handle, optionLevel, optionName, (byte*)&value, &optLen);
+            Interop.Error err = Interop.Sys.GetSockOpt(handle.FileDescriptor, optionLevel, optionName, (byte*)&value, &optLen);
 
             optionValue = value;
             return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
@@ -1021,13 +1021,13 @@ namespace System.Net.Sockets
             if (optionValue == null || optionValue.Length == 0)
             {
                 optLen = 0;
-                err = Interop.Sys.GetSockOpt(handle, optionLevel, optionName, null, &optLen);
+                err = Interop.Sys.GetSockOpt(handle.FileDescriptor, optionLevel, optionName, null, &optLen);
             }
             else
             {
                 fixed (byte* pinnedValue = optionValue)
                 {
-                    err = Interop.Sys.GetSockOpt(handle, optionLevel, optionName, pinnedValue, &optLen);
+                    err = Interop.Sys.GetSockOpt(handle.FileDescriptor, optionLevel, optionName, pinnedValue, &optLen);
                 }
             }
 
@@ -1049,7 +1049,7 @@ namespace System.Net.Sockets
                 Interop.Sys.MulticastOption.MULTICAST_DROP;
 
             Interop.Sys.IPv4MulticastOption opt;
-            Interop.Error err = Interop.Sys.GetIPv4MulticastOption(handle, optName, &opt);
+            Interop.Error err = Interop.Sys.GetIPv4MulticastOption(handle.FileDescriptor, optName, &opt);
             if (err != Interop.Error.SUCCESS)
             {
                 optionValue = default(MulticastOption);
@@ -1074,7 +1074,7 @@ namespace System.Net.Sockets
                 Interop.Sys.MulticastOption.MULTICAST_DROP;
 
             Interop.Sys.IPv6MulticastOption opt;
-            Interop.Error err = Interop.Sys.GetIPv6MulticastOption(handle, optName, &opt);
+            Interop.Error err = Interop.Sys.GetIPv6MulticastOption(handle.FileDescriptor, optName, &opt);
             if (err != Interop.Error.SUCCESS)
             {
                 optionValue = default(IPv6MulticastOption);
@@ -1088,7 +1088,7 @@ namespace System.Net.Sockets
         public static unsafe SocketError GetLingerOption(SafeCloseSocket handle, out LingerOption optionValue)
         {
             var opt = new Interop.Sys.LingerOption();
-            Interop.Error err = Interop.Sys.GetLingerOption(handle, &opt);
+            Interop.Error err = Interop.Sys.GetLingerOption(handle.FileDescriptor, &opt);
             if (err != Interop.Error.SUCCESS)
             {
                 optionValue = default(LingerOption);
@@ -1104,52 +1104,39 @@ namespace System.Net.Sockets
             uint* fdSet = stackalloc uint[Interop.Sys.FD_SETSIZE_UINTS];
             Interop.Sys.FD_ZERO(fdSet);
 
-            bool releaseHandle = false;
-            try
+            Interop.Sys.FD_SET(handle.FileDescriptor, fdSet);
+
+            int fdCount = 0;
+            uint* readFds = null;
+            uint* writeFds = null;
+            uint* errorFds = null;
+            switch (mode)
             {
-                handle.DangerousAddRef(ref releaseHandle);
-                int fd = (int)handle.DangerousGetHandle();
-                Interop.Sys.FD_SET(fd, fdSet);
+                case SelectMode.SelectRead:
+                    readFds = fdSet;
+                    fdCount = handle.FileDescriptor + 1;
+                    break;
 
-                int fdCount = 0;
-                uint* readFds = null;
-                uint* writeFds = null;
-                uint* errorFds = null;
-                switch (mode)
-                {
-                    case SelectMode.SelectRead:
-                        readFds = fdSet;
-                        fdCount = fd + 1;
-                        break;
+                case SelectMode.SelectWrite:
+                    writeFds = fdSet;
+                    fdCount = handle.FileDescriptor + 1;
+                    break;
 
-                    case SelectMode.SelectWrite:
-                        writeFds = fdSet;
-                        fdCount = fd + 1;
-                        break;
-
-                    case SelectMode.SelectError:
-                        errorFds = fdSet;
-                        fdCount = fd + 1;
-                        break;
-                }
-
-                int socketCount = 0;
-                Interop.Error err = Interop.Sys.Select(fdCount, readFds, writeFds, errorFds, microseconds, &socketCount);
-                if (err != Interop.Error.SUCCESS)
-                {
-                    status = false;
-                    return GetSocketErrorForErrorCode(err);
-                }
-
-                status = Interop.Sys.FD_ISSET(fd, fdSet);
+                case SelectMode.SelectError:
+                    errorFds = fdSet;
+                    fdCount = handle.FileDescriptor + 1;
+                    break;
             }
-            finally
+
+            int socketCount = 0;
+            Interop.Error err = Interop.Sys.Select(fdCount, readFds, writeFds, errorFds, microseconds, &socketCount);
+            if (err != Interop.Error.SUCCESS)
             {
-                if (releaseHandle)
-                {
-                    handle.DangerousRelease();
-                }
+                status = false;
+                return GetSocketErrorForErrorCode(err);
             }
+
+            status = Interop.Sys.FD_ISSET(handle.FileDescriptor, fdSet);
             return SocketError.Success;
         }
 
@@ -1215,7 +1202,7 @@ namespace System.Net.Sockets
 
         public static SocketError Shutdown(SafeCloseSocket handle, bool isConnected, bool isDisconnected, SocketShutdown how)
         {
-            Interop.Error err = Interop.Sys.Shutdown(handle, how);
+            Interop.Error err = Interop.Sys.Shutdown(handle.FileDescriptor, how);
             if (err == Interop.Error.SUCCESS)
             {
                 return SocketError.Success;


### PR DESCRIPTION
Reverting dotnet/corefx#6126 for now.  We believe this is related to the widespread timeouts we've been seeing today in CI.

cc: @ericeil, @mmitche 