### PR TITLE
Fix RHEL7.2 CI Runs

### DIFF
--- a/netci.groovy
+++ b/netci.groovy
@@ -24,7 +24,7 @@ def targetNugetRuntimeMap = ['OSX' : 'osx.10.10-x64',
                              'FreeBSD' : 'ubuntu.14.04-x64',
                              'CentOS7.1' : 'centos.7-x64',
                              'OpenSUSE13.2' : 'ubuntu.14.04-x64',
-                             'RHEL7.2': 'rhel.7.2-x64']
+                             'RHEL7.2': 'rhel.7-x64']
 
 def branchList = ['master', 'rc2', 'pr']
 


### PR DESCRIPTION
We were passing the wrong RID as the TestNugetRuntimeId (it didn't match
what we have in our test-runtime.json file). This caused us to not
deploy some assets to the test folders, which caused problems when we
tried to run the tests because the xunit console runner was missing.