### PR TITLE
Increase linger time in SendRecvAsync tests

### DIFF
--- a/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
+++ b/src/System.Net.Sockets/tests/FunctionalTests/SendReceive.cs
@@ -130,7 +130,7 @@ namespace System.Net.Sockets.Tests
         {
             const int BytesToSend = 123456;
             const int ListenBacklog = 1;
-            const int LingerTime = 10;
+            const int LingerTime = 60;
             const int TestTimeout = 30000;
 
             var server = new Socket(listenAt.AddressFamily, SocketType.Stream, ProtocolType.Tcp);


### PR DESCRIPTION
These tests are failing with an OperationAborted status code on OSX, very rarely.  I can't reproduce the problem locally, even if I try to artifically induce the failure.  I'm guessing that the timing works out differently on the CI machines, making this (somewhat) more likely, and the only legitimate case I can see where this would happen is if the client closes the TCP connection before the server has finished reading all bytes.  Increasing the linger time should help with that, so let's give it a try.

Fixes #5750.

@pgavlin, @stephentoub, @CIPop 