### PR TITLE
Revert Optimisations to Join and GroupJoin

### DIFF
--- a/src/System.Linq/src/System/Linq/GroupJoin.cs
+++ b/src/System.Linq/src/System/Linq/GroupJoin.cs
@@ -70,18 +70,10 @@ namespace System.Linq
 
         private static IEnumerable<TResult> GroupJoinIterator<TOuter, TInner, TKey, TResult>(IEnumerable<TOuter> outer, IEnumerable<TInner> inner, Func<TOuter, TKey> outerKeySelector, Func<TInner, TKey> innerKeySelector, Func<TOuter, IEnumerable<TInner>, TResult> resultSelector, IEqualityComparer<TKey> comparer)
         {
-            using (IEnumerator<TOuter> e = outer.GetEnumerator())
+            Lookup<TKey, TInner> lookup = Lookup<TKey, TInner>.CreateForJoin(inner, innerKeySelector, comparer);
+            foreach (TOuter item in outer)
             {
-                if (e.MoveNext())
-                {
-                    Lookup<TKey, TInner> lookup = Lookup<TKey, TInner>.CreateForJoin(inner, innerKeySelector, comparer);
-                    do
-                    {
-                        TOuter item = e.Current;
-                        yield return resultSelector(item, lookup[outerKeySelector(item)]);
-                    }
-                    while (e.MoveNext());
-                }
+                yield return resultSelector(item, lookup[outerKeySelector(item)]);
             }
         }
     }

--- a/src/System.Linq/tests/EnumerableTests.cs
+++ b/src/System.Linq/tests/EnumerableTests.cs
@@ -4,8 +4,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
-using Xunit;
-using Xunit.Extensions;
+using System.Text;
 
 namespace System.Linq.Tests
 {
@@ -116,6 +115,58 @@ namespace System.Linq.Tests
                 foreach (char c in obj)
                     hash ^= (int)c;
                 return hash;
+            }
+        }
+
+        protected class StringBuildingEnumerator : IEnumerable<int>, IEnumerator<int>
+        {
+            private StringBuilder _builder;
+            private char _curChar;
+            private int _count;
+
+            public StringBuildingEnumerator(StringBuilder builder, char startChar)
+            {
+                _builder = builder;
+                _curChar = startChar;
+            }
+
+            public IEnumerator<int> GetEnumerator()
+            {
+                return this;
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return this;
+            }
+
+            public bool MoveNext()
+            {
+                if (_count == 10)
+                    return false;
+
+                ++_count;
+                _builder.Append(_curChar);
+                _curChar = (char)(_curChar + 1);
+                return true;
+            }
+
+            public int Current
+            {
+                get { return 0; }
+            }
+
+            object IEnumerator.Current
+            {
+                get { return 0; }
+            }
+
+            public void Reset()
+            {
+            }
+
+            public void Dispose()
+            {
             }
         }
 

--- a/src/System.Linq/tests/GroupJoinTests.cs
+++ b/src/System.Linq/tests/GroupJoinTests.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
+using System.Text;
 using Xunit;
 
 namespace System.Linq.Tests
@@ -466,6 +466,16 @@ namespace System.Linq.Tests
             // Don't insist on this behaviour, but check its correct if it happens
             var en = iterator as IEnumerator<IEnumerable<int>>;
             Assert.False(en != null && en.MoveNext());
+        }
+
+        [Fact]
+        public void EnumerationOrder()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringBuildingEnumerator outer = new StringBuildingEnumerator(sb, '0');
+            StringBuildingEnumerator inner = new StringBuildingEnumerator(sb, 'a');
+            outer.GroupJoin(inner, o => o, i => i, (o, ei) => o + ei.Count()).Count();
+            Assert.Equal("abcdefghij0123456789", sb.ToString());
         }
     }
 }

--- a/src/System.Linq/tests/JoinTests.cs
+++ b/src/System.Linq/tests/JoinTests.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System;
 using System.Collections.Generic;
+using System.Text;
 using Xunit;
 
 namespace System.Linq.Tests
@@ -417,6 +417,16 @@ namespace System.Linq.Tests
             // Don't insist on this behaviour, but check its correct if it happens
             var en = iterator as IEnumerator<int>;
             Assert.False(en != null && en.MoveNext());
+        }
+
+        [Fact]
+        public void EnumerationOrder()
+        {
+            StringBuilder sb = new StringBuilder();
+            StringBuildingEnumerator outer = new StringBuildingEnumerator(sb, '0');
+            StringBuildingEnumerator inner = new StringBuildingEnumerator(sb, 'a');
+            outer.Join(inner, o => o, i => i, (o, i) => o + i).Count();
+            Assert.Equal("abcdefghij0123456789", sb.ToString());
         }
     }
 }


### PR DESCRIPTION
**Do not merge unless it is deemed necessary at #6477**

Reverts #5372 and most of #6061 restoring order of `MoveNext()` calls on the two `IEnumerable<T>` objects involved.

`Join` retains the optimisation of short-circuiting on `inner` producing an empty lookup (`inner` was empty, or for every value the key produced was null) and reducing the number of field accesses made on the lookup otherwise.

Fixes #6477.