### PR TITLE
Remove build dependency on PCL reference assemblies (re-created #6077)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -103,7 +103,7 @@ build_managed_corefx()
     __binclashlog=$__scriptpath/binclash.log
     __binclashloggerdll=$__scriptpath/Tools/Microsoft.DotNet.Build.Tasks.dll
 
-    ReferenceAssemblyRoot=$__referenceassemblyroot $__scriptpath/Tools/corerun $__scriptpath/Tools/MSBuild.exe "$__buildproj" /nologo /verbosity:minimal "/fileloggerparameters:Verbosity=normal;LogFile=$__buildlog" "/l:BinClashLogger,$__binclashloggerdll;LogFile=$__binclashlog" /t:Build /p:OSGroup=$__BuildOS /p:COMPUTERNAME=$(hostname) /p:USERNAME=$(id -un) /p:TestNugetRuntimeId=$__TestNugetRuntimeId $__UnprocessedBuildArgs
+    $__scriptpath/Tools/corerun $__scriptpath/Tools/MSBuild.exe "$__buildproj" /nologo /verbosity:minimal "/fileloggerparameters:Verbosity=normal;LogFile=$__buildlog" /t:Build /p:OSGroup=$__BuildOS /p:COMPUTERNAME=$(hostname) /p:USERNAME=$(id -un) /p:TestNugetRuntimeId=$__TestNugetRuntimeId $__UnprocessedBuildArgs
     BUILDERRORLEVEL=$?
 
     echo
@@ -247,19 +247,6 @@ __BuildOS=$__HostOS
 __BuildType=Debug
 __CMakeArgs=DEBUG
 
-case $__HostOS in
-    FreeBSD)
-        __monoroot=/usr/local
-        ;;
-    OSX)
-        __monoroot=/Library/Frameworks/Mono.framework/Versions/Current
-        ;;
-    *)
-        __monoroot=/usr
-        ;;
-esac
-
-__referenceassemblyroot=$__monoroot/lib/mono/xbuild-frameworks
 BUILDERRORLEVEL=0
 
 # Set the various build properties here so that CMake and MSBuild can pick them up

--- a/dir.props
+++ b/dir.props
@@ -403,4 +403,14 @@
 
   <Import Project="$(RoslynPropsFile)" Condition="'$(OsEnvironment)'=='Unix' and Exists('$(RoslynPropsFile)')" />
 
+  <PropertyGroup>
+    <!-- We don't use any of MSBuild's resolution logic for resolving the framework, so just set these two properties to any folder that exists to skip
+         the GenerateReferenceAssemblyPaths task (not target) and to prevent it from outputting a warning (MSB3644). -->
+    <_TargetFrameworkDirectories>$(MSBuildThisFileDirectory)/Documentation</_TargetFrameworkDirectories>
+    <_FullFrameworkReferenceAssemblyPaths>$(MSBuildThisFileDirectory)/Documentation</_FullFrameworkReferenceAssemblyPaths>
+    <TargetFrameworkProfile></TargetFrameworkProfile>
+    <IgnoreDefaultInstalledAssemblyTables>true</IgnoreDefaultInstalledAssemblyTables>
+    <PortableNuGetMode>true</PortableNuGetMode>
+  </PropertyGroup>
+
 </Project>

--- a/dir.targets
+++ b/dir.targets
@@ -15,4 +15,13 @@
 
   <Import Project="$(ToolsDir)/Build.Common.targets" />
 
+  <PropertyGroup>
+    <!-- We don't use any of MSBuild's resolution logic for resolving the framework, so just set these two properties to any folder that exists to skip
+         the GenerateReferenceAssemblyPaths task (not target) and to prevent it from outputting a warning (MSB3644). -->
+    <_TargetFrameworkDirectories>$(MSBuildThisFileDirectory)/Documentation</_TargetFrameworkDirectories>
+    <_FullFrameworkReferenceAssemblyPaths>$(MSBuildThisFileDirectory)/Documentation</_FullFrameworkReferenceAssemblyPaths>
+    <TargetFrameworkProfile></TargetFrameworkProfile>
+    <IgnoreDefaultInstalledAssemblyTables>true</IgnoreDefaultInstalledAssemblyTables>
+  </PropertyGroup>
+
 </Project>

