### PR TITLE
Use nameof in System.Linq.Expressions

### DIFF
--- a/src/Common/src/System/Dynamic/Utils/ExpressionUtils.cs
+++ b/src/Common/src/System/Dynamic/Utils/ExpressionUtils.cs
@@ -141,35 +141,35 @@ namespace System.Dynamic.Utils
             }
         }
 
-        public static Expression ValidateOneArgument(MethodBase method, ExpressionType nodeKind, Expression arg, ParameterInfo pi)
+        public static Expression ValidateOneArgument(MethodBase method, ExpressionType nodeKind, Expression arguments, ParameterInfo pi)
         {
-            RequiresCanRead(arg, "arguments");
+            RequiresCanRead(arguments, nameof(arguments));
             Type pType = pi.ParameterType;
             if (pType.IsByRef)
             {
                 pType = pType.GetElementType();
             }
             TypeUtils.ValidateType(pType);
-            if (!TypeUtils.AreReferenceAssignable(pType, arg.Type))
+            if (!TypeUtils.AreReferenceAssignable(pType, arguments.Type))
             {
-                if (!TryQuote(pType, ref arg))
+                if (!TryQuote(pType, ref arguments))
                 {
                     // Throw the right error for the node we were given
                     switch (nodeKind)
                     {
                         case ExpressionType.New:
-                            throw Error.ExpressionTypeDoesNotMatchConstructorParameter(arg.Type, pType);
+                            throw Error.ExpressionTypeDoesNotMatchConstructorParameter(arguments.Type, pType);
                         case ExpressionType.Invoke:
-                            throw Error.ExpressionTypeDoesNotMatchParameter(arg.Type, pType);
+                            throw Error.ExpressionTypeDoesNotMatchParameter(arguments.Type, pType);
                         case ExpressionType.Dynamic:
                         case ExpressionType.Call:
-                            throw Error.ExpressionTypeDoesNotMatchMethodParameter(arg.Type, pType, method);
+                            throw Error.ExpressionTypeDoesNotMatchMethodParameter(arguments.Type, pType, method);
                         default:
                             throw ContractUtils.Unreachable;
                     }
                 }
             }
-            return arg;
+            return arguments;
         }
 
         public static void RequiresCanRead(Expression expression, string paramName)

