### PR TITLE
Fix use of nameof with ArgumentException

### DIFF
--- a/Documentation/coding-guidelines/coding-style.md
+++ b/Documentation/coding-guidelines/coding-style.md
@@ -55,7 +55,7 @@ namespace System.Collections.Generic
         public ObservableLinkedList(IEnumerable<T> items)
         {
             if (items == null)
-                throw new ArgumentException(nameof(items));
+                throw new ArgumentNullException(nameof(items));
 
             foreach (T item in items)
             {

--- a/src/System.Collections.NonGeneric/tests/HashtableTests.cs
+++ b/src/System.Collections.NonGeneric/tests/HashtableTests.cs
@@ -1405,7 +1405,7 @@ namespace System.Collections.Tests
                 }
                 else
                 {
-                    throw new ArgumentException(nameof(o), "is not BadHashCode type actual " + o.GetType());
+                    throw new ArgumentException("is not BadHashCode type actual " + o.GetType(), nameof(o));
                 }
             }
 

--- a/src/System.Collections/src/System/Collections/Generic/SortedList.cs
+++ b/src/System.Collections/src/System/Collections/Generic/SortedList.cs
@@ -617,7 +617,7 @@ namespace System.Collections.Generic
             {
                 if (!IsCompatibleKey(key))
                 {
-                    throw new ArgumentException(nameof(key));
+                    throw new ArgumentException(SR.Argument_InvalidArgumentForComparison, nameof(key));
                 }
 
                 if (value == null && !(default(TValue) == null))

--- a/src/System.Collections/tests/Generic/SortedList/SortedList.Tests.cs
+++ b/src/System.Collections/tests/Generic/SortedList/SortedList.Tests.cs
@@ -50,7 +50,7 @@ namespace System.Collections.Tests
             if (!IsReadOnly)
             {
                 IDictionary dictionary = new SortedList<string, string>();
-                Assert.Throws<ArgumentException>(() => dictionary[23] = CreateTValue(12345));
+                Assert.Throws<ArgumentException>("key", () => dictionary[23] = CreateTValue(12345));
                 Assert.Empty(dictionary);
             }
         }

--- a/src/System.Data.Common/src/System/Data/Common/DbConnectionStringBuilder.cs
+++ b/src/System.Data.Common/src/System/Data/Common/DbConnectionStringBuilder.cs
@@ -266,7 +266,7 @@ namespace System.Data.Common
             }
             catch (InvalidCastException)
             {
-                throw new ArgumentException(nameof(keyword), "not a string");
+                throw new ArgumentException("not a string", nameof(keyword));
             }
         }
 

--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlRandom/SqlRandomTableColumn.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/SqlRandom/SqlRandomTableColumn.cs
@@ -38,7 +38,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             {
                 if ((options & SqlRandomColumnOptions.Sparse) != 0)
                 {
-                    throw new ArgumentException("options");
+                    throw new ArgumentException("Must not be sparse", nameof(options));
                 }
 
                 if (typeInfo.Type != SqlDbType.Xml)

--- a/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceSource.cs
+++ b/src/System.Diagnostics.TraceSource/src/System/Diagnostics/TraceSource.cs
@@ -30,7 +30,7 @@ namespace System.Diagnostics
             if (name == null)
                 throw new ArgumentNullException(nameof(name));
             if (name.Length == 0)
-                throw new ArgumentException(nameof(name));
+                throw new ArgumentException(SR.Format(SR.InvalidNullEmptyArgument, nameof(name)), nameof(name));
 
             _sourceName = name;
             _switchLevel = defaultLevel;

--- a/src/System.Diagnostics.TraceSource/tests/TraceSourceClassTests.cs
+++ b/src/System.Diagnostics.TraceSource/tests/TraceSourceClassTests.cs
@@ -116,6 +116,20 @@ namespace System.Diagnostics.TraceSourceTests
             trace.TraceEvent(messageLevel, 0);
             Assert.Equal(expected, listener.GetCallCount(Method.TraceEvent));
         }
+
+        [Fact]
+        public void NullSourceName()
+        {
+            Assert.Throws<ArgumentNullException>("name", () => new TraceSource(null));
+            Assert.Throws<ArgumentNullException>("name", () => new TraceSource(null, SourceLevels.All));
+        }
+
+        [Fact]
+        public void EmptySourceName()
+        {
+            Assert.Throws<ArgumentException>("name", () => new TraceSource(string.Empty));
+            Assert.Throws<ArgumentException>("name", () => new TraceSource(string.Empty, SourceLevels.All));
+        }
     }
 
     public sealed class TraceSourceTests_Default : TraceSourceTestsBase

