### PR TITLE
Use nameof for a couple MemberData tests that were missed

### DIFF
--- a/src/Common/tests/Tests/System/Net/HttpKnownHeaderNamesTests.cs
+++ b/src/Common/tests/Tests/System/Net/HttpKnownHeaderNamesTests.cs
@@ -26,7 +26,7 @@ namespace Tests.System.Net
         }
 
         [Theory]
-        [MemberData("HttpKnownHeaderNamesPublicStringConstants")]
+        [MemberData(nameof(HttpKnownHeaderNamesPublicStringConstants))]
         public void TryGetHeaderName_AllHttpKnownHeaderNamesPublicStringConstants_Found(string constant)
         {
             char[] key = constant.ToCharArray();

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpResponseHeaderReaderTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpResponseHeaderReaderTest.cs
@@ -58,7 +58,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         }
 
         [Theory]
-        [MemberData("HeaderData")]
+        [MemberData(nameof(HeaderData))]
         public void ReadHeader_VariousInputs_MatchesExpectedBehavior(string raw, KeyValuePair<string, string>[] expectedHeaders)
         {
             char[] array = raw.ToCharArray();


### PR DESCRIPTION
#3199 added two new `MemberData` tests and was merged after #6209 was opened. This PR simply switches the two new `MemberData` tests over to using `nameof`.