### PR TITLE
Stability improvements for *nix Sockets

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.Accept.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Accept.cs
@@ -10,6 +10,23 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Accept")]
-        internal static extern unsafe Error Accept(int socket, byte* socketAddress, int* socketAddressLen, int* acceptedFd);
+        private static extern unsafe Error DangerousAccept(int socket, byte* socketAddress, int* socketAddressLen, int* acceptedFd);
+
+        internal static unsafe Error Accept(SafeHandle socket, byte* socketAddress, int* socketAddressLen, int* acceptedFd)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousAccept((int)socket.DangerousGetHandle(), socketAddress, socketAddressLen, acceptedFd);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Bind.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Bind.cs
@@ -10,6 +10,23 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Bind")]
-        internal static extern unsafe Error Bind(int socket, byte* socketAddress, int socketAddressLen);
+        private static extern unsafe Error DangerousBind(int socket, byte* socketAddress, int socketAddressLen);
+
+        internal static unsafe Error Bind(SafeHandle socket, byte* socketAddress, int socketAddressLen)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousBind((int)socket.DangerousGetHandle(), socketAddress, socketAddressLen);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Connect.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Connect.cs
@@ -10,6 +10,23 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Connect")]
-        internal static extern unsafe Error Connect(int socket, byte* socketAddress, int socketAddressLen);
+        private static extern unsafe Error DangerousConnect(int socket, byte* socketAddress, int socketAddressLen);
+
+        internal static unsafe Error Connect(SafeHandle socket, byte* socketAddress, int socketAddressLen)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousConnect((int)socket.DangerousGetHandle(), socketAddress, socketAddressLen);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Fcntl.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Fcntl.cs
@@ -11,8 +11,11 @@ internal static partial class Interop
     {
         internal static class Fcntl
         {
+            [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FcntlSetIsNonBlocking", SetLastError = true)]
+            internal static extern int DangerousSetIsNonBlocking(IntPtr fd, int isNonBlocking);
+
             [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FcntlSetIsNonBlocking", SetLastError=true)]
-            internal static extern int SetIsNonBlocking(IntPtr fd, int isNonBlocking);
+            internal static extern int SetIsNonBlocking(SafeHandle fd, int isNonBlocking);
         }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetBytesAvailable.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetBytesAvailable.cs
@@ -10,6 +10,23 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetBytesAvailable")]
-        internal static extern unsafe Error GetBytesAvailable(int socket, int* available);
+        private static extern unsafe Error DangerousGetBytesAvailable(int socket, int* available);
+
+        internal static unsafe Error GetBytesAvailable(SafeHandle socket, int* available)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousGetBytesAvailable((int)socket.DangerousGetHandle(), available);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetPeerName.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetPeerName.cs
@@ -10,6 +10,23 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetPeerName")]
-        internal static extern unsafe Error GetPeerName(int socket, byte* socketAddress, int* socketAddressLen);
+        private static extern unsafe Error DangerousGetPeerName(int socket, byte* socketAddress, int* socketAddressLen);
+
+        internal static unsafe Error GetPeerName(SafeHandle socket, byte* socketAddress, int* socketAddressLen)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousGetPeerName((int)socket.DangerousGetHandle(), socketAddress, socketAddressLen);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetSockName.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetSockName.cs
@@ -10,6 +10,23 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSockName")]
-        internal static extern unsafe Error GetSockName(int socket, byte* socketAddress, int* socketAddressLen);
+        private static extern unsafe Error DangerousGetSockName(int socket, byte* socketAddress, int* socketAddressLen);
+
+        internal static unsafe Error GetSockName(SafeHandle socket, byte* socketAddress, int* socketAddressLen)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousGetSockName((int)socket.DangerousGetHandle(), socketAddress, socketAddressLen);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetSockOpt.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetSockOpt.cs
@@ -11,6 +11,23 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSockOpt")]
-        internal static extern unsafe Error GetSockOpt(int socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int* optionLen);
+        private static extern unsafe Error DangerousGetSockOpt(int socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int* optionLen);
+
+        internal static unsafe Error GetSockOpt(SafeHandle socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int* optionLen)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousGetSockOpt((int)socket.DangerousGetHandle(), optionLevel, optionName, optionValue, optionLen);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetSocketErrorOption.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetSocketErrorOption.cs
@@ -11,6 +11,23 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetSocketErrorOption")]
-        internal static extern unsafe Error GetSocketErrorOption(int socket, Error* socketError);
+        private static extern unsafe Error DangerousGetSocketErrorOption(int socket, Error* socketError);
+
+        internal static unsafe Error GetSocketErrorOption(SafeHandle socket, Error* socketError)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousGetSocketErrorOption((int)socket.DangerousGetHandle(), socketError);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.LingerOption.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.LingerOption.cs
@@ -17,9 +17,43 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetLingerOption")]
-        internal static extern unsafe Error GetLingerOption(int socket, LingerOption* option);
+        private static extern unsafe Error DangerousGetLingerOption(int socket, LingerOption* option);
+
+        internal static unsafe Error GetLingerOption(SafeHandle socket, LingerOption* option)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousGetLingerOption((int)socket.DangerousGetHandle(), option);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetLingerOption")]
-        internal static extern unsafe Error SetLingerOption(int socket, LingerOption* option);
+        internal static extern unsafe Error DangerousSetLingerOption(int socket, LingerOption* option);
+
+        internal static unsafe Error SetLingerOption(SafeHandle socket, LingerOption* option)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousSetLingerOption((int)socket.DangerousGetHandle(), option);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Listen.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Listen.cs
@@ -10,6 +10,23 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Listen")]
-        internal static extern Error Listen(int socket, int backlog);
+        private static extern Error DangerousListen(int socket, int backlog);
+
+        internal static Error Listen(SafeHandle socket, int backlog)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousListen((int)socket.DangerousGetHandle(), backlog);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.MulticastOption.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.MulticastOption.cs
@@ -32,15 +32,83 @@ internal static partial class Interop
         }
        
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv4MulticastOption")]
-        internal static extern unsafe Error GetIPv4MulticastOption(int socket, MulticastOption multicastOption, IPv4MulticastOption* option);
+        private static extern unsafe Error DangerousGetIPv4MulticastOption(int socket, MulticastOption multicastOption, IPv4MulticastOption* option);
+
+        internal static unsafe Error GetIPv4MulticastOption(SafeHandle socket, MulticastOption multicastOption, IPv4MulticastOption* option)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousGetIPv4MulticastOption((int)socket.DangerousGetHandle(), multicastOption, option);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv4MulticastOption")]
-        internal static extern unsafe Error SetIPv4MulticastOption(int socket, MulticastOption multicastOption, IPv4MulticastOption* option);
+        private static extern unsafe Error DangerousSetIPv4MulticastOption(int socket, MulticastOption multicastOption, IPv4MulticastOption* option);
+
+        internal static unsafe Error SetIPv4MulticastOption(SafeHandle socket, MulticastOption multicastOption, IPv4MulticastOption* option)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousSetIPv4MulticastOption((int)socket.DangerousGetHandle(), multicastOption, option);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetIPv6MulticastOption")]
-        internal static extern unsafe Error GetIPv6MulticastOption(int socket, MulticastOption multicastOption, IPv6MulticastOption* option);
+        private static extern unsafe Error DangerousGetIPv6MulticastOption(int socket, MulticastOption multicastOption, IPv6MulticastOption* option);
+
+        internal static unsafe Error GetIPv6MulticastOption(SafeHandle socket, MulticastOption multicastOption, IPv6MulticastOption* option)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousGetIPv6MulticastOption((int)socket.DangerousGetHandle(), multicastOption, option);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetIPv6MulticastOption")]
-        internal static extern unsafe Error SetIPv6MulticastOption(int socket, MulticastOption multicastOption, IPv6MulticastOption* option);
+        private static extern unsafe Error DangerousSetIPv6MulticastOption(int socket, MulticastOption multicastOption, IPv6MulticastOption* option);
+
+        internal static unsafe Error SetIPv6MulticastOption(SafeHandle socket, MulticastOption multicastOption, IPv6MulticastOption* option)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousSetIPv6MulticastOption((int)socket.DangerousGetHandle(), multicastOption, option);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.ReceiveMessage.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ReceiveMessage.cs
@@ -11,6 +11,23 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReceiveMessage")]
-        internal static extern unsafe Error ReceiveMessage(int socket, MessageHeader* messageHeader, SocketFlags flags, long* received);
+        private static extern unsafe Error DangerousReceiveMessage(int socket, MessageHeader* messageHeader, SocketFlags flags, long* received);
+
+        internal static unsafe Error ReceiveMessage(SafeHandle socket, MessageHeader* messageHeader, SocketFlags flags, long* received)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousReceiveMessage((int)socket.DangerousGetHandle(), messageHeader, flags, received);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SendMessage.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SendMessage.cs
@@ -11,6 +11,23 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SendMessage")]
-        internal static extern unsafe Error SendMessage(int socket, MessageHeader* messageHeader, SocketFlags flags, long* sent);
+        private static extern unsafe Error DangerousSendMessage(int socket, MessageHeader* messageHeader, SocketFlags flags, long* sent);
+
+        internal static unsafe Error SendMessage(SafeHandle socket, MessageHeader* messageHeader, SocketFlags flags, long* sent)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousSendMessage((int)socket.DangerousGetHandle(), messageHeader, flags, sent);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SetReceiveTimeout.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SetReceiveTimeout.cs
@@ -11,6 +11,23 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetReceiveTimeout")]
-        internal static extern unsafe Error SetReceiveTimeout(int socket, int millisecondsTimeout);
+        private static extern unsafe Error DangerousSetReceiveTimeout(int socket, int millisecondsTimeout);
+
+        internal static unsafe Error SetReceiveTimeout(SafeHandle socket, int millisecondsTimeout)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousSetReceiveTimeout((int)socket.DangerousGetHandle(), millisecondsTimeout);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SetSendTimeout.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SetSendTimeout.cs
@@ -11,6 +11,23 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetSendTimeout")]
-        internal static extern unsafe Error SetSendTimeout(int socket, int millisecondsTimeout);
+        private static extern unsafe Error DangerousSetSendTimeout(int socket, int millisecondsTimeout);
+
+        internal static unsafe Error SetSendTimeout(SafeHandle socket, int millisecondsTimeout)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousSetSendTimeout((int)socket.DangerousGetHandle(), millisecondsTimeout);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SetSockOpt.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SetSockOpt.cs
@@ -11,6 +11,23 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetSockOpt")]
-        internal static extern unsafe Error SetSockOpt(int socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int optionLen);
+        internal static extern unsafe Error DangerousSetSockOpt(int socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int optionLen);
+
+        internal static unsafe Error SetSockOpt(SafeHandle socket, SocketOptionLevel optionLevel, SocketOptionName optionName, byte* optionValue, int optionLen)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousSetSockOpt((int)socket.DangerousGetHandle(), optionLevel, optionName, optionValue, optionLen);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Shutdown.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Shutdown.cs
@@ -11,6 +11,23 @@ internal static partial class Interop
     internal static partial class Sys
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Shutdown")]
-        internal static extern Error Shutdown(int socket, SocketShutdown how);
+        private static extern Error DangerousShutdown(int socket, SocketShutdown how);
+
+        internal static Error Shutdown(SafeHandle socket, SocketShutdown how)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousShutdown((int)socket.DangerousGetHandle(), how);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SocketEvent.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SocketEvent.cs
@@ -29,13 +29,13 @@ internal static partial class Interop
         }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CreateSocketEventPort")]
-        internal static extern unsafe Error CreateSocketEventPort(int* port);
+        internal static extern unsafe Error CreateSocketEventPort(out int port);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CloseSocketEventPort")]
         internal static extern Error CloseSocketEventPort(int port);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_CreateSocketEventBuffer")]
-        internal static extern unsafe Error CreateSocketEventBuffer(int count, SocketEvent** buffer);
+        internal static extern unsafe Error CreateSocketEventBuffer(int count, out SocketEvent* buffer);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_FreeSocketEventBuffer")]
         internal static extern unsafe Error FreeSocketEventBuffer(SocketEvent* buffer);

--- a/src/Common/src/Interop/Unix/System.Native/Interop.SocketEvent.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.SocketEvent.cs
@@ -41,7 +41,24 @@ internal static partial class Interop
         internal static extern unsafe Error FreeSocketEventBuffer(SocketEvent* buffer);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_TryChangeSocketEventRegistration")]
-        internal static extern Error TryChangeSocketEventRegistration(int port, int socket, SocketEvents currentEvents, SocketEvents newEvents, IntPtr data);
+        internal static extern Error DangerousTryChangeSocketEventRegistration(int port, int socket, SocketEvents currentEvents, SocketEvents newEvents, IntPtr data);
+
+        internal static Error TryChangeSocketEventRegistration(int port, SafeHandle socket, SocketEvents currentEvents, SocketEvents newEvents, IntPtr data)
+        {
+            bool release = false;
+            try
+            {
+                socket.DangerousAddRef(ref release);
+                return DangerousTryChangeSocketEventRegistration(port, (int)socket.DangerousGetHandle(), currentEvents, newEvents, data);
+            }
+            finally
+            {
+                if (release)
+                {
+                    socket.DangerousRelease();
+                }
+            }
+        }
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_WaitForSocketEvents")]
         internal static extern unsafe Error WaitForSocketEvents(int port, SocketEvent* buffer, int* count);

--- a/src/Common/src/Interop/Unix/System.Native/Interop.Write.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.Write.cs
@@ -20,5 +20,8 @@ internal static partial class Interop
         /// </returns>
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Write", SetLastError = true)]
         internal static unsafe extern int Write(SafeFileHandle fd, byte* buffer, int bufferSize);
+
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_Write", SetLastError = true)]
+        internal static unsafe extern int Write(int fd, byte* buffer, int bufferSize);
     }
 }

