### PR TITLE
Unsigned cast for EPOLLHUP bitwise AND

### DIFF
--- a/src/Native/System.Native/pal_networking.cpp
+++ b/src/Native/System.Native/pal_networking.cpp
@@ -2376,7 +2376,7 @@ static void ConvertEventEPollToSocketAsync(SocketEvent* sae, epoll_event* epoll)
     uint32_t events = epoll->events;
     if ((events & EPOLLHUP) != 0)
     {
-        events = (events & ~EPOLLHUP) | EPOLLIN | EPOLLOUT;
+        events = (events & static_cast<uint32_t>(~EPOLLHUP)) | EPOLLIN | EPOLLOUT;
     }
 
     *sae = {.Data = reinterpret_cast<uintptr_t>(epoll->data.ptr), .Events = GetSocketEvents(events)};


### PR DESCRIPTION
`~EPOLLHUP` results in signed int, which makes the compiler throw on
`events & ~EPOLLHUP`:

```ash
error: implicit conversion changes signedness: 'int' to 'unsigned int'
      [-Werror,-Wsign-conversion]
```

This change make use of `static_cast<uint32_t>` to satisfy the compiler.