### PR TITLE
Fix missing types from S.Globalization.Calendars

### DIFF
--- a/src/System.Globalization.Calendars/src/System.Globalization.Calendars.csproj
+++ b/src/System.Globalization.Calendars/src/System.Globalization.Calendars.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyName>System.Globalization.Calendars</AssemblyName>
     <AssemblyVersion>4.0.1.0</AssemblyVersion>
-    <IsPartialFacadeAssembly Condition="'$(TargetGroup)' == 'net46'">true</IsPartialFacadeAssembly>
+    <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">dotnet5.4</PackageTargetFramework>
   </PropertyGroup>
 

--- a/src/System.Globalization.Calendars/tests/System.Globalization.Calendars.Tests.csproj
+++ b/src/System.Globalization.Calendars/tests/System.Globalization.Calendars.Tests.csproj
@@ -115,5 +115,14 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- Compile tests against the contract, but copy our local-built implementation for testing -->
+    <ProjectReference Include="..\src\System.Globalization.Calendars.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <OutputItemType>Content</OutputItemType>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Targets>Build;DebugSymbolsProjectOutputGroup</Targets>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>


### PR DESCRIPTION
System.Globalization.Calendars should be a facade assembly, but in
030e29992f6be20ffb9d9d3e799118f3354bce22 we accidently made it facade
only for net46.

We didn't catch this during testing because the test assembly was always
running against the package version, but in Helix, where we test against
packages all the time, we hit the issue.

Make the assembly a partial facade all the time and update the test
project so we actually test agains the live code (doing so caused the
test to fail before the above fix, so it lets us know we won't miss this
issue in the future).