### PR TITLE
Fix Console.ReadKey() backspace handling on OSX

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetControlCharacters.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetControlCharacters.cs
@@ -1,0 +1,37 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Runtime.InteropServices;
+
+internal static partial class Interop
+{
+    internal static partial class Sys
+    {
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetControlCharacters")]
+        internal static extern void GetControlCharacters(
+            ControlCharacterNames[] controlCharacterNames, byte[] controlCharacterValues, 
+            int controlCharacterLength);
+
+        internal enum ControlCharacterNames : int
+        {
+            VINTR = 0,
+            VQUIT = 1,
+            VERASE = 2,
+            VKILL = 3,
+            VEOF = 4,
+            VTIME = 5,
+            VMIN = 6,
+            VSWTC = 7,
+            VSTART = 8,
+            VSTOP = 9,
+            VSUSP = 10,
+            VEOL = 11,
+            VREPRINT = 12,
+            VDISCARD = 13,
+            VWERASE = 14,
+            VLNEXT = 15,
+            VEOL2 = 16
+        };
+    }
+}

--- a/src/Native/System.Native/pal_console.cpp
+++ b/src/Native/System.Native/pal_console.cpp
@@ -75,6 +75,91 @@ extern "C" void SystemNative_InitializeConsole()
 #endif
 }
 
+static int TranslatePalControlCharacterName(int name)
+{
+    switch (name)
+    {
+#ifdef VINTR
+        case PAL_VINTR: return VINTR;
+#endif
+#ifdef VQUIT
+        case PAL_VQUIT: return VQUIT;
+#endif
+#ifdef VERASE
+        case PAL_VERASE: return VERASE;
+#endif
+#ifdef VKILL
+        case PAL_VKILL: return VKILL;
+#endif
+#ifdef VEOF
+        case PAL_VEOF: return VEOF;
+#endif
+#ifdef VTIME
+        case PAL_VTIME: return VTIME;
+#endif
+#ifdef VMIN
+        case PAL_VMIN: return VMIN;
+#endif
+#ifdef VSWTC
+        case PAL_VSWTC: return VSWTC;
+#endif
+#ifdef VSTART
+        case PAL_VSTART: return VSTART;
+#endif
+#ifdef VSTOP
+        case PAL_VSTOP: return VSTOP;
+#endif
+#ifdef VSUSP
+        case PAL_VSUSP: return VSUSP;
+#endif
+#ifdef VEOL
+        case PAL_VEOL: return VEOL;
+#endif
+#ifdef VREPRINT
+        case PAL_VREPRINT: return VREPRINT;
+#endif
+#ifdef VDISCARD
+        case PAL_VDISCARD: return VDISCARD;
+#endif
+#ifdef VWERASE
+        case PAL_VWERASE: return VWERASE;
+#endif
+#ifdef VLNEXT
+        case PAL_VLNEXT: return VLNEXT;
+#endif
+#ifdef VEOL2
+        case PAL_VEOL2: return VEOL2;
+#endif
+        default: return -1;
+    }
+}
+
+extern "C" void SystemNative_GetControlCharacters(
+    int32_t* controlCharacterNames, uint8_t* controlCharacterValues, 
+    int32_t controlCharacterLength)
+{
+    assert(controlCharacterNames != nullptr);
+    assert(controlCharacterValues != nullptr);
+    assert(controlCharacterLength >= 0);
+
+    memset(controlCharacterValues, 0, sizeof(uint8_t) * UnsignedCast(controlCharacterLength));
+
+#if HAVE_TCGETATTR
+    struct termios newtermios = {};
+    if (tcgetattr(STDIN_FILENO, &newtermios) >= 0)
+    {
+        for (int i = 0; i < controlCharacterLength; i++)
+        {
+            int name = TranslatePalControlCharacterName(controlCharacterNames[i]);
+            if (name >= 0)
+            {
+                controlCharacterValues[i] = newtermios.c_cc[name];
+            }
+        }
+    }
+#endif
+}
+
 extern "C" int32_t SystemNative_StdinReady()
 {
     struct pollfd fd;

--- a/src/Native/System.Native/pal_console.h
+++ b/src/Native/System.Native/pal_console.h
@@ -6,6 +6,30 @@
 
 #include "pal_types.h"
 
+/**
+* Constants for terminal control codes.
+*/
+enum
+{
+    PAL_VINTR = 0,
+    PAL_VQUIT = 1,
+    PAL_VERASE = 2,
+    PAL_VKILL = 3,
+    PAL_VEOF = 4,
+    PAL_VTIME = 5,
+    PAL_VMIN = 6,
+    PAL_VSWTC = 7,
+    PAL_VSTART = 8,
+    PAL_VSTOP = 9,
+    PAL_VSUSP = 10,
+    PAL_VEOL = 11,
+    PAL_VREPRINT = 12,
+    PAL_VDISCARD = 13,
+    PAL_VWERASE = 14,
+    PAL_VLNEXT = 15,
+    PAL_VEOL2 = 16
+};
+
 /*
  * Window Size of the terminal
  */
@@ -36,6 +60,17 @@ extern "C" int32_t SystemNative_IsATty(intptr_t fd);
  * Initializes the console for use by System.Console.
  */
 extern "C" void SystemNative_InitializeConsole();
+
+/**
+ * Gets the special control character codes for the requested control characters.
+ *
+ * controlCharacterLength is the length of the input controlCharacterNames array and the output controlCharacterValues array.
+ * The controlCharacterValues array is filled with the control codes for the corresponding control character names,
+ * or 0 if a particular name is unsupported or disabled.
+ */
+extern "C" void SystemNative_GetControlCharacters(
+    int32_t* controlCharacterNames, uint8_t* controlCharacterValues, 
+    int32_t controlCharacterLength);
 
 /**
  * Returns 1 if any input is waiting on stdin; otherwise, 0.

--- a/src/System.Console/src/System.Console.csproj
+++ b/src/System.Console/src/System.Console.csproj
@@ -191,6 +191,9 @@
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.FLock.cs">
       <Link>Common\Interop\Unix\Interop.FLock.cs</Link>
     </Compile>
+    <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.GetControlCharacters.cs">
+      <Link>Common\Interop\Unix\Interop.GetControlCharacters.cs"</Link>
+    </Compile>
     <Compile Include="$(CommonPath)\Interop\Unix\System.Native\Interop.IsATty.cs">
       <Link>Common\Interop\Unix\Interop.IsATty.cs</Link>
     </Compile>

--- a/src/System.Console/src/System/IO/StdInStreamReader.cs
+++ b/src/System.Console/src/System/IO/StdInStreamReader.cs
@@ -97,7 +97,7 @@ namespace System.IO
                     Console.WriteLine();
                     return readLineStr;
                 }
-                else if (keyInfo.Key == ConsoleKey.Backspace || keyInfo.Key == ConsoleKey.Delete)
+                else if (keyInfo.Key == ConsoleKey.Backspace)
                 {
                     int len = _readLineSB.Length;
                     if (len > 0)


### PR DESCRIPTION
The terminfo files for xterm* on OSX contain ```^H``` for the kbs entry (Backspace key); this can be seen, for example, with ```infocmp -1 xterm-256color | grep kbs```.  However, the terminal is sending ```^?```.  This commit addresses the discrepancy by consulting the termios control codes and using them as an override for what's in termios.

cc: @pallavit, @andschwa 
Fixes #6377

@andschwa, can you confirm that this both fixes your issue and doesn't introduce other unexpected ones?