### PR TITLE
Change CurlHandler to use IOExceptions for Stream failures

### DIFF
--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
@@ -268,7 +268,7 @@ namespace System.Net.Http
                         OperationCanceledException oce = _completed as OperationCanceledException;
                         return (oce != null && oce.CancellationToken.IsCancellationRequested) ?
                             Task.FromCanceled<int>(oce.CancellationToken) :
-                            Task.FromException<int>(_completed);
+                            Task.FromException<int>(MapToReadWriteIOException(_completed, isRead: true));
                     }
 
                     // Quick check for if no data was actually requested.  We do this after the check
@@ -380,7 +380,7 @@ namespace System.Net.Http
                             }
                             else
                             {
-                                _pendingReadRequest.TrySetException(_completed);
+                                _pendingReadRequest.TrySetException(MapToReadWriteIOException(_completed, isRead: true));
                             }
                         }
 

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.HttpContentAsyncStream.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.HttpContentAsyncStream.cs
@@ -180,7 +180,7 @@ namespace System.Net.Http
                     // If we've been disposed, throw an exception so as to end the CopyToAsync operation.
                     if (_disposed)
                     {
-                        throw CreateHttpRequestException();
+                        throw new ObjectDisposedException(GetType().FullName);
                     }
 
                     if (_buffer == null)
@@ -349,7 +349,7 @@ namespace System.Net.Http
                         Debug.Assert(_waiterIsReader, "We're done writing, so a waiter must be a reader");
                         if (completedCopy.IsFaulted)
                         {
-                            _asyncOp.TrySetException(completedCopy.Exception.InnerException);
+                            _asyncOp.TrySetException(MapToReadWriteIOException(completedCopy.Exception.InnerException, isRead: _waiterIsReader));
                             _copyTask = completedCopy;
                         }
                         else if (completedCopy.IsCanceled)

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.cs
@@ -2,11 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Collections.Generic;
 
 using CURLAUTH = Interop.Http.CURLAUTH;
 using CURLcode = Interop.Http.CURLcode;
@@ -625,9 +626,16 @@ nameof(value),
                 message);
         }
 
-        private static Exception CreateHttpRequestException(Exception inner = null)
+        private static HttpRequestException CreateHttpRequestException(Exception inner = null)
         {
             return new HttpRequestException(SR.net_http_client_execution_error, inner);
+        }
+
+        private static IOException MapToReadWriteIOException(Exception error, bool isRead)
+        {
+            return new IOException(
+                isRead ? SR.net_http_io_read : SR.net_http_io_write,
+                error is HttpRequestException && error.InnerException != null ? error.InnerException : error);
         }
 
         private static bool TryParseStatusLine(HttpResponseMessage response, string responseHeader, EasyRequest state)

--- a/src/System.Net.Http/tests/FunctionalTests/project.json
+++ b/src/System.Net.Http/tests/FunctionalTests/project.json
@@ -7,6 +7,7 @@
     "System.IO": "4.0.10",
     "System.IO.FileSystem": "4.0.0",
     "System.Net.Primitives": "4.0.11-rc3-23818",
+    "System.Net.Sockets": "4.1.0-rc3-23818",
     "System.Runtime.Extensions": "4.0.10",
     "System.Security.Cryptography.Algorithms": "4.0.0-rc3-23818",
     "System.Text.Encoding": "4.0.10",


### PR DESCRIPTION
As with WinHttpHandler, CurlHandler wraps exceptions in HttpRequestException.  But WinHttpHandler switches to using IOException when sending exceptions out via Stream.Read/WriteAsync.  This change does the same for CurlHandler.

This also adds a test for #6231, which was correctly failing on Unix but with the wrong exception type (which is now the correct type with the previous commit).

cc: @davidsh, @joelverhagen, @ericeil, @kapilash 