--- a/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
+++ b/src/Common/src/System/Net/SafeCloseSocket.Unix.cs
@@ -28,7 +28,7 @@ namespace System.Net.Sockets
             {
                 if (Volatile.Read(ref _asyncContext) == null)
                 {
-                    Interlocked.CompareExchange(ref _asyncContext, new SocketAsyncContext(this, SocketAsyncEngine.Instance), null);
+                    Interlocked.CompareExchange(ref _asyncContext, new SocketAsyncContext(this), null);
                 }
 
                 return _asyncContext;

--- a/src/System.Net.Sockets/src/System.Net.Sockets.csproj
+++ b/src/System.Net.Sockets/src/System.Net.Sockets.csproj
@@ -461,6 +461,12 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.SocketAddress.cs">
       <Link>Interop\Unix\System.Native\Interop.SocketAddress.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Pipe.cs">
+      <Link>Interop\Unix\System.Native\Interop.Pipe.cs</Link>
+    </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.Write.cs">
+      <Link>Interop\Unix\System.Native\Interop.Write.cs</Link>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetGroup)' == 'net46'">

--- a/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/Socket.Unix.cs
@@ -35,7 +35,7 @@ namespace System.Net.Sockets
                     throw new ArgumentException(SR.Format(SR.net_sockets_select, socketList[i].GetType().FullName, typeof(System.Net.Sockets.Socket).FullName), nameof(socketList));
                 }
 
-                int fd = socket._handle.FileDescriptor;
+                int fd = (int)socket._handle.DangerousGetHandle();
                 Interop.Sys.FD_SET(fd, fdset);
 
                 if (fd > maxFd)
@@ -61,7 +61,7 @@ namespace System.Net.Sockets
                 for (int i = socketList.Count - 1; i >= 0; i--)
                 {
                     var socket = (Socket)socketList[i];
-                    if (!Interop.Sys.FD_ISSET(socket._handle.FileDescriptor, fdset))
+                    if (!Interop.Sys.FD_ISSET((int)socket._handle.DangerousGetHandle(), fdset))
                     {
                         socketList.RemoveAt(i);
                     }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -486,34 +486,25 @@ namespace System.Net.Sockets
             }
         }
 
-        private void CloseInner()
-        {
-            Debug.Assert(Monitor.IsEntered(_queueLock));
-
-            // Drain queues
-
-            _acceptOrConnectQueue.StopAndAbort();
-            _sendQueue.StopAndAbort();
-            _receiveQueue.StopAndAbort();
-
-            // Freeing the token will prevent any future event delivery.  This socket will be unregistered
-            // from the event port automatically by the OS when it's closed.
-            _asyncEngineToken.Free();
-
-            // TODO: assert that queues are all empty if _registeredEvents was Interop.Sys.SocketEvents.None?
-
-            // TODO: assert that queues are all empty if _registeredEvents was Interop.Sys.SocketEvents.None?
-
-            // TODO: the error codes on these operations may need to be changed to account for
-            //       the close. I think Winsock returns OperationAborted in the case that
-            //       the socket for an outstanding operation is closed.
-        }
-
         public void Close()
         {
             lock (_queueLock)
             {
-                CloseInner();
+                // Drain queues
+
+                _acceptOrConnectQueue.StopAndAbort();
+                _sendQueue.StopAndAbort();
+                _receiveQueue.StopAndAbort();
+
+                // Freeing the token will prevent any future event delivery.  This socket will be unregistered
+                // from the event port automatically by the OS when it's closed.
+                _asyncEngineToken.Free();
+
+                // TODO: assert that queues are all empty if _registeredEvents was Interop.Sys.SocketEvents.None?
+
+                // TODO: the error codes on these operations may need to be changed to account for
+                //       the close. I think Winsock returns OperationAborted in the case that
+                //       the socket for an outstanding operation is closed.
             }
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -409,6 +409,18 @@ namespace System.Net.Sockets
                 }
             }
 
+            public void StopAndCompleteAll(SocketAsyncContext context)
+            {
+                OperationQueue<TOperation> queue = Stop();
+
+                TOperation op;
+                while (queue.TryDequeue(out op))
+                {
+                    bool completed = op.TryCompleteAsync(context);
+                    Debug.Assert(completed);
+                }
+            }
+
             public bool AllOfType<TCandidate>() where TCandidate : TOperation
             {
                 bool tailIsCandidateType = _tail is TCandidate;
@@ -1322,7 +1334,7 @@ namespace System.Net.Sockets
                     // Drain read queue and unregister read operations
                     Debug.Assert(_acceptOrConnectQueue.IsEmpty, "{Accept,Connect} queue should be empty before ReadClose");
 
-                    _receiveQueue.StopAndAbort();
+                    _receiveQueue.StopAndCompleteAll(this);
 
                     UnregisterRead();
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -108,6 +108,8 @@ namespace System.Net.Sockets
 
             private bool TryCompleteOrAbortAsync(SocketAsyncContext context, bool abort)
             {
+                Debug.Assert(context != null || abort);
+
                 State oldState = (State)Interlocked.CompareExchange(ref _state, (int)State.Running, (int)State.Waiting);
                 if (oldState == State.Cancelled)
                 {
@@ -367,6 +369,7 @@ namespace System.Net.Sockets
             {
                 // Insert at the head of the queue
                 Debug.Assert(!IsStopped);
+                Debug.Assert(operation.Next == null, "Operation already in queue");
 
                 operation.Next = (_tail == null) ? operation : _tail.Next;
                 _tail = operation;
@@ -511,12 +514,6 @@ namespace System.Net.Sockets
                 // Freeing the token will prevent any future event delivery.  This socket will be unregistered
                 // from the event port automatically by the OS when it's closed.
                 _asyncEngineToken.Free();
-
-                // TODO: assert that queues are all empty if _registeredEvents was Interop.Sys.SocketEvents.None?
-
-                // TODO: the error codes on these operations may need to be changed to account for
-                //       the close. I think Winsock returns OperationAborted in the case that
-                //       the socket for an outstanding operation is closed.
             }
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncContext.Unix.cs
@@ -490,7 +490,19 @@ namespace System.Net.Sockets
             Interop.Sys.SocketEvents events = _registeredEvents & ~Interop.Sys.SocketEvents.Read;
 
             Interop.Error errorCode;
-            bool unregistered = _asyncEngineToken.TryRegister(_socket, _registeredEvents, events, out errorCode);
+
+            bool unregistered;
+            try
+            {
+                unregistered = _asyncEngineToken.TryRegister(_socket, _registeredEvents, events, out errorCode);
+            }
+            catch (ObjectDisposedException)
+            {
+                // The socket has been closed, so the OS has already unregistered us.
+                unregistered = true;
+                errorCode = Interop.Error.SUCCESS;
+            }
+
             if (unregistered)
             {
                 _registeredEvents = events;

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -292,7 +292,7 @@ namespace System.Net.Sockets
             }
             catch (Exception e)
             {
-                Environment.FailFast("Exception thrown from SocketAsyncEngine event loop", e);
+                Environment.FailFast("Exception thrown from SocketAsyncEngine event loop: " + e.ToString(), e);
             }
         }
 

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -26,34 +26,34 @@ namespace System.Net.Sockets
                 AllocateToken(context, out _engine, out _handle);
             }
 
-            public bool IsAllocated
+            public bool WasAllocated
             {
                 get { return _engine != null; }
             }
 
             public void Free()
             {
-                if (IsAllocated)
+                if (WasAllocated)
                     _engine.FreeHandle(_handle);
             }
 
             public bool TryRegister(SafeCloseSocket socket, Interop.Sys.SocketEvents current, Interop.Sys.SocketEvents events, out Interop.Error error)
             {
-                Debug.Assert(IsAllocated);
+                Debug.Assert(WasAllocated);
                 return _engine.TryRegister(socket, current, events, _handle, out error);
             }
         }
 
         private const int EventBufferCount = 64;
 
