### PR TITLE
Fix two build warnings

### DIFF
--- a/src/System.Data.SqlClient/tests/project.json
+++ b/src/System.Data.SqlClient/tests/project.json
@@ -3,6 +3,7 @@
     "Microsoft.CSharp": "4.0.1-rc3-23818",
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23818",
     "System.Data.Common": "4.0.1-rc3-23818",
+    "System.Text.RegularExpressions": "4.0.10",
     "xunit": "2.1.0",
     "xunit.netcore.extensions": "1.0.0-prerelease-00123"
   },

--- a/src/System.Net.Http/tests/FunctionalTests/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/project.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "Microsoft.NETCore.Platforms": "1.0.1-rc3-23818",
     "System.Diagnostics.DiagnosticSource": "4.0.0-rc3-23818",
+    "System.Diagnostics.Tracing": "4.0.20",
     "System.Globalization": "4.0.10",
     "System.IO": "4.0.10",
     "System.IO.FileSystem": "4.0.0",


### PR DESCRIPTION
Fixes:
```
C:\Program Files (x86)\MSBuild\14.0\bin\Microsoft.Common.CurrentVersion.targets(1819,5): warning MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed. [corefx\src\System.Data.SqlClient\tests\System.Data.SqlClient.Tests.csproj]

C:\Program Files (x86)\MSBuild\14.0\bin\Microsoft.Common.CurrentVersion.targets(1819,5): warning MSB3277: Found conflicts between different versions of the same dependent assembly that could not be resolved.  These reference conflicts are listed in the build log when log verbosity is set to detailed. [corefx\src\System.Net.Http\tests\FunctionalTests\System.Net.Http.Functional.Tests.csproj]
```
cc: @weshaggard, @davidsh, @saurabh500 