### PR TITLE
Add more Http response stream tests

### DIFF
--- a/src/System.Net.Http/tests/FunctionalTests/LoopbackServer.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/LoopbackServer.cs
@@ -1,0 +1,112 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace System.Net.Http.Functional.Tests
+{
+    public class LoopbackServer
+    {
+        public enum TransferType
+        {
+            None = 0,
+            ContentLength,
+            Chunked
+        }
+
+        public enum TransferError
+        {
+            None = 0,
+            ContentLengthTooLarge,
+            ChunkSizeTooLarge,
+            MissingChunkTerminator
+        }
+
+        public static Task StartServer(
+            TransferType transferType,
+            TransferError transferError,
+            out IPEndPoint serverEndPoint)
+        {
+            var server = new TcpListener(IPAddress.Loopback, 0);
+            Task serverTask = ((Func<Task>)async delegate {
+                server.Start();
+                using (var client = await server.AcceptSocketAsync())
+                using (var stream = new NetworkStream(client))
+                using (var reader = new StreamReader(stream, Encoding.ASCII))
+                {
+                    // Read past request headers.
+                    string line;
+                    while (!string.IsNullOrEmpty(line = reader.ReadLine())) ;
+
+                    // Determine response transfer headers.
+                    string transferHeader = null;
+                    string content = "This is some response content.";
+                    if (transferType == TransferType.ContentLength)
+                    {
+                        if (transferError == TransferError.ContentLengthTooLarge)
+                        {
+                            transferHeader = $"Content-Length: {content.Length + 42}\r\n";
+                        }
+                        else
+                        {
+                            transferHeader = $"Content-Length: {content.Length}\r\n";
+                        }
+                    }
+                    else if (transferType == TransferType.Chunked)
+                    {
+                        transferHeader = "Transfer-Encoding: chunked\r\n";
+                    }
+
+                    // Write response.
+                    using (var writer = new StreamWriter(stream, Encoding.ASCII))
+                    {
+                        writer.Write("HTTP/1.1 200 OK\r\n");
+                        writer.Write($"Date: {DateTimeOffset.UtcNow:R}\r\n");
+                        writer.Write("Content-Type: text/plain\r\n");
+
+                        if (!string.IsNullOrEmpty(transferHeader))
+                        {
+                            writer.Write(transferHeader);
+                        }
+
+                        writer.Write("\r\n");
+                        if (transferType == TransferType.Chunked)
+                        {
+                            string chunkSizeInHex;
+                            if (transferError == TransferError.ChunkSizeTooLarge)
+                            {
+                                chunkSizeInHex = string.Format("{0:x}\r\n", content.Length + 42);
+                            }
+                            else
+                            {
+                                chunkSizeInHex = string.Format("{0:x}\r\n", content.Length);
+                            }
+                            writer.Write(chunkSizeInHex);
+                            writer.Write($"{content}\r\n");
+                            if (transferError != TransferError.MissingChunkTerminator)
+                            {
+                                writer.Write("0\r\n\r\n");
+                            }
+                        }
+                        else
+                        {
+                            writer.Write($"{content}\r\n");
+                        }
+                        writer.Flush();
+                    }
+
+                    client.Shutdown(SocketShutdown.Both);
+                }
+            })();
+
+            serverEndPoint = (IPEndPoint)server.LocalEndpoint;
+            return serverTask;
+        }
+    }
+}

--- a/src/System.Net.Http/tests/FunctionalTests/LoopbackServer.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/LoopbackServer.cs
@@ -78,15 +78,9 @@ namespace System.Net.Http.Functional.Tests
                         writer.Write("\r\n");
                         if (transferType == TransferType.Chunked)
                         {
-                            string chunkSizeInHex;
-                            if (transferError == TransferError.ChunkSizeTooLarge)
-                            {
-                                chunkSizeInHex = string.Format("{0:x}\r\n", content.Length + 42);
-                            }
-                            else
-                            {
-                                chunkSizeInHex = string.Format("{0:x}\r\n", content.Length);
-                            }
+                            string chunkSizeInHex = string.Format(
+                                "{0:x}\r\n",
+                                content.Length + (transferError == TransferError.ChunkSizeTooLarge ? 42 : 0));
                             writer.Write(chunkSizeInHex);
                             writer.Write($"{content}\r\n");
                             if (transferError != TransferError.MissingChunkTerminator)

--- a/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
@@ -112,7 +112,7 @@ namespace System.Net.Http.Functional.Tests
         [InlineData(LoopbackServer.TransferType.None, LoopbackServer.TransferError.None)]
         [InlineData(LoopbackServer.TransferType.ContentLength, LoopbackServer.TransferError.None)]
         [InlineData(LoopbackServer.TransferType.Chunked, LoopbackServer.TransferError.None)]
-        public async Task ReadAsStreamAsync_ValidServerResponse_ThrowsIOException(
+        public async Task ReadAsStreamAsync_ValidServerResponse_Success(
             LoopbackServer.TransferType transferType,
             LoopbackServer.TransferError transferError)
         {

--- a/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
+++ b/src/System.Net.Http/tests/FunctionalTests/System.Net.Http.Functional.Tests.csproj
@@ -40,6 +40,7 @@
     <Compile Include="HttpMethodTest.cs" />
     <Compile Include="HttpRequestMessageTest.cs" />
     <Compile Include="HttpResponseMessageTest.cs" />
+    <Compile Include="LoopbackServer.cs" />
     <Compile Include="MessageProcessingHandlerTest.cs" />
     <Compile Include="MultipartContentTest.cs" />
     <Compile Include="MultipartFormDataContentTest.cs" />


### PR DESCRIPTION
Building on PR #6250, added more response stream tests dealing with invalid response body transfer semantics.

I still plan to move the localhost server (recently added to these Http tests) to be Azure based.in the near future.
