### PR TITLE
Ensure OpenSSL compression is disabled

### DIFF
--- a/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
+++ b/src/Native/System.Security.Cryptography.Native/pal_ssl.cpp
@@ -66,7 +66,16 @@ extern "C" const SSL_METHOD* CryptoNative_TlsV1_2Method()
 
 extern "C" SSL_CTX* CryptoNative_SslCtxCreate(SSL_METHOD* method)
 {
-    return SSL_CTX_new(method);
+    SSL_CTX* ctx = SSL_CTX_new(method);
+
+    if (ctx != nullptr)
+    {
+        // As of OpenSSL 1.1.0, compression is disabled by default. In case an older build
+        // is used, ensure it's disabled.
+        SSL_CTX_set_options(ctx, SSL_OP_NO_COMPRESSION);
+    }
+
+    return ctx;
 }
 
 extern "C" void CryptoNative_SetProtocolOptions(SSL_CTX* ctx, SslProtocols protocols)


### PR DESCRIPTION
It's disabled by default since OpenSSL v1.1.0.  This ensures it's disabled even in cases where we're building with a version older than that.

@bartonjs, any reason not to do this?

cc: @bartonjs, @morganbr 