-        private static readonly object _lock = new object();
+        private static readonly object s_lock = new object();
 
         //
         // The current engine.  We replace this with a new engine when we run out of "handle" values for the current
         // engine.
-        // Must be accessed under _lock.
+        // Must be accessed under s_lock.
         //
-        private static SocketAsyncEngine _currentEngine;
+        private static SocketAsyncEngine s_currentEngine;
 
         private readonly int _port;
         private readonly Interop.Sys.SocketEvent* _buffer;
@@ -79,36 +79,36 @@ namespace System.Net.Sockets
         // In debug builds, force rollover to new SocketAsyncEngine instances so that code doesn't go untested, since
         // it's very unlikely that the "real" limits will ever be reached in test code.
         //
-        private readonly IntPtr MaxHandles = (IntPtr)(EventBufferCount * 2);
+        private static readonly IntPtr MaxHandles = (IntPtr)(EventBufferCount * 2);
 #else
         //
         // In release builds, we use *very* high limits.  No 64-bit process running on release builds should ever
         // reach the handle limit for a single event port, and even 32-bit processes should see this only very rarely.
         //
-        private readonly IntPtr MaxHandles = IntPtr.Size == 4 ? (IntPtr)int.MaxValue : (IntPtr)long.MaxValue;
+        private static readonly IntPtr MaxHandles = IntPtr.Size == 4 ? (IntPtr)int.MaxValue : (IntPtr)long.MaxValue;
 #endif
 
         //
         // Sentinel handle value to identify events from the "shutdown pipe," used to signal an event loop to stop
         // processing events.
         //
-        private readonly IntPtr ShutdownHandle = (IntPtr)(-1);
+        private static readonly IntPtr ShutdownHandle = (IntPtr)(-1);
 
         //
         // The next handle value to be allocated for this event port.
-        // Must be accessed under _lock.
+        // Must be accessed under s_lock.
         //
         private IntPtr _nextHandle;
 
         //
         // Count of handles that have been allocated for this event port, but not yet freed.
-        // Must be accessed under _lock.
+        // Must be accessed under s_lock.
         // 
         private IntPtr _outstandingHandles;
 
         //
         // Maps handle values to SocketAsyncContext instances.
-        // Must be accessed under _lock.
+        // Must be accessed under s_lock.
         //
         private readonly Dictionary<IntPtr, SocketAsyncContext> _handleToContextMap = new Dictionary<IntPtr, SocketAsyncContext>();
 
@@ -123,21 +123,21 @@ namespace System.Net.Sockets
         //
         private static void AllocateToken(SocketAsyncContext context, out SocketAsyncEngine engine, out IntPtr handle)
         {
-            lock (_lock)
+            lock (s_lock)
             {
-                if (_currentEngine == null || _currentEngine.IsFull)
+                if (s_currentEngine == null)
                 {
-                    _currentEngine = new SocketAsyncEngine();
+                    s_currentEngine = new SocketAsyncEngine();
                 }
 
-                engine = _currentEngine;
-                handle = _currentEngine.AllocateHandle(context);
+                engine = s_currentEngine;
+                handle = s_currentEngine.AllocateHandle(context);
             }
         }
 
         private IntPtr AllocateHandle(SocketAsyncContext context)
-                    {
-            Debug.Assert(Monitor.IsEntered(_lock));
+        {
+            Debug.Assert(Monitor.IsEntered(s_lock));
             Debug.Assert(!IsFull);
 
             IntPtr handle = _nextHandle;
@@ -146,48 +146,53 @@ namespace System.Net.Sockets
             _nextHandle = IntPtr.Add(_nextHandle, 1);
             _outstandingHandles = IntPtr.Add(_outstandingHandles, 1);
 
+            if (IsFull)
+            {
+                // We'll need to create a new event port for the next handle.
+                s_currentEngine = null;
+            }
+
             Debug.Assert(handle != ShutdownHandle);
             return handle;
         }
 
         private void FreeHandle(IntPtr handle)
-                        {
+        {
             Debug.Assert(handle != ShutdownHandle);
 
             bool shutdownNeeded = false;
 
-            lock (_lock)
-                            {
+            lock (s_lock)
+            {
                 if (_handleToContextMap.Remove(handle))
                 {
-                    _outstandingHandles = IntPtr.Subtract(_outstandingHandles, 1);
+                _outstandingHandles = IntPtr.Subtract(_outstandingHandles, 1);
+                Debug.Assert(_outstandingHandles.ToInt64() >= 0);
 
-                    Debug.Assert(_outstandingHandles.ToInt64() >= 0);
-
-                    //
-                    // If we've allocated all possible handles for this instance, and freed them all, then 
-                    // we don't need the event loop any more, and can reclaim resources.
-                    //
-                    if (IsFull && _outstandingHandles == IntPtr.Zero)
-                        shutdownNeeded = true;
-                }
-                            }
+                //
+                // If we've allocated all possible handles for this instance, and freed them all, then 
+                // we don't need the event loop any more, and can reclaim resources.
+                //
+                if (IsFull && _outstandingHandles == IntPtr.Zero)
+                    shutdownNeeded = true;
+            }
+            }
 
             //
             // Signal shutdown outside of the lock to reduce contention.  
             //
             if (shutdownNeeded)
-                            {
-                BeginShutdown();
+            {
+                Shutdown();
             }
-                            }
+        }
 
         private SocketAsyncContext GetContextFromHandle(IntPtr handle)
         {
             Debug.Assert(handle != ShutdownHandle);
             Debug.Assert(handle.ToInt64() < MaxHandles.ToInt64());
-            lock (_lock)
-                            {
+            lock (s_lock)
+            {
                 SocketAsyncContext context;
                 _handleToContextMap.TryGetValue(handle, out context);
                 return context;
@@ -195,23 +200,23 @@ namespace System.Net.Sockets
         }
 
         private SocketAsyncEngine()
-                                {
+        {
             _port = -1;
             _shutdownReadPipe = -1;
             _shutdownWritePipe = -1;
-                                    try
-                                    {
+            try
+            {
                 //
                 // Create the event port and buffer
                 //
                 if (Interop.Sys.CreateSocketEventPort(out _port) != Interop.Error.SUCCESS)
                 {
                     throw new InternalException();
-                                    }
+                }
                 if (Interop.Sys.CreateSocketEventBuffer(EventBufferCount, out _buffer) != Interop.Error.SUCCESS)
-                                    {
+                {
                     throw new InternalException();
-                                    }
+                }
 
                 //
                 // Create the pipe for signalling shutdown, and register for "read" events for the pipe.  Now writing
@@ -221,14 +226,14 @@ namespace System.Net.Sockets
                 if (Interop.Sys.Pipe(pipeFds, Interop.Sys.PipeFlags.O_CLOEXEC) != 0)
                 {
                     throw new InternalException();
-                                }
+                }
                 _shutdownReadPipe = pipeFds[Interop.Sys.ReadEndOfPipe];
                 _shutdownWritePipe = pipeFds[Interop.Sys.WriteEndOfPipe];
 
                 if (Interop.Sys.DangerousTryChangeSocketEventRegistration(_port, _shutdownReadPipe, Interop.Sys.SocketEvents.None, Interop.Sys.SocketEvents.Read, ShutdownHandle) != Interop.Error.SUCCESS)
                 {
                     throw new InternalException();
-                        }
+                }
 
                 //
                 // Start the event loop on its own thread.
@@ -238,25 +243,10 @@ namespace System.Net.Sockets
                     CancellationToken.None,
                     TaskCreationOptions.LongRunning,
                     TaskScheduler.Default);
-                    }
+            }
             catch
             {
-                if (_shutdownReadPipe != -1)
-                {
-                    Interop.Sys.Close((IntPtr)_shutdownReadPipe);
-                }
-                if (_shutdownWritePipe != -1)
-                {
-                    Interop.Sys.Close((IntPtr)_shutdownWritePipe);
-            }
-                if (_buffer != null)
-                {
-                    Interop.Sys.FreeSocketEventBuffer(_buffer);
-        }
-                if (_port != -1)
-        {
-                    Interop.Sys.CloseSocketEventPort(_port);
-                }
+                FreeNativeResources();
                 throw;
             }
         }
