### PR TITLE
Use nameof in System.Reflection.TypeExtensions

### DIFF
--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/AssemblyExtensions.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/AssemblyExtensions.cs
@@ -18,7 +18,7 @@ namespace System.Reflection
         /// <returns>An array that represents the types defined in this assembly that are visible outside the assembly.</returns>
         public static Type[] GetExportedTypes(this Assembly assembly)
         {
-            Requires.NotNull(assembly, "assembly");
+            Requires.NotNull(assembly, nameof(assembly));
             return assembly.ExportedTypes.ToArray();
         }
 
@@ -29,7 +29,7 @@ namespace System.Reflection
         /// <returns>An array of modules.</returns>
         public static Module[] GetModules(this Assembly assembly)
         {
-            Requires.NotNull(assembly, "assembly");
+            Requires.NotNull(assembly, nameof(assembly));
             return assembly.Modules.ToArray();
         }
 
@@ -40,7 +40,7 @@ namespace System.Reflection
         /// <returns>An array that contains all the types that are defined in this assembly.</returns>
         public static Type[] GetTypes(this Assembly assembly)
         {
-            Requires.NotNull(assembly, "assembly");
+            Requires.NotNull(assembly, nameof(assembly));
             return assembly.DefinedTypes.Select(t => t.AsType()).ToArray();
         }
     }

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/EventInfoExtensions.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/EventInfoExtensions.cs
@@ -27,7 +27,7 @@ namespace System.Reflection
         /// <returns></returns>
         public static MethodInfo GetAddMethod(this EventInfo eventInfo, bool nonPublic)
         {
-            Requires.NotNull(eventInfo, "eventInfo");
+            Requires.NotNull(eventInfo, nameof(eventInfo));
             return Helpers.FilterAccessor(eventInfo.AddMethod, nonPublic);
         }
 
@@ -49,7 +49,7 @@ namespace System.Reflection
         /// <returns>A MethodInfo object that was called when the event was raised.</returns>
         public static MethodInfo GetRaiseMethod(this EventInfo eventInfo, bool nonPublic)
         {
-            Requires.NotNull(eventInfo, "eventInfo");
+            Requires.NotNull(eventInfo, nameof(eventInfo));
             return Helpers.FilterAccessor(eventInfo.RaiseMethod, nonPublic);
         }
 
