### PR TITLE
Fixing bug #2279 to lock the root folder of all FileSystemWatchers

### DIFF
--- a/src/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
+++ b/src/System.IO.FileSystem.Watcher/src/System.IO.FileSystem.Watcher.csproj
@@ -78,6 +78,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Errors.cs">
       <Link>Common\Interop\Unix\Interop.Errors.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.FLock.cs">
+      <Link>Common\Interop\Unix\libc\Interop.FLock.cs</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\Interop.IOErrors.cs">
       <Link>Common\Interop\Unix\Interop.IOErrors.cs</Link>
     </Compile>
@@ -87,6 +90,7 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.PathConf.cs">
       <Link>Common\Interop\Unix\Interop.PathConf.cs</Link>
     </Compile>
+    <Compile Include="System\IO\FileSystemWatcher.Unix.cs" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetsLinux)' == 'true'">
     <Compile Include="System\IO\FileSystemWatcher.Linux.cs" />
@@ -113,6 +117,12 @@
     </Compile>
     <Compile Include="$(CommonPath)\Interop\OSX\Interop.RunLoop.cs">
       <Link>Common\Interop\OSX\Interop.RunLoop.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Open.cs">
+      <Link>Common\Interop\Unix\libc\Interop.Open.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.OpenFlags.cs">
+      <Link>Common\Interop\Unix\libc\Interop.OpenFlags.cs</Link>
     </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Sync.cs">
       <Link>Common\Interop\Unix\Interop.Sync.cs</Link>

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Linux.cs
@@ -70,6 +70,9 @@ namespace System.IO
                 _cancellation = cancellation;
                 _enabled = true;
 
+                // Match Windows and lock the root directory
+                LockRootDirectory(handle, _directory);
+
                 // Start the runner
                 runner.Start();
             }
@@ -77,7 +80,8 @@ namespace System.IO
             {
                 // If we fail to actually start the watching even though we've opened the 
                 // inotify handle, close the inotify handle proactively rather than waiting for it 
-                // to be finalized.
+                // to be finalized; also, release the lock on the root directory.
+                UnlockRootDirectory(handle);
                 handle.Dispose();
                 throw;
             }

--- a/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Unix.cs
+++ b/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.Unix.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace System.IO
+{
+    public partial class FileSystemWatcher
+    {
+        protected static void UnlockRootDirectory(Microsoft.Win32.SafeHandles.SafeFileHandle handle)
+        {
+            Interop.Sys.FLock(handle, Interop.Sys.LockOperations.LOCK_UN);
+        }
+
+        protected static void LockRootDirectory(Microsoft.Win32.SafeHandles.SafeFileHandle sfh, string directory)
+        {
+            // Match Windows and lock the root directory
+            // NOTE: this WILL NOT prevent this directory from being deleted from underneath us
+            //       due to *nix having advisory-only locks (by default); this means that applications
+            //       can choose to ignore locks and operate on the FD anyway.
+            if (Interop.Sys.FLock(sfh,
+                                  Interop.Sys.LockOperations.LOCK_EX | Interop.Sys.LockOperations.LOCK_NB) < 0)
+            {
+                // Match Windows and throw FileNotFoundException
+                throw new FileNotFoundException(SR.Format(SR.FSW_IOError, directory));
+            }
+        }
+    }
+}

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Changed.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Changed.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Threading;
 using Xunit;
 
@@ -161,6 +162,12 @@ public class ChangedTests
         {
             string filePath = Path.Combine(dir3.Path, "testfile.txt");
             File.WriteAllBytes(filePath, new byte[4096]);
+
+            // We did a lot of I/O so sync to avoid race conditions with the non-Windows FSWs
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Interop.Sys.Sync();
+            }
 
             // Attach the FSW to the existing structure
             AutoResetEvent eventOccurred = Utility.WatchForEvents(watcher, WatcherChangeTypes.Changed);

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.LockTest.Unix.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.LockTest.Unix.cs
@@ -1,0 +1,28 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Xunit;
+
+public class FileSystemWatcherLockTest
+{
+    [Fact]
+    public static void FileSystemWatcher_WatchLocksWatchedDirectory()
+    {
+        using (var dir = Utility.CreateTestDirectory())
+        using (var fsw = new FileSystemWatcher())
+        {
+            fsw.Path = Path.GetFullPath(dir.Path);
+            fsw.EnableRaisingEvents = true;
+
+            Microsoft.Win32.SafeHandles.SafeFileHandle handle = Interop.Sys.Open(fsw.Path, Interop.Sys.OpenFlags.O_RDONLY, 0);
+            Assert.False(handle.IsInvalid); // We should always be able to open a handle
+            Assert.True(Interop.Sys.FLock(handle, Interop.Sys.LockOperations.LOCK_EX | Interop.Sys.LockOperations.LOCK_NB) < 0);
+
+            Interop.ErrorInfo err = Interop.Sys.GetLastErrorInfo();
+            Assert.True(err.Error == Interop.Error.EWOULDBLOCK); // validate it is a sharing violation
+        }
+    }
+}

