### PR TITLE
Use nameof in System.Collections.Immutable

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/DictionaryEnumerator.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/DictionaryEnumerator.cs
@@ -12,7 +12,7 @@ namespace System.Collections.Immutable
 
         internal DictionaryEnumerator(IEnumerator<KeyValuePair<TKey, TValue>> inner)
         {
-            Requires.NotNull(inner, "inner");
+            Requires.NotNull(inner, nameof(inner));
 
             _inner = inner;
         }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray.cs
@@ -97,7 +97,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static ImmutableArray<T> CreateRange<T>(IEnumerable<T> items)
         {
-            Requires.NotNull(items, "items");
+            Requires.NotNull(items, nameof(items));
 
             // As an optimization, if the provided enumerable is actually a
             // boxed ImmutableArray<T> instance, reuse the underlying array if possible.
@@ -174,9 +174,9 @@ namespace System.Collections.Immutable
         [Pure]
         public static ImmutableArray<T> Create<T>(T[] items, int start, int length)
         {
-            Requires.NotNull(items, "items");
-            Requires.Range(start >= 0 && start <= items.Length, "start");
-            Requires.Range(length >= 0 && start + length <= items.Length, "length");
+            Requires.NotNull(items, nameof(items));
+            Requires.Range(start >= 0 && start <= items.Length, nameof(start));
+            Requires.Range(length >= 0 && start + length <= items.Length, nameof(length));
 
             if (length == 0)
             {
@@ -207,8 +207,8 @@ namespace System.Collections.Immutable
         [Pure]
         public static ImmutableArray<T> Create<T>(ImmutableArray<T> items, int start, int length)
         {
-            Requires.Range(start >= 0 && start <= items.Length, "start");
-            Requires.Range(length >= 0 && start + length <= items.Length, "length");
+            Requires.Range(start >= 0 && start <= items.Length, nameof(start));
+            Requires.Range(length >= 0 && start + length <= items.Length, nameof(length));
 
             if (length == 0)
             {
@@ -238,7 +238,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static ImmutableArray<TResult> CreateRange<TSource, TResult>(ImmutableArray<TSource> items, Func<TSource, TResult> selector)
         {
-            Requires.NotNull(selector, "selector");
+            Requires.NotNull(selector, nameof(selector));
 
             int length = items.Length;
 
@@ -273,9 +273,9 @@ namespace System.Collections.Immutable
         {
             int itemsLength = items.Length;
 
-            Requires.Range(start >= 0 && start <= itemsLength, "start");
-            Requires.Range(length >= 0 && start + length <= itemsLength, "length");
-            Requires.NotNull(selector, "selector");
+            Requires.Range(start >= 0 && start <= itemsLength, nameof(start));
+            Requires.Range(length >= 0 && start + length <= itemsLength, nameof(length));
+            Requires.NotNull(selector, nameof(selector));
 
             if (length == 0)
             {
@@ -305,7 +305,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static ImmutableArray<TResult> CreateRange<TSource, TArg, TResult>(ImmutableArray<TSource> items, Func<TSource, TArg, TResult> selector, TArg arg)
         {
-            Requires.NotNull(selector, "selector");
+            Requires.NotNull(selector, nameof(selector));
 
             int length = items.Length;
 
@@ -341,9 +341,9 @@ namespace System.Collections.Immutable
         {
             int itemsLength = items.Length;
 
-            Requires.Range(start >= 0 && start <= itemsLength, "start");
-            Requires.Range(length >= 0 && start + length <= itemsLength, "length");
-            Requires.NotNull(selector, "selector");
+            Requires.Range(start >= 0 && start <= itemsLength, nameof(start));
+            Requires.Range(length >= 0 && start + length <= itemsLength, nameof(length));
+            Requires.NotNull(selector, nameof(selector));
 
             if (length == 0)
             {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1+Builder.cs
@@ -35,7 +35,7 @@ namespace System.Collections.Immutable
             /// <param name="capacity">The initial capacity of the internal array.</param>
             internal Builder(int capacity)
             {
-                Requires.Range(capacity >= 0, "capacity");
+                Requires.Range(capacity >= 0, nameof(capacity));
                 _elements = new T[capacity];
                 _count = 0;
             }
@@ -98,7 +98,7 @@ namespace System.Collections.Immutable
 
                 set
                 {
-                    Requires.Range(value >= 0, "value");
+                    Requires.Range(value >= 0, nameof(value));
                     if (value < _count)
                     {
                         // truncation mode
@@ -216,7 +216,7 @@ namespace System.Collections.Immutable
             /// <param name="item">The object to insert into the <see cref="IList{T}"/>.</param>
             public void Insert(int index, T item)
             {
-                Requires.Range(index >= 0 && index <= this.Count, "index");
+                Requires.Range(index >= 0 && index <= this.Count, nameof(index));
                 this.EnsureCapacity(this.Count + 1);
 
                 if (index < this.Count)
@@ -244,7 +244,7 @@ namespace System.Collections.Immutable
             /// <param name="items">The items.</param>
             public void AddRange(IEnumerable<T> items)
             {
-                Requires.NotNull(items, "items");
+                Requires.NotNull(items, nameof(items));
 
                 int count;
                 if (items.TryGetCount(out count))
@@ -264,7 +264,7 @@ namespace System.Collections.Immutable
             /// <param name="items">The items.</param>
             public void AddRange(params T[] items)
             {
-                Requires.NotNull(items, "items");
+                Requires.NotNull(items, nameof(items));
 
                 var offset = this.Count;
                 this.Count += items.Length;
@@ -278,7 +278,7 @@ namespace System.Collections.Immutable
             /// <param name="items">The items.</param>
             public void AddRange<TDerived>(TDerived[] items) where TDerived : T
             {
-                Requires.NotNull(items, "items");
+                Requires.NotNull(items, nameof(items));
 
                 var offset = this.Count;
                 this.Count += items.Length;
@@ -293,8 +293,8 @@ namespace System.Collections.Immutable
             /// <param name="length">The number of elements from the source array to add.</param>
             public void AddRange(T[] items, int length)
             {
-                Requires.NotNull(items, "items");
-                Requires.Range(length >= 0 && length <= items.Length, "length");
+                Requires.NotNull(items, nameof(items));
+                Requires.Range(length >= 0 && length <= items.Length, nameof(length));
 
                 var offset = this.Count;
                 this.Count += length;
@@ -318,7 +318,7 @@ namespace System.Collections.Immutable
             /// <param name="length">The number of elements from the source array to add.</param>
             public void AddRange(ImmutableArray<T> items, int length)
             {
-                Requires.Range(length >= 0, "length");
+                Requires.Range(length >= 0, nameof(length));
 
                 if (items.array != null)
                 {
@@ -344,7 +344,7 @@ namespace System.Collections.Immutable
             /// <param name="items">The items.</param>
             public void AddRange(Builder items)
             {
-                Requires.NotNull(items, "items");
+                Requires.NotNull(items, nameof(items));
                 this.AddRange(items._elements, items.Count);
             }
 
@@ -354,7 +354,7 @@ namespace System.Collections.Immutable
             /// <param name="items">The items.</param>
             public void AddRange<TDerived>(ImmutableArray<TDerived>.Builder items) where TDerived : T
             {
-                Requires.NotNull(items, "items");
+                Requires.NotNull(items, nameof(items));
                 this.AddRange(items._elements, items.Count);
             }
 
@@ -381,7 +381,7 @@ namespace System.Collections.Immutable
             /// <param name="index">The zero-based index of the item to remove.</param>
             public void RemoveAt(int index)
             {
-                Requires.Range(index >= 0 && index < this.Count, "index");
+                Requires.Range(index >= 0 && index < this.Count, nameof(index));
 
                 if (index < this.Count - 1)
                 {
@@ -420,8 +420,8 @@ namespace System.Collections.Immutable
             /// <param name="index">The starting index of the target array.</param>
             public void CopyTo(T[] array, int index)
             {
-                Requires.NotNull(array, "array");
-                Requires.Range(index >= 0 && index + this.Count <= array.Length, "start");
+                Requires.NotNull(array, nameof(array));
+                Requires.Range(index >= 0 && index + this.Count <= array.Length, nameof(index));
                 Array.Copy(_elements, 0, array, index, this.Count);
             }
 
@@ -495,8 +495,8 @@ namespace System.Collections.Immutable
                     return -1;
                 }
 
-                Requires.Range(startIndex >= 0 && startIndex < this.Count, "startIndex");
-                Requires.Range(count >= 0 && startIndex + count <= this.Count, "count");
+                Requires.Range(startIndex >= 0 && startIndex < this.Count, nameof(startIndex));
+                Requires.Range(count >= 0 && startIndex + count <= this.Count, nameof(count));
 
                 equalityComparer = equalityComparer ?? EqualityComparer<T>.Default;
                 if (equalityComparer == EqualityComparer<T>.Default)
@@ -547,7 +547,7 @@ namespace System.Collections.Immutable
                     return -1;
                 }
 
-                Requires.Range(startIndex >= 0 && startIndex < this.Count, "startIndex");
+                Requires.Range(startIndex >= 0 && startIndex < this.Count, nameof(startIndex));
 
                 return this.LastIndexOf(item, startIndex, startIndex + 1, EqualityComparer<T>.Default);
             }
@@ -581,8 +581,8 @@ namespace System.Collections.Immutable
                     return -1;
                 }
 
-                Requires.Range(startIndex >= 0 && startIndex < this.Count, "startIndex");
-                Requires.Range(count >= 0 && startIndex - count + 1 >= 0, "count");
+                Requires.Range(startIndex >= 0 && startIndex < this.Count, nameof(startIndex));
+                Requires.Range(count >= 0 && startIndex - count + 1 >= 0, nameof(count));
 
                 equalityComparer = equalityComparer ?? EqualityComparer<T>.Default;
                 if (equalityComparer == EqualityComparer<T>.Default)
@@ -647,7 +647,7 @@ namespace System.Collections.Immutable
             [Pure]
             public void Sort(Comparison<T> comparison)
             {
-                Requires.NotNull(comparison, "comparison");
+                Requires.NotNull(comparison, nameof(comparison));
 
                 if (Count > 1)
                 {
@@ -677,8 +677,8 @@ namespace System.Collections.Immutable
             {
                 // Don't rely on Array.Sort's argument validation since our internal array may exceed
                 // the bounds of the publicly addressable region.
-                Requires.Range(index >= 0, "index");
-                Requires.Range(count >= 0 && index + count <= this.Count, "count");
+                Requires.Range(index >= 0, nameof(index));
+                Requires.Range(count >= 0 && index + count <= this.Count, nameof(count));
 
                 if (count > 1)
                 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -353,8 +353,8 @@ namespace System.Collections.Immutable
                 return -1;
             }
 
-            Requires.Range(startIndex >= 0 && startIndex < self.Length, "startIndex");
-            Requires.Range(count >= 0 && startIndex + count <= self.Length, "count");
+            Requires.Range(startIndex >= 0 && startIndex < self.Length, nameof(startIndex));
+            Requires.Range(count >= 0 && startIndex + count <= self.Length, nameof(count));
 
             equalityComparer = equalityComparer ?? EqualityComparer<T>.Default;
             if (equalityComparer == EqualityComparer<T>.Default)
@@ -442,8 +442,8 @@ namespace System.Collections.Immutable
                 return -1;
             }
 
-            Requires.Range(startIndex >= 0 && startIndex < self.Length, "startIndex");
-            Requires.Range(count >= 0 && startIndex - count + 1 >= 0, "count");
+            Requires.Range(startIndex >= 0 && startIndex < self.Length, nameof(startIndex));
+            Requires.Range(count >= 0 && startIndex - count + 1 >= 0, nameof(count));
 
             equalityComparer = equalityComparer ?? EqualityComparer<T>.Default;
             if (equalityComparer == EqualityComparer<T>.Default)
@@ -526,7 +526,7 @@ namespace System.Collections.Immutable
         {
             var self = this;
             self.ThrowNullRefIfNotInitialized();
-            Requires.Range(index >= 0 && index <= self.Length, "index");
+            Requires.Range(index >= 0 && index <= self.Length, nameof(index));
 
             if (self.Length == 0)
             {
@@ -551,8 +551,8 @@ namespace System.Collections.Immutable
         {
             var self = this;
             self.ThrowNullRefIfNotInitialized();
-            Requires.Range(index >= 0 && index <= self.Length, "index");
-            Requires.NotNull(items, "items");
+            Requires.Range(index >= 0 && index <= self.Length, nameof(index));
+            Requires.NotNull(items, nameof(items));
 
             if (self.Length == 0)
             {
@@ -589,7 +589,7 @@ namespace System.Collections.Immutable
             var self = this;
             self.ThrowNullRefIfNotInitialized();
             ThrowNullRefIfNotInitialized(items);
-            Requires.Range(index >= 0 && index <= self.Length, "index");
+            Requires.Range(index >= 0 && index <= self.Length, nameof(index));
 
             if (self.IsEmpty)
             {
@@ -666,7 +666,7 @@ namespace System.Collections.Immutable
         public ImmutableArray<T> SetItem(int index, T item)
         {
             var self = this;
-            Requires.Range(index >= 0 && index < self.Length, "index");
+            Requires.Range(index >= 0 && index < self.Length, nameof(index));
 
             T[] tmp = new T[self.Length];
             Array.Copy(self.array, 0, tmp, 0, self.Length);
@@ -765,8 +765,8 @@ namespace System.Collections.Immutable
         public ImmutableArray<T> RemoveRange(int index, int length)
         {
             var self = this;
-            Requires.Range(index >= 0 && index <= self.Length, "index");
-            Requires.Range(length >= 0 && index + length <= self.Length, "length");
+            Requires.Range(index >= 0 && index <= self.Length, nameof(index));
+            Requires.Range(length >= 0 && index + length <= self.Length, nameof(length));
 
             if (length == 0)
             {
@@ -808,7 +808,7 @@ namespace System.Collections.Immutable
         {
             var self = this;
             self.ThrowNullRefIfNotInitialized();
-            Requires.NotNull(items, "items");
+            Requires.NotNull(items, nameof(items));
 
             var indexesToRemove = new SortedSet<int>();
             foreach (var item in items)
@@ -851,7 +851,7 @@ namespace System.Collections.Immutable
         public ImmutableArray<T> RemoveRange(ImmutableArray<T> items, IEqualityComparer<T> equalityComparer)
         {
             var self = this;
-            Requires.NotNull(items.array, "items");
+            Requires.NotNull(items.array, nameof(items));
 
             if (items.IsEmpty)
             {
@@ -884,7 +884,7 @@ namespace System.Collections.Immutable
         {
             var self = this;
             self.ThrowNullRefIfNotInitialized();
-            Requires.NotNull(match, "match");
+            Requires.NotNull(match, nameof(match));
 
             if (self.IsEmpty)
             {
@@ -941,7 +941,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableArray<T> Sort(Comparison<T> comparison)
         {
-            Requires.NotNull(comparison, "comparison");
+            Requires.NotNull(comparison, nameof(comparison));
 
             var self = this;
             return self.Sort(Comparer<T>.Create(comparison));
@@ -969,8 +969,8 @@ namespace System.Collections.Immutable
         {
             var self = this;
             self.ThrowNullRefIfNotInitialized();
-            Requires.Range(index >= 0, "index");
-            Requires.Range(count >= 0 && index + count <= self.Length, "count");
+            Requires.Range(index >= 0, nameof(index));
+            Requires.Range(count >= 0 && index + count <= self.Length, nameof(count));
 
             // 0 and 1 element arrays don't need to be sorted.
             if (count > 1)
@@ -1667,7 +1667,7 @@ namespace System.Collections.Immutable
         {
             var self = this;
             self.ThrowNullRefIfNotInitialized();
-            Requires.NotNull(indexesToRemove, "indexesToRemove");
+            Requires.NotNull(indexesToRemove, nameof(indexesToRemove));
 
             if (indexesToRemove.Count == 0)
             {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary.cs
@@ -157,9 +157,9 @@ namespace System.Collections.Immutable
         [Pure]
         public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TSource, TKey, TValue>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, IEqualityComparer<TKey> keyComparer, IEqualityComparer<TValue> valueComparer)
         {
-            Requires.NotNull(source, "source");
-            Requires.NotNull(keySelector, "keySelector");
-            Requires.NotNull(elementSelector, "elementSelector");
+            Requires.NotNull(source, nameof(source));
+            Requires.NotNull(keySelector, nameof(keySelector));
+            Requires.NotNull(elementSelector, nameof(elementSelector));
             Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             return ImmutableDictionary<TKey, TValue>.Empty.WithComparers(keyComparer, valueComparer)
@@ -241,7 +241,7 @@ namespace System.Collections.Immutable
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
         public static ImmutableDictionary<TKey, TValue> ToImmutableDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source, IEqualityComparer<TKey> keyComparer, IEqualityComparer<TValue> valueComparer)
         {
-            Requires.NotNull(source, "source");
+            Requires.NotNull(source, nameof(source));
             Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             var existingDictionary = source as ImmutableDictionary<TKey, TValue>;
@@ -296,8 +296,8 @@ namespace System.Collections.Immutable
         [Pure]
         public static bool Contains<TKey, TValue>(this IImmutableDictionary<TKey, TValue> map, TKey key, TValue value)
         {
-            Requires.NotNull(map, "map");
-            Requires.NotNullAllowStructs(key, "key");
+            Requires.NotNull(map, nameof(map));
+            Requires.NotNullAllowStructs(key, nameof(key));
             return map.Contains(new KeyValuePair<TKey, TValue>(key, value));
         }
 
@@ -327,8 +327,8 @@ namespace System.Collections.Immutable
         [Pure]
         public static TValue GetValueOrDefault<TKey, TValue>(this IImmutableDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue)
         {
-            Requires.NotNull(dictionary, "dictionary");
-            Requires.NotNullAllowStructs(key, "key");
+            Requires.NotNull(dictionary, nameof(dictionary));
+            Requires.NotNullAllowStructs(key, nameof(key));
 
             TValue value;
             if (dictionary.TryGetValue(key, out value))

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+Builder.cs
@@ -72,7 +72,7 @@ namespace System.Collections.Immutable
             /// <param name="map">The map that serves as the basis for this Builder.</param>
             internal Builder(ImmutableDictionary<TKey, TValue> map)
             {
-                Requires.NotNull(map, "map");
+                Requires.NotNull(map, nameof(map));
                 _root = map._root;
                 _count = map._count;
                 _comparers = map._comparers;
@@ -94,7 +94,7 @@ namespace System.Collections.Immutable
 
                 set
                 {
-                    Requires.NotNull(value, "value");
+                    Requires.NotNull(value, nameof(value));
                     if (value != this.KeyComparer)
                     {
                         var comparers = Comparers.Get(value, this.ValueComparer);
@@ -124,7 +124,7 @@ namespace System.Collections.Immutable
 
                 set
                 {
-                    Requires.NotNull(value, "value");
+                    Requires.NotNull(value, nameof(value));
                     if (value != this.ValueComparer)
                     {
                         // When the key comparer is the same but the value comparer is different, we don't need a whole new tree
@@ -347,9 +347,9 @@ namespace System.Collections.Immutable
             /// <param name="arrayIndex">The zero-based index in <paramref name="array"/> at which copying begins.</param>
             void ICollection.CopyTo(Array array, int arrayIndex)
             {
-                Requires.NotNull(array, "array");
-                Requires.Range(arrayIndex >= 0, "arrayIndex");
-                Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
+                Requires.NotNull(array, nameof(array));
+                Requires.Range(arrayIndex >= 0, nameof(arrayIndex));
+                Requires.Range(array.Length >= arrayIndex + this.Count, nameof(arrayIndex));
 
                 foreach (var item in this)
                 {
@@ -448,7 +448,7 @@ namespace System.Collections.Immutable
             /// <param name="keys">The keys for entries to remove from the dictionary.</param>
             public void RemoveRange(IEnumerable<TKey> keys)
             {
-                Requires.NotNull(keys, "keys");
+                Requires.NotNull(keys, nameof(keys));
 
                 foreach (var key in keys)
                 {
@@ -489,7 +489,7 @@ namespace System.Collections.Immutable
             [Pure]
             public TValue GetValueOrDefault(TKey key, TValue defaultValue)
             {
-                Requires.NotNullAllowStructs(key, "key");
+                Requires.NotNullAllowStructs(key, nameof(key));
 
                 TValue value;
                 if (this.TryGetValue(key, out value))
@@ -652,7 +652,7 @@ namespace System.Collections.Immutable
             /// </summary>
             void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
             {
-                Requires.NotNull(array, "array");
+                Requires.NotNull(array, nameof(array));
 
                 foreach (var item in this)
                 {
@@ -745,7 +745,7 @@ namespace System.Collections.Immutable
         /// <param name="map">The collection to display in the debugger</param>
         public ImmutableDictionaryBuilderDebuggerProxy(ImmutableDictionary<TKey, TValue>.Builder map)
         {
-            Requires.NotNull(map, "map");
+            Requires.NotNull(map, nameof(map));
             _map = map;
         }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+Comparers.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+Comparers.cs
@@ -43,8 +43,8 @@ namespace System.Collections.Immutable
             /// <param name="valueComparer">The value comparer.</param>
             internal Comparers(IEqualityComparer<TKey> keyComparer, IEqualityComparer<TValue> valueComparer)
             {
-                Requires.NotNull(keyComparer, "keyComparer");
-                Requires.NotNull(valueComparer, "valueComparer");
+                Requires.NotNull(keyComparer, nameof(keyComparer));
+                Requires.NotNull(valueComparer, nameof(valueComparer));
 
                 _keyComparer = keyComparer;
                 _valueComparer = valueComparer;
@@ -151,8 +151,8 @@ namespace System.Collections.Immutable
             /// <returns>An instance of <see cref="Comparers"/></returns>
             internal static Comparers Get(IEqualityComparer<TKey> keyComparer, IEqualityComparer<TValue> valueComparer)
             {
-                Requires.NotNull(keyComparer, "keyComparer");
-                Requires.NotNull(valueComparer, "valueComparer");
+                Requires.NotNull(keyComparer, nameof(keyComparer));
+                Requires.NotNull(valueComparer, nameof(valueComparer));
 
                 return keyComparer == Default.KeyComparer && valueComparer == Default.ValueComparer
                     ? Default
@@ -167,7 +167,7 @@ namespace System.Collections.Immutable
             /// <returns>A new instance of <see cref="Comparers"/></returns>
             internal Comparers WithValueComparer(IEqualityComparer<TValue> valueComparer)
             {
-                Requires.NotNull(valueComparer, "valueComparer");
+                Requires.NotNull(valueComparer, nameof(valueComparer));
 
                 return _valueComparer == valueComparer
                     ? this

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+DebuggerProxy.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+DebuggerProxy.cs
@@ -29,7 +29,7 @@ namespace System.Collections.Immutable
         /// <param name="map">The collection to display in the debugger</param>
         public ImmutableDictionaryDebuggerProxy(ImmutableDictionary<TKey, TValue> map)
         {
-            Requires.NotNull(map, "map");
+            Requires.NotNull(map, nameof(map));
             _map = map;
         }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+MutationResult.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2+MutationResult.cs
@@ -41,7 +41,7 @@ namespace System.Collections.Immutable
             /// <param name="countAdjustment">The count adjustment.</param>
             internal MutationResult(SortedInt32KeyNode<HashBucket> root, int countAdjustment)
             {
-                Requires.NotNull(root, "root");
+                Requires.NotNull(root, nameof(root));
                 _root = root;
                 _countAdjustment = countAdjustment;
             }
@@ -69,7 +69,7 @@ namespace System.Collections.Immutable
             /// <returns>The new collection.</returns>
             internal ImmutableDictionary<TKey, TValue> Finalize(ImmutableDictionary<TKey, TValue> priorMap)
             {
-                Requires.NotNull(priorMap, "priorMap");
+                Requires.NotNull(priorMap, nameof(priorMap));
                 return priorMap.Wrap(this.Root, priorMap._count + this.CountAdjustment);
             }
         }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableDictionary`2.cs
@@ -51,9 +51,9 @@ namespace System.Collections.Immutable
         /// <param name="comparers">The comparers.</param>
         /// <param name="count">The number of elements in the map.</param>
         private ImmutableDictionary(SortedInt32KeyNode<HashBucket> root, Comparers comparers, int count)
-            : this(Requires.NotNullPassthrough(comparers, "comparers"))
+            : this(Requires.NotNullPassthrough(comparers, nameof(comparers)))
         {
-            Requires.NotNull(root, "root");
+            Requires.NotNull(root, nameof(root));
 
             root.Freeze(s_FreezeBucketAction);
             _root = root;
@@ -246,7 +246,7 @@ namespace System.Collections.Immutable
         {
             get
             {
-                Requires.NotNullAllowStructs(key, "key");
+                Requires.NotNullAllowStructs(key, nameof(key));
 
                 TValue value;
                 if (this.TryGetValue(key, out value))
@@ -302,7 +302,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableDictionary<TKey, TValue> Add(TKey key, TValue value)
         {
-            Requires.NotNullAllowStructs(key, "key");
+            Requires.NotNullAllowStructs(key, nameof(key));
             Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             var result = Add(key, value, KeyCollisionBehavior.ThrowIfValueDifferent, this.Origin);
@@ -316,7 +316,7 @@ namespace System.Collections.Immutable
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
         public ImmutableDictionary<TKey, TValue> AddRange(IEnumerable<KeyValuePair<TKey, TValue>> pairs)
         {
-            Requires.NotNull(pairs, "pairs");
+            Requires.NotNull(pairs, nameof(pairs));
             Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             return this.AddRange(pairs, false);
@@ -328,7 +328,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableDictionary<TKey, TValue> SetItem(TKey key, TValue value)
         {
-            Requires.NotNullAllowStructs(key, "key");
+            Requires.NotNullAllowStructs(key, nameof(key));
             Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
             Contract.Ensures(!Contract.Result<ImmutableDictionary<TKey, TValue>>().IsEmpty);
 
@@ -345,7 +345,7 @@ namespace System.Collections.Immutable
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
         public ImmutableDictionary<TKey, TValue> SetItems(IEnumerable<KeyValuePair<TKey, TValue>> items)
         {
-            Requires.NotNull(items, "items");
+            Requires.NotNull(items, nameof(items));
             Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             var result = AddRange(items, this.Origin, KeyCollisionBehavior.SetValue);
@@ -358,7 +358,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableDictionary<TKey, TValue> Remove(TKey key)
         {
-            Requires.NotNullAllowStructs(key, "key");
+            Requires.NotNullAllowStructs(key, nameof(key));
             Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             var result = Remove(key, this.Origin);
@@ -371,7 +371,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableDictionary<TKey, TValue> RemoveRange(IEnumerable<TKey> keys)
         {
-            Requires.NotNull(keys, "keys");
+            Requires.NotNull(keys, nameof(keys));
             Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             int count = _count;
@@ -404,7 +404,7 @@ namespace System.Collections.Immutable
         /// </returns>
         public bool ContainsKey(TKey key)
         {
-            Requires.NotNullAllowStructs(key, "key");
+            Requires.NotNullAllowStructs(key, nameof(key));
             return ContainsKey(key, this.Origin);
         }
 
@@ -425,7 +425,7 @@ namespace System.Collections.Immutable
         /// </summary>
         public bool TryGetValue(TKey key, out TValue value)
         {
-            Requires.NotNullAllowStructs(key, "key");
+            Requires.NotNullAllowStructs(key, nameof(key));
             return TryGetValue(key, this.Origin, out value);
         }
 
@@ -434,7 +434,7 @@ namespace System.Collections.Immutable
         /// </summary>
         public bool TryGetKey(TKey equalKey, out TKey actualKey)
         {
-            Requires.NotNullAllowStructs(equalKey, "equalKey");
+            Requires.NotNullAllowStructs(equalKey, nameof(equalKey));
             return TryGetKey(equalKey, this.Origin, out actualKey);
         }
 
@@ -642,9 +642,9 @@ namespace System.Collections.Immutable
 
         void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
         {
-            Requires.NotNull(array, "array");
-            Requires.Range(arrayIndex >= 0, "arrayIndex");
-            Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
+            Requires.NotNull(array, nameof(array));
+            Requires.Range(arrayIndex >= 0, nameof(arrayIndex));
+            Requires.Range(array.Length >= arrayIndex + this.Count, nameof(arrayIndex));
 
             foreach (var item in this)
             {
@@ -782,9 +782,9 @@ namespace System.Collections.Immutable
         /// <param name="arrayIndex">The zero-based index in <paramref name="array"/> at which copying begins.</param>
         void ICollection.CopyTo(Array array, int arrayIndex)
         {
-            Requires.NotNull(array, "array");
-            Requires.Range(arrayIndex >= 0, "arrayIndex");
-            Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
+            Requires.NotNull(array, nameof(array));
+            Requires.Range(arrayIndex >= 0, nameof(arrayIndex));
+            Requires.Range(array.Length >= arrayIndex + this.Count, nameof(arrayIndex));
 
             foreach (var item in this)
             {
@@ -861,7 +861,7 @@ namespace System.Collections.Immutable
         [Pure]
         private static ImmutableDictionary<TKey, TValue> EmptyWithComparers(Comparers comparers)
         {
-            Requires.NotNull(comparers, "comparers");
+            Requires.NotNull(comparers, nameof(comparers));
 
             return Empty._comparers == comparers
                 ? Empty
@@ -965,7 +965,7 @@ namespace System.Collections.Immutable
         /// </summary>
         private static MutationResult Add(TKey key, TValue value, KeyCollisionBehavior behavior, MutationInput origin)
         {
-            Requires.NotNullAllowStructs(key, "key");
+            Requires.NotNullAllowStructs(key, nameof(key));
 
             OperationResult result;
             int hashCode = origin.KeyComparer.GetHashCode(key);
@@ -985,7 +985,7 @@ namespace System.Collections.Immutable
         /// </summary>
         private static MutationResult AddRange(IEnumerable<KeyValuePair<TKey, TValue>> items, MutationInput origin, KeyCollisionBehavior collisionBehavior = KeyCollisionBehavior.ThrowIfValueDifferent)
         {
-            Requires.NotNull(items, "items");
+            Requires.NotNull(items, nameof(items));
 
             int countAdjustment = 0;
             var newRoot = origin.Root;
@@ -1052,9 +1052,9 @@ namespace System.Collections.Immutable
         /// </returns>
         private static ImmutableDictionary<TKey, TValue> Wrap(SortedInt32KeyNode<HashBucket> root, Comparers comparers, int count)
         {
-            Requires.NotNull(root, "root");
-            Requires.NotNull(comparers, "comparers");
-            Requires.Range(count >= 0, "count");
+            Requires.NotNull(root, nameof(root));
+            Requires.NotNull(comparers, nameof(comparers));
+            Requires.Range(count >= 0, nameof(count));
             return new ImmutableDictionary<TKey, TValue>(root, comparers, count);
         }
 
@@ -1087,7 +1087,7 @@ namespace System.Collections.Immutable
         [Pure]
         private ImmutableDictionary<TKey, TValue> AddRange(IEnumerable<KeyValuePair<TKey, TValue>> pairs, bool avoidToHashMap)
         {
-            Requires.NotNull(pairs, "pairs");
+            Requires.NotNull(pairs, nameof(pairs));
             Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             // Some optimizations may apply if we're an empty list.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableExtensions.cs
@@ -100,8 +100,8 @@ namespace System.Collections.Immutable
         /// </remarks>
         internal static T[] ToArray<T>(this IEnumerable<T> sequence, int count)
         {
-            Requires.NotNull(sequence, "sequence");
-            Requires.Range(count >= 0, "count");
+            Requires.NotNull(sequence, nameof(sequence));
+            Requires.Range(count >= 0, nameof(count));
 
             T[] array = new T[count];
             int i = 0;
@@ -249,7 +249,7 @@ namespace System.Collections.Immutable
         /// <returns>An ordered collection.  May not be thread-safe.  Never null.</returns>
         internal static IOrderedCollection<T> AsOrderedCollection<T>(this IEnumerable<T> sequence)
         {
-            Requires.NotNull(sequence, "sequence");
+            Requires.NotNull(sequence, nameof(sequence));
             Contract.Ensures(Contract.Result<IOrderedCollection<T>>() != null);
 
             var orderedCollection = sequence as IOrderedCollection<T>;
@@ -296,7 +296,7 @@ namespace System.Collections.Immutable
         internal static DisposableEnumeratorAdapter<T, TEnumerator> GetEnumerableDisposable<T, TEnumerator>(this IEnumerable<T> enumerable)
             where TEnumerator : struct, IStrongEnumerator<T>, IEnumerator<T>
         {
-            Requires.NotNull(enumerable, "enumerable");
+            Requires.NotNull(enumerable, nameof(enumerable));
 
             var strongEnumerable = enumerable as IStrongEnumerable<T, TEnumerator>;
             if (strongEnumerable != null)
@@ -328,7 +328,7 @@ namespace System.Collections.Immutable
             /// <param name="collection">The collection.</param>
             internal ListOfTWrapper(IList<T> collection)
             {
-                Requires.NotNull(collection, "collection");
+                Requires.NotNull(collection, nameof(collection));
                 _collection = collection;
             }
 
@@ -393,7 +393,7 @@ namespace System.Collections.Immutable
             /// <param name="sequence">The sequence.</param>
             internal FallbackWrapper(IEnumerable<T> sequence)
             {
-                Requires.NotNull(sequence, "sequence");
+                Requires.NotNull(sequence, nameof(sequence));
                 _sequence = sequence;
             }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+Builder.cs
@@ -65,7 +65,7 @@ namespace System.Collections.Immutable
             /// <param name="set">The set.</param>
             internal Builder(ImmutableHashSet<T> set)
             {
-                Requires.NotNull(set, "set");
+                Requires.NotNull(set, nameof(set));
                 _root = set._root;
                 _count = set._count;
                 _equalityComparer = set._equalityComparer;
@@ -109,7 +109,7 @@ namespace System.Collections.Immutable
 
                 set
                 {
-                    Requires.NotNull(value, "value");
+                    Requires.NotNull(value, nameof(value));
 
                     if (value != _equalityComparer)
                     {
@@ -377,9 +377,9 @@ namespace System.Collections.Immutable
             /// </summary>
             void ICollection<T>.CopyTo(T[] array, int arrayIndex)
             {
-                Requires.NotNull(array, "array");
-                Requires.Range(arrayIndex >= 0, "arrayIndex");
-                Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
+                Requires.NotNull(array, nameof(array));
+                Requires.Range(arrayIndex >= 0, nameof(arrayIndex));
+                Requires.Range(array.Length >= arrayIndex + this.Count, nameof(arrayIndex));
 
                 foreach (T item in this)
                 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+DebuggerProxy.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+DebuggerProxy.cs
@@ -28,7 +28,7 @@ namespace System.Collections.Immutable
         /// <param name="set">The collection to display in the debugger</param>
         public ImmutableHashSetDebuggerProxy(ImmutableHashSet<T> set)
         {
-            Requires.NotNull(set, "set");
+            Requires.NotNull(set, nameof(set));
             _set = set;
         }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+MutationInput.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+MutationInput.cs
@@ -38,7 +38,7 @@ namespace System.Collections.Immutable
             /// <param name="set">The set.</param>
             internal MutationInput(ImmutableHashSet<T> set)
             {
-                Requires.NotNull(set, "set");
+                Requires.NotNull(set, nameof(set));
                 _root = set._root;
                 _equalityComparer = set._equalityComparer;
                 _count = set._count;
@@ -52,9 +52,9 @@ namespace System.Collections.Immutable
             /// <param name="count">The count.</param>
             internal MutationInput(SortedInt32KeyNode<HashBucket> root, IEqualityComparer<T> equalityComparer, int count)
             {
-                Requires.NotNull(root, "root");
-                Requires.NotNull(equalityComparer, "equalityComparer");
-                Requires.Range(count >= 0, "count");
+                Requires.NotNull(root, nameof(root));
+                Requires.NotNull(equalityComparer, nameof(equalityComparer));
+                Requires.Range(count >= 0, nameof(count));
                 _root = root;
                 _equalityComparer = equalityComparer;
                 _count = count;

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+MutationResult.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+MutationResult.cs
@@ -55,7 +55,7 @@ namespace System.Collections.Immutable
             /// <param name="countType">The appropriate interpretation for the <paramref name="count"/> parameter.</param>
             internal MutationResult(SortedInt32KeyNode<HashBucket> root, int count, CountType countType = ImmutableHashSet<T>.CountType.Adjustment)
             {
-                Requires.NotNull(root, "root");
+                Requires.NotNull(root, nameof(root));
                 _root = root;
                 _count = count;
                 _countType = countType;
@@ -94,7 +94,7 @@ namespace System.Collections.Immutable
             /// <returns>The new collection.</returns>
             internal ImmutableHashSet<T> Finalize(ImmutableHashSet<T> priorSet)
             {
-                Requires.NotNull(priorSet, "priorSet");
+                Requires.NotNull(priorSet, nameof(priorSet));
                 int count = this.Count;
                 if (this.CountType == ImmutableHashSet<T>.CountType.Adjustment)
                 {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+NodeEnumerable.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1+NodeEnumerable.cs
@@ -28,7 +28,7 @@ namespace System.Collections.Immutable
             /// <param name="root">The root.</param>
             internal NodeEnumerable(SortedInt32KeyNode<HashBucket> root)
             {
-                Requires.NotNull(root, "root");
+                Requires.NotNull(root, nameof(root));
                 _root = root;
             }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableHashSet`1.cs
@@ -61,8 +61,8 @@ namespace System.Collections.Immutable
         /// <param name="count">The number of elements in this collection.</param>
         private ImmutableHashSet(SortedInt32KeyNode<HashBucket> root, IEqualityComparer<T> equalityComparer, int count)
         {
-            Requires.NotNull(root, "root");
-            Requires.NotNull(equalityComparer, "equalityComparer");
+            Requires.NotNull(root, nameof(root));
+            Requires.NotNull(equalityComparer, nameof(equalityComparer));
 
             root.Freeze(s_FreezeBucketAction);
             _root = root;
@@ -189,7 +189,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableHashSet<T> Add(T item)
         {
-            Requires.NotNullAllowStructs(item, "item");
+            Requires.NotNullAllowStructs(item, nameof(item));
             Contract.Ensures(Contract.Result<ImmutableHashSet<T>>() != null);
 
             var result = Add(item, this.Origin);
@@ -201,7 +201,7 @@ namespace System.Collections.Immutable
         /// </summary>
         public ImmutableHashSet<T> Remove(T item)
         {
-            Requires.NotNullAllowStructs(item, "item");
+            Requires.NotNullAllowStructs(item, nameof(item));
             Contract.Ensures(Contract.Result<ImmutableHashSet<T>>() != null);
 
             var result = Remove(item, this.Origin);
@@ -223,7 +223,7 @@ namespace System.Collections.Immutable
         [Pure]
         public bool TryGetValue(T equalValue, out T actualValue)
         {
-            Requires.NotNullAllowStructs(equalValue, "value");
+            Requires.NotNullAllowStructs(equalValue, nameof(equalValue));
 
             int hashCode = _equalityComparer.GetHashCode(equalValue);
             HashBucket bucket;
@@ -242,7 +242,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableHashSet<T> Union(IEnumerable<T> other)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
             Contract.Ensures(Contract.Result<ImmutableHashSet<T>>() != null);
 
             return this.Union(other, avoidWithComparer: false);
@@ -254,7 +254,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableHashSet<T> Intersect(IEnumerable<T> other)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
             Contract.Ensures(Contract.Result<ImmutableHashSet<T>>() != null);
 
             var result = Intersect(other, this.Origin);
@@ -266,7 +266,7 @@ namespace System.Collections.Immutable
         /// </summary>
         public ImmutableHashSet<T> Except(IEnumerable<T> other)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             var result = Except(other, _equalityComparer, _root);
             return result.Finalize(this);
@@ -280,7 +280,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableHashSet<T> SymmetricExcept(IEnumerable<T> other)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
             Contract.Ensures(Contract.Result<IImmutableSet<T>>() != null);
 
             var result = SymmetricExcept(other, this.Origin);
@@ -295,7 +295,7 @@ namespace System.Collections.Immutable
         [Pure]
         public bool SetEquals(IEnumerable<T> other)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             if (object.ReferenceEquals(this, other))
             {
@@ -313,7 +313,7 @@ namespace System.Collections.Immutable
         [Pure]
         public bool IsProperSubsetOf(IEnumerable<T> other)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             return IsProperSubsetOf(other, this.Origin);
         }
@@ -326,7 +326,7 @@ namespace System.Collections.Immutable
         [Pure]
         public bool IsProperSupersetOf(IEnumerable<T> other)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             return IsProperSupersetOf(other, this.Origin);
         }
@@ -339,7 +339,7 @@ namespace System.Collections.Immutable
         [Pure]
         public bool IsSubsetOf(IEnumerable<T> other)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             return IsSubsetOf(other, this.Origin);
         }
@@ -352,7 +352,7 @@ namespace System.Collections.Immutable
         [Pure]
         public bool IsSupersetOf(IEnumerable<T> other)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             return IsSupersetOf(other, this.Origin);
         }
@@ -365,7 +365,7 @@ namespace System.Collections.Immutable
         [Pure]
         public bool Overlaps(IEnumerable<T> other)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             return Overlaps(other, this.Origin);
         }
@@ -435,7 +435,7 @@ namespace System.Collections.Immutable
         /// </summary>
         public bool Contains(T item)
         {
-            Requires.NotNullAllowStructs(item, "item");
+            Requires.NotNullAllowStructs(item, nameof(item));
             return Contains(item, this.Origin);
         }
 
@@ -524,9 +524,9 @@ namespace System.Collections.Immutable
         /// </summary>
         void ICollection<T>.CopyTo(T[] array, int arrayIndex)
         {
-            Requires.NotNull(array, "array");
-            Requires.Range(arrayIndex >= 0, "arrayIndex");
-            Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
+            Requires.NotNull(array, nameof(array));
+            Requires.Range(arrayIndex >= 0, nameof(arrayIndex));
+            Requires.Range(array.Length >= arrayIndex + this.Count, nameof(arrayIndex));
 
             foreach (T item in this)
             {
@@ -569,9 +569,9 @@ namespace System.Collections.Immutable
         /// <param name="arrayIndex">The zero-based index in <paramref name="array"/> at which copying begins.</param>
         void ICollection.CopyTo(Array array, int arrayIndex)
         {
-            Requires.NotNull(array, "array");
-            Requires.Range(arrayIndex >= 0, "arrayIndex");
-            Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
+            Requires.NotNull(array, nameof(array));
+            Requires.Range(arrayIndex >= 0, nameof(arrayIndex));
+            Requires.Range(array.Length >= arrayIndex + this.Count, nameof(arrayIndex));
 
             foreach (T item in this)
             {
@@ -626,7 +626,7 @@ namespace System.Collections.Immutable
         /// </summary>
         private static bool IsSupersetOf(IEnumerable<T> other, MutationInput origin)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             foreach (T item in other.GetEnumerableDisposable<T, Enumerator>())
             {
@@ -644,7 +644,7 @@ namespace System.Collections.Immutable
         /// </summary>
         private static MutationResult Add(T item, MutationInput origin)
         {
-            Requires.NotNullAllowStructs(item, "item");
+            Requires.NotNullAllowStructs(item, nameof(item));
 
             OperationResult result;
             int hashCode = origin.EqualityComparer.GetHashCode(item);
@@ -665,7 +665,7 @@ namespace System.Collections.Immutable
         /// </summary>
         private static MutationResult Remove(T item, MutationInput origin)
         {
-            Requires.NotNullAllowStructs(item, "item");
+            Requires.NotNullAllowStructs(item, nameof(item));
 
             var result = OperationResult.NoChangeRequired;
             int hashCode = origin.EqualityComparer.GetHashCode(item);
@@ -705,7 +705,7 @@ namespace System.Collections.Immutable
         /// </summary>
         private static MutationResult Union(IEnumerable<T> other, MutationInput origin)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             int count = 0;
             var newRoot = origin.Root;
@@ -730,7 +730,7 @@ namespace System.Collections.Immutable
         /// </summary>
         private static bool Overlaps(IEnumerable<T> other, MutationInput origin)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             if (origin.Root.IsEmpty)
             {
@@ -753,7 +753,7 @@ namespace System.Collections.Immutable
         /// </summary>
         private static bool SetEquals(IEnumerable<T> other, MutationInput origin)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             var otherSet = new HashSet<T>(other, origin.EqualityComparer);
             if (origin.Count != otherSet.Count)
@@ -797,7 +797,7 @@ namespace System.Collections.Immutable
         /// </summary>
         private static MutationResult Intersect(IEnumerable<T> other, MutationInput origin)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             var newSet = SortedInt32KeyNode<HashBucket>.EmptyNode;
             int count = 0;
@@ -819,9 +819,9 @@ namespace System.Collections.Immutable
         /// </summary>
         private static MutationResult Except(IEnumerable<T> other, IEqualityComparer<T> equalityComparer, SortedInt32KeyNode<HashBucket> root)
         {
-            Requires.NotNull(other, "other");
-            Requires.NotNull(equalityComparer, "equalityComparer");
-            Requires.NotNull(root, "root");
+            Requires.NotNull(other, nameof(other));
+            Requires.NotNull(equalityComparer, nameof(equalityComparer));
+            Requires.NotNull(root, nameof(root));
 
             int count = 0;
             var newRoot = root;
@@ -850,7 +850,7 @@ namespace System.Collections.Immutable
         [Pure]
         private static MutationResult SymmetricExcept(IEnumerable<T> other, MutationInput origin)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             var otherAsSet = ImmutableHashSet.CreateRange(origin.EqualityComparer, other);
 
@@ -884,7 +884,7 @@ namespace System.Collections.Immutable
         /// </summary>
         private static bool IsProperSubsetOf(IEnumerable<T> other, MutationInput origin)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             if (origin.Root.IsEmpty)
             {
@@ -932,7 +932,7 @@ namespace System.Collections.Immutable
         /// </summary>
         private static bool IsProperSupersetOf(IEnumerable<T> other, MutationInput origin)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             if (origin.Root.IsEmpty)
             {
@@ -957,7 +957,7 @@ namespace System.Collections.Immutable
         /// </summary>
         private static bool IsSubsetOf(IEnumerable<T> other, MutationInput origin)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             if (origin.Root.IsEmpty)
             {
@@ -996,9 +996,9 @@ namespace System.Collections.Immutable
         /// <returns>The immutable collection.</returns>
         private static ImmutableHashSet<T> Wrap(SortedInt32KeyNode<HashBucket> root, IEqualityComparer<T> equalityComparer, int count)
         {
-            Requires.NotNull(root, "root");
-            Requires.NotNull(equalityComparer, "equalityComparer");
-            Requires.Range(count >= 0, "count");
+            Requires.NotNull(root, nameof(root));
+            Requires.NotNull(equalityComparer, nameof(equalityComparer));
+            Requires.Range(count >= 0, nameof(count));
             return new ImmutableHashSet<T>(root, equalityComparer, count);
         }
 
@@ -1021,7 +1021,7 @@ namespace System.Collections.Immutable
         [Pure]
         private ImmutableHashSet<T> Union(IEnumerable<T> items, bool avoidWithComparer)
         {
-            Requires.NotNull(items, "items");
+            Requires.NotNull(items, nameof(items));
             Contract.Ensures(Contract.Result<ImmutableHashSet<T>>() != null);
 
             // Some optimizations may apply if we're an empty set.

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableInterlocked.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableInterlocked.cs
@@ -32,7 +32,7 @@ namespace System.Collections.Immutable
         /// </returns>
         public static bool Update<T>(ref T location, Func<T, T> transformer) where T : class
         {
-            Requires.NotNull(transformer, "transformer");
+            Requires.NotNull(transformer, nameof(transformer));
 
             bool successful;
             T oldValue = Volatile.Read(ref location);
@@ -76,7 +76,7 @@ namespace System.Collections.Immutable
         /// </returns>
         public static bool Update<T, TArg>(ref T location, Func<T, TArg, T> transformer, TArg transformerArgument) where T : class
         {
-            Requires.NotNull(transformer, "transformer");
+            Requires.NotNull(transformer, nameof(transformer));
 
             bool successful;
             T oldValue = Volatile.Read(ref location);
@@ -156,10 +156,10 @@ namespace System.Collections.Immutable
         /// <returns>The value obtained from the dictionary or <paramref name="valueFactory"/> if it was not present.</returns>
         public static TValue GetOrAdd<TKey, TValue, TArg>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TArg, TValue> valueFactory, TArg factoryArgument)
         {
-            Requires.NotNull(valueFactory, "valueFactory");
+            Requires.NotNull(valueFactory, nameof(valueFactory));
 
             var map = Volatile.Read(ref location);
-            Requires.NotNull(map, "location");
+            Requires.NotNull(map, nameof(location));
 
             TValue value;
             if (map.TryGetValue(key, out value))
@@ -185,10 +185,10 @@ namespace System.Collections.Immutable
         /// <returns>The value obtained from the dictionary or <paramref name="valueFactory"/> if it was not present.</returns>
         public static TValue GetOrAdd<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TValue> valueFactory)
         {
-            Requires.NotNull(valueFactory, "valueFactory");
+            Requires.NotNull(valueFactory, nameof(valueFactory));
 
             var map = Volatile.Read(ref location);
-            Requires.NotNull(map, "location");
+            Requires.NotNull(map, nameof(location));
 
             TValue value;
             if (map.TryGetValue(key, out value))
@@ -215,7 +215,7 @@ namespace System.Collections.Immutable
             bool successful;
             do
             {
-                Requires.NotNull(priorCollection, "location");
+                Requires.NotNull(priorCollection, nameof(location));
                 TValue oldValue;
                 if (priorCollection.TryGetValue(key, out oldValue))
                 {
@@ -246,15 +246,15 @@ namespace System.Collections.Immutable
         /// <returns>The added or updated value.</returns>
         public static TValue AddOrUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, Func<TKey, TValue> addValueFactory, Func<TKey, TValue, TValue> updateValueFactory)
         {
-            Requires.NotNull(addValueFactory, "addValueFactory");
-            Requires.NotNull(updateValueFactory, "updateValueFactory");
+            Requires.NotNull(addValueFactory, nameof(addValueFactory));
+            Requires.NotNull(updateValueFactory, nameof(updateValueFactory));
 
             TValue newValue;
             var priorCollection = Volatile.Read(ref location);
             bool successful;
             do
             {
-                Requires.NotNull(priorCollection, "location");
+                Requires.NotNull(priorCollection, nameof(location));
 
                 TValue oldValue;
                 if (priorCollection.TryGetValue(key, out oldValue))
@@ -290,14 +290,14 @@ namespace System.Collections.Immutable
         /// <returns>The added or updated value.</returns>
         public static TValue AddOrUpdate<TKey, TValue>(ref ImmutableDictionary<TKey, TValue> location, TKey key, TValue addValue, Func<TKey, TValue, TValue> updateValueFactory)
         {
-            Requires.NotNull(updateValueFactory, "updateValueFactory");
+            Requires.NotNull(updateValueFactory, nameof(updateValueFactory));
 
             TValue newValue;
             var priorCollection = Volatile.Read(ref location);
             bool successful;
             do
             {
-                Requires.NotNull(priorCollection, "location");
+                Requires.NotNull(priorCollection, nameof(location));
 
                 TValue oldValue;
                 if (priorCollection.TryGetValue(key, out oldValue))
@@ -336,7 +336,7 @@ namespace System.Collections.Immutable
             bool successful;
             do
             {
-                Requires.NotNull(priorCollection, "location");
+                Requires.NotNull(priorCollection, nameof(location));
 
                 if (priorCollection.ContainsKey(key))
                 {
@@ -369,7 +369,7 @@ namespace System.Collections.Immutable
             bool successful;
             do
             {
-                Requires.NotNull(priorCollection, "location");
+                Requires.NotNull(priorCollection, nameof(location));
 
                 TValue priorValue;
                 if (!priorCollection.TryGetValue(key, out priorValue) || !valueComparer.Equals(priorValue, comparisonValue))
@@ -402,7 +402,7 @@ namespace System.Collections.Immutable
             bool successful;
             do
             {
-                Requires.NotNull(priorCollection, "location");
+                Requires.NotNull(priorCollection, nameof(location));
 
                 if (!priorCollection.TryGetValue(key, out value))
                 {
@@ -435,7 +435,7 @@ namespace System.Collections.Immutable
             bool successful;
             do
             {
-                Requires.NotNull(priorCollection, "location");
+                Requires.NotNull(priorCollection, nameof(location));
 
                 if (priorCollection.IsEmpty)
                 {
@@ -464,7 +464,7 @@ namespace System.Collections.Immutable
             bool successful;
             do
             {
-                Requires.NotNull(priorCollection, "location");
+                Requires.NotNull(priorCollection, nameof(location));
 
                 var updatedCollection = priorCollection.Push(value);
                 var interlockedResult = Interlocked.CompareExchange(ref location, updatedCollection, priorCollection);
@@ -490,7 +490,7 @@ namespace System.Collections.Immutable
             bool successful;
             do
             {
-                Requires.NotNull(priorCollection, "location");
+                Requires.NotNull(priorCollection, nameof(location));
 
                 if (priorCollection.IsEmpty)
                 {
@@ -519,7 +519,7 @@ namespace System.Collections.Immutable
             bool successful;
             do
             {
-                Requires.NotNull(priorCollection, "location");
+                Requires.NotNull(priorCollection, nameof(location));
 
                 var updatedCollection = priorCollection.Enqueue(value);
                 var interlockedResult = Interlocked.CompareExchange(ref location, updatedCollection, priorCollection);

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList.cs
@@ -99,7 +99,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static IImmutableList<T> Replace<T>(this IImmutableList<T> list, T oldValue, T newValue)
         {
-            Requires.NotNull(list, "list");
+            Requires.NotNull(list, nameof(list));
             return list.Replace(oldValue, newValue, EqualityComparer<T>.Default);
         }
 
@@ -112,7 +112,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static IImmutableList<T> Remove<T>(this IImmutableList<T> list, T value)
         {
-            Requires.NotNull(list, "list");
+            Requires.NotNull(list, nameof(list));
             return list.Remove(value, EqualityComparer<T>.Default);
         }
 
@@ -127,7 +127,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static IImmutableList<T> RemoveRange<T>(this IImmutableList<T> list, IEnumerable<T> items)
         {
-            Requires.NotNull(list, "list");
+            Requires.NotNull(list, nameof(list));
             return list.RemoveRange(items, EqualityComparer<T>.Default);
         }
 
@@ -148,7 +148,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static int IndexOf<T>(this IImmutableList<T> list, T item)
         {
-            Requires.NotNull(list, "list");
+            Requires.NotNull(list, nameof(list));
             return list.IndexOf(item, 0, list.Count, EqualityComparer<T>.Default);
         }
 
@@ -170,7 +170,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static int IndexOf<T>(this IImmutableList<T> list, T item, IEqualityComparer<T> equalityComparer)
         {
-            Requires.NotNull(list, "list");
+            Requires.NotNull(list, nameof(list));
             return list.IndexOf(item, 0, list.Count, equalityComparer);
         }
 
@@ -196,7 +196,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static int IndexOf<T>(this IImmutableList<T> list, T item, int startIndex)
         {
-            Requires.NotNull(list, "list");
+            Requires.NotNull(list, nameof(list));
             return list.IndexOf(item, startIndex, list.Count - startIndex, EqualityComparer<T>.Default);
         }
 
@@ -225,7 +225,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static int IndexOf<T>(this IImmutableList<T> list, T item, int startIndex, int count)
         {
-            Requires.NotNull(list, "list");
+            Requires.NotNull(list, nameof(list));
             return list.IndexOf(item, startIndex, count, EqualityComparer<T>.Default);
         }
 
@@ -245,7 +245,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static int LastIndexOf<T>(this IImmutableList<T> list, T item)
         {
-            Requires.NotNull(list, "list");
+            Requires.NotNull(list, nameof(list));
 
             if (list.Count == 0)
             {
@@ -273,7 +273,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static int LastIndexOf<T>(this IImmutableList<T> list, T item, IEqualityComparer<T> equalityComparer)
         {
-            Requires.NotNull(list, "list");
+            Requires.NotNull(list, nameof(list));
 
             if (list.Count == 0)
             {
@@ -305,7 +305,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static int LastIndexOf<T>(this IImmutableList<T> list, T item, int startIndex)
         {
-            Requires.NotNull(list, "list");
+            Requires.NotNull(list, nameof(list));
 
             if (list.Count == 0 && startIndex == 0)
             {
@@ -339,7 +339,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static int LastIndexOf<T>(this IImmutableList<T> list, T item, int startIndex, int count)
         {
-            Requires.NotNull(list, "list");
+            Requires.NotNull(list, nameof(list));
             return list.LastIndexOf(item, startIndex, count, EqualityComparer<T>.Default);
         }
     }

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1+Builder.cs
@@ -62,7 +62,7 @@ namespace System.Collections.Immutable
             /// <param name="list">A list to act as the basis for a new list.</param>
             internal Builder(ImmutableList<T> list)
             {
-                Requires.NotNull(list, "list");
+                Requires.NotNull(list, nameof(list));
                 _root = list._root;
                 _immutable = list;
             }
@@ -265,7 +265,7 @@ namespace System.Collections.Immutable
             /// <param name="action">The System.Action&lt;T&gt; delegate to perform on each element of the list.</param>
             public void ForEach(Action<T> action)
             {
-                Requires.NotNull(action, "action");
+                Requires.NotNull(action, nameof(action));
 
                 foreach (T item in this)
                 {
@@ -284,8 +284,8 @@ namespace System.Collections.Immutable
             /// </param>
             public void CopyTo(T[] array)
             {
-                Requires.NotNull(array, "array");
-                Requires.Range(array.Length >= this.Count, "array");
+                Requires.NotNull(array, nameof(array));
+                Requires.Range(array.Length >= this.Count, nameof(array));
                 _root.CopyTo(array);
             }
 
@@ -303,8 +303,8 @@ namespace System.Collections.Immutable
             /// </param>
             public void CopyTo(T[] array, int arrayIndex)
             {
-                Requires.NotNull(array, "array");
-                Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
+                Requires.NotNull(array, nameof(array));
+                Requires.Range(array.Length >= arrayIndex + this.Count, nameof(arrayIndex));
                 _root.CopyTo(array, arrayIndex);
             }
 
@@ -344,9 +344,9 @@ namespace System.Collections.Immutable
             /// </returns>
             public ImmutableList<T> GetRange(int index, int count)
             {
-                Requires.Range(index >= 0, "index");
-                Requires.Range(count >= 0, "count");
-                Requires.Range(index + count <= this.Count, "count");
+                Requires.Range(index >= 0, nameof(index));
+                Requires.Range(count >= 0, nameof(count));
+                Requires.Range(index + count <= this.Count, nameof(count));
                 return ImmutableList<T>.WrapNode(Node.NodeTreeFromList(this, index, count));
             }
 
@@ -367,7 +367,7 @@ namespace System.Collections.Immutable
             /// </returns>
             public ImmutableList<TOutput> ConvertAll<TOutput>(Func<T, TOutput> converter)
             {
-                Requires.NotNull(converter, "converter");
+                Requires.NotNull(converter, nameof(converter));
                 return ImmutableList<TOutput>.WrapNode(_root.ConvertAll(converter));
             }
 
@@ -386,7 +386,7 @@ namespace System.Collections.Immutable
             /// </returns>
             public bool Exists(Predicate<T> match)
             {
-                Requires.NotNull(match, "match");
+                Requires.NotNull(match, nameof(match));
                 return _root.Exists(match);
             }
 
@@ -404,7 +404,7 @@ namespace System.Collections.Immutable
             /// </returns>
             public T Find(Predicate<T> match)
             {
-                Requires.NotNull(match, "match");
+                Requires.NotNull(match, nameof(match));
                 return _root.Find(match);
             }
 
@@ -423,7 +423,7 @@ namespace System.Collections.Immutable
             /// </returns>
             public ImmutableList<T> FindAll(Predicate<T> match)
             {
-                Requires.NotNull(match, "match");
+                Requires.NotNull(match, nameof(match));
                 return _root.FindAll(match);
             }
 
@@ -442,7 +442,7 @@ namespace System.Collections.Immutable
             /// </returns>
             public int FindIndex(Predicate<T> match)
             {
-                Requires.NotNull(match, "match");
+                Requires.NotNull(match, nameof(match));
                 return _root.FindIndex(match);
             }
 
@@ -460,9 +460,9 @@ namespace System.Collections.Immutable
             /// </returns>
             public int FindIndex(int startIndex, Predicate<T> match)
             {
-                Requires.NotNull(match, "match");
-                Requires.Range(startIndex >= 0, "startIndex");
-                Requires.Range(startIndex <= this.Count, "startIndex");
+                Requires.NotNull(match, nameof(match));
+                Requires.Range(startIndex >= 0, nameof(startIndex));
+                Requires.Range(startIndex <= this.Count, nameof(startIndex));
                 return _root.FindIndex(startIndex, match);
             }
 
@@ -481,10 +481,10 @@ namespace System.Collections.Immutable
             /// </returns>
             public int FindIndex(int startIndex, int count, Predicate<T> match)
             {
-                Requires.NotNull(match, "match");
-                Requires.Range(startIndex >= 0, "startIndex");
-                Requires.Range(count >= 0, "count");
-                Requires.Range(startIndex + count <= this.Count, "count");
+                Requires.NotNull(match, nameof(match));
+                Requires.Range(startIndex >= 0, nameof(startIndex));
+                Requires.Range(count >= 0, nameof(count));
+                Requires.Range(startIndex + count <= this.Count, nameof(count));
 
                 return _root.FindIndex(startIndex, count, match);
             }
@@ -503,7 +503,7 @@ namespace System.Collections.Immutable
             /// </returns>
             public T FindLast(Predicate<T> match)
             {
-                Requires.NotNull(match, "match");
+                Requires.NotNull(match, nameof(match));
                 return _root.FindLast(match);
             }
 
@@ -522,7 +522,7 @@ namespace System.Collections.Immutable
             /// </returns>
             public int FindLastIndex(Predicate<T> match)
             {
-                Requires.NotNull(match, "match");
+                Requires.NotNull(match, nameof(match));
                 return _root.FindLastIndex(match);
             }
 
@@ -541,9 +541,9 @@ namespace System.Collections.Immutable
             /// </returns>
             public int FindLastIndex(int startIndex, Predicate<T> match)
             {
-                Requires.NotNull(match, "match");
-                Requires.Range(startIndex >= 0, "startIndex");
-                Requires.Range(startIndex == 0 || startIndex < this.Count, "startIndex");
+                Requires.NotNull(match, nameof(match));
+                Requires.Range(startIndex >= 0, nameof(startIndex));
+                Requires.Range(startIndex == 0 || startIndex < this.Count, nameof(startIndex));
                 return _root.FindLastIndex(startIndex, match);
             }
 
@@ -565,10 +565,10 @@ namespace System.Collections.Immutable
             /// </returns>
             public int FindLastIndex(int startIndex, int count, Predicate<T> match)
             {
-                Requires.NotNull(match, "match");
-                Requires.Range(startIndex >= 0, "startIndex");
-                Requires.Range(count <= this.Count, "count");
-                Requires.Range(startIndex - count + 1 >= 0, "startIndex");
+                Requires.NotNull(match, nameof(match));
+                Requires.Range(startIndex >= 0, nameof(startIndex));
+                Requires.Range(count <= this.Count, nameof(count));
+                Requires.Range(startIndex - count + 1 >= 0, nameof(startIndex));
 
                 return _root.FindLastIndex(startIndex, count, match);
             }
@@ -770,7 +770,7 @@ namespace System.Collections.Immutable
             /// </returns>
             public bool TrueForAll(Predicate<T> match)
             {
-                Requires.NotNull(match, "match");
+                Requires.NotNull(match, nameof(match));
                 return _root.TrueForAll(match);
             }
 
@@ -788,7 +788,7 @@ namespace System.Collections.Immutable
             /// </param>
             public void AddRange(IEnumerable<T> items)
             {
-                Requires.NotNull(items, "items");
+                Requires.NotNull(items, nameof(items));
 
                 this.Root = this.Root.AddRange(items);
             }
@@ -807,8 +807,8 @@ namespace System.Collections.Immutable
             /// </param>
             public void InsertRange(int index, IEnumerable<T> items)
             {
-                Requires.Range(index >= 0 && index <= this.Count, "index");
-                Requires.NotNull(items, "items");
+                Requires.Range(index >= 0 && index <= this.Count, nameof(index));
+                Requires.NotNull(items, nameof(items));
 
                 this.Root = this.Root.InsertRange(index, items);
             }
@@ -826,7 +826,7 @@ namespace System.Collections.Immutable
             /// </returns>
             public int RemoveAll(Predicate<T> match)
             {
-                Requires.NotNull(match, "match");
+                Requires.NotNull(match, nameof(match));
 
                 int count = this.Count;
                 this.Root = this.Root.RemoveAll(match);
@@ -848,9 +848,9 @@ namespace System.Collections.Immutable
             /// <param name="count">The number of elements in the range to reverse.</param> 
             public void Reverse(int index, int count)
             {
-                Requires.Range(index >= 0, "index");
-                Requires.Range(count >= 0, "count");
-                Requires.Range(index + count <= this.Count, "count");
+                Requires.Range(index >= 0, nameof(index));
+                Requires.Range(count >= 0, nameof(count));
+                Requires.Range(index + count <= this.Count, nameof(count));
 
                 this.Root = this.Root.Reverse(index, count);
             }
@@ -874,7 +874,7 @@ namespace System.Collections.Immutable
             /// <exception cref="ArgumentNullException"><paramref name="comparison"/> is null.</exception>
             public void Sort(Comparison<T> comparison)
             {
-                Requires.NotNull(comparison, "comparison");
+                Requires.NotNull(comparison, nameof(comparison));
                 this.Root = this.Root.Sort(comparison);
             }
 
@@ -907,9 +907,9 @@ namespace System.Collections.Immutable
             /// </param>
             public void Sort(int index, int count, IComparer<T> comparer)
             {
-                Requires.Range(index >= 0, "index");
-                Requires.Range(count >= 0, "count");
-                Requires.Range(index + count <= this.Count, "count");
+                Requires.Range(index >= 0, nameof(index));
+                Requires.Range(count >= 0, nameof(count));
+                Requires.Range(index + count <= this.Count, nameof(count));
                 this.Root = this.Root.Sort(index, count, comparer);
             }
 
@@ -1194,7 +1194,7 @@ namespace System.Collections.Immutable
         /// <param name="builder">The list to display in the debugger</param>
         public ImmutableListBuilderDebuggerProxy(ImmutableList<T>.Builder builder)
         {
-            Requires.NotNull(builder, "builder");
+            Requires.NotNull(builder, nameof(builder));
             _list = builder;
         }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
@@ -43,7 +43,7 @@ namespace System.Collections.Immutable
         /// <param name="root">The root of the AVL tree with the contents of this set.</param>
         private ImmutableList(Node root)
         {
-            Requires.NotNull(root, "root");
+            Requires.NotNull(root, nameof(root));
 
             root.Freeze();
             _root = root;
@@ -274,7 +274,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableList<T> AddRange(IEnumerable<T> items)
         {
-            Requires.NotNull(items, "items");
+            Requires.NotNull(items, nameof(items));
             Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
             Contract.Ensures(Contract.Result<ImmutableList<T>>().Count >= this.Count);
 
@@ -295,7 +295,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableList<T> Insert(int index, T item)
         {
-            Requires.Range(index >= 0 && index <= this.Count, "index");
+            Requires.Range(index >= 0 && index <= this.Count, nameof(index));
             Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
             Contract.Ensures(Contract.Result<ImmutableList<T>>().Count == this.Count + 1);
             return this.Wrap(_root.Insert(index, item));
@@ -307,8 +307,8 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableList<T> InsertRange(int index, IEnumerable<T> items)
         {
-            Requires.Range(index >= 0 && index <= this.Count, "index");
-            Requires.NotNull(items, "items");
+            Requires.Range(index >= 0 && index <= this.Count, nameof(index));
+            Requires.NotNull(items, nameof(items));
             Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
 
             var result = _root.InsertRange(index, items);
@@ -345,8 +345,8 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableList<T> RemoveRange(int index, int count)
         {
-            Requires.Range(index >= 0 && index <= this.Count, "index");
-            Requires.Range(count >= 0 && index + count <= this.Count, "count");
+            Requires.Range(index >= 0 && index <= this.Count, nameof(index));
+            Requires.Range(count >= 0 && index + count <= this.Count, nameof(count));
             Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
 
             var result = _root;
@@ -386,7 +386,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableList<T> RemoveRange(IEnumerable<T> items, IEqualityComparer<T> equalityComparer)
         {
-            Requires.NotNull(items, "items");
+            Requires.NotNull(items, nameof(items));
             Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
             Contract.Ensures(Contract.Result<ImmutableList<T>>().Count <= this.Count);
 
@@ -417,7 +417,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableList<T> RemoveAt(int index)
         {
-            Requires.Range(index >= 0 && index < this.Count, "index");
+            Requires.Range(index >= 0 && index < this.Count, nameof(index));
             Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
             Contract.Ensures(Contract.Result<ImmutableList<T>>().Count == this.Count - 1);
             var result = _root.RemoveAt(index);
@@ -438,7 +438,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableList<T> RemoveAll(Predicate<T> match)
         {
-            Requires.NotNull(match, "match");
+            Requires.NotNull(match, nameof(match));
             Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
 
             return this.Wrap(_root.RemoveAll(match));
@@ -526,7 +526,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableList<T> Sort(Comparison<T> comparison)
         {
-            Requires.NotNull(comparison, "comparison");
+            Requires.NotNull(comparison, nameof(comparison));
             Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
             return this.Wrap(_root.Sort(comparison));
         }
@@ -565,9 +565,9 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableList<T> Sort(int index, int count, IComparer<T> comparer)
         {
-            Requires.Range(index >= 0, "index");
-            Requires.Range(count >= 0, "count");
-            Requires.Range(index + count <= this.Count, "count");
+            Requires.Range(index >= 0, nameof(index));
+            Requires.Range(count >= 0, nameof(count));
+            Requires.Range(index + count <= this.Count, nameof(count));
             Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
 
             return this.Wrap(_root.Sort(index, count, comparer));
@@ -583,7 +583,7 @@ namespace System.Collections.Immutable
         /// <param name="action">The System.Action&lt;T&gt; delegate to perform on each element of the list.</param>
         public void ForEach(Action<T> action)
         {
-            Requires.NotNull(action, "action");
+            Requires.NotNull(action, nameof(action));
 
             foreach (T item in this)
             {
@@ -602,8 +602,8 @@ namespace System.Collections.Immutable
         /// </param>
         public void CopyTo(T[] array)
         {
-            Requires.NotNull(array, "array");
-            Requires.Range(array.Length >= this.Count, "array");
+            Requires.NotNull(array, nameof(array));
+            Requires.Range(array.Length >= this.Count, nameof(array));
             _root.CopyTo(array);
         }
 
@@ -621,9 +621,9 @@ namespace System.Collections.Immutable
         /// </param>
         public void CopyTo(T[] array, int arrayIndex)
         {
-            Requires.NotNull(array, "array");
-            Requires.Range(arrayIndex >= 0, "arrayIndex");
-            Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
+            Requires.NotNull(array, nameof(array));
+            Requires.Range(arrayIndex >= 0, nameof(arrayIndex));
+            Requires.Range(array.Length >= arrayIndex + this.Count, nameof(arrayIndex));
             _root.CopyTo(array, arrayIndex);
         }
 
@@ -663,9 +663,9 @@ namespace System.Collections.Immutable
         /// </returns>
         public ImmutableList<T> GetRange(int index, int count)
         {
-            Requires.Range(index >= 0, "index");
-            Requires.Range(count >= 0, "count");
-            Requires.Range(index + count <= this.Count, "count");
+            Requires.Range(index >= 0, nameof(index));
+            Requires.Range(count >= 0, nameof(count));
+            Requires.Range(index + count <= this.Count, nameof(count));
             return this.Wrap(Node.NodeTreeFromList(this, index, count));
         }
 
@@ -686,7 +686,7 @@ namespace System.Collections.Immutable
         /// </returns>
         public ImmutableList<TOutput> ConvertAll<TOutput>(Func<T, TOutput> converter)
         {
-            Requires.NotNull(converter, "converter");
+            Requires.NotNull(converter, nameof(converter));
             return ImmutableList<TOutput>.WrapNode(_root.ConvertAll(converter));
         }
 
@@ -705,7 +705,7 @@ namespace System.Collections.Immutable
         /// </returns>
         public bool Exists(Predicate<T> match)
         {
-            Requires.NotNull(match, "match");
+            Requires.NotNull(match, nameof(match));
             return _root.Exists(match);
         }
 
@@ -723,7 +723,7 @@ namespace System.Collections.Immutable
         /// </returns>
         public T Find(Predicate<T> match)
         {
-            Requires.NotNull(match, "match");
+            Requires.NotNull(match, nameof(match));
             return _root.Find(match);
         }
 
@@ -742,7 +742,7 @@ namespace System.Collections.Immutable
         /// </returns>
         public ImmutableList<T> FindAll(Predicate<T> match)
         {
-            Requires.NotNull(match, "match");
+            Requires.NotNull(match, nameof(match));
             return _root.FindAll(match);
         }
 
@@ -761,7 +761,7 @@ namespace System.Collections.Immutable
         /// </returns>
         public int FindIndex(Predicate<T> match)
         {
-            Requires.NotNull(match, "match");
+            Requires.NotNull(match, nameof(match));
             return _root.FindIndex(match);
         }
 
@@ -779,9 +779,9 @@ namespace System.Collections.Immutable
         /// </returns>
         public int FindIndex(int startIndex, Predicate<T> match)
         {
-            Requires.NotNull(match, "match");
-            Requires.Range(startIndex >= 0, "startIndex");
-            Requires.Range(startIndex <= this.Count, "startIndex");
+            Requires.NotNull(match, nameof(match));
+            Requires.Range(startIndex >= 0, nameof(startIndex));
+            Requires.Range(startIndex <= this.Count, nameof(startIndex));
             return _root.FindIndex(startIndex, match);
         }
 
@@ -800,10 +800,10 @@ namespace System.Collections.Immutable
         /// </returns>
         public int FindIndex(int startIndex, int count, Predicate<T> match)
         {
-            Requires.NotNull(match, "match");
-            Requires.Range(startIndex >= 0, "startIndex");
-            Requires.Range(count >= 0, "count");
-            Requires.Range(startIndex + count <= this.Count, "count");
+            Requires.NotNull(match, nameof(match));
+            Requires.Range(startIndex >= 0, nameof(startIndex));
+            Requires.Range(count >= 0, nameof(count));
+            Requires.Range(startIndex + count <= this.Count, nameof(count));
 
             return _root.FindIndex(startIndex, count, match);
         }
@@ -822,7 +822,7 @@ namespace System.Collections.Immutable
         /// </returns>
         public T FindLast(Predicate<T> match)
         {
-            Requires.NotNull(match, "match");
+            Requires.NotNull(match, nameof(match));
             return _root.FindLast(match);
         }
 
@@ -841,7 +841,7 @@ namespace System.Collections.Immutable
         /// </returns>
         public int FindLastIndex(Predicate<T> match)
         {
-            Requires.NotNull(match, "match");
+            Requires.NotNull(match, nameof(match));
             return _root.FindLastIndex(match);
         }
 
@@ -860,9 +860,9 @@ namespace System.Collections.Immutable
         /// </returns>
         public int FindLastIndex(int startIndex, Predicate<T> match)
         {
-            Requires.NotNull(match, "match");
-            Requires.Range(startIndex >= 0, "startIndex");
-            Requires.Range(startIndex == 0 || startIndex < this.Count, "startIndex");
+            Requires.NotNull(match, nameof(match));
+            Requires.Range(startIndex >= 0, nameof(startIndex));
+            Requires.Range(startIndex == 0 || startIndex < this.Count, nameof(startIndex));
             return _root.FindLastIndex(startIndex, match);
         }
 
@@ -884,10 +884,10 @@ namespace System.Collections.Immutable
         /// </returns>
         public int FindLastIndex(int startIndex, int count, Predicate<T> match)
         {
-            Requires.NotNull(match, "match");
-            Requires.Range(startIndex >= 0, "startIndex");
-            Requires.Range(count <= this.Count, "count");
-            Requires.Range(startIndex - count + 1 >= 0, "startIndex");
+            Requires.NotNull(match, nameof(match));
+            Requires.Range(startIndex >= 0, nameof(startIndex));
+            Requires.Range(count <= this.Count, nameof(count));
+            Requires.Range(startIndex - count + 1 >= 0, nameof(startIndex));
 
             return _root.FindLastIndex(startIndex, count, match);
         }
@@ -963,7 +963,7 @@ namespace System.Collections.Immutable
         /// </returns>
         public bool TrueForAll(Predicate<T> match)
         {
-            Requires.NotNull(match, "match");
+            Requires.NotNull(match, nameof(match));
             return _root.TrueForAll(match);
         }
 
@@ -1576,9 +1576,9 @@ namespace System.Collections.Immutable
             /// <param name="reversed"><c>true</c> if the list should be enumerated in reverse order.</param>
             internal Enumerator(Node root, Builder builder = null, int startIndex = -1, int count = -1, bool reversed = false)
             {
-                Requires.NotNull(root, "root");
-                Requires.Range(startIndex >= -1, "startIndex");
-                Requires.Range(count >= -1, "count");
+                Requires.NotNull(root, nameof(root));
+                Requires.Range(startIndex >= -1, nameof(startIndex));
+                Requires.Range(count >= -1, nameof(count));
                 Requires.Argument(reversed || count == -1 || (startIndex == -1 ? 0 : startIndex) + count <= root.Count);
                 Requires.Argument(!reversed || count == -1 || (startIndex == -1 ? root.Count - 1 : startIndex) - count + 1 >= 0);
 
@@ -1774,7 +1774,7 @@ namespace System.Collections.Immutable
             /// <param name="node">The starting node to push onto the stack.</param>
             private void PushNext(Node node)
             {
-                Requires.NotNull(node, "node");
+                Requires.NotNull(node, nameof(node));
                 if (!node.IsEmpty)
                 {
                     var stack = _stack.Use(ref this);
@@ -1858,8 +1858,8 @@ namespace System.Collections.Immutable
             /// <param name="frozen">Whether this node is prefrozen.</param>
             private Node(T key, Node left, Node right, bool frozen = false)
             {
-                Requires.NotNull(left, "left");
-                Requires.NotNull(right, "right");
+                Requires.NotNull(left, nameof(left));
+                Requires.NotNull(right, nameof(right));
                 Debug.Assert(!frozen || (left._frozen && right._frozen));
                 Contract.Ensures(!this.IsEmpty);
 
@@ -1973,7 +1973,7 @@ namespace System.Collections.Immutable
             {
                 get
                 {
-                    Requires.Range(index >= 0 && index < this.Count, "index");
+                    Requires.Range(index >= 0 && index < this.Count, nameof(index));
 
                     if (index < _left._count)
                     {
@@ -2050,9 +2050,9 @@ namespace System.Collections.Immutable
             [Pure]
             internal static Node NodeTreeFromList(IOrderedCollection<T> items, int start, int length)
             {
-                Requires.NotNull(items, "items");
-                Requires.Range(start >= 0, "start");
-                Requires.Range(length >= 0, "length");
+                Requires.NotNull(items, nameof(items));
+                Requires.Range(start >= 0, nameof(start));
+                Requires.Range(length >= 0, nameof(length));
 
                 if (length == 0)
                 {
@@ -2084,7 +2084,7 @@ namespace System.Collections.Immutable
             /// <returns>The new tree.</returns>
             internal Node Insert(int index, T key)
             {
-                Requires.Range(index >= 0 && index <= this.Count, "index");
+                Requires.Range(index >= 0 && index <= this.Count, nameof(index));
 
                 if (this.IsEmpty)
                 {
@@ -2126,8 +2126,8 @@ namespace System.Collections.Immutable
             /// <returns>The new tree.</returns>
             internal Node InsertRange(int index, IEnumerable<T> keys)
             {
-                Requires.Range(index >= 0 && index <= this.Count, "index");
-                Requires.NotNull(keys, "keys");
+                Requires.Range(index >= 0 && index <= this.Count, nameof(index));
+                Requires.NotNull(keys, nameof(keys));
 
                 if (this.IsEmpty)
                 {
@@ -2165,7 +2165,7 @@ namespace System.Collections.Immutable
             /// <returns>The new tree.</returns>
             internal Node RemoveAt(int index)
             {
-                Requires.Range(index >= 0 && index < this.Count, "index");
+                Requires.Range(index >= 0 && index < this.Count, nameof(index));
 
                 Node result = this;
                 if (index == _left._count)
@@ -2226,7 +2226,7 @@ namespace System.Collections.Immutable
             /// </returns>
             internal Node RemoveAll(Predicate<T> match)
             {
-                Requires.NotNull(match, "match");
+                Requires.NotNull(match, nameof(match));
                 Contract.Ensures(Contract.Result<Node>() != null);
 
                 var result = this;
@@ -2254,7 +2254,7 @@ namespace System.Collections.Immutable
             /// <returns>The new tree.</returns>
             internal Node ReplaceAt(int index, T value)
             {
-                Requires.Range(index >= 0 && index < this.Count, "index");
+                Requires.Range(index >= 0 && index < this.Count, nameof(index));
 
                 Node result = this;
                 if (index == _left._count)
@@ -2294,9 +2294,9 @@ namespace System.Collections.Immutable
             /// <returns>The reversed list.</returns>
             internal Node Reverse(int index, int count)
             {
-                Requires.Range(index >= 0, "index");
-                Requires.Range(count >= 0, "count");
-                Requires.Range(index + count <= this.Count, "index");
+                Requires.Range(index >= 0, nameof(index));
+                Requires.Range(count >= 0, nameof(count));
+                Requires.Range(index + count <= this.Count, nameof(index));
 
                 Node result = this;
                 int start = index;
@@ -2335,7 +2335,7 @@ namespace System.Collections.Immutable
             /// <returns>The sorted list.</returns>
             internal Node Sort(Comparison<T> comparison)
             {
-                Requires.NotNull(comparison, "comparison");
+                Requires.NotNull(comparison, nameof(comparison));
                 Contract.Ensures(Contract.Result<Node>() != null);
 
                 // PERF: Eventually this might be reimplemented in a way that does not require allocating an array.
@@ -2377,8 +2377,8 @@ namespace System.Collections.Immutable
             /// <returns>The sorted list.</returns>
             internal Node Sort(int index, int count, IComparer<T> comparer)
             {
-                Requires.Range(index >= 0, "index");
-                Requires.Range(count >= 0, "count");
+                Requires.Range(index >= 0, nameof(index));
+                Requires.Range(count >= 0, nameof(count));
                 Requires.Argument(index + count <= this.Count);
 
                 // PERF: Eventually this might be reimplemented in a way that does not require allocating an array.
@@ -2419,8 +2419,8 @@ namespace System.Collections.Immutable
             /// </exception>
             internal int BinarySearch(int index, int count, T item, IComparer<T> comparer)
             {
-                Requires.Range(index >= 0, "index");
-                Requires.Range(count >= 0, "count");
+                Requires.Range(index >= 0, nameof(index));
+                Requires.Range(count >= 0, nameof(count));
                 comparer = comparer ?? Comparer<T>.Default;
 
                 if (this.IsEmpty || count <= 0)
@@ -2519,10 +2519,10 @@ namespace System.Collections.Immutable
             [Pure]
             internal int IndexOf(T item, int index, int count, IEqualityComparer<T> equalityComparer)
             {
-                Requires.Range(index >= 0, "index");
-                Requires.Range(count >= 0, "count");
-                Requires.Range(count <= this.Count, "count");
-                Requires.Range(index + count <= this.Count, "count");
+                Requires.Range(index >= 0, nameof(index));
+                Requires.Range(count >= 0, nameof(count));
+                Requires.Range(count <= this.Count, nameof(count));
+                Requires.Range(index + count <= this.Count, nameof(count));
 
                 equalityComparer = equalityComparer ?? EqualityComparer<T>.Default;
                 using (var enumerator = new Enumerator(this, startIndex: index, count: count))
@@ -2562,8 +2562,8 @@ namespace System.Collections.Immutable
             [Pure]
             internal int LastIndexOf(T item, int index, int count, IEqualityComparer<T> equalityComparer)
             {
-                Requires.Range(index >= 0, "index");
-                Requires.Range(count >= 0 && count <= this.Count, "count");
+                Requires.Range(index >= 0, nameof(index));
+                Requires.Range(count >= 0 && count <= this.Count, nameof(count));
                 Requires.Argument(index - count + 1 >= 0);
 
                 equalityComparer = equalityComparer ?? EqualityComparer<T>.Default;
@@ -2594,7 +2594,7 @@ namespace System.Collections.Immutable
             /// </param>
             internal void CopyTo(T[] array)
             {
-                Requires.NotNull(array, "array");
+                Requires.NotNull(array, nameof(array));
                 Requires.Argument(array.Length >= this.Count);
 
                 int index = 0;
@@ -2618,9 +2618,9 @@ namespace System.Collections.Immutable
             /// </param>
             internal void CopyTo(T[] array, int arrayIndex)
             {
-                Requires.NotNull(array, "array");
-                Requires.Range(arrayIndex >= 0, "arrayIndex");
-                Requires.Range(arrayIndex <= array.Length, "arrayIndex");
+                Requires.NotNull(array, nameof(array));
+                Requires.Range(arrayIndex >= 0, nameof(arrayIndex));
+                Requires.Range(arrayIndex <= array.Length, nameof(arrayIndex));
                 Requires.Argument(arrayIndex + this.Count <= array.Length);
 
                 foreach (var element in this)
@@ -2647,12 +2647,12 @@ namespace System.Collections.Immutable
             /// <param name="count">The number of elements to copy.</param>
             internal void CopyTo(int index, T[] array, int arrayIndex, int count)
             {
-                Requires.NotNull(array, "array");
-                Requires.Range(index >= 0, "index");
-                Requires.Range(count >= 0, "count");
-                Requires.Range(index + count <= this.Count, "count");
-                Requires.Range(arrayIndex >= 0, "arrayIndex");
-                Requires.Range(arrayIndex + count <= array.Length, "arrayIndex");
+                Requires.NotNull(array, nameof(array));
+                Requires.Range(index >= 0, nameof(index));
+                Requires.Range(count >= 0, nameof(count));
+                Requires.Range(index + count <= this.Count, nameof(count));
+                Requires.Range(arrayIndex >= 0, nameof(arrayIndex));
+                Requires.Range(arrayIndex + count <= array.Length, nameof(arrayIndex));
 
                 using (var enumerator = new Enumerator(this, startIndex: index, count: count))
                 {
@@ -2670,9 +2670,9 @@ namespace System.Collections.Immutable
             /// <param name="arrayIndex">The zero-based index in <paramref name="array"/> at which copying begins.</param>
             internal void CopyTo(Array array, int arrayIndex)
             {
-                Requires.NotNull(array, "array");
-                Requires.Range(arrayIndex >= 0, "arrayIndex");
-                Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
+                Requires.NotNull(array, nameof(array));
+                Requires.Range(arrayIndex >= 0, nameof(arrayIndex));
+                Requires.Range(array.Length >= arrayIndex + this.Count, nameof(arrayIndex));
 
                 foreach (var element in this)
                 {
@@ -2747,7 +2747,7 @@ namespace System.Collections.Immutable
             /// </returns>
             internal bool Exists(Predicate<T> match)
             {
-                Requires.NotNull(match, "match");
+                Requires.NotNull(match, nameof(match));
 
                 foreach (T item in this)
                 {
@@ -2774,7 +2774,7 @@ namespace System.Collections.Immutable
             /// </returns>
             internal T Find(Predicate<T> match)
             {
-                Requires.NotNull(match, "match");
+                Requires.NotNull(match, nameof(match));
 
                 foreach (var item in this)
                 {
@@ -2802,7 +2802,7 @@ namespace System.Collections.Immutable
             /// </returns>
             internal ImmutableList<T> FindAll(Predicate<T> match)
             {
-                Requires.NotNull(match, "match");
+                Requires.NotNull(match, nameof(match));
                 Contract.Ensures(Contract.Result<ImmutableList<T>>() != null);
 
                 if (this.IsEmpty)
@@ -2844,7 +2844,7 @@ namespace System.Collections.Immutable
             /// </returns>
             internal int FindIndex(Predicate<T> match)
             {
-                Requires.NotNull(match, "match");
+                Requires.NotNull(match, nameof(match));
                 Contract.Ensures(Contract.Result<int>() >= -1);
 
                 return this.FindIndex(0, _count, match);
@@ -2864,9 +2864,9 @@ namespace System.Collections.Immutable
             /// </returns>
             internal int FindIndex(int startIndex, Predicate<T> match)
             {
-                Requires.Range(startIndex >= 0, "startIndex");
-                Requires.Range(startIndex <= this.Count, "startIndex");
-                Requires.NotNull(match, "match");
+                Requires.Range(startIndex >= 0, nameof(startIndex));
+                Requires.Range(startIndex <= this.Count, nameof(startIndex));
+                Requires.NotNull(match, nameof(match));
 
                 return this.FindIndex(startIndex, this.Count - startIndex, match);
             }
@@ -2886,10 +2886,10 @@ namespace System.Collections.Immutable
             /// </returns>
             internal int FindIndex(int startIndex, int count, Predicate<T> match)
             {
-                Requires.Range(startIndex >= 0, "startIndex");
-                Requires.Range(count >= 0, "count");
+                Requires.Range(startIndex >= 0, nameof(startIndex));
+                Requires.Range(count >= 0, nameof(count));
                 Requires.Argument(startIndex + count <= this.Count);
-                Requires.NotNull(match, "match");
+                Requires.NotNull(match, nameof(match));
 
                 using (var enumerator = new Enumerator(this, startIndex: startIndex, count: count))
                 {
@@ -2922,7 +2922,7 @@ namespace System.Collections.Immutable
             /// </returns>
             internal T FindLast(Predicate<T> match)
             {
-                Requires.NotNull(match, "match");
+                Requires.NotNull(match, nameof(match));
 
                 using (var enumerator = new Enumerator(this, reversed: true))
                 {
@@ -2953,7 +2953,7 @@ namespace System.Collections.Immutable
             /// </returns>
             internal int FindLastIndex(Predicate<T> match)
             {
-                Requires.NotNull(match, "match");
+                Requires.NotNull(match, nameof(match));
                 Contract.Ensures(Contract.Result<int>() >= -1);
 
                 if (this.IsEmpty)
@@ -2979,9 +2979,9 @@ namespace System.Collections.Immutable
             /// </returns>
             internal int FindLastIndex(int startIndex, Predicate<T> match)
             {
-                Requires.NotNull(match, "match");
-                Requires.Range(startIndex >= 0, "startIndex");
-                Requires.Range(startIndex == 0 || startIndex < this.Count, "startIndex");
+                Requires.NotNull(match, nameof(match));
+                Requires.Range(startIndex >= 0, nameof(startIndex));
+                Requires.Range(startIndex == 0 || startIndex < this.Count, nameof(startIndex));
 
                 if (this.IsEmpty)
                 {
@@ -3009,9 +3009,9 @@ namespace System.Collections.Immutable
             /// </returns>
             internal int FindLastIndex(int startIndex, int count, Predicate<T> match)
             {
-                Requires.NotNull(match, "match");
-                Requires.Range(startIndex >= 0, "startIndex");
-                Requires.Range(count <= this.Count, "count");
+                Requires.NotNull(match, nameof(match));
+                Requires.Range(startIndex >= 0, nameof(startIndex));
+                Requires.Range(count <= this.Count, nameof(count));
                 Requires.Argument(startIndex - count + 1 >= 0);
 
                 using (var enumerator = new Enumerator(this, startIndex: startIndex, count: count, reversed: true))
@@ -3054,7 +3054,7 @@ namespace System.Collections.Immutable
             /// <returns>The rotated tree.</returns>
             private static Node RotateLeft(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
                 Contract.Ensures(Contract.Result<Node>() != null);
 
@@ -3074,7 +3074,7 @@ namespace System.Collections.Immutable
             /// <returns>The rotated tree.</returns>
             private static Node RotateRight(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
                 Contract.Ensures(Contract.Result<Node>() != null);
 
@@ -3094,7 +3094,7 @@ namespace System.Collections.Immutable
             /// <returns>The rotated tree.</returns>
             private static Node DoubleLeft(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
                 Contract.Ensures(Contract.Result<Node>() != null);
 
@@ -3114,7 +3114,7 @@ namespace System.Collections.Immutable
             /// <returns>The rotated tree.</returns>
             private static Node DoubleRight(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
                 Contract.Ensures(Contract.Result<Node>() != null);
 
@@ -3135,7 +3135,7 @@ namespace System.Collections.Immutable
             [Pure]
             private static int Balance(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
 
                 return tree._right._height - tree._left._height;
@@ -3151,7 +3151,7 @@ namespace System.Collections.Immutable
             [Pure]
             private static bool IsRightHeavy(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
                 return Balance(tree) >= 2;
             }
@@ -3162,7 +3162,7 @@ namespace System.Collections.Immutable
             [Pure]
             private static bool IsLeftHeavy(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
                 return Balance(tree) <= -2;
             }
@@ -3175,7 +3175,7 @@ namespace System.Collections.Immutable
             [Pure]
             private static Node MakeBalanced(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
                 Contract.Ensures(Contract.Result<Node>() != null);
 
@@ -3292,7 +3292,7 @@ namespace System.Collections.Immutable
         /// <param name="list">The list to display in the debugger</param>
         public ImmutableListDebuggerProxy(ImmutableList<T> list)
         {
-            Requires.NotNull(list, "list");
+            Requires.NotNull(list, nameof(list));
             _list = list;
         }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue.cs
@@ -46,7 +46,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static ImmutableQueue<T> CreateRange<T>(IEnumerable<T> items)
         {
-            Requires.NotNull(items, "items");
+            Requires.NotNull(items, nameof(items));
 
             var queue = ImmutableQueue<T>.Empty;
             foreach (var item in items)
@@ -66,7 +66,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static ImmutableQueue<T> Create<T>(params T[] items)
         {
-            Requires.NotNull(items, "items");
+            Requires.NotNull(items, nameof(items));
 
             var queue = ImmutableQueue<T>.Empty;
             foreach (var item in items)
@@ -89,7 +89,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static IImmutableQueue<T> Dequeue<T>(this IImmutableQueue<T> queue, out T value)
         {
-            Requires.NotNull(queue, "queue");
+            Requires.NotNull(queue, nameof(queue));
 
             value = queue.Peek();
             return queue.Dequeue();

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableQueue`1.cs
@@ -52,8 +52,8 @@ namespace System.Collections.Immutable
         /// <param name="backward">The backward stack.</param>
         private ImmutableQueue(ImmutableStack<T> forward, ImmutableStack<T> backward)
         {
-            Requires.NotNull(forward, "forward");
-            Requires.NotNull(backward, "backward");
+            Requires.NotNull(forward, nameof(forward));
+            Requires.NotNull(backward, nameof(backward));
 
             _forwards = forward;
             _backwards = backward;

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary.cs
@@ -153,9 +153,9 @@ namespace System.Collections.Immutable
         [Pure]
         public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TSource, TKey, TValue>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TValue> elementSelector, IComparer<TKey> keyComparer, IEqualityComparer<TValue> valueComparer)
         {
-            Requires.NotNull(source, "source");
-            Requires.NotNull(keySelector, "keySelector");
-            Requires.NotNull(elementSelector, "elementSelector");
+            Requires.NotNull(source, nameof(source));
+            Requires.NotNull(keySelector, nameof(keySelector));
+            Requires.NotNull(elementSelector, nameof(elementSelector));
             Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             return ImmutableSortedDictionary<TKey, TValue>.Empty.WithComparers(keyComparer, valueComparer)
@@ -208,7 +208,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static ImmutableSortedDictionary<TKey, TValue> ToImmutableSortedDictionary<TKey, TValue>(this IEnumerable<KeyValuePair<TKey, TValue>> source, IComparer<TKey> keyComparer, IEqualityComparer<TValue> valueComparer)
         {
-            Requires.NotNull(source, "source");
+            Requires.NotNull(source, nameof(source));
             Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             var existingDictionary = source as ImmutableSortedDictionary<TKey, TValue>;

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2+Builder.cs
@@ -75,7 +75,7 @@ namespace System.Collections.Immutable
             /// <param name="map">A map to act as the basis for a new map.</param>
             internal Builder(ImmutableSortedDictionary<TKey, TValue> map)
             {
-                Requires.NotNull(map, "map");
+                Requires.NotNull(map, nameof(map));
                 _root = map._root;
                 _keyComparer = map.KeyComparer;
                 _valueComparer = map.ValueComparer;
@@ -294,7 +294,7 @@ namespace System.Collections.Immutable
 
                 set
                 {
-                    Requires.NotNull(value, "value");
+                    Requires.NotNull(value, nameof(value));
                     if (value != _keyComparer)
                     {
                         var newRoot = Node.EmptyNode;
@@ -331,7 +331,7 @@ namespace System.Collections.Immutable
 
                 set
                 {
-                    Requires.NotNull(value, "value");
+                    Requires.NotNull(value, nameof(value));
                     if (value != _valueComparer)
                     {
                         // When the key comparer is the same but the value comparer is different, we don't need a whole new tree
@@ -467,7 +467,7 @@ namespace System.Collections.Immutable
             /// </summary>
             public bool TryGetKey(TKey equalKey, out TKey actualKey)
             {
-                Requires.NotNullAllowStructs(equalKey, "equalKey");
+                Requires.NotNullAllowStructs(equalKey, nameof(equalKey));
                 return this.Root.TryGetKey(equalKey, _keyComparer, out actualKey);
             }
 
@@ -570,7 +570,7 @@ namespace System.Collections.Immutable
             [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures")]
             public void AddRange(IEnumerable<KeyValuePair<TKey, TValue>> items)
             {
-                Requires.NotNull(items, "items");
+                Requires.NotNull(items, nameof(items));
 
                 foreach (var pair in items)
                 {
@@ -584,7 +584,7 @@ namespace System.Collections.Immutable
             /// <param name="keys">The keys for entries to remove from the dictionary.</param>
             public void RemoveRange(IEnumerable<TKey> keys)
             {
-                Requires.NotNull(keys, "keys");
+                Requires.NotNull(keys, nameof(keys));
 
                 foreach (var key in keys)
                 {
@@ -614,7 +614,7 @@ namespace System.Collections.Immutable
             [Pure]
             public TValue GetValueOrDefault(TKey key, TValue defaultValue)
             {
-                Requires.NotNullAllowStructs(key, "key");
+                Requires.NotNullAllowStructs(key, nameof(key));
 
                 TValue value;
                 if (this.TryGetValue(key, out value))
@@ -669,7 +669,7 @@ namespace System.Collections.Immutable
         /// <param name="map">The collection to display in the debugger</param>
         public ImmutableSortedDictionaryBuilderDebuggerProxy(ImmutableSortedDictionary<TKey, TValue>.Builder map)
         {
-            Requires.NotNull(map, "map");
+            Requires.NotNull(map, nameof(map));
             _map = map;
         }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedDictionary`2.cs
@@ -68,10 +68,10 @@ namespace System.Collections.Immutable
         /// <param name="valueComparer">The value comparer.</param>
         private ImmutableSortedDictionary(Node root, int count, IComparer<TKey> keyComparer, IEqualityComparer<TValue> valueComparer)
         {
-            Requires.NotNull(root, "root");
-            Requires.Range(count >= 0, "count");
-            Requires.NotNull(keyComparer, "keyComparer");
-            Requires.NotNull(valueComparer, "valueComparer");
+            Requires.NotNull(root, nameof(root));
+            Requires.Range(count >= 0, nameof(count));
+            Requires.NotNull(keyComparer, nameof(keyComparer));
+            Requires.NotNull(valueComparer, nameof(valueComparer));
 
             root.Freeze();
             _root = root;
@@ -201,7 +201,7 @@ namespace System.Collections.Immutable
         {
             get
             {
-                Requires.NotNullAllowStructs(key, "key");
+                Requires.NotNullAllowStructs(key, nameof(key));
 
                 TValue value;
                 if (this.TryGetValue(key, out value))
@@ -250,7 +250,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableSortedDictionary<TKey, TValue> Add(TKey key, TValue value)
         {
-            Requires.NotNullAllowStructs(key, "key");
+            Requires.NotNullAllowStructs(key, nameof(key));
             Contract.Ensures(Contract.Result<ImmutableSortedDictionary<TKey, TValue>>() != null);
             bool mutated;
             var result = _root.Add(key, value, _keyComparer, _valueComparer, out mutated);
@@ -263,7 +263,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableSortedDictionary<TKey, TValue> SetItem(TKey key, TValue value)
         {
-            Requires.NotNullAllowStructs(key, "key");
+            Requires.NotNullAllowStructs(key, nameof(key));
             Contract.Ensures(Contract.Result<ImmutableSortedDictionary<TKey, TValue>>() != null);
             Contract.Ensures(!Contract.Result<ImmutableSortedDictionary<TKey, TValue>>().IsEmpty);
             bool replacedExistingValue, mutated;
@@ -280,7 +280,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableSortedDictionary<TKey, TValue> SetItems(IEnumerable<KeyValuePair<TKey, TValue>> items)
         {
-            Requires.NotNull(items, "items");
+            Requires.NotNull(items, nameof(items));
             Contract.Ensures(Contract.Result<ImmutableDictionary<TKey, TValue>>() != null);
 
             return this.AddRange(items, overwriteOnCollision: true, avoidToSortedMap: false);
@@ -293,7 +293,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableSortedDictionary<TKey, TValue> AddRange(IEnumerable<KeyValuePair<TKey, TValue>> items)
         {
-            Requires.NotNull(items, "items");
+            Requires.NotNull(items, nameof(items));
             Contract.Ensures(Contract.Result<ImmutableSortedDictionary<TKey, TValue>>() != null);
 
             return this.AddRange(items, overwriteOnCollision: false, avoidToSortedMap: false);
@@ -305,7 +305,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableSortedDictionary<TKey, TValue> Remove(TKey value)
         {
-            Requires.NotNullAllowStructs(value, "value");
+            Requires.NotNullAllowStructs(value, nameof(value));
             Contract.Ensures(Contract.Result<ImmutableSortedDictionary<TKey, TValue>>() != null);
             bool mutated;
             var result = _root.Remove(value, _keyComparer, out mutated);
@@ -318,7 +318,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableSortedDictionary<TKey, TValue> RemoveRange(IEnumerable<TKey> keys)
         {
-            Requires.NotNull(keys, "keys");
+            Requires.NotNull(keys, nameof(keys));
             Contract.Ensures(Contract.Result<ImmutableSortedDictionary<TKey, TValue>>() != null);
 
             var result = _root;
@@ -469,7 +469,7 @@ namespace System.Collections.Immutable
         /// </summary>
         public bool ContainsKey(TKey key)
         {
-            Requires.NotNullAllowStructs(key, "key");
+            Requires.NotNullAllowStructs(key, nameof(key));
             return _root.ContainsKey(key, _keyComparer);
         }
 
@@ -486,7 +486,7 @@ namespace System.Collections.Immutable
         /// </summary>
         public bool TryGetValue(TKey key, out TValue value)
         {
-            Requires.NotNullAllowStructs(key, "key");
+            Requires.NotNullAllowStructs(key, nameof(key));
             return _root.TryGetValue(key, _keyComparer, out value);
         }
 
@@ -495,7 +495,7 @@ namespace System.Collections.Immutable
         /// </summary>
         public bool TryGetKey(TKey equalKey, out TKey actualKey)
         {
-            Requires.NotNullAllowStructs(equalKey, "equalKey");
+            Requires.NotNullAllowStructs(equalKey, nameof(equalKey));
             return _root.TryGetKey(equalKey, _keyComparer, out actualKey);
         }
 
@@ -559,9 +559,9 @@ namespace System.Collections.Immutable
 
         void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
         {
-            Requires.NotNull(array, "array");
-            Requires.Range(arrayIndex >= 0, "arrayIndex");
-            Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
+            Requires.NotNull(array, nameof(array));
+            Requires.Range(arrayIndex >= 0, nameof(arrayIndex));
+            Requires.Range(array.Length >= arrayIndex + this.Count, nameof(arrayIndex));
 
             foreach (var item in this)
             {
@@ -817,7 +817,7 @@ namespace System.Collections.Immutable
         [Pure]
         private ImmutableSortedDictionary<TKey, TValue> AddRange(IEnumerable<KeyValuePair<TKey, TValue>> items, bool overwriteOnCollision, bool avoidToSortedMap)
         {
-            Requires.NotNull(items, "items");
+            Requires.NotNull(items, nameof(items));
             Contract.Ensures(Contract.Result<ImmutableSortedDictionary<TKey, TValue>>() != null);
 
             // Some optimizations may apply if we're an empty set.
@@ -876,7 +876,7 @@ namespace System.Collections.Immutable
         private ImmutableSortedDictionary<TKey, TValue> FillFromEmpty(IEnumerable<KeyValuePair<TKey, TValue>> items, bool overwriteOnCollision)
         {
             Debug.Assert(this.IsEmpty);
-            Requires.NotNull(items, "items");
+            Requires.NotNull(items, nameof(items));
 
             // If the items being added actually come from an ImmutableSortedSet<T>,
             // and the sort order is equivalent, then there is no value in reconstructing it.
@@ -991,7 +991,7 @@ namespace System.Collections.Immutable
             /// <param name="builder">The builder, if applicable.</param>
             internal Enumerator(Node root, Builder builder = null)
             {
-                Requires.NotNull(root, "root");
+                Requires.NotNull(root, nameof(root));
 
                 _root = root;
                 _builder = builder;
@@ -1135,7 +1135,7 @@ namespace System.Collections.Immutable
             /// <param name="node">The starting node to push onto the stack.</param>
             private void PushLeft(Node node)
             {
-                Requires.NotNull(node, "node");
+                Requires.NotNull(node, nameof(node));
                 var stack = _stack.Use(ref this);
                 while (!node.IsEmpty)
                 {
@@ -1215,9 +1215,9 @@ namespace System.Collections.Immutable
             /// <param name="frozen">Whether this node is prefrozen.</param>
             private Node(TKey key, TValue value, Node left, Node right, bool frozen = false)
             {
-                Requires.NotNullAllowStructs(key, "key");
-                Requires.NotNull(left, "left");
-                Requires.NotNull(right, "right");
+                Requires.NotNullAllowStructs(key, nameof(key));
+                Requires.NotNull(left, nameof(left));
+                Requires.NotNull(right, nameof(right));
                 Debug.Assert(!frozen || (left._frozen && right._frozen));
                 Contract.Ensures(!this.IsEmpty);
                 Contract.Ensures(_key != null);
@@ -1380,9 +1380,9 @@ namespace System.Collections.Immutable
             /// </summary>
             internal void CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex, int dictionarySize)
             {
-                Requires.NotNull(array, "array");
-                Requires.Range(arrayIndex >= 0, "arrayIndex");
-                Requires.Range(array.Length >= arrayIndex + dictionarySize, "arrayIndex");
+                Requires.NotNull(array, nameof(array));
+                Requires.Range(arrayIndex >= 0, nameof(arrayIndex));
+                Requires.Range(array.Length >= arrayIndex + dictionarySize, nameof(arrayIndex));
 
                 foreach (var item in this)
                 {
@@ -1395,9 +1395,9 @@ namespace System.Collections.Immutable
             /// </summary>
             internal void CopyTo(Array array, int arrayIndex, int dictionarySize)
             {
-                Requires.NotNull(array, "array");
-                Requires.Range(arrayIndex >= 0, "arrayIndex");
-                Requires.Range(array.Length >= arrayIndex + dictionarySize, "arrayIndex");
+                Requires.NotNull(array, nameof(array));
+                Requires.Range(arrayIndex >= 0, nameof(arrayIndex));
+                Requires.Range(array.Length >= arrayIndex + dictionarySize, nameof(arrayIndex));
 
                 foreach (var item in this)
                 {
@@ -1413,7 +1413,7 @@ namespace System.Collections.Immutable
             [Pure]
             internal static Node NodeTreeFromSortedDictionary(SortedDictionary<TKey, TValue> dictionary)
             {
-                Requires.NotNull(dictionary, "dictionary");
+                Requires.NotNull(dictionary, nameof(dictionary));
                 Contract.Ensures(Contract.Result<Node>() != null);
 
                 var list = dictionary.AsOrderedCollection();
@@ -1430,9 +1430,9 @@ namespace System.Collections.Immutable
             /// <param name="mutated">Receives a value indicating whether this node tree has mutated because of this operation.</param>
             internal Node Add(TKey key, TValue value, IComparer<TKey> keyComparer, IEqualityComparer<TValue> valueComparer, out bool mutated)
             {
-                Requires.NotNullAllowStructs(key, "key");
-                Requires.NotNull(keyComparer, "keyComparer");
-                Requires.NotNull(valueComparer, "valueComparer");
+                Requires.NotNullAllowStructs(key, nameof(key));
+                Requires.NotNull(keyComparer, nameof(keyComparer));
+                Requires.NotNull(valueComparer, nameof(valueComparer));
 
                 bool dummy;
                 return this.SetOrAdd(key, value, keyComparer, valueComparer, false, out dummy, out mutated);
@@ -1449,9 +1449,9 @@ namespace System.Collections.Immutable
             /// <param name="mutated">Receives a value indicating whether this node tree has mutated because of this operation.</param>
             internal Node SetItem(TKey key, TValue value, IComparer<TKey> keyComparer, IEqualityComparer<TValue> valueComparer, out bool replacedExistingValue, out bool mutated)
             {
-                Requires.NotNullAllowStructs(key, "key");
-                Requires.NotNull(keyComparer, "keyComparer");
-                Requires.NotNull(valueComparer, "valueComparer");
+                Requires.NotNullAllowStructs(key, nameof(key));
+                Requires.NotNull(keyComparer, nameof(keyComparer));
+                Requires.NotNull(valueComparer, nameof(valueComparer));
 
                 return this.SetOrAdd(key, value, keyComparer, valueComparer, true, out replacedExistingValue, out mutated);
             }
@@ -1465,8 +1465,8 @@ namespace System.Collections.Immutable
             /// <returns>The new AVL tree.</returns>
             internal Node Remove(TKey key, IComparer<TKey> keyComparer, out bool mutated)
             {
-                Requires.NotNullAllowStructs(key, "key");
-                Requires.NotNull(keyComparer, "keyComparer");
+                Requires.NotNullAllowStructs(key, nameof(key));
+                Requires.NotNull(keyComparer, nameof(keyComparer));
 
                 return this.RemoveRecursive(key, keyComparer, out mutated);
             }
@@ -1480,8 +1480,8 @@ namespace System.Collections.Immutable
             [Pure]
             internal TValue GetValueOrDefault(TKey key, IComparer<TKey> keyComparer)
             {
-                Requires.NotNullAllowStructs(key, "key");
-                Requires.NotNull(keyComparer, "keyComparer");
+                Requires.NotNullAllowStructs(key, nameof(key));
+                Requires.NotNull(keyComparer, nameof(keyComparer));
 
                 var match = this.Search(key, keyComparer);
                 return match.IsEmpty ? default(TValue) : match._value;
@@ -1497,8 +1497,8 @@ namespace System.Collections.Immutable
             [Pure]
             internal bool TryGetValue(TKey key, IComparer<TKey> keyComparer, out TValue value)
             {
-                Requires.NotNullAllowStructs(key, "key");
-                Requires.NotNull(keyComparer, "keyComparer");
+                Requires.NotNullAllowStructs(key, nameof(key));
+                Requires.NotNull(keyComparer, nameof(keyComparer));
 
                 var match = this.Search(key, keyComparer);
                 if (match.IsEmpty)
@@ -1529,8 +1529,8 @@ namespace System.Collections.Immutable
             [Pure]
             internal bool TryGetKey(TKey equalKey, IComparer<TKey> keyComparer, out TKey actualKey)
             {
-                Requires.NotNullAllowStructs(equalKey, "equalKey");
-                Requires.NotNull(keyComparer, "keyComparer");
+                Requires.NotNullAllowStructs(equalKey, nameof(equalKey));
+                Requires.NotNull(keyComparer, nameof(keyComparer));
 
                 var match = this.Search(equalKey, keyComparer);
                 if (match.IsEmpty)
@@ -1556,8 +1556,8 @@ namespace System.Collections.Immutable
             [Pure]
             internal bool ContainsKey(TKey key, IComparer<TKey> keyComparer)
             {
-                Requires.NotNullAllowStructs(key, "key");
-                Requires.NotNull(keyComparer, "keyComparer");
+                Requires.NotNullAllowStructs(key, nameof(key));
+                Requires.NotNull(keyComparer, nameof(keyComparer));
                 return !this.Search(key, keyComparer).IsEmpty;
             }
 
@@ -1577,7 +1577,7 @@ namespace System.Collections.Immutable
             [Pure]
             internal bool ContainsValue(TValue value, IEqualityComparer<TValue> valueComparer)
             {
-                Requires.NotNull(valueComparer, "valueComparer");
+                Requires.NotNull(valueComparer, nameof(valueComparer));
                 foreach (KeyValuePair<TKey, TValue> item in this)
                 {
                     if (valueComparer.Equals(value, item.Value))
@@ -1600,9 +1600,9 @@ namespace System.Collections.Immutable
             [Pure]
             internal bool Contains(KeyValuePair<TKey, TValue> pair, IComparer<TKey> keyComparer, IEqualityComparer<TValue> valueComparer)
             {
-                Requires.NotNullAllowStructs(pair.Key, "key");
-                Requires.NotNull(keyComparer, "keyComparer");
-                Requires.NotNull(valueComparer, "valueComparer");
+                Requires.NotNullAllowStructs(pair.Key, nameof(pair.Key));
+                Requires.NotNull(keyComparer, nameof(keyComparer));
+                Requires.NotNull(valueComparer, nameof(valueComparer));
 
                 var matchingNode = this.Search(pair.Key, keyComparer);
                 if (matchingNode.IsEmpty)
@@ -1641,7 +1641,7 @@ namespace System.Collections.Immutable
             /// <returns>The rotated tree.</returns>
             private static Node RotateLeft(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
                 Contract.Ensures(Contract.Result<Node>() != null);
 
@@ -1661,7 +1661,7 @@ namespace System.Collections.Immutable
             /// <returns>The rotated tree.</returns>
             private static Node RotateRight(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
                 Contract.Ensures(Contract.Result<Node>() != null);
 
@@ -1681,7 +1681,7 @@ namespace System.Collections.Immutable
             /// <returns>The rotated tree.</returns>
             private static Node DoubleLeft(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
                 Contract.Ensures(Contract.Result<Node>() != null);
 
@@ -1701,7 +1701,7 @@ namespace System.Collections.Immutable
             /// <returns>The rotated tree.</returns>
             private static Node DoubleRight(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
                 Contract.Ensures(Contract.Result<Node>() != null);
 
@@ -1722,7 +1722,7 @@ namespace System.Collections.Immutable
             [Pure]
             private static int Balance(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
 
                 return tree._right._height - tree._left._height;
@@ -1738,7 +1738,7 @@ namespace System.Collections.Immutable
             [Pure]
             private static bool IsRightHeavy(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
                 return Balance(tree) >= 2;
             }
@@ -1749,7 +1749,7 @@ namespace System.Collections.Immutable
             [Pure]
             private static bool IsLeftHeavy(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
                 return Balance(tree) <= -2;
             }
@@ -1762,7 +1762,7 @@ namespace System.Collections.Immutable
             [Pure]
             private static Node MakeBalanced(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
                 Contract.Ensures(Contract.Result<Node>() != null);
 
@@ -1791,9 +1791,9 @@ namespace System.Collections.Immutable
             [Pure]
             private static Node NodeTreeFromList(IOrderedCollection<KeyValuePair<TKey, TValue>> items, int start, int length)
             {
-                Requires.NotNull(items, "items");
-                Requires.Range(start >= 0, "start");
-                Requires.Range(length >= 0, "length");
+                Requires.NotNull(items, nameof(items));
+                Requires.Range(start >= 0, nameof(start));
+                Requires.Range(length >= 0, nameof(length));
                 Contract.Ensures(Contract.Result<Node>() != null);
 
                 if (length == 0)
@@ -2034,7 +2034,7 @@ namespace System.Collections.Immutable
         /// <param name="map">The collection to display in the debugger</param>
         public ImmutableSortedDictionaryDebuggerProxy(ImmutableSortedDictionary<TKey, TValue> map)
         {
-            Requires.NotNull(map, "map");
+            Requires.NotNull(map, nameof(map));
             _map = map;
         }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1+Builder.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1+Builder.cs
@@ -67,7 +67,7 @@ namespace System.Collections.Immutable
             /// <param name="set">A set to act as the basis for a new set.</param>
             internal Builder(ImmutableSortedSet<T> set)
             {
-                Requires.NotNull(set, "set");
+                Requires.NotNull(set, nameof(set));
                 _root = set._root;
                 _comparer = set.KeyComparer;
                 _immutable = set;
@@ -143,7 +143,7 @@ namespace System.Collections.Immutable
 
                 set
                 {
-                    Requires.NotNull(value, "value");
+                    Requires.NotNull(value, nameof(value));
 
                     if (value != _comparer)
                     {
@@ -217,7 +217,7 @@ namespace System.Collections.Immutable
             /// <param name="other">The collection of items to remove from the set.</param>
             public void ExceptWith(IEnumerable<T> other)
             {
-                Requires.NotNull(other, "other");
+                Requires.NotNull(other, nameof(other));
 
                 foreach (T item in other)
                 {
@@ -232,7 +232,7 @@ namespace System.Collections.Immutable
             /// <param name="other">The collection to compare to the current set.</param>
             public void IntersectWith(IEnumerable<T> other)
             {
-                Requires.NotNull(other, "other");
+                Requires.NotNull(other, nameof(other));
 
                 var result = ImmutableSortedSet<T>.Node.EmptyNode;
                 foreach (T item in other)
@@ -322,7 +322,7 @@ namespace System.Collections.Immutable
             /// <param name="other">The collection to compare to the current set.</param>
             public void UnionWith(IEnumerable<T> other)
             {
-                Requires.NotNull(other, "other");
+                Requires.NotNull(other, nameof(other));
 
                 foreach (T item in other)
                 {
@@ -507,7 +507,7 @@ namespace System.Collections.Immutable
         /// <param name="builder">The collection to display in the debugger</param>
         public ImmutableSortedSetBuilderDebuggerProxy(ImmutableSortedSet<T>.Builder builder)
         {
-            Requires.NotNull(builder, "builder");
+            Requires.NotNull(builder, nameof(builder));
             _set = builder;
         }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableSortedSet`1.cs
@@ -63,8 +63,8 @@ namespace System.Collections.Immutable
         /// <param name="comparer">The comparer.</param>
         private ImmutableSortedSet(Node root, IComparer<T> comparer)
         {
-            Requires.NotNull(root, "root");
-            Requires.NotNull(comparer, "comparer");
+            Requires.NotNull(root, nameof(root));
+            Requires.NotNull(comparer, nameof(comparer));
 
             root.Freeze();
             _root = root;
@@ -182,7 +182,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableSortedSet<T> Add(T value)
         {
-            Requires.NotNullAllowStructs(value, "value");
+            Requires.NotNullAllowStructs(value, nameof(value));
             Contract.Ensures(Contract.Result<ImmutableSortedSet<T>>() != null);
             bool mutated;
             return this.Wrap(_root.Add(value, _comparer, out mutated));
@@ -194,7 +194,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableSortedSet<T> Remove(T value)
         {
-            Requires.NotNullAllowStructs(value, "value");
+            Requires.NotNullAllowStructs(value, nameof(value));
             Contract.Ensures(Contract.Result<ImmutableSortedSet<T>>() != null);
             bool mutated;
             return this.Wrap(_root.Remove(value, _comparer, out mutated));
@@ -215,7 +215,7 @@ namespace System.Collections.Immutable
         [Pure]
         public bool TryGetValue(T equalValue, out T actualValue)
         {
-            Requires.NotNullAllowStructs(equalValue, "equalValue");
+            Requires.NotNullAllowStructs(equalValue, nameof(equalValue));
 
             Node searchResult = _root.Search(equalValue, _comparer);
             if (searchResult.IsEmpty)
@@ -236,7 +236,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableSortedSet<T> Intersect(IEnumerable<T> other)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
             Contract.Ensures(Contract.Result<ImmutableSortedSet<T>>() != null);
             var newSet = this.Clear();
             foreach (var item in other.GetEnumerableDisposable<T, Enumerator>())
@@ -256,7 +256,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableSortedSet<T> Except(IEnumerable<T> other)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             var result = _root;
             foreach (T item in other.GetEnumerableDisposable<T, Enumerator>())
@@ -276,7 +276,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableSortedSet<T> SymmetricExcept(IEnumerable<T> other)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             var otherAsSet = ImmutableSortedSet.CreateRange(_comparer, other);
 
@@ -306,7 +306,7 @@ namespace System.Collections.Immutable
         [Pure]
         public ImmutableSortedSet<T> Union(IEnumerable<T> other)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
             Contract.Ensures(Contract.Result<ImmutableSortedSet<T>>() != null);
 
             ImmutableSortedSet<T> immutableSortedSet;
@@ -374,7 +374,7 @@ namespace System.Collections.Immutable
         [Pure]
         public bool SetEquals(IEnumerable<T> other)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             if (object.ReferenceEquals(this, other))
             {
@@ -409,7 +409,7 @@ namespace System.Collections.Immutable
         [Pure]
         public bool IsProperSubsetOf(IEnumerable<T> other)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             if (this.IsEmpty)
             {
@@ -460,7 +460,7 @@ namespace System.Collections.Immutable
         [Pure]
         public bool IsProperSupersetOf(IEnumerable<T> other)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             if (this.IsEmpty)
             {
@@ -488,7 +488,7 @@ namespace System.Collections.Immutable
         [Pure]
         public bool IsSubsetOf(IEnumerable<T> other)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             if (this.IsEmpty)
             {
@@ -524,7 +524,7 @@ namespace System.Collections.Immutable
         [Pure]
         public bool IsSupersetOf(IEnumerable<T> other)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             foreach (T item in other.GetEnumerableDisposable<T, Enumerator>())
             {
@@ -545,7 +545,7 @@ namespace System.Collections.Immutable
         [Pure]
         public bool Overlaps(IEnumerable<T> other)
         {
-            Requires.NotNull(other, "other");
+            Requires.NotNull(other, nameof(other));
 
             if (this.IsEmpty)
             {
@@ -593,7 +593,7 @@ namespace System.Collections.Immutable
         /// </returns>
         public int IndexOf(T item)
         {
-            Requires.NotNullAllowStructs(item, "item");
+            Requires.NotNullAllowStructs(item, nameof(item));
             return _root.IndexOf(item, _comparer);
         }
 
@@ -606,7 +606,7 @@ namespace System.Collections.Immutable
         /// </summary>
         public bool Contains(T value)
         {
-            Requires.NotNullAllowStructs(value, "value");
+            Requires.NotNullAllowStructs(value, nameof(value));
             return _root.Contains(value, _comparer);
         }
 
@@ -1051,7 +1051,7 @@ namespace System.Collections.Immutable
         [Pure]
         private ImmutableSortedSet<T> UnionIncremental(IEnumerable<T> items)
         {
-            Requires.NotNull(items, "items");
+            Requires.NotNull(items, nameof(items));
             Contract.Ensures(Contract.Result<ImmutableSortedSet<T>>() != null);
 
             // Let's not implement in terms of ImmutableSortedSet.Add so that we're
@@ -1092,7 +1092,7 @@ namespace System.Collections.Immutable
         [Pure]
         private ImmutableSortedSet<T> LeafToRootRefill(IEnumerable<T> addedItems)
         {
-            Requires.NotNull(addedItems, "addedItems");
+            Requires.NotNull(addedItems, nameof(addedItems));
             Contract.Ensures(Contract.Result<ImmutableSortedSet<T>>() != null);
 
             // Rather than build up the immutable structure in the incremental way,
@@ -1228,7 +1228,7 @@ namespace System.Collections.Immutable
             /// <param name="reverse"><c>true</c> to enumerate the collection in reverse.</param>
             internal Enumerator(Node root, Builder builder = null, bool reverse = false)
             {
-                Requires.NotNull(root, "root");
+                Requires.NotNull(root, nameof(root));
 
                 _root = root;
                 _builder = builder;
@@ -1368,7 +1368,7 @@ namespace System.Collections.Immutable
             /// <param name="node">The starting node to push onto the stack.</param>
             private void PushNext(Node node)
             {
-                Requires.NotNull(node, "node");
+                Requires.NotNull(node, nameof(node));
                 var stack = _stack.Use(ref this);
                 while (!node.IsEmpty)
                 {
@@ -1394,7 +1394,7 @@ namespace System.Collections.Immutable
             /// <param name="root">The root of the data structure to reverse enumerate.</param>
             internal ReverseEnumerable(Node root)
             {
-                Requires.NotNull(root, "root");
+                Requires.NotNull(root, nameof(root));
                 _root = root;
             }
 
@@ -1492,9 +1492,9 @@ namespace System.Collections.Immutable
             /// <param name="frozen">Whether this node is prefrozen.</param>
             private Node(T key, Node left, Node right, bool frozen = false)
             {
-                Requires.NotNullAllowStructs(key, "key");
-                Requires.NotNull(left, "left");
-                Requires.NotNull(right, "right");
+                Requires.NotNullAllowStructs(key, nameof(key));
+                Requires.NotNull(left, nameof(left));
+                Requires.NotNull(right, nameof(right));
                 Debug.Assert(!frozen || (left._frozen && right._frozen));
 
                 _key = key;
@@ -1648,7 +1648,7 @@ namespace System.Collections.Immutable
             {
                 get
                 {
-                    Requires.Range(index >= 0 && index < this.Count, "index");
+                    Requires.Range(index >= 0 && index < this.Count, nameof(index));
 
                     if (index < _left._count)
                     {
@@ -1720,9 +1720,9 @@ namespace System.Collections.Immutable
             /// </summary>
             internal void CopyTo(T[] array, int arrayIndex)
             {
-                Requires.NotNull(array, "array");
-                Requires.Range(arrayIndex >= 0, "arrayIndex");
-                Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
+                Requires.NotNull(array, nameof(array));
+                Requires.Range(arrayIndex >= 0, nameof(arrayIndex));
+                Requires.Range(array.Length >= arrayIndex + this.Count, nameof(arrayIndex));
                 foreach (var item in this)
                 {
                     array[arrayIndex++] = item;
@@ -1734,9 +1734,9 @@ namespace System.Collections.Immutable
             /// </summary>
             internal void CopyTo(Array array, int arrayIndex)
             {
-                Requires.NotNull(array, "array");
-                Requires.Range(arrayIndex >= 0, "arrayIndex");
-                Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
+                Requires.NotNull(array, nameof(array));
+                Requires.Range(arrayIndex >= 0, nameof(arrayIndex));
+                Requires.Range(array.Length >= arrayIndex + this.Count, nameof(arrayIndex));
 
                 foreach (var item in this)
                 {
@@ -1753,8 +1753,8 @@ namespace System.Collections.Immutable
             /// <returns>The new tree.</returns>
             internal Node Add(T key, IComparer<T> comparer, out bool mutated)
             {
-                Requires.NotNullAllowStructs(key, "key");
-                Requires.NotNull(comparer, "comparer");
+                Requires.NotNullAllowStructs(key, nameof(key));
+                Requires.NotNull(comparer, nameof(comparer));
 
                 if (this.IsEmpty)
                 {
@@ -1800,8 +1800,8 @@ namespace System.Collections.Immutable
             /// <returns>The new tree.</returns>
             internal Node Remove(T key, IComparer<T> comparer, out bool mutated)
             {
-                Requires.NotNullAllowStructs(key, "key");
-                Requires.NotNull(comparer, "comparer");
+                Requires.NotNullAllowStructs(key, nameof(key));
+                Requires.NotNull(comparer, nameof(comparer));
 
                 if (this.IsEmpty)
                 {
@@ -1879,8 +1879,8 @@ namespace System.Collections.Immutable
             [Pure]
             internal bool Contains(T key, IComparer<T> comparer)
             {
-                Requires.NotNullAllowStructs(key, "key");
-                Requires.NotNull(comparer, "comparer");
+                Requires.NotNullAllowStructs(key, nameof(key));
+                Requires.NotNull(comparer, nameof(comparer));
                 return !this.Search(key, comparer).IsEmpty;
             }
 
@@ -1907,8 +1907,8 @@ namespace System.Collections.Immutable
             [Pure]
             internal Node Search(T key, IComparer<T> comparer)
             {
-                Requires.NotNullAllowStructs(key, "key");
-                Requires.NotNull(comparer, "comparer");
+                Requires.NotNullAllowStructs(key, nameof(key));
+                Requires.NotNull(comparer, nameof(comparer));
 
                 if (this.IsEmpty)
                 {
@@ -1941,8 +1941,8 @@ namespace System.Collections.Immutable
             [Pure]
             internal int IndexOf(T key, IComparer<T> comparer)
             {
-                Requires.NotNullAllowStructs(key, "key");
-                Requires.NotNull(comparer, "comparer");
+                Requires.NotNullAllowStructs(key, nameof(key));
+                Requires.NotNull(comparer, nameof(comparer));
 
                 if (this.IsEmpty)
                 {
@@ -2002,7 +2002,7 @@ namespace System.Collections.Immutable
             /// <returns>The rotated tree.</returns>
             private static Node RotateLeft(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
                 Contract.Ensures(Contract.Result<Node>() != null);
 
@@ -2022,7 +2022,7 @@ namespace System.Collections.Immutable
             /// <returns>The rotated tree.</returns>
             private static Node RotateRight(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
                 Contract.Ensures(Contract.Result<Node>() != null);
 
@@ -2042,7 +2042,7 @@ namespace System.Collections.Immutable
             /// <returns>The rotated tree.</returns>
             private static Node DoubleLeft(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
                 Contract.Ensures(Contract.Result<Node>() != null);
 
@@ -2062,7 +2062,7 @@ namespace System.Collections.Immutable
             /// <returns>The rotated tree.</returns>
             private static Node DoubleRight(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
                 Contract.Ensures(Contract.Result<Node>() != null);
 
@@ -2083,7 +2083,7 @@ namespace System.Collections.Immutable
             [Pure]
             private static int Balance(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
 
                 return tree._right._height - tree._left._height;
@@ -2099,7 +2099,7 @@ namespace System.Collections.Immutable
             [Pure]
             private static bool IsRightHeavy(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
                 return Balance(tree) >= 2;
             }
@@ -2110,7 +2110,7 @@ namespace System.Collections.Immutable
             [Pure]
             private static bool IsLeftHeavy(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
                 return Balance(tree) <= -2;
             }
@@ -2123,7 +2123,7 @@ namespace System.Collections.Immutable
             [Pure]
             private static Node MakeBalanced(Node tree)
             {
-                Requires.NotNull(tree, "tree");
+                Requires.NotNull(tree, nameof(tree));
                 Debug.Assert(!tree.IsEmpty);
                 Contract.Ensures(Contract.Result<Node>() != null);
 
@@ -2152,7 +2152,7 @@ namespace System.Collections.Immutable
             [Pure]
             internal static Node NodeTreeFromList(IOrderedCollection<T> items, int start, int length)
             {
-                Requires.NotNull(items, "items");
+                Requires.NotNull(items, nameof(items));
                 Debug.Assert(start >= 0);
                 Debug.Assert(length >= 0);
 
@@ -2222,7 +2222,7 @@ namespace System.Collections.Immutable
         /// <param name="set">The collection to display in the debugger</param>
         public ImmutableSortedSetDebuggerProxy(ImmutableSortedSet<T> set)
         {
-            Requires.NotNull(set, "set");
+            Requires.NotNull(set, nameof(set));
             _set = set;
         }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack.cs
@@ -46,7 +46,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static ImmutableStack<T> CreateRange<T>(IEnumerable<T> items)
         {
-            Requires.NotNull(items, "items");
+            Requires.NotNull(items, nameof(items));
 
             var stack = ImmutableStack<T>.Empty;
             foreach (var item in items)
@@ -66,7 +66,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static ImmutableStack<T> Create<T>(params T[] items)
         {
-            Requires.NotNull(items, "items");
+            Requires.NotNull(items, nameof(items));
 
             var stack = ImmutableStack<T>.Empty;
             foreach (var item in items)
@@ -91,7 +91,7 @@ namespace System.Collections.Immutable
         [Pure]
         public static IImmutableStack<T> Pop<T>(this IImmutableStack<T> stack, out T value)
         {
-            Requires.NotNull(stack, "stack");
+            Requires.NotNull(stack, nameof(stack));
             Contract.Ensures(Contract.Result<IImmutableStack<T>>() != null);
 
             value = stack.Peek();

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableStack`1.cs
@@ -54,7 +54,7 @@ namespace System.Collections.Immutable
         /// <param name="tail">The rest of the elements on the stack.</param>
         private ImmutableStack(T head, ImmutableStack<T> tail)
         {
-            Requires.NotNull(tail, "tail");
+            Requires.NotNull(tail, nameof(tail));
             _head = head;
             _tail = tail;
         }
@@ -265,7 +265,7 @@ namespace System.Collections.Immutable
             /// <param name="stack">The stack to enumerator.</param>
             internal Enumerator(ImmutableStack<T> stack)
             {
-                Requires.NotNull(stack, "stack");
+                Requires.NotNull(stack, nameof(stack));
                 _originalStack = stack;
                 _remainingStack = null;
             }
@@ -334,7 +334,7 @@ namespace System.Collections.Immutable
             /// <param name="stack">The stack to enumerator.</param>
             internal EnumeratorObject(ImmutableStack<T> stack)
             {
-                Requires.NotNull(stack, "stack");
+                Requires.NotNull(stack, nameof(stack));
                 _originalStack = stack;
             }
 
@@ -438,7 +438,7 @@ namespace System.Collections.Immutable
         /// <param name="stack">The collection to display in the debugger</param>
         public ImmutableStackDebuggerProxy(ImmutableStack<T> stack)
         {
-            Requires.NotNull(stack, "stack");
+            Requires.NotNull(stack, nameof(stack));
             _stack = stack;
         }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/KeysOrValuesCollectionAccessor.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/KeysOrValuesCollectionAccessor.cs
@@ -32,8 +32,8 @@ namespace System.Collections.Immutable
         /// <param name="keysOrValues">The keys or values enumeration to wrap as a collection.</param>
         protected KeysOrValuesCollectionAccessor(IImmutableDictionary<TKey, TValue> dictionary, IEnumerable<T> keysOrValues)
         {
-            Requires.NotNull(dictionary, "dictionary");
-            Requires.NotNull(keysOrValues, "keysOrValues");
+            Requires.NotNull(dictionary, nameof(dictionary));
+            Requires.NotNull(keysOrValues, nameof(keysOrValues));
 
             _dictionary = dictionary;
             _keysOrValues = keysOrValues;
@@ -90,9 +90,9 @@ namespace System.Collections.Immutable
         /// </summary>
         public void CopyTo(T[] array, int arrayIndex)
         {
-            Requires.NotNull(array, "array");
-            Requires.Range(arrayIndex >= 0, "arrayIndex");
-            Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
+            Requires.NotNull(array, nameof(array));
+            Requires.Range(arrayIndex >= 0, nameof(arrayIndex));
+            Requires.Range(array.Length >= arrayIndex + this.Count, nameof(arrayIndex));
 
             foreach (T item in this)
             {
@@ -131,9 +131,9 @@ namespace System.Collections.Immutable
         /// <param name="arrayIndex">The zero-based index in <paramref name="array"/> at which copying begins.</param>
         void ICollection.CopyTo(Array array, int arrayIndex)
         {
-            Requires.NotNull(array, "array");
-            Requires.Range(arrayIndex >= 0, "arrayIndex");
-            Requires.Range(array.Length >= arrayIndex + this.Count, "arrayIndex");
+            Requires.NotNull(array, nameof(array));
+            Requires.Range(arrayIndex >= 0, nameof(arrayIndex));
+            Requires.Range(array.Length >= arrayIndex + this.Count, nameof(arrayIndex));
 
             foreach (T item in this)
             {

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/SecureObjectPool.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/SecureObjectPool.cs
@@ -67,7 +67,7 @@ namespace System.Collections.Immutable
 
         public SecurePooledObject<T> PrepNew(TCaller caller, T newValue)
         {
-            Requires.NotNullAllowStructs(newValue, "newValue");
+            Requires.NotNullAllowStructs(newValue, nameof(newValue));
             var pooledObject = new SecurePooledObject<T>(newValue);
             pooledObject.Owner = caller.PoolUserId;
             return pooledObject;
@@ -86,7 +86,7 @@ namespace System.Collections.Immutable
 
         internal SecurePooledObject(T newValue)
         {
-            Requires.NotNullAllowStructs(newValue, "newValue");
+            Requires.NotNullAllowStructs(newValue, nameof(newValue));
             _value = newValue;
         }
 

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/SortedInt32KeyNode.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/SortedInt32KeyNode.cs
@@ -85,8 +85,8 @@ namespace System.Collections.Immutable
         /// <param name="frozen">Whether this node is prefrozen.</param>
         private SortedInt32KeyNode(int key, TValue value, SortedInt32KeyNode<TValue> left, SortedInt32KeyNode<TValue> right, bool frozen = false)
         {
-            Requires.NotNull(left, "left");
-            Requires.NotNull(right, "right");
+            Requires.NotNull(left, nameof(left));
+            Requires.NotNull(right, nameof(right));
             Debug.Assert(!frozen || (left._frozen && right._frozen));
 
             _key = key;
@@ -182,7 +182,7 @@ namespace System.Collections.Immutable
         /// <param name="mutated">Receives a value indicating whether this node tree has mutated because of this operation.</param>
         internal SortedInt32KeyNode<TValue> SetItem(int key, TValue value, IEqualityComparer<TValue> valueComparer, out bool replacedExistingValue, out bool mutated)
         {
-            Requires.NotNull(valueComparer, "valueComparer");
+            Requires.NotNull(valueComparer, nameof(valueComparer));
 
             return this.SetOrAdd(key, value, valueComparer, true, out replacedExistingValue, out mutated);
         }
@@ -258,7 +258,7 @@ namespace System.Collections.Immutable
         /// <returns>The rotated tree.</returns>
         private static SortedInt32KeyNode<TValue> RotateLeft(SortedInt32KeyNode<TValue> tree)
         {
-            Requires.NotNull(tree, "tree");
+            Requires.NotNull(tree, nameof(tree));
             Debug.Assert(!tree.IsEmpty);
 
             if (tree._right.IsEmpty)
@@ -277,7 +277,7 @@ namespace System.Collections.Immutable
         /// <returns>The rotated tree.</returns>
         private static SortedInt32KeyNode<TValue> RotateRight(SortedInt32KeyNode<TValue> tree)
         {
-            Requires.NotNull(tree, "tree");
+            Requires.NotNull(tree, nameof(tree));
             Debug.Assert(!tree.IsEmpty);
 
             if (tree._left.IsEmpty)
@@ -296,7 +296,7 @@ namespace System.Collections.Immutable
         /// <returns>The rotated tree.</returns>
         private static SortedInt32KeyNode<TValue> DoubleLeft(SortedInt32KeyNode<TValue> tree)
         {
-            Requires.NotNull(tree, "tree");
+            Requires.NotNull(tree, nameof(tree));
             Debug.Assert(!tree.IsEmpty);
 
             if (tree._right.IsEmpty)
@@ -315,7 +315,7 @@ namespace System.Collections.Immutable
         /// <returns>The rotated tree.</returns>
         private static SortedInt32KeyNode<TValue> DoubleRight(SortedInt32KeyNode<TValue> tree)
         {
-            Requires.NotNull(tree, "tree");
+            Requires.NotNull(tree, nameof(tree));
             Debug.Assert(!tree.IsEmpty);
 
             if (tree._left.IsEmpty)
@@ -335,7 +335,7 @@ namespace System.Collections.Immutable
         [Pure]
         private static int Balance(SortedInt32KeyNode<TValue> tree)
         {
-            Requires.NotNull(tree, "tree");
+            Requires.NotNull(tree, nameof(tree));
             Debug.Assert(!tree.IsEmpty);
 
             return tree._right._height - tree._left._height;
@@ -351,7 +351,7 @@ namespace System.Collections.Immutable
         [Pure]
         private static bool IsRightHeavy(SortedInt32KeyNode<TValue> tree)
         {
-            Requires.NotNull(tree, "tree");
+            Requires.NotNull(tree, nameof(tree));
             Debug.Assert(!tree.IsEmpty);
             return Balance(tree) >= 2;
         }
@@ -362,7 +362,7 @@ namespace System.Collections.Immutable
         [Pure]
         private static bool IsLeftHeavy(SortedInt32KeyNode<TValue> tree)
         {
-            Requires.NotNull(tree, "tree");
+            Requires.NotNull(tree, nameof(tree));
             Debug.Assert(!tree.IsEmpty);
             return Balance(tree) <= -2;
         }
@@ -375,7 +375,7 @@ namespace System.Collections.Immutable
         [Pure]
         private static SortedInt32KeyNode<TValue> MakeBalanced(SortedInt32KeyNode<TValue> tree)
         {
-            Requires.NotNull(tree, "tree");
+            Requires.NotNull(tree, nameof(tree));
             Debug.Assert(!tree.IsEmpty);
 
             if (IsRightHeavy(tree))
@@ -629,7 +629,7 @@ namespace System.Collections.Immutable
             /// <param name="root">The root of the set to be enumerated.</param>
             internal Enumerator(SortedInt32KeyNode<TValue> root)
             {
-                Requires.NotNull(root, "root");
+                Requires.NotNull(root, nameof(root));
 
                 _root = root;
                 _current = null;
@@ -757,7 +757,7 @@ namespace System.Collections.Immutable
             /// <param name="node">The starting node to push onto the stack.</param>
             private void PushLeft(SortedInt32KeyNode<TValue> node)
             {
-                Requires.NotNull(node, "node");
+                Requires.NotNull(node, nameof(node));
                 var stack = _stack.Use(ref this);
                 while (!node.IsEmpty)
                 {

--- a/src/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
+++ b/src/System.Collections.Immutable/src/System/Linq/ImmutableArrayExtensions.cs
@@ -119,7 +119,7 @@ namespace System.Linq
         public static bool Any<T>(this ImmutableArray<T> immutableArray, Func<T, bool> predicate)
         {
             immutableArray.ThrowNullRefIfNotInitialized();
-            Requires.NotNull(predicate, "predicate");
+            Requires.NotNull(predicate, nameof(predicate));
 
             foreach (var v in immutableArray.array)
             {
@@ -146,7 +146,7 @@ namespace System.Linq
         public static bool All<T>(this ImmutableArray<T> immutableArray, Func<T, bool> predicate)
         {
             immutableArray.ThrowNullRefIfNotInitialized();
-            Requires.NotNull(predicate, "predicate");
+            Requires.NotNull(predicate, nameof(predicate));
 
             foreach (var v in immutableArray.array)
             {
@@ -203,7 +203,7 @@ namespace System.Linq
         [Pure]
         public static bool SequenceEqual<TDerived, TBase>(this ImmutableArray<TBase> immutableArray, IEnumerable<TDerived> items, IEqualityComparer<TBase> comparer = null) where TDerived : TBase
         {
-            Requires.NotNull(items, "items");
+            Requires.NotNull(items, nameof(items));
 
             if (comparer == null)
             {
@@ -238,7 +238,7 @@ namespace System.Linq
         [Pure]
         public static bool SequenceEqual<TDerived, TBase>(this ImmutableArray<TBase> immutableArray, ImmutableArray<TDerived> items, Func<TBase, TBase, bool> predicate) where TDerived : TBase
         {
-            Requires.NotNull(predicate, "predicate");
+            Requires.NotNull(predicate, nameof(predicate));
             immutableArray.ThrowNullRefIfNotInitialized();
             items.ThrowNullRefIfNotInitialized();
 
@@ -270,7 +270,7 @@ namespace System.Linq
         [Pure]
         public static T Aggregate<T>(this ImmutableArray<T> immutableArray, Func<T, T, T> func)
         {
-            Requires.NotNull(func, "func");
+            Requires.NotNull(func, nameof(func));
 
             if (immutableArray.Length == 0)
             {
@@ -294,7 +294,7 @@ namespace System.Linq
         [Pure]
         public static TAccumulate Aggregate<TAccumulate, T>(this ImmutableArray<T> immutableArray, TAccumulate seed, Func<TAccumulate, T, TAccumulate> func)
         {
-            Requires.NotNull(func, "func");
+            Requires.NotNull(func, nameof(func));
 
             var result = seed;
             foreach (var v in immutableArray.array)
@@ -314,7 +314,7 @@ namespace System.Linq
         [Pure]
         public static TResult Aggregate<TAccumulate, TResult, T>(this ImmutableArray<T> immutableArray, TAccumulate seed, Func<TAccumulate, T, TAccumulate> func, Func<TAccumulate, TResult> resultSelector)
         {
-            Requires.NotNull(resultSelector, "resultSelector");
+            Requires.NotNull(resultSelector, nameof(resultSelector));
 
             return resultSelector(Aggregate(immutableArray, seed, func));
         }
@@ -351,7 +351,7 @@ namespace System.Linq
         [Pure]
         public static T First<T>(this ImmutableArray<T> immutableArray, Func<T, bool> predicate)
         {
-            Requires.NotNull(predicate, "predicate");
+            Requires.NotNull(predicate, nameof(predicate));
 
             foreach (var v in immutableArray.array)
             {
@@ -398,7 +398,7 @@ namespace System.Linq
         [Pure]
         public static T FirstOrDefault<T>(this ImmutableArray<T> immutableArray, Func<T, bool> predicate)
         {
-            Requires.NotNull(predicate, "predicate");
+            Requires.NotNull(predicate, nameof(predicate));
 
             foreach (var v in immutableArray.array)
             {
@@ -433,7 +433,7 @@ namespace System.Linq
         [Pure]
         public static T Last<T>(this ImmutableArray<T> immutableArray, Func<T, bool> predicate)
         {
-            Requires.NotNull(predicate, "predicate");
+            Requires.NotNull(predicate, nameof(predicate));
 
             for (int i = immutableArray.Length - 1; i >= 0; i--)
             {
@@ -466,7 +466,7 @@ namespace System.Linq
         [Pure]
         public static T LastOrDefault<T>(this ImmutableArray<T> immutableArray, Func<T, bool> predicate)
         {
-            Requires.NotNull(predicate, "predicate");
+            Requires.NotNull(predicate, nameof(predicate));
 
             for (int i = immutableArray.Length - 1; i >= 0; i--)
             {
@@ -498,7 +498,7 @@ namespace System.Linq
         [Pure]
         public static T Single<T>(this ImmutableArray<T> immutableArray, Func<T, bool> predicate)
         {
-            Requires.NotNull(predicate, "predicate");
+            Requires.NotNull(predicate, nameof(predicate));
 
             var first = true;
             var result = default(T);
@@ -543,7 +543,7 @@ namespace System.Linq
         [Pure]
         public static T SingleOrDefault<T>(this ImmutableArray<T> immutableArray, Func<T, bool> predicate)
         {
-            Requires.NotNull(predicate, "predicate");
+            Requires.NotNull(predicate, nameof(predicate));
 
             var first = true;
             var result = default(T);
@@ -606,7 +606,7 @@ namespace System.Linq
         [Pure]
         public static Dictionary<TKey, T> ToDictionary<TKey, T>(this ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, IEqualityComparer<TKey> comparer)
         {
-            Requires.NotNull(keySelector, "keySelector");
+            Requires.NotNull(keySelector, nameof(keySelector));
 
             var result = new Dictionary<TKey, T>(comparer);
             foreach (var v in immutableArray)
@@ -631,8 +631,8 @@ namespace System.Linq
         [Pure]
         public static Dictionary<TKey, TElement> ToDictionary<TKey, TElement, T>(this ImmutableArray<T> immutableArray, Func<T, TKey> keySelector, Func<T, TElement> elementSelector, IEqualityComparer<TKey> comparer)
         {
-            Requires.NotNull(keySelector, "keySelector");
-            Requires.NotNull(elementSelector, "elementSelector");
+            Requires.NotNull(keySelector, nameof(keySelector));
+            Requires.NotNull(elementSelector, nameof(elementSelector));
 
             var result = new Dictionary<TKey, TElement>(immutableArray.Length, comparer);
             foreach (var v in immutableArray.array)
@@ -672,7 +672,7 @@ namespace System.Linq
         [Pure]
         public static T First<T>(this ImmutableArray<T>.Builder builder)
         {
-            Requires.NotNull(builder, "builder");
+            Requires.NotNull(builder, nameof(builder));
 
             if (!builder.Any())
             {
@@ -688,7 +688,7 @@ namespace System.Linq
         [Pure]
         public static T FirstOrDefault<T>(this ImmutableArray<T>.Builder builder)
         {
-            Requires.NotNull(builder, "builder");
+            Requires.NotNull(builder, nameof(builder));
 
             return builder.Any() ? builder[0] : default(T);
         }
@@ -700,7 +700,7 @@ namespace System.Linq
         [Pure]
         public static T Last<T>(this ImmutableArray<T>.Builder builder)
         {
-            Requires.NotNull(builder, "builder");
+            Requires.NotNull(builder, nameof(builder));
 
             if (!builder.Any())
             {
@@ -716,7 +716,7 @@ namespace System.Linq
         [Pure]
         public static T LastOrDefault<T>(this ImmutableArray<T>.Builder builder)
         {
-            Requires.NotNull(builder, "builder");
+            Requires.NotNull(builder, nameof(builder));
 
             return builder.Any() ? builder[builder.Count - 1] : default(T);
         }
@@ -727,7 +727,7 @@ namespace System.Linq
         [Pure]
         public static bool Any<T>(this ImmutableArray<T>.Builder builder)
         {
-            Requires.NotNull(builder, "builder");
+            Requires.NotNull(builder, nameof(builder));
 
             return builder.Count > 0;
         }

--- a/src/System.Collections.Immutable/tests/ImmutableDictionaryTestBase.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableDictionaryTestBase.cs
@@ -571,7 +571,7 @@ namespace System.Collections.Immutable.Tests
 
         private static void KeysOrValuesTestHelper<T>(ICollection<T> collection, T containedValue)
         {
-            Requires.NotNull(collection, "collection");
+            Requires.NotNull(collection, nameof(collection));
 
             Assert.True(collection.Contains(containedValue));
             Assert.Throws<NotSupportedException>(() => collection.Add(default(T)));

--- a/src/System.Collections.Immutable/tests/ImmutableListTestBase.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableListTestBase.cs
@@ -430,8 +430,8 @@ namespace System.Collections.Immutable.Tests
 
         private void BinarySearchPartialSortedListHelper(ImmutableArray<int> inputData, int sortedIndex, int sortedLength)
         {
-            Requires.Range(sortedIndex >= 0, "sortedIndex");
-            Requires.Range(sortedLength > 0, "sortedLength");
+            Requires.Range(sortedIndex >= 0, nameof(sortedIndex));
+            Requires.Range(sortedLength > 0, nameof(sortedLength));
             inputData = inputData.Sort(sortedIndex, sortedLength, Comparer<int>.Default);
             int min = inputData[sortedIndex];
             int max = inputData[sortedIndex + sortedLength - 1];

--- a/src/System.Collections.Immutable/tests/ImmutableSetTest.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableSetTest.cs
@@ -245,7 +245,7 @@ namespace System.Collections.Immutable.Tests
 
         protected void TryGetValueTestHelper(IImmutableSet<string> set)
         {
-            Requires.NotNull(set, "set");
+            Requires.NotNull(set, nameof(set));
 
             string expected = "egg";
             set = set.Add(expected);

--- a/src/System.Collections.Immutable/tests/ImmutableTestBase.cs
+++ b/src/System.Collections.Immutable/tests/ImmutableTestBase.cs
@@ -138,9 +138,9 @@ namespace System.Collections.Immutable.Tests
         protected static void StructuralEqualityHelper<TCollection, TElement>(TCollection objectUnderTest, TElement additionalItem, Func<TCollection, IEnumerable<TElement>, bool> equalsStructurally)
             where TCollection : class, IEnumerable<TElement>
         {
-            Requires.NotNull(objectUnderTest, "objectUnderTest");
-            Requires.Argument(objectUnderTest.Count() >= 2, "objectUnderTest", "Collection must contain at least two elements.");
-            Requires.NotNull(equalsStructurally, "equalsStructurally");
+            Requires.NotNull(objectUnderTest, nameof(objectUnderTest));
+            Requires.Argument(objectUnderTest.Count() >= 2, nameof(objectUnderTest), "Collection must contain at least two elements.");
+            Requires.NotNull(equalsStructurally, nameof(equalsStructurally));
 
             var structuralEquatableUnderTest = objectUnderTest as IStructuralEquatable;
             var enumerableUnderTest = (IEnumerable<TElement>)objectUnderTest;
@@ -203,7 +203,7 @@ namespace System.Collections.Immutable.Tests
 
             internal NonGenericEnumerableWrapper(IEnumerable enumerable)
             {
-                Requires.NotNull(enumerable, "enumerable");
+                Requires.NotNull(enumerable, nameof(enumerable));
                 _enumerable = enumerable;
             }
 

--- a/src/System.Collections.Immutable/tests/TestExtensionsMethods.cs
+++ b/src/System.Collections.Immutable/tests/TestExtensionsMethods.cs
@@ -13,14 +13,14 @@ namespace System.Collections.Immutable.Tests
 
         internal static IDictionary<TKey, TValue> ToReadOnlyDictionary<TKey, TValue>(this IImmutableDictionary<TKey, TValue> dictionary)
         {
-            Requires.NotNull(dictionary, "dictionary");
+            Requires.NotNull(dictionary, nameof(dictionary));
 
             return (IDictionary<TKey, TValue>)dictionary;
         }
 
         internal static IDictionary<TKey, TValue> ToBuilder<TKey, TValue>(this IImmutableDictionary<TKey, TValue> dictionary)
         {
-            Requires.NotNull(dictionary, "dictionary");
+            Requires.NotNull(dictionary, nameof(dictionary));
 
             var hashDictionary = dictionary as ImmutableDictionary<TKey, TValue>;
             if (hashDictionary != null)


### PR DESCRIPTION
Mostly automated replacement of parameter name string literals with corresponding usage of `nameof` (via a modified version of @jaredpar's https://github.com/jaredpar/UseNameOf) along the lines of #6209.

cc: @stephentoub, @AArnott