@@ -71,7 +71,7 @@ namespace System.Reflection
         /// <returns>A MethodInfo object representing the method used to remove an event handler delegate from the event source.</returns>
         public static MethodInfo GetRemoveMethod(this EventInfo eventInfo, bool nonPublic)
         {
-            Requires.NotNull(eventInfo, "eventInfo");
+            Requires.NotNull(eventInfo, nameof(eventInfo));
             return Helpers.FilterAccessor(eventInfo.RemoveMethod, nonPublic);
         }
     }

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/MemberInfoExtensions.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/MemberInfoExtensions.cs
@@ -8,13 +8,13 @@ namespace System.Reflection
     {
         public static bool HasMetadataToken(this MemberInfo member)
         {
-            Requires.NotNull(member, "member");
+            Requires.NotNull(member, nameof(member));
             return false; // never available on .NET Native
         }
         
         public static int GetMetadataToken(this MemberInfo member)
         {
-            Requires.NotNull(member, "member");
+            Requires.NotNull(member, nameof(member));
             throw new InvalidOperationException(SR.MetadataTokenNotSupported);
         }
     }

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/MethodInfoExtensions.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/MethodInfoExtensions.cs
@@ -18,7 +18,7 @@ namespace System.Reflection
         /// <returns>A MethodInfo object for the first implementation of this method.</returns>
         public static MethodInfo GetBaseDefinition(this MethodInfo method)
         {
-            Requires.NotNull(method, "method");
+            Requires.NotNull(method, nameof(method));
 
             while (true)
             {

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/ModuleExtensions.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/ModuleExtensions.cs
@@ -8,13 +8,13 @@ namespace System.Reflection
     {
         public static bool HasModuleVersionId(this Module module)
         {
-            Requires.NotNull(module, "module");
+            Requires.NotNull(module, nameof(module));
             return false; // never available on .NET Native
         }
         
         public static Guid GetModuleVersionId(this Module module)
         {
-            Requires.NotNull(module, "module");
+            Requires.NotNull(module, nameof(module));
             throw new InvalidOperationException(SR.ModuleVersionIdNotSupported);
         }
     }

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/PropertyInfoExtensions.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/PropertyInfoExtensions.cs
@@ -32,7 +32,7 @@ namespace System.Reflection
             //       desktop can return them. However, they are extraordinarily rare and there
             //       is no portable way to get them from the core reflection contract.
 
-            Requires.NotNull(property, "property");
+            Requires.NotNull(property, nameof(property));
 
             MethodInfo getMethod = Helpers.FilterAccessor(property.GetMethod, nonPublic);
             MethodInfo setMethod = Helpers.FilterAccessor(property.SetMethod, nonPublic);
@@ -73,7 +73,7 @@ namespace System.Reflection
         /// <returns>A MethodInfo object representing the get accessor for this property, if nonPublic is true. Returns null if nonPublic is false and the get accessor is non-public, or if nonPublic is true but no get accessors exist.</returns>
         public static MethodInfo GetGetMethod(this PropertyInfo property, bool nonPublic)
         {
-            Requires.NotNull(property, "property");
+            Requires.NotNull(property, nameof(property));
             return Helpers.FilterAccessor(property.GetMethod, nonPublic);
         }
 
@@ -97,7 +97,7 @@ namespace System.Reflection
         /// null </returns>
         public static MethodInfo GetSetMethod(this PropertyInfo property, bool nonPublic)
         {
-            Requires.NotNull(property, "property");
+            Requires.NotNull(property, nameof(property));
             return Helpers.FilterAccessor(property.SetMethod, nonPublic);
         }
     }

--- a/src/System.Reflection.TypeExtensions/src/System/Reflection/TypeExtensions.CoreCLR.cs
+++ b/src/System.Reflection.TypeExtensions/src/System/Reflection/TypeExtensions.CoreCLR.cs
@@ -17,199 +17,199 @@ namespace System.Reflection
     {
         public static ConstructorInfo GetConstructor(Type type, Type[] types)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetConstructor(types);
         }
 
         public static ConstructorInfo[] GetConstructors(Type type)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetConstructors();
         }
 
         public static ConstructorInfo[] GetConstructors(Type type, BindingFlags bindingAttr)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetConstructors(bindingAttr);
         }
 
         public static MemberInfo[] GetDefaultMembers(Type type)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetDefaultMembers();
         }
 
         public static EventInfo GetEvent(Type type, string name)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetEvent(name);
         }
 
         public static EventInfo GetEvent(Type type, string name, BindingFlags bindingAttr)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetEvent(name, bindingAttr);
         }
 
         public static EventInfo[] GetEvents(Type type)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetEvents();
         }
 
         public static EventInfo[] GetEvents(Type type, BindingFlags bindingAttr)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetEvents(bindingAttr);
         }
 
         public static FieldInfo GetField(Type type, string name)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetField(name);
         }
 
         public static FieldInfo GetField(Type type, string name, BindingFlags bindingAttr)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetField(name, bindingAttr);
         }
 
         public static FieldInfo[] GetFields(Type type)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetFields();
         }
 
         public static FieldInfo[] GetFields(Type type, BindingFlags bindingAttr)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetFields(bindingAttr);
         }
 
         public static Type[] GetGenericArguments(Type type)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetGenericArguments();
         }
 
         public static Type[] GetInterfaces(Type type)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetInterfaces();
         }
 
         public static MemberInfo[] GetMember(Type type, string name)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetMember(name);
         }
 
         public static MemberInfo[] GetMember(Type type, string name, BindingFlags bindingAttr)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetMember(name, bindingAttr);
         }
 
         public static MemberInfo[] GetMembers(Type type)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetMembers();
         }
 
         public static MemberInfo[] GetMembers(Type type, BindingFlags bindingAttr)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetMembers(bindingAttr);
         }
 
         public static MethodInfo GetMethod(Type type, string name)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetMethod(name);
         }
 
         public static MethodInfo GetMethod(Type type, string name, BindingFlags bindingAttr)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetMethod(name, bindingAttr);
         }
 
         public static MethodInfo GetMethod(Type type, string name, Type[] types)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetMethod(name, types);
         }
 
         public static MethodInfo[] GetMethods(Type type)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetMethods();
         }
 
         public static MethodInfo[] GetMethods(Type type, BindingFlags bindingAttr)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetMethods(bindingAttr);
         }
 
         public static Type GetNestedType(Type type, string name, BindingFlags bindingAttr)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetNestedType(name, bindingAttr);
         }
 
         public static Type[] GetNestedTypes(Type type, BindingFlags bindingAttr)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetNestedTypes(bindingAttr);
         }
 
         public static PropertyInfo[] GetProperties(Type type)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetProperties();
         }
 
         public static PropertyInfo[] GetProperties(Type type, BindingFlags bindingAttr)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetProperties(bindingAttr);
         }
 
         public static PropertyInfo GetProperty(Type type, string name)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetProperty(name);
         }
 
         public static PropertyInfo GetProperty(Type type, string name, BindingFlags bindingAttr)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetProperty(name, bindingAttr);
         }
 
         public static PropertyInfo GetProperty(Type type, string name, Type returnType)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetProperty(name, returnType);
         }
 
         public static PropertyInfo GetProperty(Type type, string name, Type returnType, Type[] types)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.GetProperty(name, returnType, types);
         }
 
         public static bool IsAssignableFrom(Type type, Type c)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.IsAssignableFrom(c);
         }
 
         public static bool IsInstanceOfType(Type type, object o)
         {
-            Requires.NotNull(type, "type");
+            Requires.NotNull(type, nameof(type));
             return type.IsInstanceOfType(o);
         }
     }