--- a/src/System.IO.FileSystem/src/Resources/Strings.resx
+++ b/src/System.IO.FileSystem/src/Resources/Strings.resx
@@ -174,6 +174,9 @@
   <data name="Argument_EmptyPath" xml:space="preserve">
     <value>Empty path name is not legal.</value>
   </data>
+  <data name="Argument_FileNotResized" xml:space="preserve">
+    <value>The stream's length cannot be changed.</value>
+  </data>
   <data name="Argument_InvalidAppendMode" xml:space="preserve">
     <value>Append access can be requested only in write-only mode.</value>
   </data>

--- a/src/System.IO.FileSystem/src/System/IO/WinRTFileStream.cs
+++ b/src/System.IO.FileSystem/src/System/IO/WinRTFileStream.cs
@@ -201,7 +201,7 @@ namespace System.IO
             }
             else if (_innerStream.Length != value)
             {
-                throw new ArgumentException(nameof(value));
+                throw new ArgumentException(SR.Argument_FileNotResized, nameof(value));
             }
 
             // WinRT doesn't update the position when truncating a file

--- a/src/System.Net.Http.WinHttpHandler/src/Resources/Strings.resx
+++ b/src/System.Net.Http.WinHttpHandler/src/Resources/Strings.resx
@@ -162,4 +162,7 @@
   <data name="net_http_no_concurrent_io_allowed" xml:space="preserve">
     <value>The stream does not support concurrent I/O read or write operations.</value>
   </data>
+  <data name="net_http_buffer_insufficient_length" xml:space="preserve">
+    <value>The buffer was not long enough.</value>
+  </data>
 </root>

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestStream.cs
@@ -110,7 +110,7 @@ namespace System.Net.Http
 
             if (count > buffer.Length - offset)
             {
-                throw new ArgumentException(nameof(buffer));
+                throw new ArgumentException(SR.net_http_buffer_insufficient_length, nameof(buffer));
             }
 
             if (token.IsCancellationRequested)

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseStream.cs
@@ -103,7 +103,7 @@ namespace System.Net.Http
 
             if (count > buffer.Length - offset)
             {
-                throw new ArgumentException(nameof(buffer));
+                throw new ArgumentException(SR.net_http_buffer_insufficient_length, nameof(buffer));
             }
 
             if (token.IsCancellationRequested)

--- a/src/System.Net.Http/src/Resources/Strings.resx
+++ b/src/System.Net.Http/src/Resources/Strings.resx
@@ -357,4 +357,7 @@
   <data name="net_http_unix_invalid_response" xml:space="preserve">
     <value>The server returned an invalid or unrecognized response.</value>
   </data>
+  <data name="net_http_buffer_insufficient_length" xml:space="preserve">
+    <value>The buffer was not long enough.</value>
+  </data>
 </root>

--- a/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
+++ b/src/System.Net.Http/src/System/Net/Http/Unix/CurlHandler.CurlResponseMessage.cs
@@ -237,7 +237,7 @@ namespace System.Net.Http
                 if (buffer == null) throw new ArgumentNullException(nameof(buffer));
                 if (offset < 0) throw new ArgumentOutOfRangeException(nameof(offset));
                 if (count < 0) throw new ArgumentOutOfRangeException(nameof(count));
-                if (offset > buffer.Length - count) throw new ArgumentException(nameof(buffer));
+                if (offset > buffer.Length - count) throw new ArgumentException(SR.net_http_buffer_insufficient_length, nameof(buffer));
                 CheckDisposed();
 
                 EventSourceTrace("Buffer: {0}, Offset: {1}, Count: {2}", buffer.Length, offset, count);

--- a/src/System.Private.Uri/src/Resources/Strings.resx
+++ b/src/System.Private.Uri/src/Resources/Strings.resx
@@ -258,4 +258,10 @@
   <data name="IO_PathTooLong" xml:space="preserve">
     <value>The specified file name or path is too long, or a component of the specified path is too long.</value>
   </data>
+  <data name="Argument_ExtraNotValid" xml:space="preserve">
+    <value>Extra portion of URI not valid.</value>
+  </data>
+  <data name="Argument_InvalidUriSubcomponent" xml:space="preserve">
+    <value>The subcomponent, {0}, of this uri is not valid.</value>
+  </data>
 </root>

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -1388,7 +1388,7 @@ namespace System
                     : ((int)digit - (int)'a'))
                     + 10);
             }