@@ -267,19 +257,19 @@ namespace System.Net.Sockets
             {
                 bool shutdown = false;
                 while (!shutdown)
-            {
-                int numEvents = EventBufferCount;
-                Interop.Error err = Interop.Sys.WaitForSocketEvents(_port, _buffer, &numEvents);
-                if (err != Interop.Error.SUCCESS)
                 {
-                    throw new InternalException();
-                }
+                    int numEvents = EventBufferCount;
+                    Interop.Error err = Interop.Sys.WaitForSocketEvents(_port, _buffer, &numEvents);
+                    if (err != Interop.Error.SUCCESS)
+                    {
+                        throw new InternalException();
+                    }
 
-                // The native shim is responsible for ensuring this condition.
-                Debug.Assert(numEvents > 0);
+                    // The native shim is responsible for ensuring this condition.
+                    Debug.Assert(numEvents > 0);
 
-                for (int i = 0; i < numEvents; i++)
-                {
+                    for (int i = 0; i < numEvents; i++)
+                    {
                         IntPtr handle = _buffer[i].Data;
                         if (handle == ShutdownHandle)
                         {
@@ -288,15 +278,15 @@ namespace System.Net.Sockets
                         else
                         {
                             SocketAsyncContext context = GetContextFromHandle(handle);
-                    if (context != null)
-                    {
-                        context.HandleEvents(_buffer[i].Events);
-                    }
+                            if (context != null)
+                            {
+                                context.HandleEvents(_buffer[i].Events);
+                            }
                         }
                     }
                 }
 
-                EndShutdown();
+                FreeNativeResources();
             }
             catch (Exception e)
             {
@@ -304,28 +294,37 @@ namespace System.Net.Sockets
             }
         }
 
-        private void BeginShutdown()
+        private void Shutdown()
         {
             //
             // Write to the pipe, which will wake up the event loop and cause it to exit.
             //
-            byte* buf = stackalloc byte[1];
-            int bytesWritten = Interop.Sys.Write(_shutdownWritePipe, buf, 1);
+            byte b = 1;
+            int bytesWritten = Interop.Sys.Write(_shutdownWritePipe, &b, 1);
             if (bytesWritten != 1)
             {
                 throw new InternalException();
-                }
             }
+        }
 
-        private void EndShutdown()
+        private void FreeNativeResources()
         {
-            //
-            // The event loop is exiting, so we can free all native resources.
-            //
-            Interop.Sys.Close((IntPtr)_shutdownReadPipe);
-            Interop.Sys.Close((IntPtr)_shutdownWritePipe);
-            Interop.Sys.CloseSocketEventPort(_port);
-            Interop.Sys.FreeSocketEventBuffer(_buffer);
+            if (_shutdownReadPipe != -1)
+            {
+                Interop.Sys.Close((IntPtr)_shutdownReadPipe);
+            }
+            if (_shutdownWritePipe != -1)
+            {
+                Interop.Sys.Close((IntPtr)_shutdownWritePipe);
+            }
+            if (_buffer != null)
+            {
+                Interop.Sys.FreeSocketEventBuffer(_buffer);
+            }
+            if (_port != -1)
+            {
+                Interop.Sys.CloseSocketEventPort(_port);
+            }
         }
 
         private bool TryRegister(SafeCloseSocket socket, Interop.Sys.SocketEvents current, Interop.Sys.SocketEvents events, IntPtr handle, out Interop.Error error)

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -112,13 +112,7 @@ namespace System.Net.Sockets
                 return true;
             }
 
-            //
-            // @TODO: work out a better way to handle this.  For now, just do the "dangerous" thing; this is called
-            // from SafeCloseSocket.ReleaseHandle, so it can't access the file descriptor in the normal way.
-            // 
-            int fd = (int)socket.DangerousGetHandle();
-
-            error = Interop.Sys.DangerousTryChangeSocketEventRegistration(_port, fd, current, events, (IntPtr)handle);
+            error = Interop.Sys.TryChangeSocketEventRegistration(_port, socket, current, events, (IntPtr)handle);
             return error == Interop.Error.SUCCESS;
         }
     }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -34,7 +34,9 @@ namespace System.Net.Sockets
             public void Free()
             {
                 if (WasAllocated)
+                {
                     _engine.FreeHandle(_handle);
+                }
             }
 
             public bool TryRegister(SafeCloseSocket socket, Interop.Sys.SocketEvents current, Interop.Sys.SocketEvents events, out Interop.Error error)
@@ -185,7 +187,7 @@ namespace System.Net.Sockets
             //
             if (shutdownNeeded)
             {
-                Shutdown();
+                RequestEventLoopShutdown();
             }
         }
 
@@ -296,7 +298,7 @@ namespace System.Net.Sockets
             }
         }
 
