### PR TITLE
Fix inconsistent Equals implementations for Complex

### DIFF
--- a/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
+++ b/src/System.Runtime.Numerics/src/System/Numerics/Complex.cs
@@ -165,7 +165,7 @@ namespace System.Numerics
         public override bool Equals(object obj)
         {
             if (!(obj is Complex)) return false;
-            return this == ((Complex)obj);
+            return Equals((Complex)obj);
         }
 
         public bool Equals(Complex value)

--- a/src/System.Runtime.Numerics/tests/ComplexTests.cs
+++ b/src/System.Runtime.Numerics/tests/ComplexTests.cs
@@ -714,7 +714,7 @@ namespace System.Numerics.Tests
                 Assert.True(expectedEquals == complex1.GetHashCode().Equals(complex2.GetHashCode()),
                     string.Format("{0}.GetHashCode().Equals({1}.GetHashCode()) is not '{2}' as expected", complex1, complex2, expectedEquals));
             }
-            Assert.True(expected == complex1.Equals(obj), string.Format("{0}.Equals({1}) is not '{2}' as expected", complex1, obj, expectedEquals));
+            Assert.True(expectedEquals == complex1.Equals(obj), string.Format("{0}.Equals({1}) is not '{2}' as expected", complex1, obj, expectedEquals));
         }
 
         public static IEnumerable<object[]> Exp_TestData()


### PR DESCRIPTION
Fixes #6338
Now Complex.Equals(object) and Complex.Equals(Complex) will always
return consistent results.

Existing test data already cover this, but I removed a workaround for
this bug from the test code.

/cc @JonHanna