--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.LockTest.Windows.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.LockTest.Windows.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.IO;
+using Xunit;
+
+public class FileSystemWatcheLockTest
+{
+    [Fact]
+    public static void FileSystemWatcher_WatchLocksWatchedDirectory()
+    {
+        using (var dir = Utility.CreateTestDirectory())
+        using (var fsw = new FileSystemWatcher())
+        {
+            fsw.Path = Path.GetFullPath(dir.Path);
+            fsw.EnableRaisingEvents = true;
+
+            Interop.mincore.SECURITY_ATTRIBUTES attr = default(Interop.mincore.SECURITY_ATTRIBUTES);
+            Microsoft.Win32.SafeHandles.SafeFileHandle handle = Interop.mincore.CreateFile(
+                fsw.Path,
+                (int)FileAccess.Read,
+                FileShare.None,
+                ref attr,
+                FileMode.Open,
+                Interop.mincore.FileOperations.FILE_FLAG_BACKUP_SEMANTICS,
+                IntPtr.Zero);
+            Assert.True(handle.IsInvalid);
+            Assert.True(System.Runtime.InteropServices.Marshal.GetLastWin32Error() == 32); // validate it was a sharing violation
+        }
+    }
+}

--- a/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
+++ b/src/System.IO.FileSystem.Watcher/tests/System.IO.FileSystem.Watcher.Tests.csproj
@@ -10,6 +10,8 @@
     <ProjectGuid>{20411A66-C7A4-4941-8FA2-66308365FD22}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AssemblyName>System.IO.FileSystem.Watcher.Tests</AssemblyName>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <StringResourcesPath>../src/Resources/Strings.resx</StringResourcesPath>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\System.IO.FileSystem.Watcher.csproj">
@@ -37,6 +39,57 @@
     <Compile Include="FileSystemWatcher.unit.cs" />
     <Compile Include="RenamedEventArgs.unit.cs" />
     <Compile Include="XunitAssemblyAttributes.cs" />
+    <Compile Include="$(CommonPath)\System\IO\PathInternal.cs">
+       <Link>Common\System\IO\PathInternal.cs</Link>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsWindows)'=='true'">
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.BOOL.cs">
+       <Link>Common\Interop\Windows\Interop.BOOL.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.CreateFile.cs">
+       <Link>Common\Interop\Windows\Interop.CreateFile.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.FileOperations.cs">
+       <Link>Common\Interop\Windows\Interop.FileOperations.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\Interop.Libraries.cs">
+       <Link>Common\Interop\Windows\Interop.Libraries.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Windows\mincore\Interop.SECURITY_ATTRIBUTES.cs">
+       <Link>Common\Interop\Windows\Interop.SECURITY_ATTRIBUTES.cs</Link>
+    </Compile>
+     <Compile Include="$(CommonPath)\System\IO\PathInternal.Windows.cs">
+        <Link>Common\System\IO\PathInternal.Windows.cs</Link>
+     </Compile>
+     <Compile Include="FileSystemWatcher.LockTest.Windows.cs" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetsUnix)' == 'true'">
+     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Errors.cs">
+        <Link>Common\Interop\Unix\Interop.Errors.cs</Link>
+     </Compile>
+     <Compile Include="$(CommonPath)\Interop\Unix\Interop.Libraries.cs">
+        <Link>Common\Interop\Unix\Interop.Libraries.cs</Link>
+     </Compile>
+     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Open.cs">
+        <Link>Common\Interop\Unix\Interop.Open.cs</Link>
+     </Compile>
+     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.OpenFlags.cs">
+        <Link>Common\Interop\Unix\Interop.OpenFlags.cs</Link>
+     </Compile>
+     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.PathConf.cs">
+        <Link>Common\Interop\Unix\Interop.PathConf.cs</Link>
+     </Compile>
+     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.FLock.cs">
+        <Link>Common\Interop\Unix\Interop.FLock.cs</Link>
+     </Compile>
+     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Sync.cs">
+        <Link>Common\Interop\Unix\Interop.Sync.cs</Link>
+     </Compile>
+     <Compile Include="$(CommonPath)\System\IO\PathInternal.Unix.cs">
+        <Link>Common\System\IO\PathInternal.Unix.cs</Link>
+     </Compile>
+     <Compile Include="FileSystemWatcher.LockTest.Unix.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />


### PR DESCRIPTION
Fixing bug #2279 to lock the root folder of all FileSystemWatchers to match the functionality on Windows

cc @stephentoub 