### PR TITLE
Ensure LANG is set when running tests on Unix

### DIFF
--- a/run-test.sh
+++ b/run-test.sh
@@ -339,6 +339,11 @@ fi
 export CORECLR_SERVER_GC="$serverGC"
 export PAL_OUTPUTDEBUGSTRING="1"
 
+if [ "$LANG" == "" ]
+then
+    export LANG="en_US.UTF-8"
+fi
+
 
 create_test_overlay
 


### PR DESCRIPTION
Various tests depend on CurrentCulture, and when run in the service in CI, LANG is defaulting to empty which then causes the locale to default to "POSIX", which causes problems for some of the expectations in various tests.  This ensures that LANG is set.

cc: @mmitche, @ellismg 
Fixes #6070