### PR TITLE
Fix MemoryMappedFile TooLargeCapacity test

### DIFF
--- a/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
+++ b/src/System.IO.MemoryMappedFiles/tests/MemoryMappedFile.CreateFromFile.Tests.cs
@@ -821,7 +821,16 @@ namespace System.IO.MemoryMappedFiles.Tests
         {
             using (FileStream fs = new FileStream(GetTestFilePath(), FileMode.CreateNew))
             {
-                Assert.Throws<IOException>(() => MemoryMappedFile.CreateFromFile(fs, null, long.MaxValue, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, true));
+                try
+                {
+                    long length = long.MaxValue;
+                    MemoryMappedFile.CreateFromFile(fs, null, length, MemoryMappedFileAccess.ReadWrite, HandleInheritability.None, true).Dispose();
+                    Assert.Equal(length, fs.Length); // if it didn't fail to create the file, the length should be what was requested.
+                }
+                catch (IOException)
+                {
+                    // Expected exception for too large a capacity
+                }
             }
         }
 


### PR DESCRIPTION
The test is assuming that creating an MMF with a capacity equal to long.MaxValue should fail.  But some platforms allow files this long.  This commit updates the test to say that either it should fail or the file should have been updated to have the requested length.

Fixes #6279 
cc: @ellismg 