### PR TITLE
Use designators to initialize msghdr

### DIFF
--- a/src/Native/System.Native/pal_networkchange.cpp
+++ b/src/Native/System.Native/pal_networkchange.cpp
@@ -10,7 +10,6 @@
 #include "pal_utilities.h"
 
 #include <errno.h>
-#include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <net/if.h>
 #include <sys/socket.h>
@@ -52,7 +51,7 @@ extern "C" NetworkChangeKind SystemNative_ReadSingleEvent(int32_t sock)
     char buffer[4096];
     iovec iov = {buffer, sizeof(buffer)};
     sockaddr_nl sanl;
-    msghdr msg = {reinterpret_cast<void*>(&sanl), sizeof(sockaddr_nl), &iov, 1, NULL, 0, 0};
+    msghdr msg = { .msg_name = reinterpret_cast<void*>(&sanl), .msg_namelen = sizeof(sockaddr_nl), .msg_iov = &iov, .msg_iovlen = 1 };
     ssize_t len;
     while (CheckInterrupted(len = recvmsg(sock, &msg, 0)));
     if (len == -1)


### PR DESCRIPTION
In OSes such as Alpine Linux, which depend on musl-libc, `struct msghdr`
has extra two members `__pad1` and `__pad2`. This change uses C99's
way of initializing the struct.

Also removes `#include <linux/netlink.h>` from `pal_networkchange.cpp`
as it is already present in `pal_networkchange.h`.