-            throw new ArgumentOutOfRangeException(nameof(digit));
+            throw new ArgumentException(nameof(digit));
         }
 
         //

--- a/src/System.Private.Uri/src/System/Uri.cs
+++ b/src/System.Private.Uri/src/System/Uri.cs
@@ -1306,7 +1306,7 @@ namespace System
                 case UriPartial.Query:
                     return GetParts(NonPathPart | UriComponents.Path | UriComponents.Query, UriFormat.UriEscaped);
             }
-            throw new ArgumentException(nameof(part));
+            throw new ArgumentException(SR.Format(SR.Argument_InvalidUriSubcomponent, part), nameof(part));
         }
 
         //
@@ -1388,7 +1388,7 @@ namespace System
                     : ((int)digit - (int)'a'))
                     + 10);
             }
-            throw new ArgumentException(nameof(digit));
+            throw new ArgumentOutOfRangeException(nameof(digit));
         }
 
         //

--- a/src/System.Private.Uri/src/System/UriBuilder.cs
+++ b/src/System.Private.Uri/src/System/UriBuilder.cs
@@ -121,7 +121,7 @@ namespace System
                     throw;
                 }
 
-                throw new ArgumentException(nameof(extraValue));
+                throw new ArgumentException(SR.Argument_ExtraNotValid, nameof(extraValue));
             }
         }
 
@@ -156,7 +156,7 @@ namespace System
                     }
                     else
                     {
-                        throw new ArgumentException(nameof(value));
+                        throw new ArgumentException(SR.Argument_ExtraNotValid, nameof(value));
                     }
                 }
                 else
@@ -307,7 +307,7 @@ namespace System
                 {
                     if (!Uri.CheckSchemeName(value))
                     {
-                        throw new ArgumentException(nameof(value));
+                        throw new ArgumentException(SR.net_uri_BadScheme, nameof(value));
                     }
                     value = value.ToLowerInvariant();
                 }

--- a/src/System.Reflection.Metadata/src/Resources/Strings.resx
+++ b/src/System.Reflection.Metadata/src/Resources/Strings.resx
@@ -354,4 +354,7 @@
   <data name="NotTypeDefOrRefOrSpecHandle" xml:space="preserve">
     <value>Specified handle is not a TypeDefinitionHandle, TypeRefererenceHandle, or TypeSpecificationHandle.</value>
   </data>
+  <data name="NotCodeViewEntry" xml:space="preserve">
+    <value>The Debug directory was not of type CodeView.</value>
+  </data>
 </root>

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Blobs/BlobEncoders.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Ecma335/Blobs/BlobEncoders.cs
@@ -719,7 +719,7 @@ namespace Roslyn.Reflection.Metadata.Ecma335.Blobs
                 attributes != FunctionPointerAttributes.HasThis &&
                 attributes != FunctionPointerAttributes.HasExplicitThis)
             {
-                throw new ArgumentException(nameof(attributes));
+                throw new ArgumentException(SR.InvalidSignature, nameof(attributes));
             }
 
             Builder.WriteByte((byte)SignatureTypeCode.FunctionPointer);

--- a/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/PortableExecutable/PEReader.cs
@@ -514,7 +514,7 @@ namespace System.Reflection.PortableExecutable
         {
             if (entry.Type != DebugDirectoryEntryType.CodeView)
             {
-                throw new ArgumentException(nameof(entry));
+                throw new ArgumentException(SR.NotCodeViewEntry, nameof(entry));
             }
 
             using (AbstractMemoryBlock block = _peImage.GetMemoryBlock(entry.DataPointer, entry.DataSize))

--- a/src/System.Reflection.Metadata/tests/PortableExecutable/DebugDirectoryTests.cs
+++ b/src/System.Reflection.Metadata/tests/PortableExecutable/DebugDirectoryTests.cs
@@ -94,7 +94,7 @@ namespace System.Reflection.PortableExecutable.Tests
 
                 Assert.Equal(2, entries.Length);
 
-                Assert.Throws<ArgumentException>(() => reader.ReadCodeViewDebugDirectoryData(detEntry));
+                Assert.Throws<ArgumentException>("entry", () => reader.ReadCodeViewDebugDirectoryData(detEntry));
             }
         }
     }

