### PR TITLE
Detect the presence of sysctl header

### DIFF
--- a/src/Native/Common/pal_config.h.in
+++ b/src/Native/Common/pal_config.h.in
@@ -40,6 +40,7 @@
 #cmakedefine01 HAVE_IP_MREQN
 #cmakedefine01 HAVE_TCP_VAR_H
 #cmakedefine01 HAVE_RT_MSGHDR
+#cmakedefine01 HAVE_SYS_SYSCTL_H
 #cmakedefine01 HAVE_LINUX_RTNETLINK_H
 #cmakedefine01 HAVE_GETDOMAINNAME_SIZET
 #cmakedefine01 HAVE_INOTIFY

--- a/src/Native/System.Native/pal_interfaceaddresses.cpp
+++ b/src/Native/System.Native/pal_interfaceaddresses.cpp
@@ -13,7 +13,9 @@
 #include <net/if.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
+#if HAVE_SYS_SYSCTL_H
 #include <sys/sysctl.h>
+#endif
 
 #if defined(AF_PACKET)
 #include <linux/if_packet.h>

--- a/src/Native/System.Native/pal_networkstatistics.cpp
+++ b/src/Native/System.Native/pal_networkstatistics.cpp
@@ -20,7 +20,9 @@
 #include <net/route.h>
 
 #include <sys/types.h>
+#if HAVE_SYS_SYSCTL_H
 #include <sys/sysctl.h>
+#endif
 #include <sys/socketvar.h>
 #include <netinet/ip.h>
 #include <netinet/ip_icmp.h>

--- a/src/Native/configure.cmake
+++ b/src/Native/configure.cmake
@@ -345,6 +345,10 @@ check_cxx_source_compiles(
 )
 
 check_include_files(
+    sys/sysctl.h
+    HAVE_SYS_SYSCTL_H)
+
+check_include_files(
     linux/rtnetlink.h
     HAVE_LINUX_RTNETLINK_H)
 


### PR DESCRIPTION
In OSes such as Alpine Linux, which depend on musl-libc,
`<sys/sysctl.h>` is not present, although the function `sysctl` is
available.