### PR TITLE
Fix restore compatability errors on Ubuntu/OSX

### DIFF
--- a/src/System.Security.Principal/src/project.json
+++ b/src/System.Security.Principal/src/project.json
@@ -2,7 +2,7 @@
   "frameworks": {
     "dnxcore50": {
       "dependencies": {
-        "Microsoft.NETCore.Targets": "1.0.0",
+        "Microsoft.NETCore.Platforms": "1.0.1-rc3-23818",
         "System.Runtime": "4.0.0"
       }
     },

--- a/src/System.Xml.XmlSerializer/src/System.Xml.XmlSerializer.csproj
+++ b/src/System.Xml.XmlSerializer/src/System.Xml.XmlSerializer.csproj
@@ -16,6 +16,11 @@
     <PackageTargetFramework Condition="'$(PackageTargetFramework)' == ''">netstandard1.3</PackageTargetFramework>
     <NuGetTargetMoniker Condition="'$(TargetGroup)' == ''">.NETStandard,Version=v1.3</NuGetTargetMoniker>
   </PropertyGroup>
+  <!-- netcore50 project.json fork is shared for both netcore50 and netcore50aot. This redirects netcore50aot. -->
+  <PropertyGroup Condition="'$(TargetGroup)' == 'netcore50aot'">
+    <ProjectJson>netcore50/project.json</ProjectJson>
+    <ProjectLockJson>netcore50/project.lock.json</ProjectLockJson>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'netcore50_Debug|AnyCPU'" />

--- a/src/System.Xml.XmlSerializer/src/netcore50/project.json
+++ b/src/System.Xml.XmlSerializer/src/netcore50/project.json
@@ -1,7 +1,8 @@
 {
   "frameworks": {
-    "netstandard1.3": {
+    "netcore50": {
       "dependencies": {
+        "Microsoft.NETCore.Targets": "1.0.0",
         "System.Collections": "4.0.10",
         "System.Diagnostics.Debug": "4.0.10",
         "System.Diagnostics.Tools": "4.0.0",
@@ -22,15 +23,11 @@
         "System.Threading.Tasks": "4.0.10",
         "System.Xml.ReaderWriter": "4.0.10",
         "System.Xml.XmlDocument": "4.0.0"
-      },
-      "imports": [
-        "dotnet5.4"
-      ]
-    },
-    "net46": {
-      "dependencies": {
-        "Microsoft.TargetingPack.NETFramework.v4.6": "1.0.1"
       }
     }
+  },
+  "runtimes": {
+    "win8-x86": {},
+    "win8-x64": {}
   }
 }


### PR DESCRIPTION
The combination of upgrading CLI and the .NETStandard rename caused compatibility errors on non-windows restore. To fix it I added a `netcore50` project.json fork and lifted System.Runtime 4.0.0 with the prerelease `Microsoft.NETCore.Platforms` package. (4.0.0 doesn't have Ubuntu compat.)

I haven't been able to validate this locally since package restore has been very slow. Adding the PR here for visibility and in case CI can get it done more quickly.

/cc @ericstj @joperezr @stephentoub 