### PR TITLE
Format LINQ code

### DIFF
--- a/src/System.Linq/src/System/Linq/Aggregate.cs
+++ b/src/System.Linq/src/System/Linq/Aggregate.cs
@@ -12,12 +12,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (func == null)
             {
-                throw Error.ArgumentNull("func");
+                throw Error.ArgumentNull(nameof(func));
             }
 
             using (IEnumerator<TSource> e = source.GetEnumerator())
@@ -41,12 +41,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (func == null)
             {
-                throw Error.ArgumentNull("func");
+                throw Error.ArgumentNull(nameof(func));
             }
 
             TAccumulate result = seed;
@@ -62,17 +62,17 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (func == null)
             {
-                throw Error.ArgumentNull("func");
+                throw Error.ArgumentNull(nameof(func));
             }
 
             if (resultSelector == null)
             {
-                throw Error.ArgumentNull("resultSelector");
+                throw Error.ArgumentNull(nameof(resultSelector));
             }
 
             TAccumulate result = seed;

--- a/src/System.Linq/src/System/Linq/Aggregate.cs
+++ b/src/System.Linq/src/System/Linq/Aggregate.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -11,33 +10,77 @@ namespace System.Linq
     {
         public static TSource Aggregate<TSource>(this IEnumerable<TSource> source, Func<TSource, TSource, TSource> func)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (func == null) throw Error.ArgumentNull("func");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (func == null)
+            {
+                throw Error.ArgumentNull("func");
+            }
+
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 TSource result = e.Current;
-                while (e.MoveNext()) result = func(result, e.Current);
+                while (e.MoveNext())
+                {
+                    result = func(result, e.Current);
+                }
+
                 return result;
             }
         }
 
         public static TAccumulate Aggregate<TSource, TAccumulate>(this IEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> func)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (func == null) throw Error.ArgumentNull("func");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (func == null)
+            {
+                throw Error.ArgumentNull("func");
+            }
+
             TAccumulate result = seed;
-            foreach (TSource element in source) result = func(result, element);
+            foreach (TSource element in source)
+            {
+                result = func(result, element);
+            }
+
             return result;
         }
 
         public static TResult Aggregate<TSource, TAccumulate, TResult>(this IEnumerable<TSource> source, TAccumulate seed, Func<TAccumulate, TSource, TAccumulate> func, Func<TAccumulate, TResult> resultSelector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (func == null) throw Error.ArgumentNull("func");
-            if (resultSelector == null) throw Error.ArgumentNull("resultSelector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (func == null)
+            {
+                throw Error.ArgumentNull("func");
+            }
+
+            if (resultSelector == null)
+            {
+                throw Error.ArgumentNull("resultSelector");
+            }
+
             TAccumulate result = seed;
-            foreach (TSource element in source) result = func(result, element);
+            foreach (TSource element in source)
+            {
+                result = func(result, element);
+            }
+
             return resultSelector(result);
         }
     }

--- a/src/System.Linq/src/System/Linq/AnyAll.cs
+++ b/src/System.Linq/src/System/Linq/AnyAll.cs
@@ -12,7 +12,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             using (IEnumerator<TSource> e = source.GetEnumerator())
@@ -25,12 +25,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (predicate == null)
             {
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             }
 
             foreach (TSource element in source)
@@ -48,12 +48,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (predicate == null)
             {
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             }
 
             foreach (TSource element in source)

--- a/src/System.Linq/src/System/Linq/AnyAll.cs
+++ b/src/System.Linq/src/System/Linq/AnyAll.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -11,7 +10,11 @@ namespace System.Linq
     {
         public static bool Any<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 return e.MoveNext();
@@ -20,23 +23,47 @@ namespace System.Linq
 
         public static bool Any<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (predicate == null) throw Error.ArgumentNull("predicate");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (predicate == null)
+            {
+                throw Error.ArgumentNull("predicate");
+            }
+
             foreach (TSource element in source)
             {
-                if (predicate(element)) return true;
+                if (predicate(element))
+                {
+                    return true;
+                }
             }
+
             return false;
         }
 
         public static bool All<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (predicate == null) throw Error.ArgumentNull("predicate");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (predicate == null)
+            {
+                throw Error.ArgumentNull("predicate");
+            }
+
             foreach (TSource element in source)
             {
-                if (!predicate(element)) return false;
+                if (!predicate(element))
+                {
+                    return false;
+                }
             }
+
             return true;
         }
     }

--- a/src/System.Linq/src/System/Linq/Average.cs
+++ b/src/System.Linq/src/System/Linq/Average.cs
@@ -12,7 +12,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             using (IEnumerator<int> e = source.GetEnumerator())
@@ -41,7 +41,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             using (IEnumerator<int?> e = source.GetEnumerator())
@@ -78,7 +78,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             using (IEnumerator<long> e = source.GetEnumerator())
@@ -107,7 +107,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             using (IEnumerator<long?> e = source.GetEnumerator())
@@ -144,7 +144,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             using (IEnumerator<float> e = source.GetEnumerator())
@@ -170,7 +170,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             using (IEnumerator<float?> e = source.GetEnumerator())
@@ -207,7 +207,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             using (IEnumerator<double> e = source.GetEnumerator())
@@ -236,7 +236,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             using (IEnumerator<double?> e = source.GetEnumerator())
@@ -273,7 +273,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             using (IEnumerator<decimal> e = source.GetEnumerator())
@@ -299,7 +299,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             using (IEnumerator<decimal?> e = source.GetEnumerator())
@@ -333,12 +333,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             using (IEnumerator<TSource> e = source.GetEnumerator())
@@ -367,12 +367,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             using (IEnumerator<TSource> e = source.GetEnumerator())
@@ -409,12 +409,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             using (IEnumerator<TSource> e = source.GetEnumerator())
@@ -443,12 +443,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             using (IEnumerator<TSource> e = source.GetEnumerator())
@@ -485,12 +485,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             using (IEnumerator<TSource> e = source.GetEnumerator())
@@ -516,12 +516,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             using (IEnumerator<TSource> e = source.GetEnumerator())
@@ -558,12 +558,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             using (IEnumerator<TSource> e = source.GetEnumerator())
@@ -592,12 +592,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             using (IEnumerator<TSource> e = source.GetEnumerator())
@@ -634,12 +634,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             using (IEnumerator<TSource> e = source.GetEnumerator())
@@ -665,12 +665,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             using (IEnumerator<TSource> e = source.GetEnumerator())

--- a/src/System.Linq/src/System/Linq/Average.cs
+++ b/src/System.Linq/src/System/Linq/Average.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -11,10 +10,18 @@ namespace System.Linq
     {
         public static double Average(this IEnumerable<int> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             using (IEnumerator<int> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 long sum = e.Current;
                 long count = 1;
                 checked
@@ -25,13 +32,18 @@ namespace System.Linq
                         ++count;
                     }
                 }
+
                 return (double)sum / count;
             }
         }
 
         public static double? Average(this IEnumerable<int?> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             using (IEnumerator<int?> e = source.GetEnumerator())
             {
                 while (e.MoveNext())
@@ -53,19 +65,29 @@ namespace System.Linq
                                 }
                             }
                         }
+
                         return (double)sum / count;
                     }
                 }
             }
+
             return null;
         }
 
         public static double Average(this IEnumerable<long> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             using (IEnumerator<long> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 long sum = e.Current;
                 long count = 1;
                 checked
@@ -76,13 +98,18 @@ namespace System.Linq
                         ++count;
                     }
                 }
+
                 return (double)sum / count;
             }
         }
 
         public static double? Average(this IEnumerable<long?> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             using (IEnumerator<long?> e = source.GetEnumerator())
             {
                 while (e.MoveNext())
@@ -104,19 +131,29 @@ namespace System.Linq
                                 }
                             }
                         }
+
                         return (double)sum / count;
                     }
                 }
             }
+
             return null;
         }
 
         public static float Average(this IEnumerable<float> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             using (IEnumerator<float> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 double sum = e.Current;
                 long count = 1;
                 while (e.MoveNext())
@@ -124,13 +161,18 @@ namespace System.Linq
                     sum += e.Current;
                     ++count;
                 }
+
                 return (float)(sum / count);
             }
         }
 
         public static float? Average(this IEnumerable<float?> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             using (IEnumerator<float?> e = source.GetEnumerator())
             {
                 while (e.MoveNext())
@@ -152,19 +194,29 @@ namespace System.Linq
                                 }
                             }
                         }
+
                         return (float)(sum / count);
                     }
                 }
             }
+
             return null;
         }
 
         public static double Average(this IEnumerable<double> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             using (IEnumerator<double> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 double sum = e.Current;
                 long count = 1;
                 while (e.MoveNext())
@@ -175,13 +227,18 @@ namespace System.Linq
                     sum += e.Current;
                     ++count;
                 }
+
                 return sum / count;
             }
         }
 
         public static double? Average(this IEnumerable<double?> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             using (IEnumerator<double?> e = source.GetEnumerator())
             {
                 while (e.MoveNext())
@@ -203,19 +260,29 @@ namespace System.Linq
                                 }
                             }
                         }
+
                         return sum / count;
                     }
                 }
             }
+
             return null;
         }
 
         public static decimal Average(this IEnumerable<decimal> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             using (IEnumerator<decimal> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 decimal sum = e.Current;
                 long count = 1;
                 while (e.MoveNext())
@@ -223,13 +290,18 @@ namespace System.Linq
                     sum += e.Current;
                     ++count;
                 }
+
                 return sum / count;
             }
         }
 
         public static decimal? Average(this IEnumerable<decimal?> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             using (IEnumerator<decimal?> e = source.GetEnumerator())
             {
                 while (e.MoveNext())
@@ -248,20 +320,34 @@ namespace System.Linq
                                 ++count;
                             }
                         }
+
                         return sum / count;
                     }
                 }
             }
+
             return null;
         }
 
         public static double Average<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 long sum = selector(e.Current);
                 long count = 1;
                 checked
@@ -272,14 +358,23 @@ namespace System.Linq
                         ++count;
                     }
                 }
+
                 return (double)sum / count;
             }
         }
 
         public static double? Average<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 while (e.MoveNext())
@@ -301,20 +396,34 @@ namespace System.Linq
                                 }
                             }
                         }
+
                         return (double)sum / count;
                     }
                 }
             }
+
             return null;
         }
 
         public static double Average<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 long sum = selector(e.Current);
                 long count = 1;
                 checked
@@ -325,14 +434,23 @@ namespace System.Linq
                         ++count;
                     }
                 }
+
                 return (double)sum / count;
             }
         }
 
         public static double? Average<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 while (e.MoveNext())
@@ -354,20 +472,34 @@ namespace System.Linq
                                 }
                             }
                         }
+
                         return (double)sum / count;
                     }
                 }
             }
+
             return null;
         }
 
         public static float Average<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 double sum = selector(e.Current);
                 long count = 1;
                 while (e.MoveNext())
@@ -375,14 +507,23 @@ namespace System.Linq
                     sum += selector(e.Current);
                     ++count;
                 }
+
                 return (float)(sum / count);
             }
         }
 
         public static float? Average<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 while (e.MoveNext())
@@ -404,20 +545,34 @@ namespace System.Linq
                                 }
                             }
                         }
+
                         return (float)(sum / count);
                     }
                 }
             }
+
             return null;
         }
 
         public static double Average<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 double sum = selector(e.Current);
                 long count = 1;
                 while (e.MoveNext())
@@ -428,14 +583,23 @@ namespace System.Linq
                     sum += selector(e.Current);
                     ++count;
                 }
+
                 return sum / count;
             }
         }
 
         public static double? Average<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 while (e.MoveNext())
@@ -457,20 +621,34 @@ namespace System.Linq
                                 }
                             }
                         }
+
                         return sum / count;
                     }
                 }
             }
+
             return null;
         }
 
         public static decimal Average<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 decimal sum = selector(e.Current);
                 long count = 1;
                 while (e.MoveNext())
@@ -478,14 +656,23 @@ namespace System.Linq
                     sum += selector(e.Current);
                     ++count;
                 }
+
                 return sum / count;
             }
         }
 
         public static decimal? Average<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 while (e.MoveNext())
@@ -504,10 +691,12 @@ namespace System.Linq
                                 ++count;
                             }
                         }
+
                         return sum / count;
                     }
                 }
             }
+
             return null;
         }
     }

--- a/src/System.Linq/src/System/Linq/Buffer.cs
+++ b/src/System.Linq/src/System/Linq/Buffer.cs
@@ -2,15 +2,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
 {
     internal struct Buffer<TElement>
     {
-        internal TElement[] items;
-        internal int count;
+        internal readonly TElement[] _items;
+        internal readonly int _count;
 
         internal Buffer(IEnumerable<TElement> source)
         {
@@ -18,12 +17,12 @@ namespace System.Linq
             if (iterator != null)
             {
                 TElement[] array = iterator.ToArray();
-                items = array;
-                count = array.Length;
+                _items = array;
+                _count = array.Length;
             }
             else
             {
-                items = EnumerableHelpers.ToArray(source, out count);
+                _items = EnumerableHelpers.ToArray(source, out _count);
             }
         }
     }

--- a/src/System.Linq/src/System/Linq/Cast.cs
+++ b/src/System.Linq/src/System/Linq/Cast.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -12,7 +11,11 @@ namespace System.Linq
     {
         public static IEnumerable<TResult> OfType<TResult>(this IEnumerable source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             return OfTypeIterator<TResult>(source);
         }
 
@@ -20,21 +23,35 @@ namespace System.Linq
         {
             foreach (object obj in source)
             {
-                if (obj is TResult) yield return (TResult)obj;
+                if (obj is TResult)
+                {
+                    yield return (TResult)obj;
+                }
             }
         }
 
         public static IEnumerable<TResult> Cast<TResult>(this IEnumerable source)
         {
             IEnumerable<TResult> typedSource = source as IEnumerable<TResult>;
-            if (typedSource != null) return typedSource;
-            if (source == null) throw Error.ArgumentNull("source");
+            if (typedSource != null)
+            {
+                return typedSource;
+            }
+
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             return CastIterator<TResult>(source);
         }
 
         private static IEnumerable<TResult> CastIterator<TResult>(IEnumerable source)
         {
-            foreach (object obj in source) yield return (TResult)obj;
+            foreach (object obj in source)
+            {
+                yield return (TResult)obj;
+            }
         }
     }
 }

--- a/src/System.Linq/src/System/Linq/Cast.cs
+++ b/src/System.Linq/src/System/Linq/Cast.cs
@@ -13,7 +13,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             return OfTypeIterator<TResult>(source);
@@ -40,7 +40,7 @@ namespace System.Linq
 
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             return CastIterator<TResult>(source);

--- a/src/System.Linq/src/System/Linq/Concatenate.cs
+++ b/src/System.Linq/src/System/Linq/Concatenate.cs
@@ -13,7 +13,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             return AppendIterator(source, element);
@@ -33,7 +33,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             return PrependIterator(source, element);
@@ -53,12 +53,12 @@ namespace System.Linq
         {
             if (first == null)
             {
-                throw Error.ArgumentNull("first");
+                throw Error.ArgumentNull(nameof(first));
             }
 
             if (second == null)
             {
-                throw Error.ArgumentNull("second");
+                throw Error.ArgumentNull(nameof(second));
             }
 
             var concatFirst = first as ConcatIterator<TSource>;

--- a/src/System.Linq/src/System/Linq/Concatenate.cs
+++ b/src/System.Linq/src/System/Linq/Concatenate.cs
@@ -11,32 +11,55 @@ namespace System.Linq
     {
         public static IEnumerable<TSource> Append<TSource>(this IEnumerable<TSource> source, TSource element)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             return AppendIterator(source, element);
         }
 
         private static IEnumerable<TSource> AppendIterator<TSource>(IEnumerable<TSource> source, TSource element)
         {
-            foreach (TSource e1 in source) yield return e1;
+            foreach (TSource e1 in source)
+            {
+                yield return e1;
+            }
+
             yield return element;
         }
 
         public static IEnumerable<TSource> Prepend<TSource>(this IEnumerable<TSource> source, TSource element)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             return PrependIterator(source, element);
         }
 
         private static IEnumerable<TSource> PrependIterator<TSource>(IEnumerable<TSource> source, TSource element)
         {
             yield return element;
-            foreach (TSource e1 in source) yield return e1;
+
+            foreach (TSource e1 in source)
+            {
+                yield return e1;
+            }
         }
 
         public static IEnumerable<TSource> Concat<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second)
         {
-            if (first == null) throw Error.ArgumentNull("first");
-            if (second == null) throw Error.ArgumentNull("second");
+            if (first == null)
+            {
+                throw Error.ArgumentNull("first");
+            }
+
+            if (second == null)
+            {
+                throw Error.ArgumentNull("second");
+            }
 
             var concatFirst = first as ConcatIterator<TSource>;
             return concatFirst != null ?
@@ -77,15 +100,14 @@ namespace System.Linq
             }
         }
 
+        // To handle chains of >= 3 sources, we chain the concat iterators together and allow
+        // GetEnumerable to fetch enumerables from the previous sources.  This means that rather
+        // than each MoveNext/Current calls having to traverse all of the previous sources, we
+        // only have to traverse all of the previous sources once per chained enumerable.  An
+        // alternative would be to use an array to store all of the enumerables, but this has
+        // a much better memory profile and without much additional run-time cost.
         private sealed class ConcatNIterator<TSource> : ConcatIterator<TSource>
         {
-            // To handle chains of >= 3 sources, we chain the concat iterators together and allow
-            // GetEnumerable to fetch enumerables from the previous sources.  This means that rather
-            // than each MoveNext/Current calls having to traverse all of the previous sources, we
-            // only have to traverse all of the previous sources once per chained enumerable.  An
-            // alternative would be to use an array to store all of the enumerables, but this has
-            // a much better memory profile and without much additional run-time cost.
-
             private readonly ConcatIterator<TSource> _previousConcat;
             private readonly IEnumerable<TSource> _next;
             private readonly int _nextIndex;
@@ -114,6 +136,7 @@ namespace System.Linq
                     // So we use the naïve approach of just having a left and right sequence.
                     return new Concat2Iterator<TSource>(this, next);
                 }
+
                 return new ConcatNIterator<TSource>(this, next, _nextIndex + 1);
             }
 
@@ -161,6 +184,7 @@ namespace System.Linq
                     _enumerator.Dispose();
                     _enumerator = null;
                 }
+
                 base.Dispose();
             }
 
@@ -170,23 +194,23 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                if (state == 1)
+                if (_state == 1)
                 {
                     _enumerator = GetEnumerable(0).GetEnumerator();
-                    state = 2;
+                    _state = 2;
                 }
 
-                if (state > 1)
+                if (_state > 1)
                 {
                     while (true)
                     {
                         if (_enumerator.MoveNext())
                         {
-                            current = _enumerator.Current;
+                            _current = _enumerator.Current;
                             return true;
                         }
 
-                        IEnumerable<TSource> next = GetEnumerable(state++ - 1);
+                        IEnumerable<TSource> next = GetEnumerable(_state++ - 1);
                         if (next != null)
                         {
                             _enumerator.Dispose();
@@ -213,24 +237,39 @@ namespace System.Linq
                 for (int i = 0; ; i++)
                 {
                     IEnumerable<TSource> source = GetEnumerable(i);
-                    if (source == null) break;
+                    if (source == null)
+                    {
+                        break;
+                    }
 
                     list.AddRange(source);
                 }
+
                 return list;
             }
 
             public int GetCount(bool onlyIfCheap)
             {
-                if (onlyIfCheap) return -1;
+                if (onlyIfCheap)
+                {
+                    return -1;
+                }
 
                 int count = 0;
                 for (int i = 0; ; i++)
                 {
                     IEnumerable<TSource> source = GetEnumerable(i);
-                    if (source == null) break;
-                    checked { count += source.Count(); }
+                    if (source == null)
+                    {
+                        break;
+                    }
+
+                    checked
+                    {
+                        count += source.Count();
+                    }
                 }
+
                 return count;
             }
         }

--- a/src/System.Linq/src/System/Linq/Contains.cs
+++ b/src/System.Linq/src/System/Linq/Contains.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -12,16 +11,34 @@ namespace System.Linq
         public static bool Contains<TSource>(this IEnumerable<TSource> source, TSource value)
         {
             ICollection<TSource> collection = source as ICollection<TSource>;
-            if (collection != null) return collection.Contains(value);
+            if (collection != null)
+            {
+                return collection.Contains(value);
+            }
+
             return Contains(source, value, null);
         }
 
         public static bool Contains<TSource>(this IEnumerable<TSource> source, TSource value, IEqualityComparer<TSource> comparer)
         {
-            if (comparer == null) comparer = EqualityComparer<TSource>.Default;
-            if (source == null) throw Error.ArgumentNull("source");
+            if (comparer == null)
+            {
+                comparer = EqualityComparer<TSource>.Default;
+            }
+
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             foreach (TSource element in source)
-                if (comparer.Equals(element, value)) return true;
+            {
+                if (comparer.Equals(element, value))
+                {
+                    return true;
+                }
+            }
+
             return false;
         }
     }

--- a/src/System.Linq/src/System/Linq/Contains.cs
+++ b/src/System.Linq/src/System/Linq/Contains.cs
@@ -28,7 +28,7 @@ namespace System.Linq
 
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             foreach (TSource element in source)

--- a/src/System.Linq/src/System/Linq/Count.cs
+++ b/src/System.Linq/src/System/Linq/Count.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -12,65 +11,117 @@ namespace System.Linq
     {
         public static int Count<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             ICollection<TSource> collectionoft = source as ICollection<TSource>;
-            if (collectionoft != null) return collectionoft.Count;
+            if (collectionoft != null)
+            {
+                return collectionoft.Count;
+            }
+
             IIListProvider<TSource> listProv = source as IIListProvider<TSource>;
-            if (listProv != null) return listProv.GetCount(onlyIfCheap: false);
+            if (listProv != null)
+            {
+                return listProv.GetCount(onlyIfCheap: false);
+            }
+
             ICollection collection = source as ICollection;
-            if (collection != null) return collection.Count;
+            if (collection != null)
+            {
+                return collection.Count;
+            }
+
             int count = 0;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 checked
                 {
-                    while (e.MoveNext()) count++;
+                    while (e.MoveNext())
+                    {
+                        count++;
+                    }
                 }
             }
+
             return count;
         }
 
         public static int Count<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (predicate == null) throw Error.ArgumentNull("predicate");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (predicate == null)
+            {
+                throw Error.ArgumentNull("predicate");
+            }
+
             int count = 0;
             foreach (TSource element in source)
             {
                 checked
                 {
-                    if (predicate(element)) count++;
+                    if (predicate(element))
+                    {
+                        count++;
+                    }
                 }
             }
+
             return count;
         }
 
         public static long LongCount<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             long count = 0;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 checked
                 {
-                    while (e.MoveNext()) count++;
+                    while (e.MoveNext())
+                    {
+                        count++;
+                    }
                 }
             }
+
             return count;
         }
 
         public static long LongCount<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (predicate == null) throw Error.ArgumentNull("predicate");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (predicate == null)
+            {
+                throw Error.ArgumentNull("predicate");
+            }
+
             long count = 0;
             foreach (TSource element in source)
             {
                 checked
                 {
-                    if (predicate(element)) count++;
+                    if (predicate(element))
+                    {
+                        count++;
+                    }
                 }
             }
+
             return count;
         }
     }

--- a/src/System.Linq/src/System/Linq/Count.cs
+++ b/src/System.Linq/src/System/Linq/Count.cs
@@ -13,7 +13,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             ICollection<TSource> collectionoft = source as ICollection<TSource>;
@@ -53,12 +53,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (predicate == null)
             {
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             }
 
             int count = 0;
@@ -80,7 +80,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             long count = 0;
@@ -102,12 +102,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (predicate == null)
             {
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             }
 
             long count = 0;

--- a/src/System.Linq/src/System/Linq/DebugView.cs
+++ b/src/System.Linq/src/System/Linq/DebugView.cs
@@ -10,7 +10,7 @@ namespace System.Linq
 {
     // NOTE: DO NOT DELETE THE FOLLOWING DEBUG VIEW TYPES.
     // Although it might be tempting due to them not be referenced anywhere in this library,
-    // Visual Studio (and potentially other debuggers) currently depends on their existence to 
+    // Visual Studio (and potentially other debuggers) currently depends on their existence to
     // enable the "Results" view in watch windows.  Specifically:
     // - It creates the debug view by name (the view then has the same requirements as other views).
     // - It looks for the empty exception by name.
@@ -42,6 +42,7 @@ namespace System.Linq
                 {
                     throw new SystemCore_EnumerableDebugViewEmptyException();
                 }
+
                 return array;
             }
         }
@@ -80,12 +81,15 @@ namespace System.Linq
             {
                 List<object> tempList = new List<object>();
                 foreach (object item in _enumerable)
+                {
                     tempList.Add(item);
+                }
 
                 if (tempList.Count == 0)
                 {
                     throw new SystemCore_EnumerableDebugViewEmptyException();
                 }
+
                 return tempList.ToArray();
             }
         }

