### PR TITLE
Fix WinHttpHandler memory leaks

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpHandler.cs
@@ -754,6 +754,7 @@ nameof(value),
             if (state.CancellationToken.IsCancellationRequested)
             {
                 state.Tcs.TrySetCanceled(state.CancellationToken);
+                state.ClearSendRequestState();
                 return;
             }
 
@@ -894,6 +895,8 @@ nameof(value),
             {
                 HandleAsyncException(state, savedException);
             }
+            
+            state.ClearSendRequestState();
         }
 
         private void SetSessionHandleOptions()

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
@@ -55,6 +55,24 @@ namespace System.Net.Http
             }
         }
 
+        public void ClearSendRequestState()
+        {
+            // Since WinHttpRequestState has a self-referenced strong GCHandle, we
+            // need to clear out object references to break cycles and prevent leaks.
+            Tcs = null;
+            TcsSendRequest = null;
+            TcsWriteToRequestStream = null;
+            TcsInternalWriteDataToRequestStream = null;
+            TcsReceiveResponseHeaders = null;
+            RequestMessage = null;
+            Handler = null;
+            ServerCertificateValidationCallback = null;
+            TransportContext = null;
+            Proxy = null;
+            ServerCredentials = null;
+            DefaultProxyCredentials = null;
+        }
+
         public TaskCompletionSource<HttpResponseMessage> Tcs { get; set; }
 
         public CancellationToken CancellationToken { get; set; }
@@ -97,6 +115,8 @@ namespace System.Net.Http
         public TaskCompletionSource<bool> TcsWriteToRequestStream { get; set; }
         public TaskCompletionSource<bool> TcsInternalWriteDataToRequestStream { get; set; }
         public TaskCompletionSource<bool> TcsReceiveResponseHeaders { get; set; }
+        
+        // WinHttpResponseStream state.
         public TaskCompletionSource<int> TcsQueryDataAvailable { get; set; }
         public TaskCompletionSource<int> TcsReadFromResponseStream { get; set; }
 

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -17,7 +17,7 @@ namespace System.Net.Http
         private readonly WinHttpRequestState _state;
         
         // TODO (Issue 2505): temporary pinned buffer caches of 1 item. Will be replaced by PinnableBufferCache.
-        private GCHandle _cachedReceivePinnedBuffer = new GCHandle();
+        private GCHandle _cachedReceivePinnedBuffer = default(GCHandle);
 
         internal WinHttpResponseStream(WinHttpRequestState state)
         {
@@ -216,15 +216,15 @@ namespace System.Net.Http
             {
                 _disposed = true;
 
+                // TODO (Issue 2508): Pinned buffers must be released in the callback, when it is guaranteed no further
+                // operations will be made to the send/receive buffers.
+                if (_cachedReceivePinnedBuffer.IsAllocated)
+                {
+                    _cachedReceivePinnedBuffer.Free();
+                }
+
                 if (disposing)
                 {
-                    // TODO (Issue 2508): Pinned buffers must be released in the callback, when it is guaranteed no further
-                    // operations will be made to the send/receive buffers.
-                    if (_cachedReceivePinnedBuffer.IsAllocated)
-                    {
-                        _cachedReceivePinnedBuffer.Free();
-                    }
-
                     if (_state.RequestHandle != null)
                     {
                         _state.RequestHandle.Dispose();

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -221,6 +221,7 @@ namespace System.Net.Http
                 if (_cachedReceivePinnedBuffer.IsAllocated)
                 {
                     _cachedReceivePinnedBuffer.Free();
+                    _cachedReceivePinnedBuffer = default(GCHandle);
                 }
 
                 if (disposing)


### PR DESCRIPTION
The WinHttpHandler was leaking a lot of objects in cases where an explicit Dispose was not done for the various HttpResponseMessage related objects. It was leaking because there was a cycle between the strong GCHandle of WinHttpRequestState and the objects contained within it.

To break the cycle, we now clear out object references within WinHttpRequestState that are no longer needed once the SendRequest phase is completed.

There was also a leak of a pinned GCHandle and related memory in WinHttpResponseStream. The free'ing of that allocated GCHandle was done in the Dispose(bool disposing) method. However, it wasn't being called when disposing=false (i.e. a finalizer). Since it is a pinned GCHandle, it needed to be freed in all cases.

Fixes #5927.