--- a/src/System.Runtime.WindowsRuntime/src/System/IO/WinRtToNetFxStreamAdapter.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/IO/WinRtToNetFxStreamAdapter.cs
@@ -380,7 +380,7 @@ namespace System.IO
 
                 default:
                     {
-                        throw new ArgumentException(nameof(origin));
+                        throw new ArgumentException(SR.Argument_InvalidSeekOrigin, nameof(origin));
                     }
             }
         }

--- a/src/System.Runtime.WindowsRuntime/src/System/Windows/Rect.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Windows/Rect.cs
@@ -51,9 +51,9 @@ namespace Windows.Foundation
                     double height)
         {
             if (width < 0)
-                throw new ArgumentException(nameof(width));
+                throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_NeedNonNegNum, nameof(width));
             if (height < 0)
-                throw new ArgumentException(nameof(height));
+                throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_NeedNonNegNum, nameof(height));
 
             _x = (float)x;
             _y = (float)y;
@@ -120,7 +120,7 @@ namespace Windows.Foundation
             set
             {
                 if (value < 0)
-                    throw new ArgumentException("Width");
+                    throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_NeedNonNegNum, nameof(Width));
 
                 _width = (float)value;
             }
@@ -132,7 +132,7 @@ namespace Windows.Foundation
             set
             {
                 if (value < 0)
-                    throw new ArgumentException("Height");
+                    throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_NeedNonNegNum, nameof(Height));
 
                 _height = (float)value;
             }

--- a/src/System.Runtime.WindowsRuntime/src/System/Windows/Rect.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Windows/Rect.cs
@@ -51,9 +51,9 @@ namespace Windows.Foundation
                     double height)
         {
             if (width < 0)
-                throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_NeedNonNegNum, nameof(width));
+                throw new ArgumentException(nameof(width));
             if (height < 0)
-                throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_NeedNonNegNum, nameof(height));
+                throw new ArgumentException(nameof(height));
 
             _x = (float)x;
             _y = (float)y;
@@ -120,7 +120,7 @@ namespace Windows.Foundation
             set
             {
                 if (value < 0)
-                    throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_NeedNonNegNum, nameof(Width));
+                    throw new ArgumentException(nameof(Width));
 
                 _width = (float)value;
             }
@@ -132,7 +132,7 @@ namespace Windows.Foundation
             set
             {
                 if (value < 0)
-                    throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_NeedNonNegNum, nameof(Height));
+                    throw new ArgumentException(nameof(Height));
 
                 _height = (float)value;
             }

--- a/src/System.Runtime.WindowsRuntime/src/System/Windows/Size.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Windows/Size.cs
@@ -40,9 +40,9 @@ namespace Windows.Foundation
         public Size(double width, double height)
         {
             if (width < 0)
-                throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_NeedNonNegNum, nameof(width));
+                throw new ArgumentException(nameof(width));
             if (height < 0)
-                throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_NeedNonNegNum, nameof(height));
+                throw new ArgumentException(nameof(height));
 
             _width = (float)width;
             _height = (float)height;
@@ -54,7 +54,7 @@ namespace Windows.Foundation
             set
             {
                 if (value < 0)
-                    throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_NeedNonNegNum, nameof(Width));
+                    throw new ArgumentException(nameof(Width));
 
                 _width = (float)value;
             }
@@ -66,7 +66,7 @@ namespace Windows.Foundation
             set
             {
                 if (value < 0)
-                    throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_NeedNonNegNum, nameof(Height));
+                    throw new ArgumentException(nameof(Height));
 
                 _height = (float)value;
             }

--- a/src/System.Runtime.WindowsRuntime/src/System/Windows/Size.cs
+++ b/src/System.Runtime.WindowsRuntime/src/System/Windows/Size.cs
@@ -40,9 +40,9 @@ namespace Windows.Foundation
         public Size(double width, double height)
         {
             if (width < 0)
-                throw new ArgumentException(nameof(width));
+                throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_NeedNonNegNum, nameof(width));
             if (height < 0)
-                throw new ArgumentException(nameof(height));
+                throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_NeedNonNegNum, nameof(height));
 
             _width = (float)width;
             _height = (float)height;
@@ -54,7 +54,7 @@ namespace Windows.Foundation
             set
             {
                 if (value < 0)
-                    throw new ArgumentException("Width");
+                    throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_NeedNonNegNum, nameof(Width));
 
                 _width = (float)value;
             }
