### PR TITLE
Reorder some static initializers in SmiMetaDataProperty to prevent null values being stored in EmptyInstance.

### DIFF
--- a/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SmiMetaDataProperty.cs
+++ b/src/System.Data.SqlClient/src/Microsoft/SqlServer/Server/SmiMetaDataProperty.cs
@@ -35,6 +35,11 @@ namespace Microsoft.SqlServer.Server
         private SmiMetaDataProperty[] _properties;
         private bool _isReadOnly;
 
+        // Singleton empty instances to ensure each property is always non-null
+        private static readonly SmiDefaultFieldsProperty s_emptyDefaultFields = new SmiDefaultFieldsProperty(new List<bool>());
+        private static readonly SmiOrderProperty s_emptySortOrder = new SmiOrderProperty(new List<SmiOrderProperty.SmiColumnOrder>());
+        private static readonly SmiUniqueKeyProperty s_emptyUniqueKey = new SmiUniqueKeyProperty(new List<bool>());
+
         internal static readonly SmiMetaDataPropertyCollection EmptyInstance = CreateEmptyInstance();
 
         private static SmiMetaDataPropertyCollection CreateEmptyInstance()
@@ -43,11 +48,6 @@ namespace Microsoft.SqlServer.Server
             emptyInstance.SetReadOnly();
             return emptyInstance;
         }
-
-        // Singleton empty instances to ensure each property is always non-null
-        private static readonly SmiDefaultFieldsProperty s_emptyDefaultFields = new SmiDefaultFieldsProperty(new List<bool>());
-        private static readonly SmiOrderProperty s_emptySortOrder = new SmiOrderProperty(new List<SmiOrderProperty.SmiColumnOrder>());
-        private static readonly SmiUniqueKeyProperty s_emptyUniqueKey = new SmiUniqueKeyProperty(new List<bool>());
 
         internal SmiMetaDataPropertyCollection()
         {


### PR DESCRIPTION
Fixes a bug introduced in:
https://github.com/dotnet/corefx/commit/79ae21b1b9a113230da7ebfbffa4e3c3fe36f0ac#diff-b10a0158dea02392c84e28f4a764ab79R38

EmptyInstance stores default values from s_emptyDefaultFields, s_emptySortOrder, and s_emptyUniqueKey. These static variables are initialized after EmptyInstance in the file (textually), so EmptyInstance would contain null values instead. This inevitably causes NullReferenceExceptions later on.

Fixes issue: https://github.com/dotnet/corefx/issues/6355