### PR TITLE
Use nameof in System.Composition.*

### DIFF
--- a/src/System.Composition.Convention/src/System/Composition/Convention/ConventionBuilder.cs
+++ b/src/System.Composition.Convention/src/System/Composition/Convention/ConventionBuilder.cs
@@ -51,7 +51,7 @@ namespace System.Composition.Convention
         /// <returns>A <see cref="PartConventionBuilder"/> that must be used to specify the rule.</returns>
         public PartConventionBuilder ForTypesDerivedFrom(Type type)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
 
             var partBuilder = new PartConventionBuilder((t) => IsDescendentOf(t, type));
             _conventions.Add(partBuilder);
@@ -77,7 +77,7 @@ namespace System.Composition.Convention
         /// <returns>A <see cref="PartConventionBuilder"/> that must be used to specify the rule.</returns>
         public PartConventionBuilder ForType(Type type)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
 
             var partBuilder = new PartConventionBuilder((t) => t == type);
             _conventions.Add(partBuilder);
@@ -93,7 +93,7 @@ namespace System.Composition.Convention
         /// <returns>A <see cref="PartConventionBuilder{T}"/> that must be used to specify the rule.</returns>
         public PartConventionBuilder<T> ForTypesMatching<T>(Predicate<Type> typeFilter)
         {
-            Requires.NotNull(typeFilter, "typeFilter");
+            Requires.NotNull(typeFilter, nameof(typeFilter));
 
             var partBuilder = new PartConventionBuilder<T>(typeFilter);
             _conventions.Add(partBuilder);
@@ -108,7 +108,7 @@ namespace System.Composition.Convention
         /// <returns>A <see cref="PartConventionBuilder{T}"/> that must be used to specify the rule.</returns>
         public PartConventionBuilder ForTypesMatching(Predicate<Type> typeFilter)
         {
-            Requires.NotNull(typeFilter, "typeFilter");
+            Requires.NotNull(typeFilter, nameof(typeFilter));
 
             var partBuilder = new PartConventionBuilder(typeFilter);
             _conventions.Add(partBuilder);
@@ -151,7 +151,7 @@ namespace System.Composition.Convention
         /// <returns>The list of applied attributes.</returns>
         public override IEnumerable<Attribute> GetCustomAttributes(Type reflectedType, System.Reflection.MemberInfo member)
         {
-            Requires.NotNull(member, "member");
+            Requires.NotNull(member, nameof(member));
 
             // Now edit the attributes returned from the base type
             List<Attribute> cachedAttributes = null;
@@ -288,8 +288,7 @@ namespace System.Composition.Convention
         /// <returns>The list of applied attributes.</returns>
         public override IEnumerable<Attribute> GetCustomAttributes(Type reflectedType, System.Reflection.ParameterInfo parameter)
         {
-            Requires.NotNull(parameter, "reflectedType");
-            Requires.NotNull(parameter, "parameter");
+            Requires.NotNull(parameter, nameof(parameter));
             var attributes = parameter.GetCustomAttributes<Attribute>(false);
             List<Attribute> cachedAttributes = ReadParameterCustomAttributes(reflectedType, parameter);
             return cachedAttributes == null ? attributes : attributes.Concat(cachedAttributes);

--- a/src/System.Composition.Convention/src/System/Composition/Convention/ExportConventionBuilder.cs
+++ b/src/System.Composition.Convention/src/System/Composition/Convention/ExportConventionBuilder.cs
@@ -43,7 +43,7 @@ namespace System.Composition.Convention
         /// <returns>An export builder allowing further configuration.</returns>
         public ExportConventionBuilder AsContractType(Type type)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             _contractType = type;
             return this;
         }
@@ -55,7 +55,7 @@ namespace System.Composition.Convention
         /// <returns>An export builder allowing further configuration.</returns>
         public ExportConventionBuilder AsContractName(string contractName)
         {
-            Requires.NotNullOrEmpty(contractName, "contractName");
+            Requires.NotNullOrEmpty(contractName, nameof(contractName));
             _contractName = contractName;
             return this;
         }
@@ -67,7 +67,7 @@ namespace System.Composition.Convention
         /// <returns>An export builder allowing further configuration.</returns>
         public ExportConventionBuilder AsContractName(Func<Type, string> getContractNameFromPartType)
         {
-            Requires.NotNull(getContractNameFromPartType, "getContractNameFromPartType");
+            Requires.NotNull(getContractNameFromPartType, nameof(getContractNameFromPartType));
             _getContractNameFromPartType = getContractNameFromPartType;
             return this;
         }
@@ -80,7 +80,7 @@ namespace System.Composition.Convention
         /// <returns>An export builder allowing further configuration.</returns>
         public ExportConventionBuilder AddMetadata(string name, object value)
         {
-            Requires.NotNullOrEmpty(name, "name");
+            Requires.NotNullOrEmpty(name, nameof(name));
             if (_metadataItems == null)
             {
                 _metadataItems = new List<Tuple<string, object>>();
@@ -97,8 +97,8 @@ namespace System.Composition.Convention
         /// <returns>An export builder allowing further configuration.</returns>
         public ExportConventionBuilder AddMetadata(string name, Func<Type, object> getValueFromPartType)
         {
-            Requires.NotNullOrEmpty(name, "name");
-            Requires.NotNull(getValueFromPartType, "getValueFromPartType");
+            Requires.NotNullOrEmpty(name, nameof(name));
+            Requires.NotNull(getValueFromPartType, nameof(getValueFromPartType));
             if (_metadataItemFuncs == null)
             {
                 _metadataItemFuncs = new List<Tuple<string, Func<Type, object>>>();

--- a/src/System.Composition.Convention/src/System/Composition/Convention/ImportConventionBuilder.cs
+++ b/src/System.Composition.Convention/src/System/Composition/Convention/ImportConventionBuilder.cs
@@ -36,7 +36,7 @@ namespace System.Composition.Convention
         /// <returns>An import builder allowing further configuration.</returns>
         public ImportConventionBuilder AsContractName(string contractName)
         {
-            Requires.NotNullOrEmpty(contractName, "contractName");
+            Requires.NotNullOrEmpty(contractName, nameof(contractName));
             _contractName = contractName;
             return this;
         }
@@ -48,7 +48,7 @@ namespace System.Composition.Convention
         /// <returns>An export builder allowing further configuration.</returns>
         public ImportConventionBuilder AsContractName(Func<Type, string> getContractNameFromPartType)
         {
-            Requires.NotNull(getContractNameFromPartType, "getContractNameFromPartType");
+            Requires.NotNull(getContractNameFromPartType, nameof(getContractNameFromPartType));
             _getContractNameFromPartType = getContractNameFromPartType;
             return this;
         }
@@ -92,7 +92,7 @@ namespace System.Composition.Convention
         /// <returns>An import builder allowing further configuration.</returns>
         public ImportConventionBuilder AddMetadataConstraint(string name, object value)
         {
-            Requires.NotNullOrEmpty(name, "name");
+            Requires.NotNullOrEmpty(name, nameof(name));
             if (_metadataConstraintItems == null)
             {
                 _metadataConstraintItems = new List<Tuple<string, object>>();
@@ -109,8 +109,8 @@ namespace System.Composition.Convention
         /// <returns>An export builder allowing further configuration.</returns>
         public ImportConventionBuilder AddMetadataConstraint(string name, Func<Type, object> getConstraintValueFromPartType)
         {
-            Requires.NotNullOrEmpty(name, "name");
-            Requires.NotNull(getConstraintValueFromPartType, "getConstraintValueFromPartType");
+            Requires.NotNullOrEmpty(name, nameof(name));
+            Requires.NotNull(getConstraintValueFromPartType, nameof(getConstraintValueFromPartType));
 
             if (_metadataConstraintItemFuncs == null)
             {

--- a/src/System.Composition.Convention/src/System/Composition/Convention/PartConventionBuilder.cs
+++ b/src/System.Composition.Convention/src/System/Composition/Convention/PartConventionBuilder.cs
@@ -74,7 +74,7 @@ namespace System.Composition.Convention
         /// <returns>A part builder allowing further configuration of the part.</returns>
         public PartConventionBuilder Export(Action<ExportConventionBuilder> exportConfiguration)
         {
-            Requires.NotNull(exportConfiguration, "exportConfiguration");
+            Requires.NotNull(exportConfiguration, nameof(exportConfiguration));
             var exportBuilder = new ExportConventionBuilder();
             exportConfiguration(exportBuilder);
             _typeExportBuilders.Add(exportBuilder);
@@ -99,7 +99,7 @@ namespace System.Composition.Convention
         /// <returns>A part builder allowing further configuration of the part.</returns>
         public PartConventionBuilder Export<T>(Action<ExportConventionBuilder> exportConfiguration)
         {
-            Requires.NotNull(exportConfiguration, "exportConfiguration");
+            Requires.NotNull(exportConfiguration, nameof(exportConfiguration));
             var exportBuilder = new ExportConventionBuilder().AsContractType<T>();
             exportConfiguration(exportBuilder);
             _typeExportBuilders.Add(exportBuilder);
@@ -113,7 +113,7 @@ namespace System.Composition.Convention
         /// <returns>A part builder allowing further configuration of the part.</returns>
         public PartConventionBuilder SelectConstructor(Func<IEnumerable<ConstructorInfo>, ConstructorInfo> constructorSelector)
         {
-            Requires.NotNull(constructorSelector, "constructorSelector");
+            Requires.NotNull(constructorSelector, nameof(constructorSelector));
             _constructorFilter = constructorSelector;
             return this;
         }
@@ -128,7 +128,7 @@ namespace System.Composition.Convention
             Func<IEnumerable<ConstructorInfo>, ConstructorInfo> constructorSelector,
             Action<ParameterInfo, ImportConventionBuilder> importConfiguration)
         {
-            Requires.NotNull(importConfiguration, "importConfiguration");
+            Requires.NotNull(importConfiguration, nameof(importConfiguration));
             SelectConstructor(constructorSelector);
             _configureConstuctorImports = importConfiguration;
             return this;
@@ -141,7 +141,7 @@ namespace System.Composition.Convention
         /// <returns>A part builder allowing further configuration of the part.</returns>
         public PartConventionBuilder ExportInterfaces(Predicate<Type> interfaceFilter)
         {
-            Requires.NotNull(interfaceFilter, "interfaceFilter");
+            Requires.NotNull(interfaceFilter, nameof(interfaceFilter));
             return ExportInterfacesImpl(interfaceFilter, null);
         }
 
@@ -164,8 +164,8 @@ namespace System.Composition.Convention
             Predicate<Type> interfaceFilter,
             Action<Type, ExportConventionBuilder> exportConfiguration)
         {
-            Requires.NotNull(interfaceFilter, "interfaceFilter");
-            Requires.NotNull(exportConfiguration, "exportConfiguration");
+            Requires.NotNull(interfaceFilter, nameof(interfaceFilter));
+            Requires.NotNull(exportConfiguration, nameof(exportConfiguration));
             return ExportInterfacesImpl(interfaceFilter, exportConfiguration);
         }
 
@@ -184,7 +184,7 @@ namespace System.Composition.Convention
         /// <returns>A part builder allowing further configuration of the part.</returns>
         public PartConventionBuilder ExportProperties(Predicate<PropertyInfo> propertyFilter)
         {
-            Requires.NotNull(propertyFilter, "propertyFilter");
+            Requires.NotNull(propertyFilter, nameof(propertyFilter));
 
             return ExportPropertiesImpl(propertyFilter, null);
         }
@@ -199,8 +199,8 @@ namespace System.Composition.Convention
             Predicate<PropertyInfo> propertyFilter,
             Action<PropertyInfo, ExportConventionBuilder> exportConfiguration)
         {
-            Requires.NotNull(propertyFilter, "propertyFilter");
-            Requires.NotNull(exportConfiguration, "exportConfiguration");
+            Requires.NotNull(propertyFilter, nameof(propertyFilter));
+            Requires.NotNull(exportConfiguration, nameof(exportConfiguration));
             return ExportPropertiesImpl(propertyFilter, exportConfiguration);
         }
 
@@ -220,7 +220,7 @@ namespace System.Composition.Convention
         /// <returns>A part builder allowing further configuration of the part.</returns>
         public PartConventionBuilder ExportProperties<T>(Predicate<PropertyInfo> propertyFilter)
         {
-            Requires.NotNull(propertyFilter, "propertyFilter");
+            Requires.NotNull(propertyFilter, nameof(propertyFilter));
 
             return ExportPropertiesImpl<T>(propertyFilter, null);
         }
@@ -236,8 +236,8 @@ namespace System.Composition.Convention
             Predicate<PropertyInfo> propertyFilter,
             Action<PropertyInfo, ExportConventionBuilder> exportConfiguration)
         {
-            Requires.NotNull(propertyFilter, "propertyFilter");
-            Requires.NotNull(exportConfiguration, "exportConfiguration");
+            Requires.NotNull(propertyFilter, nameof(propertyFilter));
+            Requires.NotNull(exportConfiguration, nameof(exportConfiguration));
 
             return ExportPropertiesImpl<T>(propertyFilter, exportConfiguration);
         }
@@ -257,7 +257,7 @@ namespace System.Composition.Convention
         /// <returns>A part builder allowing further configuration of the part.</returns>
         public PartConventionBuilder ImportProperties(Predicate<PropertyInfo> propertyFilter)
         {
-            Requires.NotNull(propertyFilter, "propertyFilter");
+            Requires.NotNull(propertyFilter, nameof(propertyFilter));
 
             return ImportPropertiesImpl(propertyFilter, null);
         }
@@ -272,8 +272,8 @@ namespace System.Composition.Convention
             Predicate<PropertyInfo> propertyFilter,
             Action<PropertyInfo, ImportConventionBuilder> importConfiguration)
         {
-            Requires.NotNull(propertyFilter, "propertyFilter");
-            Requires.NotNull(importConfiguration, "importConfiguration");
+            Requires.NotNull(propertyFilter, nameof(propertyFilter));
+            Requires.NotNull(importConfiguration, nameof(importConfiguration));
 
             return ImportPropertiesImpl(propertyFilter, importConfiguration);
         }
@@ -294,7 +294,7 @@ namespace System.Composition.Convention
         /// <returns>A part builder allowing further configuration of the part.</returns>
         public PartConventionBuilder ImportProperties<T>(Predicate<PropertyInfo> propertyFilter)
         {
-            Requires.NotNull(propertyFilter, "propertyFilter");
+            Requires.NotNull(propertyFilter, nameof(propertyFilter));
 
             return ImportPropertiesImpl<T>(propertyFilter, null);
         }
@@ -310,8 +310,8 @@ namespace System.Composition.Convention
             Predicate<PropertyInfo> propertyFilter,
             Action<PropertyInfo, ImportConventionBuilder> importConfiguration)
         {
-            Requires.NotNull(propertyFilter, "propertyFilter");
-            Requires.NotNull(importConfiguration, "importConfiguration");
+            Requires.NotNull(propertyFilter, nameof(propertyFilter));
+            Requires.NotNull(importConfiguration, nameof(importConfiguration));
 
             return ImportPropertiesImpl<T>(propertyFilter, importConfiguration);
         }
@@ -351,7 +351,7 @@ namespace System.Composition.Convention
         /// <returns>A part builder allowing further configuration of the part.</returns>
         public PartConventionBuilder Shared(string sharingBoundary)
         {
-            Requires.NotNullOrEmpty(sharingBoundary, "sharingBoundary");
+            Requires.NotNullOrEmpty(sharingBoundary, nameof(sharingBoundary));
             return SharedImpl(sharingBoundary);
         }
 
@@ -370,7 +370,7 @@ namespace System.Composition.Convention
         /// <returns>A part builder allowing further configuration of the part.</returns>
         public PartConventionBuilder AddPartMetadata(string name, object value)
         {
-            Requires.NotNullOrEmpty(name, "name");
+            Requires.NotNullOrEmpty(name, nameof(name));
 
             if (_metadataItems == null)
             {
@@ -388,8 +388,8 @@ namespace System.Composition.Convention
         /// <returns>A part builder allowing further configuration of the part.</returns>
         public PartConventionBuilder AddPartMetadata(string name, Func<Type, object> getValueFromPartType)
         {
-            Requires.NotNullOrEmpty(name, "name");
-            Requires.NotNull(getValueFromPartType, "itemFunc");
+            Requires.NotNullOrEmpty(name, nameof(name));
+            Requires.NotNull(getValueFromPartType, nameof(getValueFromPartType));
 
             if (_metadataItemFuncs == null)
             {

--- a/src/System.Composition.Convention/src/System/Composition/Convention/PartConventionBuilderOfT.cs
+++ b/src/System.Composition.Convention/src/System/Composition/Convention/PartConventionBuilderOfT.cs
@@ -35,7 +35,7 @@ namespace System.Composition.Convention
 
             private static MethodInfo SelectMethods(Expression<Action<T>> methodSelector)
             {
-                Requires.NotNull(methodSelector, "methodSelector");
+                Requires.NotNull(methodSelector, nameof(methodSelector));
 
                 var expr = Reduce(methodSelector).Body;
                 if (expr.NodeType == ExpressionType.Call)
@@ -109,7 +109,7 @@ namespace System.Composition.Convention
 
             private static PropertyInfo SelectProperties(Expression<Func<T, object>> propertySelector)
             {
-                Requires.NotNull(propertySelector, "propertySelector");
+                Requires.NotNull(propertySelector, nameof(propertySelector));
 
                 var expr = Reduce(propertySelector).Body;
                 if (expr.NodeType == ExpressionType.MemberAccess)
@@ -166,7 +166,7 @@ namespace System.Composition.Convention
 
             private void ParseSelectConstructor(Expression<Func<ParameterImportConventionBuilder, T>> constructorSelector)
             {
-                Requires.NotNull(constructorSelector, "constructorSelector");
+                Requires.NotNull(constructorSelector, nameof(constructorSelector));
 
                 var expr = Reduce(constructorSelector).Body;
                 if (expr.NodeType != ExpressionType.New)
@@ -224,7 +224,7 @@ namespace System.Composition.Convention
         /// <returns>A part builder allowing further configuration of the part.</returns>
         public PartConventionBuilder<T> SelectConstructor(Expression<Func<ParameterImportConventionBuilder, T>> constructorSelector)
         {
-            Requires.NotNull(constructorSelector, "constructorSelector");
+            Requires.NotNull(constructorSelector, nameof(constructorSelector));
 
             var adapter = new ConstructorExpressionAdapter(constructorSelector);
             base.SelectConstructor(adapter.SelectConstructor, adapter.ConfigureConstructorImports);
@@ -251,7 +251,7 @@ namespace System.Composition.Convention
             Expression<Func<T, object>> propertySelector,
             Action<ExportConventionBuilder> exportConfiguration)
         {
-            Requires.NotNull(propertySelector, "propertySelector");
+            Requires.NotNull(propertySelector, nameof(propertySelector));
 
             var adapter = new PropertyExpressionAdapter(propertySelector, null, exportConfiguration);
             base.ExportProperties(adapter.VerifyPropertyInfo, adapter.ConfigureExport);
@@ -281,7 +281,7 @@ namespace System.Composition.Convention
             Expression<Func<T, object>> propertySelector,
             Action<ExportConventionBuilder> exportConfiguration)
         {
-            Requires.NotNull(propertySelector, "propertySelector");
+            Requires.NotNull(propertySelector, nameof(propertySelector));
 
             var adapter = new PropertyExpressionAdapter(propertySelector, null, exportConfiguration);
             base.ExportProperties<TContract>(adapter.VerifyPropertyInfo, adapter.ConfigureExport);
@@ -308,7 +308,7 @@ namespace System.Composition.Convention
             Expression<Func<T, object>> propertySelector,
             Action<ImportConventionBuilder> importConfiguration)
         {
-            Requires.NotNull(propertySelector, "propertySelector");
+            Requires.NotNull(propertySelector, nameof(propertySelector));
 
             var adapter = new PropertyExpressionAdapter(propertySelector, importConfiguration, null);
             base.ImportProperties(adapter.VerifyPropertyInfo, adapter.ConfigureImport);
@@ -337,7 +337,7 @@ namespace System.Composition.Convention
             Expression<Func<T, object>> propertySelector,
             Action<ImportConventionBuilder> importConfiguration)
         {
-            Requires.NotNull(propertySelector, "propertySelector");
+            Requires.NotNull(propertySelector, nameof(propertySelector));
 
             var adapter = new PropertyExpressionAdapter(propertySelector, importConfiguration, null);
             base.ImportProperties<TContract>(adapter.VerifyPropertyInfo, adapter.ConfigureImport);
@@ -350,7 +350,7 @@ namespace System.Composition.Convention
         /// <returns>A part builder allowing further configuration of the part.</returns>
         public PartConventionBuilder<T> NotifyImportsSatisfied(Expression<Action<T>> methodSelector)
         {
-            Requires.NotNull(methodSelector, "methodSelector");
+            Requires.NotNull(methodSelector, nameof(methodSelector));
 
             var adapter = new MethodExpressionAdapter(methodSelector);
             base.NotifyImportsSatisfied(adapter.VerifyMethodInfo);

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/CompositionHost.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/CompositionHost.cs
@@ -28,7 +28,7 @@ namespace System.Composition.Hosting
 
         private CompositionHost(LifetimeContext rootLifetimeContext)
         {
-            Requires.NotNull(rootLifetimeContext, "rootLifetimeContext");
+            Requires.NotNull(rootLifetimeContext, nameof(rootLifetimeContext));
 
             _rootLifetimeContext = rootLifetimeContext;
         }
@@ -48,7 +48,7 @@ namespace System.Composition.Hosting
         /// <returns>The container as an <see cref="CompositionHost"/>.</returns>
         public static CompositionHost CreateCompositionHost(IEnumerable<ExportDescriptorProvider> providers)
         {
-            Requires.NotNull(providers, "providers");
+            Requires.NotNull(providers, nameof(providers));
 
             var allProviders = new ExportDescriptorProvider[] {
                 new LazyExportDescriptorProvider(),

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/CompositionDependency.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/CompositionDependency.cs
@@ -41,9 +41,9 @@ namespace System.Composition.Hosting.Core
         /// <param name="contract">The contract required by the dependency.</param>
         public static CompositionDependency Satisfied(CompositionContract contract, ExportDescriptorPromise target, bool isPrerequisite, object site)
         {
-            Requires.NotNull(target, "target");
-            Requires.NotNull(site, "site");
-            Requires.NotNull(contract, "contract");
+            Requires.NotNull(target, nameof(target));
+            Requires.NotNull(site, nameof(site));
+            Requires.NotNull(contract, nameof(contract));
 
             return new CompositionDependency(contract, target, isPrerequisite, site);
         }
@@ -57,8 +57,8 @@ namespace System.Composition.Hosting.Core
         /// <param name="contract">The contract required by the dependency.</param>
         public static CompositionDependency Missing(CompositionContract contract, object site)
         {
-            Requires.NotNull(contract, "contract");
-            Requires.NotNull(site, "site");
+            Requires.NotNull(contract, nameof(contract));
+            Requires.NotNull(site, nameof(site));
 
             return new CompositionDependency(contract, site);
         }
@@ -73,9 +73,9 @@ namespace System.Composition.Hosting.Core
         /// <param name="contract">The contract required by the dependency.</param>
         public static CompositionDependency Oversupplied(CompositionContract contract, IEnumerable<ExportDescriptorPromise> targets, object site)
         {
-            Requires.NotNull(targets, "targets");
-            Requires.NotNull(site, "site");
-            Requires.NotNull(contract, "contract");
+            Requires.NotNull(targets, nameof(targets));
+            Requires.NotNull(site, nameof(site));
+            Requires.NotNull(contract, nameof(contract));
 
             return new CompositionDependency(contract, targets, site);
         }

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/CompositionOperation.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/CompositionOperation.cs
@@ -32,8 +32,8 @@ namespace System.Composition.Hosting.Core
         /// <returns>The composed object graph.</returns>
         public static object Run(LifetimeContext outermostLifetimeContext, CompositeActivator compositionRootActivator)
         {
-            Requires.NotNull(outermostLifetimeContext, "outermostLifetimeContext");
-            Requires.NotNull(compositionRootActivator, "compositionRootActivator");
+            Requires.NotNull(outermostLifetimeContext, nameof(outermostLifetimeContext));
+            Requires.NotNull(compositionRootActivator, nameof(compositionRootActivator));
 
             using (var operation = new CompositionOperation())
             {
@@ -66,7 +66,7 @@ namespace System.Composition.Hosting.Core
         /// <param name="action">Action to run.</param>
         public void AddPostCompositionAction(Action action)
         {
-            Requires.NotNull(action, "action");
+            Requires.NotNull(action, nameof(action));
 
             if (_postCompositionActions == null)
                 _postCompositionActions = new List<Action>();

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/DirectExportDescriptor.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/DirectExportDescriptor.cs
@@ -14,8 +14,8 @@ namespace System.Composition.Hosting.Core
 
         public DirectExportDescriptor(CompositeActivator activator, IDictionary<string, object> metadata)
         {
-            Requires.NotNull(activator, "activator");
-            Requires.NotNull(metadata, "metadata");
+            Requires.NotNull(activator, nameof(activator));
+            Requires.NotNull(metadata, nameof(metadata));
 
             _activator = activator;
             _metadata = metadata;


### PR DESCRIPTION
Mostly automated replacement of parameter name string literals with corresponding usage of `nameof` (via a modified version of @jaredpar's https://github.com/jaredpar/UseNameOf) along the lines of #6209 and #6265.

cc: @stephentoub, @dsplaisted