### PR TITLE
Fix Interop.OpenSsl.Decrypt to handle decompression

### DIFF
--- a/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
+++ b/src/Common/src/Interop/Unix/libssl/Interop.OpenSsl.cs
@@ -205,7 +205,7 @@ internal static partial class Interop
 
             if (retVal == count)
             {
-                retVal = Ssl.SslRead(context, outBuffer, retVal);
+                retVal = Ssl.SslRead(context, outBuffer, outBuffer.Length);
 
                 if (retVal > 0)
                 {

--- a/src/System.Net.Security/src/System/Net/SslStreamPal.Unix.cs
+++ b/src/System.Net.Security/src/System/Net/SslStreamPal.Unix.cs
@@ -131,13 +131,17 @@ namespace System.Net
             try
             {
                 Interop.Ssl.SslErrorCode errorCode = Interop.Ssl.SslErrorCode.SSL_ERROR_NONE;
-
-
                 SafeSslHandle scHandle = securityContext.SslContext;
 
-                resultSize = encrypt ?
-                    Interop.OpenSsl.Encrypt(scHandle, buffer, offset, size, out errorCode) :
-                    Interop.OpenSsl.Decrypt(scHandle, buffer, size, out errorCode);
+                if (encrypt)
+                {
+                    resultSize = Interop.OpenSsl.Encrypt(scHandle, buffer, offset, size, out errorCode);
+                }
+                else
+                {
+                    Debug.Assert(offset == 0, "Expected offset 0 when decrypting");
+                    resultSize = Interop.OpenSsl.Decrypt(scHandle, buffer, size, out errorCode);
+                }
 
                 switch (errorCode)
                 {


### PR DESCRIPTION
The Interop.OpenSsl.Decrypt implementation is assuming that data to be decrypted will never have output larger than the input, but that's not a valid assumption, such as when compression is employed and the received data to be decrypted may get longer when decompressed.  This is causing failures in SslStream on OS X, which appears to be using compression as part of the underlying OpenSSL implementation.

Fixes https://github.com/dotnet/corefx/issues/5896
cc: @bartonjs, @ericeil, @vijaykota 