### PR TITLE
Fixing bug #5700 to stabilize a flaky test

### DIFF
--- a/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Deleted.cs
+++ b/src/System.IO.FileSystem.Watcher/tests/FileSystemWatcher.Deleted.cs
@@ -73,10 +73,10 @@ public class DeletedTests
 
                 // renaming a directory
                 //
-                // We don't do this on Linux because depending on the timing of MOVED_FROM and MOVED_TO events,
+                // We don't do this on Linux and OSX because depending on the timing of MOVED_FROM and MOVED_TO events,
                 // a rename can trigger delete + create as a deliberate handling of an edge case, and this
                 // test is checking that no delete events are raised.
-                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
                     testDir.Move(testDir.Path + "_rename");
                 }


### PR DESCRIPTION
# Problem

The ```DeletedTests.FileSystemWatcher_Deleted_Negative``` test would randomly fail on OSX during CI due to the FileSystemWatcher sending a Deleted file change event when it should not have.

# Solution

The FileSystemWatcher on OS X has the same problem as the Linux FileSystemWatcher where rename events come in pairs, meaning there are two events generated for the rename operation: a rename-delete on the old item and a rename-create on the new item. If one of the notifications is not part of the current notification payload, the OS X watcher falls back to checking for the existence on disk of the specified item. This test was failing since the test caused a rename to occur to make sure a delete did not occur; in these cases, the second rename notification was part of a different payload and the original item didn't exist on disk (since it was renamed) so we sent out a delete notification (see https://github.com/dotnet/corefx/blob/master/src/System.IO.FileSystem.Watcher/src/System/IO/FileSystemWatcher.OSX.cs#L336).

Note: this fix was already done for Linux and this is just making the same fix work on OS X

Fixes #5700 

cc: @stephentoub 