### PR TITLE
Add custom attribute decoder to S.R.Metadata vNext

### DIFF
--- a/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
+++ b/src/System.Reflection.Metadata/src/System.Reflection.Metadata.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), dir.props))\dir.props" />
   <PropertyGroup>
@@ -62,6 +62,11 @@
     <Compile Include="System\Reflection\Internal\Utilities\ByteSequenceComparer.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\DecimalUtilities.cs" />
     <Compile Include="System\Reflection\Internal\Utilities\EnumerableExtensions.cs" />
+    <Compile Include="System\Reflection\Metadata\Decoding\CustomAttributeDecoder.cs" />
+    <Compile Include="System\Reflection\Metadata\Decoding\CustomAttributeNamedArgument.cs" />
+    <Compile Include="System\Reflection\Metadata\Decoding\CustomAttributeTypedArgument.cs" />
+    <Compile Include="System\Reflection\Metadata\Decoding\CustomAttributeValue.cs" />
+    <Compile Include="System\Reflection\Metadata\Decoding\ICustomAttributeTypeProvider.cs" />
     <Compile Include="System\Reflection\Metadata\Ecma335\Blobs\ExceptionRegionEncoder.cs" />
     <Compile Include="System\Reflection\Metadata\Ecma335\Blobs\InstructionEncoder.cs" />
     <Compile Include="System\Reflection\Metadata\ILOpCode.cs" />

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/CustomAttribute.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/CustomAttribute.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Diagnostics;
+using System.Reflection.Metadata.Decoding;
 using System.Reflection.Metadata.Ecma335;
 
 namespace System.Reflection.Metadata
@@ -83,6 +84,20 @@ namespace System.Reflection.Metadata
 
                 return GetProjectedValue();
             }
+        }
+
+        /// <summary>
+        /// Decodes the arguments encoded in the value blob.
+        /// </summary>
+#if FUTURE
+        public
+#else
+        internal
+#endif
+        CustomAttributeValue<TType> DecodeValue<TType>(ICustomAttributeTypeProvider<TType> provider)
+        {
+            var decoder = new CustomAttributeDecoder<TType>(provider, _reader);
+            return decoder.DecodeValue(Constructor, Value);
         }
 
         #region Projections

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeDecoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeDecoder.cs
@@ -250,7 +250,8 @@ namespace System.Reflection.Metadata.Decoding
                 info = DecodeNamedArgumentType(ref valueReader);
             }
 
