### PR TITLE
Fix a bunch of Xml OuterLoop test failures on Unix

### DIFF
--- a/src/System.Xml.ReaderWriter/src/System/Xml/Core/NewLineHandling.cs
+++ b/src/System.Xml.ReaderWriter/src/System/Xml/Core/NewLineHandling.cs
@@ -5,7 +5,7 @@
 namespace System.Xml
 {
     // NewLineHandling speficies what will XmlWriter do with new line characters. The options are:
-    //  Replace  = Replaces all new line characters with XmlWriterSettings.NewLineChars so all new lines are the same; by default NewLineChars are "\r\n"
+    //  Replace  = Replaces all new line characters with XmlWriterSettings.NewLineChars so all new lines are the same; by default NewLineChars == Environment.NewLine
     //  Entitize = Replaces all new line characters that would be normalized away by a normalizing XmlReader with character entities
     //  None     = Does not change the new line characters in input
     //

--- a/src/System.Xml.ReaderWriter/tests/Readers/NameTable/XmlNameTable.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/NameTable/XmlNameTable.cs
@@ -29,7 +29,7 @@ namespace System.Xml.Tests
         {
             int ret = base.Init(objParam);
 
-            _TestData = Path.Combine(FilePathUtil.GetTestDataPath(), @"XmlReader\");
+            _TestData = Path.Combine(FilePathUtil.GetTestDataPath(), @"XmlReader");
 
             // Create global usage test files
             string strFile = String.Empty;

--- a/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/MaxSettings.cs
+++ b/src/System.Xml.ReaderWriter/tests/Readers/ReaderSettings/MaxSettings.cs
@@ -397,7 +397,7 @@ namespace System.Xml.Tests
             return TEST_FAIL;
         }
 
-        private string _xml = @"<!DOCTYPE r [<!ENTITY e SYSTEM '" + Path.Combine(FilePathUtil.GetTestDataPath(), @"XmlReader\ent.ent") + @"'>]><r>&e;</r>";
+        private string _xml = @"<!DOCTYPE r [<!ENTITY e SYSTEM '" + Path.Combine(FilePathUtil.GetTestDataPath(), "XmlReader", "ent.ent") + @"'>]><r>&e;</r>";
     }
 }
 

--- a/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/CRWFactory.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/RwFactory/CRWFactory.cs
@@ -27,7 +27,7 @@ namespace System.Xml.Tests
         {
             int ret = base.Init(o);
 
-            _testData = Path.Combine(FilePathUtil.GetTestDataPath(), @"XmlReader\");
+            _testData = Path.Combine(FilePathUtil.GetTestDataPath(), @"XmlReader");
 
             return ret;
         }

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCXmlWriterTestModule.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/TCXmlWriterTestModule.cs
@@ -105,6 +105,7 @@ namespace System.Xml.Tests
 
         [Fact]
         [OuterLoop]
+        [ActiveIssue(6331)]
         static public void TCEOFHandling()
         {
             RunTest(() => new TCEOFHandling() { Attribute = new TestCase() { Name = "XmlWriterSettings: NewLineHandling" } });

--- a/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/XmlFactoryWriterTests.cs
+++ b/src/System.Xml.ReaderWriter/tests/Writers/XmlWriterApi/XmlFactoryWriterTests.cs
@@ -1044,7 +1044,7 @@ namespace System.Xml.Tests
             w.WriteString("\r");
             w.WriteEndElement();
             w.Dispose();
-            return CompareString("<root>\xD\xA</root>") ? TEST_PASS : TEST_FAIL;
+            return CompareString("<root>" + w.Settings.NewLineChars + "</root>") ? TEST_PASS : TEST_FAIL;
         }
 
         //[Variation(id=2, Desc="Test for LF (xA) inside element when NewLineHandling = Replace", Pri=0)]
@@ -1055,7 +1055,7 @@ namespace System.Xml.Tests
             w.WriteString("\n");
             w.WriteEndElement();
             w.Dispose();
-            return CompareString("<root>\xD\xA</root>") ? TEST_PASS : TEST_FAIL;
+            return CompareString("<root>" + w.Settings.NewLineChars + "</root>") ? TEST_PASS : TEST_FAIL;
         }
 
         //[Variation(id=3, Desc="Test for CR LF (xD xA) inside element when NewLineHandling = Replace", Pri=0)]
@@ -1066,7 +1066,7 @@ namespace System.Xml.Tests
             w.WriteString("\r\n");
             w.WriteEndElement();
             w.Dispose();
-            return CompareString("<root>\xD\xA</root>") ? TEST_PASS : TEST_FAIL;
+            return CompareString("<root>" + w.Settings.NewLineChars + "</root>") ? TEST_PASS : TEST_FAIL;
         }
 
         //[Variation(id=4, Desc="Test for CR (xD) inside element when NewLineHandling = Entitize", Pri=0)]
@@ -1393,7 +1393,7 @@ namespace System.Xml.Tests
             w.WriteEndElement();
             w.WriteEndElement();
             w.Dispose();
-            return CompareString("<Root>\xD\xA  <child />\xD\xA</Root>") ? TEST_PASS : TEST_FAIL;
+            return CompareString("<Root>" + wSettings.NewLineChars + "  <child />" + wSettings.NewLineChars + "</Root>") ? TEST_PASS : TEST_FAIL;
         }
 
         //[Variation(id=3, Desc="Indent = false, element content is empty", Pri=0)]
@@ -1498,7 +1498,7 @@ namespace System.Xml.Tests
             w.WriteElementString("foo", "");
             w.WriteEndElement();
             w.Dispose();
-            CError.Compare(CompareString("<?xml version=\"1.0\"?>\xD\xA<!DOCTYPE root [foo]>\xD\xA<root>\xD\xA  <?pi pi?>\xD\xA  <!--comment-->\xD\xA  <foo />\xD\xA</root>"), "");
+            CError.Compare(CompareString("<?xml version=\"1.0\"?>" + wSettings.NewLineChars + "<!DOCTYPE root [foo]>" + wSettings.NewLineChars + "<root>" + wSettings.NewLineChars + "  <?pi pi?>" + wSettings.NewLineChars + "  <!--comment-->" + wSettings.NewLineChars + "  <foo />" + wSettings.NewLineChars + "</root>"), "");
             return TEST_PASS;
         }
 
