### PR TITLE
Use nameof in System.Dynamic.Runtime

### DIFF
--- a/src/Common/src/System/Linq/Expressions/Compiler/AssemblyGen.cs
+++ b/src/Common/src/System/Linq/Expressions/Compiler/AssemblyGen.cs
@@ -46,8 +46,8 @@ namespace System.Linq.Expressions.Compiler
 
         private TypeBuilder DefineType(string name, Type parent, TypeAttributes attr)
         {
-            ContractUtils.RequiresNotNull(name, "name");
-            ContractUtils.RequiresNotNull(parent, "parent");
+            ContractUtils.RequiresNotNull(name, nameof(name));
+            ContractUtils.RequiresNotNull(parent, nameof(parent));
 
             StringBuilder sb = new StringBuilder(name);
 

--- a/src/Common/src/System/Runtime/CompilerServices/ReadOnlyCollectionBuilder.cs
+++ b/src/Common/src/System/Runtime/CompilerServices/ReadOnlyCollectionBuilder.cs
@@ -38,7 +38,7 @@ namespace System.Runtime.CompilerServices
         /// </summary> 
         public ReadOnlyCollectionBuilder(int capacity)
         {
-            ContractUtils.Requires(capacity >= 0, "capacity");
+            ContractUtils.Requires(capacity >= 0, nameof(capacity));
             _items = new T[capacity];
         }
 
@@ -48,7 +48,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="collection"></param>
         public ReadOnlyCollectionBuilder(IEnumerable<T> collection)
         {
-            ContractUtils.Requires(collection != null, "collection");
+            ContractUtils.Requires(collection != null, nameof(collection));
 
             ICollection<T> c = collection as ICollection<T>;
             if (c != null)
@@ -81,7 +81,7 @@ namespace System.Runtime.CompilerServices
             get { return _items.Length; }
             set
             {
-                ContractUtils.Requires(value >= _size, "value");
+                ContractUtils.Requires(value >= _size, nameof(value));
 
                 if (value != _items.Length)
                 {
@@ -129,7 +129,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="item">The object to insert into the <see cref="ReadOnlyCollectionBuilder{T}"/>.</param>
         public void Insert(int index, T item)
         {
-            ContractUtils.Requires(index <= _size, "index");
+            ContractUtils.Requires(index <= _size, nameof(index));
 
             if (_size == _items.Length)
             {
@@ -150,7 +150,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="index">The zero-based index of the item to remove.</param>
         public void RemoveAt(int index)
         {
-            ContractUtils.Requires(index >= 0 && index < _size, "index");
+            ContractUtils.Requires(index >= 0 && index < _size, nameof(index));
 
             _size--;
             if (index < _size)
@@ -170,12 +170,12 @@ namespace System.Runtime.CompilerServices
         {
             get
             {
-                ContractUtils.Requires(index < _size, "index");
+                ContractUtils.Requires(index < _size, nameof(index));
                 return _items[index];
             }
             set
             {
-                ContractUtils.Requires(index < _size, "index");
+                ContractUtils.Requires(index < _size, nameof(index));
                 _items[index] = value;
                 _version++;
             }
@@ -395,8 +395,8 @@ namespace System.Runtime.CompilerServices
 
         void System.Collections.ICollection.CopyTo(Array array, int index)
         {
-            ContractUtils.RequiresNotNull(array, "array");
-            ContractUtils.Requires(array.Rank == 1, "array");
+            ContractUtils.RequiresNotNull(array, nameof(array));
+            ContractUtils.Requires(array.Rank == 1, nameof(array));
             Array.Copy(_items, 0, array, index, _size);
         }
 
@@ -434,8 +434,8 @@ namespace System.Runtime.CompilerServices
         /// <param name="count">The number of elements in the range to reverse.</param>
         public void Reverse(int index, int count)
         {
-            ContractUtils.Requires(index >= 0, "index");
-            ContractUtils.Requires(count >= 0, "count");
+            ContractUtils.Requires(index >= 0, nameof(index));
+            ContractUtils.Requires(count >= 0, nameof(count));
 
             Array.Reverse(_items, index, count);
             _version++;

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/BinaryOperationBinder.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/BinaryOperationBinder.cs
@@ -20,7 +20,7 @@ namespace System.Dynamic
         /// <param name="operation">The binary operation kind.</param>
         protected BinaryOperationBinder(ExpressionType operation)
         {
-            ContractUtils.Requires(OperationIsValid(operation), "operation");
+            ContractUtils.Requires(OperationIsValid(operation), nameof(operation));
             _operation = operation;
         }
 
@@ -71,12 +71,12 @@ namespace System.Dynamic
         /// <returns>The <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public sealed override DynamicMetaObject Bind(DynamicMetaObject target, DynamicMetaObject[] args)
         {
-            ContractUtils.RequiresNotNull(target, "target");
-            ContractUtils.RequiresNotNull(args, "args");
-            ContractUtils.Requires(args.Length == 1, "args");
+            ContractUtils.RequiresNotNull(target, nameof(target));
+            ContractUtils.RequiresNotNull(args, nameof(args));
+            ContractUtils.Requires(args.Length == 1, nameof(args));
 
             var arg0 = args[0];
-            ContractUtils.RequiresNotNull(arg0, "args");
+            ContractUtils.RequiresNotNull(arg0, nameof(args));
 
             return target.BindBinaryOperation(this, arg0);
         }

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/BindingRestrictions.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/BindingRestrictions.cs
@@ -40,7 +40,7 @@ namespace System.Dynamic
         /// <returns>The new set of binding restrictions.</returns>
         public BindingRestrictions Merge(BindingRestrictions restrictions)
         {
-            ContractUtils.RequiresNotNull(restrictions, "restrictions");
+            ContractUtils.RequiresNotNull(restrictions, nameof(restrictions));
             if (this == Empty)
             {
                 return restrictions;
@@ -60,8 +60,8 @@ namespace System.Dynamic
         /// <returns>The new binding restrictions.</returns>
         public static BindingRestrictions GetTypeRestriction(Expression expression, Type type)
         {
-            ContractUtils.RequiresNotNull(expression, "expression");
-            ContractUtils.RequiresNotNull(type, "type");
+            ContractUtils.RequiresNotNull(expression, nameof(expression));
+            ContractUtils.RequiresNotNull(type, nameof(type));
 
             return new TypeRestriction(expression, type);
         }
@@ -90,7 +90,7 @@ namespace System.Dynamic
         /// <returns>The new binding restrictions.</returns>
         public static BindingRestrictions GetInstanceRestriction(Expression expression, object instance)
         {
-            ContractUtils.RequiresNotNull(expression, "expression");
+            ContractUtils.RequiresNotNull(expression, nameof(expression));
 
             return new InstanceRestriction(expression, instance);
         }
@@ -106,8 +106,8 @@ namespace System.Dynamic
         /// </remarks>
         public static BindingRestrictions GetExpressionRestriction(Expression expression)
         {
-            ContractUtils.RequiresNotNull(expression, "expression");
-            ContractUtils.Requires(expression.Type == typeof(bool), "expression");
+            ContractUtils.RequiresNotNull(expression, nameof(expression));
+            ContractUtils.Requires(expression.Type == typeof(bool), nameof(expression));
             return new CustomRestriction(expression);
         }
 

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/CallInfo.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/CallInfo.cs
@@ -49,12 +49,12 @@ namespace System.Dynamic
         /// <returns>The new CallInfo</returns>
         public CallInfo(int argCount, IEnumerable<string> argNames)
         {
-            ContractUtils.RequiresNotNull(argNames, "argNames");
+            ContractUtils.RequiresNotNull(argNames, nameof(argNames));
 
             var argNameCol = argNames.ToReadOnly();
 
             if (argCount < argNameCol.Count) throw Error.ArgCntMustBeGreaterThanNameCnt();
-            ContractUtils.RequiresNotNullItems(argNameCol, "argNames");
+            ContractUtils.RequiresNotNullItems(argNameCol, nameof(argNames));
 
             _argCount = argCount;
             _argNames = argNameCol;

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/ConvertBinder.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/ConvertBinder.cs
@@ -21,7 +21,7 @@ namespace System.Dynamic
         /// <param name="explicit">true if the conversion should consider explicit conversions; otherwise, false.</param>
         protected ConvertBinder(Type type, bool @explicit)
         {
-            ContractUtils.RequiresNotNull(type, "type");
+            ContractUtils.RequiresNotNull(type, nameof(type));
 
             _type = type;
             _explicit = @explicit;
@@ -76,8 +76,8 @@ namespace System.Dynamic
         /// <returns>The <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public sealed override DynamicMetaObject Bind(DynamicMetaObject target, DynamicMetaObject[] args)
         {
-            ContractUtils.RequiresNotNull(target, "target");
-            ContractUtils.Requires(args == null || args.Length == 0, "args");
+            ContractUtils.RequiresNotNull(target, nameof(target));
+            ContractUtils.Requires(args == null || args.Length == 0, nameof(args));
 
             return target.BindConvert(this);
         }

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/CreateInstanceBinder.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/CreateInstanceBinder.cs
@@ -19,7 +19,7 @@ namespace System.Dynamic
         /// <param name="callInfo">The signature of the arguments at the call site.</param>
         protected CreateInstanceBinder(CallInfo callInfo)
         {
-            ContractUtils.RequiresNotNull(callInfo, "callInfo");
+            ContractUtils.RequiresNotNull(callInfo, nameof(callInfo));
             _callInfo = callInfo;
         }
 
@@ -67,8 +67,8 @@ namespace System.Dynamic
         /// <returns>The <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public sealed override DynamicMetaObject Bind(DynamicMetaObject target, DynamicMetaObject[] args)
         {
-            ContractUtils.RequiresNotNull(target, "target");
-            ContractUtils.RequiresNotNullItems(args, "args");
+            ContractUtils.RequiresNotNull(target, nameof(target));
+            ContractUtils.RequiresNotNullItems(args, nameof(args));
 
             return target.BindCreateInstance(this, args);
         }

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/DeleteIndexBinder.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/DeleteIndexBinder.cs
@@ -19,7 +19,7 @@ namespace System.Dynamic
         /// <param name="callInfo">The signature of the arguments at the call site.</param>
         protected DeleteIndexBinder(CallInfo callInfo)
         {
-            ContractUtils.RequiresNotNull(callInfo, "callInfo");
+            ContractUtils.RequiresNotNull(callInfo, nameof(callInfo));
             _callInfo = callInfo;
         }
 
@@ -47,8 +47,8 @@ namespace System.Dynamic
         /// <returns>The <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public sealed override DynamicMetaObject Bind(DynamicMetaObject target, DynamicMetaObject[] args)
         {
-            ContractUtils.RequiresNotNull(target, "target");
-            ContractUtils.RequiresNotNullItems(args, "args");
+            ContractUtils.RequiresNotNull(target, nameof(target));
+            ContractUtils.RequiresNotNullItems(args, nameof(args));
 
             return target.BindDeleteIndex(this, args);
         }

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/DeleteMemberBinder.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/DeleteMemberBinder.cs
@@ -21,7 +21,7 @@ namespace System.Dynamic
         /// <param name="ignoreCase">true if the name should be matched ignoring case; false otherwise.</param>
         protected DeleteMemberBinder(string name, bool ignoreCase)
         {
-            ContractUtils.RequiresNotNull(name, "name");
+            ContractUtils.RequiresNotNull(name, nameof(name));
 
             _name = name;
             _ignoreCase = ignoreCase;
@@ -83,7 +83,7 @@ namespace System.Dynamic
         /// <returns>The <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public sealed override DynamicMetaObject Bind(DynamicMetaObject target, DynamicMetaObject[] args)
         {
-            ContractUtils.RequiresNotNull(target, "target");
+            ContractUtils.RequiresNotNull(target, nameof(target));
             ContractUtils.Requires(args == null || args.Length == 0);
 
             return target.BindDeleteMember(this);

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/DynamicMetaObject.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/DynamicMetaObject.cs
@@ -32,8 +32,8 @@ namespace System.Dynamic
         /// <param name="restrictions">The set of binding restrictions under which the binding is valid.</param>
         public DynamicMetaObject(Expression expression, BindingRestrictions restrictions)
         {
-            ContractUtils.RequiresNotNull(expression, "expression");
-            ContractUtils.RequiresNotNull(restrictions, "restrictions");
+            ContractUtils.RequiresNotNull(expression, nameof(expression));
+            ContractUtils.RequiresNotNull(restrictions, nameof(restrictions));
 
             _expression = expression;
             _restrictions = restrictions;
@@ -147,7 +147,7 @@ namespace System.Dynamic
         /// <returns>The new <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public virtual DynamicMetaObject BindConvert(ConvertBinder binder)
         {
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             return binder.FallbackConvert(this);
         }
 
@@ -158,7 +158,7 @@ namespace System.Dynamic
         /// <returns>The new <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public virtual DynamicMetaObject BindGetMember(GetMemberBinder binder)
         {
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             return binder.FallbackGetMember(this);
         }
 
@@ -170,7 +170,7 @@ namespace System.Dynamic
         /// <returns>The new <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public virtual DynamicMetaObject BindSetMember(SetMemberBinder binder, DynamicMetaObject value)
         {
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             return binder.FallbackSetMember(this, value);
         }
 
@@ -181,7 +181,7 @@ namespace System.Dynamic
         /// <returns>The new <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public virtual DynamicMetaObject BindDeleteMember(DeleteMemberBinder binder)
         {
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             return binder.FallbackDeleteMember(this);
         }
 
@@ -193,7 +193,7 @@ namespace System.Dynamic
         /// <returns>The new <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public virtual DynamicMetaObject BindGetIndex(GetIndexBinder binder, DynamicMetaObject[] indexes)
         {
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             return binder.FallbackGetIndex(this, indexes);
         }
 
@@ -206,7 +206,7 @@ namespace System.Dynamic
         /// <returns>The new <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public virtual DynamicMetaObject BindSetIndex(SetIndexBinder binder, DynamicMetaObject[] indexes, DynamicMetaObject value)
         {
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             return binder.FallbackSetIndex(this, indexes, value);
         }
 
@@ -218,7 +218,7 @@ namespace System.Dynamic
         /// <returns>The new <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public virtual DynamicMetaObject BindDeleteIndex(DeleteIndexBinder binder, DynamicMetaObject[] indexes)
         {
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             return binder.FallbackDeleteIndex(this, indexes);
         }
 
@@ -230,7 +230,7 @@ namespace System.Dynamic
         /// <returns>The new <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public virtual DynamicMetaObject BindInvokeMember(InvokeMemberBinder binder, DynamicMetaObject[] args)
         {
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             return binder.FallbackInvokeMember(this, args);
         }
 
@@ -242,7 +242,7 @@ namespace System.Dynamic
         /// <returns>The new <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public virtual DynamicMetaObject BindInvoke(InvokeBinder binder, DynamicMetaObject[] args)
         {
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             return binder.FallbackInvoke(this, args);
         }
 
@@ -254,7 +254,7 @@ namespace System.Dynamic
         /// <returns>The new <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public virtual DynamicMetaObject BindCreateInstance(CreateInstanceBinder binder, DynamicMetaObject[] args)
         {
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             return binder.FallbackCreateInstance(this, args);
         }
 
@@ -265,7 +265,7 @@ namespace System.Dynamic
         /// <returns>The new <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public virtual DynamicMetaObject BindUnaryOperation(UnaryOperationBinder binder)
         {
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             return binder.FallbackUnaryOperation(this);
         }
 
@@ -277,7 +277,7 @@ namespace System.Dynamic
         /// <returns>The new <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public virtual DynamicMetaObject BindBinaryOperation(BinaryOperationBinder binder, DynamicMetaObject arg)
         {
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             return binder.FallbackBinaryOperation(this, arg);
         }
 
@@ -298,15 +298,15 @@ namespace System.Dynamic
         /// <returns>The array of expressions.</returns>
         internal static Expression[] GetExpressions(DynamicMetaObject[] objects)
         {
-            ContractUtils.RequiresNotNull(objects, "objects");
+            ContractUtils.RequiresNotNull(objects, nameof(objects));
 
             Expression[] res = new Expression[objects.Length];
             for (int i = 0; i < objects.Length; i++)
             {
                 DynamicMetaObject mo = objects[i];
-                ContractUtils.RequiresNotNull(mo, "objects");
+                ContractUtils.RequiresNotNull(mo, nameof(objects));
                 Expression expr = mo.Expression;
-                ContractUtils.RequiresNotNull(expr, "objects");
+                ContractUtils.RequiresNotNull(expr, nameof(objects));
                 res[i] = expr;
             }
 
@@ -325,7 +325,7 @@ namespace System.Dynamic
         /// </returns>
         public static DynamicMetaObject Create(object value, Expression expression)
         {
-            ContractUtils.RequiresNotNull(expression, "expression");
+            ContractUtils.RequiresNotNull(expression, nameof(expression));
 
             IDynamicMetaObjectProvider ido = value as IDynamicMetaObjectProvider;
             if (ido != null)

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/DynamicMetaObjectBinder.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/DynamicMetaObjectBinder.cs
@@ -52,9 +52,9 @@ namespace System.Dynamic
         /// </returns>
         public sealed override Expression Bind(object[] args, ReadOnlyCollection<ParameterExpression> parameters, LabelTarget returnLabel)
         {
-            ContractUtils.RequiresNotNull(args, "args");
-            ContractUtils.RequiresNotNull(parameters, "parameters");
-            ContractUtils.RequiresNotNull(returnLabel, "returnLabel");
+            ContractUtils.RequiresNotNull(args, nameof(args));
+            ContractUtils.RequiresNotNull(parameters, nameof(parameters));
+            ContractUtils.RequiresNotNull(returnLabel, nameof(returnLabel));
             if (args.Length == 0)
             {
                 throw Error.OutOfRange("args.Length", 1);
@@ -194,7 +194,7 @@ namespace System.Dynamic
         /// <returns>The <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public DynamicMetaObject Defer(DynamicMetaObject target, params DynamicMetaObject[] args)
         {
-            ContractUtils.RequiresNotNull(target, "target");
+            ContractUtils.RequiresNotNull(target, nameof(target));
 
             if (args == null)
             {

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/ExpandoObject.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/ExpandoObject.cs
@@ -290,7 +290,7 @@ namespace System.Dynamic
         #region Helper methods
         private void TryAddMember(string key, object value)
         {
-            ContractUtils.RequiresNotNull(key, "key");
+            ContractUtils.RequiresNotNull(key, nameof(key));
             // Pass null to the class, which forces lookup.
             TrySetValue(null, -1, value, key, false, true);
         }
@@ -384,8 +384,8 @@ namespace System.Dynamic
 
             public void CopyTo(string[] array, int arrayIndex)
             {
-                ContractUtils.RequiresNotNull(array, "array");
-                ContractUtils.RequiresArrayRange(array, arrayIndex, _expandoCount, "arrayIndex", "Count");
+                ContractUtils.RequiresNotNull(array, nameof(array));
+                ContractUtils.RequiresArrayRange(array, arrayIndex, _expandoCount, nameof(arrayIndex), nameof(Count));
                 lock (_expando.LockObject)
                 {
                     CheckVersion();
@@ -535,8 +535,8 @@ namespace System.Dynamic
 
             public void CopyTo(object[] array, int arrayIndex)
             {
-                ContractUtils.RequiresNotNull(array, "array");
-                ContractUtils.RequiresArrayRange(array, arrayIndex, _expandoCount, "arrayIndex", "Count");
+                ContractUtils.RequiresNotNull(array, nameof(array));
+                ContractUtils.RequiresArrayRange(array, arrayIndex, _expandoCount, nameof(arrayIndex), nameof(Count));
                 lock (_expando.LockObject)
                 {
                     CheckVersion();
@@ -633,7 +633,7 @@ namespace System.Dynamic
             }
             set
             {
-                ContractUtils.RequiresNotNull(key, "key");
+                ContractUtils.RequiresNotNull(key, nameof(key));
                 // Pass null to the class, which forces lookup.
                 TrySetValue(null, -1, value, key, false, false);
             }
@@ -646,7 +646,7 @@ namespace System.Dynamic
 
         bool IDictionary<string, object>.ContainsKey(string key)
         {
-            ContractUtils.RequiresNotNull(key, "key");
+            ContractUtils.RequiresNotNull(key, nameof(key));
 
             ExpandoData data = _data;
             int index = data.Class.GetValueIndexCaseSensitive(key);
@@ -655,7 +655,7 @@ namespace System.Dynamic
 
         bool IDictionary<string, object>.Remove(string key)
         {
-            ContractUtils.RequiresNotNull(key, "key");
+            ContractUtils.RequiresNotNull(key, nameof(key));
             // Pass null to the class, which forces lookup.
             return TryDeleteValue(null, -1, key, false, Uninitialized);
         }
@@ -724,8 +724,8 @@ namespace System.Dynamic
 
         void ICollection<KeyValuePair<string, object>>.CopyTo(KeyValuePair<string, object>[] array, int arrayIndex)
         {
-            ContractUtils.RequiresNotNull(array, "array");
-            ContractUtils.RequiresArrayRange(array, arrayIndex, _count, "arrayIndex", "Count");
+            ContractUtils.RequiresNotNull(array, nameof(array));
+            ContractUtils.RequiresArrayRange(array, arrayIndex, _count, nameof(arrayIndex), nameof(ICollection<KeyValuePair<string, object>>.Count));
 
             // We want this to be atomic and not throw
             lock (LockObject)
@@ -833,7 +833,7 @@ namespace System.Dynamic
 
             public override DynamicMetaObject BindGetMember(GetMemberBinder binder)
             {
-                ContractUtils.RequiresNotNull(binder, "binder");
+                ContractUtils.RequiresNotNull(binder, nameof(binder));
                 return BindGetOrInvokeMember(
                     binder,
                     binder.Name,
@@ -845,7 +845,7 @@ namespace System.Dynamic
 
             public override DynamicMetaObject BindInvokeMember(InvokeMemberBinder binder, DynamicMetaObject[] args)
             {
-                ContractUtils.RequiresNotNull(binder, "binder");
+                ContractUtils.RequiresNotNull(binder, nameof(binder));
                 return BindGetOrInvokeMember(
                     binder,
                     binder.Name,
@@ -857,8 +857,8 @@ namespace System.Dynamic
 
             public override DynamicMetaObject BindSetMember(SetMemberBinder binder, DynamicMetaObject value)
             {
-                ContractUtils.RequiresNotNull(binder, "binder");
-                ContractUtils.RequiresNotNull(value, "value");
+                ContractUtils.RequiresNotNull(binder, nameof(binder));
+                ContractUtils.RequiresNotNull(value, nameof(value));
 
                 ExpandoClass klass;
                 int index;
@@ -886,7 +886,7 @@ namespace System.Dynamic
 
             public override DynamicMetaObject BindDeleteMember(DeleteMemberBinder binder)
             {
-                ContractUtils.RequiresNotNull(binder, "binder");
+                ContractUtils.RequiresNotNull(binder, nameof(binder));
 
                 int index = Value.Class.GetValueIndex(binder.Name, binder.IgnoreCase, Value);
 

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/GetIndexBinder.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/GetIndexBinder.cs
@@ -19,7 +19,7 @@ namespace System.Dynamic
         /// <param name="callInfo">The signature of the arguments at the call site.</param>
         protected GetIndexBinder(CallInfo callInfo)
         {
-            ContractUtils.RequiresNotNull(callInfo, "callInfo");
+            ContractUtils.RequiresNotNull(callInfo, nameof(callInfo));
             _callInfo = callInfo;
         }
 
@@ -47,8 +47,8 @@ namespace System.Dynamic
         /// <returns>The <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public sealed override DynamicMetaObject Bind(DynamicMetaObject target, DynamicMetaObject[] args)
         {
-            ContractUtils.RequiresNotNull(target, "target");
-            ContractUtils.RequiresNotNullItems(args, "args");
+            ContractUtils.RequiresNotNull(target, nameof(target));
+            ContractUtils.RequiresNotNullItems(args, nameof(args));
 
             return target.BindGetIndex(this, args);
         }

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/GetMemberBinder.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/GetMemberBinder.cs
@@ -21,7 +21,7 @@ namespace System.Dynamic
         /// <param name="ignoreCase">true if the name should be matched ignoring case; false otherwise.</param>
         protected GetMemberBinder(string name, bool ignoreCase)
         {
-            ContractUtils.RequiresNotNull(name, "name");
+            ContractUtils.RequiresNotNull(name, nameof(name));
 
             _name = name;
             _ignoreCase = ignoreCase;
@@ -83,8 +83,8 @@ namespace System.Dynamic
         /// <returns>The <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public sealed override DynamicMetaObject Bind(DynamicMetaObject target, params DynamicMetaObject[] args)
         {
-            ContractUtils.RequiresNotNull(target, "target");
-            ContractUtils.Requires(args == null || args.Length == 0, "args");
+            ContractUtils.RequiresNotNull(target, nameof(target));
+            ContractUtils.Requires(args == null || args.Length == 0, nameof(args));
 
             return target.BindGetMember(this);
         }

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/InvokeBinder.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/InvokeBinder.cs
@@ -19,7 +19,7 @@ namespace System.Dynamic
         /// <param name="callInfo">The signature of the arguments at the call site.</param>
         protected InvokeBinder(CallInfo callInfo)
         {
-            ContractUtils.RequiresNotNull(callInfo, "callInfo");
+            ContractUtils.RequiresNotNull(callInfo, nameof(callInfo));
             _callInfo = callInfo;
         }
 
@@ -67,8 +67,8 @@ namespace System.Dynamic
         /// <returns>The <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public sealed override DynamicMetaObject Bind(DynamicMetaObject target, DynamicMetaObject[] args)
         {
-            ContractUtils.RequiresNotNull(target, "target");
-            ContractUtils.RequiresNotNullItems(args, "args");
+            ContractUtils.RequiresNotNull(target, nameof(target));
+            ContractUtils.RequiresNotNullItems(args, nameof(args));
 
             return target.BindInvoke(this, args);
         }

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/InvokeMemberBinder.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/InvokeMemberBinder.cs
@@ -24,8 +24,8 @@ namespace System.Dynamic
         /// <param name="callInfo">The signature of the arguments at the call site.</param>
         protected InvokeMemberBinder(string name, bool ignoreCase, CallInfo callInfo)
         {
-            ContractUtils.RequiresNotNull(name, "name");
-            ContractUtils.RequiresNotNull(callInfo, "callInfo");
+            ContractUtils.RequiresNotNull(name, nameof(name));
+            ContractUtils.RequiresNotNull(callInfo, nameof(callInfo));
 
             _name = name;
             _ignoreCase = ignoreCase;
@@ -78,8 +78,8 @@ namespace System.Dynamic
         /// <returns>The <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public sealed override DynamicMetaObject Bind(DynamicMetaObject target, DynamicMetaObject[] args)
         {
-            ContractUtils.RequiresNotNull(target, "target");
-            ContractUtils.RequiresNotNullItems(args, "args");
+            ContractUtils.RequiresNotNull(target, nameof(target));
+            ContractUtils.RequiresNotNullItems(args, nameof(args));
 
             return target.BindInvokeMember(this, args);
         }

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/SetIndexBinder.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/SetIndexBinder.cs
@@ -19,7 +19,7 @@ namespace System.Dynamic
         /// <param name="callInfo">The signature of the arguments at the call site.</param>
         protected SetIndexBinder(CallInfo callInfo)
         {
-            ContractUtils.RequiresNotNull(callInfo, "callInfo");
+            ContractUtils.RequiresNotNull(callInfo, nameof(callInfo));
             _callInfo = callInfo;
         }
 
@@ -47,15 +47,15 @@ namespace System.Dynamic
         /// <returns>The <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public sealed override DynamicMetaObject Bind(DynamicMetaObject target, DynamicMetaObject[] args)
         {
-            ContractUtils.RequiresNotNull(target, "target");
-            ContractUtils.RequiresNotNull(args, "args");
-            ContractUtils.Requires(args.Length >= 2, "args");
+            ContractUtils.RequiresNotNull(target, nameof(target));
+            ContractUtils.RequiresNotNull(args, nameof(args));
+            ContractUtils.Requires(args.Length >= 2, nameof(args));
 
             DynamicMetaObject value = args[args.Length - 1];
             DynamicMetaObject[] indexes = args.RemoveLast();
 
-            ContractUtils.RequiresNotNull(value, "args");
-            ContractUtils.RequiresNotNullItems(indexes, "args");
+            ContractUtils.RequiresNotNull(value, nameof(args));
+            ContractUtils.RequiresNotNullItems(indexes, nameof(args));
 
             return target.BindSetIndex(this, indexes, value);
         }

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/SetMemberBinder.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/SetMemberBinder.cs
@@ -21,7 +21,7 @@ namespace System.Dynamic
         /// <param name="ignoreCase">true if the name should be matched ignoring case; false otherwise.</param>
         protected SetMemberBinder(string name, bool ignoreCase)
         {
-            ContractUtils.RequiresNotNull(name, "name");
+            ContractUtils.RequiresNotNull(name, nameof(name));
 
             _name = name;
             _ignoreCase = ignoreCase;
@@ -65,12 +65,12 @@ namespace System.Dynamic
         /// <returns>The <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public sealed override DynamicMetaObject Bind(DynamicMetaObject target, DynamicMetaObject[] args)
         {
-            ContractUtils.RequiresNotNull(target, "target");
-            ContractUtils.RequiresNotNull(args, "args");
-            ContractUtils.Requires(args.Length == 1, "args");
+            ContractUtils.RequiresNotNull(target, nameof(target));
+            ContractUtils.RequiresNotNull(args, nameof(args));
+            ContractUtils.Requires(args.Length == 1, nameof(args));
 
             var arg0 = args[0];
-            ContractUtils.RequiresNotNull(arg0, "args");
+            ContractUtils.RequiresNotNull(arg0, nameof(args));
 
             return target.BindSetMember(this, arg0);
         }

--- a/src/System.Dynamic.Runtime/src/System/Dynamic/UnaryOperationBinder.cs
+++ b/src/System.Dynamic.Runtime/src/System/Dynamic/UnaryOperationBinder.cs
@@ -20,7 +20,7 @@ namespace System.Dynamic
         /// <param name="operation">The unary operation kind.</param>
         protected UnaryOperationBinder(ExpressionType operation)
         {
-            ContractUtils.Requires(OperationIsValid(operation), "operation");
+            ContractUtils.Requires(OperationIsValid(operation), nameof(operation));
             _operation = operation;
         }
 
@@ -79,8 +79,8 @@ namespace System.Dynamic
         /// <returns>The <see cref="DynamicMetaObject"/> representing the result of the binding.</returns>
         public sealed override DynamicMetaObject Bind(DynamicMetaObject target, DynamicMetaObject[] args)
         {
-            ContractUtils.RequiresNotNull(target, "target");
-            ContractUtils.Requires(args == null || args.Length == 0, "args");
+            ContractUtils.RequiresNotNull(target, nameof(target));
+            ContractUtils.Requires(args == null || args.Length == 0, nameof(args));
 
             return target.BindUnaryOperation(this);
         }

--- a/src/System.Dynamic.Runtime/src/System/Linq/Expressions/DynamicExpression.cs
+++ b/src/System.Dynamic.Runtime/src/System/Linq/Expressions/DynamicExpression.cs
@@ -805,8 +805,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, IEnumerable<Expression> arguments)
         {
-            ContractUtils.RequiresNotNull(delegateType, "delegateType");
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(delegateType, nameof(delegateType));
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             if (!delegateType.IsSubclassOf(typeof(MulticastDelegate))) throw Error.TypeMustBeDerivedFromSystemDelegate();
 
             var method = GetValidMethodForDynamic(delegateType);
@@ -832,8 +832,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0)
         {
-            ContractUtils.RequiresNotNull(delegateType, "delegateType");
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(delegateType, nameof(delegateType));
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             if (!delegateType.IsSubclassOf(typeof(MulticastDelegate))) throw Error.TypeMustBeDerivedFromSystemDelegate();
 
             var method = GetValidMethodForDynamic(delegateType);
@@ -862,8 +862,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0, Expression arg1)
         {
-            ContractUtils.RequiresNotNull(delegateType, "delegateType");
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(delegateType, nameof(delegateType));
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             if (!delegateType.IsSubclassOf(typeof(MulticastDelegate))) throw Error.TypeMustBeDerivedFromSystemDelegate();
 
             var method = GetValidMethodForDynamic(delegateType);
@@ -895,8 +895,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0, Expression arg1, Expression arg2)
         {
-            ContractUtils.RequiresNotNull(delegateType, "delegateType");
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(delegateType, nameof(delegateType));
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             if (!delegateType.IsSubclassOf(typeof(MulticastDelegate))) throw Error.TypeMustBeDerivedFromSystemDelegate();
 
             var method = GetValidMethodForDynamic(delegateType);
@@ -931,8 +931,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static DynamicExpression MakeDynamic(Type delegateType, CallSiteBinder binder, Expression arg0, Expression arg1, Expression arg2, Expression arg3)
         {
-            ContractUtils.RequiresNotNull(delegateType, "delegateType");
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(delegateType, nameof(delegateType));
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             if (!delegateType.IsSubclassOf(typeof(MulticastDelegate))) throw Error.TypeMustBeDerivedFromSystemDelegate();
 
             var method = GetValidMethodForDynamic(delegateType);
@@ -998,7 +998,7 @@ namespace System.Linq.Expressions
         /// </remarks>
         public static DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0)
         {
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             ValidateDynamicArgument(arg0);
 
             DelegateHelpers.TypeInfo info = DelegateHelpers.GetNextTypeInfo(
@@ -1037,7 +1037,7 @@ namespace System.Linq.Expressions
         /// </remarks>
         public static DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1)
         {
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             ValidateDynamicArgument(arg0);
             ValidateDynamicArgument(arg1);
 
@@ -1081,7 +1081,7 @@ namespace System.Linq.Expressions
         /// </remarks>
         public static DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1, Expression arg2)
         {
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             ValidateDynamicArgument(arg0);
             ValidateDynamicArgument(arg1);
             ValidateDynamicArgument(arg2);
@@ -1130,7 +1130,7 @@ namespace System.Linq.Expressions
         /// </remarks>
         public static DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, Expression arg0, Expression arg1, Expression arg2, Expression arg3)
         {
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             ValidateDynamicArgument(arg0);
             ValidateDynamicArgument(arg1);
             ValidateDynamicArgument(arg2);
@@ -1180,17 +1180,17 @@ namespace System.Linq.Expressions
         /// </remarks>
         public static DynamicExpression Dynamic(CallSiteBinder binder, Type returnType, IEnumerable<Expression> arguments)
         {
-            ContractUtils.RequiresNotNull(arguments, "arguments");
-            ContractUtils.RequiresNotNull(returnType, "returnType");
+            ContractUtils.RequiresNotNull(arguments, nameof(arguments));
+            ContractUtils.RequiresNotNull(returnType, nameof(returnType));
 
             var args = arguments.ToReadOnly();
-            ContractUtils.RequiresNotEmpty(args, "args");
+            ContractUtils.RequiresNotEmpty(args, nameof(args));
             return MakeDynamic(binder, returnType, args);
         }
 
         private static DynamicExpression MakeDynamic(CallSiteBinder binder, Type returnType, ReadOnlyCollection<Expression> args)
         {
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
 
             for (int i = 0; i < args.Count; i++)
             {
@@ -1218,7 +1218,7 @@ namespace System.Linq.Expressions
         {
             ExpressionUtils.RequiresCanRead(arg, "arguments");
             var type = arg.Type;
-            ContractUtils.RequiresNotNull(type, "type");
+            ContractUtils.RequiresNotNull(type, nameof(type));
             TypeUtils.ValidateType(type);
             if (type == typeof(void)) throw Error.ArgumentTypeCannotBeVoid();
         }

--- a/src/System.Dynamic.Runtime/src/System/Runtime/CompilerServices/CallSite.cs
+++ b/src/System.Dynamic.Runtime/src/System/Runtime/CompilerServices/CallSite.cs
@@ -81,8 +81,8 @@ namespace System.Runtime.CompilerServices
         /// <returns>The new CallSite.</returns>
         public static CallSite Create(Type delegateType, CallSiteBinder binder)
         {
-            ContractUtils.RequiresNotNull(delegateType, "delegateType");
-            ContractUtils.RequiresNotNull(binder, "binder");
+            ContractUtils.RequiresNotNull(delegateType, nameof(delegateType));
+            ContractUtils.RequiresNotNull(binder, nameof(binder));
             if (!delegateType.IsSubclassOf(typeof(MulticastDelegate))) throw Error.TypeMustBeDerivedFromSystemDelegate();
 
             var ctors = s_siteCtors;
@@ -340,7 +340,7 @@ namespace System.Runtime.CompilerServices
         private static bool IsSimpleSignature(MethodInfo invoke, out Type[] sig)
         {
             ParameterInfo[] pis = invoke.GetParametersCached();
-            ContractUtils.Requires(pis.Length > 0 && pis[0].ParameterType == typeof(CallSite), "T");
+            ContractUtils.Requires(pis.Length > 0 && pis[0].ParameterType == typeof(CallSite), nameof(T));
 
             Type[] args = new Type[invoke.ReturnType != typeof(void) ? pis.Length : pis.Length - 1];
             bool supported = true;


### PR DESCRIPTION
Mostly automated replacement of parameter name string literals with corresponding usage of `nameof` (via a modified version of @jaredpar's https://github.com/jaredpar/UseNameOf) along the lines of #6209,  #6265, and #6267.

cc: @stephentoub, @VSadov 