--- a/src/System.Linq/src/System/Linq/DefaultIfEmpty.cs
+++ b/src/System.Linq/src/System/Linq/DefaultIfEmpty.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -18,7 +17,11 @@ namespace System.Linq
 
         public static IEnumerable<TSource> DefaultIfEmpty<TSource>(this IEnumerable<TSource> source, TSource defaultValue)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             return new DefaultIfEmptyIterator<TSource>(source, defaultValue);
         }
 
@@ -42,27 +45,29 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                switch (state)
+                switch (_state)
                 {
                     case 1:
                         _enumerator = _source.GetEnumerator();
                         if (_enumerator.MoveNext())
                         {
-                            current = _enumerator.Current;
-                            state = 2;
+                            _current = _enumerator.Current;
+                            _state = 2;
                         }
                         else
                         {
-                            current = _default;
-                            state = -1;
+                            _current = _default;
+                            _state = -1;
                         }
+
                         return true;
                     case 2:
                         if (_enumerator.MoveNext())
                         {
-                            current = _enumerator.Current;
+                            _current = _enumerator.Current;
                             return true;
                         }
+
                         break;
                 }
 
@@ -91,7 +96,10 @@ namespace System.Linq
             {
                 List<TSource> list = _source.ToList();
                 if (list.Count == 0)
+                {
                     list.Add(_default);
+                }
+
                 return list;
             }
 
@@ -107,6 +115,7 @@ namespace System.Linq
                     IIListProvider<TSource> listProv = _source as IIListProvider<TSource>;
                     count = listProv == null ? -1 : listProv.GetCount(onlyIfCheap: true);
                 }
+
                 return count == 0 ? 1 : count;
             }
         }

--- a/src/System.Linq/src/System/Linq/DefaultIfEmpty.cs
+++ b/src/System.Linq/src/System/Linq/DefaultIfEmpty.cs
@@ -19,7 +19,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             return new DefaultIfEmptyIterator<TSource>(source, defaultValue);

--- a/src/System.Linq/src/System/Linq/Distinct.cs
+++ b/src/System.Linq/src/System/Linq/Distinct.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -17,7 +16,11 @@ namespace System.Linq
 
         public static IEnumerable<TSource> Distinct<TSource>(this IEnumerable<TSource> source, IEqualityComparer<TSource> comparer)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             return new DistinctIterator<TSource>(source, comparer);
         }
 
@@ -42,7 +45,7 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                switch (state)
+                switch (_state)
                 {
                     case 1:
                         _enumerator = _source.GetEnumerator();
@@ -51,22 +54,24 @@ namespace System.Linq
                             Dispose();
                             return false;
                         }
+
                         TSource element = _enumerator.Current;
                         _set = new Set<TSource>(_comparer);
                         _set.Add(element);
-                        current = element;
-                        state = 2;
+                        _current = element;
+                        _state = 2;
                         return true;
                     case 2:
-                        while(_enumerator.MoveNext())
+                        while (_enumerator.MoveNext())
                         {
                             element = _enumerator.Current;
                             if (_set.Add(element))
                             {
-                                current = element;
+                                _current = element;
                                 return true;
                             }
                         }
+
                         break;
                 }
 
@@ -90,7 +95,10 @@ namespace System.Linq
             {
                 Set<TSource> set = new Set<TSource>(_comparer);
                 foreach (TSource element in _source)
+                {
                     set.Add(element);
+                }
+
                 return set;
             }
 

--- a/src/System.Linq/src/System/Linq/Distinct.cs
+++ b/src/System.Linq/src/System/Linq/Distinct.cs
@@ -18,7 +18,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             return new DistinctIterator<TSource>(source, comparer);

--- a/src/System.Linq/src/System/Linq/ElementAt.cs
+++ b/src/System.Linq/src/System/Linq/ElementAt.cs
@@ -12,7 +12,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             IPartition<TSource> partition = source as IPartition<TSource>;
@@ -50,14 +50,14 @@ namespace System.Linq
                 }
             }
 
-            throw Error.ArgumentOutOfRange("index");
+            throw Error.ArgumentOutOfRange(nameof(index));
         }
 
         public static TSource ElementAtOrDefault<TSource>(this IEnumerable<TSource> source, int index)
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             IPartition<TSource> partition = source as IPartition<TSource>;

--- a/src/System.Linq/src/System/Linq/ElementAt.cs
+++ b/src/System.Linq/src/System/Linq/ElementAt.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -11,48 +10,72 @@ namespace System.Linq
     {
         public static TSource ElementAt<TSource>(this IEnumerable<TSource> source, int index)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             IPartition<TSource> partition = source as IPartition<TSource>;
             if (partition != null)
             {
                 bool found;
                 TSource element = partition.TryGetElementAt(index, out found);
-                if (found) return element;
+                if (found)
+                {
+                    return element;
+                }
             }
             else
             {
                 IList<TSource> list = source as IList<TSource>;
-                if (list != null) return list[index];
+                if (list != null)
+                {
+                    return list[index];
+                }
+
                 if (index >= 0)
                 {
                     using (IEnumerator<TSource> e = source.GetEnumerator())
                     {
                         while (e.MoveNext())
                         {
-                            if (index == 0) return e.Current;
+                            if (index == 0)
+                            {
+                                return e.Current;
+                            }
+
                             index--;
                         }
                     }
                 }
             }
+
             throw Error.ArgumentOutOfRange("index");
         }
 
         public static TSource ElementAtOrDefault<TSource>(this IEnumerable<TSource> source, int index)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             IPartition<TSource> partition = source as IPartition<TSource>;
             if (partition != null)
             {
                 bool found;
                 return partition.TryGetElementAt(index, out found);
             }
+
             if (index >= 0)
             {
                 IList<TSource> list = source as IList<TSource>;
                 if (list != null)
                 {
-                    if (index < list.Count) return list[index];
+                    if (index < list.Count)
+                    {
+                        return list[index];
+                    }
                 }
                 else
                 {
@@ -60,12 +83,17 @@ namespace System.Linq
                     {
                         while (e.MoveNext())
                         {
-                            if (index == 0) return e.Current;
+                            if (index == 0)
+                            {
+                                return e.Current;
+                            }
+
                             index--;
                         }
                     }
                 }
             }
+
             return default(TSource);
         }
     }

--- a/src/System.Linq/src/System/Linq/Enumerable.cs
+++ b/src/System.Linq/src/System/Linq/Enumerable.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq

--- a/src/System.Linq/src/System/Linq/Errors.cs
+++ b/src/System.Linq/src/System/Linq/Errors.cs
@@ -6,18 +6,18 @@ namespace System.Linq
 {
     internal static class Error
     {
-        internal static Exception ArgumentNull(string s) { return new ArgumentNullException(s); }
+        internal static Exception ArgumentNull(string s) => new ArgumentNullException(s);
 
-        internal static Exception ArgumentOutOfRange(string s) { return new ArgumentOutOfRangeException(s); }
+        internal static Exception ArgumentOutOfRange(string s) => new ArgumentOutOfRangeException(s);
 
-        internal static Exception MoreThanOneElement() { return new InvalidOperationException(SR.MoreThanOneElement); }
+        internal static Exception MoreThanOneElement() => new InvalidOperationException(SR.MoreThanOneElement);
 
-        internal static Exception MoreThanOneMatch() { return new InvalidOperationException(SR.MoreThanOneMatch); }
+        internal static Exception MoreThanOneMatch() => new InvalidOperationException(SR.MoreThanOneMatch);
 
-        internal static Exception NoElements() { return new InvalidOperationException(SR.NoElements); }
+        internal static Exception NoElements() => new InvalidOperationException(SR.NoElements);
 
-        internal static Exception NoMatch() { return new InvalidOperationException(SR.NoMatch); }
+        internal static Exception NoMatch() => new InvalidOperationException(SR.NoMatch);
 
-        internal static Exception NotSupported() { return new NotSupportedException(); }
+        internal static Exception NotSupported() => new NotSupportedException();
     }
 }

--- a/src/System.Linq/src/System/Linq/Except.cs
+++ b/src/System.Linq/src/System/Linq/Except.cs
@@ -12,12 +12,12 @@ namespace System.Linq
         {
             if (first == null)
             {
-                throw Error.ArgumentNull("first");
+                throw Error.ArgumentNull(nameof(first));
             }
 
             if (second == null)
             {
-                throw Error.ArgumentNull("second");
+                throw Error.ArgumentNull(nameof(second));
             }
 
             return ExceptIterator(first, second, null);
@@ -27,12 +27,12 @@ namespace System.Linq
         {
             if (first == null)
             {
-                throw Error.ArgumentNull("first");
+                throw Error.ArgumentNull(nameof(first));
             }
 
             if (second == null)
             {
-                throw Error.ArgumentNull("second");
+                throw Error.ArgumentNull(nameof(second));
             }
 
             return ExceptIterator(first, second, comparer);

--- a/src/System.Linq/src/System/Linq/Except.cs
+++ b/src/System.Linq/src/System/Linq/Except.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -11,24 +10,49 @@ namespace System.Linq
     {
         public static IEnumerable<TSource> Except<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second)
         {
-            if (first == null) throw Error.ArgumentNull("first");
-            if (second == null) throw Error.ArgumentNull("second");
+            if (first == null)
+            {
+                throw Error.ArgumentNull("first");
+            }
+
+            if (second == null)
+            {
+                throw Error.ArgumentNull("second");
+            }
+
             return ExceptIterator(first, second, null);
         }
 
         public static IEnumerable<TSource> Except<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second, IEqualityComparer<TSource> comparer)
         {
-            if (first == null) throw Error.ArgumentNull("first");
-            if (second == null) throw Error.ArgumentNull("second");
+            if (first == null)
+            {
+                throw Error.ArgumentNull("first");
+            }
+
+            if (second == null)
+            {
+                throw Error.ArgumentNull("second");
+            }
+
             return ExceptIterator(first, second, comparer);
         }
 
         private static IEnumerable<TSource> ExceptIterator<TSource>(IEnumerable<TSource> first, IEnumerable<TSource> second, IEqualityComparer<TSource> comparer)
         {
             Set<TSource> set = new Set<TSource>(comparer);
-            foreach (TSource element in second) set.Add(element);
+            foreach (TSource element in second)
+            {
+                set.Add(element);
+            }
+
             foreach (TSource element in first)
-                if (set.Add(element)) yield return element;
+            {
+                if (set.Add(element))
+                {
+                    yield return element;
+                }
+            }
         }
     }
 }

--- a/src/System.Linq/src/System/Linq/First.cs
+++ b/src/System.Linq/src/System/Linq/First.cs
@@ -12,7 +12,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             IPartition<TSource> partition = source as IPartition<TSource>;
@@ -54,12 +54,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (predicate == null)
             {
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             }
 
             OrderedEnumerable<TSource> ordered = source as OrderedEnumerable<TSource>;
@@ -83,7 +83,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             IPartition<TSource> partition = source as IPartition<TSource>;
@@ -119,12 +119,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (predicate == null)
             {
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             }
 
             OrderedEnumerable<TSource> ordered = source as OrderedEnumerable<TSource>;

--- a/src/System.Linq/src/System/Linq/First.cs
+++ b/src/System.Linq/src/System/Linq/First.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -11,48 +10,82 @@ namespace System.Linq
     {
         public static TSource First<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             IPartition<TSource> partition = source as IPartition<TSource>;
             if (partition != null)
             {
                 bool found;
                 TSource first = partition.TryGetFirst(out found);
-                if (found) return first;
+                if (found)
+                {
+                    return first;
+                }
             }
             else
             {
                 IList<TSource> list = source as IList<TSource>;
                 if (list != null)
                 {
-                    if (list.Count > 0) return list[0];
+                    if (list.Count > 0)
+                    {
+                        return list[0];
+                    }
                 }
                 else
                 {
                     using (IEnumerator<TSource> e = source.GetEnumerator())
                     {
-                        if (e.MoveNext()) return e.Current;
+                        if (e.MoveNext())
+                        {
+                            return e.Current;
+                        }
                     }
                 }
             }
+
             throw Error.NoElements();
         }
 
         public static TSource First<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (predicate == null) throw Error.ArgumentNull("predicate");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (predicate == null)
+            {
+                throw Error.ArgumentNull("predicate");
+            }
+
             OrderedEnumerable<TSource> ordered = source as OrderedEnumerable<TSource>;
-            if (ordered != null) return ordered.First(predicate);
+            if (ordered != null)
+            {
+                return ordered.First(predicate);
+            }
+
             foreach (TSource element in source)
             {
-                if (predicate(element)) return element;
+                if (predicate(element))
+                {
+                    return element;
+                }
             }
+
             throw Error.NoMatch();
         }
 
         public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             IPartition<TSource> partition = source as IPartition<TSource>;
             if (partition != null)
             {
@@ -63,28 +96,51 @@ namespace System.Linq
             IList<TSource> list = source as IList<TSource>;
             if (list != null)
             {
-                if (list.Count > 0) return list[0];
+                if (list.Count > 0)
+                {
+                    return list[0];
+                }
             }
             else
             {
                 using (IEnumerator<TSource> e = source.GetEnumerator())
                 {
-                    if (e.MoveNext()) return e.Current;
+                    if (e.MoveNext())
+                    {
+                        return e.Current;
+                    }
                 }
             }
+
             return default(TSource);
         }
 
         public static TSource FirstOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (predicate == null) throw Error.ArgumentNull("predicate");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (predicate == null)
+            {
+                throw Error.ArgumentNull("predicate");
+            }
+
             OrderedEnumerable<TSource> ordered = source as OrderedEnumerable<TSource>;
-            if (ordered != null) return ordered.FirstOrDefault(predicate);
+            if (ordered != null)
+            {
+                return ordered.FirstOrDefault(predicate);
+            }
+
             foreach (TSource element in source)
             {
-                if (predicate(element)) return element;
+                if (predicate(element))
+                {
+                    return element;
+                }
             }
+
             return default(TSource);
         }
     }