-            // PERF_TODO: Cache/reuse common arguments to avoid boxing (small integers, true, false).
+            // PERF_TODO: https://github.com/dotnet/corefx/issues/6533
+            //   Cache /reuse common arguments to avoid boxing (small integers, true, false).
             object value;
             switch (info.TypeCode)
             {

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeDecoder.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeDecoder.cs
@@ -1,0 +1,373 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+
+namespace System.Reflection.Metadata.Decoding
+{
+    /// <summary>
+    /// Decodes custom attribute blobs.
+    /// </summary>
+    internal struct CustomAttributeDecoder<TType>
+    {
+        private ICustomAttributeTypeProvider<TType> _provider;
+        private MetadataReader _reader;
+
+        public CustomAttributeDecoder(ICustomAttributeTypeProvider<TType> provider, MetadataReader reader)
+        {
+            _reader = reader;
+            _provider = provider;
+        }
+
+        public CustomAttributeValue<TType> DecodeValue(EntityHandle constructor, BlobHandle value)
+        {
+            BlobHandle signature;
+            switch (constructor.Kind)
+            {
+                case HandleKind.MethodDefinition:
+                    MethodDefinition definition = _reader.GetMethodDefinition((MethodDefinitionHandle)constructor);
+                    signature = definition.Signature;
+                    break;
+
+                case HandleKind.MemberReference:
+                    MemberReference reference = _reader.GetMemberReference((MemberReferenceHandle)constructor);
+                    signature = reference.Signature;
+                    break;
+
+                default:
+                    throw new BadImageFormatException();
+            }
+
+            BlobReader signatureReader = _reader.GetBlobReader(signature);
+            BlobReader valueReader = _reader.GetBlobReader(value);
+
+            ushort prolog = valueReader.ReadUInt16();
+            if (prolog != 1)
+            {
+                throw new BadImageFormatException();
+            }
+
+            SignatureHeader header = signatureReader.ReadSignatureHeader();
+            if (header.Kind != SignatureKind.Method || header.IsGeneric)
+            {
+                throw new BadImageFormatException();
+            }
+
+            int parameterCount = signatureReader.ReadCompressedInteger();
+            SignatureTypeCode returnType = signatureReader.ReadSignatureTypeCode();
+            if (returnType != SignatureTypeCode.Void)
+            {
+                throw new BadImageFormatException();
+            }
+
+            ImmutableArray<CustomAttributeTypedArgument<TType>> fixedArguments = DecodeFixedArguments(ref signatureReader, ref valueReader, parameterCount);
+            ImmutableArray<CustomAttributeNamedArgument<TType>> namedArguments = DecodeNamedArguments(ref valueReader);
+            return new CustomAttributeValue<TType>(fixedArguments, namedArguments);
+        }
+
+        private ImmutableArray<CustomAttributeTypedArgument<TType>> DecodeFixedArguments(ref BlobReader signatureReader, ref BlobReader valueReader, int count)
+        {
+            if (count == 0)
+            {
+                return ImmutableArray<CustomAttributeTypedArgument<TType>>.Empty;
+            }
+
+            var arguments = new CustomAttributeTypedArgument<TType>[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                ArgumentTypeInfo info = DecodeFixedArgumentType(ref signatureReader);
+                arguments[i] = DecodeArgument(ref valueReader, info);
+            }
+
+            return ImmutableArray.Create(arguments);
+        }
+
+        private ImmutableArray<CustomAttributeNamedArgument<TType>> DecodeNamedArguments(ref BlobReader valueReader)
+        {
+            int count = valueReader.ReadUInt16();
+            if (count == 0)
+            {
+                return ImmutableArray<CustomAttributeNamedArgument<TType>>.Empty;
+            }
+
+            var arguments = new CustomAttributeNamedArgument<TType>[count];
+            for (int i = 0; i < count; i++)
+            {
+                CustomAttributeNamedArgumentKind kind = (CustomAttributeNamedArgumentKind)valueReader.ReadSerializationTypeCode();
+                if (kind != CustomAttributeNamedArgumentKind.Field && kind != CustomAttributeNamedArgumentKind.Property)
+                {
+                    throw new BadImageFormatException();
+                }
+
+                ArgumentTypeInfo info = DecodeNamedArgumentType(ref valueReader);
+                string name = valueReader.ReadSerializedString();
+                CustomAttributeTypedArgument<TType> argument = DecodeArgument(ref valueReader, info);
+                arguments[i] = new CustomAttributeNamedArgument<TType>(name, kind, argument.Type, argument.Value);
+            }
+
+            return ImmutableArray.Create(arguments);
+        }
+
+        private struct ArgumentTypeInfo
+        {
+            public TType Type;
+            public TType ElementType;
+            public SerializationTypeCode TypeCode;
+            public SerializationTypeCode ElementTypeCode;
+        }
+
+        // Decodes a fixed argument type of a custom attribute from its constructor signature.
+        //
+        // Note that we do not decode the full constructor signature using DecodeMethodSignature
+        // but instead decode one parameter at a time as we read the value blob. This is both
+        // better perf-wise, but even more important is that we can't actually reason about
+        // a method signature with opaque TType values without adding some unecessary chatter
+        // with the provider.
+        private ArgumentTypeInfo DecodeFixedArgumentType(ref BlobReader signatureReader, bool isElementType = false)
+        {
+            SignatureTypeCode signatureTypeCode = signatureReader.ReadSignatureTypeCode();
+
+            var info = new ArgumentTypeInfo
+            {
+                TypeCode = (SerializationTypeCode)signatureTypeCode,
+            };
+
+            switch (signatureTypeCode)
+            {
+                case SignatureTypeCode.Boolean:
+                case SignatureTypeCode.Byte:
+                case SignatureTypeCode.Char:
+                case SignatureTypeCode.Double:
+                case SignatureTypeCode.Int16:
+                case SignatureTypeCode.Int32:
+                case SignatureTypeCode.Int64:
+                case SignatureTypeCode.SByte:
+                case SignatureTypeCode.Single:
+                case SignatureTypeCode.String:
+                case SignatureTypeCode.UInt16:
+                case SignatureTypeCode.UInt32:
+                case SignatureTypeCode.UInt64:
+                    info.Type = _provider.GetPrimitiveType((PrimitiveTypeCode)signatureTypeCode);
+                    break;
+
+                case SignatureTypeCode.Object:
+                    info.TypeCode = SerializationTypeCode.TaggedObject;
+                    info.Type = _provider.GetPrimitiveType(PrimitiveTypeCode.Object);
+                    break;
+
+                case SignatureTypeCode.TypeHandle:
+                    // Parameter is type def or ref and is only allowed to be System.Type or Enum.
+                    EntityHandle handle = signatureReader.ReadTypeHandle();
+                    info.Type = GetTypeFromHandle(handle);
+                    info.TypeCode = _provider.IsSystemType(info.Type) ? SerializationTypeCode.Type : (SerializationTypeCode)_provider.GetUnderlyingEnumType(info.Type);
+                    break;
+
+                case SignatureTypeCode.SZArray:
+                    if (isElementType)
+                    {
+                        // jagged arrays are not allowed.
+                        throw new BadImageFormatException();
+                    }
+
+                    var elementInfo = DecodeFixedArgumentType(ref signatureReader, isElementType: true);
+                    info.ElementType = elementInfo.Type;
+                    info.ElementTypeCode = elementInfo.TypeCode;
+                    info.Type = _provider.GetSZArrayType(info.ElementType);
+                    break;
+
+                default:
+                    throw new BadImageFormatException();
+            }
+
+            return info;
+        }
+
+        private ArgumentTypeInfo DecodeNamedArgumentType(ref BlobReader valueReader, bool isElementType = false)
+        {
+            var info = new ArgumentTypeInfo
+            {
+                TypeCode = valueReader.ReadSerializationTypeCode(),
+            };
+
+            switch (info.TypeCode)
+            {
+                case SerializationTypeCode.Boolean:
+                case SerializationTypeCode.Byte:
+                case SerializationTypeCode.Char:
+                case SerializationTypeCode.Double:
+                case SerializationTypeCode.Int16:
+                case SerializationTypeCode.Int32:
+                case SerializationTypeCode.Int64:
+                case SerializationTypeCode.SByte:
+                case SerializationTypeCode.Single:
+                case SerializationTypeCode.String:
+                case SerializationTypeCode.UInt16:
+                case SerializationTypeCode.UInt32:
+                case SerializationTypeCode.UInt64:
+                    info.Type = _provider.GetPrimitiveType((PrimitiveTypeCode)info.TypeCode);
+                    break;
+
+                case SerializationTypeCode.Type:
+                    info.Type = _provider.GetSystemType();
+                    break;
+
+                case SerializationTypeCode.TaggedObject:
+                    info.Type = _provider.GetPrimitiveType(PrimitiveTypeCode.Object);
+                    break;
+
+                case SerializationTypeCode.SZArray:
+                    if (isElementType)
+                    {
+                        // jagged arrays are not allowed.
+                        throw new BadImageFormatException();
+                    }
+
+                    var elementInfo = DecodeNamedArgumentType(ref valueReader, isElementType: true);
+                    info.ElementType = elementInfo.Type;
+                    info.ElementTypeCode = elementInfo.TypeCode;
+                    info.Type = _provider.GetSZArrayType(info.ElementType);
+                    break;
+
+                case SerializationTypeCode.Enum:
+                    string typeName = valueReader.ReadSerializedString();
+                    info.Type = _provider.GetTypeFromSerializedName(typeName);
+                    info.TypeCode = (SerializationTypeCode)_provider.GetUnderlyingEnumType(info.Type);
+                    break;
+
+                default:
+                    throw new BadImageFormatException();
+            }
+
+            return info;
+        }
+
+        private CustomAttributeTypedArgument<TType> DecodeArgument(ref BlobReader valueReader, ArgumentTypeInfo info)
+        {
+            if (info.TypeCode == SerializationTypeCode.TaggedObject)
+            {
+                info = DecodeNamedArgumentType(ref valueReader);
+            }
+
+            // PERF_TODO: Cache/reuse common arguments to avoid boxing (small integers, true, false).
+            object value;
+            switch (info.TypeCode)
+            {
+                case SerializationTypeCode.Boolean:
+                    value = valueReader.ReadBoolean();
+                    break;
+
+                case SerializationTypeCode.Byte:
+                    value = valueReader.ReadByte();
+                    break;
+
+                case SerializationTypeCode.Char:
+                    value = valueReader.ReadChar();
+                    break;
+
+                case SerializationTypeCode.Double:
+                    value = valueReader.ReadDouble();
+                    break;
+
+                case SerializationTypeCode.Int16:
+                    value = valueReader.ReadInt16();
+                    break;
+
+                case SerializationTypeCode.Int32:
+                    value = valueReader.ReadInt32();
+                    break;
+
+                case SerializationTypeCode.Int64:
+                    value = valueReader.ReadInt64();
+                    break;
+
+                case SerializationTypeCode.SByte:
+                    value = valueReader.ReadSByte();
+                    break;
+
+                case SerializationTypeCode.Single:
+                    value = valueReader.ReadSingle();
+                    break;
+
+                case SerializationTypeCode.UInt16:
+                    value = valueReader.ReadUInt16();
+                    break;
+
+                case SerializationTypeCode.UInt32:
+                    value = valueReader.ReadUInt32();
+                    break;
+
+                case SerializationTypeCode.UInt64:
+                    value = valueReader.ReadUInt64();
+                    break;
+
+                case SerializationTypeCode.String:
+                    value = valueReader.ReadSerializedString();
+                    break;
+
+                case SerializationTypeCode.Type:
+                    string typeName = valueReader.ReadSerializedString();
+                    value = _provider.GetTypeFromSerializedName(typeName);
+                    break;
+
+                case SerializationTypeCode.SZArray:
+                    value = DecodeArrayArgument(ref valueReader, info);
+                    break;
+
+                default:
+                    throw new BadImageFormatException();
+            }
+
+            return new CustomAttributeTypedArgument<TType>(info.Type, value);
+        }
+
+        private ImmutableArray<CustomAttributeTypedArgument<TType>>? DecodeArrayArgument(ref BlobReader blobReader, ArgumentTypeInfo info)
+        {
+            int count = blobReader.ReadInt32();
+            if (count == -1)
+            {
+                return null;
+            }
+
+            if (count == 0)
+            {
+                return ImmutableArray<CustomAttributeTypedArgument<TType>>.Empty;
+            }
+
+            if (count < 0)
+            {
+                throw new BadImageFormatException();
+            }
+
+            var elementInfo = new ArgumentTypeInfo
+            {
+                Type = info.ElementType,
+                TypeCode = info.ElementTypeCode,
+            };
+
+            var array = new CustomAttributeTypedArgument<TType>[count];
+
+            for (int i = 0; i < count; i++)
+            {
+                array[i] = DecodeArgument(ref blobReader, elementInfo);
+            }
+
+            return ImmutableArray.Create(array);
+        }
+
+        private TType GetTypeFromHandle(EntityHandle handle)
+        {
+            switch (handle.Kind)
+            {
+                case HandleKind.TypeDefinition:
+                    return _provider.GetTypeFromDefinition(_reader, (TypeDefinitionHandle)handle, SignatureTypeHandleCode.Unresolved);
+
+                case HandleKind.TypeReference:
+                    return _provider.GetTypeFromReference(_reader, (TypeReferenceHandle)handle, SignatureTypeHandleCode.Unresolved);
+
+                default:
+                    throw new BadImageFormatException(SR.NotTypeDefOrRefHandle);
+            }
+        }
+    }
+}

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeNamedArgument.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeNamedArgument.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if SRM
+namespace System.Reflection.Metadata.Decoding
+#else
+namespace Roslyn.Reflection.Metadata.Decoding
+#endif
+{
+#if SRM && FUTURE
+    public 
+#endif
+    struct CustomAttributeNamedArgument<TType>
+    {
+        private readonly string _name;
+        private readonly CustomAttributeNamedArgumentKind _kind;
+        private readonly TType _type;
+        private readonly object _value;
+
+        public CustomAttributeNamedArgument(string name, CustomAttributeNamedArgumentKind kind, TType type, object value)
+        {
+            _name = name;
+            _kind = kind;
+            _type = type;
+            _value = value;
+        }
+
+        public string Name
+        {
+            get { return _name; }
+        }
+
+        public CustomAttributeNamedArgumentKind Kind
+        {
+            get { return _kind; }
+        }
+
+        public TType Type
+        {
+            get { return _type; }
+        }
+
+        public object Value
+        {
+            get { return _value; }
+        }
+    }
+}

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeNamedArgument.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeNamedArgument.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 #if SRM
 namespace System.Reflection.Metadata.Decoding

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeTypedArgument.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeTypedArgument.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if SRM
+namespace System.Reflection.Metadata.Decoding
+#else
+namespace Roslyn.Reflection.Metadata.Decoding
+#endif
+{
+#if SRM && FUTURE
+    public
+#endif
+    struct CustomAttributeTypedArgument<TType>
+    {
+        private readonly TType _type;
+        private readonly object _value;
+
+        public CustomAttributeTypedArgument(TType type, object value)
+        {
+            _type = type;
+            _value = value;
+        }
+
+        public TType Type
+        {
+            get { return _type; }
+        }
+
+        public object Value
+        {
+            get { return _value; }
+        }
+    }
+}

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeTypedArgument.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeTypedArgument.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 #if SRM
 namespace System.Reflection.Metadata.Decoding

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeValue.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeValue.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+
+#if SRM
+namespace System.Reflection.Metadata.Decoding
+#else
+namespace Roslyn.Reflection.Metadata.Decoding
+#endif
+{
+#if SRM && FUTURE
+    public
+#endif
+    struct CustomAttributeValue<TType>
+    {
+        private readonly ImmutableArray<CustomAttributeTypedArgument<TType>> _fixedArguments;
+        private readonly ImmutableArray<CustomAttributeNamedArgument<TType>> _namedArguments;
+
+        public CustomAttributeValue(ImmutableArray<CustomAttributeTypedArgument<TType>> fixedArguments, ImmutableArray<CustomAttributeNamedArgument<TType>> namedArguments)
+        {
+            _fixedArguments = fixedArguments;
+            _namedArguments = namedArguments;
+        }
+
+        public ImmutableArray<CustomAttributeTypedArgument<TType>> FixedArguments
+        {
+            get { return _fixedArguments; }
+        }
+
+        public ImmutableArray<CustomAttributeNamedArgument<TType>> NamedArguments
+        {
+            get { return _namedArguments; }
+        }
+    }
+}

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeValue.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/CustomAttributeValue.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 using System.Collections.Immutable;
 

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ICustomAttributeTypeProvider.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ICustomAttributeTypeProvider.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#if SRM
+namespace System.Reflection.Metadata.Decoding
+#else
+namespace Roslyn.Reflection.Metadata.Decoding
+#endif
+{
+#if SRM && FUTURE
+    public
+#endif
+    interface ICustomAttributeTypeProvider<TType> : IPrimitiveTypeProvider<TType>, ISZArrayTypeProvider<TType>, ITypeProvider<TType>
+    {
+        /// <summary>
+        /// Gets the TType representation for <see cref="System.Type"/>.
+        /// </summary>
+        TType GetSystemType();
+
+        /// <summary>
+        /// Returns true if the given type represents <see cref="System.Type"/>.
+        /// </summary>
+        bool IsSystemType(TType type);
+
+        /// <summary>
+        /// Get the type symbol for the given serialized type name.
+        /// The serialized type name is in so-called "reflection notation" (i.e. as understood by <see cref="Type.GetType(string)"/>.)
+        /// </summary>
+        /// <exception cref="BadImageFormatException">The name is malformed.</exception>
+        TType GetTypeFromSerializedName(string name);
+
+        /// <summary>
+        /// Gets the underlying type of the given enum type symbol.
+        /// </summary>
+        /// <exception cref="BadImageFormatException">The given type symbol does not represent an enum.</exception>
+        PrimitiveTypeCode GetUnderlyingEnumType(TType type);
+    }
+}

--- a/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ICustomAttributeTypeProvider.cs
+++ b/src/System.Reflection.Metadata/src/System/Reflection/Metadata/Decoding/ICustomAttributeTypeProvider.cs
@@ -1,5 +1,6 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
-// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
 
 #if SRM
 namespace System.Reflection.Metadata.Decoding

--- a/src/System.Reflection.Metadata/tests/Metadata/Decoding/CustomAttributeDecoderTests.cs
+++ b/src/System.Reflection.Metadata/tests/Metadata/Decoding/CustomAttributeDecoderTests.cs
@@ -1,0 +1,387 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.IO;
+using System.Reflection.Metadata.Tests;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace System.Reflection.Metadata.Decoding.Tests
+{
+    public class CustomAttributeDecoderTests
+    {
+        [Fact]
+        public void TestCustomAttributeDecoder()
+        {
+            using (FileStream stream = File.OpenRead(typeof(HasAttributes).GetTypeInfo().Assembly.Location))
+            using (var peReader = new PEReader(stream))
+            {
+                MetadataReader reader = peReader.GetMetadataReader();
+                var provider = new CustomAttributeTypeProvider();
+                TypeDefinitionHandle typeDefHandle = TestMetadataResolver.FindTestType(reader, typeof(HasAttributes));
+
+
+                int i = 0;
+                foreach (CustomAttributeHandle attributeHandle in reader.GetCustomAttributes(typeDefHandle))
+                {
+                    CustomAttribute attribute = reader.GetCustomAttribute(attributeHandle);
+                    CustomAttributeValue<string> value = attribute.DecodeValue(provider);
+
+                    switch (i++)
+                    {
+                        case 0:
+                            Assert.Empty(value.FixedArguments);
+                            Assert.Empty(value.NamedArguments);
+                            break;
+
+                        case 1:
+                            Assert.Equal(3, value.FixedArguments.Length);
+
+                            Assert.Equal("string", value.FixedArguments[0].Type);
+                            Assert.Equal("0", value.FixedArguments[0].Value);
+
+                            Assert.Equal("int32", value.FixedArguments[1].Type);
+                            Assert.Equal(1, value.FixedArguments[1].Value);
+
+                            Assert.Equal("float64", value.FixedArguments[2].Type);
+                            Assert.Equal(2.0, value.FixedArguments[2].Value);
+
+                            Assert.Empty(value.NamedArguments);
+                            break;
+
+                        case 2:
+                            Assert.Equal(3, value.NamedArguments.Length);
+
+                            Assert.Equal(CustomAttributeNamedArgumentKind.Field, value.NamedArguments[0].Kind);
+                            Assert.Equal("StringField", value.NamedArguments[0].Name);
+                            Assert.Equal("string", value.NamedArguments[0].Type);
+                            Assert.Equal("0", value.NamedArguments[0].Value);
+
+                            Assert.Equal(CustomAttributeNamedArgumentKind.Field, value.NamedArguments[1].Kind);
+                            Assert.Equal("Int32Field", value.NamedArguments[1].Name);
+                            Assert.Equal("int32", value.NamedArguments[1].Type);
+                            Assert.Equal(1, value.NamedArguments[1].Value);
+
+                            Assert.Equal(CustomAttributeNamedArgumentKind.Property, value.NamedArguments[2].Kind);
+                            Assert.Equal("SByteEnumArrayProperty", value.NamedArguments[2].Name);
+                            Assert.Equal(typeof(SByteEnum).FullName + "[]", value.NamedArguments[2].Type);
+
+                            var array = (ImmutableArray<CustomAttributeTypedArgument<string>>)(value.NamedArguments[2].Value);
+                            Assert.Equal(1, array.Length);
+                            Assert.Equal(typeof(SByteEnum).FullName, array[0].Type);
+                            Assert.Equal((sbyte)SByteEnum.Value, array[0].Value);
+                            break;
+
+                        default:
+                            // TODO: https://github.com/dotnet/corefx/issues/6534
+                            // The other cases are missing corresponding assertions. This needs some refactoring to
+                            // be data-driven. A better approach would probably be to generically compare reflection
+                            // CustomAttributeData to S.R.M CustomAttributeValue for every test attribute applied.
+                            break;
+                    }
+                }
+            }
+        }
+
+        // no arguments
+        [Test]
+
+        // multiple fixed arguments
+        [Test("0", 1, 2.0)]
+
+        // multiple named arguments
+        [Test(StringField = "0", Int32Field = 1, SByteEnumArrayProperty = new[] { SByteEnum.Value })]
+
+        // multiple fixed and named arguments
+        [Test("0", 1, 2.0, StringField = "0", Int32Field = 1, DoubleField = 2.0)]
+
+        // single fixed null argument
+        [Test((object)null)]
+        [Test((string)null)]
+        [Test((Type)null)]
+        [Test((int[])null)]
+
+        // single fixed arguments with strong type
+        [Test("string")]
+        [Test((sbyte)-1)]
+        [Test((short)-2)]
+        [Test((int)-4)]
+        [Test((long)-8)]
+        [Test((sbyte)-1)]
+        [Test((short)-2)]
+        [Test((int)-4)]
+        [Test((long)-8)]
+        [Test((byte)1)]
+        [Test((ushort)2)]
+        [Test((uint)4)]
+        [Test((ulong)8)]
+        [Test(true)]
+        [Test(false)]
+        [Test(typeof(string))]
+        [Test(SByteEnum.Value)]
+        [Test(Int16Enum.Value)]
+        [Test(Int32Enum.Value)]
+        [Test(Int64Enum.Value)]
+        [Test(ByteEnum.Value)]
+        [Test(UInt16Enum.Value)]
+        [Test(UInt32Enum.Value)]
+        [Test(UInt64Enum.Value)]
+        [Test(new string[] { })]
+        [Test(new string[] { "x", "y", "z", null })]
+        [Test(new Int32Enum[] { Int32Enum.Value })]
+
+        // same single fixed arguments as above, typed as object
+        [Test((object)("string"))]
+        [Test((object)(sbyte)-1)]
+        [Test((object)(short)-2)]
+        [Test((object)(int)-4)]
+        [Test((object)(long)-8)]
+        [Test((object)(sbyte)-1)]
+        [Test((object)(short)-2)]
+        [Test((object)(int)-4)]
+        [Test((object)(long)-8)]
+        [Test((object)(byte)1)]
+        [Test((object)(ushort)2)]
+        [Test((object)(uint)4)]
+        [Test((object)(true))]
+        [Test((object)(false))]
+        [Test((object)(typeof(string)))]
+        [Test((object)(SByteEnum.Value))]
+        [Test((object)(Int16Enum.Value))]
+        [Test((object)(Int32Enum.Value))]
+        [Test((object)(Int64Enum.Value))]
+        [Test((object)(ByteEnum.Value))]
+        [Test((object)(UInt16Enum.Value))]
+        [Test((object)(UInt32Enum.Value))]
+        [Test((object)(UInt64Enum.Value))]
+        [Test((object)(new string[] { }))]
+        [Test((object)(new string[] { "x", "y", "z", null }))]
+        [Test((object)(new Int32Enum[] { Int32Enum.Value }))]
+
+        // same values as above two cases, but put into an object[]
+        [Test(new object[] {
+            "string",
+            (sbyte)-1,
+            (short)-2,
+            (int)-4,
+            (long)-8,
+            (sbyte)-1,
+            (short)-2,
+            (int)-4,
+            (long)-8,
+            (byte)1,
+            (ushort)2,
+            (uint)4,
+            true,
+            false,
+            typeof(string),
+            SByteEnum.Value,
+            Int16Enum.Value,
+            Int32Enum.Value,
+            Int64Enum.Value,
+            SByteEnum.Value,
+            Int16Enum.Value,
+            Int32Enum.Value,
+            Int64Enum.Value,
+            new string[] {},
+            new string[] { "x", "y", "z", null },
+        })]
+
+        // same values as strongly-typed fixed arguments as named arguments
+        // single fixed arguments with strong type
+        [Test(StringField = "string")]
+        [Test(SByteField = -1)]
+        [Test(Int16Field = -2)]
+        [Test(Int32Field = -4)]
+        [Test(Int64Field = -8)]
+        [Test(SByteField = -1)]
+        [Test(Int16Field = -2)]
+        [Test(Int32Field = -4)]
+        [Test(Int64Field = -8)]
+        [Test(ByteField = 1)]
+        [Test(UInt16Field = 2)]
+        [Test(UInt32Field = 4)]
+        [Test(UInt64Field = 8)]
+        [Test(BooleanField = true)]
+        [Test(BooleanField = false)]
+        [Test(TypeField = typeof(string))]
+        [Test(SByteEnumField = SByteEnum.Value)]
+        [Test(Int16EnumField = Int16Enum.Value)]
+        [Test(Int32EnumField = Int32Enum.Value)]
+        [Test(Int64EnumField = Int64Enum.Value)]
+        [Test(ByteEnumField = ByteEnum.Value)]
+        [Test(UInt16EnumField = UInt16Enum.Value)]
+        [Test(UInt32EnumField = UInt32Enum.Value)]
+        [Test(UInt64EnumField = UInt64Enum.Value)]
+        [Test(new string[] { })]
+        [Test(new string[] { "x", "y", "z", null })]
+        [Test(new Int32Enum[] { Int32Enum.Value })]
+
+        // null named arguments
+        [Test(ObjectField = null)]
+        [Test(StringField = null)]
+
+        [Test(Int32ArrayProperty = null)]
+
+        private sealed class HasAttributes { }
+
+        public enum SByteEnum : sbyte { Value = -1 }
+        public enum Int16Enum : short { Value = -2 }
+        public enum Int32Enum : int { Value = -3 }
+        public enum Int64Enum : long { Value = -4 }
+        public enum ByteEnum : sbyte { Value = 1 }
+        public enum UInt16Enum : ushort { Value = 2 }
+        public enum UInt32Enum : uint { Value = 3 }
+        public enum UInt64Enum : ulong { Value = 4 }
+
+        [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
+        public sealed class TestAttribute : Attribute
+        {
+            public TestAttribute() { }
+            public TestAttribute(string x, int y, double z) { }
+            public TestAttribute(string value) { }
+            public TestAttribute(object value) { }
+            public TestAttribute(sbyte value) { }
+            public TestAttribute(short value) { }
+            public TestAttribute(int value) { }
+            public TestAttribute(long value) { }
+            public TestAttribute(byte value) { }
+            public TestAttribute(ushort value) { }
+            public TestAttribute(uint value) { }
+            public TestAttribute(ulong value) { }
+            public TestAttribute(bool value) { }
+            public TestAttribute(float value) { }
+            public TestAttribute(double value) { }
+            public TestAttribute(Type value) { }
+            public TestAttribute(SByteEnum value) { }
+            public TestAttribute(Int16Enum value) { }
+            public TestAttribute(Int32Enum value) { }
+            public TestAttribute(Int64Enum value) { }
+            public TestAttribute(ByteEnum value) { }
+            public TestAttribute(UInt16Enum value) { }
+            public TestAttribute(UInt32Enum value) { }
+            public TestAttribute(UInt64Enum value) { }
+            public TestAttribute(string[] value) { }
+            public TestAttribute(object[] value) { }
+            public TestAttribute(sbyte[] value) { }
+            public TestAttribute(short[] value) { }
+            public TestAttribute(int[] value) { }
+            public TestAttribute(long[] value) { }
+            public TestAttribute(byte[] value) { }
+            public TestAttribute(ushort[] value) { }
+            public TestAttribute(uint[] value) { }
+            public TestAttribute(ulong[] value) { }
+            public TestAttribute(bool[] value) { }
+            public TestAttribute(float[] value) { }
+            public TestAttribute(double[] value) { }
+            public TestAttribute(Type[] value) { }
+            public TestAttribute(SByteEnum[] value) { }
+            public TestAttribute(Int16Enum[] value) { }
+            public TestAttribute(Int32Enum[] value) { }
+            public TestAttribute(Int64Enum[] value) { }
+            public TestAttribute(ByteEnum[] value) { }
+            public TestAttribute(UInt16Enum[] value) { }
+            public TestAttribute(UInt32Enum[] value) { }
+            public TestAttribute(UInt64Enum[] value) { }
+
+            public string StringField;
+            public object ObjectField;
+            public sbyte SByteField;
+            public short Int16Field;
+            public int Int32Field;
+            public long Int64Field;
+            public byte ByteField;
+            public ushort UInt16Field;
+            public uint UInt32Field;
+            public ulong UInt64Field;
+            public bool BooleanField;
+            public float SingleField;
+            public double DoubleField;
+            public Type TypeField;
+            public SByteEnum SByteEnumField;
+            public Int16Enum Int16EnumField;
+            public Int32Enum Int32EnumField;
+            public Int64Enum Int64EnumField;
+            public ByteEnum ByteEnumField;
+            public UInt16Enum UInt16EnumField;
+            public UInt32Enum UInt32EnumField;
+            public UInt64Enum UInt64EnumField;
+
+            public string[] StringArrayProperty { get; set; }
+            public object[] ObjectArrayProperty { get; set; }
+            public sbyte[] SByteArrayProperty { get; set; }
+            public short[] Int16ArrayProperty { get; set; }
+            public int[] Int32ArrayProperty { get; set; }
+            public long[] Int64ArrayProperty { get; set; }
+            public byte[] ByteArrayProperty { get; set; }
+            public ushort[] UInt16ArrayProperty { get; set; }
+            public uint[] UInt32ArrayProperty { get; set; }
+            public ulong[] UInt64ArrayProperty { get; set; }
+            public bool[] BooleanArrayProperty { get; set; }
+            public float[] SingleArrayProperty { get; set; }
+            public double[] DoubleArrayProperty { get; set; }
+            public Type[] TypeArrayProperty { get; set; }
+            public SByteEnum[] SByteEnumArrayProperty { get; set; }
+            public Int16Enum[] Int16EnumArrayProperty { get; set; }
+            public Int32Enum[] Int32EnumArrayProperty { get; set; }
+            public Int64Enum[] Int64EnumArrayProperty { get; set; }
+            public ByteEnum[] ByteEnumArrayProperty { get; set; }
+            public UInt16Enum[] UInt16EnumArrayProperty { get; set; }
+            public UInt32Enum[] UInt32EnumArrayProperty { get; set; }
+            public UInt64Enum[] UInt64EnumArrayProperty { get; set; }
+        }
+
+
+        private class CustomAttributeTypeProvider : DisassemblingTypeProvider, ICustomAttributeTypeProvider<string>
+        {
+            public string GetSystemType()
+            {
+                return "[System.Runtime]System.Type";
+            }
+
+            public bool IsSystemType(string type)
+            {
+                return type == "[System.Runtime]System.Type"  // encountered as typeref
+                    || Type.GetType(type) == typeof(Type);    // encountered as serialized to reflection notation
+            }
+
+            public string GetTypeFromSerializedName(string name)
+            {
+                return name;
+            }
+
+            public PrimitiveTypeCode GetUnderlyingEnumType(string type)
+            {
+                Type runtimeType = Type.GetType(type.Replace('/', '+')); // '/' vs '+' is only difference between ilasm and reflection notation for fixed set below.
+
+                if (runtimeType == typeof(SByteEnum))
+                    return PrimitiveTypeCode.SByte;
+
+                if (runtimeType == typeof(Int16Enum))
+                    return PrimitiveTypeCode.Int16;
+
+                if (runtimeType == typeof(Int32Enum))
+                    return PrimitiveTypeCode.Int32;
+
+                if (runtimeType == typeof(Int64Enum))
+                    return PrimitiveTypeCode.Int64;
+
+                if (runtimeType == typeof(ByteEnum))
+                    return PrimitiveTypeCode.Byte;
+
+                if (runtimeType == typeof(UInt16Enum))
+                    return PrimitiveTypeCode.UInt16;
+
+                if (runtimeType == typeof(UInt32Enum))
+                    return PrimitiveTypeCode.UInt32;
+
+                if (runtimeType == typeof(UInt64Enum))
+                    return PrimitiveTypeCode.UInt64;
+
+                throw new ArgumentOutOfRangeException();
+            }
+        }
+    }
+}

--- a/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
+++ b/src/System.Reflection.Metadata/tests/System.Reflection.Metadata.Tests.csproj
@@ -34,6 +34,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Metadata\ClassLayoutRow.cs" />
+    <Compile Include="Metadata\Decoding\CustomAttributeDecoderTests.cs" />
     <Compile Include="Metadata\Decoding\DisassemblingTypeProvider.cs" />
     <Compile Include="Metadata\Decoding\MethodSignatureTests.cs" />
     <Compile Include="Metadata\Decoding\OpaqueHandleTypeProvider.cs" />


### PR DESCRIPTION
Port from dev/metadata branch.

It is internalized out of the upcoming release as with the metadata writer and signature decoder, and equally subject to API review.

@tmat