### PR TITLE
Add template for issues and pull requests

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,61 @@
+This template includes boilerplate for different kinds of issues. Select the
+one that is most suitable, delete first level header and the other templates.
+
+# Template 1: Bug
+
+Description of the problem
+
+## Affected platforms
+
+## Repro steps
+
+1. One
+2. Two
+3. Three
+
+## Expected behavior
+
+## Actual behavior
+
+# Template 2: Suggest new API
+
+Read http://aka.ms/apireview and include description of the problem.
+
+## Rational and Usage
+
+Include some sample code that illustrates how the API will be used. If
+applicable, include the way it could be done without the API to illustrate
+how the new API makes things easier.
+
+## Proposed API
+
+Include an outline of the API. It doens't have to be complete, but enough to
+get a handle on what would be required in terms of surface area.
+
+```C#
+namespace System.Foo {
+    public class Fizz {
+        public Fizz();
+        public void int Epic(string message);
+    }
+}
+```
+
+## Details
+
+Include interesting design points. As the discussion on this issue progresses,
+you should update this section and include major decisions so that folks joining
+later get everything at the top.
+
+# Template 3: Request an existing API to be ported
+
+## Scenario
+
+Explain why you need the API to fulfill your scenario. If applicable, outline
+the hoops you've to jump through if the API will not be ported.
+
+## APIs
+
+List the APIs. For individual API just list them. For broad technologies just
+use the name of the technology or the top-level namespace (e.g. "XML schema" or
+`System.Xml.Schema`).

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,60 +1,70 @@
+<!--
 This template includes boilerplate for different kinds of issues. Select the
-one that is most suitable, delete first level header and the other templates.
+one that is most suitable and delete the others.
+-->
 
-# Template 1: Bug
+<!-- ===============
+     Template 1: Bug
+     =============== -->
 
 Description of the problem
 
-## Affected platforms
+# Affected platforms
 
-## Repro steps
+# Repro steps
 
 1. One
 2. Two
 3. Three
 
-## Expected behavior
+# Expected behavior
 
-## Actual behavior
+# Actual behavior
 
-# Template 2: Suggest new API
+<!-- =============================
+     Template 2: Suggest a new API
+     ============================= -->
 
 Read http://aka.ms/apireview and include description of the problem.
 
-## Rational and Usage
+# Rationale and Usage
 
 Include some sample code that illustrates how the API will be used. If
 applicable, include the way it could be done without the API to illustrate
 how the new API makes things easier.
 
-## Proposed API
+# Proposed API
 
-Include an outline of the API. It doens't have to be complete, but enough to
+Include an outline of the API. It doesn't have to be complete, but enough to
 get a handle on what would be required in terms of surface area.
 
 ```C#
-namespace System.Foo {
-    public class Fizz {
+namespace System.Foo
+{
+    public class Fizz
+    {
         public Fizz();
         public void int Epic(string message);
     }
 }
 ```
 
-## Details
+# Details
 
 Include interesting design points. As the discussion on this issue progresses,
 you should update this section and include major decisions so that folks joining
 later get everything at the top.
 
-# Template 3: Request an existing API to be ported
+<!-- ================================================
+     Template 3: Request an existing API to be ported
+     ================================================ -->
 
-## Scenario
+# Scenario
 
 Explain why you need the API to fulfill your scenario. If applicable, outline
 the hoops you've to jump through if the API will not be ported.
 
-## APIs
+# APIs
 
 List the APIs. For individual API just list them. For broad technologies just
 use the name of the technology or the top-level namespace (e.g. "XML schema" or

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,23 @@
-# Notes (delete this section)
+<!--
+For new APIs, follow http://aka.ms/apireview. This requires filing an issue
+that outlines the new API first. Before we accept PRs, it must be reviewed by
+us and marked as `api-approved`.
 
-* For new APIs, follow http://aka.ms/apireview. This requires filing an issue
-  that outlines the new API first. Before we accept PRs, it muse be reviewed by
-  us and marked as `api-approved`.
+Do not create tracking PRs with pending work. Submit the PR when you want to
+review the changes with us and believe the changes are ready to be merged.
+If you want to share work-in-progress PRs, create them in your own fork.
+-->
 
-* Do not create tracking PRs with pending work. Submit the PR when you're ready
-  to review the changes with us. If you want to share work-in-progress PRs,
-  create them in your own fork.
+# Problem
 
-* Include a "Fixes #1 and #2" to link to the issue(s) this PR addresses.
+Include a summary of the problem and the change so that reviewers don't have
+to extract that information from the commit messages.
 
-* Include a summary of the problem and the change so that reviewers don't have
-  to extract that information from the commit messages.
+# Summary
+
+Include a summary of the problem and the change so that reviewers don't have
+to extract that information from the commit messages.
+
+Fixes #1, #2 (If no corresponding GitHub issues exist, delete this line)
+
+cc: @reviewer1 @reviewer2 (list relevant reviewers if you know them, otherwise delete this line)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+# Notes (delete this section)
+
+* For new APIs, follow http://aka.ms/apireview. This requires filing an issue
+  that outlines the new API first. Before we accept PRs, it muse be reviewed by
+  us and marked as `api-approved`.
+
+* Do not create tracking PRs with pending work. Submit the PR when you're ready
+  to review the changes with us. If you want to share work-in-progress PRs,
+  create them in your own fork.
+
+* Include a "Fixes #1 and #2" to link to the issue(s) this PR addresses.
+
+* Include a summary of the problem and the change so that reviewers don't have
+  to extract that information from the commit messages.


### PR DESCRIPTION
Fixes #6167.

@weshaggard @stephentoub @GerjanOnline

Follows GitHub's suggestion documented here:

* [Issue Templates](https://help.github.com/articles/creating-an-issue-template-for-your-repository/)
* [Pull Request Templates](https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/)