--- a/src/System.Linq/src/System/Linq/GroupJoin.cs
+++ b/src/System.Linq/src/System/Linq/GroupJoin.cs
@@ -12,27 +12,27 @@ namespace System.Linq
         {
             if (outer == null)
             {
-                throw Error.ArgumentNull("outer");
+                throw Error.ArgumentNull(nameof(outer));
             }
 
             if (inner == null)
             {
-                throw Error.ArgumentNull("inner");
+                throw Error.ArgumentNull(nameof(inner));
             }
 
             if (outerKeySelector == null)
             {
-                throw Error.ArgumentNull("outerKeySelector");
+                throw Error.ArgumentNull(nameof(outerKeySelector));
             }
 
             if (innerKeySelector == null)
             {
-                throw Error.ArgumentNull("innerKeySelector");
+                throw Error.ArgumentNull(nameof(innerKeySelector));
             }
 
             if (resultSelector == null)
             {
-                throw Error.ArgumentNull("resultSelector");
+                throw Error.ArgumentNull(nameof(resultSelector));
             }
 
             return GroupJoinIterator(outer, inner, outerKeySelector, innerKeySelector, resultSelector, null);
@@ -42,27 +42,27 @@ namespace System.Linq
         {
             if (outer == null)
             {
-                throw Error.ArgumentNull("outer");
+                throw Error.ArgumentNull(nameof(outer));
             }
 
             if (inner == null)
             {
-                throw Error.ArgumentNull("inner");
+                throw Error.ArgumentNull(nameof(inner));
             }
 
             if (outerKeySelector == null)
             {
-                throw Error.ArgumentNull("outerKeySelector");
+                throw Error.ArgumentNull(nameof(outerKeySelector));
             }
 
             if (innerKeySelector == null)
             {
-                throw Error.ArgumentNull("innerKeySelector");
+                throw Error.ArgumentNull(nameof(innerKeySelector));
             }
 
             if (resultSelector == null)
             {
-                throw Error.ArgumentNull("resultSelector");
+                throw Error.ArgumentNull(nameof(resultSelector));
             }
 
             return GroupJoinIterator(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer);

--- a/src/System.Linq/src/System/Linq/GroupJoin.cs
+++ b/src/System.Linq/src/System/Linq/GroupJoin.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -11,21 +10,61 @@ namespace System.Linq
     {
         public static IEnumerable<TResult> GroupJoin<TOuter, TInner, TKey, TResult>(this IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, IEnumerable<TInner>, TResult> resultSelector)
         {
-            if (outer == null) throw Error.ArgumentNull("outer");
-            if (inner == null) throw Error.ArgumentNull("inner");
-            if (outerKeySelector == null) throw Error.ArgumentNull("outerKeySelector");
-            if (innerKeySelector == null) throw Error.ArgumentNull("innerKeySelector");
-            if (resultSelector == null) throw Error.ArgumentNull("resultSelector");
+            if (outer == null)
+            {
+                throw Error.ArgumentNull("outer");
+            }
+
+            if (inner == null)
+            {
+                throw Error.ArgumentNull("inner");
+            }
+
+            if (outerKeySelector == null)
+            {
+                throw Error.ArgumentNull("outerKeySelector");
+            }
+
+            if (innerKeySelector == null)
+            {
+                throw Error.ArgumentNull("innerKeySelector");
+            }
+
+            if (resultSelector == null)
+            {
+                throw Error.ArgumentNull("resultSelector");
+            }
+
             return GroupJoinIterator(outer, inner, outerKeySelector, innerKeySelector, resultSelector, null);
         }
 
         public static IEnumerable<TResult> GroupJoin<TOuter, TInner, TKey, TResult>(this IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, IEnumerable<TInner>, TResult> resultSelector, IEqualityComparer<TKey> comparer)
         {
-            if (outer == null) throw Error.ArgumentNull("outer");
-            if (inner == null) throw Error.ArgumentNull("inner");
-            if (outerKeySelector == null) throw Error.ArgumentNull("outerKeySelector");
-            if (innerKeySelector == null) throw Error.ArgumentNull("innerKeySelector");
-            if (resultSelector == null) throw Error.ArgumentNull("resultSelector");
+            if (outer == null)
+            {
+                throw Error.ArgumentNull("outer");
+            }
+
+            if (inner == null)
+            {
+                throw Error.ArgumentNull("inner");
+            }
+
+            if (outerKeySelector == null)
+            {
+                throw Error.ArgumentNull("outerKeySelector");
+            }
+
+            if (innerKeySelector == null)
+            {
+                throw Error.ArgumentNull("innerKeySelector");
+            }
+
+            if (resultSelector == null)
+            {
+                throw Error.ArgumentNull("resultSelector");
+            }
+
             return GroupJoinIterator(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer);
         }
 

--- a/src/System.Linq/src/System/Linq/Grouping.cs
+++ b/src/System.Linq/src/System/Linq/Grouping.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -62,15 +61,14 @@ namespace System.Linq
     //
     // To limit the damage, the toolchain makes this type appear in a hidden assembly.
     // (This is also why it is no longer a nested type of Lookup<,>).
-    //
     public class Grouping<TKey, TElement> : IGrouping<TKey, TElement>, IList<TElement>
     {
-        internal TKey key;
-        internal int hashCode;
-        internal TElement[] elements;
-        internal int count;
-        internal Grouping<TKey, TElement> hashNext;
-        internal Grouping<TKey, TElement> next;
+        internal TKey _key;
+        internal int _hashCode;
+        internal TElement[] _elements;
+        internal int _count;
+        internal Grouping<TKey, TElement> _hashNext;
+        internal Grouping<TKey, TElement> _next;
 
         internal Grouping()
         {
@@ -78,14 +76,21 @@ namespace System.Linq
 
         internal void Add(TElement element)
         {
-            if (elements.Length == count) Array.Resize(ref elements, checked(count * 2));
-            elements[count] = element;
-            count++;
+            if (_elements.Length == _count)
+            {
+                Array.Resize(ref _elements, checked(_count * 2));
+            }
+
+            _elements[_count] = element;
+            _count++;
         }
 
         public IEnumerator<TElement> GetEnumerator()
         {
-            for (int i = 0; i < count; i++) yield return elements[i];
+            for (int i = 0; i < _count; i++)
+            {
+                yield return _elements[i];
+            }
         }
 
         IEnumerator IEnumerable.GetEnumerator()
@@ -97,12 +102,12 @@ namespace System.Linq
         // so that WPF binding works on this property.
         public TKey Key
         {
-            get { return key; }
+            get { return _key; }
         }
 
         int ICollection<TElement>.Count
         {
-            get { return count; }
+            get { return _count; }
         }
 
         bool ICollection<TElement>.IsReadOnly
@@ -122,12 +127,12 @@ namespace System.Linq
 
         bool ICollection<TElement>.Contains(TElement item)
         {
-            return Array.IndexOf(elements, item, 0, count) >= 0;
+            return Array.IndexOf(_elements, item, 0, _count) >= 0;
         }
 
         void ICollection<TElement>.CopyTo(TElement[] array, int arrayIndex)
         {
-            Array.Copy(elements, 0, array, arrayIndex, count);
+            Array.Copy(_elements, 0, array, arrayIndex, _count);
         }
 
         bool ICollection<TElement>.Remove(TElement item)
@@ -137,7 +142,7 @@ namespace System.Linq
 
         int IList<TElement>.IndexOf(TElement item)
         {
-            return Array.IndexOf(elements, item, 0, count);
+            return Array.IndexOf(_elements, item, 0, _count);
         }
 
         void IList<TElement>.Insert(int index, TElement item)
@@ -154,9 +159,14 @@ namespace System.Linq
         {
             get
             {
-                if (index < 0 || index >= count) throw Error.ArgumentOutOfRange("index");
-                return elements[index];
+                if (index < 0 || index >= _count)
+                {
+                    throw Error.ArgumentOutOfRange("index");
+                }
+
+                return _elements[index];
             }
+
             set
             {
                 throw Error.NotSupported();
@@ -174,10 +184,26 @@ namespace System.Linq
 
         public GroupedResultEnumerable(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, Func<TKey, IEnumerable<TElement>, TResult> resultSelector, IEqualityComparer<TKey> comparer)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (keySelector == null) throw Error.ArgumentNull("keySelector");
-            if (elementSelector == null) throw Error.ArgumentNull("elementSelector");
-            if (resultSelector == null) throw Error.ArgumentNull("resultSelector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (keySelector == null)
+            {
+                throw Error.ArgumentNull("keySelector");
+            }
+
+            if (elementSelector == null)
+            {
+                throw Error.ArgumentNull("elementSelector");
+            }
+
+            if (resultSelector == null)
+            {
+                throw Error.ArgumentNull("resultSelector");
+            }
+
             _source = source;
             _keySelector = keySelector;
             _elementSelector = elementSelector;
@@ -221,9 +247,21 @@ namespace System.Linq
 
         public GroupedResultEnumerable(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TKey, IEnumerable<TSource>, TResult> resultSelector, IEqualityComparer<TKey> comparer)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (keySelector == null) throw Error.ArgumentNull("keySelector");
-            if (resultSelector == null) throw Error.ArgumentNull("resultSelector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (keySelector == null)
+            {
+                throw Error.ArgumentNull("keySelector");
+            }
+
+            if (resultSelector == null)
+            {
+                throw Error.ArgumentNull("resultSelector");
+            }
+
             _source = source;
             _keySelector = keySelector;
             _resultSelector = resultSelector;
@@ -266,9 +304,21 @@ namespace System.Linq
 
         public GroupedEnumerable(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (keySelector == null) throw Error.ArgumentNull("keySelector");
-            if (elementSelector == null) throw Error.ArgumentNull("elementSelector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (keySelector == null)
+            {
+                throw Error.ArgumentNull("keySelector");
+            }
+
+            if (elementSelector == null)
+            {
+                throw Error.ArgumentNull("elementSelector");
+            }
+
             _source = source;
             _keySelector = keySelector;
             _elementSelector = elementSelector;
@@ -311,8 +361,16 @@ namespace System.Linq
 
         public GroupedEnumerable(IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (keySelector == null) throw Error.ArgumentNull("keySelector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (keySelector == null)
+            {
+                throw Error.ArgumentNull("keySelector");
+            }
+
             _source = source;
             _keySelector = keySelector;
             _comparer = comparer;

--- a/src/System.Linq/src/System/Linq/Grouping.cs
+++ b/src/System.Linq/src/System/Linq/Grouping.cs
@@ -161,7 +161,7 @@ namespace System.Linq
             {
                 if (index < 0 || index >= _count)
                 {
-                    throw Error.ArgumentOutOfRange("index");
+                    throw Error.ArgumentOutOfRange(nameof(index));
                 }
 
                 return _elements[index];
@@ -186,22 +186,22 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (keySelector == null)
             {
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             }
 
             if (elementSelector == null)
             {
-                throw Error.ArgumentNull("elementSelector");
+                throw Error.ArgumentNull(nameof(elementSelector));
             }
 
             if (resultSelector == null)
             {
-                throw Error.ArgumentNull("resultSelector");
+                throw Error.ArgumentNull(nameof(resultSelector));
             }
 
             _source = source;
@@ -249,17 +249,17 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (keySelector == null)
             {
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             }
 
             if (resultSelector == null)
             {
-                throw Error.ArgumentNull("resultSelector");
+                throw Error.ArgumentNull(nameof(resultSelector));
             }
 
             _source = source;
@@ -306,17 +306,17 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (keySelector == null)
             {
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             }
 
             if (elementSelector == null)
             {
-                throw Error.ArgumentNull("elementSelector");
+                throw Error.ArgumentNull(nameof(elementSelector));
             }
 
             _source = source;
@@ -363,12 +363,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (keySelector == null)
             {
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             }
 
             _source = source;

--- a/src/System.Linq/src/System/Linq/Intersect.cs
+++ b/src/System.Linq/src/System/Linq/Intersect.cs
@@ -12,12 +12,12 @@ namespace System.Linq
         {
             if (first == null)
             {
-                throw Error.ArgumentNull("first");
+                throw Error.ArgumentNull(nameof(first));
             }
 
             if (second == null)
             {
-                throw Error.ArgumentNull("second");
+                throw Error.ArgumentNull(nameof(second));
             }
 
             return IntersectIterator(first, second, null);
@@ -27,12 +27,12 @@ namespace System.Linq
         {
             if (first == null)
             {
-                throw Error.ArgumentNull("first");
+                throw Error.ArgumentNull(nameof(first));
             }
 
             if (second == null)
             {
-                throw Error.ArgumentNull("second");
+                throw Error.ArgumentNull(nameof(second));
             }
 
             return IntersectIterator(first, second, comparer);

--- a/src/System.Linq/src/System/Linq/Intersect.cs
+++ b/src/System.Linq/src/System/Linq/Intersect.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -11,24 +10,49 @@ namespace System.Linq
     {
         public static IEnumerable<TSource> Intersect<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second)
         {
-            if (first == null) throw Error.ArgumentNull("first");
-            if (second == null) throw Error.ArgumentNull("second");
+            if (first == null)
+            {
+                throw Error.ArgumentNull("first");
+            }
+
+            if (second == null)
+            {
+                throw Error.ArgumentNull("second");
+            }
+
             return IntersectIterator(first, second, null);
         }
 
         public static IEnumerable<TSource> Intersect<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second, IEqualityComparer<TSource> comparer)
         {
-            if (first == null) throw Error.ArgumentNull("first");
-            if (second == null) throw Error.ArgumentNull("second");
+            if (first == null)
+            {
+                throw Error.ArgumentNull("first");
+            }
+
+            if (second == null)
+            {
+                throw Error.ArgumentNull("second");
+            }
+
             return IntersectIterator(first, second, comparer);
         }
 
         private static IEnumerable<TSource> IntersectIterator<TSource>(IEnumerable<TSource> first, IEnumerable<TSource> second, IEqualityComparer<TSource> comparer)
         {
             Set<TSource> set = new Set<TSource>(comparer);
-            foreach (TSource element in second) set.Add(element);
+            foreach (TSource element in second)
+            {
+                set.Add(element);
+            }
+
             foreach (TSource element in first)
-                if (set.Remove(element)) yield return element;
+            {
+                if (set.Remove(element))
+                {
+                    yield return element;
+                }
+            }
         }
     }
 }

--- a/src/System.Linq/src/System/Linq/Iterator.cs
+++ b/src/System.Linq/src/System/Linq/Iterator.cs
@@ -11,11 +11,11 @@ namespace System.Linq
     {
         internal abstract class Iterator<TSource> : IEnumerable<TSource>, IEnumerator<TSource>
         {
-            private int _threadId;
+            private readonly int _threadId;
             internal int _state;
             internal TSource _current;
 
-            public Iterator()
+            protected Iterator()
             {
                 _threadId = Environment.CurrentManagedThreadId;
             }

--- a/src/System.Linq/src/System/Linq/Iterator.cs
+++ b/src/System.Linq/src/System/Linq/Iterator.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -13,8 +12,8 @@ namespace System.Linq
         internal abstract class Iterator<TSource> : IEnumerable<TSource>, IEnumerator<TSource>
         {
             private int _threadId;
-            internal int state;
-            internal TSource current;
+            internal int _state;
+            internal TSource _current;
 
             public Iterator()
             {
@@ -23,21 +22,21 @@ namespace System.Linq
 
             public TSource Current
             {
-                get { return current; }
+                get { return _current; }
             }
 
             public abstract Iterator<TSource> Clone();
 
             public virtual void Dispose()
             {
-                current = default(TSource);
-                state = -1;
+                _current = default(TSource);
+                _state = -1;
             }
 
             public IEnumerator<TSource> GetEnumerator()
             {
-                Iterator<TSource> enumerator = state == 0 && _threadId == Environment.CurrentManagedThreadId ? this : Clone();
-                enumerator.state = 1;
+                Iterator<TSource> enumerator = _state == 0 && _threadId == Environment.CurrentManagedThreadId ? this : Clone();
+                enumerator._state = 1;
                 return enumerator;
             }
 

--- a/src/System.Linq/src/System/Linq/Join.cs
+++ b/src/System.Linq/src/System/Linq/Join.cs
@@ -12,27 +12,27 @@ namespace System.Linq
         {
             if (outer == null)
             {
-                throw Error.ArgumentNull("outer");
+                throw Error.ArgumentNull(nameof(outer));
             }
 
             if (inner == null)
             {
-                throw Error.ArgumentNull("inner");
+                throw Error.ArgumentNull(nameof(inner));
             }
 
             if (outerKeySelector == null)
             {
-                throw Error.ArgumentNull("outerKeySelector");
+                throw Error.ArgumentNull(nameof(outerKeySelector));
             }
 
             if (innerKeySelector == null)
             {
-                throw Error.ArgumentNull("innerKeySelector");
+                throw Error.ArgumentNull(nameof(innerKeySelector));
             }
 
             if (resultSelector == null)
             {
-                throw Error.ArgumentNull("resultSelector");
+                throw Error.ArgumentNull(nameof(resultSelector));
             }
 
             return JoinIterator(outer, inner, outerKeySelector, innerKeySelector, resultSelector, null);
@@ -42,27 +42,27 @@ namespace System.Linq
         {
             if (outer == null)
             {
-                throw Error.ArgumentNull("outer");
+                throw Error.ArgumentNull(nameof(outer));
             }
 
             if (inner == null)
             {
-                throw Error.ArgumentNull("inner");
+                throw Error.ArgumentNull(nameof(inner));
             }
 
             if (outerKeySelector == null)
             {
-                throw Error.ArgumentNull("outerKeySelector");
+                throw Error.ArgumentNull(nameof(outerKeySelector));
             }
 
             if (innerKeySelector == null)
             {
-                throw Error.ArgumentNull("innerKeySelector");
+                throw Error.ArgumentNull(nameof(innerKeySelector));
             }
 
             if (resultSelector == null)
             {
-                throw Error.ArgumentNull("resultSelector");
+                throw Error.ArgumentNull(nameof(resultSelector));
             }
 
             return JoinIterator(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer);

--- a/src/System.Linq/src/System/Linq/Join.cs
+++ b/src/System.Linq/src/System/Linq/Join.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -11,21 +10,61 @@ namespace System.Linq
     {
         public static IEnumerable<TResult> Join<TOuter, TInner, TKey, TResult>(this IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, TInner, TResult> resultSelector)
         {
-            if (outer == null) throw Error.ArgumentNull("outer");
-            if (inner == null) throw Error.ArgumentNull("inner");
-            if (outerKeySelector == null) throw Error.ArgumentNull("outerKeySelector");
-            if (innerKeySelector == null) throw Error.ArgumentNull("innerKeySelector");
-            if (resultSelector == null) throw Error.ArgumentNull("resultSelector");
+            if (outer == null)
+            {
+                throw Error.ArgumentNull("outer");
+            }
+
+            if (inner == null)
+            {
+                throw Error.ArgumentNull("inner");
+            }
+
+            if (outerKeySelector == null)
+            {
+                throw Error.ArgumentNull("outerKeySelector");
+            }
+
+            if (innerKeySelector == null)
+            {
+                throw Error.ArgumentNull("innerKeySelector");
+            }
+
+            if (resultSelector == null)
+            {
+                throw Error.ArgumentNull("resultSelector");
+            }
+
             return JoinIterator(outer, inner, outerKeySelector, innerKeySelector, resultSelector, null);
         }
 
         public static IEnumerable<TResult> Join<TOuter, TInner, TKey, TResult>(this IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, TInner, TResult> resultSelector, IEqualityComparer<TKey> comparer)
         {
-            if (outer == null) throw Error.ArgumentNull("outer");
-            if (inner == null) throw Error.ArgumentNull("inner");
-            if (outerKeySelector == null) throw Error.ArgumentNull("outerKeySelector");
-            if (innerKeySelector == null) throw Error.ArgumentNull("innerKeySelector");
-            if (resultSelector == null) throw Error.ArgumentNull("resultSelector");
+            if (outer == null)
+            {
+                throw Error.ArgumentNull("outer");
+            }
+
+            if (inner == null)
+            {
+                throw Error.ArgumentNull("inner");
+            }
+
+            if (outerKeySelector == null)
+            {
+                throw Error.ArgumentNull("outerKeySelector");
+            }
+
+            if (innerKeySelector == null)
+            {
+                throw Error.ArgumentNull("innerKeySelector");
+            }
+
+            if (resultSelector == null)
+            {
+                throw Error.ArgumentNull("resultSelector");
+            }
+
             return JoinIterator(outer, inner, outerKeySelector, innerKeySelector, resultSelector, comparer);
         }
 
@@ -44,14 +83,15 @@ namespace System.Linq
                             Grouping<TKey, TInner> g = lookup.GetGrouping(outerKeySelector(item), create: false);
                             if (g != null)
                             {
-                                int count = g.count;
-                                TInner[] elements = g.elements;
+                                int count = g._count;
+                                TInner[] elements = g._elements;
                                 for (int i = 0; i != count; ++i)
                                 {
                                     yield return resultSelector(item, elements[i]);
                                 }
                             }
-                        } while (e.MoveNext());
+                        }
+                        while (e.MoveNext());
                     }
                 }
             }

--- a/src/System.Linq/src/System/Linq/Last.cs
+++ b/src/System.Linq/src/System/Linq/Last.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -11,13 +10,20 @@ namespace System.Linq
     {
         public static TSource Last<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             IPartition<TSource> partition = source as IPartition<TSource>;
             if (partition != null)
             {
                 bool found;
                 TSource last = partition.TryGetLast(out found);
-                if (found) return last;
+                if (found)
+                {
+                    return last;
+                }
             }
             else
             {
@@ -25,7 +31,10 @@ namespace System.Linq
                 if (list != null)
                 {
                     int count = list.Count;
-                    if (count > 0) return list[count - 1];
+                    if (count > 0)
+                    {
+                        return list[count - 1];
+                    }
                 }
                 else
                 {
@@ -37,28 +46,45 @@ namespace System.Linq
                             do
                             {
                                 result = e.Current;
-                            } while (e.MoveNext());
+                            }
+                            while (e.MoveNext());
                             return result;
                         }
                     }
                 }
             }
+
             throw Error.NoElements();
         }
 
         public static TSource Last<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (predicate == null) throw Error.ArgumentNull("predicate");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (predicate == null)
+            {
+                throw Error.ArgumentNull("predicate");
+            }
+
             OrderedEnumerable<TSource> ordered = source as OrderedEnumerable<TSource>;
-            if (ordered != null) return ordered.Last(predicate);
+            if (ordered != null)
+            {
+                return ordered.Last(predicate);
+            }
+
             IList<TSource> list = source as IList<TSource>;
             if (list != null)
             {
                 for (int i = list.Count - 1; i >= 0; --i)
                 {
                     TSource result = list[i];
-                    if (predicate(result)) return result;
+                    if (predicate(result))
+                    {
+                        return result;
+                    }
                 }
             }
             else
@@ -73,19 +99,28 @@ namespace System.Linq
                             while (e.MoveNext())
                             {
                                 TSource element = e.Current;
-                                if (predicate(element)) result = element;
+                                if (predicate(element))
+                                {
+                                    result = element;
+                                }
                             }
+
                             return result;
                         }
                     }
                 }
             }
+
             throw Error.NoMatch();
         }
 
         public static TSource LastOrDefault<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             IPartition<TSource> partition = source as IPartition<TSource>;
             if (partition != null)
             {
@@ -97,7 +132,10 @@ namespace System.Linq
             if (list != null)
             {
                 int count = list.Count;
-                if (count > 0) return list[count - 1];
+                if (count > 0)
+                {
+                    return list[count - 1];
+                }
             }
             else
             {
@@ -109,28 +147,46 @@ namespace System.Linq
                         do
                         {
                             result = e.Current;
-                        } while (e.MoveNext());
+                        }
+                        while (e.MoveNext());
                         return result;
                     }
                 }
             }
+
             return default(TSource);
         }
 
         public static TSource LastOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (predicate == null) throw Error.ArgumentNull("predicate");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (predicate == null)
+            {
+                throw Error.ArgumentNull("predicate");
+            }
+
             OrderedEnumerable<TSource> ordered = source as OrderedEnumerable<TSource>;
-            if (ordered != null) return ordered.LastOrDefault(predicate);
+            if (ordered != null)
+            {
+                return ordered.LastOrDefault(predicate);
+            }
+
             IList<TSource> list = source as IList<TSource>;
             if (list != null)
             {
                 for (int i = list.Count - 1; i >= 0; --i)
                 {
                     TSource element = list[i];
-                    if (predicate(element)) return element;
+                    if (predicate(element))
+                    {
+                        return element;
+                    }
                 }
+
                 return default(TSource);
             }
             else
@@ -143,6 +199,7 @@ namespace System.Linq
                         result = element;
                     }
                 }
+
                 return result;
             }
         }

--- a/src/System.Linq/src/System/Linq/Last.cs
+++ b/src/System.Linq/src/System/Linq/Last.cs
@@ -48,6 +48,7 @@ namespace System.Linq
                                 result = e.Current;
                             }
                             while (e.MoveNext());
+
                             return result;
                         }
                     }
@@ -149,6 +150,7 @@ namespace System.Linq
                             result = e.Current;
                         }
                         while (e.MoveNext());
+
                         return result;
                     }
                 }

--- a/src/System.Linq/src/System/Linq/Last.cs
+++ b/src/System.Linq/src/System/Linq/Last.cs
@@ -12,7 +12,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             IPartition<TSource> partition = source as IPartition<TSource>;
@@ -61,12 +61,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (predicate == null)
             {
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             }
 
             OrderedEnumerable<TSource> ordered = source as OrderedEnumerable<TSource>;
@@ -118,7 +118,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             IPartition<TSource> partition = source as IPartition<TSource>;
@@ -161,12 +161,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (predicate == null)
             {
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             }
 
             OrderedEnumerable<TSource> ordered = source as OrderedEnumerable<TSource>;

--- a/src/System.Linq/src/System/Linq/Lookup.cs
+++ b/src/System.Linq/src/System/Linq/Lookup.cs
@@ -19,12 +19,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (keySelector == null)
             {
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             }
 
             return Lookup<TKey, TSource>.Create(source, keySelector, comparer);
@@ -39,17 +39,17 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (keySelector == null)
             {
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             }
 
             if (elementSelector == null)
             {
-                throw Error.ArgumentNull("elementSelector");
+                throw Error.ArgumentNull(nameof(elementSelector));
             }
 
             return Lookup<TKey, TElement>.Create(source, keySelector, elementSelector, comparer);

--- a/src/System.Linq/src/System/Linq/Lookup.cs
+++ b/src/System.Linq/src/System/Linq/Lookup.cs
@@ -77,6 +77,7 @@ namespace System.Linq
             Debug.Assert(source != null);
             Debug.Assert(keySelector != null);
             Debug.Assert(elementSelector != null);
+
             Lookup<TKey, TElement> lookup = new Lookup<TKey, TElement>(comparer);
             foreach (TSource item in source)
             {
@@ -90,6 +91,7 @@ namespace System.Linq
         {
             Debug.Assert(source != null);
             Debug.Assert(keySelector != null);
+
             Lookup<TKey, TElement> lookup = new Lookup<TKey, TElement>(comparer);
             foreach (TElement item in source)
             {
@@ -116,12 +118,7 @@ namespace System.Linq
 
         private Lookup(IEqualityComparer<TKey> comparer)
         {
-            if (comparer == null)
-            {
-                comparer = EqualityComparer<TKey>.Default;
-            }
-
-            _comparer = comparer;
+            _comparer = comparer ?? EqualityComparer<TKey>.Default;
             _groupings = new Grouping<TKey, TElement>[7];
         }
 
@@ -326,6 +323,7 @@ namespace System.Linq
                 newGroupings[index] = g;
             }
             while (g != _lastGrouping);
+
             _groupings = newGroupings;
         }
     }

--- a/src/System.Linq/src/System/Linq/Max.cs
+++ b/src/System.Linq/src/System/Linq/Max.cs
@@ -12,7 +12,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             int value;
@@ -41,7 +41,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             int? value = null;
@@ -103,7 +103,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             long value;
@@ -132,7 +132,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             long? value = null;
@@ -188,7 +188,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             double value;
@@ -232,7 +232,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             double? value = null;
@@ -286,7 +286,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             float value;
@@ -325,7 +325,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             float? value = null;
@@ -379,7 +379,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             decimal value;
@@ -408,7 +408,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             decimal? value = null;
@@ -445,7 +445,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             Comparer<TSource> comparer = Comparer<TSource>.Default;
@@ -503,12 +503,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             int value;
@@ -537,12 +537,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             int? value = null;
@@ -604,12 +604,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             long value;
@@ -638,12 +638,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             long? value = null;
@@ -699,12 +699,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             float value;
@@ -743,12 +743,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             float? value = null;
@@ -802,12 +802,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             double value;
@@ -851,12 +851,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             double? value = null;
@@ -910,12 +910,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             decimal value;
@@ -944,12 +944,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             decimal? value = null;
@@ -986,12 +986,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             Comparer<TResult> comparer = Comparer<TResult>.Default;

--- a/src/System.Linq/src/System/Linq/Max.cs
+++ b/src/System.Linq/src/System/Linq/Max.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -11,32 +10,54 @@ namespace System.Linq
     {
         public static int Max(this IEnumerable<int> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             int value;
             using (IEnumerator<int> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 value = e.Current;
                 while (e.MoveNext())
                 {
                     int x = e.Current;
-                    if (x > value) value = x;
+                    if (x > value)
+                    {
+                        value = x;
+                    }
                 }
             }
+
             return value;
         }
 
         public static int? Max(this IEnumerable<int?> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             int? value = null;
             using (IEnumerator<int?> e = source.GetEnumerator())
             {
                 do
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = e.Current;
-                } while (!value.HasValue);
+                }
+                while (!value.HasValue);
+
                 int valueVal = value.GetValueOrDefault();
                 if (valueVal >= 0)
                 {
@@ -63,6 +84,7 @@ namespace System.Linq
                     {
                         int? cur = e.Current;
                         int x = cur.GetValueOrDefault();
+
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                         // unless nulls either never happen or always happen.
                         if (cur.HasValue & x > valueVal)
@@ -73,37 +95,60 @@ namespace System.Linq
                     }
                 }
             }
+
             return value;
         }
 
         public static long Max(this IEnumerable<long> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             long value;
             using (IEnumerator<long> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 value = e.Current;
                 while (e.MoveNext())
                 {
                     long x = e.Current;
-                    if (x > value) value = x;
+                    if (x > value)
+                    {
+                        value = x;
+                    }
                 }
             }
+
             return value;
         }
 
         public static long? Max(this IEnumerable<long?> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             long? value = null;
             using (IEnumerator<long?> e = source.GetEnumerator())
             {
                 do
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = e.Current;
-                } while (!value.HasValue);
+                }
+                while (!value.HasValue);
+
                 long valueVal = value.GetValueOrDefault();
                 if (valueVal >= 0)
                 {
@@ -124,6 +169,7 @@ namespace System.Linq
                     {
                         long? cur = e.Current;
                         long x = cur.GetValueOrDefault();
+
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                         // unless nulls either never happen or always happen.
                         if (cur.HasValue & x > valueVal)
@@ -134,57 +180,95 @@ namespace System.Linq
                     }
                 }
             }
+
             return value;
         }
 
         public static double Max(this IEnumerable<double> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             double value;
             using (IEnumerator<double> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 value = e.Current;
+
                 // As described in a comment on Min(this IEnumerable<double>) NaN is ordered
                 // less than all other values. We need to do explicit checks to ensure this, but
                 // once we've found a value that is not NaN we need no longer worry about it,
                 // so first loop until such a value is found (or not, as the case may be).
                 while (double.IsNaN(value))
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = e.Current;
                 }
+
                 while (e.MoveNext())
                 {
                     double x = e.Current;
-                    if (x > value) value = x;
+                    if (x > value)
+                    {
+                        value = x;
+                    }
                 }
             }
+
             return value;
         }
 
         public static double? Max(this IEnumerable<double?> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             double? value = null;
             using (IEnumerator<double?> e = source.GetEnumerator())
             {
                 do
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = e.Current;
-                } while (!value.HasValue);
+                }
+                while (!value.HasValue);
+
                 double valueVal = value.GetValueOrDefault();
                 while (double.IsNaN(valueVal))
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     double? cur = e.Current;
-                    if (cur.HasValue) valueVal = (value = cur).GetValueOrDefault();
+                    if (cur.HasValue)
+                    {
+                        valueVal = (value = cur).GetValueOrDefault();
+                    }
                 }
+
                 while (e.MoveNext())
                 {
                     double? cur = e.Current;
                     double x = cur.GetValueOrDefault();
+
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
                     if (cur.HasValue & x > valueVal)
@@ -194,53 +278,90 @@ namespace System.Linq
                     }
                 }
             }
+
             return value;
         }
 
         public static float Max(this IEnumerable<float> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             float value;
             using (IEnumerator<float> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 value = e.Current;
                 while (float.IsNaN(value))
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = e.Current;
                 }
+
                 while (e.MoveNext())
                 {
                     float x = e.Current;
-                    if (x > value) value = x;
+                    if (x > value)
+                    {
+                        value = x;
+                    }
                 }
             }
+
             return value;
         }
 
         public static float? Max(this IEnumerable<float?> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             float? value = null;
             using (IEnumerator<float?> e = source.GetEnumerator())
             {
                 do
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = e.Current;
-                } while (!value.HasValue);
+                }
+                while (!value.HasValue);
+
                 float valueVal = value.GetValueOrDefault();
                 while (float.IsNaN(valueVal))
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     float? cur = e.Current;
-                    if (cur.HasValue) valueVal = (value = cur).GetValueOrDefault();
+                    if (cur.HasValue)
+                    {
+                        valueVal = (value = cur).GetValueOrDefault();
+                    }
                 }
+
                 while (e.MoveNext())
                 {
                     float? cur = e.Current;
                     float x = cur.GetValueOrDefault();
+
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
                     if (cur.HasValue & x > valueVal)
@@ -250,37 +371,60 @@ namespace System.Linq
                     }
                 }
             }
+
             return value;
         }
 
         public static decimal Max(this IEnumerable<decimal> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             decimal value;
             using (IEnumerator<decimal> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 value = e.Current;
                 while (e.MoveNext())
                 {
                     decimal x = e.Current;
-                    if (x > value) value = x;
+                    if (x > value)
+                    {
+                        value = x;
+                    }
                 }
             }
+
             return value;
         }
 
         public static decimal? Max(this IEnumerable<decimal?> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             decimal? value = null;
             using (IEnumerator<decimal?> e = source.GetEnumerator())
             {
                 do
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = e.Current;
-                } while (!value.HasValue);
+                }
+                while (!value.HasValue);
+
                 decimal valueVal = value.GetValueOrDefault();
                 while (e.MoveNext())
                 {
@@ -293,12 +437,17 @@ namespace System.Linq
                     }
                 }
             }
+
             return value;
         }
 
         public static TSource Max<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             Comparer<TSource> comparer = Comparer<TSource>.Default;
             TSource value = default(TSource);
             if (value == null)
@@ -307,13 +456,22 @@ namespace System.Linq
                 {
                     do
                     {
-                        if (!e.MoveNext()) return value;
+                        if (!e.MoveNext())
+                        {
+                            return value;
+                        }
+
                         value = e.Current;
-                    } while (value == null);
+                    }
+                    while (value == null);
+
                     while (e.MoveNext())
                     {
                         TSource x = e.Current;
-                        if (x != null && comparer.Compare(x, value) > 0) value = x;
+                        if (x != null && comparer.Compare(x, value) > 0)
+                        {
+                            value = x;
+                        }
                     }
                 }
             }
@@ -321,48 +479,86 @@ namespace System.Linq
             {
                 using (IEnumerator<TSource> e = source.GetEnumerator())
                 {
-                    if (!e.MoveNext()) throw Error.NoElements();
+                    if (!e.MoveNext())
+                    {
+                        throw Error.NoElements();
+                    }
+
                     value = e.Current;
                     while (e.MoveNext())
                     {
                         TSource x = e.Current;
-                        if (comparer.Compare(x, value) > 0) value = x;
+                        if (comparer.Compare(x, value) > 0)
+                        {
+                            value = x;
+                        }
                     }
                 }
             }
+
             return value;
         }
 
         public static int Max<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             int value;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 value = selector(e.Current);
                 while (e.MoveNext())
                 {
                     int x = selector(e.Current);
-                    if (x > value) value = x;
+                    if (x > value)
+                    {
+                        value = x;
+                    }
                 }
             }
