### PR TITLE
Response stream reads should return error for insufficient data

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/Resources/Strings.resx
+++ b/src/System.Net.Http.WinHttpHandler/src/Resources/Strings.resx
@@ -144,6 +144,9 @@
   <data name="net_http_io_read" xml:space="preserve">
     <value>The read operation failed, see inner exception.</value>
   </data>
+  <data name="net_http_io_read_incomplete" xml:space="preserve">
+    <value>Unable to read data from the transport connection. The connection was closed before all data could be read. Expected {0} bytes, read {1} bytes.</value>
+  </data>
   <data name="net_http_io_write" xml:space="preserve">
     <value>The write operation failed, see inner exception.</value>
   </data>

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -149,8 +149,6 @@ namespace System.Net.Http
             Debug.Assert(state.TcsReadFromResponseStream != null, "TcsReadFromResponseStream is null");
             Debug.Assert(!state.TcsReadFromResponseStream.Task.IsCompleted, "TcsReadFromResponseStream.Task is completed");
             
-            state.CurrentBytesRead += (long)bytesRead;
-
             // If we read to the end of the stream and we're using 'Content-Length' semantics on the response body,
             // then verify we read at least the number of bytes required.
             if (bytesRead == 0
@@ -165,6 +163,7 @@ namespace System.Net.Http
             }
             else
             {
+                state.CurrentBytesRead += (long)bytesRead;
                 state.TcsReadFromResponseStream.TrySetResult((int)bytesRead);
             }
         }

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -149,7 +149,24 @@ namespace System.Net.Http
             Debug.Assert(state.TcsReadFromResponseStream != null, "TcsReadFromResponseStream is null");
             Debug.Assert(!state.TcsReadFromResponseStream.Task.IsCompleted, "TcsReadFromResponseStream.Task is completed");
             
-            state.TcsReadFromResponseStream.TrySetResult((int)bytesRead);
+            state.CurrentBytesRead += (long)bytesRead;
+
+            // If we read to the end of the stream and we're using 'Content-Length' semantics on the response body,
+            // then verify we read at least the number of bytes required.
+            if (bytesRead == 0
+                && state.ExpectedBytesToRead.HasValue
+                && state.CurrentBytesRead < state.ExpectedBytesToRead.Value)
+            {
+                state.TcsReadFromResponseStream.TrySetException(
+                    new IOException(string.Format(
+                        SR.net_http_io_read_incomplete,
+                        state.ExpectedBytesToRead.Value,
+                        state.CurrentBytesRead)));
+            }
+            else
+            {
+                state.TcsReadFromResponseStream.TrySetResult((int)bytesRead);
+            }
         }
 
         private static void OnRequestWriteComplete(WinHttpRequestState state)

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
@@ -99,6 +99,8 @@ namespace System.Net.Http
         public TaskCompletionSource<bool> TcsReceiveResponseHeaders { get; set; }
         public TaskCompletionSource<int> TcsQueryDataAvailable { get; set; }
         public TaskCompletionSource<int> TcsReadFromResponseStream { get; set; }
+        public long? ExpectedBytesToRead { get; set; }
+        public long CurrentBytesRead { get; set; }
 
         #region IDisposable Members
         private void Dispose(bool disposing)

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -91,6 +91,11 @@ namespace System.Net.Http
             // Parse raw response headers and place them into response message.
             ParseResponseHeaders(requestHandle, response, buffer, stripEncodingHeaders);
 
+            if (response.RequestMessage.Method != HttpMethod.Head)
+            {
+                state.ExpectedBytesToRead = response.Content.Headers.ContentLength;
+            }
+
             return response;
         }
 

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpHandlerTest.cs
@@ -501,14 +501,14 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
         {
             var handler = new WinHttpHandler();
             var client = new HttpClient(handler);
-            TestServer.SetResponse(DecompressionMethods.None, TestServer.ExpectedResponseBody);
 
-            HttpResponseMessage response = await client.GetAsync(TestServer.FakeServerEndpoint);
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            response = await client.GetAsync(TestServer.FakeServerEndpoint);
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-            response = await client.GetAsync(TestServer.FakeServerEndpoint);
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            for (int i = 0; i < 3; i++)
+            {
+                TestServer.SetResponse(DecompressionMethods.None, TestServer.ExpectedResponseBody);
+                HttpResponseMessage response = await client.GetAsync(TestServer.FakeServerEndpoint);
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            }
+
             client.Dispose();
         }
 

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -255,6 +255,9 @@
   <data name="net_http_io_read" xml:space="preserve">
     <value>The read operation failed, see inner exception.</value>
   </data>
+  <data name="net_http_io_read_incomplete" xml:space="preserve">
+    <value>Unable to read data from the transport connection. The connection was closed before all data could be read. Expected {0} bytes, read {1} bytes.</value>
+  </data>
   <data name="net_http_io_write" xml:space="preserve">
     <value>The write operation failed, see inner exception.</value>
   </data>

--- a/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
+++ b/src/System.Net.Http/tests/FunctionalTests/ResponseStreamTest.cs
@@ -91,7 +91,6 @@ namespace System.Net.Http.Functional.Tests
             }
         }
 
-        [ActiveIssue(6231, PlatformID.Windows)]
         [Theory]
         [InlineData(LoopbackServer.TransferType.ContentLength, LoopbackServer.TransferError.ContentLengthTooLarge)]
         [InlineData(LoopbackServer.TransferType.Chunked, LoopbackServer.TransferError.MissingChunkTerminator)]


### PR DESCRIPTION
WinHttpResponseStream was not tracking the amount of data read when the response used 'Content-Length' semantics. So, if the amount of bytes read from the server was less than expected, we did not return an error. This was different behavior than .NET Framework.

Fixed WinHttpResponseStream so that it will track the total number of bytes read and compare it to the expected number of bytes if using 'Content-Length' semantics. Note that we don't do this checking if the HTTP request is a HEAD request. That is because the definition of that HTTP verb is to return headers "as-if" it was returning a real response body. So, the 'Content-Length' might be set but there is no response body for a HEAD request.

For cases of using 'Transfer-Encoding: chunked' semantics for the response body, there is already error checking at the lower HTTP layer in WinHTTP.

Fixes #6231.