### PR TITLE
Fix memory leak caused by cycle reference in WinHttpRequestState

### DIFF
--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestCallback.cs
@@ -228,6 +228,7 @@ namespace System.Net.Http
         private static void OnRequestSendingRequest(WinHttpRequestState state)
         {
             Debug.Assert(state != null, "OnRequestSendingRequest: state is null");
+            Debug.Assert(state.RequestHandle != null, "OnRequestSendingRequest: state.RequestHandle is null");
             
             if (state.RequestMessage.RequestUri.Scheme != UriScheme.Https)
             {
@@ -319,6 +320,7 @@ namespace System.Net.Http
                         // (which means we have no certs to send). For security reasons, we don't
                         // allow the certificate to be re-applied. But we need to tell WinHttp
                         // explicitly that we don't have any certificate to send.
+                        Debug.Assert(state.RequestHandle != null, "OnRequestError: state.RequestHandle is null");
                         WinHttpHandler.SetNoClientCertificate(state.RequestHandle);
                         state.RetryRequest = true;
                         state.TcsReceiveResponseHeaders.TrySetResult(false);

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpRequestState.cs
@@ -66,6 +66,7 @@ namespace System.Net.Http
             TcsReceiveResponseHeaders = null;
             RequestMessage = null;
             Handler = null;
+            RequestHandle = null;
             ServerCertificateValidationCallback = null;
             TransportContext = null;
             Proxy = null;

--- a/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
+++ b/src/System.Net.Http.WinHttpHandler/src/System/Net/Http/WinHttpResponseParser.cs
@@ -53,7 +53,7 @@ namespace System.Net.Http
             }
 
             // Create response stream and wrap it in a StreamContent object.
-            var responseStream = new WinHttpResponseStream(state);
+            var responseStream = new WinHttpResponseStream(requestHandle, state);
             Stream decompressedStream = responseStream;
 
             if (doManualDecompressionCheck)

--- a/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpResponseStreamTest.cs
+++ b/src/System.Net.Http.WinHttpHandler/tests/UnitTests/WinHttpResponseStreamTest.cs
@@ -376,7 +376,7 @@ namespace System.Net.Http.WinHttpHandlerUnitTests
             handle.Context = state.ToIntPtr();
             state.RequestHandle = handle;
 
-            return new WinHttpResponseStream(state);
+            return new WinHttpResponseStream(handle, state);
         }
     }
 }


### PR DESCRIPTION
The fix made in PR #6285 for this memory leak turned out to be insufficient. The request handle object for the stream (SafeWinHttpHandle) was part of the strong root chain in WinHttpRequestState. And even when the WinHttpResponseStream object was finalized (implicit Dispose), the request handle was not finalized and thus leaks were happening.

To address this, the request handle object reference is now cleared from the WinHttpRequestState object (along with other object references) once the WinHttpResponseStream is created. WinHttpResponseStream then gets passed the request handle reference. Then normal finalizer rules can apply to both WinHttpResponseStream and the request handle. Once the request handle gets disposed (via finalizing), native WinHTTP will send a final status callback (HANDLE_CLOSING) and that is how the state object will then get unrooted and freed.

Tested this fix with WCF streaming scenarios and used WinDBG to verify the heaps.

There are future plans to improve this code via refactoring as part of #2501.

Fixes #5927.