+
             return value;
         }
 
         public static int? Max<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             int? value = null;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 do
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = selector(e.Current);
-                } while (!value.HasValue);
+                }
+                while (!value.HasValue);
+
                 int valueVal = value.GetValueOrDefault();
                 if (valueVal >= 0)
                 {
@@ -389,6 +585,7 @@ namespace System.Linq
                     {
                         int? cur = selector(e.Current);
                         int x = cur.GetValueOrDefault();
+
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                         // unless nulls either never happen or always happen.
                         if (cur.HasValue & x > valueVal)
@@ -399,39 +596,70 @@ namespace System.Linq
                     }
                 }
             }
+
             return value;
         }
 
         public static long Max<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             long value;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 value = selector(e.Current);
                 while (e.MoveNext())
                 {
                     long x = selector(e.Current);
-                    if (x > value) value = x;
+                    if (x > value)
+                    {
+                        value = x;
+                    }
                 }
             }
+
             return value;
         }
 
         public static long? Max<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             long? value = null;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 do
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = selector(e.Current);
-                } while (!value.HasValue);
+                }
+                while (!value.HasValue);
+
                 long valueVal = value.GetValueOrDefault();
                 if (valueVal >= 0)
                 {
@@ -452,6 +680,7 @@ namespace System.Linq
                     {
                         long? cur = selector(e.Current);
                         long x = cur.GetValueOrDefault();
+
                         // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                         // unless nulls either never happen or always happen.
                         if (cur.HasValue & x > valueVal)
@@ -462,55 +691,100 @@ namespace System.Linq
                     }
                 }
             }
+
             return value;
         }
 
         public static float Max<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             float value;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 value = selector(e.Current);
                 while (float.IsNaN(value))
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = selector(e.Current);
                 }
+
                 while (e.MoveNext())
                 {
                     float x = selector(e.Current);
-                    if (x > value) value = x;
+                    if (x > value)
+                    {
+                        value = x;
+                    }
                 }
             }
+
             return value;
         }
 
         public static float? Max<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             float? value = null;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 do
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = selector(e.Current);
-                } while (!value.HasValue);
+                }
+                while (!value.HasValue);
+
                 float valueVal = value.GetValueOrDefault();
                 while (float.IsNaN(valueVal))
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     float? cur = selector(e.Current);
-                    if (cur.HasValue) valueVal = (value = cur).GetValueOrDefault();
+                    if (cur.HasValue)
+                    {
+                        valueVal = (value = cur).GetValueOrDefault();
+                    }
                 }
+
                 while (e.MoveNext())
                 {
                     float? cur = selector(e.Current);
                     float x = cur.GetValueOrDefault();
+
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
                     if (cur.HasValue & x > valueVal)
@@ -520,59 +794,105 @@ namespace System.Linq
                     }
                 }
             }
+
             return value;
         }
 
         public static double Max<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             double value;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 value = selector(e.Current);
+
                 // As described in a comment on Min(this IEnumerable<double>) NaN is ordered
                 // less than all other values. We need to do explicit checks to ensure this, but
                 // once we've found a value that is not NaN we need no longer worry about it,
                 // so first loop until such a value is found (or not, as the case may be).
                 while (double.IsNaN(value))
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = selector(e.Current);
                 }
+
                 while (e.MoveNext())
                 {
                     double x = selector(e.Current);
-                    if (x > value) value = x;
+                    if (x > value)
+                    {
+                        value = x;
+                    }
                 }
             }
+
             return value;
         }
 
         public static double? Max<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             double? value = null;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 do
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = selector(e.Current);
-                } while (!value.HasValue);
+                }
+                while (!value.HasValue);
+
                 double valueVal = value.GetValueOrDefault();
                 while (double.IsNaN(valueVal))
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     double? cur = selector(e.Current);
-                    if (cur.HasValue) valueVal = (value = cur).GetValueOrDefault();
+                    if (cur.HasValue)
+                    {
+                        valueVal = (value = cur).GetValueOrDefault();
+                    }
                 }
+
                 while (e.MoveNext())
                 {
                     double? cur = selector(e.Current);
                     double x = cur.GetValueOrDefault();
+
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
                     if (cur.HasValue & x > valueVal)
@@ -582,39 +902,70 @@ namespace System.Linq
                     }
                 }
             }
+
             return value;
         }
 
         public static decimal Max<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             decimal value;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 value = selector(e.Current);
                 while (e.MoveNext())
                 {
                     decimal x = selector(e.Current);
-                    if (x > value) value = x;
+                    if (x > value)
+                    {
+                        value = x;
+                    }
                 }
             }
+
             return value;
         }
 
         public static decimal? Max<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             decimal? value = null;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 do
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = selector(e.Current);
-                } while (!value.HasValue);
+                }
+                while (!value.HasValue);
+
                 decimal valueVal = value.GetValueOrDefault();
                 while (e.MoveNext())
                 {
@@ -627,13 +978,22 @@ namespace System.Linq
                     }
                 }
             }
+
             return value;
         }
 
         public static TResult Max<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             Comparer<TResult> comparer = Comparer<TResult>.Default;
             TResult value = default(TResult);
             if (value == null)
@@ -642,13 +1002,22 @@ namespace System.Linq
                 {
                     do
                     {
-                        if (!e.MoveNext()) return value;
+                        if (!e.MoveNext())
+                        {
+                            return value;
+                        }
+
                         value = selector(e.Current);
-                    } while (value == null);
+                    }
+                    while (value == null);
+
                     while (e.MoveNext())
                     {
                         TResult x = selector(e.Current);
-                        if (x != null && comparer.Compare(x, value) > 0) value = x;
+                        if (x != null && comparer.Compare(x, value) > 0)
+                        {
+                            value = x;
+                        }
                     }
                 }
             }
@@ -656,15 +1025,23 @@ namespace System.Linq
             {
                 using (IEnumerator<TSource> e = source.GetEnumerator())
                 {
-                    if (!e.MoveNext()) throw Error.NoElements();
+                    if (!e.MoveNext())
+                    {
+                        throw Error.NoElements();
+                    }
+
                     value = selector(e.Current);
                     while (e.MoveNext())
                     {
                         TResult x = selector(e.Current);
-                        if (comparer.Compare(x, value) > 0) value = x;
+                        if (comparer.Compare(x, value) > 0)
+                        {
+                            value = x;
+                        }
                     }
                 }
             }
+
             return value;
         }
     }

--- a/src/System.Linq/src/System/Linq/Min.cs
+++ b/src/System.Linq/src/System/Linq/Min.cs
@@ -12,7 +12,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             int value;
@@ -41,7 +41,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             int? value = null;
@@ -85,7 +85,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             long value;
@@ -114,7 +114,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             long? value = null;
@@ -154,7 +154,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             float value;
@@ -196,7 +196,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             float? value = null;
@@ -240,7 +240,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             double value;
@@ -273,7 +273,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             double? value = null;
@@ -317,7 +317,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             decimal value;
@@ -346,7 +346,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             decimal? value = null;
@@ -383,7 +383,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             Comparer<TSource> comparer = Comparer<TSource>.Default;
@@ -441,12 +441,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             int value;
@@ -475,12 +475,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             int? value = null;
@@ -524,12 +524,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             long value;
@@ -558,12 +558,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             long? value = null;
@@ -603,12 +603,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             float value;
@@ -650,12 +650,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             float? value = null;
@@ -699,12 +699,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             double value;
@@ -737,12 +737,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             double? value = null;
@@ -786,12 +786,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             decimal value;
@@ -820,12 +820,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             decimal? value = null;
@@ -862,12 +862,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             Comparer<TResult> comparer = Comparer<TResult>.Default;

--- a/src/System.Linq/src/System/Linq/Min.cs
+++ b/src/System.Linq/src/System/Linq/Min.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -11,24 +10,40 @@ namespace System.Linq
     {
         public static int Min(this IEnumerable<int> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             int value;
             using (IEnumerator<int> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 value = e.Current;
                 while (e.MoveNext())
                 {
                     int x = e.Current;
-                    if (x < value) value = x;
+                    if (x < value)
+                    {
+                        value = x;
+                    }
                 }
             }
+
             return value;
         }
 
         public static int? Min(this IEnumerable<int?> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             int? value = null;
             using (IEnumerator<int?> e = source.GetEnumerator())
             {
@@ -36,9 +51,15 @@ namespace System.Linq
                 // so we don't have to keep testing for nullity.
                 do
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = e.Current;
-                } while (!value.HasValue);
+                }
+                while (!value.HasValue);
+
                 // Keep hold of the wrapped value, and do comparisons on that, rather than
                 // using the lifted operation each time.
                 int valueVal = value.GetValueOrDefault();
@@ -46,6 +67,7 @@ namespace System.Linq
                 {
                     int? cur = e.Current;
                     int x = cur.GetValueOrDefault();
+
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
                     if (cur.HasValue & x < valueVal)
@@ -55,42 +77,66 @@ namespace System.Linq
                     }
                 }
             }
+
             return value;
         }
 
         public static long Min(this IEnumerable<long> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             long value;
             using (IEnumerator<long> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 value = e.Current;
                 while (e.MoveNext())
                 {
                     long x = e.Current;
-                    if (x < value) value = x;
+                    if (x < value)
+                    {
+                        value = x;
+                    }
                 }
             }
+
             return value;
         }
 
         public static long? Min(this IEnumerable<long?> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             long? value = null;
             using (IEnumerator<long?> e = source.GetEnumerator())
             {
                 do
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = e.Current;
-                } while (!value.HasValue);
+                }
+                while (!value.HasValue);
+
                 long valueVal = value.GetValueOrDefault();
                 while (e.MoveNext())
                 {
                     long? cur = e.Current;
                     long x = cur.GetValueOrDefault();
+
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
                     if (cur.HasValue & x < valueVal)
@@ -100,21 +146,34 @@ namespace System.Linq
                     }
                 }
             }
+
             return value;
         }
 
         public static float Min(this IEnumerable<float> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             float value;
             using (IEnumerator<float> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 value = e.Current;
                 while (e.MoveNext())
                 {
                     float x = e.Current;
-                    if (x < value) value = x;
+                    if (x < value)
+                    {
+                        value = x;
+                    }
+
                     // Normally NaN < anything is false, as is anything < NaN
                     // However, this leads to some irksome outcomes in Min and Max.
                     // If we use those semantics then Min(NaN, 5.0) is NaN, but
@@ -123,23 +182,37 @@ namespace System.Linq
                     // negative infinity.
                     // Not testing for NaN therefore isn't an option, but since we
                     // can't find a smaller value, we can short-circuit.
-                    else if (float.IsNaN(x)) return x;
+                    else if (float.IsNaN(x))
+                    {
+                        return x;
+                    }
                 }
             }
+
             return value;
         }
 
         public static float? Min(this IEnumerable<float?> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             float? value = null;
             using (IEnumerator<float?> e = source.GetEnumerator())
             {
                 do
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = e.Current;
-                } while (!value.HasValue);
+                }
+                while (!value.HasValue);
+
                 float valueVal = value.GetValueOrDefault();
                 while (e.MoveNext())
                 {
@@ -152,42 +225,71 @@ namespace System.Linq
                             valueVal = x;
                             value = cur;
                         }
-                        else if (float.IsNaN(x)) return cur;
+                        else if (float.IsNaN(x))
+                        {
+                            return cur;
+                        }
                     }
                 }
             }
+
             return value;
         }
 
         public static double Min(this IEnumerable<double> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             double value;
             using (IEnumerator<double> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 value = e.Current;
                 while (e.MoveNext())
                 {
                     double x = e.Current;
-                    if (x < value) value = x;
-                    else if (double.IsNaN(x)) return x;
+                    if (x < value)
+                    {
+                        value = x;
+                    }
+                    else if (double.IsNaN(x))
+                    {
+                        return x;
+                    }
                 }
             }
+
             return value;
         }
 
         public static double? Min(this IEnumerable<double?> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             double? value = null;
             using (IEnumerator<double?> e = source.GetEnumerator())
             {
                 do
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = e.Current;
-                } while (!value.HasValue);
+                }
+                while (!value.HasValue);
+
                 double valueVal = value.GetValueOrDefault();
                 while (e.MoveNext())
                 {
@@ -200,41 +302,67 @@ namespace System.Linq
                             valueVal = x;
                             value = cur;
                         }
-                        else if (double.IsNaN(x)) return cur;
+                        else if (double.IsNaN(x))
+                        {
+                            return cur;
+                        }
                     }
                 }
             }
+
             return value;
         }
 
         public static decimal Min(this IEnumerable<decimal> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             decimal value;
             using (IEnumerator<decimal> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 value = e.Current;
                 while (e.MoveNext())
                 {
                     decimal x = e.Current;
-                    if (x < value) value = x;
+                    if (x < value)
+                    {
+                        value = x;
+                    }
                 }
             }
+
             return value;
         }
 
         public static decimal? Min(this IEnumerable<decimal?> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             decimal? value = null;
             using (IEnumerator<decimal?> e = source.GetEnumerator())
             {
                 do
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = e.Current;
-                } while (!value.HasValue);
+                }
+                while (!value.HasValue);
+
                 decimal valueVal = value.GetValueOrDefault();
                 while (e.MoveNext())
                 {
@@ -247,12 +375,17 @@ namespace System.Linq
                     }
                 }
             }
+
             return value;
         }
 
         public static TSource Min<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             Comparer<TSource> comparer = Comparer<TSource>.Default;
             TSource value = default(TSource);
             if (value == null)
@@ -261,13 +394,22 @@ namespace System.Linq
                 {
                     do
                     {
-                        if (!e.MoveNext()) return value;
+                        if (!e.MoveNext())
+                        {
+                            return value;
+                        }
+
                         value = e.Current;
-                    } while (value == null);
+                    }
+                    while (value == null);
+
                     while (e.MoveNext())
                     {
                         TSource x = e.Current;
-                        if (x != null && comparer.Compare(x, value) < 0) value = x;
+                        if (x != null && comparer.Compare(x, value) < 0)
+                        {
+                            value = x;
+                        }
                     }
                 }
             }
@@ -275,40 +417,72 @@ namespace System.Linq
             {
                 using (IEnumerator<TSource> e = source.GetEnumerator())
                 {
-                    if (!e.MoveNext()) throw Error.NoElements();
+                    if (!e.MoveNext())
+                    {
+                        throw Error.NoElements();
+                    }
+
                     value = e.Current;
                     while (e.MoveNext())
                     {
                         TSource x = e.Current;
-                        if (comparer.Compare(x, value) < 0) value = x;
+                        if (comparer.Compare(x, value) < 0)
+                        {
+                            value = x;
+                        }
                     }
                 }
             }
+
             return value;
         }
 
         public static int Min<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             int value;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 value = selector(e.Current);
                 while (e.MoveNext())
                 {
                     int x = selector(e.Current);
-                    if (x < value) value = x;
+                    if (x < value)
+                    {
+                        value = x;
+                    }
                 }
             }
+
             return value;
         }
 
         public static int? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             int? value = null;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
@@ -316,9 +490,15 @@ namespace System.Linq
                 // so we don't have to keep testing for nullity.
                 do
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = selector(e.Current);
-                } while (!value.HasValue);
+                }
+                while (!value.HasValue);
+
                 // Keep hold of the wrapped value, and do comparisons on that, rather than
                 // using the lifted operation each time.
                 int valueVal = value.GetValueOrDefault();
@@ -326,6 +506,7 @@ namespace System.Linq
                 {
                     int? cur = selector(e.Current);
                     int x = cur.GetValueOrDefault();
+
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
                     if (cur.HasValue & x < valueVal)
@@ -335,44 +516,76 @@ namespace System.Linq
                     }
                 }
             }
+
             return value;
         }
 
         public static long Min<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             long value;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 value = selector(e.Current);
                 while (e.MoveNext())
                 {
                     long x = selector(e.Current);
-                    if (x < value) value = x;
+                    if (x < value)
+                    {
+                        value = x;
+                    }
                 }
             }
+
             return value;
         }
 
         public static long? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             long? value = null;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 do
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = selector(e.Current);
-                } while (!value.HasValue);
+                }
+                while (!value.HasValue);
+
                 long valueVal = value.GetValueOrDefault();
                 while (e.MoveNext())
                 {
                     long? cur = selector(e.Current);
                     long x = cur.GetValueOrDefault();
+
                     // Do not replace & with &&. The branch prediction cost outweighs the extra operation
                     // unless nulls either never happen or always happen.
                     if (cur.HasValue & x < valueVal)
@@ -382,22 +595,39 @@ namespace System.Linq
                     }
                 }
             }
+
             return value;
         }
 
         public static float Min<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             float value;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 value = selector(e.Current);
                 while (e.MoveNext())
                 {
                     float x = selector(e.Current);
-                    if (x < value) value = x;
+                    if (x < value)
+                    {
+                        value = x;
+                    }
+
                     // Normally NaN < anything is false, as is anything < NaN
                     // However, this leads to some irksome outcomes in Min and Max.
                     // If we use those semantics then Min(NaN, 5.0) is NaN, but
@@ -406,24 +636,42 @@ namespace System.Linq
                     // negative infinity.
                     // Not testing for NaN therefore isn't an option, but since we
                     // can't find a smaller value, we can short-circuit.
-                    else if (float.IsNaN(x)) return x;
+                    else if (float.IsNaN(x))
+                    {
+                        return x;
+                    }
                 }
             }
+
             return value;
         }
 
         public static float? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             float? value = null;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 do
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = selector(e.Current);
-                } while (!value.HasValue);
+                }
+                while (!value.HasValue);
+
                 float valueVal = value.GetValueOrDefault();
                 while (e.MoveNext())
                 {
@@ -436,44 +684,81 @@ namespace System.Linq
                             valueVal = x;
                             value = cur;
                         }
-                        else if (float.IsNaN(x)) return cur;
+                        else if (float.IsNaN(x))
+                        {
+                            return cur;
+                        }
                     }
                 }
             }
+
             return value;
         }
 
         public static double Min<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             double value;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 value = selector(e.Current);
                 while (e.MoveNext())
                 {
                     double x = selector(e.Current);
-                    if (x < value) value = x;
-                    else if (double.IsNaN(x)) return x;
+                    if (x < value)
+                    {
+                        value = x;
+                    }
+                    else if (double.IsNaN(x))
+                    {
+                        return x;
+                    }
                 }
             }
+
             return value;
         }
 
         public static double? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             double? value = null;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 do
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = selector(e.Current);
-                } while (!value.HasValue);
+                }
+                while (!value.HasValue);
+
                 double valueVal = value.GetValueOrDefault();
                 while (e.MoveNext())
                 {
@@ -486,43 +771,77 @@ namespace System.Linq
                             valueVal = x;
                             value = cur;
                         }
-                        else if (double.IsNaN(x)) return cur;
+                        else if (double.IsNaN(x))
+                        {
+                            return cur;
+                        }
                     }
                 }
             }
+
             return value;
         }
 
         public static decimal Min<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             decimal value;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                if (!e.MoveNext()) throw Error.NoElements();
+                if (!e.MoveNext())
+                {
+                    throw Error.NoElements();
+                }
+
                 value = selector(e.Current);
                 while (e.MoveNext())
                 {
                     decimal x = selector(e.Current);
-                    if (x < value) value = x;
+                    if (x < value)
+                    {
+                        value = x;
+                    }
                 }
             }
+
             return value;
         }
 
         public static decimal? Min<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             decimal? value = null;
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 do
                 {
-                    if (!e.MoveNext()) return value;
+                    if (!e.MoveNext())
+                    {
+                        return value;
+                    }
+
                     value = selector(e.Current);
-                } while (!value.HasValue);
+                }
+                while (!value.HasValue);
+
                 decimal valueVal = value.GetValueOrDefault();
                 while (e.MoveNext())
                 {
@@ -535,13 +854,22 @@ namespace System.Linq
                     }
                 }
             }
+
             return value;
         }
 
         public static TResult Min<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             Comparer<TResult> comparer = Comparer<TResult>.Default;
             TResult value = default(TResult);
             if (value == null)
@@ -550,13 +878,22 @@ namespace System.Linq
                 {
                     do
                     {
-                        if (!e.MoveNext()) return value;
+                        if (!e.MoveNext())
+                        {
+                            return value;
+                        }
+
                         value = selector(e.Current);
-                    } while (value == null);
+                    }
+                    while (value == null);
+
                     while (e.MoveNext())
                     {
                         TResult x = selector(e.Current);
-                        if (x != null && comparer.Compare(x, value) < 0) value = x;
+                        if (x != null && comparer.Compare(x, value) < 0)
+                        {
+                            value = x;
+                        }
                     }
                 }
             }
@@ -564,15 +901,23 @@ namespace System.Linq
             {
                 using (IEnumerator<TSource> e = source.GetEnumerator())
                 {
-                    if (!e.MoveNext()) throw Error.NoElements();
+                    if (!e.MoveNext())
+                    {
+                        throw Error.NoElements();
+                    }
+
                     value = selector(e.Current);
                     while (e.MoveNext())
                     {
                         TResult x = selector(e.Current);
-                        if (comparer.Compare(x, value) < 0) value = x;
+                        if (comparer.Compare(x, value) < 0)
+                        {
+                            value = x;
+                        }
                     }
                 }
             }
+
             return value;
         }
     }

--- a/src/System.Linq/src/System/Linq/OrderBy.cs
+++ b/src/System.Linq/src/System/Linq/OrderBy.cs
@@ -32,7 +32,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             return source.CreateOrderedEnumerable(keySelector, null, false);
@@ -42,7 +42,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             return source.CreateOrderedEnumerable(keySelector, comparer, false);
@@ -52,7 +52,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             return source.CreateOrderedEnumerable(keySelector, null, true);
@@ -62,7 +62,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             return source.CreateOrderedEnumerable(keySelector, comparer, true);

--- a/src/System.Linq/src/System/Linq/OrderBy.cs
+++ b/src/System.Linq/src/System/Linq/OrderBy.cs
@@ -10,22 +10,22 @@ namespace System.Linq
     {
         public static IOrderedEnumerable<TSource> OrderBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
         {
-            return new OrderedEnumerable<TSource, TKey>(source, keySelector, null, false);
+            return new OrderedEnumerable<TSource, TKey>(source, keySelector, null, false, null);
         }
 
         public static IOrderedEnumerable<TSource> OrderBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
         {
-            return new OrderedEnumerable<TSource, TKey>(source, keySelector, comparer, false);
+            return new OrderedEnumerable<TSource, TKey>(source, keySelector, comparer, false, null);
         }
 
         public static IOrderedEnumerable<TSource> OrderByDescending<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector)
         {
-            return new OrderedEnumerable<TSource, TKey>(source, keySelector, null, true);
+            return new OrderedEnumerable<TSource, TKey>(source, keySelector, null, true, null);
         }
 
         public static IOrderedEnumerable<TSource> OrderByDescending<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
         {
-            return new OrderedEnumerable<TSource, TKey>(source, keySelector, comparer, true);
+            return new OrderedEnumerable<TSource, TKey>(source, keySelector, comparer, true, null);
         }
 
         public static IOrderedEnumerable<TSource> ThenBy<TSource, TKey>(this IOrderedEnumerable<TSource> source, Func<TSource, TKey> keySelector)

--- a/src/System.Linq/src/System/Linq/OrderBy.cs
+++ b/src/System.Linq/src/System/Linq/OrderBy.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -31,25 +30,41 @@ namespace System.Linq
 
         public static IOrderedEnumerable<TSource> ThenBy<TSource, TKey>(this IOrderedEnumerable<TSource> source, Func<TSource, TKey> keySelector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             return source.CreateOrderedEnumerable(keySelector, null, false);
         }
 
         public static IOrderedEnumerable<TSource> ThenBy<TSource, TKey>(this IOrderedEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             return source.CreateOrderedEnumerable(keySelector, comparer, false);
         }
 
         public static IOrderedEnumerable<TSource> ThenByDescending<TSource, TKey>(this IOrderedEnumerable<TSource> source, Func<TSource, TKey> keySelector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             return source.CreateOrderedEnumerable(keySelector, null, true);
         }
 
         public static IOrderedEnumerable<TSource> ThenByDescending<TSource, TKey>(this IOrderedEnumerable<TSource> source, Func<TSource, TKey> keySelector, IComparer<TKey> comparer)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             return source.CreateOrderedEnumerable(keySelector, comparer, true);
         }
     }

--- a/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -208,9 +208,7 @@ namespace System.Linq
 
         IOrderedEnumerable<TElement> IOrderedEnumerable<TElement>.CreateOrderedEnumerable<TKey>(Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending)
         {
-            OrderedEnumerable<TElement, TKey> result = new OrderedEnumerable<TElement, TKey>(_source, keySelector, comparer, descending);
-            result._parent = this;
-            return result;
+            return new OrderedEnumerable<TElement, TKey>(_source, keySelector, comparer, descending, this);
         }
 
         public IPartition<TElement> Skip(int count)
@@ -288,6 +286,7 @@ namespace System.Linq
                     value = e.Current;
                 }
                 while (!predicate(value));
+
                 comparer.SetElement(value);
                 while (e.MoveNext())
                 {
@@ -318,6 +317,7 @@ namespace System.Linq
                     value = e.Current;
                 }
                 while (!predicate(value));