@@ -218,19 +218,19 @@ namespace System.Reflection
     {
         public static Type[] GetExportedTypes(Assembly assembly)
         {
-            Requires.NotNull(assembly, "assembly");
+            Requires.NotNull(assembly, nameof(assembly));
             return assembly.GetExportedTypes();
         }
 
         public static Module[] GetModules(Assembly assembly)
         {
-            Requires.NotNull(assembly, "assembly");
+            Requires.NotNull(assembly, nameof(assembly));
             return assembly.GetModules();
         }
 
         public static Type[] GetTypes(Assembly assembly)
         {
-            Requires.NotNull(assembly, "assembly");
+            Requires.NotNull(assembly, nameof(assembly));
             return assembly.GetTypes();
         }
     }
@@ -239,37 +239,37 @@ namespace System.Reflection
     {
         public static MethodInfo GetAddMethod(EventInfo eventInfo)
         {
-            Requires.NotNull(eventInfo, "eventInfo");
+            Requires.NotNull(eventInfo, nameof(eventInfo));
             return eventInfo.GetAddMethod();
         }
 
         public static MethodInfo GetAddMethod(EventInfo eventInfo, bool nonPublic)
         {
-            Requires.NotNull(eventInfo, "eventInfo");
+            Requires.NotNull(eventInfo, nameof(eventInfo));
             return eventInfo.GetAddMethod(nonPublic);
         }
 
         public static MethodInfo GetRaiseMethod(EventInfo eventInfo)
         {
-            Requires.NotNull(eventInfo, "eventInfo");
+            Requires.NotNull(eventInfo, nameof(eventInfo));
             return eventInfo.GetRaiseMethod();
         }
 
         public static MethodInfo GetRaiseMethod(EventInfo eventInfo, bool nonPublic)
         {
-            Requires.NotNull(eventInfo, "eventInfo");
+            Requires.NotNull(eventInfo, nameof(eventInfo));
             return eventInfo.GetRaiseMethod(nonPublic);
         }
 
         public static MethodInfo GetRemoveMethod(EventInfo eventInfo)
         {
-            Requires.NotNull(eventInfo, "eventInfo");
+            Requires.NotNull(eventInfo, nameof(eventInfo));
             return eventInfo.GetRemoveMethod();
         }
 
         public static MethodInfo GetRemoveMethod(EventInfo eventInfo, bool nonPublic)
         {
-            Requires.NotNull(eventInfo, "eventInfo");
+            Requires.NotNull(eventInfo, nameof(eventInfo));
             return eventInfo.GetRemoveMethod(nonPublic);
         }
     }
