### PR TITLE
Use cast helper for statfs::f_type

### DIFF
--- a/src/Native/System.Native/pal_mount.cpp
+++ b/src/Native/System.Native/pal_mount.cpp
@@ -134,7 +134,7 @@ SystemNative_GetFormatInfoForMountPoint(const char* name, char* formatNameBuffer
         }
 #else
         assert(formatType != nullptr);
-        *formatType = stats.f_type;
+        *formatType = SignedCast(stats.f_type);
         SafeStringCopy(formatNameBuffer, bufferLength, "");
 #endif
     }


### PR DESCRIPTION
In musl-libc, `statfs::f_type` is defined as `unsigned long`.
This change makes use of `SignedCast` helper to overcome the disparity.

https://fossies.org/dox/musl-1.0.5/arch_2arm_2bits_2statfs_8h_source.html#l00002