--- a/src/Common/src/System/Linq/Expressions/Compiler/AssemblyGen.cs
+++ b/src/Common/src/System/Linq/Expressions/Compiler/AssemblyGen.cs
@@ -46,8 +46,8 @@ namespace System.Linq.Expressions.Compiler
 
         private TypeBuilder DefineType(string name, Type parent, TypeAttributes attr)
         {
-            ContractUtils.RequiresNotNull(name, "name");
-            ContractUtils.RequiresNotNull(parent, "parent");
+            ContractUtils.RequiresNotNull(name, nameof(name));
+            ContractUtils.RequiresNotNull(parent, nameof(parent));
 
             StringBuilder sb = new StringBuilder(name);
 

--- a/src/Common/src/System/Runtime/CompilerServices/ReadOnlyCollectionBuilder.cs
+++ b/src/Common/src/System/Runtime/CompilerServices/ReadOnlyCollectionBuilder.cs
@@ -38,7 +38,7 @@ namespace System.Runtime.CompilerServices
         /// </summary> 
         public ReadOnlyCollectionBuilder(int capacity)
         {
-            ContractUtils.Requires(capacity >= 0, "capacity");
+            ContractUtils.Requires(capacity >= 0, nameof(capacity));
             _items = new T[capacity];
         }
 
@@ -48,7 +48,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="collection"></param>
         public ReadOnlyCollectionBuilder(IEnumerable<T> collection)
         {
-            ContractUtils.Requires(collection != null, "collection");
+            ContractUtils.Requires(collection != null, nameof(collection));
 
             ICollection<T> c = collection as ICollection<T>;
             if (c != null)
@@ -81,7 +81,7 @@ namespace System.Runtime.CompilerServices
             get { return _items.Length; }
             set
             {
-                ContractUtils.Requires(value >= _size, "value");
+                ContractUtils.Requires(value >= _size, nameof(value));
 
                 if (value != _items.Length)
                 {
@@ -129,7 +129,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="item">The object to insert into the <see cref="ReadOnlyCollectionBuilder{T}"/>.</param>
         public void Insert(int index, T item)
         {
-            ContractUtils.Requires(index <= _size, "index");
+            ContractUtils.Requires(index <= _size, nameof(index));
 
             if (_size == _items.Length)
             {
@@ -150,7 +150,7 @@ namespace System.Runtime.CompilerServices
         /// <param name="index">The zero-based index of the item to remove.</param>
         public void RemoveAt(int index)
         {
-            ContractUtils.Requires(index >= 0 && index < _size, "index");
+            ContractUtils.Requires(index >= 0 && index < _size, nameof(index));
 
             _size--;
             if (index < _size)
@@ -170,12 +170,12 @@ namespace System.Runtime.CompilerServices
         {
             get
             {
-                ContractUtils.Requires(index < _size, "index");
+                ContractUtils.Requires(index < _size, nameof(index));
                 return _items[index];
             }
             set
             {
-                ContractUtils.Requires(index < _size, "index");
+                ContractUtils.Requires(index < _size, nameof(index));
                 _items[index] = value;
                 _version++;
             }
@@ -312,14 +312,14 @@ namespace System.Runtime.CompilerServices
 
         int System.Collections.IList.Add(object value)
         {
-            ValidateNullValue(value, "value");
+            ValidateNullValue(value, nameof(value));
             try
             {
                 Add((T)value);
             }
             catch (InvalidCastException)
             {
-                ThrowInvalidTypeException(value, "value");
+                ThrowInvalidTypeException(value, nameof(value));
             }
             return Count - 1;
         }
@@ -344,14 +344,14 @@ namespace System.Runtime.CompilerServices
 
         void System.Collections.IList.Insert(int index, object value)
         {
-            ValidateNullValue(value, "value");
+            ValidateNullValue(value, nameof(value));
             try
             {
                 Insert(index, (T)value);
             }
             catch (InvalidCastException)
             {
-                ThrowInvalidTypeException(value, "value");
+                ThrowInvalidTypeException(value, nameof(value));
             }
         }
 
@@ -376,7 +376,7 @@ namespace System.Runtime.CompilerServices
             }
             set
             {
-                ValidateNullValue(value, "value");
+                ValidateNullValue(value, nameof(value));
 
                 try
                 {
@@ -384,7 +384,7 @@ namespace System.Runtime.CompilerServices
                 }
                 catch (InvalidCastException)
                 {
-                    ThrowInvalidTypeException(value, "value");
+                    ThrowInvalidTypeException(value, nameof(value));
                 }
             }
         }
@@ -395,8 +395,8 @@ namespace System.Runtime.CompilerServices
 
         void System.Collections.ICollection.CopyTo(Array array, int index)
         {
-            ContractUtils.RequiresNotNull(array, "array");
-            ContractUtils.Requires(array.Rank == 1, "array");
+            ContractUtils.RequiresNotNull(array, nameof(array));
+            ContractUtils.Requires(array.Rank == 1, nameof(array));
             Array.Copy(_items, 0, array, index, _size);
         }
 
@@ -434,8 +434,8 @@ namespace System.Runtime.CompilerServices
         /// <param name="count">The number of elements in the range to reverse.</param>
         public void Reverse(int index, int count)
         {
-            ContractUtils.Requires(index >= 0, "index");
-            ContractUtils.Requires(count >= 0, "count");
+            ContractUtils.Requires(index >= 0, nameof(index));
+            ContractUtils.Requires(count >= 0, nameof(count));
 
             Array.Reverse(_items, index, count);
             _version++;

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BinaryExpression.cs
@@ -625,8 +625,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression Assign(Expression left, Expression right)
         {
-            RequiresCanWrite(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanWrite(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             TypeUtils.ValidateType(left.Type);
             TypeUtils.ValidateType(right.Type);
             if (!TypeUtils.AreReferenceAssignable(left.Type, right.Type))
@@ -1064,8 +1064,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression Equal(Expression left, Expression right, bool liftToNull, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 return GetEqualityComparisonOperator(ExpressionType.Equal, "op_Equality", left, right, liftToNull);
@@ -1083,8 +1083,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression ReferenceEqual(Expression left, Expression right)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (TypeUtils.HasReferenceEquality(left.Type, right.Type))
             {
                 return new LogicalBinaryExpression(ExpressionType.Equal, left, right);
@@ -1116,8 +1116,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression NotEqual(Expression left, Expression right, bool liftToNull, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 return GetEqualityComparisonOperator(ExpressionType.NotEqual, "op_Inequality", left, right, liftToNull);
@@ -1135,8 +1135,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression ReferenceNotEqual(Expression left, Expression right)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (TypeUtils.HasReferenceEquality(left.Type, right.Type))
             {
                 return new LogicalBinaryExpression(ExpressionType.NotEqual, left, right);
@@ -1210,8 +1210,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression GreaterThan(Expression left, Expression right, bool liftToNull, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 return GetComparisonOperator(ExpressionType.GreaterThan, "op_GreaterThan", left, right, liftToNull);
@@ -1244,8 +1244,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression LessThan(Expression left, Expression right, bool liftToNull, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 return GetComparisonOperator(ExpressionType.LessThan, "op_LessThan", left, right, liftToNull);
@@ -1278,8 +1278,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression GreaterThanOrEqual(Expression left, Expression right, bool liftToNull, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 return GetComparisonOperator(ExpressionType.GreaterThanOrEqual, "op_GreaterThanOrEqual", left, right, liftToNull);
@@ -1312,8 +1312,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression LessThanOrEqual(Expression left, Expression right, bool liftToNull, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 return GetComparisonOperator(ExpressionType.LessThanOrEqual, "op_LessThanOrEqual", left, right, liftToNull);
@@ -1366,8 +1366,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression AndAlso(Expression left, Expression right, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             Type returnType;
             if (method == null)
             {
@@ -1420,8 +1420,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression OrElse(Expression left, Expression right, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             Type returnType;
             if (method == null)
             {
@@ -1477,8 +1477,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression Coalesce(Expression left, Expression right, LambdaExpression conversion)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
 
             if (conversion == null)
             {
@@ -1578,8 +1578,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression Add(Expression left, Expression right, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (left.Type == right.Type && TypeUtils.IsArithmetic(left.Type))
@@ -1632,9 +1632,9 @@ namespace System.Linq.Expressions
 
         public static BinaryExpression AddAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanWrite(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanWrite(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (left.Type == right.Type && TypeUtils.IsArithmetic(left.Type))
@@ -1718,9 +1718,9 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression AddAssignChecked(Expression left, Expression right, MethodInfo method, LambdaExpression conversion)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanWrite(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanWrite(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
 
             if (method == null)
             {
@@ -1762,8 +1762,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression AddChecked(Expression left, Expression right, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (left.Type == right.Type && TypeUtils.IsArithmetic(left.Type))
@@ -1799,8 +1799,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression Subtract(Expression left, Expression right, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (left.Type == right.Type && TypeUtils.IsArithmetic(left.Type))
@@ -1852,9 +1852,9 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression SubtractAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanWrite(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanWrite(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (left.Type == right.Type && TypeUtils.IsArithmetic(left.Type))
@@ -1911,9 +1911,9 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression SubtractAssignChecked(Expression left, Expression right, MethodInfo method, LambdaExpression conversion)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanWrite(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanWrite(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (left.Type == right.Type && TypeUtils.IsArithmetic(left.Type))
@@ -1954,8 +1954,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression SubtractChecked(Expression left, Expression right, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (left.Type == right.Type && TypeUtils.IsArithmetic(left.Type))
@@ -1991,8 +1991,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression Divide(Expression left, Expression right, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (left.Type == right.Type && TypeUtils.IsArithmetic(left.Type))
@@ -2044,9 +2044,9 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression DivideAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanWrite(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanWrite(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (left.Type == right.Type && TypeUtils.IsArithmetic(left.Type))
@@ -2087,8 +2087,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression Modulo(Expression left, Expression right, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (left.Type == right.Type && TypeUtils.IsArithmetic(left.Type))
@@ -2140,9 +2140,9 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression ModuloAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanWrite(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanWrite(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (left.Type == right.Type && TypeUtils.IsArithmetic(left.Type))
@@ -2183,8 +2183,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression Multiply(Expression left, Expression right, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (left.Type == right.Type && TypeUtils.IsArithmetic(left.Type))
@@ -2236,9 +2236,9 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression MultiplyAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanWrite(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanWrite(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (left.Type == right.Type && TypeUtils.IsArithmetic(left.Type))
@@ -2295,9 +2295,9 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression MultiplyAssignChecked(Expression left, Expression right, MethodInfo method, LambdaExpression conversion)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanWrite(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanWrite(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (left.Type == right.Type && TypeUtils.IsArithmetic(left.Type))
@@ -2338,8 +2338,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression MultiplyChecked(Expression left, Expression right, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (left.Type == right.Type && TypeUtils.IsArithmetic(left.Type))
@@ -2391,8 +2391,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression LeftShift(Expression left, Expression right, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (IsSimpleShift(left.Type, right.Type))
@@ -2445,9 +2445,9 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression LeftShiftAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanWrite(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanWrite(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (IsSimpleShift(left.Type, right.Type))
@@ -2489,8 +2489,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression RightShift(Expression left, Expression right, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (IsSimpleShift(left.Type, right.Type))
@@ -2543,9 +2543,9 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression RightShiftAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanWrite(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanWrite(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (IsSimpleShift(left.Type, right.Type))
@@ -2587,8 +2587,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression And(Expression left, Expression right, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (left.Type == right.Type && TypeUtils.IsIntegerOrBool(left.Type))
@@ -2640,9 +2640,9 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression AndAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanWrite(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanWrite(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (left.Type == right.Type && TypeUtils.IsIntegerOrBool(left.Type))
@@ -2683,8 +2683,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression Or(Expression left, Expression right, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (left.Type == right.Type && TypeUtils.IsIntegerOrBool(left.Type))
@@ -2736,9 +2736,9 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression OrAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanWrite(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanWrite(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (left.Type == right.Type && TypeUtils.IsIntegerOrBool(left.Type))
@@ -2778,8 +2778,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression ExclusiveOr(Expression left, Expression right, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (left.Type == right.Type && TypeUtils.IsIntegerOrBool(left.Type))
@@ -2830,9 +2830,9 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression ExclusiveOrAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanWrite(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanWrite(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 if (left.Type == right.Type && TypeUtils.IsIntegerOrBool(left.Type))
@@ -2872,8 +2872,8 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression Power(Expression left, Expression right, MethodInfo method)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 Type mathType = typeof(System.Math);
@@ -2926,9 +2926,9 @@ namespace System.Linq.Expressions
         /// </returns>
         public static BinaryExpression PowerAssign(Expression left, Expression right, MethodInfo method, LambdaExpression conversion)
         {
-            RequiresCanRead(left, "left");
-            RequiresCanWrite(left, "left");
-            RequiresCanRead(right, "right");
+            RequiresCanRead(left, nameof(left));
+            RequiresCanWrite(left, nameof(left));
+            RequiresCanRead(right, nameof(right));
             if (method == null)
             {
                 Type mathType = typeof(System.Math);
@@ -2954,8 +2954,8 @@ namespace System.Linq.Expressions
         /// <returns>A BinaryExpression that has the NodeType property equal to ArrayIndex and the Left and Right properties set to the specified values.</returns>
         public static BinaryExpression ArrayIndex(Expression array, Expression index)
         {
-            RequiresCanRead(array, "array");
-            RequiresCanRead(index, "index");
+            RequiresCanRead(array, nameof(array));
+            RequiresCanRead(index, nameof(index));
             if (index.Type != typeof(int))
             {
                 throw Error.ArgumentMustBeArrayIndexType();

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/BlockExpression.cs
@@ -190,7 +190,7 @@ namespace System.Linq.Expressions
             {
                 case 0: return ReturnObject<Expression>(_arg0);
                 case 1: return _arg1;
-                default: throw Error.ArgumentOutOfRange("index");
+                default: throw Error.ArgumentOutOfRange(nameof(index));
             }
         }
 
@@ -236,7 +236,7 @@ namespace System.Linq.Expressions
                 case 0: return ReturnObject<Expression>(_arg0);
                 case 1: return _arg1;
                 case 2: return _arg2;
-                default: throw Error.ArgumentOutOfRange("index");
+                default: throw Error.ArgumentOutOfRange(nameof(index));
             }
         }
 
@@ -284,7 +284,7 @@ namespace System.Linq.Expressions
                 case 1: return _arg1;
                 case 2: return _arg2;
                 case 3: return _arg3;
-                default: throw Error.ArgumentOutOfRange("index");
+                default: throw Error.ArgumentOutOfRange(nameof(index));
             }
         }
 
@@ -334,7 +334,7 @@ namespace System.Linq.Expressions
                 case 2: return _arg2;
                 case 3: return _arg3;
                 case 4: return _arg4;
-                default: throw Error.ArgumentOutOfRange("index");
+                default: throw Error.ArgumentOutOfRange(nameof(index));
             }
         }
 
@@ -429,7 +429,7 @@ namespace System.Linq.Expressions
             if (variables != null && variables != VariablesList)
             {
                 // Need to validate the new variables (uniqueness, not byref)
-                ValidateVariables(variables, "variables");
+                ValidateVariables(variables, nameof(variables));
                 return variables;
             }
             else
@@ -459,7 +459,7 @@ namespace System.Linq.Expressions
             switch (index)
             {
                 case 0: return ReturnObject<Expression>(_body);
-                default: throw Error.ArgumentOutOfRange("index");
+                default: throw Error.ArgumentOutOfRange(nameof(index));
             }
         }
 
@@ -481,7 +481,7 @@ namespace System.Linq.Expressions
             if (args == null)
             {
                 Debug.Assert(variables.Count == Variables.Count);
-                ValidateVariables(variables, "variables");
+                ValidateVariables(variables, nameof(variables));
                 return new Scope1(variables, _body);
             }
             Debug.Assert(args.Length == 1);
@@ -529,7 +529,7 @@ namespace System.Linq.Expressions
             if (args == null)
             {
                 Debug.Assert(variables.Count == Variables.Count);
-                ValidateVariables(variables, "variables");
+                ValidateVariables(variables, nameof(variables));
                 return new ScopeN(variables, _body);
             }
             Debug.Assert(args.Length == ExpressionCount);
@@ -559,7 +559,7 @@ namespace System.Linq.Expressions
             if (args == null)
             {
                 Debug.Assert(variables.Count == Variables.Count);
-                ValidateVariables(variables, "variables");
+                ValidateVariables(variables, nameof(variables));
                 return new ScopeWithType(variables, Body, _type);
             }
             Debug.Assert(args.Length == ExpressionCount);
@@ -731,8 +731,8 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="BlockExpression"/>.</returns>
         public static BlockExpression Block(Expression arg0, Expression arg1)
         {
-            RequiresCanRead(arg0, "arg0");
-            RequiresCanRead(arg1, "arg1");
+            RequiresCanRead(arg0, nameof(arg0));
+            RequiresCanRead(arg1, nameof(arg1));
 
             return new Block2(arg0, arg1);
         }
@@ -745,9 +745,9 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="BlockExpression"/>.</returns>
         public static BlockExpression Block(Expression arg0, Expression arg1, Expression arg2)
         {
-            RequiresCanRead(arg0, "arg0");
-            RequiresCanRead(arg1, "arg1");
-            RequiresCanRead(arg2, "arg2");
+            RequiresCanRead(arg0, nameof(arg0));
+            RequiresCanRead(arg1, nameof(arg1));
+            RequiresCanRead(arg2, nameof(arg2));
             return new Block3(arg0, arg1, arg2);
         }
 
@@ -761,10 +761,10 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="BlockExpression"/>.</returns>
         public static BlockExpression Block(Expression arg0, Expression arg1, Expression arg2, Expression arg3)
         {
-            RequiresCanRead(arg0, "arg0");
-            RequiresCanRead(arg1, "arg1");
-            RequiresCanRead(arg2, "arg2");
-            RequiresCanRead(arg3, "arg3");
+            RequiresCanRead(arg0, nameof(arg0));
+            RequiresCanRead(arg1, nameof(arg1));
+            RequiresCanRead(arg2, nameof(arg2));
+            RequiresCanRead(arg3, nameof(arg3));
             return new Block4(arg0, arg1, arg2, arg3);
         }
 
@@ -779,11 +779,11 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="BlockExpression"/>.</returns>
         public static BlockExpression Block(Expression arg0, Expression arg1, Expression arg2, Expression arg3, Expression arg4)
         {
-            RequiresCanRead(arg0, "arg0");
-            RequiresCanRead(arg1, "arg1");
-            RequiresCanRead(arg2, "arg2");
-            RequiresCanRead(arg3, "arg3");
-            RequiresCanRead(arg4, "arg4");
+            RequiresCanRead(arg0, nameof(arg0));
+            RequiresCanRead(arg1, nameof(arg1));
+            RequiresCanRead(arg2, nameof(arg2));
+            RequiresCanRead(arg3, nameof(arg3));
+            RequiresCanRead(arg4, nameof(arg4));
 
             return new Block5(arg0, arg1, arg2, arg3, arg4);
         }
@@ -795,7 +795,7 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="BlockExpression"/>.</returns>
         public static BlockExpression Block(params Expression[] expressions)
         {
-            ContractUtils.RequiresNotNull(expressions, "expressions");
+            ContractUtils.RequiresNotNull(expressions, nameof(expressions));
 
             return GetOptimizedBlockExpression(expressions);
         }
@@ -818,7 +818,7 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="BlockExpression"/>.</returns>
         public static BlockExpression Block(Type type, params Expression[] expressions)
         {
-            ContractUtils.RequiresNotNull(expressions, "expressions");
+            ContractUtils.RequiresNotNull(expressions, nameof(expressions));
             return Block(type, (IEnumerable<Expression>)expressions);
         }
 
@@ -864,7 +864,7 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="BlockExpression"/>.</returns>
         public static BlockExpression Block(IEnumerable<ParameterExpression> variables, IEnumerable<Expression> expressions)
         {
-            ContractUtils.RequiresNotNull(expressions, "expressions");
+            ContractUtils.RequiresNotNull(expressions, nameof(expressions));
             var variableList = variables.ToReadOnly();
 
             if (variableList.Count == 0)
@@ -885,8 +885,8 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="BlockExpression"/>.</returns>
         public static BlockExpression Block(Type type, IEnumerable<ParameterExpression> variables, IEnumerable<Expression> expressions)
         {
-            ContractUtils.RequiresNotNull(type, "type");
-            ContractUtils.RequiresNotNull(expressions, "expressions");
+            ContractUtils.RequiresNotNull(type, nameof(type));
+            ContractUtils.RequiresNotNull(expressions, nameof(expressions));
 
             var expressionList = expressions.ToReadOnly();
             var variableList = variables.ToReadOnly();
@@ -901,7 +901,7 @@ namespace System.Linq.Expressions
 
                     if (lastExpression == null)
                     {
-                        throw Error.ArgumentNull("expressions");
+                        throw Error.ArgumentNull(nameof(expressions));
                     }
 
                     if (lastExpression.Type == type)
@@ -914,23 +914,23 @@ namespace System.Linq.Expressions
             return BlockCore(type, variableList, expressionList);
         }
 
-        private static BlockExpression BlockCore(Type type, ReadOnlyCollection<ParameterExpression> variableList, ReadOnlyCollection<Expression> expressionList)
+        private static BlockExpression BlockCore(Type type, ReadOnlyCollection<ParameterExpression> variables, ReadOnlyCollection<Expression> expressions)
         {
-            RequiresCanRead(expressionList, "expressions");
-            ValidateVariables(variableList, "variables");
+            RequiresCanRead(expressions, nameof(expressions));
+            ValidateVariables(variables, nameof(variables));
 
             if (type != null)
             {
-                if (expressionList.Count == 0)
+                if (expressions.Count == 0)
                 {
                     if (type != typeof(void))
                     {
                         throw Error.ArgumentTypesMustMatch();
                     }
 
-                    return new ScopeWithType(variableList, expressionList, type);
+                    return new ScopeWithType(variables, expressions, type);
                 }
-                Expression last = expressionList.Last();
+                Expression last = expressions.Last();
                 if (type != typeof(void))
                 {
                     if (!TypeUtils.AreReferenceAssignable(type, last.Type))
@@ -941,18 +941,18 @@ namespace System.Linq.Expressions
 
                 if (!TypeUtils.AreEquivalent(type, last.Type))
                 {
-                    return new ScopeWithType(variableList, expressionList, type);
+                    return new ScopeWithType(variables, expressions, type);
                 }
             }
 
-            switch (expressionList.Count)
+            switch (expressions.Count)
             {
                 case 0:
-                    return new ScopeWithType(variableList, expressionList, typeof(void));
+                    return new ScopeWithType(variables, expressions, typeof(void));
                 case 1:
-                    return new Scope1(variableList, expressionList[0]);
+                    return new Scope1(variables, expressions[0]);
                 default:
-                    return new ScopeN(variableList, expressionList);
+                    return new ScopeN(variables, expressions);
             }
         }
 
@@ -987,7 +987,7 @@ namespace System.Linq.Expressions
 
         private static BlockExpression GetOptimizedBlockExpression(IReadOnlyList<Expression> expressions)
         {
-            RequiresCanRead(expressions, "expressions");
+            RequiresCanRead(expressions, nameof(expressions));
             switch (expressions.Count)
             {
                 case 0: return BlockCore(typeof(void), EmptyReadOnlyCollection<ParameterExpression>.Instance, EmptyReadOnlyCollection<Expression>.Instance);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/CatchBlock.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/CatchBlock.cs
@@ -114,7 +114,7 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="CatchBlock"/>.</returns>
         public static CatchBlock Catch(ParameterExpression variable, Expression body)
         {
-            ContractUtils.RequiresNotNull(variable, "variable");
+            ContractUtils.RequiresNotNull(variable, nameof(variable));
             return MakeCatchBlock(variable.Type, variable, body, null);
         }
 
@@ -141,7 +141,7 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="CatchBlock"/>.</returns>
         public static CatchBlock Catch(ParameterExpression variable, Expression body, Expression filter)
         {
-            ContractUtils.RequiresNotNull(variable, "variable");
+            ContractUtils.RequiresNotNull(variable, nameof(variable));
             return MakeCatchBlock(variable.Type, variable, body, filter);
         }
 
@@ -156,16 +156,16 @@ namespace System.Linq.Expressions
         /// <remarks><paramref name="type"/> must be non-null and match the type of <paramref name="variable"/> (if it is supplied).</remarks>
         public static CatchBlock MakeCatchBlock(Type type, ParameterExpression variable, Expression body, Expression filter)
         {
-            ContractUtils.RequiresNotNull(type, "type");
-            ContractUtils.Requires(variable == null || TypeUtils.AreEquivalent(variable.Type, type), "variable");
+            ContractUtils.RequiresNotNull(type, nameof(type));
+            ContractUtils.Requires(variable == null || TypeUtils.AreEquivalent(variable.Type, type), nameof(variable));
             if (variable != null && variable.IsByRef)
             {
                 throw Error.VariableMustNotBeByRef(variable, variable.Type);
             }
-            RequiresCanRead(body, "body");
+            RequiresCanRead(body, nameof(body));
             if (filter != null)
             {
-                RequiresCanRead(filter, "filter");
+                RequiresCanRead(filter, nameof(filter));
                 if (filter.Type != typeof(bool)) throw Error.ArgumentMustBeBoolean();
             }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/ILGen.cs
@@ -94,7 +94,7 @@ namespace System.Linq.Expressions.Compiler
         /// </summary>
         internal static void EmitLoadValueIndirect(this ILGenerator il, Type type)
         {
-            ContractUtils.RequiresNotNull(type, "type");
+            ContractUtils.RequiresNotNull(type, nameof(type));
 
             if (type.GetTypeInfo().IsValueType)
             {
@@ -151,7 +151,7 @@ namespace System.Linq.Expressions.Compiler
         /// </summary>
         internal static void EmitStoreValueIndirect(this ILGenerator il, Type type)
         {
-            ContractUtils.RequiresNotNull(type, "type");
+            ContractUtils.RequiresNotNull(type, nameof(type));
 
             if (type.GetTypeInfo().IsValueType)
             {
@@ -198,7 +198,7 @@ namespace System.Linq.Expressions.Compiler
 
         internal static void EmitLoadElement(this ILGenerator il, Type type)
         {
-            ContractUtils.RequiresNotNull(type, "type");
+            ContractUtils.RequiresNotNull(type, nameof(type));
 
             if (!type.GetTypeInfo().IsValueType)
             {
@@ -254,7 +254,7 @@ namespace System.Linq.Expressions.Compiler
         /// </summary>
         internal static void EmitStoreElement(this ILGenerator il, Type type)
         {
-            ContractUtils.RequiresNotNull(type, "type");
+            ContractUtils.RequiresNotNull(type, nameof(type));
 
             if (type.GetTypeInfo().IsEnum)
             {
@@ -302,7 +302,7 @@ namespace System.Linq.Expressions.Compiler
 
         internal static void EmitType(this ILGenerator il, Type type)
         {
-            ContractUtils.RequiresNotNull(type, "type");
+            ContractUtils.RequiresNotNull(type, nameof(type));
 
             il.Emit(OpCodes.Ldtoken, type);
             il.Emit(OpCodes.Call, typeof(Type).GetMethod("GetTypeFromHandle"));
@@ -314,7 +314,7 @@ namespace System.Linq.Expressions.Compiler
 
         internal static void EmitFieldAddress(this ILGenerator il, FieldInfo fi)
         {
-            ContractUtils.RequiresNotNull(fi, "fi");
+            ContractUtils.RequiresNotNull(fi, nameof(fi));
 
             if (fi.IsStatic)
             {
@@ -328,7 +328,7 @@ namespace System.Linq.Expressions.Compiler
 
         internal static void EmitFieldGet(this ILGenerator il, FieldInfo fi)
         {
-            ContractUtils.RequiresNotNull(fi, "fi");
+            ContractUtils.RequiresNotNull(fi, nameof(fi));
 
             if (fi.IsStatic)
             {
@@ -342,7 +342,7 @@ namespace System.Linq.Expressions.Compiler
 
         internal static void EmitFieldSet(this ILGenerator il, FieldInfo fi)
         {
-            ContractUtils.RequiresNotNull(fi, "fi");
+            ContractUtils.RequiresNotNull(fi, nameof(fi));
 
             if (fi.IsStatic)
             {
@@ -357,7 +357,7 @@ namespace System.Linq.Expressions.Compiler
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1711:IdentifiersShouldNotHaveIncorrectSuffix")]
         internal static void EmitNew(this ILGenerator il, ConstructorInfo ci)
         {
-            ContractUtils.RequiresNotNull(ci, "ci");
+            ContractUtils.RequiresNotNull(ci, nameof(ci));
 
             if (ci.DeclaringType.GetTypeInfo().ContainsGenericParameters)
             {
@@ -370,8 +370,8 @@ namespace System.Linq.Expressions.Compiler
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1711:IdentifiersShouldNotHaveIncorrectSuffix")]
         internal static void EmitNew(this ILGenerator il, Type type, Type[] paramTypes)
         {
-            ContractUtils.RequiresNotNull(type, "type");
-            ContractUtils.RequiresNotNull(paramTypes, "paramTypes");
+            ContractUtils.RequiresNotNull(type, nameof(type));
+            ContractUtils.RequiresNotNull(paramTypes, nameof(paramTypes));
 
             ConstructorInfo ci = type.GetConstructor(paramTypes);
             if (ci == null) throw Error.TypeDoesNotHaveConstructorForTheSignature();
@@ -389,7 +389,7 @@ namespace System.Linq.Expressions.Compiler
 
         internal static void EmitString(this ILGenerator il, string value)
         {
-            ContractUtils.RequiresNotNull(value, "value");
+            ContractUtils.RequiresNotNull(value, nameof(value));
             il.Emit(OpCodes.Ldstr, value);
         }
 
@@ -1051,7 +1051,7 @@ namespace System.Linq.Expressions.Compiler
         /// </summary>
         internal static void EmitArray<T>(this ILGenerator il, IList<T> items)
         {
-            ContractUtils.RequiresNotNull(items, "items");
+            ContractUtils.RequiresNotNull(items, nameof(items));
 
             il.EmitInt(items.Count);
             il.Emit(OpCodes.Newarr, typeof(T));
@@ -1070,8 +1070,8 @@ namespace System.Linq.Expressions.Compiler
         /// </summary>
         internal static void EmitArray(this ILGenerator il, Type elementType, int count, Action<int> emit)
         {
-            ContractUtils.RequiresNotNull(elementType, "elementType");
-            ContractUtils.RequiresNotNull(emit, "emit");
+            ContractUtils.RequiresNotNull(elementType, nameof(elementType));
+            ContractUtils.RequiresNotNull(emit, nameof(emit));
             Debug.Assert(count >= 0);
 
             il.EmitInt(count);
@@ -1094,7 +1094,7 @@ namespace System.Linq.Expressions.Compiler
         /// </summary>
         internal static void EmitArray(this ILGenerator il, Type arrayType)
         {
-            ContractUtils.RequiresNotNull(arrayType, "arrayType");
+            ContractUtils.RequiresNotNull(arrayType, nameof(arrayType));
             Debug.Assert(arrayType.IsArray);
 
             if (arrayType.IsVector())

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Temps.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Compiler/StackSpiller.Temps.cs
@@ -252,7 +252,7 @@ namespace System.Linq.Expressions.Compiler
                         last += _expressions.Length;
                     }
                     int count = last - first + 1;
-                    ContractUtils.RequiresArrayRange(_expressions, first, count, "first", "last");
+                    ContractUtils.RequiresArrayRange(_expressions, first, count, nameof(first), nameof(last));
 
                     if (count == _expressions.Length)
                     {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ConditionalExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ConditionalExpression.cs
@@ -160,9 +160,9 @@ namespace System.Linq.Expressions
         /// and <see cref="P:ConditionalExpression.IfFalse"/> properties set to the specified values.</returns>
         public static ConditionalExpression Condition(Expression test, Expression ifTrue, Expression ifFalse)
         {
-            RequiresCanRead(test, "test");
-            RequiresCanRead(ifTrue, "ifTrue");
-            RequiresCanRead(ifFalse, "ifFalse");
+            RequiresCanRead(test, nameof(test));
+            RequiresCanRead(ifTrue, nameof(ifTrue));
+            RequiresCanRead(ifFalse, nameof(ifFalse));
 
             if (test.Type != typeof(bool))
             {
@@ -192,10 +192,10 @@ namespace System.Linq.Expressions
         /// reference assignable to the result type. The <paramref name="type"/> is allowed to be <see cref="System.Void"/>.</remarks>
         public static ConditionalExpression Condition(Expression test, Expression ifTrue, Expression ifFalse, Type type)
         {
-            RequiresCanRead(test, "test");
-            RequiresCanRead(ifTrue, "ifTrue");
-            RequiresCanRead(ifFalse, "ifFalse");
-            ContractUtils.RequiresNotNull(type, "type");
+            RequiresCanRead(test, nameof(test));
+            RequiresCanRead(ifTrue, nameof(ifTrue));
+            RequiresCanRead(ifFalse, nameof(ifFalse));
+            ContractUtils.RequiresNotNull(type, nameof(type));
 
             if (test.Type != typeof(bool))
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ConstantExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ConstantExpression.cs
@@ -123,7 +123,7 @@ namespace System.Linq.Expressions
         /// </returns>
         public static ConstantExpression Constant(object value, Type type)
         {
-            ContractUtils.RequiresNotNull(type, "type");
+            ContractUtils.RequiresNotNull(type, nameof(type));
             if (value == null && type.GetTypeInfo().IsValueType && !TypeUtils.IsNullableType(type))
             {
                 throw Error.ArgumentTypesMustMatch();

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/DebugInfoExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/DebugInfoExpression.cs
@@ -228,7 +228,7 @@ namespace System.Linq.Expressions
         /// <returns>An instance of <see cref="DebugInfoExpression"/>.</returns>
         public static DebugInfoExpression DebugInfo(SymbolDocumentInfo document, int startLine, int startColumn, int endLine, int endColumn)
         {
-            ContractUtils.RequiresNotNull(document, "document");
+            ContractUtils.RequiresNotNull(document, nameof(document));
             if (startLine == 0xfeefee && startColumn == 0 && endLine == 0xfeefee && endColumn == 0)
             {
                 return new ClearDebugInfoExpression(document);
@@ -245,7 +245,7 @@ namespace System.Linq.Expressions
         /// <returns>An instance of <see cref="DebugInfoExpression"/> for clearning a sequence point.</returns>
         public static DebugInfoExpression ClearDebugInfo(SymbolDocumentInfo document)
         {
-            ContractUtils.RequiresNotNull(document, "document");
+            ContractUtils.RequiresNotNull(document, nameof(document));
 
             return new ClearDebugInfoExpression(document);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ElementInit.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ElementInit.cs
@@ -101,12 +101,12 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="T:ElementInit">ElementInit</see> expression.</returns>
         public static ElementInit ElementInit(MethodInfo addMethod, IEnumerable<Expression> arguments)
         {
-            ContractUtils.RequiresNotNull(addMethod, "addMethod");
-            ContractUtils.RequiresNotNull(arguments, "arguments");
+            ContractUtils.RequiresNotNull(addMethod, nameof(addMethod));
+            ContractUtils.RequiresNotNull(arguments, nameof(arguments));
 
             var argumentsRO = arguments.ToReadOnly();
 
-            RequiresCanRead(argumentsRO, "arguments");
+            RequiresCanRead(argumentsRO, nameof(arguments));
             ValidateElementInitAddMethodInfo(addMethod);
             ValidateArgumentTypes(addMethod, ExpressionType.Call, ref argumentsRO);
             return new ElementInit(addMethod, argumentsRO);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/GotoExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/GotoExpression.cs
@@ -354,7 +354,7 @@ namespace System.Linq.Expressions
         /// </returns>
         public static GotoExpression MakeGoto(GotoExpressionKind kind, LabelTarget target, Expression value, Type type)
         {
-            ValidateGoto(target, ref value, "target", "value");
+            ValidateGoto(target, ref value, nameof(target), nameof(value));
             return new GotoExpression(kind, target, value, type);
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/IndexExpression.cs
@@ -181,7 +181,7 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="IndexExpression"/>.</returns>
         public static IndexExpression ArrayAccess(Expression array, IEnumerable<Expression> indexes)
         {
-            RequiresCanRead(array, "array");
+            RequiresCanRead(array, nameof(array));
 
             Type arrayType = array.Type;
             if (!arrayType.IsArray)
@@ -197,7 +197,7 @@ namespace System.Linq.Expressions
 
             foreach (Expression e in indexList)
             {
-                RequiresCanRead(e, "indexes");
+                RequiresCanRead(e, nameof(indexes));
                 if (e.Type != typeof(int))
                 {
                     throw Error.ArgumentMustBeArrayIndexType();
@@ -219,8 +219,8 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="IndexExpression"/>.</returns>
         public static IndexExpression Property(Expression instance, string propertyName, params Expression[] arguments)
         {
-            RequiresCanRead(instance, "instance");
-            ContractUtils.RequiresNotNull(propertyName, "indexerName");
+            RequiresCanRead(instance, nameof(instance));
+            ContractUtils.RequiresNotNull(propertyName, nameof(propertyName));
             PropertyInfo pi = FindInstanceProperty(instance.Type, propertyName, arguments);
             return Property(instance, pi, arguments);
         }
@@ -389,7 +389,7 @@ namespace System.Linq.Expressions
             // should match the type returned by the get method.
             // Accessor parameters cannot be ByRef.
 
-            ContractUtils.RequiresNotNull(property, "property");
+            ContractUtils.RequiresNotNull(property, nameof(property));
             if (property.PropertyType.IsByRef) throw Error.PropertyCannotHaveRefType();
             if (property.PropertyType == typeof(void)) throw Error.PropertyTypeCannotBeVoid();
 
@@ -437,7 +437,7 @@ namespace System.Linq.Expressions
 
         private static void ValidateAccessor(Expression instance, MethodInfo method, ParameterInfo[] indexes, ref ReadOnlyCollection<Expression> arguments)
         {
-            ContractUtils.RequiresNotNull(arguments, "arguments");
+            ContractUtils.RequiresNotNull(arguments, nameof(arguments));
 
             ValidateMethodInfo(method);
             if ((method.CallingConvention & CallingConventions.VarArgs) != 0) throw Error.AccessorsCannotHaveVarArgs();
@@ -448,7 +448,7 @@ namespace System.Linq.Expressions
             else
             {
                 if (instance == null) throw Error.OnlyStaticMethodsHaveNullInstance();
-                RequiresCanRead(instance, "instance");
+                RequiresCanRead(instance, nameof(instance));
                 ValidateCallInstanceType(instance.Type, method);
             }
 
@@ -468,7 +468,7 @@ namespace System.Linq.Expressions
                 {
                     Expression arg = arguments[i];
                     ParameterInfo pi = indexes[i];
-                    RequiresCanRead(arg, "arguments");
+                    RequiresCanRead(arg, nameof(arguments));
 
                     Type pType = pi.ParameterType;
                     if (pType.IsByRef) throw Error.AccessorsCannotHaveByRefArgs();

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/Interpreter/InterpretedFrame.cs
@@ -141,7 +141,7 @@ namespace System.Linq.Expressions.Interpreter
 
         public static bool IsInterpretedFrame(MethodBase method)
         {
-            //ContractUtils.RequiresNotNull(method, "method");
+            //ContractUtils.RequiresNotNull(method, nameof(method));
             return method.DeclaringType == typeof(Interpreter) && method.Name == "Run";
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/InvocationExpression.cs
@@ -480,7 +480,7 @@ namespace System.Linq.Expressions
         {
             // COMPAT: This method is marked as non-public to avoid a gap between a 0-ary and 2-ary overload (see remark for the unary case below).
 
-            RequiresCanRead(expression, "expression");
+            RequiresCanRead(expression, nameof(expression));
 
             var method = GetInvokeMethod(expression);
 
@@ -516,7 +516,7 @@ namespace System.Linq.Expressions
         {
             // COMPAT: This method is marked as non-public to ensure compile-time compatibility for Expression.Invoke(e, null).
 
-            RequiresCanRead(expression, "expression");
+            RequiresCanRead(expression, nameof(expression));
 
             var method = GetInvokeMethod(expression);
 
@@ -556,7 +556,7 @@ namespace System.Linq.Expressions
         internal static InvocationExpression Invoke(Expression expression, Expression arg0, Expression arg1)
         {
             // NB: This method is marked as non-public to avoid public API additions at this point.
-            RequiresCanRead(expression, "expression");
+            RequiresCanRead(expression, nameof(expression));
 
             var method = GetInvokeMethod(expression);
 
@@ -601,7 +601,7 @@ namespace System.Linq.Expressions
         {
             // NB: This method is marked as non-public to avoid public API additions at this point.
 
-            RequiresCanRead(expression, "expression");
+            RequiresCanRead(expression, nameof(expression));
 
             var method = GetInvokeMethod(expression);
 
@@ -650,7 +650,7 @@ namespace System.Linq.Expressions
         {
             // NB: This method is marked as non-public to avoid public API additions at this point.
 
-            RequiresCanRead(expression, "expression");
+            RequiresCanRead(expression, nameof(expression));
 
             var method = GetInvokeMethod(expression);
 
@@ -703,7 +703,7 @@ namespace System.Linq.Expressions
         {
             // NB: This method is marked as non-public to avoid public API additions at this point.
 
-            RequiresCanRead(expression, "expression");
+            RequiresCanRead(expression, nameof(expression));
 
             var method = GetInvokeMethod(expression);
 
@@ -789,7 +789,7 @@ namespace System.Linq.Expressions
                     return Invoke(expression, argumentList[0], argumentList[1], argumentList[2], argumentList[3], argumentList[4]);
             }
 
-            RequiresCanRead(expression, "expression");
+            RequiresCanRead(expression, nameof(expression));
 
             var args = argumentList.ToReadOnly(); // Ensure is TrueReadOnlyCollection when count > 5. Returns fast if it already is.
             var mi = GetInvokeMethod(expression);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelExpression.cs
@@ -106,7 +106,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="LabelExpression"/> with the given default value.</returns>
         public static LabelExpression Label(LabelTarget target, Expression defaultValue)
         {
-            ValidateGoto(target, ref defaultValue, "target", "defaultValue");
+            ValidateGoto(target, ref defaultValue, nameof(target), nameof(defaultValue));
             return new LabelExpression(target, defaultValue);
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelTarget.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LabelTarget.cs
@@ -89,7 +89,7 @@ namespace System.Linq.Expressions
         /// <returns>The new <see cref="LabelTarget"/>.</returns>
         public static LabelTarget Label(Type type, string name)
         {
-            ContractUtils.RequiresNotNull(type, "type");
+            ContractUtils.RequiresNotNull(type, nameof(type));
             TypeUtils.ValidateType(type);
             return new LabelTarget(type, name);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LambdaExpression.cs
@@ -474,7 +474,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="LambdaExpression"/> that has the <see cref="P:NodeType"/> property equal to Lambda and the <see cref="P:Body"/> and <see cref="P:Parameters"/> properties set to the specified values.</returns>
         public static LambdaExpression Lambda(Expression body, string name, bool tailCall, IEnumerable<ParameterExpression> parameters)
         {
-            ContractUtils.RequiresNotNull(body, "body");
+            ContractUtils.RequiresNotNull(body, nameof(body));
 
             var parameterList = parameters.ToReadOnly();
 
@@ -537,8 +537,8 @@ namespace System.Linq.Expressions
 
         private static void ValidateLambdaArgs(Type delegateType, ref Expression body, ReadOnlyCollection<ParameterExpression> parameters)
         {
-            ContractUtils.RequiresNotNull(delegateType, "delegateType");
-            RequiresCanRead(body, "body");
+            ContractUtils.RequiresNotNull(delegateType, nameof(delegateType));
+            RequiresCanRead(body, nameof(body));
 
             if (!typeof(MulticastDelegate).IsAssignableFrom(delegateType) || delegateType == typeof(MulticastDelegate))
             {
@@ -569,7 +569,7 @@ namespace System.Linq.Expressions
                 {
                     ParameterExpression pex = parameters[i];
                     ParameterInfo pi = pis[i];
-                    RequiresCanRead(pex, "parameters");
+                    RequiresCanRead(pex, nameof(parameters));
                     Type pType = pi.ParameterType;
                     if (pex.IsByRef)
                     {
@@ -705,8 +705,8 @@ namespace System.Linq.Expressions
         /// to System.Void to produce an Action.</remarks>
         public static Type GetDelegateType(params Type[] typeArgs)
         {
-            ContractUtils.RequiresNotEmpty(typeArgs, "typeArgs");
-            ContractUtils.RequiresNotNullItems(typeArgs, "typeArgs");
+            ContractUtils.RequiresNotEmpty(typeArgs, nameof(typeArgs));
+            ContractUtils.RequiresNotNullItems(typeArgs, nameof(typeArgs));
             return Compiler.DelegateHelpers.MakeDelegateType(typeArgs);
         }
     }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ListInitExpression.cs
@@ -136,8 +136,8 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="ListInitExpression"/> that has the <see cref="P:ListInitExpression.NodeType"/> property equal to ListInit and the <see cref="P:ListInitExpression.NewExpression"/> property set to the specified value.</returns>
         public static ListInitExpression ListInit(NewExpression newExpression, IEnumerable<Expression> initializers)
         {
-            ContractUtils.RequiresNotNull(newExpression, "newExpression");
-            ContractUtils.RequiresNotNull(initializers, "initializers");
+            ContractUtils.RequiresNotNull(newExpression, nameof(newExpression));
+            ContractUtils.RequiresNotNull(initializers, nameof(initializers));
 
             var initializerlist = initializers.ToReadOnly();
             if (initializerlist.Count == 0)
@@ -174,8 +174,8 @@ namespace System.Linq.Expressions
             {
                 return ListInit(newExpression, initializers);
             }
-            ContractUtils.RequiresNotNull(newExpression, "newExpression");
-            ContractUtils.RequiresNotNull(initializers, "initializers");
+            ContractUtils.RequiresNotNull(newExpression, nameof(newExpression));
+            ContractUtils.RequiresNotNull(initializers, nameof(initializers));
 
             var initializerlist = initializers.ToReadOnly();
             if (initializerlist.Count == 0)
@@ -220,8 +220,8 @@ namespace System.Linq.Expressions
         /// </remarks>
         public static ListInitExpression ListInit(NewExpression newExpression, IEnumerable<ElementInit> initializers)
         {
-            ContractUtils.RequiresNotNull(newExpression, "newExpression");
-            ContractUtils.RequiresNotNull(initializers, "initializers");
+            ContractUtils.RequiresNotNull(newExpression, nameof(newExpression));
+            ContractUtils.RequiresNotNull(initializers, nameof(initializers));
             var initializerlist = initializers.ToReadOnly();
             if (initializerlist.Count == 0)
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/LoopExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/LoopExpression.cs
@@ -127,7 +127,7 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="LoopExpression"/>.</returns>
         public static LoopExpression Loop(Expression body, LabelTarget @break, LabelTarget @continue)
         {
-            RequiresCanRead(body, "body");
+            RequiresCanRead(body, nameof(body));
             if (@continue != null && @continue.Type != typeof(void)) throw Error.LabelTypeMustBeVoid();
             return new LoopExpression(body, @break, @continue);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberAssignment.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberAssignment.cs
@@ -57,8 +57,8 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="MemberAssignment"/>.</returns>
         public static MemberAssignment Bind(MemberInfo member, Expression expression)
         {
-            ContractUtils.RequiresNotNull(member, "member");
-            RequiresCanRead(expression, "expression");
+            ContractUtils.RequiresNotNull(member, nameof(member));
+            RequiresCanRead(expression, nameof(expression));
             Type memberType;
             ValidateSettableFieldOrPropertyMember(member, out memberType);
             if (!memberType.IsAssignableFrom(expression.Type))
@@ -76,8 +76,8 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="MemberAssignment"/>.</returns>
         public static MemberAssignment Bind(MethodInfo propertyAccessor, Expression expression)
         {
-            ContractUtils.RequiresNotNull(propertyAccessor, "propertyAccessor");
-            ContractUtils.RequiresNotNull(expression, "expression");
+            ContractUtils.RequiresNotNull(propertyAccessor, nameof(propertyAccessor));
+            ContractUtils.RequiresNotNull(expression, nameof(expression));
             ValidateMethodInfo(propertyAccessor);
             return Bind(GetProperty(propertyAccessor), expression);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberExpression.cs
@@ -152,7 +152,7 @@ namespace System.Linq.Expressions
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1719:ParameterNamesShouldNotMatchMemberNames")]
         public static MemberExpression Field(Expression expression, FieldInfo field)
         {
-            ContractUtils.RequiresNotNull(field, "field");
+            ContractUtils.RequiresNotNull(field, nameof(field));
 
             if (field.IsStatic)
             {
@@ -161,7 +161,7 @@ namespace System.Linq.Expressions
             else
             {
                 if (expression == null) throw new ArgumentException(Strings.OnlyStaticFieldsHaveNullInstance, nameof(field));
-                RequiresCanRead(expression, "expression");
+                RequiresCanRead(expression, nameof(expression));
                 if (!TypeUtils.AreReferenceAssignable(field.DeclaringType, expression.Type))
                 {
                     throw Error.FieldInfoNotDefinedForType(field.DeclaringType, field.Name, expression.Type);
@@ -178,7 +178,7 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="MemberExpression"/>.</returns>
         public static MemberExpression Field(Expression expression, string fieldName)
         {
-            RequiresCanRead(expression, "expression");
+            RequiresCanRead(expression, nameof(expression));
 
             // bind to public names first
             FieldInfo fi = expression.Type.GetField(fieldName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy);
@@ -204,7 +204,7 @@ namespace System.Linq.Expressions
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1719:ParameterNamesShouldNotMatchMemberNames")]
         public static MemberExpression Field(Expression expression, Type type, string fieldName)
         {
-            ContractUtils.RequiresNotNull(type, "type");
+            ContractUtils.RequiresNotNull(type, nameof(type));
 
             // bind to public names first
             FieldInfo fi = type.GetField(fieldName, BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy);
@@ -231,8 +231,8 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="MemberExpression"/>.</returns>
         public static MemberExpression Property(Expression expression, string propertyName)
         {
-            RequiresCanRead(expression, "expression");
-            ContractUtils.RequiresNotNull(propertyName, "propertyName");
+            RequiresCanRead(expression, nameof(expression));
+            ContractUtils.RequiresNotNull(propertyName, nameof(propertyName));
             // bind to public names first
             PropertyInfo pi = expression.Type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy);
             if (pi == null)
@@ -255,8 +255,8 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="MemberExpression"/>.</returns>
         public static MemberExpression Property(Expression expression, Type type, string propertyName)
         {
-            ContractUtils.RequiresNotNull(type, "type");
-            ContractUtils.RequiresNotNull(propertyName, "propertyName");
+            ContractUtils.RequiresNotNull(type, nameof(type));
+            ContractUtils.RequiresNotNull(propertyName, nameof(propertyName));
             // bind to public names first
             PropertyInfo pi = type.GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy);
             if (pi == null)
@@ -279,7 +279,7 @@ namespace System.Linq.Expressions
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1719:ParameterNamesShouldNotMatchMemberNames")]
         public static MemberExpression Property(Expression expression, PropertyInfo property)
         {
-            ContractUtils.RequiresNotNull(property, "property");
+            ContractUtils.RequiresNotNull(property, nameof(property));
 
             MethodInfo mi = property.GetGetMethod(true);
 
@@ -308,7 +308,7 @@ namespace System.Linq.Expressions
             else
             {
                 if (expression == null) throw new ArgumentException(Strings.OnlyStaticPropertiesHaveNullInstance, nameof(property));
-                RequiresCanRead(expression, "expression");
+                RequiresCanRead(expression, nameof(expression));
                 if (!TypeUtils.IsValidInstanceType(property, expression.Type))
                 {
                     throw Error.PropertyNotDefinedForType(property, expression.Type);
@@ -326,7 +326,7 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="MemberExpression"/>.</returns>
         public static MemberExpression Property(Expression expression, MethodInfo propertyAccessor)
         {
-            ContractUtils.RequiresNotNull(propertyAccessor, "propertyAccessor");
+            ContractUtils.RequiresNotNull(propertyAccessor, nameof(propertyAccessor));
             ValidateMethodInfo(propertyAccessor);
             return Property(expression, GetProperty(propertyAccessor));
         }
@@ -378,7 +378,7 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="MemberExpression"/>.</returns>
         public static MemberExpression PropertyOrField(Expression expression, string propertyOrFieldName)
         {
-            RequiresCanRead(expression, "expression");
+            RequiresCanRead(expression, nameof(expression));
             // bind to public names first
             PropertyInfo pi = expression.Type.GetProperty(propertyOrFieldName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase | BindingFlags.FlattenHierarchy);
             if (pi != null)
@@ -404,7 +404,7 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="MemberExpression"/>.</returns>
         public static MemberExpression MakeMemberAccess(Expression expression, MemberInfo member)
         {
-            ContractUtils.RequiresNotNull(member, "member");
+            ContractUtils.RequiresNotNull(member, nameof(member));
 
             FieldInfo fi = member as FieldInfo;
             if (fi != null)

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberInitExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberInitExpression.cs
@@ -175,8 +175,8 @@ namespace System.Linq.Expressions
         ///<exception cref="T:System.ArgumentException">The <see cref="P:System.Linq.Expressions.MemberBinding.Member" /> property of an element of <paramref name="bindings" /> does not represent a member of the type that <paramref name="newExpression" />.Type represents.</exception>
         public static MemberInitExpression MemberInit(NewExpression newExpression, IEnumerable<MemberBinding> bindings)
         {
-            ContractUtils.RequiresNotNull(newExpression, "newExpression");
-            ContractUtils.RequiresNotNull(bindings, "bindings");
+            ContractUtils.RequiresNotNull(newExpression, nameof(newExpression));
+            ContractUtils.RequiresNotNull(bindings, nameof(bindings));
             var roBindings = bindings.ToReadOnly();
             ValidateMemberInitArgs(newExpression.Type, roBindings);
             return new MemberInitExpression(newExpression, roBindings);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberListBinding.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberListBinding.cs
@@ -76,8 +76,8 @@ namespace System.Linq.Expressions
         ///<paramref name="member" /> does not represent a field or property.-or-The <see cref="P:System.Reflection.FieldInfo.FieldType" /> or <see cref="P:System.Reflection.PropertyInfo.PropertyType" /> of the field or property that <paramref name="member" /> represents does not implement <see cref="T:System.Collections.IEnumerable" />.</exception>
         public static MemberListBinding ListBind(MemberInfo member, IEnumerable<ElementInit> initializers)
         {
-            ContractUtils.RequiresNotNull(member, "member");
-            ContractUtils.RequiresNotNull(initializers, "initializers");
+            ContractUtils.RequiresNotNull(member, nameof(member));
+            ContractUtils.RequiresNotNull(initializers, nameof(initializers));
             Type memberType;
             ValidateGettableFieldOrPropertyMember(member, out memberType);
             var initList = initializers.ToReadOnly();
@@ -108,8 +108,8 @@ namespace System.Linq.Expressions
         ///<paramref name="propertyAccessor" /> does not represent a property accessor method.-or-The <see cref="P:System.Reflection.PropertyInfo.PropertyType" /> of the property that the method represented by <paramref name="propertyAccessor" /> accesses does not implement <see cref="T:System.Collections.IEnumerable" />.</exception>        
         public static MemberListBinding ListBind(MethodInfo propertyAccessor, IEnumerable<ElementInit> initializers)
         {
-            ContractUtils.RequiresNotNull(propertyAccessor, "propertyAccessor");
-            ContractUtils.RequiresNotNull(initializers, "initializers");
+            ContractUtils.RequiresNotNull(propertyAccessor, nameof(propertyAccessor));
+            ContractUtils.RequiresNotNull(initializers, nameof(initializers));
             return ListBind(GetProperty(propertyAccessor), initializers);
         }
 
@@ -122,7 +122,7 @@ namespace System.Linq.Expressions
             for (int i = 0, n = initializers.Count; i < n; i++)
             {
                 ElementInit element = initializers[i];
-                ContractUtils.RequiresNotNull(element, "initializers");
+                ContractUtils.RequiresNotNull(element, nameof(initializers));
                 ValidateCallInstanceType(listType, element.AddMethod);
             }
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberMemberBinding.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MemberMemberBinding.cs
@@ -75,8 +75,8 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="MemberMemberBinding"/> that has the <see cref="P:MemberBinding.BindingType"/> property equal to <see cref="MemberBinding"/> and the <see cref="P:MemberBinding.Member"/> and <see cref="P:MemberMemberBindings.Bindings"/> properties set to the specified values.</returns>
         public static MemberMemberBinding MemberBind(MemberInfo member, IEnumerable<MemberBinding> bindings)
         {
-            ContractUtils.RequiresNotNull(member, "member");
-            ContractUtils.RequiresNotNull(bindings, "bindings");
+            ContractUtils.RequiresNotNull(member, nameof(member));
+            ContractUtils.RequiresNotNull(bindings, nameof(bindings));
             ReadOnlyCollection<MemberBinding> roBindings = bindings.ToReadOnly();
             Type memberType;
             ValidateGettableFieldOrPropertyMember(member, out memberType);
@@ -111,7 +111,7 @@ namespace System.Linq.Expressions
         /// </returns>
         public static MemberMemberBinding MemberBind(MethodInfo propertyAccessor, IEnumerable<MemberBinding> bindings)
         {
-            ContractUtils.RequiresNotNull(propertyAccessor, "propertyAccessor");
+            ContractUtils.RequiresNotNull(propertyAccessor, nameof(propertyAccessor));
             return MemberBind(GetProperty(propertyAccessor), bindings);
         }
 
@@ -142,7 +142,7 @@ namespace System.Linq.Expressions
             for (int i = 0, n = bindings.Count; i < n; i++)
             {
                 MemberBinding b = bindings[i];
-                ContractUtils.RequiresNotNull(b, "bindings");
+                ContractUtils.RequiresNotNull(b, nameof(bindings));
                 if (!b.Member.DeclaringType.IsAssignableFrom(type))
                 {
                     throw Error.NotAMemberOfType(b.Member.Name, type);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/MethodCallExpression.cs
@@ -706,7 +706,7 @@ namespace System.Linq.Expressions
         {
             // NB: Keeping this method as internal to avoid public API changes; it's internal for MethodCallExpression0.Rewrite.
 
-            ContractUtils.RequiresNotNull(method, "method");
+            ContractUtils.RequiresNotNull(method, nameof(method));
 
             ParameterInfo[] pis = ValidateMethodAndGetParameters(null, method);
 
@@ -723,8 +723,8 @@ namespace System.Linq.Expressions
         ///<paramref name="method" /> is null.</exception>
         public static MethodCallExpression Call(MethodInfo method, Expression arg0)
         {
-            ContractUtils.RequiresNotNull(method, "method");
-            ContractUtils.RequiresNotNull(arg0, "arg0");
+            ContractUtils.RequiresNotNull(method, nameof(method));
+            ContractUtils.RequiresNotNull(arg0, nameof(arg0));
 
             ParameterInfo[] pis = ValidateMethodAndGetParameters(null, method);
 
@@ -744,9 +744,9 @@ namespace System.Linq.Expressions
         ///<paramref name="method" /> is null.</exception>
         public static MethodCallExpression Call(MethodInfo method, Expression arg0, Expression arg1)
         {
-            ContractUtils.RequiresNotNull(method, "method");
-            ContractUtils.RequiresNotNull(arg0, "arg0");
-            ContractUtils.RequiresNotNull(arg1, "arg1");
+            ContractUtils.RequiresNotNull(method, nameof(method));
+            ContractUtils.RequiresNotNull(arg0, nameof(arg0));
+            ContractUtils.RequiresNotNull(arg1, nameof(arg1));
 
             ParameterInfo[] pis = ValidateMethodAndGetParameters(null, method);
 
@@ -768,10 +768,10 @@ namespace System.Linq.Expressions
         ///<paramref name="method" /> is null.</exception>
         public static MethodCallExpression Call(MethodInfo method, Expression arg0, Expression arg1, Expression arg2)
         {
-            ContractUtils.RequiresNotNull(method, "method");
-            ContractUtils.RequiresNotNull(arg0, "arg0");
-            ContractUtils.RequiresNotNull(arg1, "arg1");
-            ContractUtils.RequiresNotNull(arg2, "arg2");
+            ContractUtils.RequiresNotNull(method, nameof(method));
+            ContractUtils.RequiresNotNull(arg0, nameof(arg0));
+            ContractUtils.RequiresNotNull(arg1, nameof(arg1));
+            ContractUtils.RequiresNotNull(arg2, nameof(arg2));
 
             ParameterInfo[] pis = ValidateMethodAndGetParameters(null, method);
 
@@ -795,11 +795,11 @@ namespace System.Linq.Expressions
         ///<paramref name="method" /> is null.</exception>
         public static MethodCallExpression Call(MethodInfo method, Expression arg0, Expression arg1, Expression arg2, Expression arg3)
         {
-            ContractUtils.RequiresNotNull(method, "method");
-            ContractUtils.RequiresNotNull(arg0, "arg0");
-            ContractUtils.RequiresNotNull(arg1, "arg1");
-            ContractUtils.RequiresNotNull(arg2, "arg2");
-            ContractUtils.RequiresNotNull(arg3, "arg3");
+            ContractUtils.RequiresNotNull(method, nameof(method));
+            ContractUtils.RequiresNotNull(arg0, nameof(arg0));
+            ContractUtils.RequiresNotNull(arg1, nameof(arg1));
+            ContractUtils.RequiresNotNull(arg2, nameof(arg2));
+            ContractUtils.RequiresNotNull(arg3, nameof(arg3));
 
             ParameterInfo[] pis = ValidateMethodAndGetParameters(null, method);
 
@@ -826,12 +826,12 @@ namespace System.Linq.Expressions
         ///<returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> properties set to the specified values.</returns>
         public static MethodCallExpression Call(MethodInfo method, Expression arg0, Expression arg1, Expression arg2, Expression arg3, Expression arg4)
         {
-            ContractUtils.RequiresNotNull(method, "method");
-            ContractUtils.RequiresNotNull(arg0, "arg0");
-            ContractUtils.RequiresNotNull(arg1, "arg1");
-            ContractUtils.RequiresNotNull(arg2, "arg2");
-            ContractUtils.RequiresNotNull(arg3, "arg3");
-            ContractUtils.RequiresNotNull(arg4, "arg4");
+            ContractUtils.RequiresNotNull(method, nameof(method));
+            ContractUtils.RequiresNotNull(arg0, nameof(arg0));
+            ContractUtils.RequiresNotNull(arg1, nameof(arg1));
+            ContractUtils.RequiresNotNull(arg2, nameof(arg2));
+            ContractUtils.RequiresNotNull(arg3, nameof(arg3));
+            ContractUtils.RequiresNotNull(arg4, nameof(arg4));
 
             ParameterInfo[] pis = ValidateMethodAndGetParameters(null, method);
 
@@ -876,7 +876,7 @@ namespace System.Linq.Expressions
         ///<returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> properties set to the specified values.</returns>
         public static MethodCallExpression Call(Expression instance, MethodInfo method)
         {
-            ContractUtils.RequiresNotNull(method, "method");
+            ContractUtils.RequiresNotNull(method, nameof(method));
 
             ParameterInfo[] pis = ValidateMethodAndGetParameters(instance, method);
 
@@ -913,8 +913,8 @@ namespace System.Linq.Expressions
         {
             // COMPAT: This method is marked as non-public to ensure compile-time compatibility for Expression.Call(e, m, null).
 
-            ContractUtils.RequiresNotNull(method, "method");
-            ContractUtils.RequiresNotNull(arg0, "arg0");
+            ContractUtils.RequiresNotNull(method, nameof(method));
+            ContractUtils.RequiresNotNull(arg0, nameof(arg0));
 
             ParameterInfo[] pis = ValidateMethodAndGetParameters(instance, method);
 
@@ -940,9 +940,9 @@ namespace System.Linq.Expressions
         ///<returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> properties set to the specified values.</returns>
         public static MethodCallExpression Call(Expression instance, MethodInfo method, Expression arg0, Expression arg1)
         {
-            ContractUtils.RequiresNotNull(method, "method");
-            ContractUtils.RequiresNotNull(arg0, "arg0");
-            ContractUtils.RequiresNotNull(arg1, "arg1");
+            ContractUtils.RequiresNotNull(method, nameof(method));
+            ContractUtils.RequiresNotNull(arg0, nameof(arg0));
+            ContractUtils.RequiresNotNull(arg1, nameof(arg1));
 
             ParameterInfo[] pis = ValidateMethodAndGetParameters(instance, method);
 
@@ -970,10 +970,10 @@ namespace System.Linq.Expressions
         ///<returns>A <see cref="T:System.Linq.Expressions.MethodCallExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.Call" /> and the <see cref="P:System.Linq.Expressions.MethodCallExpression.Object" /> and <see cref="P:System.Linq.Expressions.MethodCallExpression.Method" /> properties set to the specified values.</returns>
         public static MethodCallExpression Call(Expression instance, MethodInfo method, Expression arg0, Expression arg1, Expression arg2)
         {
-            ContractUtils.RequiresNotNull(method, "method");
-            ContractUtils.RequiresNotNull(arg0, "arg0");
-            ContractUtils.RequiresNotNull(arg1, "arg1");
-            ContractUtils.RequiresNotNull(arg2, "arg2");
+            ContractUtils.RequiresNotNull(method, nameof(method));
+            ContractUtils.RequiresNotNull(arg0, nameof(arg0));
+            ContractUtils.RequiresNotNull(arg1, nameof(arg1));
+            ContractUtils.RequiresNotNull(arg2, nameof(arg2));
 
             ParameterInfo[] pis = ValidateMethodAndGetParameters(instance, method);
 
@@ -1004,8 +1004,8 @@ namespace System.Linq.Expressions
         ///<exception cref="T:System.InvalidOperationException">No method whose name is <paramref name="methodName" />, whose type parameters match <paramref name="typeArguments" />, and whose parameter types match <paramref name="arguments" /> is found in <paramref name="instance" />.Type or its base types.-or-More than one method whose name is <paramref name="methodName" />, whose type parameters match <paramref name="typeArguments" />, and whose parameter types match <paramref name="arguments" /> is found in <paramref name="instance" />.Type or its base types.</exception>
         public static MethodCallExpression Call(Expression instance, string methodName, Type[] typeArguments, params Expression[] arguments)
         {
-            ContractUtils.RequiresNotNull(instance, "instance");
-            ContractUtils.RequiresNotNull(methodName, "methodName");
+            ContractUtils.RequiresNotNull(instance, nameof(instance));
+            ContractUtils.RequiresNotNull(methodName, nameof(methodName));
             if (arguments == null)
             {
                 arguments = Array.Empty<Expression>();
@@ -1029,8 +1029,8 @@ namespace System.Linq.Expressions
         ///<exception cref="T:System.InvalidOperationException">No method whose name is <paramref name="methodName" />, whose type parameters match <paramref name="typeArguments" />, and whose parameter types match <paramref name="arguments" /> is found in <paramref name="type" /> or its base types.-or-More than one method whose name is <paramref name="methodName" />, whose type parameters match <paramref name="typeArguments" />, and whose parameter types match <paramref name="arguments" /> is found in <paramref name="type" /> or its base types.</exception>
         public static MethodCallExpression Call(Type type, string methodName, Type[] typeArguments, params Expression[] arguments)
         {
-            ContractUtils.RequiresNotNull(type, "type");
-            ContractUtils.RequiresNotNull(methodName, "methodName");
+            ContractUtils.RequiresNotNull(type, nameof(type));
+            ContractUtils.RequiresNotNull(methodName, nameof(methodName));
 
             if (arguments == null) arguments = Array.Empty<Expression>();
             BindingFlags flags = BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy;
@@ -1078,7 +1078,7 @@ namespace System.Linq.Expressions
                 }
             }
 
-            ContractUtils.RequiresNotNull(method, "method");
+            ContractUtils.RequiresNotNull(method, nameof(method));
 
             ReadOnlyCollection<Expression> argList = arguments.ToReadOnly();
 
@@ -1113,7 +1113,7 @@ namespace System.Linq.Expressions
             else
             {
                 if (instance == null) throw new ArgumentException(Strings.OnlyStaticMethodsHaveNullInstance, nameof(method));
-                RequiresCanRead(instance, "instance");
+                RequiresCanRead(instance, nameof(instance));
                 ValidateCallInstanceType(instance.Type, method);
             }
         }
@@ -1267,8 +1267,8 @@ namespace System.Linq.Expressions
         ///<paramref name="array" />.Type does not represent an array type.-or-The rank of <paramref name="array" />.Type does not match the number of elements in <paramref name="indexes" />.-or-The <see cref="P:System.Linq.Expressions.Expression.Type" /> property of one or more elements of <paramref name="indexes" /> does not represent the <see cref="T:System.Int32" /> type.</exception>
         public static MethodCallExpression ArrayIndex(Expression array, IEnumerable<Expression> indexes)
         {
-            RequiresCanRead(array, "array");
-            ContractUtils.RequiresNotNull(indexes, "indexes");
+            RequiresCanRead(array, nameof(array));
+            ContractUtils.RequiresNotNull(indexes, nameof(indexes));
 
             Type arrayType = array.Type;
             if (!arrayType.IsArray)
@@ -1284,7 +1284,7 @@ namespace System.Linq.Expressions
 
             foreach (Expression e in indexList)
             {
-                RequiresCanRead(e, "indexes");
+                RequiresCanRead(e, nameof(indexes));
                 if (e.Type != typeof(int))
                 {
                     throw Error.ArgumentMustBeArrayIndexType();

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewArrayExpression.cs
@@ -144,8 +144,8 @@ namespace System.Linq.Expressions
         /// <returns>An instance of the <see cref="NewArrayExpression"/>.</returns>
         public static NewArrayExpression NewArrayInit(Type type, IEnumerable<Expression> initializers)
         {
-            ContractUtils.RequiresNotNull(type, "type");
-            ContractUtils.RequiresNotNull(initializers, "initializers");
+            ContractUtils.RequiresNotNull(type, nameof(type));
+            ContractUtils.RequiresNotNull(initializers, nameof(initializers));
             if (type.Equals(typeof(void)))
             {
                 throw Error.ArgumentCannotBeOfTypeVoid();
@@ -157,7 +157,7 @@ namespace System.Linq.Expressions
             for (int i = 0, n = initializerList.Count; i < n; i++)
             {
                 Expression expr = initializerList[i];
-                RequiresCanRead(expr, "initializers");
+                RequiresCanRead(expr, nameof(initializers));
 
                 if (!TypeUtils.AreReferenceAssignable(type, expr.Type))
                 {
@@ -212,8 +212,8 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="NewArrayExpression"/> that has the <see cref="P:NodeType"/> property equal to type and the <see cref="P:Expressions"/> property set to the specified value.</returns>
         public static NewArrayExpression NewArrayBounds(Type type, IEnumerable<Expression> bounds)
         {
-            ContractUtils.RequiresNotNull(type, "type");
-            ContractUtils.RequiresNotNull(bounds, "bounds");
+            ContractUtils.RequiresNotNull(type, nameof(type));
+            ContractUtils.RequiresNotNull(bounds, nameof(bounds));
 
             if (type.Equals(typeof(void)))
             {
@@ -228,7 +228,7 @@ namespace System.Linq.Expressions
             for (int i = 0; i < dimensions; i++)
             {
                 Expression expr = boundsList[i];
-                RequiresCanRead(expr, "bounds");
+                RequiresCanRead(expr, nameof(bounds));
                 if (!TypeUtils.IsInteger(expr.Type))
                 {
                     throw Error.ArgumentMustBeInteger();

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/NewExpression.cs
@@ -162,8 +162,8 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="NewExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="P:New"/> and the <see cref="P:Constructor"/> and <see cref="P:Arguments"/> properties set to the specified value.</returns>
         public static NewExpression New(ConstructorInfo constructor, IEnumerable<Expression> arguments)
         {
-            ContractUtils.RequiresNotNull(constructor, "constructor");
-            ContractUtils.RequiresNotNull(constructor.DeclaringType, "constructor.DeclaringType");
+            ContractUtils.RequiresNotNull(constructor, nameof(constructor));
+            ContractUtils.RequiresNotNull(constructor.DeclaringType, nameof(constructor) + "." + nameof(constructor.DeclaringType));
             TypeUtils.ValidateType(constructor.DeclaringType);
             ValidateConstructor(constructor);
             var argList = arguments.ToReadOnly();
@@ -182,7 +182,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="NewExpression"/> that has the <see cref="NodeType"/> property equal to <see cref="P:New"/> and the <see cref="P:Constructor"/>, <see cref="P:Arguments"/> and <see cref="P:Members"/> properties set to the specified value.</returns>
         public static NewExpression New(ConstructorInfo constructor, IEnumerable<Expression> arguments, IEnumerable<MemberInfo> members)
         {
-            ContractUtils.RequiresNotNull(constructor, "constructor");
+            ContractUtils.RequiresNotNull(constructor, nameof(constructor));
             ValidateConstructor(constructor);
             var memberList = members.ToReadOnly();
             var argList = arguments.ToReadOnly();
@@ -211,7 +211,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="NewExpression"/> that has the <see cref="NodeType"/> property equal to New and the Constructor property set to the ConstructorInfo that represents the parameterless constructor of the specified type.</returns>
         public static NewExpression New(Type type)
         {
-            ContractUtils.RequiresNotNull(type, "type");
+            ContractUtils.RequiresNotNull(type, nameof(type));
             if (type == typeof(void))
             {
                 throw Error.ArgumentCannotBeOfTypeVoid();
@@ -252,7 +252,7 @@ namespace System.Linq.Expressions
                     Expression arg = arguments[i];
                     RequiresCanRead(arg, "argument");
                     MemberInfo member = members[i];
-                    ContractUtils.RequiresNotNull(member, "member");
+                    ContractUtils.RequiresNotNull(member, nameof(member));
                     if (!TypeUtils.AreEquivalent(member.DeclaringType, constructor.DeclaringType))
                     {
                         throw Error.ArgumentMemberNotDeclOnType(member.Name, constructor.DeclaringType.Name);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/ParameterExpression.cs
@@ -209,7 +209,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="ParameterExpression" /> node with the specified name and type.</returns>
         public static ParameterExpression Parameter(Type type, string name)
         {
-            ContractUtils.RequiresNotNull(type, "type");
+            ContractUtils.RequiresNotNull(type, nameof(type));
 
             if (type == typeof(void))
             {
@@ -233,7 +233,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="ParameterExpression" /> node with the specified name and type.</returns>
         public static ParameterExpression Variable(Type type, string name)
         {
-            ContractUtils.RequiresNotNull(type, "type");
+            ContractUtils.RequiresNotNull(type, nameof(type));
             if (type == typeof(void)) throw Error.ArgumentCannotBeOfTypeVoid();
             if (type.IsByRef) throw Error.TypeMustNotBeByRef();
             return ParameterExpression.Make(type, name, false);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/RuntimeVariablesExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/RuntimeVariablesExpression.cs
@@ -97,7 +97,7 @@ namespace System.Linq.Expressions
         /// <returns>An instance of <see cref="T:System.Linq.Expressions.RuntimeVariablesExpression" /> that has the <see cref="P:System.Linq.Expressions.Expression.NodeType" /> property equal to <see cref="F:System.Linq.Expressions.ExpressionType.RuntimeVariables" /> and the <see cref="P:System.Linq.Expressions.RuntimeVariablesExpression.Variables" /> property set to the specified value.</returns>
         public static RuntimeVariablesExpression RuntimeVariables(IEnumerable<ParameterExpression> variables)
         {
-            ContractUtils.RequiresNotNull(variables, "variables");
+            ContractUtils.RequiresNotNull(variables, nameof(variables));
 
             var vars = variables.ToReadOnly();
             for (int i = 0; i < vars.Count; i++)
@@ -105,7 +105,7 @@ namespace System.Linq.Expressions
                 Expression v = vars[i];
                 if (v == null)
                 {
-                    throw new ArgumentNullException("variables[" + i + "]");
+                    throw new ArgumentNullException($"{nameof(variables)}[{i}]");
                 }
             }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchCase.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchCase.cs
@@ -89,11 +89,11 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="T:SwitchCase">SwitchCase</see>.</returns>
         public static SwitchCase SwitchCase(Expression body, IEnumerable<Expression> testValues)
         {
-            RequiresCanRead(body, "body");
+            RequiresCanRead(body, nameof(body));
 
             var values = testValues.ToReadOnly();
-            ContractUtils.RequiresNotEmpty(values, "testValues");
-            RequiresCanRead(values, "testValues");
+            ContractUtils.RequiresNotEmpty(values, nameof(testValues));
+            RequiresCanRead(values, nameof(testValues));
 
             return new SwitchCase(body, values);
         }

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/SwitchExpression.cs
@@ -199,11 +199,11 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="SwitchExpression"/>.</returns>
         public static SwitchExpression Switch(Type type, Expression switchValue, Expression defaultBody, MethodInfo comparison, IEnumerable<SwitchCase> cases)
         {
-            RequiresCanRead(switchValue, "switchValue");
+            RequiresCanRead(switchValue, nameof(switchValue));
             if (switchValue.Type == typeof(void)) throw Error.ArgumentCannotBeOfTypeVoid();
 
             var caseList = cases.ToReadOnly();
-            ContractUtils.RequiresNotNullItems(caseList, "cases");
+            ContractUtils.RequiresNotNullItems(caseList, nameof(cases));
 
             // Type of the result. Either provided, or it is type of the branches.
             Type resultType;
@@ -240,8 +240,8 @@ namespace System.Linq.Expressions
                 var rightParam = pms[1];
                 foreach (var c in caseList)
                 {
-                    ContractUtils.RequiresNotNull(c, "cases");
-                    ValidateSwitchCaseType(c.Body, customType, resultType, "cases");
+                    ContractUtils.RequiresNotNull(c, nameof(cases));
+                    ValidateSwitchCaseType(c.Body, customType, resultType, nameof(cases));
                     for (int i = 0; i < c.TestValues.Count; i++)
                     {
                         // When a comparison method is provided, test values can have different type but have to
@@ -269,8 +269,8 @@ namespace System.Linq.Expressions
                 var firstTestValue = caseList[0].TestValues[0];
                 foreach (var c in caseList)
                 {
-                    ContractUtils.RequiresNotNull(c, "cases");
-                    ValidateSwitchCaseType(c.Body, customType, resultType, "cases");
+                    ContractUtils.RequiresNotNull(c, nameof(cases));
+                    ValidateSwitchCaseType(c.Body, customType, resultType, nameof(cases));
                     // When no comparison method is provided, require all test values to have the same type.
                     for (int i = 0; i < c.TestValues.Count; i++)
                     {
@@ -296,7 +296,7 @@ namespace System.Linq.Expressions
             }
             else
             {
-                ValidateSwitchCaseType(defaultBody, customType, resultType, "defaultBody");
+                ValidateSwitchCaseType(defaultBody, customType, resultType, nameof(defaultBody));
             }
 
             // if we have a non-boolean userdefined equals, we don't want it.

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/SymbolDocumentInfo.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/SymbolDocumentInfo.cs
@@ -17,7 +17,7 @@ namespace System.Linq.Expressions
 
         internal SymbolDocumentInfo(string fileName)
         {
-            ContractUtils.RequiresNotNull(fileName, "fileName");
+            ContractUtils.RequiresNotNull(fileName, nameof(fileName));
             _fileName = fileName;
         }
 

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/TryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/TryExpression.cs
@@ -174,10 +174,10 @@ namespace System.Linq.Expressions
         /// <returns>The created <see cref="TryExpression"/>.</returns>
         public static TryExpression MakeTry(Type type, Expression body, Expression @finally, Expression fault, IEnumerable<CatchBlock> handlers)
         {
-            RequiresCanRead(body, "body");
+            RequiresCanRead(body, nameof(body));
 
             var @catch = handlers.ToReadOnly();
-            ContractUtils.RequiresNotNullItems(@catch, "handlers");
+            ContractUtils.RequiresNotNullItems(@catch, nameof(handlers));
             ValidateTryAndCatchHaveSameType(type, body, @catch);
 
             if (fault != null)
@@ -186,11 +186,11 @@ namespace System.Linq.Expressions
                 {
                     throw Error.FaultCannotHaveCatchOrFinally();
                 }
-                RequiresCanRead(fault, "fault");
+                RequiresCanRead(fault, nameof(fault));
             }
             else if (@finally != null)
             {
-                RequiresCanRead(@finally, "finally");
+                RequiresCanRead(@finally, nameof(@finally));
             }
             else if (@catch.Count == 0)
             {

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/TypeBinaryExpression.cs
@@ -202,8 +202,8 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="TypeBinaryExpression"/> for which the <see cref="NodeType"/> property is equal to <see cref="TypeIs"/> and for which the <see cref="Expression"/> and <see cref="TypeBinaryExpression.TypeOperand"/> properties are set to the specified values.</returns>
         public static TypeBinaryExpression TypeIs(Expression expression, Type type)
         {
-            RequiresCanRead(expression, "expression");
-            ContractUtils.RequiresNotNull(type, "type");
+            RequiresCanRead(expression, nameof(expression));
+            ContractUtils.RequiresNotNull(type, nameof(type));
             if (type.IsByRef) throw Error.TypeMustNotBeByRef();
 
             return new TypeBinaryExpression(expression, type, ExpressionType.TypeIs);
@@ -217,8 +217,8 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="TypeBinaryExpression"/> for which the <see cref="NodeType"/> property is equal to <see cref="TypeEqual"/> and for which the <see cref="Expression"/> and <see cref="TypeBinaryExpression.TypeOperand"/> properties are set to the specified values.</returns>
         public static TypeBinaryExpression TypeEqual(Expression expression, Type type)
         {
-            RequiresCanRead(expression, "expression");
-            ContractUtils.RequiresNotNull(type, "type");
+            RequiresCanRead(expression, nameof(expression));
+            ContractUtils.RequiresNotNull(type, nameof(type));
             if (type.IsByRef) throw Error.TypeMustNotBeByRef();
 
             return new TypeBinaryExpression(expression, type, ExpressionType.TypeEqual);

--- a/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
+++ b/src/System.Linq.Expressions/src/System/Linq/Expressions/UnaryExpression.cs
@@ -509,7 +509,7 @@ namespace System.Linq.Expressions
         /// <exception cref="InvalidOperationException">Thown when <paramref name="method"/> is null and the unary minus operator is not defined for expression.Type or expression.Type (or its corresponding non-nullable type if it is a nullable value type) is not assignable to the argument type of the method represented by method.</exception>
         public static UnaryExpression Negate(Expression expression, MethodInfo method)
         {
-            RequiresCanRead(expression, "expression");
+            RequiresCanRead(expression, nameof(expression));
             if (method == null)
             {
                 if (TypeUtils.IsArithmetic(expression.Type) && !TypeUtils.IsUnsignedInt(expression.Type))
@@ -544,7 +544,7 @@ namespace System.Linq.Expressions
         /// <exception cref="InvalidOperationException">Thown when <paramref name="method"/> is null and the unary minus operator is not defined for expression.Type or expression.Type (or its corresponding non-nullable type if it is a nullable value type) is not assignable to the argument type of the method represented by method.</exception>
         public static UnaryExpression UnaryPlus(Expression expression, MethodInfo method)
         {
-            RequiresCanRead(expression, "expression");
+            RequiresCanRead(expression, nameof(expression));
             if (method == null)
             {
                 if (TypeUtils.IsArithmetic(expression.Type))
@@ -579,7 +579,7 @@ namespace System.Linq.Expressions
         ///<paramref name="method" /> is null and the unary minus operator is not defined for <paramref name="expression" />.Type.-or-<paramref name="expression" />.Type (or its corresponding non-nullable type if it is a nullable value type) is not assignable to the argument type of the method represented by <paramref name="method" />.</exception>
         public static UnaryExpression NegateChecked(Expression expression, MethodInfo method)
         {
-            RequiresCanRead(expression, "expression");
+            RequiresCanRead(expression, nameof(expression));
             if (method == null)
             {
                 if (TypeUtils.IsArithmetic(expression.Type) && !TypeUtils.IsUnsignedInt(expression.Type))
@@ -614,7 +614,7 @@ namespace System.Linq.Expressions
         ///<paramref name="method" /> is null and the unary not operator is not defined for <paramref name="expression" />.Type.-or-<paramref name="expression" />.Type (or its corresponding non-nullable type if it is a nullable value type) is not assignable to the argument type of the method represented by <paramref name="method" />.</exception>
         public static UnaryExpression Not(Expression expression, MethodInfo method)
         {
-            RequiresCanRead(expression, "expression");
+            RequiresCanRead(expression, nameof(expression));
             if (method == null)
             {
                 if (TypeUtils.IsIntegerOrBool(expression.Type))
@@ -649,7 +649,7 @@ namespace System.Linq.Expressions
         /// <returns>An instance of <see cref="UnaryExpression"/>.</returns>
         public static UnaryExpression IsFalse(Expression expression, MethodInfo method)
         {
-            RequiresCanRead(expression, "expression");
+            RequiresCanRead(expression, nameof(expression));
             if (method == null)
             {
                 if (TypeUtils.IsBool(expression.Type))
@@ -679,7 +679,7 @@ namespace System.Linq.Expressions
         /// <returns>An instance of <see cref="UnaryExpression"/>.</returns>
         public static UnaryExpression IsTrue(Expression expression, MethodInfo method)
         {
-            RequiresCanRead(expression, "expression");
+            RequiresCanRead(expression, nameof(expression));
             if (method == null)
             {
                 if (TypeUtils.IsBool(expression.Type))
@@ -709,7 +709,7 @@ namespace System.Linq.Expressions
         /// <returns>An instance of <see cref="UnaryExpression"/>.</returns>
         public static UnaryExpression OnesComplement(Expression expression, MethodInfo method)
         {
-            RequiresCanRead(expression, "expression");
+            RequiresCanRead(expression, nameof(expression));
             if (method == null)
             {
                 if (TypeUtils.IsInteger(expression.Type))
@@ -729,8 +729,8 @@ namespace System.Linq.Expressions
         ///<paramref name="expression" /> or <paramref name="type" /> is null.</exception>
         public static UnaryExpression TypeAs(Expression expression, Type type)
         {
-            RequiresCanRead(expression, "expression");
-            ContractUtils.RequiresNotNull(type, "type");
+            RequiresCanRead(expression, nameof(expression));
+            ContractUtils.RequiresNotNull(type, nameof(type));
             TypeUtils.ValidateType(type);
 
             if (type.GetTypeInfo().IsValueType && !TypeUtils.IsNullableType(type))
@@ -748,8 +748,8 @@ namespace System.Linq.Expressions
         /// <returns>An instance of <see cref="UnaryExpression"/>.</returns>
         public static UnaryExpression Unbox(Expression expression, Type type)
         {
-            RequiresCanRead(expression, "expression");
-            ContractUtils.RequiresNotNull(type, "type");
+            RequiresCanRead(expression, nameof(expression));
+            ContractUtils.RequiresNotNull(type, nameof(type));
             if (!expression.Type.GetTypeInfo().IsInterface && expression.Type != typeof(object))
             {
                 throw Error.InvalidUnboxType();
@@ -784,8 +784,8 @@ namespace System.Linq.Expressions
         ///<exception cref="T:System.InvalidOperationException">No conversion operator is defined between <paramref name="expression" />.Type and <paramref name="type" />.-or-<paramref name="expression" />.Type is not assignable to the argument type of the method represented by <paramref name="method" />.-or-The return type of the method represented by <paramref name="method" /> is not assignable to <paramref name="type" />.-or-<paramref name="expression" />.Type or <paramref name="type" /> is a nullable value type and the corresponding non-nullable value type does not equal the argument type or the return type, respectively, of the method represented by <paramref name="method" />.</exception>
         public static UnaryExpression Convert(Expression expression, Type type, MethodInfo method)
         {
-            RequiresCanRead(expression, "expression");
-            ContractUtils.RequiresNotNull(type, "type");
+            RequiresCanRead(expression, nameof(expression));
+            ContractUtils.RequiresNotNull(type, nameof(type));
             TypeUtils.ValidateType(type);
 
             if (method == null)
@@ -825,8 +825,8 @@ namespace System.Linq.Expressions
         ///<exception cref="T:System.InvalidOperationException">No conversion operator is defined between <paramref name="expression" />.Type and <paramref name="type" />.-or-<paramref name="expression" />.Type is not assignable to the argument type of the method represented by <paramref name="method" />.-or-The return type of the method represented by <paramref name="method" /> is not assignable to <paramref name="type" />.-or-<paramref name="expression" />.Type or <paramref name="type" /> is a nullable value type and the corresponding non-nullable value type does not equal the argument type or the return type, respectively, of the method represented by <paramref name="method" />.</exception>
         public static UnaryExpression ConvertChecked(Expression expression, Type type, MethodInfo method)
         {
-            RequiresCanRead(expression, "expression");
-            ContractUtils.RequiresNotNull(type, "type");
+            RequiresCanRead(expression, nameof(expression));
+            ContractUtils.RequiresNotNull(type, nameof(type));
             TypeUtils.ValidateType(type);
 
             if (method == null)
@@ -853,7 +853,7 @@ namespace System.Linq.Expressions
         ///<paramref name="array" />.Type does not represent an array type.</exception>
         public static UnaryExpression ArrayLength(Expression array)
         {
-            ContractUtils.RequiresNotNull(array, "array");
+            ContractUtils.RequiresNotNull(array, nameof(array));
             if (!array.Type.IsArray || !typeof(Array).IsAssignableFrom(array.Type))
             {
                 throw Error.ArgumentMustBeArray();
@@ -872,7 +872,7 @@ namespace System.Linq.Expressions
         ///<paramref name="expression" /> is null.</exception>
         public static UnaryExpression Quote(Expression expression)
         {
-            RequiresCanRead(expression, "expression");
+            RequiresCanRead(expression, nameof(expression));
             bool validQuote = expression is LambdaExpression;
             if (!validQuote) throw Error.QuotedExpressionMustBeLambda();
             return new UnaryExpression(ExpressionType.Quote, expression, expression.GetType(), null);
@@ -915,12 +915,12 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression"/> that represents the exception.</returns>
         public static UnaryExpression Throw(Expression value, Type type)
         {
-            ContractUtils.RequiresNotNull(type, "type");
+            ContractUtils.RequiresNotNull(type, nameof(type));
             TypeUtils.ValidateType(type);
 
             if (value != null)
             {
-                RequiresCanRead(value, "value");
+                RequiresCanRead(value, nameof(value));
                 if (value.Type.GetTypeInfo().IsValueType) throw Error.ArgumentMustNotHaveValueType();
             }
             return new UnaryExpression(ExpressionType.Throw, value, type, null);
@@ -944,7 +944,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression"/> that represents the incremented expression.</returns>
         public static UnaryExpression Increment(Expression expression, MethodInfo method)
         {
-            RequiresCanRead(expression, "expression");
+            RequiresCanRead(expression, nameof(expression));
             if (method == null)
             {
                 if (TypeUtils.IsArithmetic(expression.Type))
@@ -974,7 +974,7 @@ namespace System.Linq.Expressions
         /// <returns>A <see cref="T:System.Linq.Expressions.UnaryExpression"/> that represents the decremented expression.</returns>
         public static UnaryExpression Decrement(Expression expression, MethodInfo method)
         {
-            RequiresCanRead(expression, "expression");
+            RequiresCanRead(expression, nameof(expression));
             if (method == null)
             {
                 if (TypeUtils.IsArithmetic(expression.Type))
@@ -1080,8 +1080,8 @@ namespace System.Linq.Expressions
 
         private static UnaryExpression MakeOpAssignUnary(ExpressionType kind, Expression expression, MethodInfo method)
         {
-            RequiresCanRead(expression, "expression");
-            RequiresCanWrite(expression, "expression");
+            RequiresCanRead(expression, nameof(expression));
+            RequiresCanWrite(expression, nameof(expression));
 
             UnaryExpression result;
             if (method == null)


### PR DESCRIPTION
Mostly automated replacement of parameter name string literals with corresponding usage of `nameof` (via a modified version of @jaredpar's https://github.com/jaredpar/UseNameOf) along the lines of #6209,  #6265, #6267, and #6271.

cc: @stephentoub, @VSadov 