-        private void Shutdown()
+        private void RequestEventLoopShutdown()
         {
             //
             // Write to the pipe, which will wake up the event loop and cause it to exit.

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -166,16 +166,18 @@ namespace System.Net.Sockets
             {
                 if (_handleToContextMap.Remove(handle))
                 {
-                _outstandingHandles = IntPtr.Subtract(_outstandingHandles, 1);
-                Debug.Assert(_outstandingHandles.ToInt64() >= 0);
+                    _outstandingHandles = IntPtr.Subtract(_outstandingHandles, 1);
+                    Debug.Assert(_outstandingHandles.ToInt64() >= 0);
 
-                //
-                // If we've allocated all possible handles for this instance, and freed them all, then 
-                // we don't need the event loop any more, and can reclaim resources.
-                //
-                if (IsFull && _outstandingHandles == IntPtr.Zero)
-                    shutdownNeeded = true;
-            }
+                    //
+                    // If we've allocated all possible handles for this instance, and freed them all, then 
+                    // we don't need the event loop any more, and can reclaim resources.
+                    //
+                    if (IsFull && _outstandingHandles == IntPtr.Zero)
+                    {
+                        shutdownNeeded = true;
+                    }
+                }
             }
 
             //

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -12,74 +13,260 @@ namespace System.Net.Sockets
 {
     internal sealed unsafe class SocketAsyncEngine
     {
+        //
+        // Encapsulates a particular SocketAsyncContext object's access to a SocketAsyncEngine.  
+        //
+        public struct Token
+        {
+            private readonly SocketAsyncEngine _engine;
+            private readonly IntPtr _handle;
+
+            public Token(SocketAsyncContext context)
+            {
+                AllocateToken(context, out _engine, out _handle);
+            }
+
+            public bool IsAllocated
+            {
+                get { return _engine != null; }
+            }
+
+            public void Free()
+            {
+                if (IsAllocated)
+                    _engine.FreeHandle(_handle);
+            }
+
+            public bool TryRegister(SafeCloseSocket socket, Interop.Sys.SocketEvents current, Interop.Sys.SocketEvents events, out Interop.Error error)
+            {
+                Debug.Assert(IsAllocated);
+                return _engine.TryRegister(socket, current, events, _handle, out error);
+            }
+        }
+
         private const int EventBufferCount = 64;
 
-        private static SocketAsyncEngine _engine;
-        private static readonly object _initLock = new object();
+        private static readonly object _lock = new object();
+
+        //
+        // The current engine.  We replace this with a new engine when we run out of "handle" values for the current
+        // engine.
+        // Must be accessed under _lock.
+        //
+        private static SocketAsyncEngine _currentEngine;
 
         private readonly int _port;
         private readonly Interop.Sys.SocketEvent* _buffer;
 
-        public static SocketAsyncEngine Instance
+        //
+        // The read and write ends of a native pipe, used to signal that this instance's event loop should stop 
+        // processing events.
+        // 
+        private readonly int _shutdownReadPipe;
+        private readonly int _shutdownWritePipe;
+
+        //
+        // Each SocketAsyncContext is associated with a particular "handle" value, used to identify that 
+        // SocketAsyncContext when events are raised.  These handle values are never resused, because we do not have
+        // a way to ensure that we will never see an event for a socket/handle that has been freed.  Instead, we
+        // allocate monotonically increasing handle values up to some limit; when we would exceed that limit,
+        // we allocate a new SocketAsyncEngine (and thus a new event port) and start the handle values over at zero.
+        // Thus we can uniquely identify a given SocketAsyncContext by the *pair* {SocketAsyncEngine, handle},
+        // and avoid any issues with misidentifying the target of an event we read from the port.
+        //
+#if DEBUG
+        //
+        // In debug builds, force rollover to new SocketAsyncEngine instances so that code doesn't go untested, since
+        // it's very unlikely that the "real" limits will ever be reached in test code.
+        //
+        private readonly IntPtr MaxHandles = (IntPtr)(EventBufferCount * 2);
+#else
+        //
+        // In release builds, we use *very* high limits.  No 64-bit process running on release builds should ever
+        // reach the handle limit for a single event port, and even 32-bit processes should see this only very rarely.
+        //
+        private readonly IntPtr MaxHandles = IntPtr.Size == 4 ? (IntPtr)int.MaxValue : (IntPtr)long.MaxValue;
+#endif
+
+        //
+        // Sentinel handle value to identify events from the "shutdown pipe," used to signal an event loop to stop
+        // processing events.
+        //
+        private readonly IntPtr ShutdownHandle = (IntPtr)(-1);
+
+        //
+        // The next handle value to be allocated for this event port.
+        // Must be accessed under _lock.
+        //
+        private IntPtr _nextHandle;
+
+        //
+        // Count of handles that have been allocated for this event port, but not yet freed.
+        // Must be accessed under _lock.
+        // 
+        private IntPtr _outstandingHandles;
+
+        //
+        // Maps handle values to SocketAsyncContext instances.
+        // Must be accessed under _lock.
+        //
+        private readonly Dictionary<IntPtr, SocketAsyncContext> _handleToContextMap = new Dictionary<IntPtr, SocketAsyncContext>();
+
+        //
+        // True if we've reached the handle value limit for this event port, and thus must allocate a new event port
+        // on the next handle allocation.
+        //
+        private bool IsFull { get { return _nextHandle == MaxHandles; } }
+
+        //
+        // Allocates a new {SocketAsyncEngine, handle} pair.
+        //
+        private static void AllocateToken(SocketAsyncContext context, out SocketAsyncEngine engine, out IntPtr handle)
         {
-            get
+            lock (_lock)
             {
-                if (Volatile.Read(ref _engine) == null)
+                if (_currentEngine == null || _currentEngine.IsFull)
                 {
-                    lock (_initLock)
-                    {
-                        if (_engine == null)
-                        {
-                            int port;
-                            Interop.Error err = Interop.Sys.CreateSocketEventPort(&port);
-                            if (err != Interop.Error.SUCCESS)
-                            {
-                                throw new InternalException();
-                            }
-
-                            Interop.Sys.SocketEvent* buffer;
-                            err = Interop.Sys.CreateSocketEventBuffer(EventBufferCount, &buffer);
-                            if (err != Interop.Error.SUCCESS)
-                            {
-                                Interop.Sys.CloseSocketEventPort(port);
-                                throw new InternalException();
-                            }
-
-                            var engine = new SocketAsyncEngine(port, buffer);
-                            Task.Factory.StartNew(o =>
-                            {
-                                var eng = (SocketAsyncEngine)o;
-                                for (;;)
-                                {
-                                    try
-                                    {
-                                        eng.EventLoop();
-                                    }
-                                    catch (Exception e)
-                                    {
-                                        Debug.Fail(string.Format("Exception thrown from event loop: {0}", e.Message));
-                                    }
-                                }
-                            }, engine, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default);
-
-                            Volatile.Write(ref _engine, engine);
-                        }
-                    }
+                    _currentEngine = new SocketAsyncEngine();
                 }
 
-                return _engine;
+                engine = _currentEngine;
+                handle = _currentEngine.AllocateHandle(context);
             }
         }
 
-        private SocketAsyncEngine(int port, Interop.Sys.SocketEvent* buffer)
+        private IntPtr AllocateHandle(SocketAsyncContext context)
+                    {
+            Debug.Assert(Monitor.IsEntered(_lock));
+            Debug.Assert(!IsFull);
+
+            IntPtr handle = _nextHandle;
+            _handleToContextMap.Add(handle, context);
+
+            _nextHandle = IntPtr.Add(_nextHandle, 1);
+            _outstandingHandles = IntPtr.Add(_outstandingHandles, 1);
+
+            Debug.Assert(handle != ShutdownHandle);
+            return handle;
+        }
+
+        private void FreeHandle(IntPtr handle)
+                        {
+            Debug.Assert(handle != ShutdownHandle);
+
+            bool shutdownNeeded = false;
+
+            lock (_lock)
+                            {
+                if (_handleToContextMap.Remove(handle))
+                {
+                    _outstandingHandles = IntPtr.Subtract(_outstandingHandles, 1);
+
+                    Debug.Assert(_outstandingHandles.ToInt64() >= 0);
+
+                    //
+                    // If we've allocated all possible handles for this instance, and freed them all, then 
+                    // we don't need the event loop any more, and can reclaim resources.
+                    //
+                    if (IsFull && _outstandingHandles == IntPtr.Zero)
+                        shutdownNeeded = true;
+                }
+                            }
+
+            //
+            // Signal shutdown outside of the lock to reduce contention.  
+            //
+            if (shutdownNeeded)
+                            {
+                BeginShutdown();
+            }
+                            }
+
+        private SocketAsyncContext GetContextFromHandle(IntPtr handle)
         {
-            _port = port;
-            _buffer = buffer;
+            Debug.Assert(handle != ShutdownHandle);
+            Debug.Assert(handle.ToInt64() < MaxHandles.ToInt64());
+            lock (_lock)
+                            {
+                SocketAsyncContext context;
+                _handleToContextMap.TryGetValue(handle, out context);
+                return context;
+            }
+        }
+
+        private SocketAsyncEngine()
+                                {
+            _port = -1;
+            _shutdownReadPipe = -1;
+            _shutdownWritePipe = -1;
+                                    try
+                                    {
+                //
+                // Create the event port and buffer
+                //
+                if (Interop.Sys.CreateSocketEventPort(out _port) != Interop.Error.SUCCESS)
+                {
+                    throw new InternalException();
+                                    }
+                if (Interop.Sys.CreateSocketEventBuffer(EventBufferCount, out _buffer) != Interop.Error.SUCCESS)
+                                    {
+                    throw new InternalException();
+                                    }
+
+                //
+                // Create the pipe for signalling shutdown, and register for "read" events for the pipe.  Now writing
+                // to the pipe will send an event to the event loop.
+                //
+                int* pipeFds = stackalloc int[2];
+                if (Interop.Sys.Pipe(pipeFds, Interop.Sys.PipeFlags.O_CLOEXEC) != 0)
+                {
+                    throw new InternalException();
+                                }
+                _shutdownReadPipe = pipeFds[Interop.Sys.ReadEndOfPipe];
+                _shutdownWritePipe = pipeFds[Interop.Sys.WriteEndOfPipe];
+
+                if (Interop.Sys.DangerousTryChangeSocketEventRegistration(_port, _shutdownReadPipe, Interop.Sys.SocketEvents.None, Interop.Sys.SocketEvents.Read, ShutdownHandle) != Interop.Error.SUCCESS)
+                {
+                    throw new InternalException();
+                        }
+
+                //
+                // Start the event loop on its own thread.
+                //
+                Task.Factory.StartNew(
+                    EventLoop,
+                    CancellationToken.None,
+                    TaskCreationOptions.LongRunning,
+                    TaskScheduler.Default);
+                    }
+            catch
+            {
+                if (_shutdownReadPipe != -1)
+                {
+                    Interop.Sys.Close((IntPtr)_shutdownReadPipe);
+                }
+                if (_shutdownWritePipe != -1)
+                {
+                    Interop.Sys.Close((IntPtr)_shutdownWritePipe);
+            }
+                if (_buffer != null)
+                {
+                    Interop.Sys.FreeSocketEventBuffer(_buffer);
+        }
+                if (_port != -1)
+        {
+                    Interop.Sys.CloseSocketEventPort(_port);
+                }
+                throw;
+            }
         }
 
         private void EventLoop()
         {
-            for (;;)
+            try
+            {
+                bool shutdown = false;
+                while (!shutdown)
             {
                 int numEvents = EventBufferCount;
                 Interop.Error err = Interop.Sys.WaitForSocketEvents(_port, _buffer, &numEvents);
@@ -93,18 +280,55 @@ namespace System.Net.Sockets
 
                 for (int i = 0; i < numEvents; i++)
                 {
-                    var handle = (GCHandle)(IntPtr)_buffer[i].Data;
-                    var context = (SocketAsyncContext)handle.Target;
-
+                        IntPtr handle = _buffer[i].Data;
+                        if (handle == ShutdownHandle)
+                        {
+                            shutdown = true;
+                        }
+                        else
+                        {
+                            SocketAsyncContext context = GetContextFromHandle(handle);
                     if (context != null)
                     {
                         context.HandleEvents(_buffer[i].Events);
                     }
+                        }
+                    }
                 }
+
+                EndShutdown();
+            }
+            catch (Exception e)
+            {
+                Environment.FailFast("Exception thrown from SocketAsyncEngine event loop", e);
             }
         }
 
-        public bool TryRegister(SafeCloseSocket socket, Interop.Sys.SocketEvents current, Interop.Sys.SocketEvents events, GCHandle handle, out Interop.Error error)
+        private void BeginShutdown()
+        {
+            //
+            // Write to the pipe, which will wake up the event loop and cause it to exit.
+            //
+            byte* buf = stackalloc byte[1];
+            int bytesWritten = Interop.Sys.Write(_shutdownWritePipe, buf, 1);
+            if (bytesWritten != 1)
+            {
+                throw new InternalException();
+                }
+            }
+
+        private void EndShutdown()
+        {
+            //
+            // The event loop is exiting, so we can free all native resources.
+            //
+            Interop.Sys.Close((IntPtr)_shutdownReadPipe);
+            Interop.Sys.Close((IntPtr)_shutdownWritePipe);
+            Interop.Sys.CloseSocketEventPort(_port);
+            Interop.Sys.FreeSocketEventBuffer(_buffer);
+        }
+
+        private bool TryRegister(SafeCloseSocket socket, Interop.Sys.SocketEvents current, Interop.Sys.SocketEvents events, IntPtr handle, out Interop.Error error)
         {
             if (current == events)
             {
@@ -112,7 +336,7 @@ namespace System.Net.Sockets
                 return true;
             }
 
-            error = Interop.Sys.TryChangeSocketEventRegistration(_port, socket, current, events, (IntPtr)handle);
+            error = Interop.Sys.TryChangeSocketEventRegistration(_port, socket, current, events, handle);
             return error == Interop.Error.SUCCESS;
         }
     }

--- a/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
+++ b/src/System.Net.Sockets/src/System/Net/Sockets/SocketPal.Unix.cs
@@ -157,7 +157,7 @@ namespace System.Net.Sockets
             return SafeCloseSocket.CreateSocket(addressFamily, socketType, protocolType, out socket);
         }
 
-        private static unsafe int Receive(int fd, SocketFlags flags, int available, byte[] buffer, int offset, int count, byte[] socketAddress, ref int socketAddressLen, out SocketFlags receivedFlags, out Interop.Error errno)
+        private static unsafe int Receive(SafeCloseSocket socket, SocketFlags flags, int available, byte[] buffer, int offset, int count, byte[] socketAddress, ref int socketAddressLen, out SocketFlags receivedFlags, out Interop.Error errno)
         {
             Debug.Assert(socketAddress != null || socketAddressLen == 0);
 
@@ -184,7 +184,7 @@ namespace System.Net.Sockets
                     IOVectorCount = 1
                 };
 
