### PR TITLE
Fix false assumption in Expression.TypeEqual

### DIFF
--- a/src/System.Dynamic.Runtime/tests/Dynamic.Simple/DelegateTest.cs
+++ b/src/System.Dynamic.Runtime/tests/Dynamic.Simple/DelegateTest.cs
@@ -24,5 +24,38 @@ namespace SampleDynamicTests
             int result = d(4, 6);
             Assert.Equal(24, result);
         }
+
+        private static int Foo(string s, dynamic d, object o)
+        {
+            return s.Length + d.ToString().Length + o.ToString().Length;
+        }
+
+        private static void Bar(string s, dynamic d, object o)
+        {
+        }
+
+        [Fact]
+        [ActiveIssue(6258)]
+        public static void VariantFuncTest()
+        {
+            Func<string, dynamic, object, int> del = Foo;
+            Func<string, dynamic, string, int> func = del;
+
+            dynamic arg = "saw";
+
+            Assert.Equal(16, func("came", arg, "conquered"));
+        }
+
+        [Fact]
+        [ActiveIssue(6258)]
+        public static void VariantActTest()
+        {
+            Action<string, dynamic, object> del = Bar;
+            Action<string, dynamic, string> act = del;
+
+            dynamic arg = "saw";
+
+            act("came", arg, "conquered");
+        }
     }
 }

--- a/src/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
+++ b/src/System.Linq.Expressions/tests/TypeBinary/TypeEqual.cs
@@ -203,5 +203,43 @@ namespace System.Linq.Expressions.Tests
             visitor.Visit(expression);
             Assert.Same(expression, visitor.LastTypeBinaryVisited);
         }
+
+        [Fact]
+        public void VariantDelegateArgumentCompiled()
+        {
+            Action<object> ao = x => { };
+            Action<string> a = x => { };
+            Action<string> b = ao;
+
+            var param = Expression.Parameter(typeof(Action<string>));
+
+            Func<Action<string>, bool> isActStr = Expression.Lambda<Func<Action<string>, bool>>(
+                Expression.TypeEqual(param, typeof(Action<string>)),
+                param
+            ).Compile(false);
+
+            Assert.False(isActStr(ao));
+            Assert.True(isActStr(a));
+            Assert.False(isActStr(b));
+        }
+
+        [Fact]
+        public void VariantDelegateArgumentInterpreted()
+        {
+            Action<object> ao = x => { };
+            Action<string> a = x => { };
+            Action<string> b = ao;
+
+            var param = Expression.Parameter(typeof(Action<string>));
+
+            Func<Action<string>, bool> isActStr = Expression.Lambda<Func<Action<string>, bool>>(
+                Expression.TypeEqual(param, typeof(Action<string>)),
+                param
+            ).Compile(true);
+
+            Assert.False(isActStr(ao));
+            Assert.True(isActStr(a));
+            Assert.False(isActStr(b));
+        }
     }
 }


### PR DESCRIPTION
`ReduceTypeEqual` has a false assumption that if `obj is T` and `typeof(T).IsSealed` then `obj.GetType() == typeof(T)`.

It will reduce to `Expression.Constant(true)` based on this assumption, and as of d5e3d82 will reduce to `Expression.Constant(false)` based on it too.

Remove the assumption entirely, removing both false positives and false negatives.

Fixes #6258