+
                 comparer.SetElement(value);
                 while (e.MoveNext())
                 {
@@ -408,6 +408,7 @@ namespace System.Linq
                     value = e.Current;
                 }
                 while (!predicate(value));
+
                 comparer.SetElement(value);
                 while (e.MoveNext())
                 {
@@ -438,6 +439,7 @@ namespace System.Linq
                     value = e.Current;
                 }
                 while (!predicate(value));
+
                 comparer.SetElement(value);
                 while (e.MoveNext())
                 {
@@ -455,12 +457,12 @@ namespace System.Linq
 
     internal sealed class OrderedEnumerable<TElement, TKey> : OrderedEnumerable<TElement>
     {
-        internal OrderedEnumerable<TElement> _parent;
-        internal Func<TElement, TKey> _keySelector;
-        internal IComparer<TKey> _comparer;
-        internal bool _descending;
+        internal readonly OrderedEnumerable<TElement> _parent;
+        internal readonly Func<TElement, TKey> _keySelector;
+        internal readonly IComparer<TKey> _comparer;
+        internal readonly bool _descending;
 
-        internal OrderedEnumerable(IEnumerable<TElement> source, Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending)
+        internal OrderedEnumerable(IEnumerable<TElement> source, Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending, OrderedEnumerable<TElement> parent)
         {
             if (source == null)
             {
@@ -473,7 +475,7 @@ namespace System.Linq
             }
 
             _source = source;
-            _parent = null;
+            _parent = parent;
             _keySelector = keySelector;
             _comparer = comparer ?? Comparer<TKey>.Default;
             _descending = descending;
@@ -653,6 +655,7 @@ namespace System.Linq
                     j--;
                 }
                 while (i <= j);
+
                 if (j - left <= right - i)
                 {
                     if (left < j)
@@ -712,6 +715,7 @@ namespace System.Linq
                     j--;
                 }
                 while (i <= j);
+
                 if (minIdx >= i)
                 {
                     left = i + 1;
@@ -781,6 +785,7 @@ namespace System.Linq
                     j--;
                 }
                 while (i <= j);
+
                 if (i <= idx)
                 {
                     left = i + 1;
@@ -810,16 +815,17 @@ namespace System.Linq
                 }
             }
             while (left < right);
+
             return map[idx];
         }
     }
 
     internal sealed class EnumerableSorter<TElement, TKey> : EnumerableSorter<TElement>
     {
-        internal Func<TElement, TKey> _keySelector;
-        internal IComparer<TKey> _comparer;
-        internal bool _descending;
-        internal EnumerableSorter<TElement> _next;
+        internal readonly Func<TElement, TKey> _keySelector;
+        internal readonly IComparer<TKey> _comparer;
+        internal readonly bool _descending;
+        internal readonly EnumerableSorter<TElement> _next;
         internal TKey[] _keys;
 
         internal EnumerableSorter(Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending, EnumerableSorter<TElement> next)

--- a/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -464,12 +464,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (keySelector == null)
             {
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             }
 
             _source = source;

--- a/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
+++ b/src/System.Linq/src/System/Linq/OrderedEnumerable.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 
@@ -10,54 +9,63 @@ namespace System.Linq
 {
     internal abstract class OrderedEnumerable<TElement> : IOrderedEnumerable<TElement>, IPartition<TElement>
     {
-        internal IEnumerable<TElement> source;
+        internal IEnumerable<TElement> _source;
 
         private int[] SortedMap(Buffer<TElement> buffer)
         {
-            return GetEnumerableSorter().Sort(buffer.items, buffer.count);
+            return GetEnumerableSorter().Sort(buffer._items, buffer._count);
         }
 
         private int[] SortedMap(Buffer<TElement> buffer, int minIdx, int maxIdx)
         {
-            return GetEnumerableSorter().Sort(buffer.items, buffer.count, minIdx, maxIdx);
+            return GetEnumerableSorter().Sort(buffer._items, buffer._count, minIdx, maxIdx);
         }
 
         public IEnumerator<TElement> GetEnumerator()
         {
-            Buffer<TElement> buffer = new Buffer<TElement>(source);
-            if (buffer.count > 0)
+            Buffer<TElement> buffer = new Buffer<TElement>(_source);
+            if (buffer._count > 0)
             {
                 int[] map = SortedMap(buffer);
-                for (int i = 0; i < buffer.count; i++) yield return buffer.items[map[i]];
+                for (int i = 0; i < buffer._count; i++)
+                {
+                    yield return buffer._items[map[i]];
+                }
             }
         }
 
         public TElement[] ToArray()
         {
-            Buffer<TElement> buffer = new Buffer<TElement>(source);
+            Buffer<TElement> buffer = new Buffer<TElement>(_source);
 
-            int count = buffer.count;
+            int count = buffer._count;
             if (count == 0)
             {
-                return buffer.items;
+                return buffer._items;
             }
 
             TElement[] array = new TElement[count];
             int[] map = SortedMap(buffer);
-            for (int i = 0; i != array.Length; i++) array[i] = buffer.items[map[i]];
+            for (int i = 0; i != array.Length; i++)
+            {
+                array[i] = buffer._items[map[i]];
+            }
 
             return array;
         }
 
         public List<TElement> ToList()
         {
-            Buffer<TElement> buffer = new Buffer<TElement>(source);
-            int count = buffer.count;
+            Buffer<TElement> buffer = new Buffer<TElement>(_source);
+            int count = buffer._count;
             List<TElement> list = new List<TElement>(count);
             if (count > 0)
             {
                 int[] map = SortedMap(buffer);
-                for (int i = 0; i != count; i++) list.Add(buffer.items[map[i]]);
+                for (int i = 0; i != count; i++)
+                {
+                    list.Add(buffer._items[map[i]]);
+                }
             }
 
             return list;
@@ -65,25 +73,36 @@ namespace System.Linq
 
         public int GetCount(bool onlyIfCheap)
         {
-            IIListProvider<TElement> listProv = source as IIListProvider<TElement>;
-            if (listProv != null) return listProv.GetCount(onlyIfCheap);
-            return !onlyIfCheap || source is ICollection<TElement> || source is ICollection ? source.Count() : -1;
+            IIListProvider<TElement> listProv = _source as IIListProvider<TElement>;
+            if (listProv != null)
+            {
+                return listProv.GetCount(onlyIfCheap);
+            }
+
+            return !onlyIfCheap || _source is ICollection<TElement> || _source is ICollection ? _source.Count() : -1;
         }
 
         internal IEnumerator<TElement> GetEnumerator(int minIdx, int maxIdx)
         {
-            Buffer<TElement> buffer = new Buffer<TElement>(source);
-            int count = buffer.count;
+            Buffer<TElement> buffer = new Buffer<TElement>(_source);
+            int count = buffer._count;
             if (count > minIdx)
             {
-                if (count <= maxIdx) maxIdx = count - 1;
-                if (minIdx == maxIdx) yield return GetEnumerableSorter().ElementAt(buffer.items, count, minIdx);
+                if (count <= maxIdx)
+                {
+                    maxIdx = count - 1;
+                }
+
+                if (minIdx == maxIdx)
+                {
+                    yield return GetEnumerableSorter().ElementAt(buffer._items, count, minIdx);
+                }
                 else
                 {
                     int[] map = SortedMap(buffer, minIdx, maxIdx);
                     while (minIdx <= maxIdx)
                     {
-                        yield return buffer.items[map[minIdx]];
+                        yield return buffer._items[map[minIdx]];
                         ++minIdx;
                     }
                 }
@@ -92,46 +111,80 @@ namespace System.Linq
 
         internal TElement[] ToArray(int minIdx, int maxIdx)
         {
-            Buffer<TElement> buffer = new Buffer<TElement>(source);
-            int count = buffer.count;
-            if (count <= minIdx) return Array.Empty<TElement>();
-            if (count <= maxIdx) maxIdx = count - 1;
-            if (minIdx == maxIdx) return new TElement[] { GetEnumerableSorter().ElementAt(buffer.items, count, minIdx) };
+            Buffer<TElement> buffer = new Buffer<TElement>(_source);
+            int count = buffer._count;
+            if (count <= minIdx)
+            {
+                return Array.Empty<TElement>();
+            }
+
+            if (count <= maxIdx)
+            {
+                maxIdx = count - 1;
+            }
+
+            if (minIdx == maxIdx)
+            {
+                return new TElement[] { GetEnumerableSorter().ElementAt(buffer._items, count, minIdx) };
+            }
+
             int[] map = SortedMap(buffer, minIdx, maxIdx);
             TElement[] array = new TElement[maxIdx - minIdx + 1];
             int idx = 0;
             while (minIdx <= maxIdx)
             {
-                array[idx] = buffer.items[map[minIdx]];
+                array[idx] = buffer._items[map[minIdx]];
                 ++idx;
                 ++minIdx;
             }
+
             return array;
         }
 
         internal List<TElement> ToList(int minIdx, int maxIdx)
         {
-            Buffer<TElement> buffer = new Buffer<TElement>(source);
-            int count = buffer.count;
-            if (count <= minIdx) return new List<TElement>();
-            if (count <= maxIdx) maxIdx = count - 1;
-            if (minIdx == maxIdx) return new List<TElement>(1) { GetEnumerableSorter().ElementAt(buffer.items, count, minIdx) };
+            Buffer<TElement> buffer = new Buffer<TElement>(_source);
+            int count = buffer._count;
+            if (count <= minIdx)
+            {
+                return new List<TElement>();
+            }
+
+            if (count <= maxIdx)
+            {
+                maxIdx = count - 1;
+            }
+
+            if (minIdx == maxIdx)
+            {
+                return new List<TElement>(1) { GetEnumerableSorter().ElementAt(buffer._items, count, minIdx) };
+            }
+
             int[] map = SortedMap(buffer, minIdx, maxIdx);
             List<TElement> list = new List<TElement>(maxIdx - minIdx + 1);
             while (minIdx <= maxIdx)
             {
-                list.Add(buffer.items[map[minIdx]]);
+                list.Add(buffer._items[map[minIdx]]);
                 ++minIdx;
             }
+
             return list;
         }
 
         internal int GetCount(int minIdx, int maxIdx, bool onlyIfCheap)
         {
             int count = GetCount(onlyIfCheap);
-            if (count <= 0) return count;
-            if (count <= minIdx) return 0;
-            return (count <= maxIdx? count : maxIdx + 1) - minIdx;
+            if (count <= 0)
+            {
+                return count;
+            }
+
+            if (count <= minIdx)
+            {
+                return 0;
+            }
+
+            return (count <= maxIdx ? count : maxIdx + 1) - minIdx;
         }
 
         private EnumerableSorter<TElement> GetEnumerableSorter()
@@ -155,8 +208,8 @@ namespace System.Linq
 
         IOrderedEnumerable<TElement> IOrderedEnumerable<TElement>.CreateOrderedEnumerable<TKey>(Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending)
         {
-            OrderedEnumerable<TElement, TKey> result = new OrderedEnumerable<TElement, TKey>(source, keySelector, comparer, descending);
-            result.parent = this;
+            OrderedEnumerable<TElement, TKey> result = new OrderedEnumerable<TElement, TKey>(_source, keySelector, comparer, descending);
+            result._parent = this;
             return result;
         }
 
@@ -172,17 +225,22 @@ namespace System.Linq
 
         public TElement TryGetElementAt(int index, out bool found)
         {
-            if (index == 0) return TryGetFirst(out found);
+            if (index == 0)
+            {
+                return TryGetFirst(out found);
+            }
+
             if (index > 0)
             {
-                Buffer<TElement> buffer = new Buffer<TElement>(source);
-                int count = buffer.count;
+                Buffer<TElement> buffer = new Buffer<TElement>(_source);
+                int count = buffer._count;
                 if (index < count)
                 {
                     found = true;
-                    return GetEnumerableSorter().ElementAt(buffer.items, count, index);
+                    return GetEnumerableSorter().ElementAt(buffer._items, count, index);
                 }
             }
+
             found = false;
             return default(TElement);
         }
@@ -190,20 +248,25 @@ namespace System.Linq
         public TElement TryGetFirst(out bool found)
         {
             CachingComparer<TElement> comparer = GetComparer();
-            using (IEnumerator<TElement> e = source.GetEnumerator())
+            using (IEnumerator<TElement> e = _source.GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
                     found = false;
                     return default(TElement);
                 }
+
                 TElement value = e.Current;
                 comparer.SetElement(value);
                 while (e.MoveNext())
                 {
                     TElement x = e.Current;
-                    if (comparer.Compare(x, true) < 0) value = x;
+                    if (comparer.Compare(x, true) < 0)
+                    {
+                        value = x;
+                    }
                 }
+
                 found = true;
                 return value;
             }
@@ -212,20 +275,29 @@ namespace System.Linq
         public TElement First(Func<TElement, bool> predicate)
         {
             CachingComparer<TElement> comparer = GetComparer();
-            using (IEnumerator<TElement> e = source.GetEnumerator())
+            using (IEnumerator<TElement> e = _source.GetEnumerator())
             {
                 TElement value;
                 do
                 {
-                    if (!e.MoveNext()) throw Error.NoMatch();
+                    if (!e.MoveNext())
+                    {
+                        throw Error.NoMatch();
+                    }
+
                     value = e.Current;
-                } while (!predicate(value));
+                }
+                while (!predicate(value));
                 comparer.SetElement(value);
                 while (e.MoveNext())
                 {
                     TElement x = e.Current;
-                    if (predicate(x) && comparer.Compare(x, true) < 0) value = x;
+                    if (predicate(x) && comparer.Compare(x, true) < 0)
+                    {
+                        value = x;
+                    }
                 }
+
                 return value;
             }
         }
@@ -233,27 +305,36 @@ namespace System.Linq
         public TElement FirstOrDefault(Func<TElement, bool> predicate)
         {
             CachingComparer<TElement> comparer = GetComparer();
-            using (IEnumerator<TElement> e = source.GetEnumerator())
+            using (IEnumerator<TElement> e = _source.GetEnumerator())
             {
                 TElement value;
                 do
                 {
-                    if (!e.MoveNext()) return default(TElement);
+                    if (!e.MoveNext())
+                    {
+                        return default(TElement);
+                    }
+
                     value = e.Current;
-                } while (!predicate(value));
+                }
+                while (!predicate(value));
                 comparer.SetElement(value);
                 while (e.MoveNext())
                 {
                     TElement x = e.Current;
-                    if (predicate(x) && comparer.Compare(x, true) < 0) value = x;
+                    if (predicate(x) && comparer.Compare(x, true) < 0)
+                    {
+                        value = x;
+                    }
                 }
+
                 return value;
             }
         }
 
         public TElement TryGetLast(out bool found)
         {
-            using (IEnumerator<TElement> e = source.GetEnumerator())
+            using (IEnumerator<TElement> e = _source.GetEnumerator())
             {
                 if (!e.MoveNext())
                 {
@@ -267,8 +348,12 @@ namespace System.Linq
                 while (e.MoveNext())
                 {
                     TElement current = e.Current;
-                    if (comparer.Compare(current, false) >= 0) value = current;
+                    if (comparer.Compare(current, false) >= 0)
+                    {
+                        value = current;
+                    }
                 }
+
                 found = true;
                 return value;
             }
@@ -276,49 +361,63 @@ namespace System.Linq
 
         public TElement TryGetLast(int minIdx, int maxIdx, out bool found)
         {
-            Buffer<TElement> buffer = new Buffer<TElement>(source);
-            int count = buffer.count;
+            Buffer<TElement> buffer = new Buffer<TElement>(_source);
+            int count = buffer._count;
             if (minIdx >= count)
             {
                 found = false;
                 return default(TElement);
             }
+
             found = true;
-            return (maxIdx < count - 1) ? GetEnumerableSorter().ElementAt(buffer.items, count, maxIdx) : Last(buffer);
+            return (maxIdx < count - 1) ? GetEnumerableSorter().ElementAt(buffer._items, count, maxIdx) : Last(buffer);
         }
 
         private TElement Last(Buffer<TElement> buffer)
         {
             CachingComparer<TElement> comparer = GetComparer();
-            TElement[] items = buffer.items;
-            int count = buffer.count;
+            TElement[] items = buffer._items;
+            int count = buffer._count;
             TElement value = items[0];
             comparer.SetElement(value);
             for (int i = 1; i != count; ++i)
             {
                 TElement x = items[i];
-                if (comparer.Compare(x, false) >= 0) value = x;
+                if (comparer.Compare(x, false) >= 0)
+                {
+                    value = x;
+                }
             }
+
             return value;
         }
 
         public TElement Last(Func<TElement, bool> predicate)
         {
             CachingComparer<TElement> comparer = GetComparer();
-            using (IEnumerator<TElement> e = source.GetEnumerator())
+            using (IEnumerator<TElement> e = _source.GetEnumerator())
             {
                 TElement value;
                 do
                 {
-                    if (!e.MoveNext()) throw Error.NoMatch();
+                    if (!e.MoveNext())
+                    {
+                        throw Error.NoMatch();
+                    }
+
                     value = e.Current;
-                } while (!predicate(value));
+                }
+                while (!predicate(value));
                 comparer.SetElement(value);
                 while (e.MoveNext())
                 {
                     TElement x = e.Current;
-                    if (predicate(x) && comparer.Compare(x, false) >= 0) value = x;
+                    if (predicate(x) && comparer.Compare(x, false) >= 0)
+                    {
+                        value = x;
+                    }
                 }
+
                 return value;
             }
         }
@@ -326,20 +425,29 @@ namespace System.Linq
         public TElement LastOrDefault(Func<TElement, bool> predicate)
         {
             CachingComparer<TElement> comparer = GetComparer();
-            using (IEnumerator<TElement> e = source.GetEnumerator())
+            using (IEnumerator<TElement> e = _source.GetEnumerator())
             {
                 TElement value;
                 do
                 {
-                    if (!e.MoveNext()) return default(TElement);
+                    if (!e.MoveNext())
+                    {
+                        return default(TElement);
+                    }
+
                     value = e.Current;
-                } while (!predicate(value));
+                }
+                while (!predicate(value));
                 comparer.SetElement(value);
                 while (e.MoveNext())
                 {
                     TElement x = e.Current;
-                    if (predicate(x) && comparer.Compare(x, false) > 0) value = x;
+                    if (predicate(x) && comparer.Compare(x, false) > 0)
+                    {
+                        value = x;
+                    }
                 }
+
                 return value;
             }
         }
@@ -347,35 +455,47 @@ namespace System.Linq
 
     internal sealed class OrderedEnumerable<TElement, TKey> : OrderedEnumerable<TElement>
     {
-        internal OrderedEnumerable<TElement> parent;
-        internal Func<TElement, TKey> keySelector;
-        internal IComparer<TKey> comparer;
-        internal bool descending;
+        internal OrderedEnumerable<TElement> _parent;
+        internal Func<TElement, TKey> _keySelector;
+        internal IComparer<TKey> _comparer;
+        internal bool _descending;
 
         internal OrderedEnumerable(IEnumerable<TElement> source, Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (keySelector == null) throw Error.ArgumentNull("keySelector");
-            this.source = source;
-            this.parent = null;
-            this.keySelector = keySelector;
-            this.comparer = comparer != null ? comparer : Comparer<TKey>.Default;
-            this.descending = descending;
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (keySelector == null)
+            {
+                throw Error.ArgumentNull("keySelector");
+            }
+
+            _source = source;
+            _parent = null;
+            _keySelector = keySelector;
+            _comparer = comparer ?? Comparer<TKey>.Default;
+            _descending = descending;
         }
 
         internal override EnumerableSorter<TElement> GetEnumerableSorter(EnumerableSorter<TElement> next)
         {
-            EnumerableSorter<TElement> sorter = new EnumerableSorter<TElement, TKey>(keySelector, comparer, descending, next);
-            if (parent != null) sorter = parent.GetEnumerableSorter(sorter);
+            EnumerableSorter<TElement> sorter = new EnumerableSorter<TElement, TKey>(_keySelector, _comparer, _descending, next);
+            if (_parent != null)
+            {
+                sorter = _parent.GetEnumerableSorter(sorter);
+            }
+
             return sorter;
         }
 
         internal override CachingComparer<TElement> GetComparer(CachingComparer<TElement> childComparer)
         {
             CachingComparer<TElement> cmp = childComparer == null
-                ? new CachingComparer<TElement, TKey>(keySelector, comparer, descending)
-                : new CachingComparerWithChild<TElement, TKey>(keySelector, comparer, descending, childComparer);
-            return parent != null ? parent.GetComparer(cmp) : cmp;
+                ? new CachingComparer<TElement, TKey>(_keySelector, _comparer, _descending)
+                : new CachingComparerWithChild<TElement, TKey>(_keySelector, _comparer, _descending, childComparer);
+            return _parent != null ? _parent.GetComparer(cmp) : cmp;
         }
     }
 
@@ -385,54 +505,70 @@ namespace System.Linq
     internal abstract class CachingComparer<TElement>
     {
         internal abstract int Compare(TElement element, bool cacheLower);
+
         internal abstract void SetElement(TElement element);
     }
 
     internal class CachingComparer<TElement, TKey> : CachingComparer<TElement>
     {
-        protected readonly Func<TElement, TKey> KeySelector;
-        protected readonly IComparer<TKey> Comparer;
-        protected readonly bool Descending;
-        protected TKey LastKey;
+        protected readonly Func<TElement, TKey> _keySelector;
+        protected readonly IComparer<TKey> _comparer;
+        protected readonly bool _descending;
+        protected TKey _lastKey;
+
         public CachingComparer(Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending)
         {
-            KeySelector = keySelector;
-            Comparer = comparer;
-            Descending = descending;
+            _keySelector = keySelector;
+            _comparer = comparer;
+            _descending = descending;
         }
+
         internal override int Compare(TElement element, bool cacheLower)
         {
-            TKey newKey = KeySelector(element);
-            int cmp = Descending ? Comparer.Compare(LastKey, newKey) : Comparer.Compare(newKey, LastKey);
-            if (cacheLower == cmp < 0) LastKey = newKey;
+            TKey newKey = _keySelector(element);
+            int cmp = _descending ? _comparer.Compare(_lastKey, newKey) : _comparer.Compare(newKey, _lastKey);
+            if (cacheLower == cmp < 0)
+            {
+                _lastKey = newKey;
+            }
+
             return cmp;
         }
+
         internal override void SetElement(TElement element)
         {
-            LastKey = KeySelector(element);
+            _lastKey = _keySelector(element);
         }
     }
 
     internal sealed class CachingComparerWithChild<TElement, TKey> : CachingComparer<TElement, TKey>
     {
         private readonly CachingComparer<TElement> _child;
+
         public CachingComparerWithChild(Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending, CachingComparer<TElement> child)
             : base(keySelector, comparer, descending)
         {
             _child = child;
         }
+
         internal override int Compare(TElement element, bool cacheLower)
         {
-            TKey newKey = KeySelector(element);
-            int cmp = Descending ? Comparer.Compare(LastKey, newKey) : Comparer.Compare(newKey, LastKey);
-            if (cmp == 0) return _child.Compare(element, cacheLower);
+            TKey newKey = _keySelector(element);
+            int cmp = _descending ? _comparer.Compare(_lastKey, newKey) : _comparer.Compare(newKey, _lastKey);
+            if (cmp == 0)
+            {
+                return _child.Compare(element, cacheLower);
+            }
+
             if (cacheLower == cmp < 0)
             {
-                LastKey = newKey;
+                _lastKey = newKey;
                 _child.SetElement(element);
             }
+
             return cmp;
         }
+
         internal override void SetElement(TElement element)
         {
             base.SetElement(element);
@@ -450,7 +586,11 @@ namespace System.Linq
         {
             ComputeKeys(elements, count);
             int[] map = new int[count];
-            for (int i = 0; i < count; i++) map[i] = i;
+            for (int i = 0; i < count; i++)
+            {
+                map[i] = i;
+            }
+
             return map;
         }
 
@@ -487,33 +627,56 @@ namespace System.Linq
                 int x = map[i + ((j - i) >> 1)];
                 do
                 {
-                    while (i < map.Length && CompareKeys(x, map[i]) > 0) i++;
-                    while (j >= 0 && CompareKeys(x, map[j]) < 0) j--;
-                    if (i > j) break;
+                    while (i < map.Length && CompareKeys(x, map[i]) > 0)
+                    {
+                        i++;
+                    }
+
+                    while (j >= 0 && CompareKeys(x, map[j]) < 0)
+                    {
+                        j--;
+                    }
+
+                    if (i > j)
+                    {
+                        break;
+                    }
+
                     if (i < j)
                     {
                         int temp = map[i];
                         map[i] = map[j];
                         map[j] = temp;
                     }
+
                     i++;
                     j--;
-                } while (i <= j);
+                }
+                while (i <= j);
                 if (j - left <= right - i)
                 {
-                    if (left < j) QuickSort(map, left, j);
+                    if (left < j)
+                    {
+                        QuickSort(map, left, j);
+                    }
+
                     left = i;
                 }
                 else
                 {
-                    if (i < right) QuickSort(map, i, right);
+                    if (i < right)
+                    {
+                        QuickSort(map, i, right);
+                    }
+
                     right = j;
                 }
-            } while (left < right);
+            }
+            while (left < right);
         }
 
         // Sorts the k elements between minIdx and maxIdx without sorting all elements
-        // Time complexity: O(n + k log k) best and average case. O(n^2) worse case.  
+        // Time complexity: O(n + k log k) best and average case. O(n^2) worse case.
         private void PartialQuickSort(int[] map, int left, int right, int minIdx, int maxIdx)
         {
             do
@@ -523,31 +686,61 @@ namespace System.Linq
                 int x = map[i + ((j - i) >> 1)];
                 do
                 {
-                    while (i < map.Length && CompareKeys(x, map[i]) > 0) i++;
-                    while (j >= 0 && CompareKeys(x, map[j]) < 0) j--;
-                    if (i > j) break;
+                    while (i < map.Length && CompareKeys(x, map[i]) > 0)
+                    {
+                        i++;
+                    }
+
+                    while (j >= 0 && CompareKeys(x, map[j]) < 0)
+                    {
+                        j--;
+                    }
+
+                    if (i > j)
+                    {
+                        break;
+                    }
+
                     if (i < j)
                     {
                         int temp = map[i];
                         map[i] = map[j];
                         map[j] = temp;
                     }
+
                     i++;
                     j--;
-                } while (i <= j);
-                if (minIdx >= i) left = i + 1;
-                else if (maxIdx <= j) right = j - 1;
+                }
+                while (i <= j);
+                if (minIdx >= i)
+                {
+                    left = i + 1;
+                }
+                else if (maxIdx <= j)
+                {
+                    right = j - 1;
+                }
+
                 if (j - left <= right - i)
                 {
-                    if (left < j) PartialQuickSort(map, left, j, minIdx, maxIdx);
+                    if (left < j)
+                    {
+                        PartialQuickSort(map, left, j, minIdx, maxIdx);
+                    }
+
                     left = i;
                 }
                 else
                 {
-                    if (i < right) PartialQuickSort(map, i, right, minIdx, maxIdx);
+                    if (i < right)
+                    {
+                        PartialQuickSort(map, i, right, minIdx, maxIdx);
+                    }
+
                     right = j;
                 }
-            } while (left < right);
+            }
+            while (left < right);
         }
 
         // Finds the element that would be at idx if the collection was sorted.