-                errno = Interop.Sys.ReceiveMessage(fd, &messageHeader, flags, &received);
+                errno = Interop.Sys.ReceiveMessage(socket, &messageHeader, flags, &received);
                 receivedFlags = messageHeader.Flags;
                 sockAddrLen = messageHeader.SocketAddressLen;
             }
@@ -198,7 +198,7 @@ namespace System.Net.Sockets
             return checked((int)received);
         }
 
-        private static unsafe int Send(int fd, SocketFlags flags, byte[] buffer, ref int offset, ref int count, byte[] socketAddress, int socketAddressLen, out Interop.Error errno)
+        private static unsafe int Send(SafeCloseSocket socket, SocketFlags flags, byte[] buffer, ref int offset, ref int count, byte[] socketAddress, int socketAddressLen, out Interop.Error errno)
         {
             int sent;
 
@@ -224,7 +224,7 @@ namespace System.Net.Sockets
                 };
 
                 long bytesSent;
-                errno = Interop.Sys.SendMessage(fd, &messageHeader, flags, &bytesSent);
+                errno = Interop.Sys.SendMessage(socket, &messageHeader, flags, &bytesSent);
 
                 sent = checked((int)bytesSent);
             }
@@ -240,7 +240,7 @@ namespace System.Net.Sockets
             return sent;
         }
 
-        private static unsafe int Send(int fd, SocketFlags flags, IList<ArraySegment<byte>> buffers, ref int bufferIndex, ref int offset, byte[] socketAddress, int socketAddressLen, out Interop.Error errno)
+        private static unsafe int Send(SafeCloseSocket socket, SocketFlags flags, IList<ArraySegment<byte>> buffers, ref int bufferIndex, ref int offset, byte[] socketAddress, int socketAddressLen, out Interop.Error errno)
         {
             // Pin buffers and set up iovecs.
             int startIndex = bufferIndex, startOffset = offset;
@@ -283,7 +283,7 @@ namespace System.Net.Sockets
                     };
 
                     long bytesSent;
-                    errno = Interop.Sys.SendMessage(fd, &messageHeader, flags, &bytesSent);
+                    errno = Interop.Sys.SendMessage(socket, &messageHeader, flags, &bytesSent);
 
                     sent = checked((int)bytesSent);
                 }
@@ -324,7 +324,7 @@ namespace System.Net.Sockets
             return sent;
         }
 
-        private static unsafe int Receive(int fd, SocketFlags flags, int available, IList<ArraySegment<byte>> buffers, byte[] socketAddress, ref int socketAddressLen, out SocketFlags receivedFlags, out Interop.Error errno)
+        private static unsafe int Receive(SafeCloseSocket socket, SocketFlags flags, int available, IList<ArraySegment<byte>> buffers, byte[] socketAddress, ref int socketAddressLen, out SocketFlags receivedFlags, out Interop.Error errno)
         {
             // Pin buffers and set up iovecs.
             int maxBuffers = buffers.Count;
@@ -371,7 +371,7 @@ namespace System.Net.Sockets
                         IOVectorCount = iovCount
                     };
 
-                    errno = Interop.Sys.ReceiveMessage(fd, &messageHeader, flags, &received);
+                    errno = Interop.Sys.ReceiveMessage(socket, &messageHeader, flags, &received);
                     receivedFlags = messageHeader.Flags;
                     sockAddrLen = messageHeader.SocketAddressLen;
                 }
@@ -397,7 +397,7 @@ namespace System.Net.Sockets
             return checked((int)received);
         }
 
-        private static unsafe int ReceiveMessageFrom(int fd, SocketFlags flags, int available, byte[] buffer, int offset, int count, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, out Interop.Error errno)
+        private static unsafe int ReceiveMessageFrom(SafeCloseSocket socket, SocketFlags flags, int available, byte[] buffer, int offset, int count, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, out Interop.Error errno)
         {
             Debug.Assert(socketAddress != null);
 
@@ -428,7 +428,7 @@ namespace System.Net.Sockets
                     ControlBufferLen = cmsgBufferLen
                 };
 
-                errno = Interop.Sys.ReceiveMessage(fd, &messageHeader, flags, &received);
+                errno = Interop.Sys.ReceiveMessage(socket, &messageHeader, flags, &received);
                 receivedFlags = messageHeader.Flags;
                 sockAddrLen = messageHeader.SocketAddressLen;
             }
@@ -444,14 +444,14 @@ namespace System.Net.Sockets
             return checked((int)received);
         }
 
-        public static unsafe bool TryCompleteAccept(int fileDescriptor, byte[] socketAddress, ref int socketAddressLen, out int acceptedFd, out SocketError errorCode)
+        public static unsafe bool TryCompleteAccept(SafeCloseSocket socket, byte[] socketAddress, ref int socketAddressLen, out int acceptedFd, out SocketError errorCode)
         {
             int fd;
             Interop.Error errno;
             int sockAddrLen = socketAddressLen;
             fixed (byte* rawSocketAddress = socketAddress)
             {
-                errno = Interop.Sys.Accept(fileDescriptor, rawSocketAddress, &sockAddrLen, &fd);
+                errno = Interop.Sys.Accept(socket, rawSocketAddress, &sockAddrLen, &fd);
             }
 
             if (errno == Interop.Error.SUCCESS)
@@ -476,7 +476,7 @@ namespace System.Net.Sockets
             return false;
         }
 
-        public static unsafe bool TryStartConnect(int fileDescriptor, byte[] socketAddress, int socketAddressLen, out SocketError errorCode)
+        public static unsafe bool TryStartConnect(SafeCloseSocket socket, byte[] socketAddress, int socketAddressLen, out SocketError errorCode)
         {
             Debug.Assert(socketAddress != null);
             Debug.Assert(socketAddressLen > 0);
@@ -484,7 +484,7 @@ namespace System.Net.Sockets
             Interop.Error err;
             fixed (byte* rawSocketAddress = socketAddress)
             {
-                err = Interop.Sys.Connect(fileDescriptor, rawSocketAddress, socketAddressLen);
+                err = Interop.Sys.Connect(socket, rawSocketAddress, socketAddressLen);
             }
 
             if (err == Interop.Error.SUCCESS)
@@ -503,10 +503,10 @@ namespace System.Net.Sockets
             return false;
         }
 