--- a/src/Common/src/Microsoft/Internal/Assumes.InternalErrorException.cs
+++ b/src/Common/src/Microsoft/Internal/Assumes.InternalErrorException.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.Runtime.Serialization;
 
 namespace Microsoft.Internal
 {

--- a/src/Common/src/Microsoft/Internal/Assumes.cs
+++ b/src/Common/src/Microsoft/Internal/Assumes.cs
@@ -4,9 +4,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Runtime.Serialization;
 
 namespace Microsoft.Internal
 {

--- a/src/Common/src/Microsoft/Internal/EmptyArray.cs
+++ b/src/Common/src/Microsoft/Internal/EmptyArray.cs
@@ -2,14 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Composition;
-using System.Diagnostics;
-using System.Diagnostics.Contracts;
-using System.Globalization;
-using System.Reflection;
-
 namespace Microsoft.Internal
 {
     internal static class EmptyArray<T>

--- a/src/Common/src/System/IO/PathInternal.cs
+++ b/src/Common/src/System/IO/PathInternal.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics.Contracts;
 using System.Text;
 
 namespace System.IO

--- a/src/Common/src/System/Net/ContextAwareResult.cs
+++ b/src/Common/src/System/Net/ContextAwareResult.cs
@@ -4,7 +4,6 @@
 
 using System.Diagnostics;
 using System.Security;
-using System.Security.Principal;
 using System.Threading;
 
 namespace System.Net

--- a/src/Common/src/System/Net/DebugCriticalHandleMinusOneIsInvalid.cs
+++ b/src/Common/src/System/Net/DebugCriticalHandleMinusOneIsInvalid.cs
@@ -4,13 +4,6 @@
 
 using Microsoft.Win32.SafeHandles;
 
-using System.Diagnostics.CodeAnalysis;
-using System.Net.NetworkInformation;
-using System.Net.Sockets;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Threading;
-
 namespace System.Net
 {
 #if DEBUG

--- a/src/Common/src/System/Net/DebugCriticalHandleZeroOrMinusOneIsInvalid.cs
+++ b/src/Common/src/System/Net/DebugCriticalHandleZeroOrMinusOneIsInvalid.cs
@@ -4,13 +4,6 @@
 
 using Microsoft.Win32.SafeHandles;
 
-using System.Diagnostics.CodeAnalysis;
-using System.Net.NetworkInformation;
-using System.Net.Sockets;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Threading;
-
 namespace System.Net
 {
 #if DEBUG

--- a/src/Common/src/System/Net/DebugSafeHandle.cs
+++ b/src/Common/src/System/Net/DebugSafeHandle.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.Win32.SafeHandles;
 
-using System.Diagnostics.CodeAnalysis;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;

--- a/src/Common/src/System/Net/DebugSafeHandleMinusOneIsInvalid.cs
+++ b/src/Common/src/System/Net/DebugSafeHandleMinusOneIsInvalid.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.Win32.SafeHandles;
 
-using System.Diagnostics.CodeAnalysis;
 using System.Net.NetworkInformation;
 using System.Net.Sockets;
 using System.Runtime.CompilerServices;

--- a/src/Common/src/System/Net/Logging/LoggingHash.cs
+++ b/src/Common/src/System/Net/Logging/LoggingHash.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Tracing;
 using System.Globalization;
 using System.Runtime.InteropServices;

--- a/src/Common/src/System/Net/NetworkInformation/HostInformationPal.NetNative.cs
+++ b/src/Common/src/System/Net/NetworkInformation/HostInformationPal.NetNative.cs
@@ -6,9 +6,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Threading;
-
 using Windows.Networking;
-using Windows.Networking.Connectivity;
 
 namespace System.Net.NetworkInformation
 {
@@ -37,7 +35,7 @@ namespace System.Net.NetworkInformation
         {
             Interop.IpHlpApi.FIXED_INFO fixedInfo = new Interop.IpHlpApi.FIXED_INFO();
 
-            IReadOnlyList<HostName> hostNamesList = Windows.Networking.Connectivity.NetworkInformation.GetHostNames();
+            IReadOnlyList<HostName> hostNamesList = global::Windows.Networking.Connectivity.NetworkInformation.GetHostNames();
 
             foreach (HostName entry in hostNamesList)
             {

--- a/src/System.AppContext/src/System.AppContext.csproj
+++ b/src/System.AppContext/src/System.AppContext.csproj
@@ -32,6 +32,7 @@
 
   <ItemGroup Condition="'$(TargetGroup)'=='netcore50'">
     <TargetingPackReference Include="Windows" />
+    <ProjectReference Include="$(SourceDir)/mscorlib.WinRT-Facade/mscorlib.WinRT-Facade.csproj" />
     <Compile Include="System\AppContext.cs" />
   </ItemGroup>
   <ItemGroup Condition="'$(IsPartialFacadeAssembly)'=='true'">

--- a/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
+++ b/src/System.Collections.Immutable/src/System.Collections.Immutable.csproj
@@ -7,8 +7,6 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Collections.Immutable</RootNamespace>
     <AssemblyName>System.Collections.Immutable</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
     <DocumentationFile>$(OutputPath)System.Collections.Immutable.xml</DocumentationFile>
     <GenerateAppxPackageOnBuild>False</GenerateAppxPackageOnBuild>

--- a/src/System.Collections.Immutable/src/project.json
+++ b/src/System.Collections.Immutable/src/project.json
@@ -1,0 +1,17 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.0",
+    "System.Diagnostics.Contracts": "4.0.0",
+    "System.Diagnostics.Debug": "4.0.0",
+    "System.Linq": "4.0.0",
+    "System.Diagnostics.Tools": "4.0.0",
+    "System.Globalization": "4.0.0",
+    "System.Resources.ResourceManager": "4.0.0",
+    "System.Runtime": "4.0.0",
+    "System.Runtime.Extensions": "4.0.0",
+    "System.Threading": "4.0.0",
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Composition.AttributedModel/src/System.Composition.AttributedModel.csproj
+++ b/src/System.Composition.AttributedModel/src/System.Composition.AttributedModel.csproj
@@ -1,24 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{C6257381-C624-494A-A9D9-5586E60856EA}</ProjectGuid>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Composition</RootNamespace>
     <AssemblyName>System.Composition.AttributedModel</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
-
     <Compile Include="System\Composition\Convention\AttributedModelProvider.cs" />
     <Compile Include="System\Composition\ExportAttribute.cs" />
     <Compile Include="System\Composition\ExportMetadataAttribute.cs" />
@@ -34,11 +24,4 @@
     <Compile Include="System\Composition\SharingBoundaryAttribute.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/System.Composition.AttributedModel/src/System/Composition/Convention/AttributedModelProvider.cs
+++ b/src/System.Composition.AttributedModel/src/System/Composition/Convention/AttributedModelProvider.cs
@@ -2,12 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace System.Composition.Convention
 {

--- a/src/System.Composition.AttributedModel/src/System/Composition/ExportAttribute.cs
+++ b/src/System.Composition.AttributedModel/src/System/Composition/ExportAttribute.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace System.Composition

--- a/src/System.Composition.AttributedModel/src/System/Composition/ExportMetadataAttribute.cs
+++ b/src/System.Composition.AttributedModel/src/System/Composition/ExportMetadataAttribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace System.Composition
 {
     /// <summary>

--- a/src/System.Composition.AttributedModel/src/System/Composition/ImportAttribute.cs
+++ b/src/System.Composition.AttributedModel/src/System/Composition/ImportAttribute.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace System.Composition

--- a/src/System.Composition.AttributedModel/src/System/Composition/ImportManyAttribute.cs
+++ b/src/System.Composition.AttributedModel/src/System/Composition/ImportManyAttribute.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace System.Composition

--- a/src/System.Composition.AttributedModel/src/System/Composition/ImportMetadataConstraintAttribute.cs
+++ b/src/System.Composition.AttributedModel/src/System/Composition/ImportMetadataConstraintAttribute.cs
@@ -2,11 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 namespace System.Composition
 {
     /// <summary>

--- a/src/System.Composition.AttributedModel/src/System/Composition/ImportingConstructorAttribute.cs
+++ b/src/System.Composition.AttributedModel/src/System/Composition/ImportingConstructorAttribute.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-
 namespace System.Composition
 {
     /// <summary>

--- a/src/System.Composition.AttributedModel/src/System/Composition/MetadataAttributeAttribute.cs
+++ b/src/System.Composition.AttributedModel/src/System/Composition/MetadataAttributeAttribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace System.Composition
 {
     /// <summary>

--- a/src/System.Composition.AttributedModel/src/System/Composition/OnImportsSatisfiedAttribute.cs
+++ b/src/System.Composition.AttributedModel/src/System/Composition/OnImportsSatisfiedAttribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace System.Composition
 {
     /// <summary>

--- a/src/System.Composition.AttributedModel/src/System/Composition/PartMetadataAttribute.cs
+++ b/src/System.Composition.AttributedModel/src/System/Composition/PartMetadataAttribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace System.Composition
 {
     /// <summary>

--- a/src/System.Composition.AttributedModel/src/System/Composition/PartNotDiscoverableAttribute.cs
+++ b/src/System.Composition.AttributedModel/src/System/Composition/PartNotDiscoverableAttribute.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace System.Composition
 {
     /// <summary>

--- a/src/System.Composition.AttributedModel/src/System/Composition/SharedAttribute.cs
+++ b/src/System.Composition.AttributedModel/src/System/Composition/SharedAttribute.cs
@@ -2,11 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 namespace System.Composition
 {
     /// <summary>

--- a/src/System.Composition.AttributedModel/src/System/Composition/SharingBoundaryAttribute.cs
+++ b/src/System.Composition.AttributedModel/src/System/Composition/SharingBoundaryAttribute.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.ObjectModel;
 
 namespace System.Composition

--- a/src/System.Composition.AttributedModel/src/project.json
+++ b/src/System.Composition.AttributedModel/src/project.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.0",
+    "System.Diagnostics.Debug": "4.0.0",
+    "System.Diagnostics.Tools": "4.0.0",
+    "System.Reflection": "4.0.0",
+    "System.Runtime": "4.0.0"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Composition.Convention/src/System.Composition.Convention.csproj
+++ b/src/System.Composition.Convention/src/System.Composition.Convention.csproj
@@ -1,22 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{E6592FAD-10B5-4B56-9287-D72DD136992F}</ProjectGuid>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>System.Composition.Convention</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="$(CommonPath)\Microsoft\Internal\Assumes.cs">
       <Link>Microsoft\Internal\Assumes.cs</Link>
@@ -68,16 +59,5 @@
       <Name>System.Composition.AttributedModel</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Microsoft\Diagnostics\" />
-    <Folder Include="Properties\" />
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/System.Composition.Convention/src/project.json
+++ b/src/System.Composition.Convention/src/project.json
@@ -1,0 +1,18 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.0",
+    "System.Globalization": "4.0.0",
+    "System.Diagnostics.Contracts": "4.0.0",
+    "System.Diagnostics.Debug": "4.0.0",
+    "System.Diagnostics.Tools": "4.0.0",
+    "System.Linq": "4.0.0",
+    "System.Linq.Expressions": "4.0.0",
+    "System.Reflection": "4.0.0",
+    "System.Reflection.Extensions": "4.0.0",
+    "System.Resources.ResourceManager": "4.0.0",
+    "System.Threading": "4.0.0"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Composition.Convention/tests/ExceptionAssert.cs
+++ b/src/System.Composition.Convention/tests/ExceptionAssert.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Composition.UnitTests.Util;
-using System.Runtime.Serialization;
 using Xunit;
 
 namespace System.Composition.Convention

--- a/src/System.Composition.Convention/tests/System.Composition.Convention.Tests.csproj
+++ b/src/System.Composition.Convention/tests/System.Composition.Convention.Tests.csproj
@@ -1,22 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{853BB14F-8A5B-42B4-A053-21DE1AEBB335}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ConventionsUnitTests</RootNamespace>
     <AssemblyName>System.Composition.Convention.Tests</AssemblyName>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TestProjectType>UnitTest</TestProjectType>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
@@ -66,11 +57,4 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/System.Composition.Hosting/src/System.Composition.Hosting.csproj
+++ b/src/System.Composition.Hosting/src/System.Composition.Hosting.csproj
@@ -1,22 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{2B8FECC6-34A1-48FE-BA75-99572D2D6DB2}</ProjectGuid>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <AssemblyName>System.Composition.Hosting</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <ProjectReference Include="..\..\System.Composition.Runtime\src\System.Composition.Runtime.csproj">
       <Project>{2711dfd2-8541-4628-bc53-eb784a14cdcf}</Project>
@@ -90,11 +80,4 @@
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/CompositionHost.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/CompositionHost.cs
@@ -8,8 +8,6 @@ using System.Composition.Hosting.Providers.CurrentScope;
 using System.Composition.Hosting.Providers.ExportFactory;
 using System.Composition.Hosting.Providers.ImportMany;
 using System.Composition.Hosting.Providers.Lazy;
-using System.Composition.Hosting.Providers.Metadata;
-using System.Composition.Runtime;
 using System.Linq;
 
 using Microsoft.Internal;

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/CompositionDependency.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/CompositionDependency.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Composition.Hosting.Util;
-using System.Composition.Runtime;
 using System.Linq;
 using System.Text;
 using Microsoft.Internal;

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/CompositionOperation.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/CompositionOperation.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Composition;
 using System.Collections.Generic;
 using System.Threading;
 using Microsoft.Internal;

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/CycleBreakingExportDescriptor.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/CycleBreakingExportDescriptor.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Internal;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/CycleBreakingMetadataDictionary.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/CycleBreakingMetadataDictionary.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using Microsoft.Internal;
 

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/DependencyAccessor.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/DependencyAccessor.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Composition.Runtime;
 using System.Linq;
 
 namespace System.Composition.Hosting.Core

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/ExportDescriptorPromise.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/ExportDescriptorPromise.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Composition.Runtime;
 using System.Linq;
 using Microsoft.Internal;
 

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/ExportDescriptorRegistry.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/ExportDescriptorRegistry.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Composition.Runtime;
 using Microsoft.Internal;
 
 namespace System.Composition.Hosting.Core

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/ExportDescriptorRegistryUpdate.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/ExportDescriptorRegistryUpdate.cs
@@ -3,11 +3,9 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Composition.Runtime;
 using System.Linq;
 using System.Text;
 using Microsoft.Internal;
-using System.Composition.Hosting.Properties;
 
 namespace System.Composition.Hosting.Core
 {

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/LifetimeContext.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Core/LifetimeContext.cs
@@ -4,10 +4,8 @@
 
 using System.Collections.Generic;
 using System.Composition.Hosting.Util;
-using System.Composition.Runtime;
 using System.Threading;
 using Microsoft.Internal;
-using System.Composition.Hosting.Properties;
 
 namespace System.Composition.Hosting.Core
 {

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/Constants.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/Constants.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace System.Composition.Hosting.Providers
 {
     /// <summary>

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/CurrentScope/CurrentScopeExportDescriptorProvider.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/CurrentScope/CurrentScopeExportDescriptorProvider.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Composition.Hosting.Core;
-using System.Composition.Runtime;
 
 namespace System.Composition.Hosting.Providers.CurrentScope
 {

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/ExportFactory/ExportFactoryExportDescriptorProvider.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/ExportFactory/ExportFactoryExportDescriptorProvider.cs
@@ -5,10 +5,8 @@
 using System.Linq;
 using System.Reflection;
 using System.Composition.Hosting.Core;
-using System.Composition.Runtime;
 using System.Collections.Generic;
 using System.Composition.Hosting.Util;
-using System.Composition.Hosting.Properties;
 using Microsoft.Internal;
 
 namespace System.Composition.Hosting.Providers.ExportFactory

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/ExportFactory/ExportFactoryWithMetadataExportDescriptorProvider.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/ExportFactory/ExportFactoryWithMetadataExportDescriptorProvider.cs
@@ -5,12 +5,9 @@
 using System.Reflection;
 using System.Composition.Hosting.Util;
 using System.Composition.Hosting.Core;
-using System.Composition.Runtime;
 using System.Linq;
-using System.Threading;
 using System.Collections.Generic;
 using System.Composition.Hosting.Providers.Metadata;
-using System.Composition.Hosting.Properties;
 using Microsoft.Internal;
 
 namespace System.Composition.Hosting.Providers.ExportFactory

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/ImportMany/ImportManyExportDescriptorProvider.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/ImportMany/ImportManyExportDescriptorProvider.cs
@@ -5,10 +5,8 @@
 using System.Reflection;
 using System.Composition.Hosting.Core;
 using System.Composition.Hosting.Util;
-using System.Composition.Runtime;
 using System.Collections.Generic;
 using System.Linq;
-using System.Composition.Hosting.Properties;
 
 namespace System.Composition.Hosting.Providers.ImportMany
 {

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/Lazy/LazyExportDescriptorProvider.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/Lazy/LazyExportDescriptorProvider.cs
@@ -5,10 +5,8 @@
 using System.Linq;
 using System.Reflection;
 using System.Composition.Hosting.Core;
-using System.Composition.Runtime;
 using System.Collections.Generic;
 using System.Composition.Hosting.Util;
-using System.Composition.Hosting.Properties;
 
 namespace System.Composition.Hosting.Providers.Lazy
 {

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/Lazy/LazyWithMetadataExportDescriptorProvider.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/Lazy/LazyWithMetadataExportDescriptorProvider.cs
@@ -4,9 +4,7 @@
 
 using System.Reflection;
 using System.Composition.Hosting.Core;
-using System.Composition.Runtime;
 using System.Linq;
-using System.Threading;
 using System.Composition.Hosting.Util;
 using System.Collections.Generic;
 using System.Composition.Hosting.Providers.Metadata;

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/Metadata/MetadataViewProvider.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Providers/Metadata/MetadataViewProvider.cs
@@ -2,16 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Composition.Hosting.Core;
-using System.Composition.Hosting.Util;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Internal;
 
 namespace System.Composition.Hosting.Providers.Metadata

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Util/Formatters.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Util/Formatters.cs
@@ -3,10 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
-using System.Text;
-
 using Microsoft.Internal;
 
 namespace System.Composition.Hosting.Util

--- a/src/System.Composition.Hosting/src/System/Composition/Hosting/Util/SmallSparseInitonlyArray.cs
+++ b/src/System.Composition.Hosting/src/System/Composition/Hosting/Util/SmallSparseInitonlyArray.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Composition.Hosting;
-
 using Microsoft.Internal;
 
 namespace System.Composition.Hosting.Util

--- a/src/System.Composition.Hosting/src/project.json
+++ b/src/System.Composition.Hosting/src/project.json
@@ -1,0 +1,19 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.0",
+    "System.Diagnostics.Contracts": "4.0.0",
+    "System.Diagnostics.Debug": "4.0.0",
+    "System.Diagnostics.Tools": "4.0.0",
+    "System.Globalization": "4.0.0",
+    "System.Linq": "4.0.0",
+    "System.Linq.Expressions": "4.0.0",
+    "System.ObjectModel": "4.0.0",
+    "System.Reflection": "4.0.0",
+    "System.Reflection.Extensions": "4.0.0",
+    "System.Resources.ResourceManager": "4.0.0",
+    "System.Threading": "4.0.0"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Composition.Runtime/src/System.Composition.Runtime.csproj
+++ b/src/System.Composition.Runtime/src/System.Composition.Runtime.csproj
@@ -1,23 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{2711DFD2-8541-4628-BC53-EB784A14CDCF}</ProjectGuid>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Composition</RootNamespace>
     <AssemblyName>System.Composition.Runtime</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
@@ -39,11 +29,4 @@
     <Compile Include="System\Composition\Runtime\Util\Formatters.cs" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/System.Composition.Runtime/src/System/Composition/CompositionContext.cs
+++ b/src/System.Composition.Runtime/src/System/Composition/CompositionContext.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Reflection;
-using System.Composition.Runtime;
 using System.Collections.Generic;
 using System.Composition.Hosting.Core;
 using System.Composition.Hosting;

--- a/src/System.Composition.Runtime/src/System/Composition/ExportFactoryOfT.cs
+++ b/src/System.Composition.Runtime/src/System/Composition/ExportFactoryOfT.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace System.Composition
 {
     /// <summary>

--- a/src/System.Composition.Runtime/src/System/Composition/ExportFactoryOfTTMetadata.cs
+++ b/src/System.Composition.Runtime/src/System/Composition/ExportFactoryOfTTMetadata.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace System.Composition
 {
     /// <summary>

--- a/src/System.Composition.Runtime/src/System/Composition/ExportOfT.cs
+++ b/src/System.Composition.Runtime/src/System/Composition/ExportOfT.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Linq;
-
 namespace System.Composition
 {
     /// <summary>

--- a/src/System.Composition.Runtime/src/System/Composition/Hosting/CompositionFailedException.cs
+++ b/src/System.Composition.Runtime/src/System/Composition/Hosting/CompositionFailedException.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-
 namespace System.Composition.Hosting
 {
     /// <summary>

--- a/src/System.Composition.Runtime/src/System/Composition/Hosting/Core/CompositionContract.cs
+++ b/src/System.Composition.Runtime/src/System/Composition/Hosting/Core/CompositionContract.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Composition.Runtime.Util;

--- a/src/System.Composition.Runtime/src/System/Composition/Runtime/Util/Formatters.cs
+++ b/src/System.Composition.Runtime/src/System/Composition/Runtime/Util/Formatters.cs
@@ -2,11 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace System.Composition.Runtime.Util
 {

--- a/src/System.Composition.Runtime/src/project.json
+++ b/src/System.Composition.Runtime/src/project.json
@@ -1,0 +1,14 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.0",
+    "System.Diagnostics.Debug": "4.0.0",
+    "System.Diagnostics.Tools": "4.0.0",
+    "System.Globalization": "4.0.0",
+    "System.Linq": "4.0.0",
+    "System.Reflection": "4.0.0",
+    "System.Resources.ResourceManager": "4.0.0",
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Composition.TypedParts/src/System.Composition.TypedParts.csproj
+++ b/src/System.Composition.TypedParts/src/System.Composition.TypedParts.csproj
@@ -1,23 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{B4B5E15C-E6B9-48EA-94C2-F067484D4D3E}</ProjectGuid>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Composition</RootNamespace>
     <AssemblyName>System.Composition.TypedParts</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <PropertyGroup>
     <ExternallyShipping>true</ExternallyShipping>
   </PropertyGroup>
@@ -73,11 +63,4 @@
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/System.Composition.TypedParts/src/System/Composition/CompositionContextExtensions.cs
+++ b/src/System.Composition.TypedParts/src/System/Composition/CompositionContextExtensions.cs
@@ -4,7 +4,6 @@
 
 using System.Composition.Convention;
 using System.Composition.Hosting;
-using System.Composition.Runtime;
 using System.Composition.TypedParts;
 using System.Composition.TypedParts.ActivationFeatures;
 using System.Composition.TypedParts.Util;

--- a/src/System.Composition.TypedParts/src/System/Composition/Convention/AttributedModelProviderExtensions.cs
+++ b/src/System.Composition.TypedParts/src/System/Composition/Convention/AttributedModelProviderExtensions.cs
@@ -2,13 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Collections.Generic;
-using System.Composition.Convention;
 using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace System.Composition.Convention
 {

--- a/src/System.Composition.TypedParts/src/System/Composition/Debugging/DiscoveredPartDebuggerProxy.cs
+++ b/src/System.Composition.TypedParts/src/System/Composition/Debugging/DiscoveredPartDebuggerProxy.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Composition.TypedParts.Discovery;
 using System.Linq;

--- a/src/System.Composition.TypedParts/src/System/Composition/TypedParts/ActivationFeatures/ActivationFeature.cs
+++ b/src/System.Composition.TypedParts/src/System/Composition/TypedParts/ActivationFeatures/ActivationFeature.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using Microsoft.Internal;
-using System;
 using System.Collections.Generic;
 using System.Composition.Hosting.Core;
 using System.Reflection;

--- a/src/System.Composition.TypedParts/src/System/Composition/TypedParts/ActivationFeatures/DisposalFeature.cs
+++ b/src/System.Composition.TypedParts/src/System/Composition/TypedParts/ActivationFeatures/DisposalFeature.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Composition.Hosting.Core;
 using System.Reflection;

--- a/src/System.Composition.TypedParts/src/System/Composition/TypedParts/ActivationFeatures/LifetimeFeature.cs
+++ b/src/System.Composition.TypedParts/src/System/Composition/TypedParts/ActivationFeatures/LifetimeFeature.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Composition.Hosting.Core;
 using System.Reflection;

--- a/src/System.Composition.TypedParts/src/System/Composition/TypedParts/ActivationFeatures/OnImportsSatisfiedFeature.cs
+++ b/src/System.Composition.TypedParts/src/System/Composition/TypedParts/ActivationFeatures/OnImportsSatisfiedFeature.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Composition.Convention;
 using System.Composition.Hosting;
 using System.Composition.Hosting.Core;
-using System.Composition.Runtime;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;

--- a/src/System.Composition.TypedParts/src/System/Composition/TypedParts/ActivationFeatures/PropertyInjectionFeature.cs
+++ b/src/System.Composition.TypedParts/src/System/Composition/TypedParts/ActivationFeatures/PropertyInjectionFeature.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Composition.Hosting.Core;
 using System.Linq;

--- a/src/System.Composition.TypedParts/src/System/Composition/TypedParts/ContractHelpers.cs
+++ b/src/System.Composition.TypedParts/src/System/Composition/TypedParts/ContractHelpers.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Composition.Hosting.Core;
-using System.Composition.Runtime;
 using System.Composition.TypedParts.ActivationFeatures;
 using System.Composition.Hosting;
 

--- a/src/System.Composition.TypedParts/src/System/Composition/TypedParts/Discovery/DiscoveredExport.cs
+++ b/src/System.Composition.TypedParts/src/System/Composition/TypedParts/Discovery/DiscoveredExport.cs
@@ -2,12 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Composition.Hosting.Core;
-using System.Composition.Runtime;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
 
 namespace System.Composition.TypedParts.Discovery

--- a/src/System.Composition.TypedParts/src/System/Composition/TypedParts/Discovery/DiscoveredInstanceExport.cs
+++ b/src/System.Composition.TypedParts/src/System/Composition/TypedParts/Discovery/DiscoveredInstanceExport.cs
@@ -4,7 +4,6 @@
 
 using System.Collections.Generic;
 using System.Composition.Hosting.Core;
-using System.Composition.Runtime;
 using System.Reflection;
 
 namespace System.Composition.TypedParts.Discovery

--- a/src/System.Composition.TypedParts/src/System/Composition/TypedParts/Discovery/DiscoveredPart.cs
+++ b/src/System.Composition.TypedParts/src/System/Composition/TypedParts/Discovery/DiscoveredPart.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -11,7 +10,6 @@ using System.Diagnostics;
 using System.Composition.Debugging;
 using System.Composition.TypedParts.ActivationFeatures;
 using System.Composition.Hosting.Core;
-using System.Composition.Runtime;
 using System.Composition.Convention;
 using System.Composition.Hosting;
 

--- a/src/System.Composition.TypedParts/src/System/Composition/TypedParts/Discovery/DiscoveredPropertyExport.cs
+++ b/src/System.Composition.TypedParts/src/System/Composition/TypedParts/Discovery/DiscoveredPropertyExport.cs
@@ -2,11 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Composition.Hosting.Core;
-using System.Composition.Runtime;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 

--- a/src/System.Composition.TypedParts/src/System/Composition/TypedParts/Discovery/TypeInspector.cs
+++ b/src/System.Composition.TypedParts/src/System/Composition/TypedParts/Discovery/TypeInspector.cs
@@ -2,12 +2,10 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Composition.Convention;
 using System.Composition.Hosting;
 using System.Composition.Hosting.Core;
-using System.Composition.Runtime;
 using System.Composition.TypedParts.ActivationFeatures;
 using System.Linq;
 using System.Reflection;

--- a/src/System.Composition.TypedParts/src/System/Composition/TypedParts/TypedPartExportDescriptorProvider.cs
+++ b/src/System.Composition.TypedParts/src/System/Composition/TypedParts/TypedPartExportDescriptorProvider.cs
@@ -2,11 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
 using System.Composition.Convention;
 using System.Composition.Hosting.Core;
-using System.Composition.Runtime;
 using System.Composition.TypedParts.ActivationFeatures;
 using System.Composition.TypedParts.Discovery;
 using System.Linq;

--- a/src/System.Composition.TypedParts/src/System/Composition/TypedParts/Util/DirectAttributeContext.cs
+++ b/src/System.Composition.TypedParts/src/System/Composition/TypedParts/Util/DirectAttributeContext.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using System.Composition.Convention;
 using Microsoft.Internal;

--- a/src/System.Composition.TypedParts/src/project.json
+++ b/src/System.Composition.TypedParts/src/project.json
@@ -1,0 +1,17 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.0",
+    "System.Diagnostics.Debug": "4.0.0",
+    "System.Diagnostics.Tools": "4.0.0",
+    "System.Globalization": "4.0.0",
+    "System.Linq": "4.0.0",
+    "System.Linq.Expressions": "4.0.0",
+    "System.Reflection": "4.0.0",
+    "System.Reflection.Extensions": "4.0.0",
+    "System.Resources.ResourceManager": "4.0.0",
+    "System.Runtime.Extensions": "4.0.0"
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Composition/demos/Microsoft.Composition.Demos.ExtendedCollectionImports/KeyByMetadataAttribute.cs
+++ b/src/System.Composition/demos/Microsoft.Composition.Demos.ExtendedCollectionImports/KeyByMetadataAttribute.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Composition;
 
 namespace Microsoft.Composition.Demos.ExtendedCollectionImports

--- a/src/System.Composition/demos/Microsoft.Composition.Demos.ExtendedCollectionImports/Microsoft.Composition.Demos.ExtendedCollectionImports.csproj
+++ b/src/System.Composition/demos/Microsoft.Composition.Demos.ExtendedCollectionImports/Microsoft.Composition.Demos.ExtendedCollectionImports.csproj
@@ -1,23 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{44C7E52C-3873-4C64-875C-8A23A8376D60}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Microsoft.Composition.Demos.ExtendedCollectionImports</RootNamespace>
     <AssemblyName>Microsoft.Composition.Demos.ExtendedCollectionImports</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="Dictionaries\DictionaryExportDescriptorProvider.cs" />
@@ -43,15 +33,5 @@
       <Name>System.Composition.Runtime</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/System.Composition/demos/Microsoft.Composition.Demos.ExtendedCollectionImports/project.json
+++ b/src/System.Composition/demos/Microsoft.Composition.Demos.ExtendedCollectionImports/project.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {
+    "System.Collections": "4.0.0",
+    "System.Linq": "4.0.0",
+    "System.Reflection": "4.0.0",
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Composition/perftests/Microsoft.Composition.ThroughputHarness.csproj
+++ b/src/System.Composition/perftests/Microsoft.Composition.ThroughputHarness.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{E3E3DA53-B8AC-46B6-8AAB-EBF751A2D0C3}</ProjectGuid>
@@ -8,12 +7,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CompositionThroughput</RootNamespace>
     <AssemblyName>CompositionThroughput</AssemblyName>
-    <FileAlignment>512</FileAlignment>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="Benchmark.cs" />
     <Compile Include="ControlBenchmark.cs" />
@@ -54,15 +50,5 @@
       <Name>System.Composition.TypedParts</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/System.Composition/scenarios/TestLibrary/TestClass.cs
+++ b/src/System.Composition/scenarios/TestLibrary/TestClass.cs
@@ -3,11 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Collections.Generic;
 using System.Composition;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 [assembly: System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
 

--- a/src/System.Composition/scenarios/TestLibrary/TestLibrary.csproj
+++ b/src/System.Composition/scenarios/TestLibrary/TestLibrary.csproj
@@ -1,24 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{DA6841A5-0344-4CC7-98B0-89CBEE18DEE3}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>TestLibrary</RootNamespace>
     <AssemblyName>TestLibrary</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile259</TargetFrameworkProfile>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\..\oob\</SolutionDir>
-    <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="TestClass.cs" />
     <Compile Include="$(CommonPath)\System\Diagnostics\CodeAnalysis\ExcludeFromCodeCoverageAttribute.cs">
@@ -32,11 +21,4 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/System.Composition/scenarios/TestLibrary/project.json
+++ b/src/System.Composition/scenarios/TestLibrary/project.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "System.Runtime": "4.0.0",
+  },
+  "frameworks": {
+    "dnxcore50": {}
+  }
+}

--- a/src/System.Composition/tests/System.Composition.Tests.csproj
+++ b/src/System.Composition/tests/System.Composition.Tests.csproj
@@ -2,27 +2,12 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <ProductVersion>
-    </ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{4852A19F-C05C-478D-BFA0-59FD03DE0E3F}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Composition.Lightweight.UnitTests</RootNamespace>
     <AssemblyName>System.Composition.Tests</AssemblyName>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <ExternallyShipping>false</ExternallyShipping>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
-  <ItemGroup>
-    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
-      <Visible>False</Visible>
-    </CodeAnalysisDependentAssemblyPaths>
-  </ItemGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="ActivationEventOrderingTests.cs" />
     <Compile Include="CardinalityTests.cs" />
@@ -87,15 +72,5 @@
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/ActivityTracker.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/ActivityTracker.cs
@@ -14,7 +14,6 @@ using Contract = Microsoft.Diagnostics.Contracts.Internal.Contract;
 #if ES_BUILD_STANDALONE
 namespace Microsoft.Diagnostics.Tracing
 #else
-using System.Threading.Tasks;
 namespace System.Diagnostics.Tracing
 #endif
 {

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventSource.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventSource.cs
@@ -195,8 +195,6 @@ using Microsoft.Win32;
 
 #if ES_BUILD_STANDALONE
 using EventDescriptor = Microsoft.Diagnostics.Tracing.EventDescriptor;
-#else
-using System.Threading.Tasks;
 #endif
 
 using Microsoft.Reflection;

--- a/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventSourceException.cs
+++ b/src/System.Diagnostics.Tracing/src/System/Diagnostics/Tracing/EventSourceException.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Runtime.Serialization;
-
 #if ES_BUILD_STANDALONE
 using Environment = Microsoft.Diagnostics.Tracing.Internal.Environment;
 #endif

--- a/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
+++ b/src/System.IO.FileSystem/src/System.IO.FileSystem.csproj
@@ -35,7 +35,8 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'net46_Release|AnyCPU'" />
 
   <ItemGroup Condition="'$(EnableWinRT)' == 'true'">
-    <TargetingPackReference Include="windows" />
+    <TargetingPackReference Include="Windows" />
+    <ProjectReference Include="$(SourceDir)/mscorlib.WinRT-Facade/mscorlib.WinRT-Facade.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetGroup)' != 'net46'">

--- a/src/System.IO.FileSystem/src/System/IO/WinRTFileSystem.cs
+++ b/src/System.IO.FileSystem/src/System/IO/WinRTFileSystem.cs
@@ -563,7 +563,7 @@ namespace System.IO
                 throw Win32Marshal.GetExceptionForWin32Error(Interop.mincore.Errors.ERROR_DIR_NOT_EMPTY, fullPath);
 
             // StorageFolder.Delete ignores readonly attribute.  Detect and throw.
-            if ((folder.Attributes & Windows.Storage.FileAttributes.ReadOnly) == Windows.Storage.FileAttributes.ReadOnly)
+            if ((folder.Attributes & WinRTFileAttributes.ReadOnly) == WinRTFileAttributes.ReadOnly)
                 throw new IOException(SR.Format(SR.UnauthorizedAccess_IODenied_Path, fullPath));
 
             StorageFolder parentFolder = await folder.GetParentAsync().TranslateWinRTTask(fullPath, isDirectory: true);

--- a/src/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
+++ b/src/System.IO.IsolatedStorage/src/System.IO.IsolatedStorage.csproj
@@ -15,6 +15,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Release|AnyCPU'" />
   <ItemGroup>
+    <ProjectReference Include="$(SourceDir)/mscorlib.WinRT-Facade/mscorlib.WinRT-Facade.csproj" />
     <TargetingPackReference Include="Windows" />
   </ItemGroup>
   <ItemGroup>

--- a/src/System.Net.Http/src/System.Net.Http.csproj
+++ b/src/System.Net.Http/src/System.Net.Http.csproj
@@ -302,6 +302,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetGroup)' == 'netcore50'">
+    <ProjectReference Include="$(SourceDir)/mscorlib.WinRT-Facade/mscorlib.WinRT-Facade.csproj" />
     <Compile Include="$(CommonPath)\System\NotImplemented.cs">
       <Link>Common\System\NotImplemented.cs</Link>
     </Compile>

--- a/src/System.Net.NameResolution/System.Net.NameResolution.sln
+++ b/src/System.Net.NameResolution/System.Net.NameResolution.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{EC3CAC27-AC09-4A62-BBE3-87FB0AFF5EF2}"
 EndProject
@@ -19,11 +19,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PalTests", "PalTests", "{B4
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Net.NameResolution.Functional.Tests", "tests\FunctionalTests\System.Net.NameResolution.Functional.Tests.csproj", "{4FE5ECEE-ACC5-4558-A946-573426599B73}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Net.NameResolution.Linux.Pal.Tests", "tests\PalTests\System.Net.NameResolution.Linux.Pal.Tests.csproj", "{F6D1C093-081D-46DE-B5A8-516533375FDD}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Net.NameResolution.OSX.Pal.Tests", "tests\PalTests\System.Net.NameResolution.OSX.Pal.Tests.csproj", "{4C70E926-14E6-4176-9B0E-D6E36D142A47}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Net.NameResolution.Windows.Pal.Tests", "tests\PalTests\System.Net.NameResolution.Windows.Pal.Tests.csproj", "{C2A9E586-CB17-44BE-AAC9-904D53899B95}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Net.NameResolution.Pal.Tests", "tests\PalTests\System.Net.NameResolution.Pal.Tests.csproj", "{F6D1C093-081D-46DE-B5A8-516533375FDD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -101,38 +97,6 @@ Global
 		{F6D1C093-081D-46DE-B5A8-516533375FDD}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
 		{F6D1C093-081D-46DE-B5A8-516533375FDD}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
 		{F6D1C093-081D-46DE-B5A8-516533375FDD}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
-		{4C70E926-14E6-4176-9B0E-D6E36D142A47}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
-		{4C70E926-14E6-4176-9B0E-D6E36D142A47}.Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
-		{4C70E926-14E6-4176-9B0E-D6E36D142A47}.Linux_Debug|Any CPU.ActiveCfg = Linux_Debug|Any CPU
-		{4C70E926-14E6-4176-9B0E-D6E36D142A47}.Linux_Debug|Any CPU.Build.0 = Linux_Debug|Any CPU
-		{4C70E926-14E6-4176-9B0E-D6E36D142A47}.Linux_Release|Any CPU.ActiveCfg = Linux_Release|Any CPU
-		{4C70E926-14E6-4176-9B0E-D6E36D142A47}.Linux_Release|Any CPU.Build.0 = Linux_Release|Any CPU
-		{4C70E926-14E6-4176-9B0E-D6E36D142A47}.OSX_Debug|Any CPU.ActiveCfg = OSX_Debug|Any CPU
-		{4C70E926-14E6-4176-9B0E-D6E36D142A47}.OSX_Debug|Any CPU.Build.0 = OSX_Debug|Any CPU
-		{4C70E926-14E6-4176-9B0E-D6E36D142A47}.OSX_Release|Any CPU.ActiveCfg = OSX_Release|Any CPU
-		{4C70E926-14E6-4176-9B0E-D6E36D142A47}.OSX_Release|Any CPU.Build.0 = OSX_Release|Any CPU
-		{4C70E926-14E6-4176-9B0E-D6E36D142A47}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
-		{4C70E926-14E6-4176-9B0E-D6E36D142A47}.Release|Any CPU.Build.0 = Windows_Release|Any CPU
-		{4C70E926-14E6-4176-9B0E-D6E36D142A47}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
-		{4C70E926-14E6-4176-9B0E-D6E36D142A47}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
-		{4C70E926-14E6-4176-9B0E-D6E36D142A47}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
-		{4C70E926-14E6-4176-9B0E-D6E36D142A47}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
-		{C2A9E586-CB17-44BE-AAC9-904D53899B95}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
-		{C2A9E586-CB17-44BE-AAC9-904D53899B95}.Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
-		{C2A9E586-CB17-44BE-AAC9-904D53899B95}.Linux_Debug|Any CPU.ActiveCfg = Linux_Debug|Any CPU
-		{C2A9E586-CB17-44BE-AAC9-904D53899B95}.Linux_Debug|Any CPU.Build.0 = Linux_Debug|Any CPU
-		{C2A9E586-CB17-44BE-AAC9-904D53899B95}.Linux_Release|Any CPU.ActiveCfg = Linux_Release|Any CPU
-		{C2A9E586-CB17-44BE-AAC9-904D53899B95}.Linux_Release|Any CPU.Build.0 = Linux_Release|Any CPU
-		{C2A9E586-CB17-44BE-AAC9-904D53899B95}.OSX_Debug|Any CPU.ActiveCfg = OSX_Debug|Any CPU
-		{C2A9E586-CB17-44BE-AAC9-904D53899B95}.OSX_Debug|Any CPU.Build.0 = OSX_Debug|Any CPU
-		{C2A9E586-CB17-44BE-AAC9-904D53899B95}.OSX_Release|Any CPU.ActiveCfg = OSX_Release|Any CPU
-		{C2A9E586-CB17-44BE-AAC9-904D53899B95}.OSX_Release|Any CPU.Build.0 = OSX_Release|Any CPU
-		{C2A9E586-CB17-44BE-AAC9-904D53899B95}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
-		{C2A9E586-CB17-44BE-AAC9-904D53899B95}.Release|Any CPU.Build.0 = Windows_Release|Any CPU
-		{C2A9E586-CB17-44BE-AAC9-904D53899B95}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
-		{C2A9E586-CB17-44BE-AAC9-904D53899B95}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
-		{C2A9E586-CB17-44BE-AAC9-904D53899B95}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
-		{C2A9E586-CB17-44BE-AAC9-904D53899B95}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -144,7 +108,5 @@ Global
 		{B4ECAB65-25BE-429A-AC6C-924174138F0B} = {1FBB81D4-E5E8-4F31-8F23-02DFDFC6339F}
 		{4FE5ECEE-ACC5-4558-A946-573426599B73} = {9828545B-B1F9-4321-AC18-5A223661C0AA}
 		{F6D1C093-081D-46DE-B5A8-516533375FDD} = {B4ECAB65-25BE-429A-AC6C-924174138F0B}
-		{4C70E926-14E6-4176-9B0E-D6E36D142A47} = {B4ECAB65-25BE-429A-AC6C-924174138F0B}
-		{C2A9E586-CB17-44BE-AAC9-904D53899B95} = {B4ECAB65-25BE-429A-AC6C-924174138F0B}
 	EndGlobalSection
 EndGlobal

--- a/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
+++ b/src/System.Net.NetworkInformation/src/System.Net.NetworkInformation.csproj
@@ -413,6 +413,9 @@
     <TargetingPackReference Include="mscorlib" />
     <TargetingPackReference Include="System" />
   </ItemGroup>
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcore50'">
+    <ProjectReference Include="$(SourceDir)/mscorlib.WinRT-Facade/mscorlib.WinRT-Facade.csproj" />
+  </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/System.Net.Primitives/src/System.Net.Primitives.csproj
+++ b/src/System.Net.Primitives/src/System.Net.Primitives.csproj
@@ -237,6 +237,10 @@
     <TargetingPackReference Include="System" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcore50'">
+    <ProjectReference Include="$(SourceDir)/mscorlib.WinRT-Facade/mscorlib.WinRT-Facade.csproj" />
+  </ItemGroup>
+
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/System.Net.Primitives/src/System/Net/CookieException.cs
+++ b/src/System.Net.Primitives/src/System/Net/CookieException.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics.CodeAnalysis;
-
 // The NETNative_SystemNetHttp #define is used in some source files to indicate we are compiling classes
 // directly into the .NET Native System.Net.Http.dll implementation assembly in order to use internal class
 // methods. Internal methods are needed in order to map cookie response headers from the WinRT Windows.Web.Http APIs.

--- a/src/System.Net.Primitives/src/System/Net/SecureProtocols/SslEnumTypes.cs
+++ b/src/System.Net.Primitives/src/System/Net/SecureProtocols/SslEnumTypes.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Runtime.InteropServices;
 

--- a/src/System.Net.Requests/src/System/Net/WebResponse.cs
+++ b/src/System.Net.Requests/src/System/Net/WebResponse.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Collections;
-using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.IO;
 

--- a/src/System.Net.Sockets/System.Net.Sockets.sln
+++ b/src/System.Net.Sockets/System.Net.Sockets.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "ref", "ref", "{89BE5448-6E11-4ABC-87C6-988225002CB3}"
 EndProject
@@ -57,10 +57,10 @@ Global
 		{9E212427-18B3-4EF4-966C-ED18AAC08422}.Windows_Release|Any CPU.Build.0 = Debug|Any CPU
 		{43311AFB-D7C4-4E5A-B1DE-855407F90D1B}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
 		{43311AFB-D7C4-4E5A-B1DE-855407F90D1B}.Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
-		{43311AFB-D7C4-4E5A-B1DE-855407F90D1B}.FreeBSD_Debug|Any CPU.ActiveCfg = FreeBSD_Debug|Any CPU
-		{43311AFB-D7C4-4E5A-B1DE-855407F90D1B}.FreeBSD_Debug|Any CPU.Build.0 = FreeBSD_Debug|Any CPU
-		{43311AFB-D7C4-4E5A-B1DE-855407F90D1B}.FreeBSD_Release|Any CPU.ActiveCfg = FreeBSD_Release|Any CPU
-		{43311AFB-D7C4-4E5A-B1DE-855407F90D1B}.FreeBSD_Release|Any CPU.Build.0 = FreeBSD_Release|Any CPU
+		{43311AFB-D7C4-4E5A-B1DE-855407F90D1B}.FreeBSD_Debug|Any CPU.ActiveCfg = net46_Release|Any CPU
+		{43311AFB-D7C4-4E5A-B1DE-855407F90D1B}.FreeBSD_Debug|Any CPU.Build.0 = net46_Release|Any CPU
+		{43311AFB-D7C4-4E5A-B1DE-855407F90D1B}.FreeBSD_Release|Any CPU.ActiveCfg = net46_Release|Any CPU
+		{43311AFB-D7C4-4E5A-B1DE-855407F90D1B}.FreeBSD_Release|Any CPU.Build.0 = net46_Release|Any CPU
 		{43311AFB-D7C4-4E5A-B1DE-855407F90D1B}.Linux_Debug|Any CPU.ActiveCfg = Linux_Debug|Any CPU
 		{43311AFB-D7C4-4E5A-B1DE-855407F90D1B}.Linux_Debug|Any CPU.Build.0 = Linux_Debug|Any CPU
 		{43311AFB-D7C4-4E5A-B1DE-855407F90D1B}.Linux_Release|Any CPU.ActiveCfg = Linux_Release|Any CPU
@@ -95,26 +95,26 @@ Global
 		{8CBA022C-635F-4C8D-9D29-CD8AAC68C8E6}.Windows_Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8CBA022C-635F-4C8D-9D29-CD8AAC68C8E6}.Windows_Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8CBA022C-635F-4C8D-9D29-CD8AAC68C8E6}.Windows_Release|Any CPU.Build.0 = Release|Any CPU
-		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.FreeBSD_Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.FreeBSD_Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.FreeBSD_Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.FreeBSD_Release|Any CPU.Build.0 = Release|Any CPU
-		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Linux_Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Linux_Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Linux_Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Linux_Release|Any CPU.Build.0 = Release|Any CPU
-		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.OSX_Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.OSX_Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.OSX_Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.OSX_Release|Any CPU.Build.0 = Release|Any CPU
-		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Windows_Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Windows_Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Windows_Release|Any CPU.ActiveCfg = Release|Any CPU
-		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Windows_Release|Any CPU.Build.0 = Release|Any CPU
+		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
+		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.FreeBSD_Debug|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.FreeBSD_Debug|Any CPU.Build.0 = Windows_Release|Any CPU
+		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.FreeBSD_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.FreeBSD_Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Linux_Debug|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Linux_Debug|Any CPU.Build.0 = Windows_Release|Any CPU
+		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Linux_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Linux_Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.OSX_Debug|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.OSX_Debug|Any CPU.Build.0 = Windows_Release|Any CPU
+		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.OSX_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.OSX_Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Release|Any CPU.Build.0 = Windows_Release|Any CPU
+		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Windows_Debug|Any CPU.ActiveCfg = Windows_Debug|Any CPU
+		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Windows_Debug|Any CPU.Build.0 = Windows_Debug|Any CPU
+		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Windows_Release|Any CPU.ActiveCfg = Windows_Release|Any CPU
+		{BB5C85AD-C51A-4903-80E9-6F6E1AC1AD34}.Windows_Release|Any CPU.Build.0 = Windows_Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
@@ -2,9 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Threading;
 using System.Threading.Tasks;
-using System.Diagnostics.CodeAnalysis;
 
 namespace System.Net.Sockets
 {

--- a/src/System.Net.Sockets/src/System/Net/Sockets/UdpReceiveResult.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/UdpReceiveResult.cs
@@ -2,8 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Diagnostics.CodeAnalysis;
-
 namespace System.Net.Sockets
 {
     public struct UdpReceiveResult : IEquatable<UdpReceiveResult>

--- a/src/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
+++ b/src/System.Net.WebSockets.Client/src/System.Net.WebSockets.Client.csproj
@@ -126,6 +126,10 @@
     <TargetingPackReference Include="System" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetGroup)' == 'netcore50'">
+    <ProjectReference Include="$(SourceDir)/mscorlib.WinRT-Facade/mscorlib.WinRT-Facade.csproj" />
+  </ItemGroup>
+
   <ItemGroup>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
+++ b/src/System.Runtime.Extensions/src/System.Runtime.Extensions.csproj
@@ -188,6 +188,7 @@
     <TargetingPackReference Include="System.Private.CoreLib.InteropServices" />
     <TargetingPackReference Include="System.Private.Interop" />
     <TargetingPackReference Include="System.Private.Threading" />
+    <ProjectReference Include="$(SourceDir)/mscorlib.WinRT-Facade/mscorlib.WinRT-Facade.csproj" />
     <ProjectReference Include="..\..\System.Runtime\src\System.Runtime.csproj" />
     <ProjectReference Include="..\..\System.Private.Uri\src\System.Private.Uri.csproj" />
   </ItemGroup>

--- a/src/System.Runtime.WindowsRuntime/ref/project.json
+++ b/src/System.Runtime.WindowsRuntime/ref/project.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "Microsoft.NETCore.Portable.Compatibility": "1.0.0",
     "Microsoft.TargetingPack.Private.WinRT": "1.0.1",
     "System.Runtime": "4.0.0",
     "System.IO": "4.0.0",

--- a/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
+++ b/src/System.Runtime.WindowsRuntime/src/System.Runtime.WindowsRuntime.csproj
@@ -28,6 +28,7 @@
     <TargetingPackReference Include="System.Private.Interop.Extensions"/>
     <TargetingPackReference Include="System.Private.Threading.AsyncCausalitySupport"/>
     <TargetingPackReference Include="Windows" />
+    <ProjectReference Include="$(SourceDir)/mscorlib.WinRT-Facade/mscorlib.WinRT-Facade.csproj" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetGroup)'==''">
     <TargetingPackReference Include="mscorlib"/>

--- a/src/System.Runtime.WindowsRuntime/src/project.json
+++ b/src/System.Runtime.WindowsRuntime/src/project.json
@@ -5,6 +5,25 @@
         "Microsoft.TargetingPack.Private.CoreCLR": "1.0.0-rc3-23818",
         "Microsoft.TargetingPack.Private.WinRT": "1.0.1"
       }
+    },
+    "netcore50": {
+      "dependencies": {
+        "Microsoft.TargetingPack.Private.NetNative": "1.0.0-rc3-23818",
+        "Microsoft.TargetingPack.Private.WinRT": "1.0.1",
+        "System.Collections": "4.0.0",
+        "System.Diagnostics.Debug": "4.0.10",
+        "System.Dynamic.Runtime": "4.0.10",
+        "System.Globalization": "4.0.0",
+        "System.IO": "4.0.10",
+        "System.Reflection": "4.0.0",
+        "System.Resources.ResourceManager": "4.0.0",
+        "System.Runtime": "4.0.20",
+        "System.Runtime.Extensions": "4.0.0",
+        "System.Runtime.InteropServices": "4.0.20",
+        "System.Runtime.InteropServices.WindowsRuntime": "4.0.0",
+        "System.Threading": "4.0.10.0",
+        "System.Threading.Tasks": "4.0.10.0"
+      }
     }
   }
 }

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Create.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Create.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
-using System.Diagnostics.Contracts;
-
 using Microsoft.Win32.SafeHandles;
 
 using Internal.Cryptography;

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Delete.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Delete.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
-using System.Diagnostics.Contracts;
-
-using Microsoft.Win32.SafeHandles;
-
 using Internal.Cryptography;
 
 using ErrorCode = Interop.NCrypt.ErrorCode;

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Exists.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Exists.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
-using System.Diagnostics.Contracts;
-
 using Microsoft.Win32.SafeHandles;
 
 using Internal.Cryptography;

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Export.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Export.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
-using System.Diagnostics.Contracts;
-
-using Microsoft.Win32.SafeHandles;
-
 using Internal.Cryptography;
 
 using ErrorCode = Interop.NCrypt.ErrorCode;

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Import.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Import.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
-using System.Diagnostics.Contracts;
-
 using Microsoft.Win32.SafeHandles;
 
 using Internal.Cryptography;

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Open.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Open.cs
@@ -2,10 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
-using System.Diagnostics.Contracts;
-
 using Microsoft.Win32.SafeHandles;
 
 using Internal.Cryptography;

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.OpenHandle.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.OpenHandle.cs
@@ -2,15 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
-using System.Diagnostics.Contracts;
-
 using Microsoft.Win32.SafeHandles;
 
 using Internal.Cryptography;
-
-using ErrorCode = Interop.NCrypt.ErrorCode;
 
 namespace System.Security.Cryptography
 {

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Properties.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.Properties.cs
@@ -2,12 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
-using System.Diagnostics.Contracts;
-
-using Microsoft.Win32.SafeHandles;
-
 using Internal.Cryptography;
 
 using ErrorCode = Interop.NCrypt.ErrorCode;

--- a/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.StandardProperties.cs
+++ b/src/System.Security.Cryptography.Cng/src/System/Security/Cryptography/CngKey.StandardProperties.cs
@@ -2,9 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
-using System.Diagnostics;
-using System.Diagnostics.Contracts;
 using System.Runtime.InteropServices;
 
 using Microsoft.Win32.SafeHandles;

--- a/src/System.Threading.Tasks.Dataflow/src/Internal/TargetCore.cs
+++ b/src/System.Threading.Tasks.Dataflow/src/Internal/TargetCore.cs
@@ -11,13 +11,11 @@
 //
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Contracts;
 using System.Linq;
-using System.Security;
 
 namespace System.Threading.Tasks.Dataflow.Internal
 {

--- a/src/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.WP8.csproj
+++ b/src/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.WP8.csproj
@@ -3,22 +3,17 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{0C10C503-FD37-4990-BD0F-B79FE22203DD}</ProjectGuid>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Threading.Tasks.Dataflow</RootNamespace>
     <AssemblyName>System.Threading.Tasks.Dataflow</AssemblyName>
     <AssemblyVersion>4.6.0.0</AssemblyVersion>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile78</TargetFrameworkProfile>
-    <FileAlignment>512</FileAlignment>
     <DocumentationFile>$(OutputPath)System.Threading.Tasks.Dataflow.XML</DocumentationFile>
-    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <PackageTargetFramework>dotnet5.1</PackageTargetFramework>
+    <ProjectJson>wp8/project.json</ProjectJson>
+    <ProjectLockJson>wp8/project.lock.json</ProjectLockJson>
   </PropertyGroup>
   <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="Base\DataflowBlock.cs" />
     <Compile Include="Base\DataflowBlockOptions.cs" />

--- a/src/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.csproj
+++ b/src/System.Threading.Tasks.Dataflow/src/System.Threading.Tasks.Dataflow.csproj
@@ -3,15 +3,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
     <ProjectGuid>{1DD0FF15-6234-4BD6-850A-317F05479554}</ProjectGuid>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Threading.Tasks.Dataflow</RootNamespace>
     <AssemblyName>System.Threading.Tasks.Dataflow</AssemblyName>
     <AssemblyVersion>4.6.0.0</AssemblyVersion>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile7</TargetFrameworkProfile>
-    <FileAlignment>512</FileAlignment>
     <DocumentationFile>$(OutputPath)System.Threading.Tasks.Dataflow.XML</DocumentationFile>
-    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);CONCURRENT_COLLECTIONS;FEATURE_TRACING</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
@@ -24,10 +19,8 @@
     </PackageDestination>
   </ItemGroup>
   <!-- Default configurations to help VS understand the configurations -->
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="Base\DataflowBlock.cs" />
     <Compile Include="Base\DataflowBlockOptions.cs" />
@@ -68,8 +61,7 @@
     <None Include="XmlDocs\CommonXmlDocComments.xml" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="XmlDocs\System.Threading.Tasks.Dataflow.xml">
-    </Content>
+    <Content Include="XmlDocs\System.Threading.Tasks.Dataflow.xml" />
   </ItemGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
 </Project>

--- a/src/System.Threading.Tasks.Dataflow/src/project.json
+++ b/src/System.Threading.Tasks.Dataflow/src/project.json
@@ -1,0 +1,22 @@
+{
+  "frameworks": {
+    "dnxcore50": {
+      "dependencies": {
+        "System.Collections": "4.0.0",
+        "System.Collections.Concurrent": "4.0.0",
+        "System.Diagnostics.Contracts": "4.0.0",
+        "System.Diagnostics.Debug": "4.0.0",
+        "System.Diagnostics.Tools": "4.0.0",
+        "System.Diagnostics.Tracing": "4.0.0",
+        "System.Dynamic.Runtime": "4.0.0",
+        "System.Linq": "4.0.0",
+        "System.Resources.ResourceManager": "4.0.0",
+        "System.Runtime": "4.0.0",
+        "System.Runtime.Extensions": "4.0.0",
+        "System.Runtime.Serialization.Primitives": "4.0.0",
+        "System.Threading": "4.0.0",
+        "System.Threading.Tasks": "4.0.0",
+      }
+    }
+  }
+}

--- a/src/System.Threading.Tasks.Dataflow/src/wp8/project.json
+++ b/src/System.Threading.Tasks.Dataflow/src/wp8/project.json
@@ -1,0 +1,20 @@
+{
+  "frameworks": {
+    "dnxcore50": {
+      "dependencies": {
+        "System.Collections": "4.0.0",
+        "System.Diagnostics.Contracts": "4.0.0",
+        "System.Diagnostics.Debug": "4.0.0",
+        "System.Diagnostics.Tools": "4.0.0",
+        "System.Dynamic.Runtime": "4.0.0",
+        "System.Linq": "4.0.0",
+        "System.Resources.ResourceManager": "4.0.0",
+        "System.Runtime": "4.0.0",
+        "System.Runtime.Extensions": "4.0.0",
+        "System.Runtime.Serialization.Primitives": "4.0.0",
+        "System.Threading": "4.0.0",
+        "System.Threading.Tasks": "4.0.0",
+      }
+    }
+  }
+}

--- a/src/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
+++ b/src/System.Threading.Tasks.Dataflow/tests/System.Threading.Tasks.Dataflow.Tests.csproj
@@ -2,20 +2,12 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{72E21903-0FBA-444E-9855-3B4F05DFC1F9}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>System.Threading.Tasks.Dataflow.Tests</RootNamespace>
     <AssemblyName>System.Threading.Tasks.Dataflow.Tests</AssemblyName>
-    <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>bcca2a00</NuGetPackageImportStamp>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <ItemGroup>
     <Compile Include="Dataflow\*.cs" />
     <Compile Include="$(CommonTestPath)\System\Diagnostics\Tracing\TestEventListener.cs">

--- a/src/mscorlib.WinRT-Facade/TypeForwards.cs
+++ b/src/mscorlib.WinRT-Facade/TypeForwards.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.CompilerServices;
+
+// The following types are can be referenced by windows.winmd and are spec'ed to come from mscorlib
+[assembly: TypeForwardedTo(typeof(System.Attribute))]
+[assembly: TypeForwardedTo(typeof(System.Boolean))]
+[assembly: TypeForwardedTo(typeof(System.Byte))]
+[assembly: TypeForwardedTo(typeof(System.Char))]
+[assembly: TypeForwardedTo(typeof(System.Double))]
+[assembly: TypeForwardedTo(typeof(System.Enum))]
+[assembly: TypeForwardedTo(typeof(System.FlagsAttribute))]
+[assembly: TypeForwardedTo(typeof(System.Guid))]
+[assembly: TypeForwardedTo(typeof(System.Int16))]
+[assembly: TypeForwardedTo(typeof(System.Int32))]
+[assembly: TypeForwardedTo(typeof(System.Int64))]
+[assembly: TypeForwardedTo(typeof(System.IntPtr))]
+[assembly: TypeForwardedTo(typeof(System.MulticastDelegate))]
+[assembly: TypeForwardedTo(typeof(System.Object))]
+[assembly: TypeForwardedTo(typeof(System.Runtime.CompilerServices.IsConst))]
+[assembly: TypeForwardedTo(typeof(System.Single))]
+[assembly: TypeForwardedTo(typeof(System.String))]
+[assembly: TypeForwardedTo(typeof(System.Type))]
+[assembly: TypeForwardedTo(typeof(System.UInt16))]
+[assembly: TypeForwardedTo(typeof(System.UInt32))]
+[assembly: TypeForwardedTo(typeof(System.UInt64))]
+[assembly: TypeForwardedTo(typeof(System.ValueType))]
+[assembly: TypeForwardedTo(typeof(void))] // System.Void
+
+// XAML compiler is checking for the following
+[assembly: TypeForwardedTo(typeof(System.Array))]

--- a/src/mscorlib.WinRT-Facade/mscorlib.WinRT-Facade.builds
+++ b/src/mscorlib.WinRT-Facade/mscorlib.WinRT-Facade.builds
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <ItemGroup>
+    <Project Include="mscorlib.WinRT-Facade.csproj" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.traversal.targets))\dir.traversal.targets" />
+</Project>
+

--- a/src/mscorlib.WinRT-Facade/mscorlib.WinRT-Facade.csproj
+++ b/src/mscorlib.WinRT-Facade/mscorlib.WinRT-Facade.csproj
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
+  <PropertyGroup>
+    <AssemblyName>mscorlib</AssemblyName>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+  </PropertyGroup>
+  <!-- Default configurations to help VS understand the configurations -->
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
+  <ItemGroup>
+    <Compile Include="TypeForwards.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.targets))\dir.targets" />
+</Project>

--- a/src/mscorlib.WinRT-Facade/project.json
+++ b/src/mscorlib.WinRT-Facade/project.json
@@ -1,0 +1,9 @@
+{
+  "frameworks": {
+    "dnxcore50": {
+      "dependencies": {
+        "System.Runtime": "4.0.20",
+      },
+    }
+  }
+}


### PR DESCRIPTION
See discussion at https://github.com/dotnet/corefx/pull/6077. I'm re-creating this because the CI was not restarting the Windows job for whatever reason.

@weshaggard @ericstj 

Resolves #5901 