### PR TITLE
ImmutableArray: Remove workaround for bug in native compiler

### DIFF
--- a/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
+++ b/src/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableArray`1.cs
@@ -1620,12 +1620,6 @@ namespace System.Collections.Immutable
             // so touching it, and potentially causing a cache miss, is not going to be an
             // extra expense.
             var unused = this.array.Length;
-
-            // This line is a workaround for a bug in C# compiler
-            // The code in this line will not be emitted, but it will prevent incorrect
-            // optimizing away of "Length" call above in Release builds.
-            // TODO: remove the workaround when building with Roslyn which does not have this bug.
-            var unused2 = unused;
         }
 
         /// <summary>


### PR DESCRIPTION
Since CoreFX is being built with Roslyn and does not depend on the native compiler, I went ahead and removed a snippet in `ImmutableArray` that worked around a bug in the latter.

cc @stephentoub