### PR TITLE
Fixes test issue where SELECT INTO statements can't find pubs..authors table, despite it being present in the database

### DIFF
--- a/src/System.Data.SqlClient/tests/ManualTests/SQL/ParallelTransactionsTest/ParallelTransactionsTest.cs
+++ b/src/System.Data.SqlClient/tests/ManualTests/SQL/ParallelTransactionsTest/ParallelTransactionsTest.cs
@@ -154,7 +154,7 @@ namespace System.Data.SqlClient.ManualTesting.Tests
             using (var conn = new SqlConnection(connectionString))
             {
                 conn.Open();
-                SqlCommand cmd = new SqlCommand(string.Format("SELECT au_id, au_lname, au_fname, phone, address, city, state, zip, contract into {0} from authors", tempTableName), conn);
+                SqlCommand cmd = new SqlCommand(string.Format("SELECT au_id, au_lname, au_fname, phone, address, city, state, zip, contract into {0} from pubs.dbo.authors", tempTableName), conn);
                 cmd.ExecuteNonQuery();
                 cmd.CommandText = string.Format("alter table {0} add constraint au_id_{1} primary key (au_id)", tempTableName, uniqueKey);
                 cmd.ExecuteNonQuery();


### PR DESCRIPTION
Issue was showing up in ParallelTransactionsTest when trying to create temp tables using SELECT INTO with authors table as the source. The command would fail with "Invalid object name 'authors'", even though the table was present in the database and could be queried from using the same connection.