### PR TITLE
Disable Console.set_Title test failing outer loop on Windows 10

### DIFF
--- a/src/System.Console/tests/WindowAndCursorProps.cs
+++ b/src/System.Console/tests/WindowAndCursorProps.cs
@@ -100,6 +100,7 @@ public class WindowAndCursorProps
         Assert.Throws<PlatformNotSupportedException>(() => Console.Title);
     }
 
+    [ActiveIssue(6223, PlatformID.Windows)]
     [Fact]
     [OuterLoop] // changes the title and we can't change it back automatically in the test
     public static void Title_Set()


### PR DESCRIPTION
cc: @pallavit 
#6223

This is preventing a clean run of outerloop on Windows 10.