@@ -1520,7 +1520,7 @@ namespace System.Xml.Tests
             w.WriteStartElement("foo");
             w.WriteElementString("bar", "text2");
             w.Dispose();
-            CError.Compare(CompareString("<master>\xD\xA  <root>\xD\xA    <foo>text</foo>\xD\xA  </root>text<foo><bar>text2</bar></foo></master>"), "");
+            CError.Compare(CompareString("<master>" + wSettings.NewLineChars + "  <root>" + wSettings.NewLineChars + "    <foo>text</foo>" + wSettings.NewLineChars + "  </root>text<foo><bar>text2</bar></foo></master>"), "");
             return TEST_PASS;
         }
 
@@ -1606,7 +1606,7 @@ namespace System.Xml.Tests
             w.WriteStartElement("e4");
             w.WriteEndDocument();
             w.Dispose();
-            CError.Compare(CompareString("<e1>\xD\xA  <e2>\xD\xA    <e3>\xD\xA      <e4 />\xD\xA    </e3>\xD\xA  </e2>\xD\xA</e1>"), "");
+            CError.Compare(CompareString("<e1>" + wSettings.NewLineChars + "  <e2>" + wSettings.NewLineChars + "    <e3>" + wSettings.NewLineChars + "      <e4 />" + wSettings.NewLineChars + "    </e3>" + wSettings.NewLineChars + "  </e2>" + wSettings.NewLineChars + "</e1>"), "");
             return TEST_PASS;
         }
 
@@ -1627,7 +1627,7 @@ namespace System.Xml.Tests
             w.WriteEndElement();
             w.WriteEndElement();
             w.Dispose();
-            CError.Compare(CompareString("<e1>\xD\xA  <e2>\xD\xA    <e3>\xD\xA      <e4 />\xD\xA    </e3>\xD\xA  </e2>\xD\xA</e1>"), "");
+            CError.Compare(CompareString("<e1>" + wSettings.NewLineChars + "  <e2>" + wSettings.NewLineChars + "    <e3>" + wSettings.NewLineChars + "      <e4 />" + wSettings.NewLineChars + "    </e3>" + wSettings.NewLineChars + "  </e2>" + wSettings.NewLineChars + "</e1>"), "");
             return TEST_PASS;
         }
 
@@ -1648,7 +1648,7 @@ namespace System.Xml.Tests
             w.WriteFullEndElement();
             w.WriteFullEndElement();
             w.Dispose();
-            CError.Compare(CompareString("<e1>\xD\xA  <e2>\xD\xA    <e3>\xD\xA      <e4></e4>\xD\xA    </e3>\xD\xA  </e2>\xD\xA</e1>"), "");
+            CError.Compare(CompareString("<e1>" + wSettings.NewLineChars + "  <e2>" + wSettings.NewLineChars + "    <e3>" + wSettings.NewLineChars + "      <e4></e4>" + wSettings.NewLineChars + "    </e3>" + wSettings.NewLineChars + "  </e2>" + wSettings.NewLineChars + "</e1>"), "");
             return TEST_PASS;
         }
 
@@ -1667,7 +1667,7 @@ namespace System.Xml.Tests
             w.WriteComment("c");
             w.WriteProcessingInstruction("pi", "pi");
             w.Dispose();
-            CError.Compare(CompareString("<root />\xD\xA<!--c-->\xD\xA<?pi pi?>  <!--c--><?pi pi?>"), "");
+            CError.Compare(CompareString("<root />" + wSettings.NewLineChars + "<!--c-->" + wSettings.NewLineChars + "<?pi pi?>  <!--c--><?pi pi?>"), "");
             return TEST_PASS;
         }
 
@@ -1685,7 +1685,7 @@ namespace System.Xml.Tests
             w.WriteAttributeString("a2", "value");
             w.WriteEndDocument();
             w.Dispose();
-            CError.Compare(CompareString("<root a1=\"value\">\xD\xA  <foo a2=\"value\" />\xD\xA</root>"), "");
+            CError.Compare(CompareString("<root a1=\"value\">" + wSettings.NewLineChars + "  <foo a2=\"value\" />" + wSettings.NewLineChars + "</root>"), "");
             return TEST_PASS;
         }
 
@@ -1701,7 +1701,7 @@ namespace System.Xml.Tests
             w.WriteProcessingInstruction("pi", "value");
             w.WriteStartElement("root");
             w.Dispose();
-            CError.Compare(CompareString("<?pi value?>\xD\xA<root />"), "");
+            CError.Compare(CompareString("<?pi value?>" + wSettings.NewLineChars + "<root />"), "");
             return TEST_PASS;
         }
 
@@ -1717,7 +1717,7 @@ namespace System.Xml.Tests
             w.WriteComment("value");
             w.WriteStartElement("root");
             w.Dispose();
-            CError.Compare(CompareString("<!--value-->\xD\xA<root />"), "");
+            CError.Compare(CompareString("<!--value-->" + wSettings.NewLineChars + "<root />"), "");
             return TEST_PASS;
         }
 
@@ -1779,7 +1779,7 @@ namespace System.Xml.Tests
                 w.WriteString("text");
                 w.WriteStartElement("a");
             }
-            CError.Compare(CompareString("<root>\xD\xA  <child>\xD\xA    <a />text<a /></child>\xD\xA</root>"), "");
+            CError.Compare(CompareString("<root>" + wSettings.NewLineChars + "  <child>" + wSettings.NewLineChars + "    <a />text<a /></child>" + wSettings.NewLineChars + "</root>"), "");
             return TEST_PASS;
         }
 
@@ -1841,7 +1841,7 @@ namespace System.Xml.Tests
                 }
                 w.WriteStartElement("root");
                 w.Dispose();
-                string expectedResult = string.Format("<?xml version=\"1.0\" encoding=\"{0}\"?>\xD\xA<root />", encoding.WebName);
+                string expectedResult = string.Format("<?xml version=\"1.0\" encoding=\"{0}\"?>" + wSettings.NewLineChars + "<root />", encoding.WebName);
                 CError.Compare(CompareString(expectedResult), "");
             }
             return TEST_PASS;
