### PR TITLE
Add support for in6_addr::s6_addr

### DIFF
--- a/src/Native/Common/pal_config.h.in
+++ b/src/Native/Common/pal_config.h.in
@@ -15,6 +15,7 @@
 #cmakedefine01 PRIORITY_REQUIRES_INT_WHO
 #cmakedefine01 KEVENT_REQUIRES_INT_PARAMS
 #cmakedefine01 HAVE_IN6_U
+#cmakedefine01 HAVE_U6_ADDR
 #cmakedefine01 HAVE_IOCTL
 #cmakedefine01 HAVE_TIOCGWINSZ
 #cmakedefine01 HAVE_SCHED_GETAFFINITY

--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -166,9 +166,12 @@ static void ConvertByteArrayToIn6Addr(in6_addr& addr, const uint8_t* buffer, int
 #if HAVE_IN6_U
     assert(bufferLength == ARRAY_SIZE(addr.__in6_u.__u6_addr8));
     memcpy(addr.__in6_u.__u6_addr8, buffer, UnsignedCast(bufferLength));
-#else
+#elif HAVE_U6_ADDR
     assert(bufferLength == ARRAY_SIZE(addr.__u6_addr.__u6_addr8));
     memcpy(addr.__u6_addr.__u6_addr8, buffer, UnsignedCast(bufferLength));
+#else
+    assert(bufferLength == ARRAY_SIZE(addr.s6_addr));
+    memcpy(addr.s6_addr, buffer, UnsignedCast(bufferLength));
 #endif
 }
 
@@ -177,9 +180,12 @@ static void ConvertIn6AddrToByteArray(uint8_t* buffer, int32_t bufferLength, con
 #if HAVE_IN6_U
     assert(bufferLength == ARRAY_SIZE(addr.__in6_u.__u6_addr8));
     memcpy(buffer, addr.__in6_u.__u6_addr8, UnsignedCast(bufferLength));
-#else
+#elif HAVE_U6_ADDR
     assert(bufferLength == ARRAY_SIZE(addr.__u6_addr.__u6_addr8));
     memcpy(buffer, addr.__u6_addr.__u6_addr8, UnsignedCast(bufferLength));
+#else
+    assert(bufferLength == ARRAY_SIZE(addr.s6_addr));
+    memcpy(buffer, addr.s6_addr, UnsignedCast(bufferLength));
 #endif
 }
 

--- a/src/Native/configure.cmake
+++ b/src/Native/configure.cmake
@@ -149,6 +149,12 @@ check_struct_has_member(
     "netdb.h"
     HAVE_IN6_U)
 
+check_struct_has_member(
+    "struct in6_addr"
+    __u6_addr
+    "netdb.h"
+    HAVE_U6_ADDR)
+
 check_cxx_source_compiles(
     "
     #include <string.h>


### PR DESCRIPTION
On Alpine Linux, `__in6_u.__u6_addr8` and `__u6_addr.__u6_addr8` are
not present. The suitable candidte candidate is `s6_addr`.

https://fossies.org/dox/musl-1.0.5/in_8h.html#ac7f92897f00d3373bf818709dfb0724a