-        public static unsafe bool TryCompleteConnect(int fileDescriptor, int socketAddressLen, out SocketError errorCode)
+        public static unsafe bool TryCompleteConnect(SafeCloseSocket socket, int socketAddressLen, out SocketError errorCode)
         {
             Interop.Error socketError;
-            Interop.Error err = Interop.Sys.GetSocketErrorOption(fileDescriptor, &socketError);
+            Interop.Error err = Interop.Sys.GetSocketErrorOption(socket, &socketError);
             if (err != Interop.Error.SUCCESS)
             {
                 Debug.Assert(err == Interop.Error.EBADF);
@@ -529,20 +529,20 @@ namespace System.Net.Sockets
             return true;
         }
 
-        public static bool TryCompleteReceiveFrom(int fileDescriptor, byte[] buffer, int offset, int count, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, out SocketError errorCode)
+        public static bool TryCompleteReceiveFrom(SafeCloseSocket socket, byte[] buffer, int offset, int count, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, out SocketError errorCode)
         {
-            return TryCompleteReceiveFrom(fileDescriptor, buffer, null, offset, count, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode);
+            return TryCompleteReceiveFrom(socket, buffer, null, offset, count, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode);
         }
 
-        public static bool TryCompleteReceiveFrom(int fileDescriptor, IList<ArraySegment<byte>> buffers, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, out SocketError errorCode)
+        public static bool TryCompleteReceiveFrom(SafeCloseSocket socket, IList<ArraySegment<byte>> buffers, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, out SocketError errorCode)
         {
-            return TryCompleteReceiveFrom(fileDescriptor, null, buffers, 0, 0, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode);
+            return TryCompleteReceiveFrom(socket, null, buffers, 0, 0, flags, socketAddress, ref socketAddressLen, out bytesReceived, out receivedFlags, out errorCode);
         }
 
-        public static unsafe bool TryCompleteReceiveFrom(int fileDescriptor, byte[] buffer, IList<ArraySegment<byte>> buffers, int offset, int count, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, out SocketError errorCode)
+        public static unsafe bool TryCompleteReceiveFrom(SafeCloseSocket socket, byte[] buffer, IList<ArraySegment<byte>> buffers, int offset, int count, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, out int bytesReceived, out SocketFlags receivedFlags, out SocketError errorCode)
         {
             int available;
-            Interop.Error errno = Interop.Sys.GetBytesAvailable(fileDescriptor, &available);
+            Interop.Error errno = Interop.Sys.GetBytesAvailable(socket, &available);
             if (errno != Interop.Error.SUCCESS)
             {
                 bytesReceived = 0;
@@ -559,11 +559,11 @@ namespace System.Net.Sockets
             int received;
             if (buffer != null)
             {
-                received = Receive(fileDescriptor, flags, available, buffer, offset, count, socketAddress, ref socketAddressLen, out receivedFlags, out errno);
+                received = Receive(socket, flags, available, buffer, offset, count, socketAddress, ref socketAddressLen, out receivedFlags, out errno);
             }
             else
             {
-                received = Receive(fileDescriptor, flags, available, buffers, socketAddress, ref socketAddressLen, out receivedFlags, out errno);
+                received = Receive(socket, flags, available, buffers, socketAddress, ref socketAddressLen, out receivedFlags, out errno);
             }
 
             if (received != -1)
@@ -585,10 +585,10 @@ namespace System.Net.Sockets
             return false;
         }
 
-        public static unsafe bool TryCompleteReceiveMessageFrom(int fileDescriptor, byte[] buffer, int offset, int count, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out int bytesReceived, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, out SocketError errorCode)
+        public static unsafe bool TryCompleteReceiveMessageFrom(SafeCloseSocket socket, byte[] buffer, int offset, int count, SocketFlags flags, byte[] socketAddress, ref int socketAddressLen, bool isIPv4, bool isIPv6, out int bytesReceived, out SocketFlags receivedFlags, out IPPacketInformation ipPacketInformation, out SocketError errorCode)
         {
             int available;
-            Interop.Error errno = Interop.Sys.GetBytesAvailable(fileDescriptor, &available);
+            Interop.Error errno = Interop.Sys.GetBytesAvailable(socket, &available);
             if (errno != Interop.Error.SUCCESS)
             {
                 bytesReceived = 0;
@@ -603,7 +603,7 @@ namespace System.Net.Sockets
                 available = 1;
             }
 
-            int received = ReceiveMessageFrom(fileDescriptor, flags, available, buffer, offset, count, socketAddress, ref socketAddressLen, isIPv4, isIPv6, out receivedFlags, out ipPacketInformation, out errno);
+            int received = ReceiveMessageFrom(socket, flags, available, buffer, offset, count, socketAddress, ref socketAddressLen, isIPv4, isIPv6, out receivedFlags, out ipPacketInformation, out errno);
 
             if (received != -1)
             {
@@ -624,19 +624,19 @@ namespace System.Net.Sockets
             return false;
         }
 
-        public static bool TryCompleteSendTo(int fileDescriptor, byte[] buffer, ref int offset, ref int count, SocketFlags flags, byte[] socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
+        public static bool TryCompleteSendTo(SafeCloseSocket socket, byte[] buffer, ref int offset, ref int count, SocketFlags flags, byte[] socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
         {
             int bufferIndex = 0;
-            return TryCompleteSendTo(fileDescriptor, buffer, null, ref bufferIndex, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode);
+            return TryCompleteSendTo(socket, buffer, null, ref bufferIndex, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode);
         }
 
-        public static bool TryCompleteSendTo(int fileDescriptor, IList<ArraySegment<byte>> buffers, ref int bufferIndex, ref int offset, SocketFlags flags, byte[] socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
+        public static bool TryCompleteSendTo(SafeCloseSocket socket, IList<ArraySegment<byte>> buffers, ref int bufferIndex, ref int offset, SocketFlags flags, byte[] socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
         {
             int count = 0;
-            return TryCompleteSendTo(fileDescriptor, null, buffers, ref bufferIndex, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode);
+            return TryCompleteSendTo(socket, null, buffers, ref bufferIndex, ref offset, ref count, flags, socketAddress, socketAddressLen, ref bytesSent, out errorCode);
         }
 
-        public static bool TryCompleteSendTo(int fileDescriptor, byte[] buffer, IList<ArraySegment<byte>> buffers, ref int bufferIndex, ref int offset, ref int count, SocketFlags flags, byte[] socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
+        public static bool TryCompleteSendTo(SafeCloseSocket socket, byte[] buffer, IList<ArraySegment<byte>> buffers, ref int bufferIndex, ref int offset, ref int count, SocketFlags flags, byte[] socketAddress, int socketAddressLen, ref int bytesSent, out SocketError errorCode)
         {
             for (;;)
             {
@@ -644,11 +644,11 @@ namespace System.Net.Sockets
                 Interop.Error errno;
                 if (buffer != null)
                 {
-                    sent = Send(fileDescriptor, flags, buffer, ref offset, ref count, socketAddress, socketAddressLen, out errno);
+                    sent = Send(socket, flags, buffer, ref offset, ref count, socketAddress, socketAddressLen, out errno);
                 }
                 else
                 {
-                    sent = Send(fileDescriptor, flags, buffers, ref bufferIndex, ref offset, socketAddress, socketAddressLen, out errno);
+                    sent = Send(socket, flags, buffers, ref bufferIndex, ref offset, socketAddress, socketAddressLen, out errno);
                 }
 
                 if (sent == -1)
@@ -689,7 +689,7 @@ namespace System.Net.Sockets
             int addrLen = nameLen;
             fixed (byte* rawBuffer = buffer)
             {
-                err = Interop.Sys.GetSockName(handle.FileDescriptor, rawBuffer, &addrLen);
+                err = Interop.Sys.GetSockName(handle, rawBuffer, &addrLen);
             }
 
             nameLen = addrLen;
@@ -699,7 +699,7 @@ namespace System.Net.Sockets
         public static unsafe SocketError GetAvailable(SafeCloseSocket handle, out int available)
         {
             int value = 0;
-            Interop.Error err = Interop.Sys.GetBytesAvailable(handle.FileDescriptor, &value);
+            Interop.Error err = Interop.Sys.GetBytesAvailable(handle, &value);
             available = value;
 
             return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
@@ -711,7 +711,7 @@ namespace System.Net.Sockets
             int addrLen = nameLen;
             fixed (byte* rawBuffer = buffer)
             {
-                err = Interop.Sys.GetPeerName(handle.FileDescriptor, rawBuffer, &addrLen);
+                err = Interop.Sys.GetPeerName(handle, rawBuffer, &addrLen);
             }
 
             nameLen = addrLen;
@@ -723,7 +723,7 @@ namespace System.Net.Sockets
             Interop.Error err;
             fixed (byte* rawBuffer = buffer)
             {
-                err = Interop.Sys.Bind(handle.FileDescriptor, rawBuffer, nameLen);
+                err = Interop.Sys.Bind(handle, rawBuffer, nameLen);
             }
 
             return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
@@ -731,7 +731,7 @@ namespace System.Net.Sockets
 
         public static SocketError Listen(SafeCloseSocket handle, int backlog)
         {
-            Interop.Error err = Interop.Sys.Listen(handle.FileDescriptor, backlog);
+            Interop.Error err = Interop.Sys.Listen(handle, backlog);
             return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
         }
 
@@ -750,7 +750,7 @@ namespace System.Net.Sockets
             handle.AsyncContext.CheckForPriorConnectFailure();
 
             SocketError errorCode;
-            bool completed = TryStartConnect(handle.FileDescriptor, socketAddress, socketAddressLen, out errorCode);
+            bool completed = TryStartConnect(handle, socketAddress, socketAddressLen, out errorCode);
             if (completed)
             {
                 handle.AsyncContext.RegisterConnectResult(errorCode);
@@ -779,7 +779,7 @@ namespace System.Net.Sockets
             int bufferIndex = 0;
             int offset = 0;
             SocketError errorCode;
-            bool completed = TryCompleteSendTo(handle.FileDescriptor, bufferList, ref bufferIndex, ref offset, socketFlags, null, 0, ref bytesTransferred, out errorCode);
+            bool completed = TryCompleteSendTo(handle, bufferList, ref bufferIndex, ref offset, socketFlags, null, 0, ref bytesTransferred, out errorCode);
             return completed ? errorCode : SocketError.WouldBlock;
         }
 
@@ -792,7 +792,7 @@ namespace System.Net.Sockets
 
             bytesTransferred = 0;
             SocketError errorCode;
-            bool completed = TryCompleteSendTo(handle.FileDescriptor, buffer, ref offset, ref count, socketFlags, null, 0, ref bytesTransferred, out errorCode);
+            bool completed = TryCompleteSendTo(handle, buffer, ref offset, ref count, socketFlags, null, 0, ref bytesTransferred, out errorCode);
             return completed ? errorCode : SocketError.WouldBlock;
         }
 
@@ -805,7 +805,7 @@ namespace System.Net.Sockets
 
             bytesTransferred = 0;
             SocketError errorCode;
-            bool completed = TryCompleteSendTo(handle.FileDescriptor, buffer, ref offset, ref count, socketFlags, socketAddress, socketAddressLen, ref bytesTransferred, out errorCode);
+            bool completed = TryCompleteSendTo(handle, buffer, ref offset, ref count, socketFlags, socketAddress, socketAddressLen, ref bytesTransferred, out errorCode);
             return completed ? errorCode : SocketError.WouldBlock;
         }
 
@@ -819,7 +819,7 @@ namespace System.Net.Sockets
             else
             {
                 int socketAddressLen = 0;
-                if (!TryCompleteReceiveFrom(handle.FileDescriptor, buffers, socketFlags, null, ref socketAddressLen, out bytesTransferred, out socketFlags, out errorCode))
+                if (!TryCompleteReceiveFrom(handle, buffers, socketFlags, null, ref socketAddressLen, out bytesTransferred, out socketFlags, out errorCode))
                 {
                     errorCode = SocketError.WouldBlock;
                 }
@@ -837,7 +837,7 @@ namespace System.Net.Sockets
 
             int socketAddressLen = 0;
             SocketError errorCode;
-            bool completed = TryCompleteReceiveFrom(handle.FileDescriptor, buffer, offset, count, socketFlags, null, ref socketAddressLen, out bytesTransferred, out socketFlags, out errorCode);
+            bool completed = TryCompleteReceiveFrom(handle, buffer, offset, count, socketFlags, null, ref socketAddressLen, out bytesTransferred, out socketFlags, out errorCode);
             return completed ? errorCode : SocketError.WouldBlock;
         }
 
@@ -856,7 +856,7 @@ namespace System.Net.Sockets
             }
             else
             {
-                if (!TryCompleteReceiveMessageFrom(handle.FileDescriptor, buffer, offset, count, socketFlags, socketAddressBuffer, ref socketAddressLen, isIPv4, isIPv6, out bytesTransferred, out socketFlags, out ipPacketInformation, out errorCode))
+                if (!TryCompleteReceiveMessageFrom(handle, buffer, offset, count, socketFlags, socketAddressBuffer, ref socketAddressLen, isIPv4, isIPv6, out bytesTransferred, out socketFlags, out ipPacketInformation, out errorCode))
                 {
                     errorCode = SocketError.WouldBlock;
                 }
@@ -875,7 +875,7 @@ namespace System.Net.Sockets
             }
 
             SocketError errorCode;
-            bool completed = TryCompleteReceiveFrom(handle.FileDescriptor, buffer, offset, count, socketFlags, socketAddress, ref socketAddressLen, out bytesTransferred, out socketFlags, out errorCode);
+            bool completed = TryCompleteReceiveFrom(handle, buffer, offset, count, socketFlags, socketAddress, ref socketAddressLen, out bytesTransferred, out socketFlags, out errorCode);
             return completed ? errorCode : SocketError.WouldBlock;
         }
 
@@ -900,18 +900,18 @@ namespace System.Net.Sockets
                 if (optionName == SocketOptionName.ReceiveTimeout)
                 {
                     handle.ReceiveTimeout = optionValue == 0 ? -1 : optionValue;
-                    err = Interop.Sys.SetReceiveTimeout(handle.FileDescriptor, optionValue);
+                    err = Interop.Sys.SetReceiveTimeout(handle, optionValue);
                     return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
                 }
                 else if (optionName == SocketOptionName.SendTimeout)
                 {
                     handle.SendTimeout = optionValue == 0 ? -1 : optionValue;
-                    err = Interop.Sys.SetSendTimeout(handle.FileDescriptor, optionValue);
+                    err = Interop.Sys.SetSendTimeout(handle, optionValue);
                     return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
                 }
             }
 
-            err = Interop.Sys.SetSockOpt(handle.FileDescriptor, optionLevel, optionName, (byte*)&optionValue, sizeof(int));
+            err = Interop.Sys.SetSockOpt(handle, optionLevel, optionName, (byte*)&optionValue, sizeof(int));
             return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
         }
 
@@ -920,13 +920,13 @@ namespace System.Net.Sockets
             Interop.Error err;
             if (optionValue == null || optionValue.Length == 0)
             {
-                err = Interop.Sys.SetSockOpt(handle.FileDescriptor, optionLevel, optionName, null, 0);
+                err = Interop.Sys.SetSockOpt(handle, optionLevel, optionName, null, 0);
             }
             else
             {
                 fixed (byte* pinnedValue = optionValue)
                 {
-                    err = Interop.Sys.SetSockOpt(handle.FileDescriptor, optionLevel, optionName, pinnedValue, optionValue.Length);
+                    err = Interop.Sys.SetSockOpt(handle, optionLevel, optionName, pinnedValue, optionValue.Length);
                 }
             }
 
@@ -947,7 +947,7 @@ namespace System.Net.Sockets
                 InterfaceIndex = optionValue.InterfaceIndex
             };
 
-            Interop.Error err = Interop.Sys.SetIPv4MulticastOption(handle.FileDescriptor, optName, &opt);
+            Interop.Error err = Interop.Sys.SetIPv4MulticastOption(handle, optName, &opt);
             return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
         }
 
@@ -964,7 +964,7 @@ namespace System.Net.Sockets
                 InterfaceIndex = (int)optionValue.InterfaceIndex
             };
 
-            Interop.Error err = Interop.Sys.SetIPv6MulticastOption(handle.FileDescriptor, optName, &opt);
+            Interop.Error err = Interop.Sys.SetIPv6MulticastOption(handle, optName, &opt);
             return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
         }
 
@@ -975,7 +975,7 @@ namespace System.Net.Sockets
                 Seconds = optionValue.LingerTime
             };
 
