### PR TITLE
Correctly cleaning up the ToolRuntime folder once a new version is required.

### DIFF
--- a/init-tools.cmd
+++ b/init-tools.cmd
@@ -29,6 +29,8 @@ if exist "%BUILD_TOOLS_SEMAPHORE%" (
   goto :EOF
 )
 
+if exist "%TOOLRUNTIME_DIR%" rmdir /S /Q "%TOOLRUNTIME_DIR%"
+
 if NOT exist "%PROJECT_JSON_PATH%" mkdir "%PROJECT_JSON_PATH%"
 echo %PROJECT_JSON_CONTENTS% > %PROJECT_JSON_FILE%
 echo Running %0 > %INIT_TOOLS_LOG%


### PR DESCRIPTION
Corefx has the same issue than buildtools: dotnet/buildtools#474
This line fixes that here as well.

CC: @weshaggard 