### PR TITLE
Return self on nop Skip or Take

### DIFF
--- a/src/System.Linq/src/System/Linq/Partition.cs
+++ b/src/System.Linq/src/System/Linq/Partition.cs
@@ -171,7 +171,7 @@ namespace System.Linq
             int maxIndex = _minIndex + count - 1;
             if ((uint)maxIndex >= (uint)_maxIndex)
             {
-                maxIndex = _maxIndex;
+                return this;
             }
 
             return new OrderedPartition<TElement>(_source, _minIndex, maxIndex);
@@ -266,7 +266,7 @@ namespace System.Linq
             public IPartition<TSource> Take(int count)
             {
                 int maxIndex = _minIndex + count - 1;
-                return new ListPartition<TSource>(_source, _minIndex, (uint)maxIndex >= (uint)_maxIndex ? _maxIndex : maxIndex);
+                return (uint)maxIndex >= (uint)_maxIndex ? this : new ListPartition<TSource>(_source, _minIndex, maxIndex);
             }
 
             public TSource TryGetElementAt(int index, out bool found)

--- a/src/System.Linq/src/System/Linq/Range.cs
+++ b/src/System.Linq/src/System/Linq/Range.cs
@@ -116,9 +116,9 @@ namespace System.Linq
             public IPartition<int> Take(int count)
             {
                 int curCount = _end - _start;
-                if (count > curCount)
+                if (count >= curCount)
                 {
-                    count = curCount;
+                    return this;
                 }
 
                 return new RangeIterator(_start, count);

--- a/src/System.Linq/src/System/Linq/Repeat.cs
+++ b/src/System.Linq/src/System/Linq/Repeat.cs
@@ -106,9 +106,9 @@ namespace System.Linq
 
             public IPartition<TResult> Take(int count)
             {
-                if (count > _count)
+                if (count >= _count)
                 {
-                    count = _count;
+                    return this;
                 }
 
                 return new RepeatIterator<TResult>(_current, count);

--- a/src/System.Linq/src/System/Linq/Select.cs
+++ b/src/System.Linq/src/System/Linq/Select.cs
@@ -217,11 +217,7 @@ namespace System.Linq
 
             public IPartition<TResult> Skip(int count)
             {
-                if (count == 0)
-                {
-                    return (IPartition<TResult>)Clone();
-                }
-
+                Debug.Assert(count > 0);
                 if (count >= _source.Length)
                 {
                     return EmptyPartition<TResult>.Instance;
@@ -232,7 +228,7 @@ namespace System.Linq
 
             public IPartition<TResult> Take(int count)
             {
-                return count >= _source.Length ? (IPartition<TResult>)Clone() : new SelectListPartitionIterator<TSource, TResult>(_source, _selector, 0, count - 1);
+                return count >= _source.Length ? (IPartition<TResult>)this : new SelectListPartitionIterator<TSource, TResult>(_source, _selector, 0, count - 1);
             }
 
             public TResult TryGetElementAt(int index, out bool found)
@@ -355,7 +351,8 @@ namespace System.Linq
 
             public IPartition<TResult> Skip(int count)
             {
-                return count == 0 ? (IPartition<TResult>)Clone() : new SelectListPartitionIterator<TSource, TResult>(_source, _selector, count, int.MaxValue);
+                Debug.Assert(count > 0);
+                return new SelectListPartitionIterator<TSource, TResult>(_source, _selector, count, int.MaxValue);
             }
 
             public IPartition<TResult> Take(int count)
@@ -494,7 +491,8 @@ namespace System.Linq
 
             public IPartition<TResult> Skip(int count)
             {
-                return count == 0 ? (IPartition<TResult>)Clone() : new SelectListPartitionIterator<TSource, TResult>(_source, _selector, count, int.MaxValue);
+                Debug.Assert(count > 0);
+                return new SelectListPartitionIterator<TSource, TResult>(_source, _selector, count, int.MaxValue);
             }
 
             public IPartition<TResult> Take(int count)
@@ -599,7 +597,8 @@ namespace System.Linq
 
             public IPartition<TResult> Skip(int count)
             {
-                return count == 0 ? (IPartition<TResult>)Clone() : new SelectIPartitionIterator<TSource, TResult>(_source.Skip(count), _selector);
+                Debug.Assert(count > 0);
+                return new SelectIPartitionIterator<TSource, TResult>(_source.Skip(count), _selector);
             }
 
             public IPartition<TResult> Take(int count)
@@ -729,6 +728,7 @@ namespace System.Linq
 
             public IPartition<TResult> Skip(int count)
             {
+                Debug.Assert(count > 0);
                 int minIndex = _minIndex + count;
                 return minIndex >= _maxIndex ? EmptyPartition<TResult>.Instance : new SelectListPartitionIterator<TSource, TResult>(_source, _selector, minIndex, _maxIndex);
             }
@@ -736,7 +736,7 @@ namespace System.Linq
             public IPartition<TResult> Take(int count)
             {
                 int maxIndex = _minIndex + count - 1;
-                return new SelectListPartitionIterator<TSource, TResult>(_source, _selector, _minIndex, (uint)maxIndex >= (uint)_maxIndex ? _maxIndex : maxIndex);
+                return (uint)maxIndex >= (uint)_maxIndex ? this : new SelectListPartitionIterator<TSource, TResult>(_source, _selector, _minIndex, maxIndex);
             }
 
             public TResult TryGetElementAt(int index, out bool found)

--- a/src/System.Linq/src/System/Linq/Skip.cs
+++ b/src/System.Linq/src/System/Linq/Skip.cs
@@ -15,15 +15,24 @@ namespace System.Linq
                 throw Error.ArgumentNull(nameof(source));
             }
 
-            if (count < 0)
+            if (count <= 0)
             {
+                // Return source if not actually skipping, but only if it's a type from here, to avoid
+                // issues if collections are used as keys or otherwise must not be aliased.
+                if (source is Iterator<TSource> || source is IPartition<TSource>)
+                {
+                    return source;
+                }
+
                 count = 0;
             }
-
-            IPartition<TSource> partition = source as IPartition<TSource>;
-            if (partition != null)
+            else
             {
-                return partition.Skip(count);
+                IPartition<TSource> partition = source as IPartition<TSource>;
+                if (partition != null)
+                {
+                    return partition.Skip(count);
+                }
             }
 
             IList<TSource> sourceList = source as IList<TSource>;


### PR DESCRIPTION
In a `Skip()` of zero or less or a `Take()` known to be taking all of an enumerable then:

1. If the source is known to originate from a linq query, return the source as the result, avoiding an allocation and dropping one step of chained `MoveNext()`/`Current`.

2. Otherwise return a thin wrapper that uses the source's `GetEnumerator()` to implement its own, dropping one step of chained `MoveNext()`/`Current`.

Both of these are observable changes, but both happen in the same case as the observable change discussed at https://github.com/dotnet/corefx/pull/6127#discussion_r53035666 and avoid returning an object that originated outside of a query and so avoids returning what is likely to be a key or otherwise have something depend upon it not being aliased.

cc: @stephentoub @VSadov 