-            Interop.Error err = Interop.Sys.SetLingerOption(handle.FileDescriptor, &opt);
+            Interop.Error err = Interop.Sys.SetLingerOption(handle, &opt);
             return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
         }
 
@@ -1007,7 +1007,7 @@ namespace System.Net.Sockets
 
             int value = 0;
             int optLen = sizeof(int);
-            Interop.Error err = Interop.Sys.GetSockOpt(handle.FileDescriptor, optionLevel, optionName, (byte*)&value, &optLen);
+            Interop.Error err = Interop.Sys.GetSockOpt(handle, optionLevel, optionName, (byte*)&value, &optLen);
 
             optionValue = value;
             return err == Interop.Error.SUCCESS ? SocketError.Success : GetSocketErrorForErrorCode(err);
@@ -1021,13 +1021,13 @@ namespace System.Net.Sockets
             if (optionValue == null || optionValue.Length == 0)
             {
                 optLen = 0;
-                err = Interop.Sys.GetSockOpt(handle.FileDescriptor, optionLevel, optionName, null, &optLen);
+                err = Interop.Sys.GetSockOpt(handle, optionLevel, optionName, null, &optLen);
             }
             else
             {
                 fixed (byte* pinnedValue = optionValue)
                 {
-                    err = Interop.Sys.GetSockOpt(handle.FileDescriptor, optionLevel, optionName, pinnedValue, &optLen);
+                    err = Interop.Sys.GetSockOpt(handle, optionLevel, optionName, pinnedValue, &optLen);
                 }
             }
 
@@ -1049,7 +1049,7 @@ namespace System.Net.Sockets
                 Interop.Sys.MulticastOption.MULTICAST_DROP;
 
             Interop.Sys.IPv4MulticastOption opt;
-            Interop.Error err = Interop.Sys.GetIPv4MulticastOption(handle.FileDescriptor, optName, &opt);
+            Interop.Error err = Interop.Sys.GetIPv4MulticastOption(handle, optName, &opt);
             if (err != Interop.Error.SUCCESS)
             {
                 optionValue = default(MulticastOption);
@@ -1074,7 +1074,7 @@ namespace System.Net.Sockets
                 Interop.Sys.MulticastOption.MULTICAST_DROP;
 
             Interop.Sys.IPv6MulticastOption opt;
-            Interop.Error err = Interop.Sys.GetIPv6MulticastOption(handle.FileDescriptor, optName, &opt);
+            Interop.Error err = Interop.Sys.GetIPv6MulticastOption(handle, optName, &opt);
             if (err != Interop.Error.SUCCESS)
             {
                 optionValue = default(IPv6MulticastOption);
@@ -1088,7 +1088,7 @@ namespace System.Net.Sockets
         public static unsafe SocketError GetLingerOption(SafeCloseSocket handle, out LingerOption optionValue)
         {
             var opt = new Interop.Sys.LingerOption();
-            Interop.Error err = Interop.Sys.GetLingerOption(handle.FileDescriptor, &opt);
+            Interop.Error err = Interop.Sys.GetLingerOption(handle, &opt);
             if (err != Interop.Error.SUCCESS)
             {
                 optionValue = default(LingerOption);
@@ -1104,39 +1104,52 @@ namespace System.Net.Sockets
             uint* fdSet = stackalloc uint[Interop.Sys.FD_SETSIZE_UINTS];
             Interop.Sys.FD_ZERO(fdSet);
 
-            Interop.Sys.FD_SET(handle.FileDescriptor, fdSet);
-
-            int fdCount = 0;
-            uint* readFds = null;
-            uint* writeFds = null;
-            uint* errorFds = null;
-            switch (mode)
+            bool releaseHandle = false;
+            try
             {
-                case SelectMode.SelectRead:
-                    readFds = fdSet;
-                    fdCount = handle.FileDescriptor + 1;
-                    break;
+                handle.DangerousAddRef(ref releaseHandle);
+                int fd = (int)handle.DangerousGetHandle();
+                Interop.Sys.FD_SET(fd, fdSet);
 
-                case SelectMode.SelectWrite:
-                    writeFds = fdSet;
-                    fdCount = handle.FileDescriptor + 1;
-                    break;
+                int fdCount = 0;
+                uint* readFds = null;
+                uint* writeFds = null;
+                uint* errorFds = null;
+                switch (mode)
+                {
+                    case SelectMode.SelectRead:
+                        readFds = fdSet;
+                        fdCount = fd + 1;
+                        break;
 
-                case SelectMode.SelectError:
-                    errorFds = fdSet;
-                    fdCount = handle.FileDescriptor + 1;
-                    break;
+                    case SelectMode.SelectWrite:
+                        writeFds = fdSet;
+                        fdCount = fd + 1;
+                        break;
+
+                    case SelectMode.SelectError:
+                        errorFds = fdSet;
+                        fdCount = fd + 1;
+                        break;
+                }
+
+                int socketCount = 0;
+                Interop.Error err = Interop.Sys.Select(fdCount, readFds, writeFds, errorFds, microseconds, &socketCount);
+                if (err != Interop.Error.SUCCESS)
+                {
+                    status = false;
+                    return GetSocketErrorForErrorCode(err);
+                }
+
+                status = Interop.Sys.FD_ISSET(fd, fdSet);
             }
-
-            int socketCount = 0;
-            Interop.Error err = Interop.Sys.Select(fdCount, readFds, writeFds, errorFds, microseconds, &socketCount);
-            if (err != Interop.Error.SUCCESS)
+            finally
             {
-                status = false;
-                return GetSocketErrorForErrorCode(err);
+                if (releaseHandle)
+                {
+                    handle.DangerousRelease();
+                }
             }
-
-            status = Interop.Sys.FD_ISSET(handle.FileDescriptor, fdSet);
             return SocketError.Success;
         }
 
@@ -1202,7 +1215,7 @@ namespace System.Net.Sockets
 
         public static SocketError Shutdown(SafeCloseSocket handle, bool isConnected, bool isDisconnected, SocketShutdown how)
         {
-            Interop.Error err = Interop.Sys.Shutdown(handle.FileDescriptor, how);
+            Interop.Error err = Interop.Sys.Shutdown(handle, how);
             if (err == Interop.Error.SUCCESS)
             {
                 return SocketError.Success;


### PR DESCRIPTION
This PR contains the changes from #6126 and #6186, plus fixes for issues with both of those PRs.  #6126 had to be reverted, so this undoes the revert and fixes the issues that were leading to tests crashing/hanging.  #6186 turns out to fix one reason tests were crashing/hanging, so it needs to be folded into this PR prior to merging. 

@pgavlin @stephentoub 

Fixes #5750
Fixes #6173
Fixes #4563 
Fixes #4890
Fixes #5628 
Fixes #6311 
Fixes #6306 
Fixes #6154 
 