@@ -1867,7 +1867,7 @@ namespace System.Xml.Tests
                 w.WriteEndElement();
                 w.WriteEndElement();
             }
-            CError.Compare(CompareString("<root>\xD\xA  <e1>\xD\xA    <e2 />text</e1>\xD\xA</root>"), "");
+            CError.Compare(CompareString("<root>" + wSettings.NewLineChars + "  <e1>" + wSettings.NewLineChars + "    <e2 />text</e1>" + wSettings.NewLineChars + "</root>"), "");
             return TEST_PASS;
         }
 
@@ -1887,7 +1887,7 @@ namespace System.Xml.Tests
                 w.WriteStartElement("root");
                 w.WriteEndElement();
             }
-            CError.Compare(CompareString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\xD\xA<?piname1 pitext1?>\xD\xA<?piname2 pitext2?>\xD\xA<root />"), "");
+            CError.Compare(CompareString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + wSettings.NewLineChars + "<?piname1 pitext1?>" + wSettings.NewLineChars + "<?piname2 pitext2?>" + wSettings.NewLineChars + "<root />"), "");
             return TEST_PASS;
         }
 
@@ -1907,7 +1907,7 @@ namespace System.Xml.Tests
                 w.WriteProcessingInstruction("piname2", "pitext2");
                 w.WriteStartElement("root");
             }
-            CError.Compare(CompareString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\xD\xA<!DOCTYPE name PUBLIC \"publicid\" \"systemid\"[subset]>\xD\xA<?piname1 pitext1?>\xD\xA<?piname2 pitext2?>\xD\xA<root />"), "");
+            CError.Compare(CompareString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + wSettings.NewLineChars + "<!DOCTYPE name PUBLIC \"publicid\" \"systemid\"[subset]>" + wSettings.NewLineChars + "<?piname1 pitext1?>" + wSettings.NewLineChars + "<?piname2 pitext2?>" + wSettings.NewLineChars + "<root />"), "");
             return TEST_PASS;
         }
 
@@ -1945,7 +1945,7 @@ namespace System.Xml.Tests
                 w.WriteEndElement();
                 w.WriteEndElement();
             }
-            CError.Compare(CompareString("<?piname1 pitext1?>\xD\xA<!--comment1-->\xD\xA<?piname2 pitext2?>\xD\xA<root>\xD\xA  <e1>\xD\xA    <e2>\xD\xA      <e3>\xD\xA        <e4 />text1<?piname3 pitext3?></e3>\xD\xA      <!--comment2--><![CDATA[cdata1]]>text2<?piname4 pitext4?><![CDATA[cdata2]]><!--comment3--><?piname5 pitext5?></e2>\xD\xA  </e1>\xD\xA</root>"), "");
+            CError.Compare(CompareString("<?piname1 pitext1?>" + wSettings.NewLineChars + "<!--comment1-->" + wSettings.NewLineChars + "<?piname2 pitext2?>" + wSettings.NewLineChars + "<root>" + wSettings.NewLineChars + "  <e1>" + wSettings.NewLineChars + "    <e2>" + wSettings.NewLineChars + "      <e3>" + wSettings.NewLineChars + "        <e4 />text1<?piname3 pitext3?></e3>" + wSettings.NewLineChars + "      <!--comment2--><![CDATA[cdata1]]>text2<?piname4 pitext4?><![CDATA[cdata2]]><!--comment3--><?piname5 pitext5?></e2>" + wSettings.NewLineChars + "  </e1>" + wSettings.NewLineChars + "</root>"), "");
             return TEST_PASS;
         }
     }
@@ -1980,7 +1980,7 @@ namespace System.Xml.Tests
             w.WriteEndElement();
             w.Dispose();
 
-            return CompareString("<root>\xD\xA\x9<child />\xD\xA</root>") ? TEST_PASS : TEST_FAIL;
+            return CompareString("<root>" + wSettings.NewLineChars + "\x9<child />" + wSettings.NewLineChars + "</root>") ? TEST_PASS : TEST_FAIL;
         }
 
         //[Variation(id=2, Desc="Set to multiple whitespace chars", Pri=0)]
@@ -1999,7 +1999,7 @@ namespace System.Xml.Tests
             w.WriteEndElement();
             w.Dispose();
 
-            return CompareString("<root>\xD\xA     <child />\xD\xA</root>") ? TEST_PASS : TEST_FAIL;
+            return CompareString("<root>" + wSettings.NewLineChars + "     <child />" + wSettings.NewLineChars + "</root>") ? TEST_PASS : TEST_FAIL;
         }
 
         //[Variation(id=3, Desc="Set to 0xA", Pri=0)]
@@ -2018,7 +2018,7 @@ namespace System.Xml.Tests
             w.WriteEndElement();
             w.Dispose();
 
-            return CompareString("<root>\xD\xA\xA<child />\xD\xA</root>") ? TEST_PASS : TEST_FAIL;
+            return CompareString("<root>" + wSettings.NewLineChars + "\xA<child />" + wSettings.NewLineChars + "</root>") ? TEST_PASS : TEST_FAIL;
         }
 
         //[Variation(id=4, Desc="Set to 0xD", Pri=0)]
@@ -2037,7 +2037,7 @@ namespace System.Xml.Tests
             w.WriteEndElement();
             w.Dispose();
 
-            return CompareString("<root>\xD\xA\xD<child />\xD\xA</root>") ? TEST_PASS : TEST_FAIL;
+            return CompareString("<root>" + wSettings.NewLineChars + "\xD<child />" + wSettings.NewLineChars + "</root>") ? TEST_PASS : TEST_FAIL;
         }
 
         //[Variation(id=5, Desc="Set to 0x20", Pri=0)]
@@ -2056,7 +2056,7 @@ namespace System.Xml.Tests
             w.WriteEndElement();
             w.Dispose();
 
-            return CompareString("<root>\xD\xA\x20<child />\xD\xA</root>") ? TEST_PASS : TEST_FAIL;
+            return CompareString("<root>" + wSettings.NewLineChars + "\x20<child />" + wSettings.NewLineChars + "</root>") ? TEST_PASS : TEST_FAIL;
         }
 
         //[Variation(id=6, Desc="Set to element start tag", Pri=1, Param="<")]
