### PR TITLE
Expose Debugger.NotifyOfCrossThreadDependency in contract

### DIFF
--- a/src/System.Diagnostics.Debug/ref/System.Diagnostics.Debug.cs
+++ b/src/System.Diagnostics.Debug/ref/System.Diagnostics.Debug.cs
@@ -62,6 +62,7 @@ namespace System.Diagnostics
         public static bool IsAttached { get { return default(bool); } }
         public static void Break() { }
         public static bool Launch() { return default(bool); }
+        public static void NotifyOfCrossThreadDependency() { }
     }
     [System.AttributeUsageAttribute((System.AttributeTargets)(384), AllowMultiple = false)]
     public sealed partial class DebuggerBrowsableAttribute : System.Attribute

--- a/src/System.Diagnostics.Debug/ref/System.Diagnostics.Debug.csproj
+++ b/src/System.Diagnostics.Debug/ref/System.Diagnostics.Debug.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
-    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <OutputType>Library</OutputType>
     <PackageTargetFramework>dotnet5.4</PackageTargetFramework>
     <NuGetTargetMoniker>.NETPlatform,Version=v5.4</NuGetTargetMoniker>

--- a/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
+++ b/src/System.Diagnostics.Debug/src/System.Diagnostics.Debug.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <ProjectGuid>{E7E8DE8A-9EC1-46A8-A6EE-727DB32DBEB8}</ProjectGuid>
     <AssemblyName>System.Diagnostics.Debug</AssemblyName>
-    <AssemblyVersion>4.0.11.0</AssemblyVersion>
+    <AssemblyVersion>4.1.0.0</AssemblyVersion>
     <IsPartialFacadeAssembly>true</IsPartialFacadeAssembly>
     <NoWarn>0436</NoWarn>
     <ResourcesSourceOutputDirectory Condition="'$(TargetGroup)' != ''">None</ResourcesSourceOutputDirectory>


### PR DESCRIPTION
Goes with:
https://github.com/dotnet/coreclr/pull/3340
https://github.com/dotnet/corert/pull/933

Fixes #5868 