### PR TITLE
Short-circuit ImmutableArray.Replace for equal values

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -703,6 +703,11 @@ namespace System.Collections.Immutable
         {
             var self = this;
             
+            if (equalityComparer == null)
+            {
+                equalityComparer = EqualityComparer<T>.Default;
+            }
+            
             if (equalityComparer.Equals(oldValue, newValue))
             {
                 return self;

--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -702,6 +702,12 @@ namespace System.Collections.Immutable
         public ImmutableArray<T> Replace(T oldValue, T newValue, IEqualityComparer<T> equalityComparer)
         {
             var self = this;
+            
+            if (equalityComparer.Equals(oldValue, newValue))
+            {
+                return self;
+            }
+            
             int index = self.IndexOf(oldValue, equalityComparer);
             if (index < 0)
             {


### PR DESCRIPTION
This pull request short-circuits `ImmutableArray.Replace` if the items are same using the default equality comparer. **Note:** It may cause a potential compat issue if the `equalityComparer` says the items are equal, but they're not. Additionally, it adds an overhead of another virtual method call in the (probably more common) case where they're not equal, although `IndexOf` does a lot of them so I'm not sure if that's an issue. Do you guys think this is worth merging?

cc @stephentoub 