@@ -2134,7 +2134,7 @@ namespace System.Xml.Tests
             w.WriteEndElement();
             w.Dispose();
 
-            return CompareString("<root\xD\xA  attr1=\"value1\"\xD\xA  attr2=\"value2\" />") ? TEST_PASS : TEST_FAIL;
+            return CompareString("<root" + wSettings.NewLineChars + "  attr1=\"value1\"" + wSettings.NewLineChars + "  attr2=\"value2\" />") ? TEST_PASS : TEST_FAIL;
         }
 
         //[Variation(id=3, Desc="Attributes of nested elements", Pri=1)]

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CGenericTestModule.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CGenericTestModule.cs
@@ -57,7 +57,7 @@ namespace System.Xml.Tests
 
         public override int Init(object objParam)
         {
-            _TestData = Path.Combine(FilePathUtil.GetTestDataPath(), @"XmlReader\");
+            _TestData = Path.Combine(FilePathUtil.GetTestDataPath(), @"XmlReader");
 
             _TestData = _TestData.ToLowerInvariant();
 

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CXMLGeneralTest.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CXMLGeneralTest.cs
@@ -920,7 +920,7 @@ namespace System.Xml.Tests
         public int LookupNamespace9()
         {
             string ns = "http://www.w3.org/1999/XMLSchema";
-            string filename = TestData + "Common/bug_57723.xml";
+            string filename = Path.Combine(TestData, "Common", "bug_57723.xml");
 
             ReloadSource(filename);
 
@@ -1865,7 +1865,7 @@ namespace System.Xml.Tests
         [Variation("Call Skip in while read loop", Pri = 0)]
         public int skip307543()
         {
-            string fileName = Path.Combine(TestData, @"Common\skip307543.xml");
+            string fileName = Path.Combine(TestData, "Common", "skip307543.xml");
             ReloadSource(fileName);
             while (DataReader.Read())
                 DataReader.Skip();
@@ -2394,7 +2394,7 @@ namespace System.Xml.Tests
             if (IsXsltReader() || IsXPathNavigatorReader())
                 return TEST_SKIPPED;
 
-            string filename = TestData + "Common/bug_62426.xml";
+            string filename = Path.Combine(TestData, "Common", "bug_62426.xml");
             if (IsBinaryReader())
                 filename = Path.GetFileName(filename) + ".bin";
 
@@ -2433,7 +2433,7 @@ namespace System.Xml.Tests
             if (IsXsltReader() || IsXPathNavigatorReader())
                 return TEST_SKIPPED;
 
-            string filename = TestData + "Common/file#%23.xml";
+            string filename = Path.Combine(TestData, "Common", "file#%23.xml");
             if (IsBinaryReader())
                 filename = Path.GetFileName(filename) + ".bin";
 
@@ -2458,12 +2458,12 @@ namespace System.Xml.Tests
             if (IsXsltReader() || IsXPathNavigatorReader())
                 return TEST_SKIPPED;
 
-            string filepath = TestData + "Common/";
-            string filename = filepath + "bug_60677.xml";
+            string filepath = Path.Combine(TestData, "Common");
+            string filename = Path.Combine(filepath, "bug_60677.xml");
             if (IsBinaryReader())
                 filename = Path.GetFileName(filename) + ".bin";
 
-            string fileent = filepath + "A/B/bug60677.ent";
+            string fileent = Path.Combine(filepath, "A", "B", "bug60677.ent");
 
             Uri uriFile = new Uri("file:" + filename);
             Uri uriEnt = new Uri("file:" + fileent);
@@ -2490,12 +2490,12 @@ namespace System.Xml.Tests
             if (!IsXmlValidatingReader())
                 return TEST_SKIPPED;
 
-            string filepath = TestData + "Common/";
-            string filename = filepath + "bug_60677.xml";
+            string filepath = Path.Combine(TestData, "Common");
+            string filename = Path.Combine(filepath, "bug_60677.xml");
             if (IsBinaryReader())
                 filename = Path.GetFileName(filename) + ".bin";
 
-            string fileent = filepath + "bug_60677.xml";
+            string fileent = Path.Combine(filepath, "bug_60677.xml");
 
             Uri uriFile = new Uri("file:" + filename);
             Uri uriEnt = new Uri("file:" + fileent);
@@ -2519,7 +2519,7 @@ namespace System.Xml.Tests
             if (IsXsltReader() || IsXmlNodeReader() || IsXmlNodeReaderDataDoc() || IsCoreReader() || IsXPathNavigatorReader())
                 return TEST_SKIPPED;
 
-            string filename = TestData + "Common/Bug94358.xml";
+            string filename = Path.Combine(TestData, "Common", "Bug94358.xml");
             if (IsBinaryReader())
                 filename = Path.GetFileName(filename) + ".bin";
 

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CXMLReaderAttrTest.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CXMLReaderAttrTest.cs
@@ -1558,7 +1558,7 @@ namespace System.Xml.Tests
         [Variation("XmlReader: Does not count depth for attributes of xml decl. and Doctype")]
         public int MoveToNextAttribute9()
         {
-            ReloadSource(TestData + "Common/Bug424573.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "Bug424573.xml"));
             DataReader.Read();
             if (DataReader.HasAttributes)
             {

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CommonTest.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/CommonTest.cs
@@ -206,7 +206,7 @@ namespace System.Xml.Tests
         [Variation("Read with invalid characters")]
         public int Read4()
         {
-            string filename = TestData + "Common/bad.xml";
+            string filename = Path.Combine(TestData, "Common", "bad.xml");
             try
             {
                 ReloadSource(filename);
@@ -263,7 +263,7 @@ namespace System.Xml.Tests
         [Variation("Read invalid text declaration")]
         public int Read8()
         {
-            string filename = TestData + "Common/bug_65660a.xml";
+            string filename = Path.Combine(TestData, "Common", "bug_65660a.xml");
             try
             {
                 ReloadSource(filename);
@@ -360,7 +360,7 @@ namespace System.Xml.Tests
         [Variation("Read with invalid entity value")]
         public int Read16()
         {
-            string filename = TestData + "Common/bug_62766.xml";
+            string filename = Path.Combine(TestData, "Common", "bug_62766.xml");
             try
             {
                 ReloadSource(filename);
@@ -383,7 +383,7 @@ namespace System.Xml.Tests
         public int Read17()
         {
             if (IsXmlNodeReader() || IsXmlNodeReaderDataDoc() || IsXPathNavigatorReader()) return TEST_SKIPPED;
-            string filename = TestData + "Common/invalid-ucs4.xml";
+            string filename = Path.Combine(TestData, "Common", "invalid-ucs4.xml");
             bool bPassed = TestInvalidXmlFile(filename, 35, 10, "Xml_InvalidCharInThisEncoding");
 
             return BoolToLTMResult(bPassed);
@@ -393,7 +393,7 @@ namespace System.Xml.Tests
         public int Read18()
         {
             if (IsXmlNodeReader() || IsXmlNodeReaderDataDoc() || IsXPathNavigatorReader()) return TEST_SKIPPED;
-            string filename = TestData + "Common/invalid-ucs4_1234.xml";
+            string filename = Path.Combine(TestData, "Common", "invalid-ucs4_1234.xml");
             bool bPassed = TestInvalidXmlFile(filename, 35, 10, "Xml_InvalidCharInThisEncoding");
 
             return BoolToLTMResult(bPassed);
@@ -403,7 +403,7 @@ namespace System.Xml.Tests
         public int Read19()
         {
             if (IsXmlNodeReader() || IsXmlNodeReaderDataDoc() || IsXPathNavigatorReader()) return TEST_SKIPPED;
-            string filename = TestData + "Common/invalid-ucs4_2143.xml";
+            string filename = Path.Combine(TestData, "Common", "invalid-ucs4_2143.xml");
             bool bPassed = TestInvalidXmlFile(filename, 35, 10, "Xml_InvalidCharInThisEncoding");
 
             return BoolToLTMResult(bPassed);
@@ -413,7 +413,7 @@ namespace System.Xml.Tests
         public int Read20()
         {
             if (IsXmlNodeReader() || IsXmlNodeReaderDataDoc() || IsXPathNavigatorReader()) return TEST_SKIPPED;
-            string filename = TestData + "Common/invalid-ucs4_3412.xml";
+            string filename = Path.Combine(TestData, "Common", "invalid-ucs4_3412.xml");
             bool bPassed = TestInvalidXmlFile(filename, 35, 10, "Xml_InvalidCharInThisEncoding");
 
             return BoolToLTMResult(bPassed);
@@ -461,7 +461,7 @@ namespace System.Xml.Tests
             if (IsCoreReader() || IsXmlNodeReader() || IsXmlNodeReaderDataDoc() || IsXPathNavigatorReader())
                 return TEST_SKIPPED;
 
-            string filename = TestData + "Common/bug_57841.xml";
+            string filename = Path.Combine(TestData, "Common", "bug_57841.xml");
 
             int[][] expPos = new int[][] { new int[] { 9, 7 }, new int[] { 9, 14 }, new int[] { 9, 21 }, new int[] { 9, 28 }, new int[] { 9, 35 } };
 
@@ -812,7 +812,7 @@ namespace System.Xml.Tests
         public int InvalidCommentCharacters()
         {
             if (IsXmlNodeReader() || IsXmlNodeReaderDataDoc() || IsXPathNavigatorReader()) return TEST_SKIPPED;
-            string filename = TestData + "Common/Bug92020c.xml";
+            string filename = Path.Combine(TestData, "Common", "Bug92020c.xml");
             bool bPassed = TestInvalidXmlFile(filename, 2, 18, "Xml_InvalidCommentChars");
             return BoolToLTMResult(bPassed);
         }
@@ -821,7 +821,7 @@ namespace System.Xml.Tests
         public int FactoryReaderInvalidCharacter()
         {
             if (!IsFactoryReader()) return TEST_SKIPPED;
-            string filename = TestData + "Common/Bug26771.xml";
+            string filename = Path.Combine(TestData, "Common", "Bug26771.xml");
             bool bPassed = TestInvalidXmlFile(filename, 33, 235, "Xml_InvalidCharacter");
             return BoolToLTMResult(bPassed);
         }
@@ -847,7 +847,7 @@ namespace System.Xml.Tests
         [Variation("Read valid UCS4 file")]
         public int v1()
         {
-            string filename = TestData + "Common/valid-ucs4.xml";
+            string filename = Path.Combine(TestData, "Common", "valid-ucs4.xml");
             TestUCS4Encoding(filename, "ucs-4");
 
             return TEST_PASS;
@@ -872,7 +872,7 @@ namespace System.Xml.Tests
         [Variation("Read stream less than 4K")]
         public int v3()
         {
-            string filename = TestData + "Common/bug_62146.xml";
+            string filename = Path.Combine(TestData, "Common", "bug_62146.xml");
             ReloadSource(filename);
             while (DataReader.Read()) ;
 
@@ -933,7 +933,7 @@ namespace System.Xml.Tests
         [Variation("Read valid UCS4 file 1234")]
         public int v7()
         {
-            string filename = TestData + "Common/valid-ucs4_1234.xml";
+            string filename = Path.Combine(TestData, "Common", "valid-ucs4_1234.xml");
             TestUCS4Encoding(filename, "ucs-4 (Bigendian)");
 
             return TEST_PASS;
@@ -942,7 +942,7 @@ namespace System.Xml.Tests
         [Variation("Read valid UCS4 file 2143")]
         public int v8()
         {
-            string filename = TestData + "Common/valid-ucs4_2143.xml";
+            string filename = Path.Combine(TestData, "Common", "valid-ucs4_2143.xml");
             TestUCS4Encoding(filename, "ucs-4 (order 2143)");
 
             return TEST_PASS;
@@ -951,7 +951,7 @@ namespace System.Xml.Tests
         [Variation("Read valid UCS4 file 3412")]
         public int v9()
         {
-            string filename = TestData + "Common/valid-ucs4_3412.xml";
+            string filename = Path.Combine(TestData, "Common", "valid-ucs4_3412.xml");
             TestUCS4Encoding(filename, "ucs-4 (order 3412)");
 
             return TEST_PASS;
@@ -991,7 +991,7 @@ namespace System.Xml.Tests
         [Variation("Root element 18 chars length")]
         public int v13()
         {
-            string filename = TestData + "Common/Bug_70237.xml";
+            string filename = Path.Combine(TestData, "Common", "Bug_70237.xml");
             ReloadSource(filename);
             string name = "a1234567890abcdefg";
             DataReader.PositionOnElement(name);
@@ -1005,7 +1005,7 @@ namespace System.Xml.Tests
         [Variation("File with external DTD")]
         public int v14()
         {
-            string filename = TestData + "Common/Bug68766.xml";
+            string filename = Path.Combine(TestData, "Common", "Bug68766.xml");
             ReloadSource(filename);
 
             while (DataReader.Read()) ;
@@ -1123,7 +1123,7 @@ namespace System.Xml.Tests
         [Variation("Parsing valid xml with huge attributes")]
         public int Read36()
         {
-            ReloadSource(TestData + @"Common/hugeattributes.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "hugeattributes.xml"));
             while (DataReader.Read())
             {
                 object ob = DataReader.Value;
@@ -1280,7 +1280,7 @@ namespace System.Xml.Tests
         [Variation("Parsing valid xml with 100 attributes with same names and diff.namespaces")]
         public int Read46()
         {
-            ReloadSource(TestData + @"Common/100attr.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "100attr.xml"));
             while (DataReader.Read())
             {
                 object ob = DataReader.Value;
@@ -1336,7 +1336,7 @@ namespace System.Xml.Tests
         [Variation("Parsing valid xml with large number of attributes inside single element")]
         public int Read49()
         {
-            ReloadSource(TestData + @"Common/AttributesLargeNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "AttributesLargeNumber.xml"));
             while (DataReader.Read())
             {
                 object ob = DataReader.Value;
@@ -1490,9 +1490,9 @@ namespace System.Xml.Tests
         //[Variation("Parsing xml with DTD and 200 attributes with ns", Param = 2)]
         public int Read55()
         {
-            string xml = TestData + "Common/Attr200Valid.xml";
+            string xml = Path.Combine(TestData, "Common", "Attr200Valid.xml");
             if ((int)CurVariation.Param == 2)
-                xml = TestData + "Common/Attr200WithNS.xml";
+                xml = Path.Combine(TestData, "Common", "Attr200WithNS.xml");
             ReloadSource(xml);
             while (DataReader.Read())
             {
@@ -1515,7 +1515,7 @@ namespace System.Xml.Tests
         public int Read56()
         {
             int param = (int)CurVariation.Param;
-            string xml = (param == 1) ? TestData + "Common/Attr201Invalid.xml" : TestData + "Common/Attr201WithNS.xml";
+            string xml = Path.Combine(TestData, "Common", (param == 1) ? "Attr201Invalid.xml" : "Attr201WithNS.xml");
             try
             {
                 ReloadSource(xml);
@@ -1595,7 +1595,7 @@ namespace System.Xml.Tests
         [Variation("Parse xml with in ascii encoding")]
         public int Read61()
         {
-            string uri = TestData + "Common/riversrss.xml";
+            string uri = Path.Combine(TestData, "Common", "riversrss.xml");
             ReloadSource(uri);
             while (DataReader.Read()) ;
             return TEST_PASS;
@@ -1639,7 +1639,7 @@ namespace System.Xml.Tests
         public int Read65()
         {
             int param = (int)CurVariation.Param;
-            string xml = (param == 1) ? TestData + "Common/1_GB18030.xml" : TestData + "Common/3_UTF32.xml";
+            string xml = Path.Combine(TestData, "Common", (param == 1) ? "1_GB18030.xml" : "3_UTF32.xml");
             ReloadSource(xml);
             while (DataReader.Read()) CError.WriteLine(DataReader.Value);
             return TEST_PASS;
@@ -1648,7 +1648,7 @@ namespace System.Xml.Tests
         [Variation("Parse input with a character zero 0x00 at root level.")]
         public int Read66()
         {
-            string xml = TestData + "Common/Bug615675.xml";
+            string xml = Path.Combine(TestData, "Common", "Bug615675.xml");
             try
             {
                 ReloadSource(xml);
@@ -1662,7 +1662,7 @@ namespace System.Xml.Tests
         //[Variation("3.Parse input with utf-16 encoding", Param = "charset03.xml")]
         public int Read68()
         {
-            string xml = TestData + "Common/" + (string)CurVariation.Param;
+            string xml = Path.Combine(TestData, "Common", "" + (string)CurVariation.Param);
             ReloadSource(xml);
             while (DataReader.Read()) CError.WriteLine(DataReader.Value);
             return TEST_PASS;
@@ -1671,7 +1671,7 @@ namespace System.Xml.Tests
         [Variation("2.Parse input with utf-16 encoding", Param = "charset02.xml")]
         public int Read68a()
         {
-            string xml = TestData + "Common/" + (string)CurVariation.Param;
+            string xml = Path.Combine(TestData, "Common", "" + (string)CurVariation.Param);
             try
             {
                 ReloadSource(xml);

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ErrorCondition.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ErrorCondition.cs
@@ -149,7 +149,7 @@ namespace System.Xml.Tests
             int param = (int)CurVariation.Param;
             XmlReaderSettings rs = new XmlReaderSettings();
             XmlReader r = ReaderHelper.Create(new StringReader("<a/>"));
-            string uri = TestData + @"Common/file_23.xml";
+            string uri = Path.Combine(TestData, "Common", "file_23.xml");
             try
             {
                 switch (param)

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/LineNumber.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/LineNumber.cs
@@ -53,7 +53,7 @@ namespace System.Xml.Tests
         [Variation("LineNumber/LinePos after Read and NodeType = Element", Priority = 0)]
         public int TestLinePos1()
         {
-            ReloadSource(TestData + "Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
             DataReader.PositionOnElement(ST_ELEMENT);
             CheckPos(0, 0);
             return TEST_PASS;
@@ -62,7 +62,7 @@ namespace System.Xml.Tests
         [Variation("LineNumber/LinePos after Read and NodeType = CDATA", Priority = 0)]
         public int TestLinePos2()
         {
-            ReloadSource(TestData + "Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
             PositionOnNodeType2(XmlNodeType.CDATA);
             CheckPos(0, 0);
             return TEST_PASS;
@@ -71,7 +71,7 @@ namespace System.Xml.Tests
         [Variation("LineNumber/LinePos after Read and NodeType = Comment", Priority = 0)]
         public int TestLinePos4()
         {
-            ReloadSource(TestData + "Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
             PositionOnNodeType2(XmlNodeType.Comment);
             CheckPos(0, 0);
             return TEST_PASS;
@@ -80,7 +80,7 @@ namespace System.Xml.Tests
         [Variation("LineNumber/LinePos after Read and NodeType = EndElement", Priority = 0)]
         public int TestLinePos6()
         {
-            ReloadSource(TestData + "Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
             PositionOnNodeType2(XmlNodeType.EndElement);
             CheckPos(0, 0);
             return TEST_PASS;
@@ -90,7 +90,7 @@ namespace System.Xml.Tests
         public int TestLinePos7()
         {
             CError.Skip("Skipped");
-            ReloadSource(TestData + "Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
             PositionOnNodeType2(XmlNodeType.EntityReference);
 
             CheckPos(11, 14);
@@ -113,7 +113,7 @@ namespace System.Xml.Tests
         [Variation("LineNumber/LinePos after Read and NodeType = ProcessingInstruction", Priority = 0)]
         public int TestLinePos9()
         {
-            ReloadSource(TestData + "Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
 
             PositionOnNodeType2(XmlNodeType.ProcessingInstruction);
             CheckPos(0, 0);
@@ -126,7 +126,7 @@ namespace System.Xml.Tests
         [Variation("LineNumber/LinePos after Read and NodeType = SignificantWhitespace", Priority = 0)]
         public int TestLinePos10()
         {
-            ReloadSource(TestData + "Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
             PositionOnNodeType2(XmlNodeType.SignificantWhitespace);
             CheckPos(0, 0);
             return TEST_PASS;
@@ -135,7 +135,7 @@ namespace System.Xml.Tests
         [Variation("LineNumber/LinePos after Read and NodeType = Text", Priority = 0)]
         public int TestLinePos11()
         {
-            ReloadSource(TestData + "Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
             PositionOnNodeType2(XmlNodeType.Text);
             CheckPos(0, 0);
             return TEST_PASS;
@@ -144,7 +144,7 @@ namespace System.Xml.Tests
         [Variation("LineNumber/LinePos after Read and NodeType = Whitespace", Priority = 0)]
         public int TestLinePos12()
         {
-            ReloadSource(TestData + "Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
             PositionOnNodeType2(XmlNodeType.Whitespace);
             CheckPos(0, 0);
             PositionOnNodeType2(XmlNodeType.Whitespace);
@@ -158,7 +158,7 @@ namespace System.Xml.Tests
         public int TestLinePos13()
         {
             if (IsSubtreeReader()) CError.Skip("Skipped");
-            ReloadSource(TestData + "Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
             PositionOnNodeType2(XmlNodeType.XmlDeclaration);
             CheckPos(0, 0);
             return TEST_PASS;
@@ -167,7 +167,7 @@ namespace System.Xml.Tests
         [Variation("LineNumber/LinePos after MoveToElement")]
         public int TestLinePos14()
         {
-            ReloadSource(TestData + "Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
 
             DataReader.PositionOnElement(ST_ELEMENT);
             CheckPos(0, 0);
@@ -180,7 +180,7 @@ namespace System.Xml.Tests
         [Variation("LineNumber/LinePos after MoveToFirstAttribute/MoveToNextAttribute")]
         public int TestLinePos15()
         {
-            ReloadSource(TestData + "Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
             DataReader.PositionOnElement(ST_ELEMENT);
             CheckPos(0, 0);
             DataReader.MoveToFirstAttribute();
@@ -195,7 +195,7 @@ namespace System.Xml.Tests
         [Variation("LineNumber/LinePos after MoveToAttribute")]
         public int TestLinePos16()
         {
-            ReloadSource(TestData + "Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
             DataReader.PositionOnElement(ST_ELEMENT);
             CheckPos(0, 0);
             DataReader.MoveToAttribute(1);
@@ -216,7 +216,7 @@ namespace System.Xml.Tests
         [Variation("LineNumber/LinePos after Skip")]
         public int TestLinePos18()
         {
-            ReloadSource(TestData + "Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
             DataReader.PositionOnElement(ST_ELEMENT);
             DataReader.MoveToFirstAttribute();
             DataReader.Skip();
@@ -230,7 +230,7 @@ namespace System.Xml.Tests
         [Variation("LineNumber/LinePos after ReadInnerXml")]
         public int TestLinePos19()
         {
-            ReloadSource(TestData + "Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
             DataReader.PositionOnElement(ST_ELEMENT);
             DataReader.MoveToFirstAttribute();
             DataReader.ReadInnerXml();
@@ -246,7 +246,7 @@ namespace System.Xml.Tests
         {
             if (IsSubtreeReader()) CError.Skip("Skipped");
 
-            ReloadSource(TestData + "Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
 
             PositionOnNodeType2(XmlNodeType.XmlDeclaration);
             DataReader.MoveToContent();
@@ -267,7 +267,7 @@ namespace System.Xml.Tests
         {
             if (IsCustomReader()) CError.Skip("Skipped");
 
-            ReloadSource(TestData + "Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
             DataReader.PositionOnElement(ST_BASE64);
 
             byte[] arr = new byte[3];
@@ -287,7 +287,7 @@ namespace System.Xml.Tests
         {
             if (IsCustomReader()) CError.Skip("Skipped");
 
-            ReloadSource(TestData + "Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
             DataReader.PositionOnElement(ST_BINHEX);
 
             byte[] arr = new byte[1];
@@ -306,7 +306,7 @@ namespace System.Xml.Tests
         [Variation("LineNumber/LinePos after ReadEndElement")]
         public int TestLinePos26()
         {
-            ReloadSource(TestData + "Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
             DataReader.PositionOnElement(ST_CHARENTITY);
 
             DataReader.Read(); // Text
@@ -322,7 +322,7 @@ namespace System.Xml.Tests
         [Variation("LineNumber/LinePos after ReadString")]
         public int TestLinePos27()
         {
-            ReloadSource(TestData + "Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
             DataReader.PositionOnElement(ST_ENTITYREF);
 
             DataReader.Read();
@@ -345,7 +345,7 @@ namespace System.Xml.Tests
         [Variation("LineNumber/LinePos after element containing entities in attribute values")]
         public int TestLinePos39()
         {
-            ReloadSource(TestData + "Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
             DataReader.PositionOnElement("EMBEDDED");
             CheckPos(0, 0);
             return TEST_PASS;
@@ -354,7 +354,7 @@ namespace System.Xml.Tests
         [Variation("LineNumber/LinePos when Read = false")]
         public int TestLinePos40()
         {
-            ReloadSource(TestData + @"Common/LineNumber.xml");
+            ReloadSource(Path.Combine(TestData, "Common", "LineNumber.xml"));
             while (DataReader.Read()) ;
             CheckPos(0, 0);
             return TEST_PASS;
@@ -477,7 +477,7 @@ namespace System.Xml.Tests
         [Variation("Check error message on a non-wellformed XML")]
         public int ReadingNonWellFormedXmlThrows()
         {
-            string filename = TestData + "Common/Bug86503.txt";
+            string filename = Path.Combine(TestData, "Common", "Bug86503.txt");
             try
             {
                 ReloadSource(filename);
@@ -490,7 +490,7 @@ namespace System.Xml.Tests
         [Variation("When an XmlException is thrown both XmlException.LineNumber and XmlTextReader.LineNumber should be same")]
         public int XmlExceptionAndXmlTextReaderLineNumberShouldBeSameAfterExceptionIsThrown()
         {
-            string filename = TestData + "Common/invalid-ucs4.xml";
+            string filename = Path.Combine(TestData, "Common", "invalid-ucs4.xml");
             if (!IsCustomReader())
             {
                 try
@@ -535,9 +535,9 @@ namespace System.Xml.Tests
         public int LineNumberAndLinePositionAreCorrect()
         {
             XmlReaderSettings rs = new XmlReaderSettings();
-            Stream fs = FilePathUtil.getStream(TestData + "Common\\Bug297091.xsl");
+            Stream fs = FilePathUtil.getStream(Path.Combine(TestData, "Common", "Bug297091.xsl"));
             {
-                XmlReader DataReader = ReaderHelper.Create(fs, rs, TestData + "Common\\Bug297091.xsl");
+                XmlReader DataReader = ReaderHelper.Create(fs, rs, Path.Combine(TestData, "Common", "Bug297091.xsl"));
 
                 DataReader.Read();
                 if (DataReader.NodeType != XmlNodeType.Element || ((IXmlLineInfo)DataReader).LineNumber != 1 || ((IXmlLineInfo)DataReader).LinePosition != 2)

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ReadBase64.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ReadBase64.cs
@@ -1062,7 +1062,7 @@ namespace System.Xml.Tests
         [Variation("WS:WireCompat:hex binary fails to send/return data after 1787 bytes")]
         public int TestReadBase64ReadsTheContent()
         {
-            string filename = TestData + "Common/Bug99148.xml";
+            string filename = Path.Combine(TestData, "Common", "Bug99148.xml");
             ReloadSource(filename);
 
             DataReader.MoveToContent();

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ReadBinHex.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/ReadBinHex.cs
@@ -442,7 +442,7 @@ namespace System.Xml.Tests
         [Variation("WS:WireCompat:hex binary fails to send/return data after 1787 bytes")]
         public int TestTextReadBinHex_24()
         {
-            string filename = TestData + "Common/Bug99148.xml";
+            string filename = Path.Combine(TestData, "Common", "Bug99148.xml");
             ReloadSource(filename);
 
             DataReader.MoveToContent();
@@ -866,7 +866,7 @@ namespace System.Xml.Tests
         [Variation("WS:WireCompat:hex binary fails to send/return data after 1787 bytes")]
         public int TestTextReadBinHex_24()
         {
-            string filename = TestData + "Common/Bug99148.xml";
+            string filename = Path.Combine(TestData, "Common", "Bug99148.xml");
             ReloadSource(filename);
 
             DataReader.MoveToContent();

--- a/src/System.Xml.ReaderWriter/tests/XmlReaderLib/XmlException.cs
+++ b/src/System.Xml.ReaderWriter/tests/XmlReaderLib/XmlException.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using OLEDB.Test.ModuleCore;
+using System.IO;
 
 namespace System.Xml.Tests
 {
@@ -94,7 +95,7 @@ namespace System.Xml.Tests
         [Variation("Inner exception on non-supported encoding")]
         public int ReadingNonSupportedEncodingDoesntThrow()
         {
-            string filename = TestData + "Common/Bug81489.xml";
+            string filename = Path.Combine(TestData, "Common", "Bug81489.xml");
             ReloadSource(filename);
             while (DataReader.Read()) ;
             return TEST_PASS;
@@ -119,7 +120,7 @@ namespace System.Xml.Tests
         [Variation("XmlReader: scanner error on invalid character for an encoding give pointer to scanner buffer, not file position")]
         public int InvalidEncodingCharacterThrowsExceptionWithCorrectLineNumberAndPosition()
         {
-            string filename = TestData + "Common/Bug61321.xml";
+            string filename = Path.Combine(TestData, "Common", "Bug61321.xml");
             ReloadSource(filename);
 
             try
@@ -137,7 +138,7 @@ namespace System.Xml.Tests
         [Variation("XmlDocument.Load: XmlException contains ambiguous error when finding unexpected token")]
         public int UnexpectedTokenThrowsErrorWithCorrectPositions()
         {
-            string filename = TestData + "Common/Bug95253.xml";
+            string filename = Path.Combine(TestData, "Common", "Bug95253.xml");
             ReloadSource(filename);
             try
             {
@@ -154,7 +155,7 @@ namespace System.Xml.Tests
         [Variation("Check to see if SourceUri1 is set correctly")]
         public int SourceUri1()
         {
-            string filename = TestData + "Common/Bug95253.xml";
+            string filename = Path.Combine(TestData, "Common", "Bug95253.xml");
             ReloadSource(filename);
 
             try


### PR DESCRIPTION
- Lots of tests were depending on '\' being the path separator
- Lots of tests were depending on Environment.NewLine being "\r\n"

I'm trying to get our outer loop tests passing on Unix, and these are standing in the way.

cc: @ellismg, @krwq 