### PR TITLE
Increase timeout on a threading test

### DIFF
--- a/src/System.Threading/tests/SemaphoreSlimTests.cs
+++ b/src/System.Threading/tests/SemaphoreSlimTests.cs
@@ -171,7 +171,7 @@ namespace System.Threading.Tests
             RunSemaphoreSlimTest8_ConcWaitAndRelease
               (0, 1000, 50, 0, 0, 50, 0, 100);
             RunSemaphoreSlimTest8_ConcWaitAsyncAndRelease
-               (5, 1000, 50, 50, 50, 0, 5, 1000);
+               (5, 1000, 50, 50, 50, 0, 5, 5000);
             RunSemaphoreSlimTest8_ConcWaitAsyncAndRelease
                (0, 1000, 50, 25, 25, 25, 0, 5000);
             RunSemaphoreSlimTest8_ConcWaitAsyncAndRelease


### PR DESCRIPTION
These tests should really be rewritten.  In the meantime, bumping up a timeout that's causing a sporadic failure in the lab when under load.

Fixes https://github.com/dotnet/corefx/issues/6399