@@ -562,70 +755,112 @@ namespace System.Linq
                 int x = map[i + ((j - i) >> 1)];
                 do
                 {
-                    while (i < map.Length && CompareKeys(x, map[i]) > 0) i++;
-                    while (j >= 0 && CompareKeys(x, map[j]) < 0) j--;
-                    if (i > j) break;
+                    while (i < map.Length && CompareKeys(x, map[i]) > 0)
+                    {
+                        i++;
+                    }
+
+                    while (j >= 0 && CompareKeys(x, map[j]) < 0)
+                    {
+                        j--;
+                    }
+
+                    if (i > j)
+                    {
+                        break;
+                    }
+
                     if (i < j)
                     {
                         int temp = map[i];
                         map[i] = map[j];
                         map[j] = temp;
                     }
+
                     i++;
                     j--;
-                } while (i <= j);
-                if (i <= idx) left = i + 1;
-                else right = j - 1;
+                }
+                while (i <= j);
+                if (i <= idx)
+                {
+                    left = i + 1;
+                }
+                else
+                {
+                    right = j - 1;
+                }
+
                 if (j - left <= right - i)
                 {
-                    if (left < j) right = j;
+                    if (left < j)
+                    {
+                        right = j;
+                    }
+
                     left = i;
                 }
                 else
                 {
-                    if (i < right) left = i;
+                    if (i < right)
+                    {
+                        left = i;
+                    }
+
                     right = j;
                 }
-            } while (left < right);
+            }
+            while (left < right);
             return map[idx];
         }
     }
 
     internal sealed class EnumerableSorter<TElement, TKey> : EnumerableSorter<TElement>
     {
-        internal Func<TElement, TKey> keySelector;
-        internal IComparer<TKey> comparer;
-        internal bool descending;
-        internal EnumerableSorter<TElement> next;
-        internal TKey[] keys;
+        internal Func<TElement, TKey> _keySelector;
+        internal IComparer<TKey> _comparer;
+        internal bool _descending;
+        internal EnumerableSorter<TElement> _next;
+        internal TKey[] _keys;
 
         internal EnumerableSorter(Func<TElement, TKey> keySelector, IComparer<TKey> comparer, bool descending, EnumerableSorter<TElement> next)
         {
-            this.keySelector = keySelector;
-            this.comparer = comparer;
-            this.descending = descending;
-            this.next = next;
+            _keySelector = keySelector;
+            _comparer = comparer;
+            _descending = descending;
+            _next = next;
         }
 
         internal override void ComputeKeys(TElement[] elements, int count)
         {
-            keys = new TKey[count];
-            for (int i = 0; i < count; i++) keys[i] = keySelector(elements[i]);
-            if (next != null) next.ComputeKeys(elements, count);
+            _keys = new TKey[count];
+            for (int i = 0; i < count; i++)
+            {
+                _keys[i] = _keySelector(elements[i]);
+            }
+
+            if (_next != null)
+            {
+                _next.ComputeKeys(elements, count);
+            }
         }
 
         internal override int CompareAnyKeys(int index1, int index2)
         {
-            int c = comparer.Compare(keys[index1], keys[index2]);
+            int c = _comparer.Compare(_keys[index1], _keys[index2]);
             if (c == 0)
             {
-                if (next == null) return index1 - index2;
-                return next.CompareAnyKeys(index1, index2);
+                if (_next == null)
+                {
+                    return index1 - index2;
+                }
+
+                return _next.CompareAnyKeys(index1, index2);
             }
+
             // -c will result in a negative value for int.MinValue (-int.MinValue == int.MinValue).
             // Flipping keys earlier is more likely to trigger something strange in a comparer,
             // particularly as it comes to the sort being stable.
-            return (descending != (c > 0)) ? 1 : -1;
+            return (_descending != (c > 0)) ? 1 : -1;
         }
     }
 }

--- a/src/System.Linq/src/System/Linq/Partition.cs
+++ b/src/System.Linq/src/System/Linq/Partition.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -170,7 +169,11 @@ namespace System.Linq
         public IPartition<TElement> Take(int count)
         {
             int maxIndex = _minIndex + count - 1;
-            if ((uint)maxIndex >= (uint)_maxIndex) maxIndex = _maxIndex;
+            if ((uint)maxIndex >= (uint)_maxIndex)
+            {
+                maxIndex = _maxIndex;
+            }
+
             return new OrderedPartition<TElement>(_source, _minIndex, maxIndex);
         }
 
@@ -238,12 +241,13 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                if ((state == 1 & _index <= _maxIndex) && _index < _source.Count)
+                if ((_state == 1 & _index <= _maxIndex) && _index < _source.Count)
                 {
-                    current = _source[_index];
+                    _current = _source[_index];
                     ++_index;
                     return true;
                 }
+
                 Dispose();
                 return false;
             }
@@ -307,7 +311,11 @@ namespace System.Linq
                 get
                 {
                     int count = _source.Count;
-                    if (count <= _minIndex) return 0;
+                    if (count <= _minIndex)
+                    {
+                        return 0;
+                    }
+
                     return Math.Min(count - 1, _maxIndex) - _minIndex + 1;
                 }
             }
@@ -315,21 +323,35 @@ namespace System.Linq
             public TSource[] ToArray()
             {
                 int count = Count;
-                if (count == 0) return Array.Empty<TSource>();
+                if (count == 0)
+                {
+                    return Array.Empty<TSource>();
+                }
+
                 TSource[] array = new TSource[count];
                 for (int i = 0, curIdx = _minIndex; i != array.Length; ++i, ++curIdx)
+                {
                     array[i] = _source[curIdx];
+                }
+
                 return array;
             }
 
             public List<TSource> ToList()
             {
                 int count = Count;
-                if (count == 0) return new List<TSource>();
+                if (count == 0)
+                {
+                    return new List<TSource>();
+                }
+
                 List<TSource> list = new List<TSource>(count);
                 int end = _minIndex + count;
                 for (int i = _minIndex; i != end; ++i)
+                {
                     list.Add(_source[i]);
+                }
+
                 return list;
             }
 

--- a/src/System.Linq/src/System/Linq/Range.cs
+++ b/src/System.Linq/src/System/Linq/Range.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -13,8 +12,16 @@ namespace System.Linq
         public static IEnumerable<int> Range(int start, int count)
         {
             long max = ((long)start) + count - 1;
-            if (count < 0 || max > Int32.MaxValue) throw Error.ArgumentOutOfRange("count");
-            if (count == 0) return EmptyPartition<int>.Instance;
+            if (count < 0 || max > int.MaxValue)
+            {
+                throw Error.ArgumentOutOfRange("count");
+            }
+
+            if (count == 0)
+            {
+                return EmptyPartition<int>.Instance;
+            }
+
             return new RangeIterator(start, count);
         }
 
@@ -37,24 +44,29 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                switch (state)
+                switch (_state)
                 {
                     case 1:
                         Debug.Assert(_start != _end);
-                        current = _start;
-                        state = 2;
+                        _current = _start;
+                        _state = 2;
                         return true;
                     case 2:
-                        if (++current == _end) break;
+                        if (++_current == _end)
+                        {
+                            break;
+                        }
+
                         return true;
                 }
-                state = -1;
+
+                _state = -1;
                 return false;
             }
 
             public override void Dispose()
             {
-                state = -1; // Don't reset current
+                _state = -1; // Don't reset current
             }
 
             public override IEnumerable<TResult> Select<TResult>(Func<int, TResult> selector)
@@ -93,14 +105,22 @@ namespace System.Linq
 
             public IPartition<int> Skip(int count)
             {
-                if (count >= _end - _start) return EmptyPartition<int>.Instance;
+                if (count >= _end - _start)
+                {
+                    return EmptyPartition<int>.Instance;
+                }
+
                 return new RangeIterator(_start + count, _end - _start - count);
             }
 
             public IPartition<int> Take(int count)
             {
                 int curCount = _end - _start;
-                if (count > curCount) count = curCount;
+                if (count > curCount)
+                {
+                    count = curCount;
+                }
+
                 return new RangeIterator(_start, count);
             }
 

--- a/src/System.Linq/src/System/Linq/Range.cs
+++ b/src/System.Linq/src/System/Linq/Range.cs
@@ -14,7 +14,7 @@ namespace System.Linq
             long max = ((long)start) + count - 1;
             if (count < 0 || max > int.MaxValue)
             {
-                throw Error.ArgumentOutOfRange("count");
+                throw Error.ArgumentOutOfRange(nameof(count));
             }
 
             if (count == 0)

--- a/src/System.Linq/src/System/Linq/Repeat.cs
+++ b/src/System.Linq/src/System/Linq/Repeat.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -12,8 +11,16 @@ namespace System.Linq
     {
         public static IEnumerable<TResult> Repeat<TResult>(TResult element, int count)
         {
-            if (count < 0) throw Error.ArgumentOutOfRange("count");
-            if (count == 0) return EmptyPartition<TResult>.Instance;
+            if (count < 0)
+            {
+                throw Error.ArgumentOutOfRange("count");
+            }
+
+            if (count == 0)
+            {
+                return EmptyPartition<TResult>.Instance;
+            }
+
             return new RepeatIterator<TResult>(element, count);
         }
 
@@ -25,29 +32,30 @@ namespace System.Linq
             public RepeatIterator(TResult element, int count)
             {
                 Debug.Assert(count > 0);
-                current = element;
+                _current = element;
                 _count = count;
             }
 
             public override Iterator<TResult> Clone()
             {
-                return new RepeatIterator<TResult>(current, _count);
+                return new RepeatIterator<TResult>(_current, _count);
             }
 
             public override void Dispose()
             {
                 // Don't let base Dispose wipe current.
-                state = -1;
+                _state = -1;
             }
 
             public override bool MoveNext()
             {
-                if (state == 1 & _sent != _count)
+                if (_state == 1 & _sent != _count)
                 {
                     ++_sent;
                     return true;
                 }
-                state = -1;
+
+                _state = -1;
                 return false;
             }
 
@@ -59,9 +67,12 @@ namespace System.Linq
             public TResult[] ToArray()
             {
                 TResult[] array = new TResult[_count];
-                if (current != null)
+                if (_current != null)
                 {
-                    for (int i = 0; i != array.Length; ++i) array[i] = current;
+                    for (int i = 0; i != array.Length; ++i)
+                    {
+                        array[i] = _current;
+                    }
                 }
 
                 return array;
@@ -70,7 +81,10 @@ namespace System.Linq
             public List<TResult> ToList()
             {
                 List<TResult> list = new List<TResult>(_count);
-                for (int i = 0; i != _count; ++i) list.Add(current);
+                for (int i = 0; i != _count; ++i)
+                {
+                    list.Add(_current);
+                }
 
                 return list;
             }
@@ -82,14 +96,22 @@ namespace System.Linq
 
             public IPartition<TResult> Skip(int count)
             {
-                if (count >= _count) return EmptyPartition<TResult>.Instance;
-                return new RepeatIterator<TResult>(current, _count - count);
+                if (count >= _count)
+                {
+                    return EmptyPartition<TResult>.Instance;
+                }
+
+                return new RepeatIterator<TResult>(_current, _count - count);
             }
 
             public IPartition<TResult> Take(int count)
             {
-                if (count > _count) count = _count;
-                return new RepeatIterator<TResult>(current, count);
+                if (count > _count)
+                {
+                    count = _count;
+                }
+
+                return new RepeatIterator<TResult>(_current, count);
             }
 
             public TResult TryGetElementAt(int index, out bool found)
@@ -97,7 +119,7 @@ namespace System.Linq
                 if ((uint)index < (uint)_count)
                 {
                     found = true;
-                    return current;
+                    return _current;
                 }
 
                 found = false;
@@ -107,13 +129,13 @@ namespace System.Linq
             public TResult TryGetFirst(out bool found)
             {
                 found = true;
-                return current;
+                return _current;
             }
 
             public TResult TryGetLast(out bool found)
             {
                 found = true;
-                return current;
+                return _current;
             }
         }
     }

--- a/src/System.Linq/src/System/Linq/Repeat.cs
+++ b/src/System.Linq/src/System/Linq/Repeat.cs
@@ -13,7 +13,7 @@ namespace System.Linq
         {
             if (count < 0)
             {
-                throw Error.ArgumentOutOfRange("count");
+                throw Error.ArgumentOutOfRange(nameof(count));
             }
 
             if (count == 0)

--- a/src/System.Linq/src/System/Linq/Reverse.cs
+++ b/src/System.Linq/src/System/Linq/Reverse.cs
@@ -14,7 +14,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             return new ReverseIterator<TSource>(source);

--- a/src/System.Linq/src/System/Linq/Reverse.cs
+++ b/src/System.Linq/src/System/Linq/Reverse.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -13,7 +12,11 @@ namespace System.Linq
     {
         public static IEnumerable<TSource> Reverse<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             return new ReverseIterator<TSource>(source);
         }
 
@@ -36,21 +39,22 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                switch (state)
+                switch (_state)
                 {
                     case 1:
                         Buffer<TSource> buffer = new Buffer<TSource>(_source);
-                        _buffer = buffer.items;
-                        _index = buffer.count - 1;
-                        state = 2;
+                        _buffer = buffer._items;
+                        _index = buffer._count - 1;
+                        _state = 2;
                         goto case 2;
                     case 2:
                         if (_index != -1)
                         {
-                            current = _buffer[_index];
+                            _current = _buffer[_index];
                             --_index;
                             return true;
                         }
+
                         break;
                 }
 
@@ -67,6 +71,7 @@ namespace System.Linq
             public TSource[] ToArray()
             {
                 TSource[] array = _source.ToArray();
+
                 // Array.Reverse() involves boxing for non-primitive value types, but
                 // checking that has its own cost, so just use this approach for all types.
                 for (int i = 0, j = array.Length - 1; i < j; ++i, --j)
@@ -75,6 +80,7 @@ namespace System.Linq
                     array[i] = array[j];
                     array[j] = temp;
                 }
+
                 return array;
             }
 
@@ -90,8 +96,15 @@ namespace System.Linq
                 if (onlyIfCheap)
                 {
                     IIListProvider<TSource> listProv = _source as IIListProvider<TSource>;
-                    if (listProv != null) return listProv.GetCount(onlyIfCheap: true);
-                    if (!(_source is ICollection<TSource>) && !(_source is ICollection)) return -1;
+                    if (listProv != null)
+                    {
+                        return listProv.GetCount(onlyIfCheap: true);
+                    }
+
+                    if (!(_source is ICollection<TSource>) && !(_source is ICollection))
+                    {
+                        return -1;
+                    }
                 }
 
                 return _source.Count();

--- a/src/System.Linq/src/System/Linq/Select.cs
+++ b/src/System.Linq/src/System/Linq/Select.cs
@@ -13,12 +13,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             Iterator<TSource> iterator = source as Iterator<TSource>;
@@ -58,12 +58,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             return SelectIterator(source, selector);

--- a/src/System.Linq/src/System/Linq/Select.cs
+++ b/src/System.Linq/src/System/Linq/Select.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -12,28 +11,61 @@ namespace System.Linq
     {
         public static IEnumerable<TResult> Select<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             Iterator<TSource> iterator = source as Iterator<TSource>;
-            if (iterator != null) return iterator.Select(selector);
+            if (iterator != null)
+            {
+                return iterator.Select(selector);
+            }
+
             IList<TSource> ilist = source as IList<TSource>;
             if (ilist != null)
             {
                 TSource[] array = source as TSource[];
-                if (array != null) return new SelectArrayIterator<TSource, TResult>(array, selector);
+                if (array != null)
+                {
+                    return new SelectArrayIterator<TSource, TResult>(array, selector);
+                }
+
                 List<TSource> list = source as List<TSource>;
-                if (list != null) return new SelectListIterator<TSource, TResult>(list, selector);
+                if (list != null)
+                {
+                    return new SelectListIterator<TSource, TResult>(list, selector);
+                }
+
                 return new SelectIListIterator<TSource, TResult>(ilist, selector);
             }
+
             IPartition<TSource> partition = source as IPartition<TSource>;
-            if (partition != null) return new SelectIPartitionIterator<TSource, TResult>(partition, selector);
+            if (partition != null)
+            {
+                return new SelectIPartitionIterator<TSource, TResult>(partition, selector);
+            }
+
             return new SelectEnumerableIterator<TSource, TResult>(source, selector);
         }
 
         public static IEnumerable<TResult> Select<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, int, TResult> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             return SelectIterator(source, selector);
         }
 
@@ -42,7 +74,11 @@ namespace System.Linq
             int index = -1;
             foreach (TSource element in source)
             {
-                checked { index++; }
+                checked
+                {
+                    index++;
+                }
+
                 yield return selector(element, index);
             }
         }
@@ -78,26 +114,29 @@ namespace System.Linq
                     _enumerator.Dispose();
                     _enumerator = null;
                 }
+
                 base.Dispose();
             }
 
             public override bool MoveNext()
             {
-                switch (state)
+                switch (_state)
                 {
                     case 1:
                         _enumerator = _source.GetEnumerator();
-                        state = 2;
+                        _state = 2;
                         goto case 2;
                     case 2:
                         if (_enumerator.MoveNext())
                         {
-                            current = _selector(_enumerator.Current);
+                            _current = _selector(_enumerator.Current);
                             return true;
                         }
+
                         Dispose();
                         break;
                 }
+
                 return false;
             }
 
@@ -128,11 +167,12 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                if (state == 1 && _index < _source.Length)
+                if (_state == 1 && _index < _source.Length)
                 {
-                    current = _selector(_source[_index++]);
+                    _current = _selector(_source[_index++]);
                     return true;
                 }
+
                 Dispose();
                 return false;
             }
@@ -154,6 +194,7 @@ namespace System.Linq
                 {
                     results[i] = _selector(_source[i]);
                 }
+
                 return results;
             }
 
@@ -165,6 +206,7 @@ namespace System.Linq
                 {
                     results.Add(_selector(source[i]));
                 }
+
                 return results;
             }
 
@@ -175,8 +217,16 @@ namespace System.Linq
 
             public IPartition<TResult> Skip(int count)
             {
-                if (count == 0) return (IPartition<TResult>)Clone();
-                if (count >= _source.Length) return EmptyPartition<TResult>.Instance;
+                if (count == 0)
+                {
+                    return (IPartition<TResult>)Clone();
+                }
+
+                if (count >= _source.Length)
+                {
+                    return EmptyPartition<TResult>.Instance;
+                }
+
                 return new SelectListPartitionIterator<TSource, TResult>(_source, _selector, count, int.MaxValue);
             }
 
@@ -244,21 +294,23 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                switch (state)
+                switch (_state)
                 {
                     case 1:
                         _enumerator = _source.GetEnumerator();
-                        state = 2;
+                        _state = 2;
                         goto case 2;
                     case 2:
                         if (_enumerator.MoveNext())
                         {
-                            current = _selector(_enumerator.Current);
+                            _current = _selector(_enumerator.Current);
                             return true;
                         }
+
                         Dispose();
                         break;
                 }
+
                 return false;
             }
 
@@ -280,6 +332,7 @@ namespace System.Linq
                 {
                     results[i] = _selector(_source[i]);
                 }
+
                 return results;
             }
 
@@ -291,6 +344,7 @@ namespace System.Linq
                 {
                     results.Add(_selector(_source[i]));
                 }
+
                 return results;
             }
 
@@ -368,21 +422,23 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                switch (state)
+                switch (_state)
                 {
                     case 1:
                         _enumerator = _source.GetEnumerator();
-                        state = 2;
+                        _state = 2;
                         goto case 2;
                     case 2:
                         if (_enumerator.MoveNext())
                         {
-                            current = _selector(_enumerator.Current);
+                            _current = _selector(_enumerator.Current);
                             return true;
                         }
+
                         Dispose();
                         break;
                 }
+
                 return false;
             }
 
@@ -393,6 +449,7 @@ namespace System.Linq
                     _enumerator.Dispose();
                     _enumerator = null;
                 }
+
                 base.Dispose();
             }
 
@@ -414,6 +471,7 @@ namespace System.Linq
                 {
                     results[i] = _selector(_source[i]);
                 }
+
                 return results;
             }
 
@@ -425,6 +483,7 @@ namespace System.Linq
                 {
                     results.Add(_selector(_source[i]));
                 }
+
                 return results;
             }
 
@@ -502,21 +561,23 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                switch (state)
+                switch (_state)
                 {
                     case 1:
                         _enumerator = _source.GetEnumerator();
-                        state = 2;
+                        _state = 2;
                         goto case 2;
                     case 2:
                         if (_enumerator.MoveNext())
                         {
-                            current = _selector(_enumerator.Current);
+                            _current = _selector(_enumerator.Current);
                             return true;
                         }
+
                         Dispose();
                         break;
                 }
+
                 return false;
             }
 
@@ -527,6 +588,7 @@ namespace System.Linq
                     _enumerator.Dispose();
                     _enumerator = null;
                 }
+
                 base.Dispose();
             }
 
@@ -581,11 +643,12 @@ namespace System.Linq
                     default:
                         TResult[] array = new TResult[count];
                         int index = 0;
-                        foreach(TSource input in _source)
+                        foreach (TSource input in _source)
                         {
                             array[index] = _selector(input);
                             ++index;
                         }
+
                         return array;
                 }
             }
@@ -605,8 +668,11 @@ namespace System.Linq
                         list = new List<TResult>(count);
                         break;
                 }
+
                 foreach (TSource input in _source)
+                {
                     list.Add(_selector(input));
+                }
 
                 return list;
             }
@@ -645,12 +711,13 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                if ((state == 1 & _index <= _maxIndex) && _index < _source.Count)
+                if ((_state == 1 & _index <= _maxIndex) && _index < _source.Count)
                 {
-                    current = _selector(_source[_index]);
+                    _current = _selector(_source[_index]);
                     ++_index;
                     return true;
                 }
+
                 Dispose();
                 return false;
             }
@@ -714,7 +781,11 @@ namespace System.Linq
                 get
                 {
                     int count = _source.Count;
-                    if (count <= _minIndex) return 0;
+                    if (count <= _minIndex)
+                    {
+                        return 0;
+                    }
+
                     return Math.Min(count - 1, _maxIndex) - _minIndex + 1;
                 }
             }
@@ -722,21 +793,35 @@ namespace System.Linq
             public TResult[] ToArray()
             {
                 int count = Count;
-                if (count == 0) return Array.Empty<TResult>();
+                if (count == 0)
+                {
+                    return Array.Empty<TResult>();
+                }
+
                 TResult[] array = new TResult[count];
                 for (int i = 0, curIdx = _minIndex; i != array.Length; ++i, ++curIdx)
+                {
                     array[i] = _selector(_source[curIdx]);
+                }
+
                 return array;
             }
 
             public List<TResult> ToList()
             {
                 int count = Count;
-                if (count == 0) return new List<TResult>();
+                if (count == 0)
+                {
+                    return new List<TResult>();
+                }
+
                 List<TResult> list = new List<TResult>(count);
                 int end = _minIndex + count;
                 for (int i = _minIndex; i != end; ++i)
+                {
                     list.Add(_selector(_source[i]));
+                }
+
                 return list;
             }
 

