### PR TITLE
Enable Environment.FailFast stderr output in run-test.sh

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -337,6 +337,7 @@ then
 fi
 
 export CORECLR_SERVER_GC="$serverGC"
+export PAL_OUTPUTDEBUGSTRING="1"
 
 
 create_test_overlay


### PR DESCRIPTION
coreclr will print out the Environment.FailFast message to stderr, but only when the PAL_OUTPUTDEBUGSTRING environment variable is set.  I'm setting it in run-test.sh so that fail fasts in CI and other test runs will show something in the log.

cc: @ericeil, @ellismg 