@@ -66,7 +66,7 @@ namespace Windows.Foundation
             set
             {
                 if (value < 0)
-                    throw new ArgumentException("Height");
+                    throw new ArgumentOutOfRangeException(SR.ArgumentOutOfRange_NeedNonNegNum, nameof(Height));
 
                 _height = (float)value;
             }

--- a/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509SubjectKeyIdentifierExtension.cs
+++ b/src/System.Security.Cryptography.X509Certificates/src/System/Security/Cryptography/X509Certificates/X509SubjectKeyIdentifierExtension.cs
@@ -74,7 +74,7 @@ namespace System.Security.Cryptography.X509Certificates
             if (subjectKeyIdentifier == null)
                 throw new ArgumentNullException(nameof(subjectKeyIdentifier));
             if (subjectKeyIdentifier.Length == 0)
-                throw new ArgumentException(nameof(subjectKeyIdentifier));
+                throw new ArgumentException(SR.Arg_EmptyOrNullArray, nameof(subjectKeyIdentifier));
             return X509Pal.Instance.EncodeX509SubjectKeyIdentifierExtension(subjectKeyIdentifier);
         }
 
@@ -122,7 +122,7 @@ namespace System.Security.Cryptography.X509Certificates
                     return X509Pal.Instance.ComputeCapiSha1OfPublicKey(key);
 
                 default:
-                    throw new ArgumentException(nameof(algorithm));
+                    throw new ArgumentException(SR.Format(SR.Arg_EnumIllegalVal, algorithm), nameof(algorithm));
             }
         }
 

--- a/src/System.Threading.Tasks/tests/Task/TaskRtTests.cs
+++ b/src/System.Threading.Tasks/tests/Task/TaskRtTests.cs
@@ -1014,7 +1014,7 @@ namespace System.Threading.Tasks.Tests
                 myAsyncResult mar = new myAsyncResult(cb, o);
 
                 // Allow for exception throwing to test our handling of that.
-                if (maxBytes == -1) throw new ArgumentException(nameof(maxBytes));
+                if (maxBytes == -1) throw new ArgumentException("Value was not valid", nameof(maxBytes));
 
                 Task t = Task.Factory.StartNew(delegate
                 {

--- a/src/System.Threading.Tasks/tests/TaskFactory/TaskFactoryTests.cs
+++ b/src/System.Threading.Tasks/tests/TaskFactory/TaskFactoryTests.cs
@@ -598,7 +598,7 @@ namespace System.Threading.Tasks.Tests
                 myAsyncResult mar = new myAsyncResult(cb, o);
 
                 // Allow for exception throwing to test our handling of that.
-                if (maxBytes == -1) throw new ArgumentException(nameof(maxBytes));
+                if (maxBytes == -1) throw new ArgumentException("Value was not valid", nameof(maxBytes));
 
                 Task t = Task.Factory.StartNew(delegate
                 {

--- a/src/System.Threading.Tasks/tests/TaskFactory/TaskFactory_FromAsyncTests.cs
+++ b/src/System.Threading.Tasks/tests/TaskFactory/TaskFactory_FromAsyncTests.cs
@@ -439,7 +439,7 @@ namespace System.Threading.Tasks.Tests
 
                 // Allow for exception throwing to test our handling of that.
                 if (maxBytes == -1)
-                    throw new ArgumentException(nameof(maxBytes));
+                    throw new ArgumentException("Value was not valid", nameof(maxBytes));
 
                 Task t = Task.Factory.StartNew(delegate
                 {

--- a/src/System.Xml.XmlSerializer/src/System/Xml/BinHexDecoder.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/BinHexDecoder.cs
@@ -124,7 +124,7 @@ namespace System.Xml
         {
             if (chars == null)
             {
-                throw new ArgumentException(nameof(chars));
+                throw new ArgumentNullException(nameof(chars));
             }
 
             int len = chars.Length;

--- a/src/System.Xml.XmlSerializer/src/System/Xml/BinHexDecoder.cs
+++ b/src/System.Xml.XmlSerializer/src/System/Xml/BinHexDecoder.cs
@@ -124,7 +124,7 @@ namespace System.Xml
         {
             if (chars == null)
             {
-                throw new ArgumentNullException(nameof(chars));
+                throw new ArgumentException(nameof(chars));
             }
 
             int len = chars.Length;


### PR DESCRIPTION
Simply a squashed version of the already reviewed https://github.com/dotnet/corefx/pull/6270.
Replaces https://github.com/dotnet/corefx/pull/6270.
Fixes #6251 