--- a/src/System.Linq/src/System/Linq/SelectMany.cs
+++ b/src/System.Linq/src/System/Linq/SelectMany.cs
@@ -12,12 +12,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             return SelectManyIterator(source, selector);
@@ -38,12 +38,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             return SelectManyIterator(source, selector);
@@ -70,17 +70,17 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (collectionSelector == null)
             {
-                throw Error.ArgumentNull("collectionSelector");
+                throw Error.ArgumentNull(nameof(collectionSelector));
             }
 
             if (resultSelector == null)
             {
-                throw Error.ArgumentNull("resultSelector");
+                throw Error.ArgumentNull(nameof(resultSelector));
             }
 
             return SelectManyIterator(source, collectionSelector, resultSelector);
@@ -107,17 +107,17 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (collectionSelector == null)
             {
-                throw Error.ArgumentNull("collectionSelector");
+                throw Error.ArgumentNull(nameof(collectionSelector));
             }
 
             if (resultSelector == null)
             {
-                throw Error.ArgumentNull("resultSelector");
+                throw Error.ArgumentNull(nameof(resultSelector));
             }
 
             return SelectManyIterator(source, collectionSelector, resultSelector);

--- a/src/System.Linq/src/System/Linq/SelectMany.cs
+++ b/src/System.Linq/src/System/Linq/SelectMany.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -11,8 +10,16 @@ namespace System.Linq
     {
         public static IEnumerable<TResult> SelectMany<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, IEnumerable<TResult>> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             return SelectManyIterator(source, selector);
         }
 
@@ -29,8 +36,16 @@ namespace System.Linq
 
         public static IEnumerable<TResult> SelectMany<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, int, IEnumerable<TResult>> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             return SelectManyIterator(source, selector);
         }
 
@@ -39,7 +54,11 @@ namespace System.Linq
             int index = -1;
             foreach (TSource element in source)
             {
-                checked { index++; }
+                checked
+                {
+                    index++;
+                }
+
                 foreach (TResult subElement in selector(element, index))
                 {
                     yield return subElement;
@@ -49,9 +68,21 @@ namespace System.Linq
 
         public static IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this IEnumerable<TSource> source, Func<TSource, int, IEnumerable<TCollection>> collectionSelector, Func<TSource, TCollection, TResult> resultSelector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (collectionSelector == null) throw Error.ArgumentNull("collectionSelector");
-            if (resultSelector == null) throw Error.ArgumentNull("resultSelector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (collectionSelector == null)
+            {
+                throw Error.ArgumentNull("collectionSelector");
+            }
+
+            if (resultSelector == null)
+            {
+                throw Error.ArgumentNull("resultSelector");
+            }
+
             return SelectManyIterator(source, collectionSelector, resultSelector);
         }
 
@@ -60,7 +91,11 @@ namespace System.Linq
             int index = -1;
             foreach (TSource element in source)
             {
-                checked { index++; }
+                checked
+                {
+                    index++;
+                }
+
                 foreach (TCollection subElement in collectionSelector(element, index))
                 {
                     yield return resultSelector(element, subElement);
@@ -70,9 +105,21 @@ namespace System.Linq
 
         public static IEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this IEnumerable<TSource> source, Func<TSource, IEnumerable<TCollection>> collectionSelector, Func<TSource, TCollection, TResult> resultSelector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (collectionSelector == null) throw Error.ArgumentNull("collectionSelector");
-            if (resultSelector == null) throw Error.ArgumentNull("resultSelector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (collectionSelector == null)
+            {
+                throw Error.ArgumentNull("collectionSelector");
+            }
+
+            if (resultSelector == null)
+            {
+                throw Error.ArgumentNull("resultSelector");
+            }
+
             return SelectManyIterator(source, collectionSelector, resultSelector);
         }
 

--- a/src/System.Linq/src/System/Linq/SequenceEqual.cs
+++ b/src/System.Linq/src/System/Linq/SequenceEqual.cs
@@ -22,12 +22,12 @@ namespace System.Linq
 
             if (first == null)
             {
-                throw Error.ArgumentNull("first");
+                throw Error.ArgumentNull(nameof(first));
             }
 
             if (second == null)
             {
-                throw Error.ArgumentNull("second");
+                throw Error.ArgumentNull(nameof(second));
             }
 
             ICollection<TSource> firstCol = first as ICollection<TSource>;

--- a/src/System.Linq/src/System/Linq/SequenceEqual.cs
+++ b/src/System.Linq/src/System/Linq/SequenceEqual.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -16,15 +15,29 @@ namespace System.Linq
 
         public static bool SequenceEqual<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second, IEqualityComparer<TSource> comparer)
         {
-            if (comparer == null) comparer = EqualityComparer<TSource>.Default;
-            if (first == null) throw Error.ArgumentNull("first");
-            if (second == null) throw Error.ArgumentNull("second");
+            if (comparer == null)
+            {
+                comparer = EqualityComparer<TSource>.Default;
+            }
+
+            if (first == null)
+            {
+                throw Error.ArgumentNull("first");
+            }
+
+            if (second == null)
+            {
+                throw Error.ArgumentNull("second");
+            }
 
             ICollection<TSource> firstCol = first as ICollection<TSource>;
             if (firstCol != null)
             {
                 ICollection<TSource> secondCol = second as ICollection<TSource>;
-                if (secondCol != null && firstCol.Count != secondCol.Count) return false;
+                if (secondCol != null && firstCol.Count != secondCol.Count)
+                {
+                    return false;
+                }
             }
 
             using (IEnumerator<TSource> e1 = first.GetEnumerator())
@@ -32,8 +45,12 @@ namespace System.Linq
             {
                 while (e1.MoveNext())
                 {
-                    if (!(e2.MoveNext() && comparer.Equals(e1.Current, e2.Current))) return false;
+                    if (!(e2.MoveNext() && comparer.Equals(e1.Current, e2.Current)))
+                    {
+                        return false;
+                    }
                 }
+
                 return !e2.MoveNext();
             }
         }

--- a/src/System.Linq/src/System/Linq/Set.cs
+++ b/src/System.Linq/src/System/Linq/Set.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -10,17 +9,21 @@ namespace System.Linq
 {
     internal class Set<TElement>
     {
+        private readonly IEqualityComparer<TElement> _comparer;
         private int[] _buckets;
         private Slot[] _slots;
         private int _count;
-        private readonly IEqualityComparer<TElement> _comparer;
 #if DEBUG
         private bool _haveRemoved;
 #endif
 
         public Set(IEqualityComparer<TElement> comparer)
         {
-            if (comparer == null) comparer = EqualityComparer<TElement>.Default;
+            if (comparer == null)
+            {
+                comparer = EqualityComparer<TElement>.Default;
+            }
+
             _comparer = comparer;
             _buckets = new int[7];
             _slots = new Slot[7];
@@ -33,17 +36,25 @@ namespace System.Linq
             Debug.Assert(!_haveRemoved, "This class is optimised for never calling Add after Remove. If your changes need to do so, undo that optimization.");
 #endif
             int hashCode = InternalGetHashCode(value);
-            for (int i = _buckets[hashCode % _buckets.Length] - 1; i >= 0; i = _slots[i].next)
+            for (int i = _buckets[hashCode % _buckets.Length] - 1; i >= 0; i = _slots[i]._next)
             {
-                if (_slots[i].hashCode == hashCode && _comparer.Equals(_slots[i].value, value)) return false;
+                if (_slots[i]._hashCode == hashCode && _comparer.Equals(_slots[i]._value, value))
+                {
+                    return false;
+                }
             }
-            if (_count == _slots.Length) Resize();
+
+            if (_count == _slots.Length)
+            {
+                Resize();
+            }
+
             int index = _count;
             _count++;
             int bucket = hashCode % _buckets.Length;
-            _slots[index].hashCode = hashCode;
-            _slots[index].value = value;
-            _slots[index].next = _buckets[bucket] - 1;
+            _slots[index]._hashCode = hashCode;
+            _slots[index]._value = value;
+            _slots[index]._next = _buckets[bucket] - 1;
             _buckets[bucket] = index + 1;
             return true;
         }
@@ -57,39 +68,42 @@ namespace System.Linq
             int hashCode = InternalGetHashCode(value);
             int bucket = hashCode % _buckets.Length;
             int last = -1;
-            for (int i = _buckets[bucket] - 1; i >= 0; last = i, i = _slots[i].next)
+            for (int i = _buckets[bucket] - 1; i >= 0; last = i, i = _slots[i]._next)
             {
-                if (_slots[i].hashCode == hashCode && _comparer.Equals(_slots[i].value, value))
+                if (_slots[i]._hashCode == hashCode && _comparer.Equals(_slots[i]._value, value))
                 {
                     if (last < 0)
                     {
-                        _buckets[bucket] = _slots[i].next + 1;
+                        _buckets[bucket] = _slots[i]._next + 1;
                     }
                     else
                     {
-                        _slots[last].next = _slots[i].next;
+                        _slots[last]._next = _slots[i]._next;
                     }
-                    _slots[i].hashCode = -1;
-                    _slots[i].value = default(TElement);
-                    _slots[i].next = -1;
+
+                    _slots[i]._hashCode = -1;
+                    _slots[i]._value = default(TElement);
+                    _slots[i]._next = -1;
                     return true;
                 }
             }
+
             return false;
         }
 
         private void Resize()
         {
-            int newSize = checked(_count * 2 + 1);
+            int newSize = checked((_count * 2) + 1);
             int[] newBuckets = new int[newSize];
             Slot[] newSlots = new Slot[newSize];
             Array.Copy(_slots, 0, newSlots, 0, _count);
             for (int i = 0; i < _count; i++)
             {
-                int bucket = newSlots[i].hashCode % newSize;
-                newSlots[i].next = newBuckets[bucket] - 1;
+                int bucket = newSlots[i]._hashCode % newSize;
+                newSlots[i]._next = newBuckets[bucket] - 1;
                 newBuckets[bucket] = i + 1;
             }
+
             _buckets = newBuckets;
             _slots = newSlots;
         }
@@ -101,7 +115,10 @@ namespace System.Linq
 #endif
             TElement[] array = new TElement[_count];
             for (int i = 0; i != array.Length; ++i)
-                array[i] = _slots[i].value;
+            {
+                array[i] = _slots[i]._value;
+            }
+
             return array;
         }
 
@@ -113,7 +130,10 @@ namespace System.Linq
             int count = _count;
             List<TElement> list = new List<TElement>(count);
             for (int i = 0; i != count; ++i)
-                list.Add(_slots[i].value);
+            {
+                list.Add(_slots[i]._value);
+            }
+
             return list;
         }
 
@@ -130,9 +150,9 @@ namespace System.Linq
 
         internal struct Slot
         {
-            internal int hashCode;
-            internal int next;
-            internal TElement value;
+            internal int _hashCode;
+            internal int _next;
+            internal TElement _value;
         }
     }
 }

--- a/src/System.Linq/src/System/Linq/Set.cs
+++ b/src/System.Linq/src/System/Linq/Set.cs
@@ -7,7 +7,7 @@ using System.Diagnostics;
 
 namespace System.Linq
 {
-    internal class Set<TElement>
+    internal sealed class Set<TElement>
     {
         private readonly IEqualityComparer<TElement> _comparer;
         private int[] _buckets;
@@ -19,12 +19,7 @@ namespace System.Linq
 
         public Set(IEqualityComparer<TElement> comparer)
         {
-            if (comparer == null)
-            {
-                comparer = EqualityComparer<TElement>.Default;
-            }
-
-            _comparer = comparer;
+            _comparer = comparer ?? EqualityComparer<TElement>.Default;
             _buckets = new int[7];
             _slots = new Slot[7];
         }

--- a/src/System.Linq/src/System/Linq/Single.cs
+++ b/src/System.Linq/src/System/Linq/Single.cs
@@ -12,7 +12,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             IList<TSource> list = source as IList<TSource>;
@@ -48,12 +48,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (predicate == null)
             {
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             }
 
             using (IEnumerator<TSource> e = source.GetEnumerator())
@@ -83,7 +83,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             IList<TSource> list = source as IList<TSource>;
@@ -119,12 +119,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (predicate == null)
             {
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             }
 
             using (IEnumerator<TSource> e = source.GetEnumerator())

--- a/src/System.Linq/src/System/Linq/Single.cs
+++ b/src/System.Linq/src/System/Linq/Single.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -11,7 +10,11 @@ namespace System.Linq
     {
         public static TSource Single<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             IList<TSource> list = source as IList<TSource>;
             if (list != null)
             {
@@ -25,18 +28,34 @@ namespace System.Linq
             {
                 using (IEnumerator<TSource> e = source.GetEnumerator())
                 {
-                    if (!e.MoveNext()) throw Error.NoElements();
+                    if (!e.MoveNext())
+                    {
+                        throw Error.NoElements();
+                    }
+
                     TSource result = e.Current;
-                    if (!e.MoveNext()) return result;
+                    if (!e.MoveNext())
+                    {
+                        return result;
+                    }
                 }
             }
+
             throw Error.MoreThanOneElement();
         }
 
         public static TSource Single<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (predicate == null) throw Error.ArgumentNull("predicate");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (predicate == null)
+            {
+                throw Error.ArgumentNull("predicate");
+            }
+
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 while (e.MoveNext())
@@ -46,18 +65,27 @@ namespace System.Linq
                     {
                         while (e.MoveNext())
                         {
-                            if (predicate(e.Current)) throw Error.MoreThanOneMatch();
+                            if (predicate(e.Current))
+                            {
+                                throw Error.MoreThanOneMatch();
+                            }
                         }
+
                         return result;
                     }
                 }
             }
+
             throw Error.NoMatch();
         }
 
         public static TSource SingleOrDefault<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             IList<TSource> list = source as IList<TSource>;
             if (list != null)
             {
@@ -71,18 +99,34 @@ namespace System.Linq
             {
                 using (IEnumerator<TSource> e = source.GetEnumerator())
                 {
-                    if (!e.MoveNext()) return default(TSource);
+                    if (!e.MoveNext())
+                    {
+                        return default(TSource);
+                    }
+
                     TSource result = e.Current;
-                    if (!e.MoveNext()) return result;
+                    if (!e.MoveNext())
+                    {
+                        return result;
+                    }
                 }
             }
+
             throw Error.MoreThanOneElement();
         }
 
         public static TSource SingleOrDefault<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (predicate == null) throw Error.ArgumentNull("predicate");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (predicate == null)
+            {
+                throw Error.ArgumentNull("predicate");
+            }
+
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
                 while (e.MoveNext())
@@ -92,12 +136,17 @@ namespace System.Linq
                     {
                         while (e.MoveNext())
                         {
-                            if (predicate(e.Current)) throw Error.MoreThanOneMatch();
+                            if (predicate(e.Current))
+                            {
+                                throw Error.MoreThanOneMatch();
+                            }
                         }
+
                         return result;
                     }
                 }
             }
+
             return default(TSource);
         }
     }

--- a/src/System.Linq/src/System/Linq/Skip.cs
+++ b/src/System.Linq/src/System/Linq/Skip.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -11,12 +10,28 @@ namespace System.Linq
     {
         public static IEnumerable<TSource> Skip<TSource>(this IEnumerable<TSource> source, int count)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (count < 0) count = 0;
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (count < 0)
+            {
+                count = 0;
+            }
+
             IPartition<TSource> partition = source as IPartition<TSource>;
-            if (partition != null) return partition.Skip(count);
+            if (partition != null)
+            {
+                return partition.Skip(count);
+            }
+
             IList<TSource> sourceList = source as IList<TSource>;
-            if (sourceList != null) return new ListPartition<TSource>(sourceList, count, int.MaxValue);
+            if (sourceList != null)
+            {
+                return new ListPartition<TSource>(sourceList, count, int.MaxValue);
+            }
+
             return SkipIterator(source, count);
         }
 
@@ -24,18 +39,33 @@ namespace System.Linq
         {
             using (IEnumerator<TSource> e = source.GetEnumerator())
             {
-                while (count > 0 && e.MoveNext()) count--;
+                while (count > 0 && e.MoveNext())
+                {
+                    count--;
+                }
+
                 if (count <= 0)
                 {
-                    while (e.MoveNext()) yield return e.Current;
+                    while (e.MoveNext())
+                    {
+                        yield return e.Current;
+                    }
                 }
             }
         }
 
         public static IEnumerable<TSource> SkipWhile<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (predicate == null) throw Error.ArgumentNull("predicate");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (predicate == null)
+            {
+                throw Error.ArgumentNull("predicate");
+            }
+
             return SkipWhileIterator(source, predicate);
         }
 
@@ -50,7 +80,10 @@ namespace System.Linq
                     {
                         yield return element;
                         while (e.MoveNext())
+                        {
                             yield return e.Current;
+                        }
+
                         yield break;
                     }
                 }
@@ -59,8 +92,16 @@ namespace System.Linq
 
         public static IEnumerable<TSource> SkipWhile<TSource>(this IEnumerable<TSource> source, Func<TSource, int, bool> predicate)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (predicate == null) throw Error.ArgumentNull("predicate");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (predicate == null)
+            {
+                throw Error.ArgumentNull("predicate");
+            }
+
             return SkipWhileIterator(source, predicate);
         }
 
@@ -71,13 +112,20 @@ namespace System.Linq
                 int index = -1;
                 while (e.MoveNext())
                 {
-                    checked { index++; }
+                    checked
+                    {
+                        index++;
+                    }
+
                     TSource element = e.Current;
                     if (!predicate(element, index))
                     {
                         yield return element;
                         while (e.MoveNext())
+                        {
                             yield return e.Current;
+                        }
+
                         yield break;
                     }
                 }

--- a/src/System.Linq/src/System/Linq/Skip.cs
+++ b/src/System.Linq/src/System/Linq/Skip.cs
@@ -12,7 +12,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (count < 0)
@@ -58,12 +58,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (predicate == null)
             {
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             }
 
             return SkipWhileIterator(source, predicate);
@@ -94,12 +94,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (predicate == null)
             {
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             }
 
             return SkipWhileIterator(source, predicate);

--- a/src/System.Linq/src/System/Linq/Sum.cs
+++ b/src/System.Linq/src/System/Linq/Sum.cs
@@ -12,7 +12,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             int sum = 0;
@@ -31,7 +31,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             int sum = 0;
@@ -53,7 +53,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             long sum = 0;
@@ -72,7 +72,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             long sum = 0;
@@ -94,7 +94,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             double sum = 0;
@@ -110,7 +110,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             double sum = 0;
@@ -129,7 +129,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             double sum = 0;
@@ -145,7 +145,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             double sum = 0;
@@ -164,7 +164,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             decimal sum = 0;
@@ -180,7 +180,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             decimal sum = 0;
@@ -199,12 +199,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             int sum = 0;
@@ -223,12 +223,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             int sum = 0;
@@ -251,12 +251,12 @@ namespace System.Linq
         {
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             long sum = 0;
@@ -275,12 +275,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             long sum = 0;
@@ -303,12 +303,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             double sum = 0;
@@ -324,12 +324,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             double sum = 0;
@@ -349,12 +349,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             double sum = 0;
@@ -370,12 +370,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             double sum = 0;
@@ -395,12 +395,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             decimal sum = 0;
@@ -416,12 +416,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (selector == null)
             {
-                throw Error.ArgumentNull("selector");
+                throw Error.ArgumentNull(nameof(selector));
             }
 
             decimal sum = 0;

--- a/src/System.Linq/src/System/Linq/Sum.cs
+++ b/src/System.Linq/src/System/Linq/Sum.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -11,230 +10,430 @@ namespace System.Linq
     {
         public static int Sum(this IEnumerable<int> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             int sum = 0;
             checked
             {
-                foreach (int v in source) sum += v;
+                foreach (int v in source)
+                {
+                    sum += v;
+                }
             }
+
             return sum;
         }
 
         public static int? Sum(this IEnumerable<int?> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             int sum = 0;
             checked
             {
                 foreach (int? v in source)
                 {
-                    if (v != null) sum += v.GetValueOrDefault();
+                    if (v != null)
+                    {
+                        sum += v.GetValueOrDefault();
+                    }
                 }
             }
+
             return sum;
         }
 
         public static long Sum(this IEnumerable<long> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             long sum = 0;
             checked
             {
-                foreach (long v in source) sum += v;
+                foreach (long v in source)
+                {
+                    sum += v;
+                }
             }
+
             return sum;
         }
 
         public static long? Sum(this IEnumerable<long?> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             long sum = 0;
             checked
             {
                 foreach (long? v in source)
                 {
-                    if (v != null) sum += v.GetValueOrDefault();
+                    if (v != null)
+                    {
+                        sum += v.GetValueOrDefault();
+                    }
                 }
             }
+
             return sum;
         }
 
         public static float Sum(this IEnumerable<float> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             double sum = 0;
-            foreach (float v in source) sum += v;
+            foreach (float v in source)
+            {
+                sum += v;
+            }
+
             return (float)sum;
         }
 
         public static float? Sum(this IEnumerable<float?> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             double sum = 0;
             foreach (float? v in source)
             {
-                if (v != null) sum += v.GetValueOrDefault();
+                if (v != null)
+                {
+                    sum += v.GetValueOrDefault();
+                }
             }
+
             return (float)sum;
         }
 
         public static double Sum(this IEnumerable<double> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             double sum = 0;
-            foreach (double v in source) sum += v;
+            foreach (double v in source)
+            {
+                sum += v;
+            }
+
             return sum;
         }
 
         public static double? Sum(this IEnumerable<double?> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             double sum = 0;
             foreach (double? v in source)
             {
-                if (v != null) sum += v.GetValueOrDefault();
+                if (v != null)
+                {
+                    sum += v.GetValueOrDefault();
+                }
             }
+
             return sum;
         }
 
         public static decimal Sum(this IEnumerable<decimal> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             decimal sum = 0;
-            foreach (decimal v in source) sum += v;
+            foreach (decimal v in source)
+            {
+                sum += v;
+            }
+
             return sum;
         }
 
         public static decimal? Sum(this IEnumerable<decimal?> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             decimal sum = 0;
             foreach (decimal? v in source)
             {
-                if (v != null) sum += v.GetValueOrDefault();
+                if (v != null)
+                {
+                    sum += v.GetValueOrDefault();
+                }
             }
+
             return sum;
         }
 
         public static int Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, int> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             int sum = 0;
             checked
             {
-                foreach (TSource item in source) sum += selector(item);
+                foreach (TSource item in source)
+                {
+                    sum += selector(item);
+                }
             }
+
             return sum;
         }
 
         public static int? Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, int?> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             int sum = 0;
             checked
             {
                 foreach (TSource item in source)
                 {
                     int? v = selector(item);
-                    if (v != null) sum += v.GetValueOrDefault();
+                    if (v != null)
+                    {
+                        sum += v.GetValueOrDefault();
+                    }
                 }
             }
+
             return sum;
         }
 
         public static long Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, long> selector)
         {
-            if (selector == null) throw Error.ArgumentNull("selector");
-            if (source == null) throw Error.ArgumentNull("source");
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             long sum = 0;
             checked
             {
-                foreach (TSource item in source) sum += selector(item);
+                foreach (TSource item in source)
+                {
+                    sum += selector(item);
+                }
             }
+
             return sum;
         }
 
         public static long? Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, long?> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             long sum = 0;
             checked
             {
                 foreach (TSource item in source)
                 {
                     long? v = selector(item);
-                    if (v != null) sum += v.GetValueOrDefault();
+                    if (v != null)
+                    {
+                        sum += v.GetValueOrDefault();
+                    }
                 }
             }
+
             return sum;
         }
 
         public static float Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, float> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             double sum = 0;
-            foreach (TSource item in source) sum += selector(item);
+            foreach (TSource item in source)
+            {
+                sum += selector(item);
+            }
+
             return (float)sum;
         }
 
         public static float? Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, float?> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             double sum = 0;
             foreach (TSource item in source)
             {
                 float? v = selector(item);
-                if (v != null) sum += v.GetValueOrDefault();
+                if (v != null)
+                {
+                    sum += v.GetValueOrDefault();
+                }
             }
+
             return (float)sum;
         }
 
         public static double Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, double> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             double sum = 0;
-            foreach (TSource item in source) sum += selector(item);
+            foreach (TSource item in source)
+            {
+                sum += selector(item);
+            }
+
             return sum;
         }
 
         public static double? Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, double?> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             double sum = 0;
             foreach (TSource item in source)
             {
                 double? v = selector(item);
-                if (v != null) sum += v.GetValueOrDefault();
+                if (v != null)
+                {
+                    sum += v.GetValueOrDefault();
+                }
             }
+
             return sum;
         }
 
         public static decimal Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             decimal sum = 0;
-            foreach (TSource item in source) sum += selector(item);
+            foreach (TSource item in source)
+            {
+                sum += selector(item);
+            }
+
             return sum;
         }
 
         public static decimal? Sum<TSource>(this IEnumerable<TSource> source, Func<TSource, decimal?> selector)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (selector == null) throw Error.ArgumentNull("selector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (selector == null)
+            {
+                throw Error.ArgumentNull("selector");
+            }
+
             decimal sum = 0;
             foreach (TSource item in source)
             {
                 decimal? v = selector(item);
-                if (v != null) sum += v.GetValueOrDefault();
+                if (v != null)
+                {
+                    sum += v.GetValueOrDefault();
+                }
             }
+
             return sum;
         }
     }

