### PR TITLE
Fix several dataflow ETW events

### DIFF
--- a/src/System.Threading.Tasks.Dataflow/src/Internal/DataflowEtwProvider.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/DataflowEtwProvider.cs
@@ -107,27 +107,10 @@ namespace System.Threading.Tasks.Dataflow.Internal
             }
         }
 
-        [ThreadStatic]
-        private static object[] t_sharedArray;
-
         [Event(TASKLAUNCHED_EVENTID, Level = EventLevel.Informational)]
         private void TaskLaunchedForMessageHandling(int blockId, TaskLaunchedReason reason, int availableMessages, int taskId)
         {
-            // There is no explicit WriteEvent() overload matching this event's fields:
-            //     WriteEvent(TASKLAUNCHED_EVENTID, blockId, (int)reason, availableMessages, taskId);
-            // Therefore this call would hit the "params" overload, which leads to multiple object 
-            // allocations every time this event is fired.
-
-            if (t_sharedArray == null)
-            {
-                t_sharedArray = new object[4];
-            }
-            t_sharedArray[0] = blockId;
-            t_sharedArray[1] = (int)reason;
-            t_sharedArray[2] = availableMessages;
-            t_sharedArray[3] = taskId;
-
-            WriteEvent(TASKLAUNCHED_EVENTID, t_sharedArray);
+            WriteEvent(TASKLAUNCHED_EVENTID, blockId, reason, availableMessages, taskId);
         }
 
         /// <summary>Describes the reason a task is being launched.</summary>
@@ -183,7 +166,7 @@ namespace System.Threading.Tasks.Dataflow.Internal
         [Event(BLOCKCOMPLETED_EVENTID, Level = EventLevel.Informational)]
         private void DataflowBlockCompleted(int blockId, BlockCompletionReason reason, string exceptionData)
         {
-            WriteEvent(BLOCKCOMPLETED_EVENTID, blockId, (int)reason, exceptionData);
+            WriteEvent(BLOCKCOMPLETED_EVENTID, blockId, reason, exceptionData);
         }
     #endregion
 

--- a/src/System.Threading.Tasks.Dataflow/tests/Dataflow/EtwTests.cs
+++ b/src/System.Threading.Tasks.Dataflow/tests/Dataflow/EtwTests.cs
@@ -57,36 +57,32 @@ namespace System.Threading.Tasks.Dataflow.Tests
                         Assert.Equal(expected: 0, actual: remaining);
                     });
 
-                // Bug: It appears that private reflection problems are causing events with enum arguments
-                //      to fail to fire on .NET Core.  Needs further investigation.  The following
-                //      two tests are disabled as a result.
+                // Check that task launched events fire
+                const int TaskLaunchedId = 2;
+                ce.Reset(1);
+                listener.RunWithCallback(ev => {
+                        Assert.Equal(expected: TaskLaunchedId, actual: ev.EventId);
+                        ce.Signal();
+                    },
+                    () => {
+                        ab.Post(42);
+                        ce.Wait();
+                        Assert.Equal(expected: 0, actual: ce.CurrentCount);
+                    });
 
-                //// Check that task launched events fire
-                //const int TaskLaunchedId = 2;
-                //ce.Reset(1);
-                //listener.RunWithCallback(ev => {
-                //        Assert.Equal(expected: TaskLaunchedId, actual: ev.EventId);
-                //        ce.Signal();
-                //    },
-                //    () => {
-                //        ab.Post(42);
-                //        ce.Wait();
-                //        Assert.Equal(expected: 0, actual: ce.CurrentCount);
-                //    });
-
-                //// Check that completion events fire
-                //const int BlockCompletedId = 3;
-                //ce.Reset(2);
-                //listener.RunWithCallback(ev => {
-                //        Assert.Equal(expected: BlockCompletedId, actual: ev.EventId);
-                //        ce.Signal();
-                //    },
-                //    () => {
-                //        ab.Complete();
-                //        bb.Complete();
-                //        ce.Wait();
-                //        Assert.Equal(expected: 0, actual: ce.CurrentCount);
-                //    });
+                // Check that completion events fire
+                const int BlockCompletedId = 3;
+                ce.Reset(2);
+                listener.RunWithCallback(ev => {
+                        Assert.Equal(expected: BlockCompletedId, actual: ev.EventId);
+                        ce.Signal();
+                    },
+                    () => {
+                        ab.Complete();
+                        bb.Complete();
+                        ce.Wait();
+                        Assert.Equal(expected: 0, actual: ce.CurrentCount);
+                    });
 
             }
         }


### PR DESCRIPTION
Two dataflow ETW events haven't been firing for a while now (#1000).  In addition to that, in #6259 I noticed that we were getting a ton of mismatched type errors.  While there may be some other issue lurking in EventSource that's contributing to #1000, by changing how we fire the event to use the original enum value rather than casting it to int, both of these issues go away.  The events are a bit more expensive now, in that I have them just using the params array version of WriteEvent, but these didn't need to be optimized to that extent, anyway.

cc: @davmason, @ellismg 
Fixes #1000
Fixes #4872