@@ -284,7 +284,7 @@ namespace System.Reflection
         /// <remarks>This maybe</remarks>
         public static bool HasMetadataToken(this MemberInfo member)
         {
-            Requires.NotNull(member, "member");
+            Requires.NotNull(member, nameof(member));
 
             try
             {
@@ -306,7 +306,7 @@ namespace System.Reflection
         /// </exception>
         public static int GetMetadataToken(this MemberInfo member)
         {
-            Requires.NotNull(member, "member");
+            Requires.NotNull(member, nameof(member));
 
             int token = GetMetadataTokenOrZeroOrThrow(member); 
 
@@ -339,7 +339,7 @@ namespace System.Reflection
     {
         public static MethodInfo GetBaseDefinition(MethodInfo method)
         {
-            Requires.NotNull(method, "method");
+            Requires.NotNull(method, nameof(method));
             return method.GetBaseDefinition();
         }
     }
@@ -348,13 +348,13 @@ namespace System.Reflection
     {
         public static bool HasModuleVersionId(this Module module)
         {
-            Requires.NotNull(module, "module");
+            Requires.NotNull(module, nameof(module));
             return true; // not expected to fail on platforms with Module.ModuleVersionId built-in.
         }
 
         public static Guid GetModuleVersionId(this Module module)
         {
-            Requires.NotNull(module, "module");
+            Requires.NotNull(module, nameof(module));
             return module.ModuleVersionId;
         }
     }
@@ -363,37 +363,37 @@ namespace System.Reflection
     {
         public static MethodInfo[] GetAccessors(PropertyInfo property)
         {
-            Requires.NotNull(property, "property");
+            Requires.NotNull(property, nameof(property));
             return property.GetAccessors();
         }
 
         public static MethodInfo[] GetAccessors(PropertyInfo property, bool nonPublic)
         {
-            Requires.NotNull(property, "property");
+            Requires.NotNull(property, nameof(property));
             return property.GetAccessors(nonPublic);
         }
 
         public static MethodInfo GetGetMethod(PropertyInfo property)
         {
-            Requires.NotNull(property, "property");
+            Requires.NotNull(property, nameof(property));
             return property.GetGetMethod();
         }
 
         public static MethodInfo GetGetMethod(PropertyInfo property, bool nonPublic)
         {
-            Requires.NotNull(property, "property");
+            Requires.NotNull(property, nameof(property));
             return property.GetGetMethod(nonPublic);
         }
 
         public static MethodInfo GetSetMethod(PropertyInfo property)
         {
-            Requires.NotNull(property, "property");
+            Requires.NotNull(property, nameof(property));
             return property.GetSetMethod();
         }
 
         public static MethodInfo GetSetMethod(PropertyInfo property, bool nonPublic)
         {
-            Requires.NotNull(property, "property");
+            Requires.NotNull(property, nameof(property));
             return property.GetSetMethod(nonPublic);
         }
     }


### PR DESCRIPTION
It has its own Requires.NotNull.  This changes them to use nameof rather than hardcoded strings.

This was just a quick search-and-replace.