--- a/src/System.Linq/src/System/Linq/Take.cs
+++ b/src/System.Linq/src/System/Linq/Take.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -11,12 +10,28 @@ namespace System.Linq
     {
         public static IEnumerable<TSource> Take<TSource>(this IEnumerable<TSource> source, int count)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (count <= 0) return EmptyPartition<TSource>.Instance;
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (count <= 0)
+            {
+                return EmptyPartition<TSource>.Instance;
+            }
+
             IPartition<TSource> partition = source as IPartition<TSource>;
-            if (partition != null) return partition.Take(count);
+            if (partition != null)
+            {
+                return partition.Take(count);
+            }
+
             IList<TSource> sourceList = source as IList<TSource>;
-            if (sourceList != null) return new ListPartition<TSource>(sourceList, 0, count - 1);
+            if (sourceList != null)
+            {
+                return new ListPartition<TSource>(sourceList, 0, count - 1);
+            }
+
             return TakeIterator(source, count);
         }
 
@@ -25,14 +40,25 @@ namespace System.Linq
             foreach (TSource element in source)
             {
                 yield return element;
-                if (--count == 0) break;
+                if (--count == 0)
+                {
+                    break;
+                }
             }
         }
 
         public static IEnumerable<TSource> TakeWhile<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (predicate == null) throw Error.ArgumentNull("predicate");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (predicate == null)
+            {
+                throw Error.ArgumentNull("predicate");
+            }
+
             return TakeWhileIterator(source, predicate);
         }
 
@@ -40,15 +66,27 @@ namespace System.Linq
         {
             foreach (TSource element in source)
             {
-                if (!predicate(element)) break;
+                if (!predicate(element))
+                {
+                    break;
+                }
+
                 yield return element;
             }
         }
 
         public static IEnumerable<TSource> TakeWhile<TSource>(this IEnumerable<TSource> source, Func<TSource, int, bool> predicate)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (predicate == null) throw Error.ArgumentNull("predicate");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (predicate == null)
+            {
+                throw Error.ArgumentNull("predicate");
+            }
+
             return TakeWhileIterator(source, predicate);
         }
 
@@ -57,8 +95,16 @@ namespace System.Linq
             int index = -1;
             foreach (TSource element in source)
             {
-                checked { index++; }
-                if (!predicate(element, index)) break;
+                checked
+                {
+                    index++;
+                }
+
+                if (!predicate(element, index))
+                {
+                    break;
+                }
+
                 yield return element;
             }
         }

--- a/src/System.Linq/src/System/Linq/Take.cs
+++ b/src/System.Linq/src/System/Linq/Take.cs
@@ -12,7 +12,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (count <= 0)
@@ -51,12 +51,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (predicate == null)
             {
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             }
 
             return TakeWhileIterator(source, predicate);
@@ -79,12 +79,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (predicate == null)
             {
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             }
 
             return TakeWhileIterator(source, predicate);

--- a/src/System.Linq/src/System/Linq/ToCollection.cs
+++ b/src/System.Linq/src/System/Linq/ToCollection.cs
@@ -12,7 +12,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             IIListProvider<TSource> arrayProvider = source as IIListProvider<TSource>;
@@ -23,7 +23,7 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             IIListProvider<TSource> listProvider = source as IIListProvider<TSource>;
@@ -39,12 +39,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (keySelector == null)
             {
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             }
 
             int capacity = 0;
@@ -110,17 +110,17 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (keySelector == null)
             {
-                throw Error.ArgumentNull("keySelector");
+                throw Error.ArgumentNull(nameof(keySelector));
             }
 
             if (elementSelector == null)
             {
-                throw Error.ArgumentNull("elementSelector");
+                throw Error.ArgumentNull(nameof(elementSelector));
             }
 
             int capacity = 0;

--- a/src/System.Linq/src/System/Linq/ToCollection.cs
+++ b/src/System.Linq/src/System/Linq/ToCollection.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -11,14 +10,22 @@ namespace System.Linq
     {
         public static TSource[] ToArray<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             IIListProvider<TSource> arrayProvider = source as IIListProvider<TSource>;
             return arrayProvider != null ? arrayProvider.ToArray() : EnumerableHelpers.ToArray(source);
         }
 
         public static List<TSource> ToList<TSource>(this IEnumerable<TSource> source)
         {
-            if (source == null) throw Error.ArgumentNull("source");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
             IIListProvider<TSource> listProvider = source as IIListProvider<TSource>;
             return listProvider != null ? listProvider.ToList() : new List<TSource>(source);
         }
@@ -30,8 +37,15 @@ namespace System.Linq
 
         public static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (keySelector == null) throw Error.ArgumentNull("keySelector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (keySelector == null)
+            {
+                throw Error.ArgumentNull("keySelector");
+            }
 
             int capacity = 0;
             ICollection<TSource> collection = source as ICollection<TSource>;
@@ -39,34 +53,53 @@ namespace System.Linq
             {
                 capacity = collection.Count;
                 if (capacity == 0)
+                {
                     return new Dictionary<TKey, TSource>(comparer);
+                }
 
                 TSource[] array = collection as TSource[];
                 if (array != null)
+                {
                     return ToDictionary(array, keySelector, comparer);
+                }
+
                 List<TSource> list = collection as List<TSource>;
                 if (list != null)
+                {
                     return ToDictionary(list, keySelector, comparer);
+                }
             }
 
             Dictionary<TKey, TSource> d = new Dictionary<TKey, TSource>(capacity, comparer);
-            foreach (TSource element in source) d.Add(keySelector(element), element);
+            foreach (TSource element in source)
+            {
+                d.Add(keySelector(element), element);
+            }
+
             return d;
         }
 
         private static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(TSource[] source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
         {
             Dictionary<TKey, TSource> d = new Dictionary<TKey, TSource>(source.Length, comparer);
-            for (int i = 0; i < source.Length; i++) d.Add(keySelector(source[i]), source[i]);
-            return d;
-        }
-        private static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(List<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
-        {
-            Dictionary<TKey, TSource> d = new Dictionary<TKey, TSource>(source.Count, comparer);
-            foreach (TSource element in source) d.Add(keySelector(element), element);
+            for (int i = 0; i < source.Length; i++)
+            {
+                d.Add(keySelector(source[i]), source[i]);
+            }
+
             return d;
         }
 
+        private static Dictionary<TKey, TSource> ToDictionary<TSource, TKey>(List<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
+        {
+            Dictionary<TKey, TSource> d = new Dictionary<TKey, TSource>(source.Count, comparer);
+            foreach (TSource element in source)
+            {
+                d.Add(keySelector(element), element);
+            }
+
+            return d;
+        }
 
         public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector)
         {
@@ -75,9 +108,20 @@ namespace System.Linq
 
         public static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(this IEnumerable<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (keySelector == null) throw Error.ArgumentNull("keySelector");
-            if (elementSelector == null) throw Error.ArgumentNull("elementSelector");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (keySelector == null)
+            {
+                throw Error.ArgumentNull("keySelector");
+            }
+
+            if (elementSelector == null)
+            {
+                throw Error.ArgumentNull("elementSelector");
+            }
 
             int capacity = 0;
             ICollection<TSource> collection = source as ICollection<TSource>;
@@ -85,32 +129,51 @@ namespace System.Linq
             {
                 capacity = collection.Count;
                 if (capacity == 0)
+                {
                     return new Dictionary<TKey, TElement>(comparer);
+                }
 
                 TSource[] array = collection as TSource[];
                 if (array != null)
+                {
                     return ToDictionary(array, keySelector, elementSelector, comparer);
+                }
+
                 List<TSource> list = collection as List<TSource>;
                 if (list != null)
+                {
                     return ToDictionary(list, keySelector, elementSelector, comparer);
+                }
             }
 
             Dictionary<TKey, TElement> d = new Dictionary<TKey, TElement>(capacity, comparer);
-            foreach (TSource element in source) d.Add(keySelector(element), elementSelector(element));
+            foreach (TSource element in source)
+            {
+                d.Add(keySelector(element), elementSelector(element));
+            }
+
             return d;
         }
 
         private static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(TSource[] source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
         {
             Dictionary<TKey, TElement> d = new Dictionary<TKey, TElement>(source.Length, comparer);
-            for (int i = 0; i < source.Length; i++) d.Add(keySelector(source[i]), elementSelector(source[i]));
+            for (int i = 0; i < source.Length; i++)
+            {
+                d.Add(keySelector(source[i]), elementSelector(source[i]));
+            }
+
             return d;
         }
 
         private static Dictionary<TKey, TElement> ToDictionary<TSource, TKey, TElement>(List<TSource> source, Func<TSource, TKey> keySelector, Func<TSource, TElement> elementSelector, IEqualityComparer<TKey> comparer)
         {
             Dictionary<TKey, TElement> d = new Dictionary<TKey, TElement>(source.Count, comparer);
-            foreach (TSource element in source) d.Add(keySelector(element), elementSelector(element));
+            foreach (TSource element in source)
+            {
+                d.Add(keySelector(element), elementSelector(element));
+            }
+
             return d;
         }
     }

--- a/src/System.Linq/src/System/Linq/Union.cs
+++ b/src/System.Linq/src/System/Linq/Union.cs
@@ -18,12 +18,12 @@ namespace System.Linq
         {
             if (first == null)
             {
-                throw Error.ArgumentNull("first");
+                throw Error.ArgumentNull(nameof(first));
             }
 
             if (second == null)
             {
-                throw Error.ArgumentNull("second");
+                throw Error.ArgumentNull(nameof(second));
             }
 
             UnionIterator<TSource> union = first as UnionIterator<TSource>;

--- a/src/System.Linq/src/System/Linq/Union.cs
+++ b/src/System.Linq/src/System/Linq/Union.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -17,17 +16,37 @@ namespace System.Linq
 
         public static IEnumerable<TSource> Union<TSource>(this IEnumerable<TSource> first, IEnumerable<TSource> second, IEqualityComparer<TSource> comparer)
         {
-            if (first == null) throw Error.ArgumentNull("first");
-            if (second == null) throw Error.ArgumentNull("second");
+            if (first == null)
+            {
+                throw Error.ArgumentNull("first");
+            }
+
+            if (second == null)
+            {
+                throw Error.ArgumentNull("second");
+            }
+
             UnionIterator<TSource> union = first as UnionIterator<TSource>;
             return union != null && EquivalentEqualityComparers(comparer, union._comparer) ? union.Union(second) : new UnionIterator2<TSource>(first, second, comparer);
         }
 
         private static bool EquivalentEqualityComparers<TSource>(IEqualityComparer<TSource> x, IEqualityComparer<TSource> y)
         {
-            if (ReferenceEquals(x, y)) return true;
-            if (x == null) return y.Equals(EqualityComparer<TSource>.Default);
-            if (y == null) return x.Equals(EqualityComparer<TSource>.Default);
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
+
+            if (x == null)
+            {
+                return y.Equals(EqualityComparer<TSource>.Default);
+            }
+
+            if (y == null)
+            {
+                return x.Equals(EqualityComparer<TSource>.Default);
+            }
+
             return x.Equals(y);
         }
 
@@ -61,7 +80,9 @@ namespace System.Linq
             protected void SetEnumerator(IEnumerator<TSource> enumerator)
             {
                 if (_enumerator != null)
+                {
                     _enumerator.Dispose();
+                }
 
                 _enumerator = enumerator;
             }
@@ -71,7 +92,7 @@ namespace System.Linq
                 Set<TSource> set = new Set<TSource>(_comparer);
                 TSource element = _enumerator.Current;
                 set.Add(element);
-                current = element;
+                _current = element;
                 _set = set;
             }
 
@@ -83,7 +104,7 @@ namespace System.Linq
                     TSource element = _enumerator.Current;
                     if (set.Add(element))
                     {
-                        current = element;
+                        _current = element;
                         return true;
                     }
                 }
@@ -93,12 +114,12 @@ namespace System.Linq
 
             public sealed override bool MoveNext()
             {
-                if (state == 1)
+                if (_state == 1)
                 {
-                    for (IEnumerable<TSource> enumerable = GetEnumerable(0); enumerable != null; enumerable = GetEnumerable(state - 1))
+                    for (IEnumerable<TSource> enumerable = GetEnumerable(0); enumerable != null; enumerable = GetEnumerable(_state - 1))
                     {
                         IEnumerator<TSource> enumerator = enumerable.GetEnumerator();
-                        ++state;
+                        ++_state;
                         if (enumerator.MoveNext())
                         {
                             SetEnumerator(enumerator);
@@ -107,17 +128,23 @@ namespace System.Linq
                         }
                     }
                 }
-                else if (state > 0)
+                else if (_state > 0)
                 {
-                    for (;;)
+                    while (true)
                     {
                         if (GetNext())
+                        {
                             return true;
-                        IEnumerable<TSource> enumerable = GetEnumerable(state - 1);
+                        }
+
+                        IEnumerable<TSource> enumerable = GetEnumerable(_state - 1);
                         if (enumerable == null)
+                        {
                             break;
+                        }
+
                         SetEnumerator(enumerable.GetEnumerator());
-                        ++state;
+                        ++_state;
                     }
                 }
 
@@ -132,10 +159,14 @@ namespace System.Linq
                 {
                     IEnumerable<TSource> enumerable = GetEnumerable(index);
                     if (enumerable == null)
+                    {
                         return set;
+                    }
 
                     foreach (TSource item in enumerable)
+                    {
                         set.Add(item);
+                    }
                 }
             }
 
@@ -218,7 +249,11 @@ namespace System.Linq
 
             internal override IEnumerable<TSource> GetEnumerable(int index)
             {
-                if (index > _nextIndex) return null;
+                if (index > _nextIndex)
+                {
+                    return null;
+                }
+
                 UnionIteratorN<TSource> union = this;
                 while (index < union._nextIndex)
                 {
@@ -231,6 +266,7 @@ namespace System.Linq
                         return previous.GetEnumerable(index);
                     }
                 }
+
                 return union._next;
             }
 
@@ -243,6 +279,7 @@ namespace System.Linq
                     // So we use the naïve approach of just having a left and right sequence.
                     return new UnionIterator2<TSource>(this, next, _comparer);
                 }
+
                 return new UnionIteratorN<TSource>(this, next, _nextIndex + 1);
             }
         }

--- a/src/System.Linq/src/System/Linq/Where.cs
+++ b/src/System.Linq/src/System/Linq/Where.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -12,21 +11,49 @@ namespace System.Linq
     {
         public static IEnumerable<TSource> Where<TSource>(this IEnumerable<TSource> source, Func<TSource, bool> predicate)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (predicate == null) throw Error.ArgumentNull("predicate");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (predicate == null)
+            {
+                throw Error.ArgumentNull("predicate");
+            }
+
             Iterator<TSource> iterator = source as Iterator<TSource>;
-            if (iterator != null) return iterator.Where(predicate);
+            if (iterator != null)
+            {
+                return iterator.Where(predicate);
+            }
+
             TSource[] array = source as TSource[];
-            if (array != null) return new WhereArrayIterator<TSource>(array, predicate);
+            if (array != null)
+            {
+                return new WhereArrayIterator<TSource>(array, predicate);
+            }
+
             List<TSource> list = source as List<TSource>;
-            if (list != null) return new WhereListIterator<TSource>(list, predicate);
+            if (list != null)
+            {
+                return new WhereListIterator<TSource>(list, predicate);
+            }
+
             return new WhereEnumerableIterator<TSource>(source, predicate);
         }
 
         public static IEnumerable<TSource> Where<TSource>(this IEnumerable<TSource> source, Func<TSource, int, bool> predicate)
         {
-            if (source == null) throw Error.ArgumentNull("source");
-            if (predicate == null) throw Error.ArgumentNull("predicate");
+            if (source == null)
+            {
+                throw Error.ArgumentNull("source");
+            }
+
+            if (predicate == null)
+            {
+                throw Error.ArgumentNull("predicate");
+            }
+
             return WhereIterator(source, predicate);
         }
 
@@ -35,8 +62,15 @@ namespace System.Linq
             int index = -1;
             foreach (TSource element in source)
             {
-                checked { index++; }
-                if (predicate(element, index)) yield return element;
+                checked
+                {
+                    index++;
+                }
+
+                if (predicate(element, index))
+                {
+                    yield return element;
+                }
             }
         }
 
@@ -71,16 +105,17 @@ namespace System.Linq
                     _enumerator.Dispose();
                     _enumerator = null;
                 }
+
                 base.Dispose();
             }
 
             public override bool MoveNext()
             {
-                switch (state)
+                switch (_state)
                 {
                     case 1:
                         _enumerator = _source.GetEnumerator();
-                        state = 2;
+                        _state = 2;
                         goto case 2;
                     case 2:
                         while (_enumerator.MoveNext())
@@ -88,13 +123,15 @@ namespace System.Linq
                             TSource item = _enumerator.Current;
                             if (_predicate(item))
                             {
-                                current = item;
+                                _current = item;
                                 return true;
                             }
                         }
+
                         Dispose();
                         break;
                 }
+
                 return false;
             }
 
@@ -130,7 +167,7 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                if (state == 1)
+                if (_state == 1)
                 {
                     while (_index < _source.Length)
                     {
@@ -138,12 +175,14 @@ namespace System.Linq
                         _index++;
                         if (_predicate(item))
                         {
-                            current = item;
+                            _current = item;
                             return true;
                         }
                     }
+
                     Dispose();
                 }
+
                 return false;
             }
 
@@ -179,11 +218,11 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                switch (state)
+                switch (_state)
                 {
                     case 1:
                         _enumerator = _source.GetEnumerator();
-                        state = 2;
+                        _state = 2;
                         goto case 2;
                     case 2:
                         while (_enumerator.MoveNext())
@@ -191,13 +230,15 @@ namespace System.Linq
                             TSource item = _enumerator.Current;
                             if (_predicate(item))
                             {
-                                current = item;
+                                _current = item;
                                 return true;
                             }
                         }
+
                         Dispose();
                         break;
                 }
+
                 return false;
             }
 
@@ -236,7 +277,7 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                if (state == 1)
+                if (_state == 1)
                 {
                     while (_index < _source.Length)
                     {
@@ -244,12 +285,14 @@ namespace System.Linq
                         _index++;
                         if (_predicate(item))
                         {
-                            current = _selector(item);
+                            _current = _selector(item);
                             return true;
                         }
                     }
+
                     Dispose();
                 }
+
                 return false;
             }
 
@@ -283,11 +326,11 @@ namespace System.Linq
 
             public override bool MoveNext()
             {
-                switch (state)
+                switch (_state)
                 {
                     case 1:
                         _enumerator = _source.GetEnumerator();
-                        state = 2;
+                        _state = 2;
                         goto case 2;
                     case 2:
                         while (_enumerator.MoveNext())
@@ -295,13 +338,15 @@ namespace System.Linq
                             TSource item = _enumerator.Current;
                             if (_predicate(item))
                             {
-                                current = _selector(item);
+                                _current = _selector(item);
                                 return true;
                             }
                         }
+
                         Dispose();
                         break;
                 }
+
                 return false;
             }
 
@@ -340,16 +385,17 @@ namespace System.Linq
                     _enumerator.Dispose();
                     _enumerator = null;
                 }
+
                 base.Dispose();
             }
 
             public override bool MoveNext()
             {
-                switch (state)
+                switch (_state)
                 {
                     case 1:
                         _enumerator = _source.GetEnumerator();
-                        state = 2;
+                        _state = 2;
                         goto case 2;
                     case 2:
                         while (_enumerator.MoveNext())
@@ -357,13 +403,15 @@ namespace System.Linq
                             TSource item = _enumerator.Current;
                             if (_predicate(item))
                             {
-                                current = _selector(item);
+                                _current = _selector(item);
                                 return true;
                             }
                         }
+
                         Dispose();
                         break;
                 }
+
                 return false;
             }
 

--- a/src/System.Linq/src/System/Linq/Where.cs
+++ b/src/System.Linq/src/System/Linq/Where.cs
@@ -13,12 +13,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (predicate == null)
             {
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             }
 
             Iterator<TSource> iterator = source as Iterator<TSource>;
@@ -46,12 +46,12 @@ namespace System.Linq
         {
             if (source == null)
             {
-                throw Error.ArgumentNull("source");
+                throw Error.ArgumentNull(nameof(source));
             }
 
             if (predicate == null)
             {
-                throw Error.ArgumentNull("predicate");
+                throw Error.ArgumentNull(nameof(predicate));
             }
 
             return WhereIterator(source, predicate);

--- a/src/System.Linq/src/System/Linq/Where.cs
+++ b/src/System.Linq/src/System/Linq/Where.cs
@@ -79,7 +79,7 @@ namespace System.Linq
             return x => predicate1(x) && predicate2(x);
         }
 
-        internal class WhereEnumerableIterator<TSource> : Iterator<TSource>
+        internal sealed class WhereEnumerableIterator<TSource> : Iterator<TSource>
         {
             private readonly IEnumerable<TSource> _source;
             private readonly Func<TSource, bool> _predicate;
@@ -146,7 +146,7 @@ namespace System.Linq
             }
         }
 
-        internal class WhereArrayIterator<TSource> : Iterator<TSource>
+        internal sealed class WhereArrayIterator<TSource> : Iterator<TSource>
         {
             private readonly TSource[] _source;
             private readonly Func<TSource, bool> _predicate;
@@ -197,7 +197,7 @@ namespace System.Linq
             }
         }
 
-        internal class WhereListIterator<TSource> : Iterator<TSource>
+        internal sealed class WhereListIterator<TSource> : Iterator<TSource>
         {
             private readonly List<TSource> _source;
             private readonly Func<TSource, bool> _predicate;
@@ -253,7 +253,7 @@ namespace System.Linq
             }
         }
 
-        internal class WhereSelectArrayIterator<TSource, TResult> : Iterator<TResult>
+        internal sealed class WhereSelectArrayIterator<TSource, TResult> : Iterator<TResult>
         {
             private readonly TSource[] _source;
             private readonly Func<TSource, bool> _predicate;
@@ -302,7 +302,7 @@ namespace System.Linq
             }
         }
 
-        internal class WhereSelectListIterator<TSource, TResult> : Iterator<TResult>
+        internal sealed class WhereSelectListIterator<TSource, TResult> : Iterator<TResult>
         {
             private readonly List<TSource> _source;
             private readonly Func<TSource, bool> _predicate;
@@ -356,7 +356,7 @@ namespace System.Linq
             }
         }
 
-        internal class WhereSelectEnumerableIterator<TSource, TResult> : Iterator<TResult>
+        internal sealed class WhereSelectEnumerableIterator<TSource, TResult> : Iterator<TResult>
         {
             private readonly IEnumerable<TSource> _source;
             private readonly Func<TSource, bool> _predicate;

--- a/src/System.Linq/src/System/Linq/Zip.cs
+++ b/src/System.Linq/src/System/Linq/Zip.cs
@@ -12,17 +12,17 @@ namespace System.Linq
         {
             if (first == null)
             {
-                throw Error.ArgumentNull("first");
+                throw Error.ArgumentNull(nameof(first));
             }
 
             if (second == null)
             {
-                throw Error.ArgumentNull("second");
+                throw Error.ArgumentNull(nameof(second));
             }
 
             if (resultSelector == null)
             {
-                throw Error.ArgumentNull("resultSelector");
+                throw Error.ArgumentNull(nameof(resultSelector));
             }
 
             return ZipIterator(first, second, resultSelector);

--- a/src/System.Linq/src/System/Linq/Zip.cs
+++ b/src/System.Linq/src/System/Linq/Zip.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 
 namespace System.Linq
@@ -11,9 +10,21 @@ namespace System.Linq
     {
         public static IEnumerable<TResult> Zip<TFirst, TSecond, TResult>(this IEnumerable<TFirst> first, IEnumerable<TSecond> second, Func<TFirst, TSecond, TResult> resultSelector)
         {
-            if (first == null) throw Error.ArgumentNull("first");
-            if (second == null) throw Error.ArgumentNull("second");
-            if (resultSelector == null) throw Error.ArgumentNull("resultSelector");
+            if (first == null)
+            {
+                throw Error.ArgumentNull("first");
+            }
+
+            if (second == null)
+            {
+                throw Error.ArgumentNull("second");
+            }
+
+            if (resultSelector == null)
+            {
+                throw Error.ArgumentNull("resultSelector");
+            }
+
             return ZipIterator(first, second, resultSelector);
         }
 
@@ -21,8 +32,12 @@ namespace System.Linq
         {
             using (IEnumerator<TFirst> e1 = first.GetEnumerator())
             using (IEnumerator<TSecond> e2 = second.GetEnumerator())
+            {
                 while (e1.MoveNext() && e2.MoveNext())
+                {
                     yield return resultSelector(e1.Current, e2.Current);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Almost entirely automated formatting of LINQ code, via VS refactorings (e.g. renaming fields to follow corefx naming guidelines), StyleCop rules (e.g. using braces in many more places), and CodeFormatter (e.g. inserting blank lines in various places, adding readonly in several places).  Also changed Error.* calls to use nameof.

cc: @VSadov, @JonHanna 
Contributes to #6150