### PR TITLE
Move routing and failover message ONLY for Login Timeout Error

### DIFF
--- a/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionTimeoutErrorInternal.cs
+++ b/src/System.Data.SqlClient/src/System/Data/SqlClient/SqlConnectionTimeoutErrorInternal.cs
@@ -196,7 +196,7 @@ namespace System.Data.SqlClient
 
             // This message is to be added only when within the various stages of a connection. 
             // In all other cases, it will default to the original error message.
-            if ((_currentPhase != SqlConnectionTimeoutErrorPhase.Undefined) || (_currentPhase != SqlConnectionTimeoutErrorPhase.Complete))
+            if ((_currentPhase != SqlConnectionTimeoutErrorPhase.Undefined) && (_currentPhase != SqlConnectionTimeoutErrorPhase.Complete))
             {
                 // NOTE: In case of a failover scenario, add a string that this failure occurred as part of the primary or secondary server
                 if (_isFailoverScenario)
@@ -216,13 +216,13 @@ namespace System.Data.SqlClient
                         _originalPhaseDurations[(int)SqlConnectionTimeoutErrorPhase.ProcessConnectionAuth].GetMilliSecondDuration(),
                         _originalPhaseDurations[(int)SqlConnectionTimeoutErrorPhase.PostLogin].GetMilliSecondDuration());
                 }
+            }
 
-                // NOTE: To display duration in each phase.
-                if (durationString != null)
-                {
-                    errorBuilder.Append("  ");
-                    errorBuilder.Append(durationString);
-                }
+            // NOTE: To display duration in each phase.
+            if (durationString != null)
+            {
+                errorBuilder.Append("  ");
+                errorBuilder.Append(durationString);
             }
 
             return errorBuilder.ToString();


### PR DESCRIPTION
During Timeout this routing and failover message always included in the error message even if it is not "Login Timeout error"
This was caused confusion as this Routing and Failover message was specifically detailed for Login Timeout.

Changes :
     Fix the condition to include the failover and routing message ONLY in "Login Timeout"