### PR TITLE
Fix argument exception bug in coding style sample

### DIFF
--- a/Documentation/coding-guidelines/coding-style.md
+++ b/Documentation/coding-guidelines/coding-style.md
@@ -55,7 +55,7 @@ namespace System.Collections.Generic
         public ObservableLinkedList(IEnumerable<T> items)
         {
             if (items == null)
-                throw new ArgumentException(nameof(items));
+                throw new ArgumentNullException(nameof(items));
 
             foreach (T item in items)
             {


### PR DESCRIPTION
Fixing one of the most common .NET bugs of all time in our style sample. 

(Aside: Seeing this and the recent community PR to fix these up in actual source code reminds me that there is an FxCop rule (my all-time favourite) that I recently ported to a Roslyn analyzer to find this. Are there plans to add automated roslyn analyzer runs to corefx?)

@stephentoub @weshaggard 