### PR TITLE
Plinq nameof fixup

### DIFF
--- a/src/System.Linq.Parallel/tests/ExchangeTests.cs
+++ b/src/System.Linq.Parallel/tests/ExchangeTests.cs
@@ -169,7 +169,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
         public static void Merge_ArgumentException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;

--- a/src/System.Linq.Parallel/tests/ExchangeTests.cs
+++ b/src/System.Linq.Parallel/tests/ExchangeTests.cs
@@ -89,7 +89,7 @@ namespace System.Linq.Parallel.Tests
         // or WithMergeOptions
 
         [Theory]
-        [MemberData(nameof(PartitioningData), (object)(new int[] { 0, 1, 2, 16, 1024 }))]
+        [MemberData(nameof(PartitioningData), new[] { 0, 1, 2, 16, 1024 })]
         public static void Partitioning_Default(Labeled<ParallelQuery<int>> labeled, int count, int partitions)
         {
             int seen = 0;
@@ -101,14 +101,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(PartitioningData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
+        [MemberData(nameof(PartitioningData), new[] { 1024 * 4, 1024 * 1024 })]
         public static void Partitioning_Default_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int partitions)
         {
             Partitioning_Default(labeled, count, partitions);
         }
 
         [Theory]
-        [MemberData(nameof(PartitioningData), (object)(new int[] { 0, 1, 2, 16, 1024 }))]
+        [MemberData(nameof(PartitioningData), new[] { 0, 1, 2, 16, 1024 })]
         public static void Partitioning_Striped(Labeled<ParallelQuery<int>> labeled, int count, int partitions)
         {
             int seen = 0;
@@ -120,14 +120,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(PartitioningData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
+        [MemberData(nameof(PartitioningData), new[] { 1024 * 4, 1024 * 1024 })]
         public static void Partitioning_Striped_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int partitions)
         {
             Partitioning_Striped(labeled, count, partitions);
         }
 
         [Theory]
-        [MemberData(nameof(MergeData), (object)(new int[] { 0, 1, 2, 16, 1024 }))]
+        [MemberData(nameof(MergeData), new[] { 0, 1, 2, 16, 1024 })]
         public static void Merge_Ordered(Labeled<ParallelQuery<int>> labeled, int count, ParallelMergeOptions options)
         {
             int seen = 0;
@@ -139,14 +139,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(MergeData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
+        [MemberData(nameof(MergeData), new[] { 1024 * 4, 1024 * 1024 })]
         public static void Merge_Ordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, ParallelMergeOptions options)
         {
             Merge_Ordered(labeled, count, options);
         }
 
         [Theory]
-        [MemberData(nameof(ThrowOnCount_AllMergeOptions_MemberData), (object)(new int[] { 4, 8 }))]
+        [MemberData(nameof(ThrowOnCount_AllMergeOptions_MemberData), new[] { 4, 8 })]
         // FailingMergeData has enumerables that throw errors when attempting to perform the nth enumeration.
         // This test checks whether the query runs in a pipelined or buffered fashion.
         public static void Merge_Ordered_Pipelining(Labeled<ParallelQuery<int>> labeled, int count, ParallelMergeOptions options)
@@ -155,7 +155,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MergeData), (object)(new int[] { 4, 8 }))]
+        [MemberData(nameof(MergeData), new[] { 4, 8 })]
         // This test checks whether the query runs in a pipelined or buffered fashion.
         public static void Merge_Ordered_Pipelining_Select(Labeled<ParallelQuery<int>> labeled, int count, ParallelMergeOptions options)
         {
@@ -169,7 +169,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void Merge_ArgumentException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -195,7 +195,7 @@ namespace System.Linq.Parallel.Tests
         // the source enumerator... but then other worker threads may generate ODEs.
         // This test verifies any such ODEs are not reflected in the output exception.
         [Theory]
-        [MemberData(nameof(UnorderedSources.BinaryRanges), new int[] { 16 }, new int[] { 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.BinaryRanges), new[] { 16 }, new[] { 16 }, MemberType = typeof(UnorderedSources))]
         public static void PlinqChunkPartitioner_DontEnumerateAfterException(Labeled<ParallelQuery<int>> left, int leftCount,
             Labeled<ParallelQuery<int>> right, int rightCount)
         {
@@ -215,7 +215,7 @@ namespace System.Linq.Parallel.Tests
         // enumerator disposes the source enumerator... but then other worker threads may generate ODEs.
         // This test verifies any such ODEs are not reflected in the output exception.
         [Theory]
-        [MemberData(nameof(UnorderedSources.BinaryRanges), new int[] { 16 }, new int[] { 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.BinaryRanges), new[] { 16 }, new[] { 16 }, MemberType = typeof(UnorderedSources))]
         public static void ManualChunkPartitioner_DontEnumerateAfterException(
             Labeled<ParallelQuery<int>> left, int leftCount,
             Labeled<ParallelQuery<int>> right, int rightCount)

--- a/src/System.Linq.Parallel/tests/PlinqModesTests.cs
+++ b/src/System.Linq.Parallel/tests/PlinqModesTests.cs
@@ -137,7 +137,7 @@ namespace System.Linq.Parallel.Tests
 
         // Check that some queries run in parallel by default, and some require forcing.
         [Theory]
-        [MemberData(nameof(WithExecutionModeQueryData), new int[] { 1, 4 })] // DOP of 1 to verify sequential and 4 to verify parallel
+        [MemberData(nameof(WithExecutionModeQueryData), new[] { 1, 4 })] // DOP of 1 to verify sequential and 4 to verify parallel
         public static void WithExecutionMode(
             Labeled<ParallelQuery<int>> labeled,
             int requestedDop, int expectedDop,
@@ -150,7 +150,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void WithExecutionMode_ArgumentException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;

--- a/src/System.Linq.Parallel/tests/PlinqModesTests.cs
+++ b/src/System.Linq.Parallel/tests/PlinqModesTests.cs
@@ -150,7 +150,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
         public static void WithExecutionMode_ArgumentException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;

--- a/src/System.Linq.Parallel/tests/QueryOperators/AggregateTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AggregateTests.cs
@@ -34,7 +34,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Sum(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -52,14 +52,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Sum_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Aggregate_Sum(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Sum_Seed(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -68,14 +68,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Sum_Seed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Aggregate_Sum_Seed(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), 1, new int[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), 1, new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Product_Seed(Labeled<ParallelQuery<int>> labeled, int count, int start)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -86,14 +86,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), 1, new int[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), 1, new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Product_Seed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int start)
         {
             Aggregate_Product_Seed(labeled, count, start);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Collection_Seed(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -102,14 +102,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 512, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 512, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Collection_Seed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Aggregate_Collection_Seed(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Sum_Result(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -118,14 +118,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Sum_Result_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Aggregate_Sum_Result(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), 1, new int[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), 1, new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Product_Result(Labeled<ParallelQuery<int>> labeled, int count, int start)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -134,14 +134,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), 1, new int[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), 1, new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Product_Results_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int start)
         {
             Aggregate_Product_Result(labeled, count, start);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Collection_Results(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -150,14 +150,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 512, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 512, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Collection_Results_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Aggregate_Collection_Results(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Sum_Accumulator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -171,14 +171,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Sum_Accumulator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Aggregate_Sum_Accumulator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), 1, new int[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), 1, new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Product_Accumulator(Labeled<ParallelQuery<int>> labeled, int count, int start)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -192,14 +192,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), 1, new int[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), 1, new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Product_Accumulator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int start)
         {
             Aggregate_Product_Accumulator(labeled, count, start);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Collection_Accumulator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -213,14 +213,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 512, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 512, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Collection_Accumulator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Aggregate_Collection_Accumulator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Sum_SeedFunction(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -234,14 +234,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Sum_SeedFunction_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Aggregate_Sum_SeedFunction(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), 1, new int[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), 1, new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Product_SeedFunction(Labeled<ParallelQuery<int>> labeled, int count, int start)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -255,14 +255,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), 1, new int[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), 1, new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Product_SeedFunction_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int start)
         {
             Aggregate_Product_SeedFunction(labeled, count, start);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Collection_SeedFunction(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -276,7 +276,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 512, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 512, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Collection_SeedFunction_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Aggregate_Collection_SeedFunction(labeled, count);
@@ -294,7 +294,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -307,7 +307,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(AggregateExceptionData), (object)(new int[] { 2 }))]
+        [MemberData(nameof(AggregateExceptionData), new[] { 2 })]
         public static void Aggregate_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.Aggregate((i, j) => { throw new DeliberateTestException(); }));

--- a/src/System.Linq.Parallel/tests/QueryOperators/AggregateTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AggregateTests.cs
@@ -34,7 +34,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Sum(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -52,14 +52,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Sum_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Aggregate_Sum(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Sum_Seed(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -68,14 +68,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Sum_Seed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Aggregate_Sum_Seed(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), 1, new int[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), 1, new int[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Product_Seed(Labeled<ParallelQuery<int>> labeled, int count, int start)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -86,14 +86,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), 1, new int[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), 1, new int[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Product_Seed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int start)
         {
             Aggregate_Product_Seed(labeled, count, start);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Collection_Seed(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -102,14 +102,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 512, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 512, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Collection_Seed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Aggregate_Collection_Seed(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Sum_Result(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -118,14 +118,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Sum_Result_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Aggregate_Sum_Result(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), 1, new int[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), 1, new int[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Product_Result(Labeled<ParallelQuery<int>> labeled, int count, int start)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -134,14 +134,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), 1, new int[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), 1, new int[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Product_Results_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int start)
         {
             Aggregate_Product_Result(labeled, count, start);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Collection_Results(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -150,14 +150,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 512, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 512, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Collection_Results_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Aggregate_Collection_Results(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Sum_Accumulator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -171,14 +171,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Sum_Accumulator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Aggregate_Sum_Accumulator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), 1, new int[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), 1, new int[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Product_Accumulator(Labeled<ParallelQuery<int>> labeled, int count, int start)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -192,14 +192,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), 1, new int[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), 1, new int[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Product_Accumulator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int start)
         {
             Aggregate_Product_Accumulator(labeled, count, start);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Collection_Accumulator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -213,14 +213,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 512, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 512, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Collection_Accumulator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Aggregate_Collection_Accumulator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Sum_SeedFunction(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -234,14 +234,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Sum_SeedFunction_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Aggregate_Sum_SeedFunction(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), 1, new int[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), 1, new int[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Product_SeedFunction(Labeled<ParallelQuery<int>> labeled, int count, int start)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -255,14 +255,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), 1, new int[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), 1, new int[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Product_SeedFunction_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int start)
         {
             Aggregate_Product_SeedFunction(labeled, count, start);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Collection_SeedFunction(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -276,7 +276,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 512, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 512, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
         public static void Aggregate_Collection_SeedFunction_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Aggregate_Collection_SeedFunction(labeled, count);
@@ -294,7 +294,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
         public static void Aggregate_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();

--- a/src/System.Linq.Parallel/tests/QueryOperators/AllTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AllTests.cs
@@ -20,7 +20,7 @@ namespace System.Linq.Parallel.Tests
         // All
         //
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void All_AllFalse(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -29,14 +29,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         public static void All_AllFalse_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             All_AllFalse(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void All_AllTrue(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -47,7 +47,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         public static void All_AllTrue_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             All_AllTrue(labeled, count);
@@ -86,7 +86,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void All_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -96,7 +96,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void All_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.All(x => { throw new DeliberateTestException(); }));

--- a/src/System.Linq.Parallel/tests/QueryOperators/AllTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AllTests.cs
@@ -20,7 +20,7 @@ namespace System.Linq.Parallel.Tests
         // All
         //
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void All_AllFalse(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -29,14 +29,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void All_AllFalse_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             All_AllFalse(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void All_AllTrue(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -47,14 +47,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void All_AllTrue_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             All_AllTrue(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(OnlyOneData), (object)(new int[] { 2, 16 }))]
+        [MemberData(nameof(OnlyOneData), new[] { 2, 16 })]
         public static void All_OneFalse(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -63,14 +63,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(OnlyOneData), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }))]
+        [MemberData(nameof(OnlyOneData), new[] { 1024 * 1024, 1024 * 1024 * 4 })]
         public static void All_OneFalse_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             All_OneFalse(labeled, count, position);
         }
 
         [Theory]
-        [MemberData(nameof(OnlyOneData), (object)(new int[] { 2, 16 }))]
+        [MemberData(nameof(OnlyOneData), new[] { 2, 16 })]
         public static void All_OneTrue(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -79,14 +79,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(OnlyOneData), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }))]
+        [MemberData(nameof(OnlyOneData), new[] { 1024 * 1024, 1024 * 1024 * 4 })]
         public static void All_OneTrue_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             All_OneTrue(labeled, count, position);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void All_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -96,7 +96,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void All_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.All(x => { throw new DeliberateTestException(); }));

--- a/src/System.Linq.Parallel/tests/QueryOperators/AnyTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AnyTests.cs
@@ -20,7 +20,7 @@ namespace System.Linq.Parallel.Tests
         // Any
         //
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Any_Contents(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -29,14 +29,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Any_Contents_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Any_Contents(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Any_AllFalse(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -47,14 +47,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Any_AllFalse_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Any_AllFalse(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Any_AllTrue(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -63,14 +63,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Any_AllTrue_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Any_AllTrue(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(OnlyOneData), (object)(new int[] { 2, 16 }))]
+        [MemberData(nameof(OnlyOneData), new[] { 2, 16 })]
         public static void Any_OneFalse(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -79,14 +79,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(OnlyOneData), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }))]
+        [MemberData(nameof(OnlyOneData), new[] { 1024 * 1024, 1024 * 1024 * 4 })]
         public static void Any_OneFalse_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             Any_OneFalse(labeled, count, position);
         }
 
         [Theory]
-        [MemberData(nameof(OnlyOneData), (object)(new int[] { 2, 16 }))]
+        [MemberData(nameof(OnlyOneData), new[] { 2, 16 })]
         public static void Any_OneTrue(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -95,7 +95,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(OnlyOneData), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }))]
+        [MemberData(nameof(OnlyOneData), new[] { 1024 * 1024, 1024 * 1024 * 4 })]
         public static void Any_OneTrue_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             Any_OneTrue(labeled, count, position);
@@ -112,7 +112,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Any_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -123,7 +123,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Any_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.Any(x => { throw new DeliberateTestException(); }));

--- a/src/System.Linq.Parallel/tests/QueryOperators/AnyTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AnyTests.cs
@@ -20,7 +20,7 @@ namespace System.Linq.Parallel.Tests
         // Any
         //
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Any_Contents(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -29,14 +29,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         public static void Any_Contents_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Any_Contents(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Any_AllFalse(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -47,14 +47,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         public static void Any_AllFalse_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Any_AllFalse(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Any_AllTrue(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -63,7 +63,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         public static void Any_AllTrue_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Any_AllTrue(labeled, count);
@@ -112,7 +112,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void Any_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -123,7 +123,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void Any_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.Any(x => { throw new DeliberateTestException(); }));

--- a/src/System.Linq.Parallel/tests/QueryOperators/AsEnumerableTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AsEnumerableTests.cs
@@ -10,7 +10,7 @@ namespace System.Linq.Parallel.Tests
     public class AsEnumerableTests
     {
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void AsEnumerable_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             IntegerRangeSet seen = new IntegerRangeSet(0, count);
@@ -21,14 +21,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void AsEnumerable_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             AsEnumerable_Unordered(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void AsEnumerable(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int seen = 0;
@@ -39,7 +39,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 128 }, MemberType = typeof(Sources))]
         public static void AsEnumerable_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             AsEnumerable(labeled, count);
@@ -47,7 +47,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [ActiveIssue("AsEnumerable.Cast<T>() retains origin type")]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 16 }, MemberType = typeof(Sources))]
         public static void AsEnumerable_LinqBinding(Labeled<ParallelQuery<int>> labeled, int count)
         {
             IEnumerable<int> enumerable = labeled.Item.AsEnumerable();

--- a/src/System.Linq.Parallel/tests/QueryOperators/AsEnumerableTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AsEnumerableTests.cs
@@ -10,7 +10,7 @@ namespace System.Linq.Parallel.Tests
     public class AsEnumerableTests
     {
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void AsEnumerable_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             IntegerRangeSet seen = new IntegerRangeSet(0, count);
@@ -21,7 +21,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         public static void AsEnumerable_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             AsEnumerable_Unordered(labeled, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/AsSequentialTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AsSequentialTests.cs
@@ -10,7 +10,7 @@ namespace System.Linq.Parallel.Tests
     public class AsSequentialTests
     {
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void AsSequential_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             IntegerRangeSet seen = new IntegerRangeSet(0, count);
@@ -21,7 +21,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         public static void AsSequential_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             AsSequential_Unordered(labeled, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/AsSequentialTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AsSequentialTests.cs
@@ -10,7 +10,7 @@ namespace System.Linq.Parallel.Tests
     public class AsSequentialTests
     {
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void AsSequential_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             IntegerRangeSet seen = new IntegerRangeSet(0, count);
@@ -21,14 +21,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void AsSequential_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             AsSequential_Unordered(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void AsSequential(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int seen = 0;
@@ -39,7 +39,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 128 }, MemberType = typeof(Sources))]
         public static void AsSequential_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             AsSequential(labeled, count);
@@ -47,7 +47,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [ActiveIssue("AsSequential.Cast<T>() retains origin type")]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 16 }, MemberType = typeof(Sources))]
         public static void AsSequential_LinqBinding(Labeled<ParallelQuery<int>> labeled, int count)
         {
             IEnumerable<int> seq = labeled.Item.AsSequential();

--- a/src/System.Linq.Parallel/tests/QueryOperators/AverageTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AverageTests.cs
@@ -78,7 +78,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
         public static void Average_Long_Overflow(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<OverflowException>(() => labeled.Item.Select(x => x == 0 ? 1 : long.MaxValue).Average());
@@ -243,7 +243,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void Average_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -266,7 +266,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void Average_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.Average((Func<int, int>)(x => { throw new DeliberateTestException(); })));

--- a/src/System.Linq.Parallel/tests/QueryOperators/AverageTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/AverageTests.cs
@@ -22,7 +22,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(AverageData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(AverageData), new[] { 1, 2, 16 })]
         public static void Average_Int(Labeled<ParallelQuery<int>> labeled, int count, double average)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -34,14 +34,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(AverageData), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }))]
+        [MemberData(nameof(AverageData), new[] { 1024 * 1024, 1024 * 1024 * 4 })]
         public static void Average_Int_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, double average)
         {
             Average_Int(labeled, count, average);
         }
 
         [Theory]
-        [MemberData(nameof(AverageData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(AverageData), new[] { 1, 2, 16 })]
         public static void Average_Int_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, double average)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -50,7 +50,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(AverageData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(AverageData), new[] { 1, 2, 16 })]
         public static void Average_Int_AllNull(Labeled<ParallelQuery<int>> labeled, int count, double average)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -59,7 +59,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(AverageData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(AverageData), new[] { 1, 2, 16 })]
         public static void Average_Long(Labeled<ParallelQuery<int>> labeled, int count, double average)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -71,14 +71,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(AverageData), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }))]
+        [MemberData(nameof(AverageData), new[] { 1024 * 1024, 1024 * 1024 * 4 })]
         public static void Average_Long_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, double average)
         {
             Average_Long(labeled, count, average);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void Average_Long_Overflow(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<OverflowException>(() => labeled.Item.Select(x => x == 0 ? 1 : long.MaxValue).Average());
@@ -88,7 +88,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(AverageData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(AverageData), new[] { 1, 2, 16 })]
         public static void Average_Long_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, double average)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -97,7 +97,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(AverageData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(AverageData), new[] { 1, 2, 16 })]
         public static void Average_Long_AllNull(Labeled<ParallelQuery<int>> labeled, int count, double average)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -106,7 +106,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(AverageData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(AverageData), new[] { 1, 2, 16 })]
         public static void Average_Float(Labeled<ParallelQuery<int>> labeled, int count, float average)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -118,14 +118,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(AverageData), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }))]
+        [MemberData(nameof(AverageData), new[] { 1024 * 1024, 1024 * 1024 * 4 })]
         public static void Average_Float_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, float average)
         {
             Average_Float(labeled, count, average);
         }
 
         [Theory]
-        [MemberData(nameof(AverageData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(AverageData), new[] { 1, 2, 16 })]
         public static void Average_Float_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, float average)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -134,7 +134,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(AverageData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(AverageData), new[] { 1, 2, 16 })]
         public static void Average_Float_AllNull(Labeled<ParallelQuery<int>> labeled, int count, float average)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -143,7 +143,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(AverageData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(AverageData), new[] { 1, 2, 16 })]
         public static void Average_Double(Labeled<ParallelQuery<int>> labeled, int count, double average)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -155,14 +155,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(AverageData), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }))]
+        [MemberData(nameof(AverageData), new[] { 1024 * 1024, 1024 * 1024 * 4 })]
         public static void Average_Double_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, double average)
         {
             Average_Double(labeled, count, average);
         }
 
         [Theory]
-        [MemberData(nameof(AverageData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(AverageData), new[] { 1, 2, 16 })]
         public static void Average_Double_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, double average)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -171,7 +171,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(AverageData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(AverageData), new[] { 1, 2, 16 })]
         public static void Average_Double_AllNull(Labeled<ParallelQuery<int>> labeled, int count, double average)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -180,7 +180,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(AverageData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(AverageData), new[] { 1, 2, 16 })]
         public static void Average_Decimal(Labeled<ParallelQuery<int>> labeled, int count, decimal average)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -192,14 +192,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(AverageData), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }))]
+        [MemberData(nameof(AverageData), new[] { 1024 * 1024, 1024 * 1024 * 4 })]
         public static void Average_Decimal_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, decimal average)
         {
             Average_Decimal(labeled, count, average);
         }
 
         [Theory]
-        [MemberData(nameof(AverageData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(AverageData), new[] { 1, 2, 16 })]
         public static void Average_Decimal_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, decimal average)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -208,7 +208,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(AverageData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(AverageData), new[] { 1, 2, 16 })]
         public static void Average_Decimal_AllNull(Labeled<ParallelQuery<int>> labeled, int count, decimal average)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -243,7 +243,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Average_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -266,7 +266,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Average_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.Average((Func<int, int>)(x => { throw new DeliberateTestException(); })));

--- a/src/System.Linq.Parallel/tests/QueryOperators/CastTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/CastTests.cs
@@ -9,7 +9,7 @@ namespace System.Linq.Parallel.Tests
     public class CastTests
     {
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Cast_Unordered_Valid(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -23,7 +23,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(UnorderedSources))]
         public static void Cast_Unordered_Valid_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Cast_Unordered_Valid(labeled, count);
@@ -51,7 +51,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Cast_Unordered_Valid_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -62,7 +62,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(UnorderedSources))]
         public static void Cast_Unordered_Valid_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Cast_Unordered_Valid_NotPipelined(labeled, count);
@@ -87,7 +87,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0 }), MemberType = typeof(UnorderedSources))]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0 }), MemberType = typeof(Sources))]
         public static void Cast_Empty(Labeled<ParallelQuery<int>> labeled, int count)
         {
@@ -99,7 +99,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(Sources))]
         public static void Cast_InvalidCastException(Labeled<ParallelQuery<int>> labeled, int count)
         {
@@ -108,7 +108,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(Sources))]
         public static void Cast_Assignable_InvalidCastException(Labeled<ParallelQuery<int>> labeled, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/CastTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/CastTests.cs
@@ -9,7 +9,7 @@ namespace System.Linq.Parallel.Tests
     public class CastTests
     {
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Cast_Unordered_Valid(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -23,14 +23,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 1024 }, MemberType = typeof(UnorderedSources))]
         public static void Cast_Unordered_Valid_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Cast_Unordered_Valid(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void Cast_Valid(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -44,14 +44,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 1024 }, MemberType = typeof(Sources))]
         public static void Cast_Valid_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Cast_Valid(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Cast_Unordered_Valid_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -62,14 +62,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 1024 }, MemberType = typeof(UnorderedSources))]
         public static void Cast_Unordered_Valid_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Cast_Unordered_Valid_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void Cast_Valid_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -80,15 +80,15 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 1024 }, MemberType = typeof(Sources))]
         public static void Cast_Valid_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Cast_Valid(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0 }), MemberType = typeof(UnorderedSources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0 }, MemberType = typeof(Sources))]
         public static void Cast_Empty(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> empty = labeled.Item;
@@ -99,8 +99,8 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void Cast_InvalidCastException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<InvalidCastException>(() => labeled.Item.Cast<double>().ForAll(x => {; }));
@@ -108,8 +108,8 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void Cast_Assignable_InvalidCastException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<InvalidCastException>(() => labeled.Item.Select(x => (Int32)x).Cast<Castable>().ForAll(x => {; }));

--- a/src/System.Linq.Parallel/tests/QueryOperators/ConcatTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ConcatTests.cs
@@ -29,7 +29,7 @@ namespace System.Linq.Parallel.Tests
         // Concat
         //
         [Theory]
-        [MemberData(nameof(ConcatUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(ConcatUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void Concat_Unordered(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -44,14 +44,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ConcatUnorderedData), (object)(new int[] { 1024, 1024 * 16 }))]
+        [MemberData(nameof(ConcatUnorderedData), new[] { 1024, 1024 * 16 })]
         public static void Concat_Unordered_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Concat_Unordered(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(ConcatData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(ConcatData), new[] { 0, 1, 2, 16 })]
         public static void Concat(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -66,14 +66,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ConcatData), (object)(new int[] { 1024, 1024 * 16 }))]
+        [MemberData(nameof(ConcatData), new[] { 1024, 1024 * 16 })]
         public static void Concat_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Concat(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(ConcatUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(ConcatUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void Concat_Unordered_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -85,14 +85,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ConcatUnorderedData), (object)(new int[] { 1024, 1024 * 16 }))]
+        [MemberData(nameof(ConcatUnorderedData), new[] { 1024, 1024 * 16 })]
         public static void Concat_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Concat_Unordered_NotPipelined(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(ConcatData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(ConcatData), new[] { 0, 1, 2, 16 })]
         public static void Concat_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -104,7 +104,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ConcatData), (object)(new int[] { 1024, 1024 * 16 }))]
+        [MemberData(nameof(ConcatData), new[] { 1024, 1024 * 16 })]
         public static void Concat_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Concat_NotPipelined(left, leftCount, right, rightCount);

--- a/src/System.Linq.Parallel/tests/QueryOperators/ContainsTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ContainsTests.cs
@@ -20,7 +20,7 @@ namespace System.Linq.Parallel.Tests
         // Contains
         //
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         public static void Contains_NoMatching(Labeled<ParallelQuery<int>> labeled, int count)
         {
@@ -32,7 +32,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(Sources))]
         public static void Contains_NoMatching_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
@@ -40,7 +40,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 16 }), MemberType = typeof(UnorderedSources))]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 16 }), MemberType = typeof(Sources))]
         public static void Contains_MultipleMatching(Labeled<ParallelQuery<int>> labeled, int count)
         {
@@ -50,7 +50,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(Sources))]
         public static void Contains_MultipleMatching_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
@@ -76,7 +76,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void Contains_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -87,7 +87,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void Contains_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.Contains(1, new FailingEqualityComparer<int>()));

--- a/src/System.Linq.Parallel/tests/QueryOperators/ContainsTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ContainsTests.cs
@@ -20,8 +20,8 @@ namespace System.Linq.Parallel.Tests
         // Contains
         //
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void Contains_NoMatching(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -32,16 +32,16 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(Sources))]
         public static void Contains_NoMatching_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Contains_NoMatching(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 16 }), MemberType = typeof(UnorderedSources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 16 }, MemberType = typeof(Sources))]
         public static void Contains_MultipleMatching(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -50,15 +50,15 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(Sources))]
         public static void Contains_MultipleMatching_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Contains_MultipleMatching(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(OnlyOneData), (object)(new int[] { 2, 16 }))]
+        [MemberData(nameof(OnlyOneData), new[] { 2, 16 })]
         public static void Contains_OneMatching(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -69,14 +69,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(OnlyOneData), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }))]
+        [MemberData(nameof(OnlyOneData), new[] { 1024 * 1024, 1024 * 1024 * 4 })]
         public static void Contains_OneMatching_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             Contains_OneMatching(labeled, count, position);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Contains_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -87,7 +87,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Contains_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.Contains(1, new FailingEqualityComparer<int>()));

--- a/src/System.Linq.Parallel/tests/QueryOperators/CountLongCountTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/CountLongCountTests.cs
@@ -20,8 +20,8 @@ namespace System.Linq.Parallel.Tests
         // Count and LongCount
         //
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Count_All(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -31,16 +31,16 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Count_All_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Count_All(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void LongCount_All(Labeled<ParallelQuery<int>> labeled, long count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -50,16 +50,16 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void LongCount_All_Longrunning(Labeled<ParallelQuery<int>> labeled, long count)
         {
             LongCount_All(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Count_None(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -68,16 +68,16 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Count_None_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Count_None(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void LongCount_None(Labeled<ParallelQuery<int>> labeled, long count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -86,15 +86,15 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void LongCount_None_Longrunning(Labeled<ParallelQuery<int>> labeled, long count)
         {
             LongCount_None(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(OnlyOneData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(OnlyOneData), new[] { 0, 1, 2, 16 })]
         public static void Count_One(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -103,14 +103,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(OnlyOneData), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }))]
+        [MemberData(nameof(OnlyOneData), new[] { 1024 * 1024, 1024 * 1024 * 4 })]
         public static void Count_One_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             Count_One(labeled, count, position);
         }
 
         [Theory]
-        [MemberData(nameof(OnlyOneData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(OnlyOneData), new[] { 0, 1, 2, 16 })]
         public static void LongCount_One(Labeled<ParallelQuery<int>> labeled, int count, long position)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -119,14 +119,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(OnlyOneData), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }))]
+        [MemberData(nameof(OnlyOneData), new[] { 1024 * 1024, 1024 * 1024 * 4 })]
         public static void LongCount_One_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, long position)
         {
             LongCount_One(labeled, count, position);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void CountLongCount_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -140,7 +140,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void CountLongCount_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.Count(x => { throw new DeliberateTestException(); }));

--- a/src/System.Linq.Parallel/tests/QueryOperators/CountLongCountTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/CountLongCountTests.cs
@@ -21,7 +21,7 @@ namespace System.Linq.Parallel.Tests
         //
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Count_All(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -32,7 +32,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         public static void Count_All_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Count_All(labeled, count);
@@ -40,7 +40,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void LongCount_All(Labeled<ParallelQuery<int>> labeled, long count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -51,7 +51,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         public static void LongCount_All_Longrunning(Labeled<ParallelQuery<int>> labeled, long count)
         {
             LongCount_All(labeled, count);
@@ -59,7 +59,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Count_None(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -69,7 +69,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         public static void Count_None_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Count_None(labeled, count);
@@ -77,7 +77,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void LongCount_None(Labeled<ParallelQuery<int>> labeled, long count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -87,7 +87,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         public static void LongCount_None_Longrunning(Labeled<ParallelQuery<int>> labeled, long count)
         {
             LongCount_None(labeled, count);
@@ -126,7 +126,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void CountLongCount_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -140,7 +140,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void CountLongCount_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.Count(x => { throw new DeliberateTestException(); }));

--- a/src/System.Linq.Parallel/tests/QueryOperators/DefaultIfEmptyTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/DefaultIfEmptyTests.cs
@@ -24,7 +24,7 @@ namespace System.Linq.Parallel.Tests
         // DefaultIfEmpty
         //
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void DefaultIfEmpty_Unordered_NotEmpty(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -38,14 +38,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 1024 }, MemberType = typeof(UnorderedSources))]
         public static void DefaultIfEmpty_Unordered_NotEmpty_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             DefaultIfEmpty_Unordered_NotEmpty(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void DefaultIfEmpty_NotEmpty(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -59,14 +59,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 1024 }, MemberType = typeof(Sources))]
         public static void DefaultIfEmpty_NotEmpty_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             DefaultIfEmpty_NotEmpty(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void DefaultIfEmpty_Unordered_NotEmpty_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -77,14 +77,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 1024 }, MemberType = typeof(UnorderedSources))]
         public static void DefaultIfEmpty_Unordered_NotEmpty_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             DefaultIfEmpty_Unordered_NotEmpty_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void DefaultIfEmpty_NotEmpty_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -98,7 +98,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 1024 }, MemberType = typeof(Sources))]
         public static void DefaultIfEmpty_NotEmpty_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             DefaultIfEmpty_NotEmpty_NotPipelined(labeled, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/DefaultIfEmptyTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/DefaultIfEmptyTests.cs
@@ -24,7 +24,7 @@ namespace System.Linq.Parallel.Tests
         // DefaultIfEmpty
         //
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void DefaultIfEmpty_Unordered_NotEmpty(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -38,7 +38,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(UnorderedSources))]
         public static void DefaultIfEmpty_Unordered_NotEmpty_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             DefaultIfEmpty_Unordered_NotEmpty(labeled, count);
@@ -66,7 +66,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void DefaultIfEmpty_Unordered_NotEmpty_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -77,7 +77,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(UnorderedSources))]
         public static void DefaultIfEmpty_Unordered_NotEmpty_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             DefaultIfEmpty_Unordered_NotEmpty_NotPipelined(labeled, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/DistinctTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/DistinctTests.cs
@@ -39,7 +39,7 @@ namespace System.Linq.Parallel.Tests
         // Distinct
         //
         [Theory]
-        [MemberData(nameof(DistinctUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(DistinctUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void Distinct_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -53,14 +53,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(DistinctUnorderedData), (object)(new int[] { 1024 * 4, 1024 * 128 }))]
+        [MemberData(nameof(DistinctUnorderedData), new[] { 1024 * 4, 1024 * 128 })]
         public static void Distinct_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Distinct_Unordered(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(DistinctData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(DistinctData), new[] { 0, 1, 2, 16 })]
         public static void Distinct(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -74,14 +74,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(DistinctData), (object)(new int[] { 1024 * 4, 1024 * 128 }))]
+        [MemberData(nameof(DistinctData), new[] { 1024 * 4, 1024 * 128 })]
         public static void Distinct_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Distinct(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(DistinctUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(DistinctUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void Distinct_Unordered_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -92,14 +92,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(DistinctUnorderedData), (object)(new int[] { 1024 * 4, 1024 * 128 }))]
+        [MemberData(nameof(DistinctUnorderedData), new[] { 1024 * 4, 1024 * 128 })]
         public static void Distinct_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Distinct_Unordered_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(DistinctData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(DistinctData), new[] { 0, 1, 2, 16 })]
         public static void Distinct_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -110,14 +110,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(DistinctData), (object)(new int[] { 1024 * 4, 1024 * 128 }))]
+        [MemberData(nameof(DistinctData), new[] { 1024 * 4, 1024 * 128 })]
         public static void Distinct_NotPiplined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Distinct_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(DistinctSourceMultipleData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(DistinctSourceMultipleData), new[] { 0, 1, 2, 16 })]
         public static void Distinct_Unordered_SourceMultiple(ParallelQuery<int> query, int count)
         {
             // The difference between this test and the previous, is that it's not possible to
@@ -131,14 +131,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(DistinctSourceMultipleData), (object)(new int[] { 1024 * 4, 1024 * 128 }))]
+        [MemberData(nameof(DistinctSourceMultipleData), new[] { 1024 * 4, 1024 * 128 })]
         public static void Distinct_Unordered_SourceMultiple_Longrunning(ParallelQuery<int> query, int count)
         {
             Distinct_Unordered_SourceMultiple(query, count);
         }
 
         [Theory]
-        [MemberData(nameof(DistinctSourceMultipleData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(DistinctSourceMultipleData), new[] { 0, 1, 2, 16 })]
         public static void Distinct_SourceMultiple(ParallelQuery<int> query, int count)
         {
             int seen = 0;
@@ -148,7 +148,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(DistinctSourceMultipleData), (object)(new int[] { 1024 * 4, 1024 * 128 }))]
+        [MemberData(nameof(DistinctSourceMultipleData), new[] { 1024 * 4, 1024 * 128 })]
         public static void Distinct_SourceMultiple_Longrunning(ParallelQuery<int> query, int count)
         {
             Distinct_SourceMultiple(query, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/ElementAtElementAtOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ElementAtElementAtOrDefaultTests.cs
@@ -32,8 +32,8 @@ namespace System.Linq.Parallel.Tests
         // ElementAt and ElementAtOrDefault
         //
         [Theory]
-        [MemberData(nameof(ElementAtUnorderedData), (object)(new int[] { 1, 2, 16 }))]
-        [MemberData(nameof(ElementAtData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(ElementAtUnorderedData), new[] { 1, 2, 16 })]
+        [MemberData(nameof(ElementAtData), new[] { 1, 2, 16 })]
         public static void ElementAt(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             // For unordered collections, which element is chosen isn't actually guaranteed, but an effect of the implementation.
@@ -44,15 +44,15 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ElementAtUnorderedData), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }))]
-        [MemberData(nameof(ElementAtData), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }))]
+        [MemberData(nameof(ElementAtUnorderedData), new[] { 1024 * 1024, 1024 * 1024 * 4 })]
+        [MemberData(nameof(ElementAtData), new[] { 1024 * 1024, 1024 * 1024 * 4 })]
         public static void ElementAt_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             ElementAt(labeled, count, position);
         }
 
         [Theory]
-        [MemberData(nameof(ElementAtOutOfRangeData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(ElementAtOutOfRangeData), new[] { 0, 1, 2, 16 })]
         public static void ElementAt_OutOfRange(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -61,15 +61,15 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ElementAtOutOfRangeData), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }))]
+        [MemberData(nameof(ElementAtOutOfRangeData), new[] { 1024 * 1024, 1024 * 1024 * 4 })]
         public static void ElementAt_OutOfRange_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             ElementAt_OutOfRange(labeled, count, position);
         }
 
         [Theory]
-        [MemberData(nameof(ElementAtUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(ElementAtData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(ElementAtUnorderedData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(ElementAtData), new[] { 0, 1, 2, 16 })]
         public static void ElementAtOrDefault(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             // For unordered collections, which element is chosen isn't actually guaranteed, but an effect of the implementation.
@@ -80,15 +80,15 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ElementAtUnorderedData), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }))]
-        [MemberData(nameof(ElementAtData), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }))]
+        [MemberData(nameof(ElementAtUnorderedData), new[] { 1024 * 1024, 1024 * 1024 * 4 })]
+        [MemberData(nameof(ElementAtData), new[] { 1024 * 1024, 1024 * 1024 * 4 })]
         public static void ElementAtOrDefault_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             ElementAtOrDefault(labeled, count, position);
         }
 
         [Theory]
-        [MemberData(nameof(ElementAtOutOfRangeData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(ElementAtOutOfRangeData), new[] { 0, 1, 2, 16 })]
         public static void ElementAtOrDefault_OutOfRange(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -97,14 +97,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ElementAtOutOfRangeData), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }))]
+        [MemberData(nameof(ElementAtOutOfRangeData), new[] { 1024 * 1024, 1024 * 1024 * 4 })]
         public static void ElementAtOrDefault_OutOfRange_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             ElementAtOrDefault_OutOfRange(labeled, count, position);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void ElementAt_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();

--- a/src/System.Linq.Parallel/tests/QueryOperators/ElementAtElementAtOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ElementAtElementAtOrDefaultTests.cs
@@ -104,7 +104,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void ElementAt_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();

--- a/src/System.Linq.Parallel/tests/QueryOperators/ExceptTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ExceptTests.cs
@@ -35,7 +35,7 @@ namespace System.Linq.Parallel.Tests
             foreach (int leftCount in counts.Cast<int>())
             {
                 ParallelQuery<int> left = Enumerable.Range(0, leftCount * DuplicateFactor).Select(x => x % leftCount).ToArray().AsParallel().AsOrdered();
-                foreach (int rightCount in new int[] { 0, 1, Math.Max(DuplicateFactor * 2, leftCount), 2 * Math.Max(DuplicateFactor, leftCount) })
+                foreach (int rightCount in new[] { 0, 1, Math.Max(DuplicateFactor * 2, leftCount), 2 * Math.Max(DuplicateFactor, leftCount) })
                 {
                     int rightStart = 0 - rightCount / 2;
                     yield return new object[] { left, leftCount,
@@ -48,7 +48,7 @@ namespace System.Linq.Parallel.Tests
         // Except
         //
         [Theory]
-        [MemberData(nameof(ExceptUnorderedData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(ExceptUnorderedData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Except_Unordered(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int start, int count)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -63,14 +63,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ExceptUnorderedData), new int[] { 1024, 1024 * 16 }, new int[] { 0, 1024, 1024 * 32 })]
+        [MemberData(nameof(ExceptUnorderedData), new[] { 1024, 1024 * 16 }, new[] { 0, 1024, 1024 * 32 })]
         public static void Except_Unordered_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int start, int count)
         {
             Except_Unordered(left, leftCount, right, rightCount, start, count);
         }
 
         [Theory]
-        [MemberData(nameof(ExceptData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(ExceptData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Except(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int start, int count)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -85,14 +85,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ExceptData), new int[] { 1024, 1024 * 16 }, new int[] { 0, 1024, 1024 * 32 })]
+        [MemberData(nameof(ExceptData), new[] { 1024, 1024 * 16 }, new[] { 0, 1024, 1024 * 32 })]
         public static void Except_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int start, int count)
         {
             Except(left, leftCount, right, rightCount, start, count);
         }
 
         [Theory]
-        [MemberData(nameof(ExceptUnorderedData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(ExceptUnorderedData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Except_Unordered_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int start, int count)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -104,14 +104,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ExceptUnorderedData), new int[] { 1024, 1024 * 16 }, new int[] { 0, 1024, 1024 * 32 })]
+        [MemberData(nameof(ExceptUnorderedData), new[] { 1024, 1024 * 16 }, new[] { 0, 1024, 1024 * 32 })]
         public static void Except_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int start, int count)
         {
             Except_Unordered_NotPipelined(left, leftCount, right, rightCount, start, count);
         }
 
         [Theory]
-        [MemberData(nameof(ExceptData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(ExceptData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Except_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int start, int count)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -123,14 +123,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ExceptData), new int[] { 1024, 1024 * 16 }, new int[] { 0, 1024, 1024 * 32 })]
+        [MemberData(nameof(ExceptData), new[] { 1024, 1024 * 16 }, new[] { 0, 1024, 1024 * 32 })]
         public static void Except_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int start, int count)
         {
             Except_NotPipelined(left, leftCount, right, rightCount, start, count);
         }
 
         [Theory]
-        [MemberData(nameof(ExceptUnorderedData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(ExceptUnorderedData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Except_Unordered_Distinct(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int start, int count)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -148,14 +148,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ExceptUnorderedData), new int[] { 1024, 1024 * 16 }, new int[] { 0, 1024, 1024 * 32 })]
+        [MemberData(nameof(ExceptUnorderedData), new[] { 1024, 1024 * 16 }, new[] { 0, 1024, 1024 * 32 })]
         public static void Except_Unordered_Distinct_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int start, int count)
         {
             Except_Unordered_Distinct(left, leftCount, right, rightCount, start, count);
         }
 
         [Theory]
-        [MemberData(nameof(ExceptData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(ExceptData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Except_Distinct(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int start, int count)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -173,14 +173,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ExceptData), new int[] { 1024, 1024 * 16 }, new int[] { 0, 1024, 1024 * 32 })]
+        [MemberData(nameof(ExceptData), new[] { 1024, 1024 * 16 }, new[] { 0, 1024, 1024 * 32 })]
         public static void Except_Distinct_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int start, int count)
         {
             Except_Distinct(left, leftCount, right, rightCount, start, count);
         }
 
         [Theory]
-        [MemberData(nameof(ExceptUnorderedData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(ExceptUnorderedData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Except_Unordered_Distinct_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int start, int count)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -196,14 +196,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ExceptData), new int[] { 1024, 1024 * 16 }, new int[] { 0, 1024, 1024 * 32 })]
+        [MemberData(nameof(ExceptData), new[] { 1024, 1024 * 16 }, new[] { 0, 1024, 1024 * 32 })]
         public static void Except_Unordered_Distinct_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int start, int count)
         {
             Except_Unordered_Distinct_NotPipelined(left, leftCount, right, rightCount, start, count);
         }
 
         [Theory]
-        [MemberData(nameof(ExceptData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(ExceptData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Except_Distinct_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int start, int count)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -219,14 +219,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ExceptData), new int[] { 1024, 1024 * 16 }, new int[] { 0, 1024, 1024 * 32 })]
+        [MemberData(nameof(ExceptData), new[] { 1024, 1024 * 16 }, new[] { 0, 1024, 1024 * 32 })]
         public static void Except_Distinct_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int start, int count)
         {
             Except_Distinct_NotPipelined(left, leftCount, right, rightCount, start, count);
         }
 
         [Theory]
-        [MemberData(nameof(ExceptSourceMultipleData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(ExceptSourceMultipleData), new[] { 0, 1, 2, 16 })]
         public static void Except_Unordered_SourceMultiple(ParallelQuery<int> leftQuery, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int start, int count)
         {
             // The difference between this test and the previous, is that it's not possible to
@@ -240,14 +240,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ExceptSourceMultipleData), (object)(new int[] { 1024, 1024 * 16 }))]
+        [MemberData(nameof(ExceptSourceMultipleData), new[] { 1024, 1024 * 16 })]
         public static void Except_Unordered_SourceMultiple_Longrunning(ParallelQuery<int> leftQuery, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int start, int count)
         {
             Except_Unordered_SourceMultiple(leftQuery, leftCount, rightQuery, rightCount, start, count);
         }
 
         [Theory]
-        [MemberData(nameof(ExceptSourceMultipleData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(ExceptSourceMultipleData), new[] { 0, 1, 2, 16 })]
         public static void Except_SourceMultiple(ParallelQuery<int> leftQuery, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int start, int count)
         {
             int seen = start;
@@ -257,7 +257,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ExceptSourceMultipleData), (object)(new int[] { 1024, 1024 * 16 }))]
+        [MemberData(nameof(ExceptSourceMultipleData), new[] { 1024, 1024 * 16 })]
         public static void Except_SourceMultiple_Longrunning(ParallelQuery<int> leftQuery, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int start, int count)
         {
             Except_SourceMultiple(leftQuery, leftCount, rightQuery, rightCount, start, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/FirstFirstOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/FirstFirstOrDefaultTests.cs
@@ -26,8 +26,8 @@ namespace System.Linq.Parallel.Tests
         // First and FirstOrDefault
         //
         [Theory]
-        [MemberData(nameof(FirstUnorderedData), (object)(new int[] { 1, 2, 16 }))]
-        [MemberData(nameof(FirstData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(FirstUnorderedData), new[] { 1, 2, 16 })]
+        [MemberData(nameof(FirstData), new[] { 1, 2, 16 })]
         public static void First(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             // For unordered collections, which element is chosen isn't actually guaranteed, but an effect of the implementation.
@@ -39,16 +39,16 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(FirstUnorderedData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
-        [MemberData(nameof(FirstData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
+        [MemberData(nameof(FirstUnorderedData), new[] { 1024 * 4, 1024 * 1024 })]
+        [MemberData(nameof(FirstData), new[] { 1024 * 4, 1024 * 1024 })]
         public static void First_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             First(labeled, count, position);
         }
 
         [Theory]
-        [MemberData(nameof(FirstUnorderedData), (object)(new int[] { 1, 2, 16 }))]
-        [MemberData(nameof(FirstData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(FirstUnorderedData), new[] { 1, 2, 16 })]
+        [MemberData(nameof(FirstData), new[] { 1, 2, 16 })]
         public static void FirstOrDefault(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             // For unordered collections, which element is chosen isn't actually guaranteed, but an effect of the implementation.
@@ -60,16 +60,16 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(FirstUnorderedData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
-        [MemberData(nameof(FirstData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
+        [MemberData(nameof(FirstUnorderedData), new[] { 1024 * 4, 1024 * 1024 })]
+        [MemberData(nameof(FirstData), new[] { 1024 * 4, 1024 * 1024 })]
         public static void FirstOrDefault_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             FirstOrDefault(labeled, count, position);
         }
 
         [Theory]
-        [MemberData(nameof(FirstUnorderedData), (object)(new int[] { 0 }))]
-        [MemberData(nameof(FirstData), (object)(new int[] { 0 }))]
+        [MemberData(nameof(FirstUnorderedData), new[] { 0 })]
+        [MemberData(nameof(FirstData), new[] { 0 })]
         public static void First_Empty(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -77,8 +77,8 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(FirstUnorderedData), (object)(new int[] { 0 }))]
-        [MemberData(nameof(FirstData), (object)(new int[] { 0 }))]
+        [MemberData(nameof(FirstUnorderedData), new[] { 0 })]
+        [MemberData(nameof(FirstData), new[] { 0 })]
         public static void FirstOrDefault_Empty(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -86,8 +86,8 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(FirstUnorderedData), (object)(new int[] { 1, 2, 16 }))]
-        [MemberData(nameof(FirstData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(FirstUnorderedData), new[] { 1, 2, 16 })]
+        [MemberData(nameof(FirstData), new[] { 0, 1, 2, 16 })]
         public static void First_NoMatch(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -98,16 +98,16 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(FirstUnorderedData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
-        [MemberData(nameof(FirstData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
+        [MemberData(nameof(FirstUnorderedData), new[] { 1024 * 4, 1024 * 1024 })]
+        [MemberData(nameof(FirstData), new[] { 1024 * 4, 1024 * 1024 })]
         public static void First_NoMatch_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             First_NoMatch(labeled, count, position);
         }
 
         [Theory]
-        [MemberData(nameof(FirstUnorderedData), (object)(new int[] { 1, 2, 16 }))]
-        [MemberData(nameof(FirstData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(FirstUnorderedData), new[] { 1, 2, 16 })]
+        [MemberData(nameof(FirstData), new[] { 0, 1, 2, 16 })]
         public static void FirstOrDefault_NoMatch(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -118,15 +118,15 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(FirstUnorderedData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
-        [MemberData(nameof(FirstData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
+        [MemberData(nameof(FirstUnorderedData), new[] { 1024 * 4, 1024 * 1024 })]
+        [MemberData(nameof(FirstData), new[] { 1024 * 4, 1024 * 1024 })]
         public static void FirstOrDefault_NoMatch_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             FirstOrDefault_NoMatch(labeled, count, position);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void First_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -140,7 +140,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void First_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.First(x => { throw new DeliberateTestException(); }));

--- a/src/System.Linq.Parallel/tests/QueryOperators/FirstFirstOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/FirstFirstOrDefaultTests.cs
@@ -126,7 +126,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void First_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -140,7 +140,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void First_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.First(x => { throw new DeliberateTestException(); }));

--- a/src/System.Linq.Parallel/tests/QueryOperators/ForAllTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ForAllTests.cs
@@ -10,8 +10,8 @@ namespace System.Linq.Parallel.Tests
     public class ForAllTests
     {
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ForAll(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -22,15 +22,15 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 1024, 1024 * 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void ForAll_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ForAll(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void ForAll_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -40,7 +40,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void ForAll_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.ForAll(x => { throw new DeliberateTestException(); }));

--- a/src/System.Linq.Parallel/tests/QueryOperators/ForAllTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ForAllTests.cs
@@ -11,7 +11,7 @@ namespace System.Linq.Parallel.Tests
     {
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ForAll(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -23,14 +23,14 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 1024, 1024 * 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         public static void ForAll_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ForAll(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void ForAll_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -40,7 +40,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void ForAll_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.ForAll(x => { throw new DeliberateTestException(); }));

--- a/src/System.Linq.Parallel/tests/QueryOperators/GetEnumeratorTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/GetEnumeratorTests.cs
@@ -10,7 +10,7 @@ namespace System.Linq.Parallel.Tests
     public class GetEnumeratorTests
     {
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void GetEnumerator_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             IntegerRangeSet seen = new IntegerRangeSet(0, count);
@@ -41,7 +41,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
         public static void GetEnumerator_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GetEnumerator_Unordered(labeled, count);
@@ -86,7 +86,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void GetEnumerator_MoveNextAfterQueryOpeningFailsIsIllegal(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item.Select<int, int>(x => { throw new DeliberateTestException(); }).OrderBy(x => x);
@@ -101,7 +101,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 16 }), MemberType = typeof(UnorderedSources))]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 16 }), MemberType = typeof(Sources))]
         public static void GetEnumerator_CurrentBeforeMoveNext(Labeled<ParallelQuery<int>> labeled, int count)
         {
@@ -118,7 +118,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         public static void GetEnumerator_MoveNextAfterEnd(Labeled<ParallelQuery<int>> labeled, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/GetEnumeratorTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/GetEnumeratorTests.cs
@@ -10,7 +10,7 @@ namespace System.Linq.Parallel.Tests
     public class GetEnumeratorTests
     {
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void GetEnumerator_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             IntegerRangeSet seen = new IntegerRangeSet(0, count);
@@ -41,14 +41,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 128 }, MemberType = typeof(UnorderedSources))]
         public static void GetEnumerator_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GetEnumerator_Unordered(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void GetEnumerator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int seen = 0;
@@ -79,14 +79,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 128 }, MemberType = typeof(Sources))]
         public static void GetEnumerator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GetEnumerator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void GetEnumerator_MoveNextAfterQueryOpeningFailsIsIllegal(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item.Select<int, int>(x => { throw new DeliberateTestException(); }).OrderBy(x => x);
@@ -101,8 +101,8 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 16 }), MemberType = typeof(UnorderedSources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 16 }, MemberType = typeof(Sources))]
         public static void GetEnumerator_CurrentBeforeMoveNext(Labeled<ParallelQuery<int>> labeled, int count)
         {
             IEnumerator<int> enumerator = labeled.Item.GetEnumerator();
@@ -118,8 +118,8 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void GetEnumerator_MoveNextAfterEnd(Labeled<ParallelQuery<int>> labeled, int count)
         {
             IEnumerator<int> enumerator = labeled.Item.GetEnumerator();

--- a/src/System.Linq.Parallel/tests/QueryOperators/GroupByTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/GroupByTests.cs
@@ -12,7 +12,7 @@ namespace System.Linq.Parallel.Tests
         private const int GroupFactor = 8;
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }, MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -34,14 +34,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_Unordered(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }, MemberType = typeof(Sources))]
         public static void GroupBy(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -63,14 +63,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 16 }, MemberType = typeof(Sources))]
         public static void GroupBy_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }, MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -88,14 +88,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_Unordered_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }, MemberType = typeof(Sources))]
         public static void GroupBy_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -113,14 +113,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 16 }, MemberType = typeof(Sources))]
         public static void GroupBy_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }, MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -142,14 +142,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_Unordered_CustomComparator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }, MemberType = typeof(Sources))]
         // GroupBy doesn't select the first 'identical' key.  Issue #1490
         public static void GroupBy_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
@@ -172,14 +172,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 16 }, MemberType = typeof(Sources))]
         public static void GroupBy_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_CustomComparator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }, MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_ElementSelector(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -198,14 +198,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_ElementSelector_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_Unordered_ElementSelector(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }, MemberType = typeof(Sources))]
         public static void GroupBy_ElementSelector(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -223,14 +223,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 16 }, MemberType = typeof(Sources))]
         public static void GroupBy_ElementSelector_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_ElementSelector(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }, MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_ElementSelector_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -249,14 +249,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_ElementSelector_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_Unordered_ElementSelector_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }, MemberType = typeof(Sources))]
         public static void GroupBy_ElementSelector_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -274,14 +274,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 16 }, MemberType = typeof(Sources))]
         public static void GroupBy_ElementSelector_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_ElementSelector_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }, MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_ResultSelector(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -298,14 +298,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_ResultSelector_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_Unordered_ResultSelector(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }, MemberType = typeof(Sources))]
         public static void GroupBy_ResultSelector(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -322,14 +322,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 16 }, MemberType = typeof(Sources))]
         public static void GroupBy_ResultSelector_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_ResultSelector(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 7, 8, 15, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 7, 8, 15, 16 }, MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_ResultSelector_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -346,14 +346,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_ResultSelector_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_Unordered_ResultSelector_CustomComparator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }, MemberType = typeof(Sources))]
         public static void GroupBy_ResultSelector_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -370,14 +370,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 16 }, MemberType = typeof(Sources))]
         public static void GroupBy_ResultSelector_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_ResultSelector_CustomComparator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 7, 8, 15, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 7, 8, 15, 16 }, MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_ElementSelector_ResultSelector(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -395,14 +395,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_ElementSelector_ResultSelector_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_Unordered_ElementSelector_ResultSelector(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }, MemberType = typeof(Sources))]
         public static void GroupBy_ElementSelector_ResultSelector(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -419,7 +419,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 16 }, MemberType = typeof(Sources))]
         public static void GroupBy_ElementSelector_ResultSelector_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_ElementSelector_ResultSelector(labeled, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/GroupByTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/GroupByTests.cs
@@ -12,7 +12,7 @@ namespace System.Linq.Parallel.Tests
         private const int GroupFactor = 8;
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -34,7 +34,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_Unordered(labeled, count);
@@ -70,7 +70,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -88,7 +88,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_Unordered_NotPipelined(labeled, count);
@@ -120,7 +120,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -142,7 +142,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_Unordered_CustomComparator(labeled, count);
@@ -179,7 +179,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_ElementSelector(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -198,7 +198,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_ElementSelector_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_Unordered_ElementSelector(labeled, count);
@@ -230,7 +230,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_ElementSelector_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -249,7 +249,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_ElementSelector_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_Unordered_ElementSelector_NotPipelined(labeled, count);
@@ -281,7 +281,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, GroupFactor - 1, GroupFactor, GroupFactor * 2 - 1, GroupFactor * 2 }), MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_ResultSelector(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -298,7 +298,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_ResultSelector_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_Unordered_ResultSelector(labeled, count);
@@ -329,7 +329,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 7, 8, 15, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 7, 8, 15, 16 }), MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_ResultSelector_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -346,7 +346,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_ResultSelector_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_Unordered_ResultSelector_CustomComparator(labeled, count);
@@ -377,7 +377,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 7, 8, 15, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 7, 8, 15, 16 }), MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_ElementSelector_ResultSelector(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -395,7 +395,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
         public static void GroupBy_Unordered_ElementSelector_ResultSelector_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             GroupBy_Unordered_ElementSelector_ResultSelector(labeled, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/GroupJoinTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/GroupJoinTests.cs
@@ -25,7 +25,7 @@ namespace System.Linq.Parallel.Tests
         // GroupJoin
         //
         [Theory]
-        [MemberData(nameof(UnorderedSources.BinaryRanges), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.BinaryRanges), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 16 }, MemberType = typeof(UnorderedSources))]
         public static void GroupJoin_Unordered(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -48,14 +48,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.BinaryRanges), new int[] { 1024 * 4, 1024 * 8 }, new int[] { 0, 1, 1024 * 4, 1024 * 8 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.BinaryRanges), new[] { 1024 * 4, 1024 * 8 }, new[] { 0, 1, 1024 * 4, 1024 * 8 }, MemberType = typeof(UnorderedSources))]
         public static void GroupJoin_Unordered_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             GroupJoin_Unordered(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(GroupJoinData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 16 })]
+        [MemberData(nameof(GroupJoinData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 16 })]
         public static void GroupJoin(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -78,14 +78,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(GroupJoinData), new int[] { 1024 * 4, 1024 * 8 }, new int[] { 0, 1, 1024 * 4, 1024 * 8 })]
+        [MemberData(nameof(GroupJoinData), new[] { 1024 * 4, 1024 * 8 }, new[] { 0, 1, 1024 * 4, 1024 * 8 })]
         public static void GroupJoin_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             GroupJoin(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.BinaryRanges), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.BinaryRanges), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 16 }, MemberType = typeof(UnorderedSources))]
         public static void GroupJoin_Unordered_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -109,14 +109,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.BinaryRanges), new int[] { 1024 * 4, 1024 * 8 }, new int[] { 0, 1, 1024 * 4, 1024 * 8 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.BinaryRanges), new[] { 1024 * 4, 1024 * 8 }, new[] { 0, 1, 1024 * 4, 1024 * 8 }, MemberType = typeof(UnorderedSources))]
         public static void GroupJoin_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             GroupJoin_Unordered_NotPipelined(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(GroupJoinData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 16 })]
+        [MemberData(nameof(GroupJoinData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 16 })]
         public static void GroupJoin_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -140,14 +140,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(GroupJoinData), new int[] { 1024 * 4, 1024 * 8 }, new int[] { 0, 1, 1024 * 4, 1024 * 8 })]
+        [MemberData(nameof(GroupJoinData), new[] { 1024 * 4, 1024 * 8 }, new[] { 0, 1, 1024 * 4, 1024 * 8 })]
         public static void GroupJoin_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             GroupJoin_NotPipelined(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.BinaryRanges), new int[] { 0, 1, 2, 15, 16 }, new int[] { 0, 1, 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.BinaryRanges), new[] { 0, 1, 2, 15, 16 }, new[] { 0, 1, 16 }, MemberType = typeof(UnorderedSources))]
         public static void GroupJoin_Unordered_Multiple(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -173,14 +173,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.BinaryRanges), new int[] { 1024 * 4, 1024 * 8 }, new int[] { 0, 1, 1024 * 4, 1024 * 8 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.BinaryRanges), new[] { 1024 * 4, 1024 * 8 }, new[] { 0, 1, 1024 * 4, 1024 * 8 }, MemberType = typeof(UnorderedSources))]
         public static void GroupJoin_Unordered_Multiple_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             GroupJoin_Unordered_Multiple(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(GroupJoinData), new int[] { 0, 1, 2, 15, 16 }, new int[] { 0, 1, 16 })]
+        [MemberData(nameof(GroupJoinData), new[] { 0, 1, 2, 15, 16 }, new[] { 0, 1, 16 })]
         // GroupJoin doesn't always return elements from the right in order.  See Issue #1155
         public static void GroupJoin_Multiple(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
@@ -207,14 +207,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(GroupJoinData), new int[] { 1024 * 4, 1024 * 8 }, new int[] { 0, 1, 1024 * 4, 1024 * 8 })]
+        [MemberData(nameof(GroupJoinData), new[] { 1024 * 4, 1024 * 8 }, new[] { 0, 1, 1024 * 4, 1024 * 8 })]
         public static void GroupJoin_Multiple_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             GroupJoin_Multiple(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.BinaryRanges), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.BinaryRanges), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 16 }, MemberType = typeof(UnorderedSources))]
         public static void GroupJoin_Unordered_CustomComparator(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -240,14 +240,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.BinaryRanges), new int[] { 512, 1024 }, new int[] { 0, 1, 1024, 1024 * 4 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.BinaryRanges), new[] { 512, 1024 }, new[] { 0, 1, 1024, 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void GroupJoin_Unordered_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             GroupJoin_Unordered_CustomComparator(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(GroupJoinData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 16 })]
+        [MemberData(nameof(GroupJoinData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 16 })]
         public static void GroupJoin_CustomComparator(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -273,7 +273,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(GroupJoinData), new int[] { 512, 1024 }, new int[] { 0, 1, 1024, 1024 * 4 })]
+        [MemberData(nameof(GroupJoinData), new[] { 512, 1024 }, new[] { 0, 1, 1024, 1024 * 4 })]
         public static void GroupJoin_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             GroupJoin_CustomComparator(left, leftCount, right, rightCount);

--- a/src/System.Linq.Parallel/tests/QueryOperators/IntersectTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/IntersectTests.cs
@@ -35,7 +35,7 @@ namespace System.Linq.Parallel.Tests
             foreach (int leftCount in counts.Cast<int>())
             {
                 ParallelQuery<int> left = Enumerable.Range(0, leftCount * DuplicateFactor).Select(x => x % leftCount).ToArray().AsParallel().AsOrdered();
-                foreach (int rightCount in new int[] { 0, 1, Math.Max(DuplicateFactor * 2, leftCount), 2 * Math.Max(DuplicateFactor, leftCount * 2) })
+                foreach (int rightCount in new[] { 0, 1, Math.Max(DuplicateFactor * 2, leftCount), 2 * Math.Max(DuplicateFactor, leftCount * 2) })
                 {
                     int rightStart = 0 - rightCount / 2;
                     yield return new object[] { left, leftCount,
@@ -48,7 +48,7 @@ namespace System.Linq.Parallel.Tests
         // Intersect
         //
         [Theory]
-        [MemberData(nameof(IntersectUnorderedData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(IntersectUnorderedData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Intersect_Unordered(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int count)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -63,14 +63,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(IntersectUnorderedData), new int[] { 512, 1024 * 16 }, new int[] { 0, 1, 512, 1024 * 32 })]
+        [MemberData(nameof(IntersectUnorderedData), new[] { 512, 1024 * 16 }, new[] { 0, 1, 512, 1024 * 32 })]
         public static void Intersect_Unordered_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int count)
         {
             Intersect_Unordered(left, leftCount, right, rightCount, count);
         }
 
         [Theory]
-        [MemberData(nameof(IntersectData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(IntersectData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Intersect(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int count)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -85,14 +85,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(IntersectData), new int[] { 512, 1024 * 16 }, new int[] { 0, 1, 512, 1024 * 32 })]
+        [MemberData(nameof(IntersectData), new[] { 512, 1024 * 16 }, new[] { 0, 1, 512, 1024 * 32 })]
         public static void Intersect_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int count)
         {
             Intersect(left, leftCount, right, rightCount, count);
         }
 
         [Theory]
-        [MemberData(nameof(IntersectUnorderedData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(IntersectUnorderedData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Intersect_Unordered_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int count)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -104,14 +104,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(IntersectUnorderedData), new int[] { 512, 1024 * 16 }, new int[] { 0, 1, 512, 1024 * 32 })]
+        [MemberData(nameof(IntersectUnorderedData), new[] { 512, 1024 * 16 }, new[] { 0, 1, 512, 1024 * 32 })]
         public static void Intersect_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int count)
         {
             Intersect_Unordered_NotPipelined(left, leftCount, right, rightCount, count);
         }
 
         [Theory]
-        [MemberData(nameof(IntersectData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(IntersectData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Intersect_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int count)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -123,14 +123,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(IntersectData), new int[] { 512, 1024 * 16 }, new int[] { 0, 1, 512, 1024 * 32 })]
+        [MemberData(nameof(IntersectData), new[] { 512, 1024 * 16 }, new[] { 0, 1, 512, 1024 * 32 })]
         public static void Intersect_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int count)
         {
             Intersect_NotPipelined(left, leftCount, right, rightCount, count);
         }
 
         [Theory]
-        [MemberData(nameof(IntersectUnorderedData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(IntersectUnorderedData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Intersect_Unordered_Distinct(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int count)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -147,14 +147,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(IntersectUnorderedData), new int[] { 512, 1024 * 16 }, new int[] { 0, 1, 512, 1024 * 32 })]
+        [MemberData(nameof(IntersectUnorderedData), new[] { 512, 1024 * 16 }, new[] { 0, 1, 512, 1024 * 32 })]
         public static void Intersect_Unordered_Distinct_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int count)
         {
             Intersect_Unordered_Distinct(left, leftCount, right, rightCount, count);
         }
 
         [Theory]
-        [MemberData(nameof(IntersectData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(IntersectData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Intersect_Distinct(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int count)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -171,14 +171,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(IntersectData), new int[] { 512, 1024 * 16 }, new int[] { 0, 1, 512, 1024 * 32 })]
+        [MemberData(nameof(IntersectData), new[] { 512, 1024 * 16 }, new[] { 0, 1, 512, 1024 * 32 })]
         public static void Intersect_Distinct_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int count)
         {
             Intersect_Distinct(left, leftCount, right, rightCount, count);
         }
 
         [Theory]
-        [MemberData(nameof(IntersectUnorderedData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(IntersectUnorderedData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Intersect_Unordered_Distinct_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int count)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -192,14 +192,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(IntersectUnorderedData), new int[] { 512, 1024 * 16 }, new int[] { 0, 1, 512, 1024 * 32 })]
+        [MemberData(nameof(IntersectUnorderedData), new[] { 512, 1024 * 16 }, new[] { 0, 1, 512, 1024 * 32 })]
         public static void Intersect_Unordered_Distinct_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int count)
         {
             Intersect_Unordered_Distinct_NotPipelined(left, leftCount, right, rightCount, count);
         }
 
         [Theory]
-        [MemberData(nameof(IntersectData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(IntersectData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Intersect_Distinct_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int count)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -213,14 +213,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(IntersectData), new int[] { 512, 1024 * 16 }, new int[] { 0, 1, 512, 1024 * 32 })]
+        [MemberData(nameof(IntersectData), new[] { 512, 1024 * 16 }, new[] { 0, 1, 512, 1024 * 32 })]
         public static void Intersect_Distinct_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount, int count)
         {
             Intersect_Distinct_NotPipelined(left, leftCount, right, rightCount, count);
         }
 
         [Theory]
-        [MemberData(nameof(IntersectSourceMultipleData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(IntersectSourceMultipleData), new[] { 0, 1, 2, 16 })]
         public static void Intersect_Unordered_SourceMultiple(ParallelQuery<int> leftQuery, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int count)
         {
             // The difference between this test and the previous, is that it's not possible to
@@ -234,14 +234,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(IntersectSourceMultipleData), (object)(new int[] { 512, 1024 * 16 }))]
+        [MemberData(nameof(IntersectSourceMultipleData), new[] { 512, 1024 * 16 })]
         public static void Intersect_Unordered_SourceMultiple_Longrunning(ParallelQuery<int> leftQuery, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int count)
         {
             Intersect_Unordered_SourceMultiple(leftQuery, leftCount, rightQuery, rightCount, count);
         }
 
         [Theory]
-        [MemberData(nameof(IntersectSourceMultipleData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(IntersectSourceMultipleData), new[] { 0, 1, 2, 16 })]
         public static void Intersect_SourceMultiple(ParallelQuery<int> leftQuery, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int count)
         {
             int seen = 0;
@@ -251,7 +251,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(IntersectSourceMultipleData), (object)(new int[] { 512, 1024 * 16 }))]
+        [MemberData(nameof(IntersectSourceMultipleData), new[] { 512, 1024 * 16 })]
         public static void Intersect_SourceMultiple_Longrunning(ParallelQuery<int> leftQuery, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int count)
         {
             Intersect_SourceMultiple(leftQuery, leftCount, rightQuery, rightCount, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/JoinTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/JoinTests.cs
@@ -24,7 +24,7 @@ namespace System.Linq.Parallel.Tests
         // Join
         //
         [Theory]
-        [MemberData(nameof(UnorderedSources.BinaryRanges), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.BinaryRanges), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Join_Unordered(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -40,14 +40,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.BinaryRanges), new int[] { 1024 * 4, 1024 * 8 }, new int[] { 0, 1, 1024 * 8, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.BinaryRanges), new[] { 1024 * 4, 1024 * 8 }, new[] { 0, 1, 1024 * 8, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void Join_Unordered_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Join_Unordered(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(JoinData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 16 })]
+        [MemberData(nameof(JoinData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 16 })]
         public static void Join(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -63,14 +63,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(JoinData), new int[] { 1024 * 4, 1024 * 8 }, new int[] { 0, 1, 1024 * 8, 1024 * 16 })]
+        [MemberData(nameof(JoinData), new[] { 1024 * 4, 1024 * 8 }, new[] { 0, 1, 1024 * 8, 1024 * 16 })]
         public static void Join_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Join(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.BinaryRanges), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.BinaryRanges), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Join_Unordered_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -83,14 +83,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.BinaryRanges), new int[] { 1024 * 4, 1024 * 8 }, new int[] { 0, 1, 1024 * 8, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.BinaryRanges), new[] { 1024 * 4, 1024 * 8 }, new[] { 0, 1, 1024 * 8, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void Join_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Join_Unordered_NotPipelined(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(JoinData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 16 })]
+        [MemberData(nameof(JoinData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 16 })]
         public static void Join_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -103,14 +103,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(JoinData), new int[] { 1024 * 4, 1024 * 8 }, new int[] { 0, 1, 1024 * 8, 1024 * 16 })]
+        [MemberData(nameof(JoinData), new[] { 1024 * 4, 1024 * 8 }, new[] { 0, 1, 1024 * 8, 1024 * 16 })]
         public static void Join_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Join_NotPipelined(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.BinaryRanges), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.BinaryRanges), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Join_Unordered_Multiple(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -130,14 +130,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.BinaryRanges), new int[] { 1024 * 4, 1024 * 8 }, new int[] { 0, 1, 1024 * 8, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.BinaryRanges), new[] { 1024 * 4, 1024 * 8 }, new[] { 0, 1, 1024 * 8, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void Join_Unordered_Multiple_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Join_Unordered_Multiple(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(JoinData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 16 })]
+        [MemberData(nameof(JoinData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 16 })]
         // Join doesn't always return items from the right ordered.  See Issue #1155
         public static void Join_Multiple(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
@@ -165,14 +165,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(JoinData), new int[] { 1024 * 4, 1024 * 8 }, new int[] { 0, 1, 1024 * 8, 1024 * 16 })]
+        [MemberData(nameof(JoinData), new[] { 1024 * 4, 1024 * 8 }, new[] { 0, 1, 1024 * 8, 1024 * 16 })]
         public static void Join_Multiple_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Join_Multiple(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.BinaryRanges), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 16 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.BinaryRanges), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Join_Unordered_CustomComparator(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -202,14 +202,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.BinaryRanges), new int[] { 512, 1024 }, new int[] { 0, 1, 1024 }, MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.BinaryRanges), new[] { 512, 1024 }, new[] { 0, 1, 1024 }, MemberType = typeof(UnorderedSources))]
         public static void Join_Unordered_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Join_Unordered_CustomComparator(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(JoinData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 16 })]
+        [MemberData(nameof(JoinData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 16 })]
         public static void Join_CustomComparator(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -239,14 +239,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(JoinData), new int[] { 512, 1024 }, new int[] { 0, 1, 1024 })]
+        [MemberData(nameof(JoinData), new[] { 512, 1024 }, new[] { 0, 1, 1024 })]
         public static void Join_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Join_CustomComparator(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(JoinData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 16 })]
+        [MemberData(nameof(JoinData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 16 })]
         public static void Join_InnerJoin_Ordered(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -268,7 +268,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(JoinData), new int[] { 1024 * 4, 1024 * 8 }, new int[] { 0, 1, 1024 * 8, 1024 * 16 })]
+        [MemberData(nameof(JoinData), new[] { 1024 * 4, 1024 * 8 }, new[] { 0, 1, 1024 * 8, 1024 * 16 })]
         public static void Join_InnerJoin_Ordered_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Join_InnerJoin_Ordered(left, leftCount, right, rightCount);

--- a/src/System.Linq.Parallel/tests/QueryOperators/LastLastOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/LastLastOrDefaultTests.cs
@@ -26,8 +26,8 @@ namespace System.Linq.Parallel.Tests
         // Last and LastOrDefault
         //
         [Theory]
-        [MemberData(nameof(LastUnorderedData), (object)(new int[] { 1, 2, 16 }))]
-        [MemberData(nameof(LastData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(LastUnorderedData), new[] { 1, 2, 16 })]
+        [MemberData(nameof(LastData), new[] { 1, 2, 16 })]
         public static void Last(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             // For unordered collections, which element is chosen isn't actually guaranteed, but an effect of the implementation.
@@ -39,16 +39,16 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(LastUnorderedData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
-        [MemberData(nameof(LastData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
+        [MemberData(nameof(LastUnorderedData), new[] { 1024 * 4, 1024 * 1024 })]
+        [MemberData(nameof(LastData), new[] { 1024 * 4, 1024 * 1024 })]
         public static void Last_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             Last(labeled, count, position);
         }
 
         [Theory]
-        [MemberData(nameof(LastUnorderedData), (object)(new int[] { 1, 2, 16 }))]
-        [MemberData(nameof(LastData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(LastUnorderedData), new[] { 1, 2, 16 })]
+        [MemberData(nameof(LastData), new[] { 1, 2, 16 })]
         public static void LastOrDefault(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             // For unordered collections, which element is chosen isn't actually guaranteed, but an effect of the implementation.
@@ -60,16 +60,16 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(LastUnorderedData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
-        [MemberData(nameof(LastData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
+        [MemberData(nameof(LastUnorderedData), new[] { 1024 * 4, 1024 * 1024 })]
+        [MemberData(nameof(LastData), new[] { 1024 * 4, 1024 * 1024 })]
         public static void LastOrDefault_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             LastOrDefault(labeled, count, position);
         }
 
         [Theory]
-        [MemberData(nameof(LastUnorderedData), (object)(new int[] { 0 }))]
-        [MemberData(nameof(LastData), (object)(new int[] { 0 }))]
+        [MemberData(nameof(LastUnorderedData), new[] { 0 })]
+        [MemberData(nameof(LastData), new[] { 0 })]
         public static void Last_Empty(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -77,8 +77,8 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(LastUnorderedData), (object)(new int[] { 0 }))]
-        [MemberData(nameof(LastData), (object)(new int[] { 0 }))]
+        [MemberData(nameof(LastUnorderedData), new[] { 0 })]
+        [MemberData(nameof(LastData), new[] { 0 })]
         public static void LastOrDefault_Empty(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -86,8 +86,8 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(LastUnorderedData), (object)(new int[] { 1, 2, 16 }))]
-        [MemberData(nameof(LastData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(LastUnorderedData), new[] { 1, 2, 16 })]
+        [MemberData(nameof(LastData), new[] { 1, 2, 16 })]
         public static void Last_NoMatch(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -98,16 +98,16 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(LastUnorderedData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
-        [MemberData(nameof(LastData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
+        [MemberData(nameof(LastUnorderedData), new[] { 1024 * 4, 1024 * 1024 })]
+        [MemberData(nameof(LastData), new[] { 1024 * 4, 1024 * 1024 })]
         public static void Last_NoMatch_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             Last_NoMatch(labeled, count, position);
         }
 
         [Theory]
-        [MemberData(nameof(LastUnorderedData), (object)(new int[] { 1, 2, 16 }))]
-        [MemberData(nameof(LastData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(LastUnorderedData), new[] { 1, 2, 16 })]
+        [MemberData(nameof(LastData), new[] { 1, 2, 16 })]
         public static void LastOrDefault_NoMatch(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -118,15 +118,15 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(LastUnorderedData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
-        [MemberData(nameof(LastData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
+        [MemberData(nameof(LastUnorderedData), new[] { 1024 * 4, 1024 * 1024 })]
+        [MemberData(nameof(LastData), new[] { 1024 * 4, 1024 * 1024 })]
         public static void LastOrDefault_NoMatch_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int position)
         {
             LastOrDefault_NoMatch(labeled, count, position);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Last_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -140,7 +140,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Last_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.Last(x => { throw new DeliberateTestException(); }));

--- a/src/System.Linq.Parallel/tests/QueryOperators/LastLastOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/LastLastOrDefaultTests.cs
@@ -126,7 +126,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void Last_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -140,7 +140,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void Last_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.Last(x => { throw new DeliberateTestException(); }));

--- a/src/System.Linq.Parallel/tests/QueryOperators/MaxTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/MaxTests.cs
@@ -257,7 +257,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0 }), MemberType = typeof(UnorderedSources))]
         public static void Max_EmptyNullable(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Assert.Null(labeled.Item.Max(x => (int?)x));
@@ -269,7 +269,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0 }), MemberType = typeof(UnorderedSources))]
         public static void Max_InvalidOperationException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Assert.Throws<InvalidOperationException>(() => labeled.Item.Max());
@@ -281,7 +281,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void Max_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -306,7 +306,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void Max_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.Max((Func<int, int>)(x => { throw new DeliberateTestException(); })));
@@ -328,7 +328,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
         public static void Max_AggregateException_NotComparable(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<ArgumentException>(() => labeled.Item.Max(x => new NotComparable(x)));

--- a/src/System.Linq.Parallel/tests/QueryOperators/MaxTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/MaxTests.cs
@@ -25,7 +25,7 @@ namespace System.Linq.Parallel.Tests
         //
 
         [Theory]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Int(Labeled<ParallelQuery<int>> labeled, int count, int max)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -37,14 +37,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1024 * 32, 1024 * 1024 }))]
+        [MemberData(nameof(MaxData), new[] { 1024 * 32, 1024 * 1024 })]
         public static void Max_Int_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int max)
         {
             Max_Int(labeled, count, max);
         }
 
         [Theory]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Int_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, int max)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -53,7 +53,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Int_AllNull(Labeled<ParallelQuery<int>> labeled, int count, int max)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -62,7 +62,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Long(Labeled<ParallelQuery<int>> labeled, int count, long max)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -74,14 +74,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1024 * 32, 1024 * 1024 }))]
+        [MemberData(nameof(MaxData), new[] { 1024 * 32, 1024 * 1024 })]
         public static void Max_Long_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, long max)
         {
             Max_Long(labeled, count, max);
         }
 
         [Theory]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Long_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, long max)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -90,7 +90,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Long_AllNull(Labeled<ParallelQuery<int>> labeled, int count, long max)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -99,7 +99,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Float(Labeled<ParallelQuery<int>> labeled, int count, float max)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -113,14 +113,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1024 * 32, 1024 * 1024 }))]
+        [MemberData(nameof(MaxData), new[] { 1024 * 32, 1024 * 1024 })]
         public static void Max_Float_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, float max)
         {
             Max_Float(labeled, count, max);
         }
 
         [Theory]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Float_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, float max)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -129,7 +129,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Float_AllNull(Labeled<ParallelQuery<int>> labeled, int count, float max)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -138,7 +138,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Double(Labeled<ParallelQuery<int>> labeled, int count, double max)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -152,14 +152,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1024 * 32, 1024 * 1024 }))]
+        [MemberData(nameof(MaxData), new[] { 1024 * 32, 1024 * 1024 })]
         public static void Max_Double_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, double max)
         {
             Max_Double(labeled, count, max);
         }
 
         [Theory]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Double_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, double max)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -168,7 +168,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Double_AllNull(Labeled<ParallelQuery<int>> labeled, int count, double max)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -177,7 +177,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Decimal(Labeled<ParallelQuery<int>> labeled, int count, decimal max)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -189,14 +189,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1024 * 32, 1024 * 1024 }))]
+        [MemberData(nameof(MaxData), new[] { 1024 * 32, 1024 * 1024 })]
         public static void Max_Decimal_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, decimal max)
         {
             Max_Decimal(labeled, count, max);
         }
 
         [Theory]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Decimal_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, decimal max)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -205,7 +205,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Decimal_AllNull(Labeled<ParallelQuery<int>> labeled, int count, decimal max)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -214,7 +214,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Other(Labeled<ParallelQuery<int>> labeled, int count, int max)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -224,14 +224,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1024 * 32, 1024 * 1024 }))]
+        [MemberData(nameof(MaxData), new[] { 1024 * 32, 1024 * 1024 })]
         public static void Max_Other_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int max)
         {
             Max_Other(labeled, count, max);
         }
 
         [Theory]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1, }))]
+        [MemberData(nameof(MaxData), new[] { 1 })]
         public static void Max_NotComparable(Labeled<ParallelQuery<int>> labeled, int count, int max)
         {
             NotComparable a = new NotComparable(0);
@@ -239,7 +239,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Other_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, int max)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -248,7 +248,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MaxData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MaxData), new[] { 1, 2, 16 })]
         public static void Max_Other_AllNull(Labeled<ParallelQuery<int>> labeled, int count, int max)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -257,7 +257,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0 }, MemberType = typeof(UnorderedSources))]
         public static void Max_EmptyNullable(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Assert.Null(labeled.Item.Max(x => (int?)x));
@@ -269,7 +269,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0 }, MemberType = typeof(UnorderedSources))]
         public static void Max_InvalidOperationException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Assert.Throws<InvalidOperationException>(() => labeled.Item.Max());
@@ -281,7 +281,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Max_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -306,7 +306,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Max_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.Max((Func<int, int>)(x => { throw new DeliberateTestException(); })));
@@ -328,7 +328,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void Max_AggregateException_NotComparable(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<ArgumentException>(() => labeled.Item.Max(x => new NotComparable(x)));

--- a/src/System.Linq.Parallel/tests/QueryOperators/MinTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/MinTests.cs
@@ -290,7 +290,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0 }), MemberType = typeof(UnorderedSources))]
         public static void Min_EmptyNullable(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Assert.Null(labeled.Item.Min(x => (int?)x));
@@ -302,7 +302,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0 }), MemberType = typeof(UnorderedSources))]
         public static void Min_InvalidOperationException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Assert.Throws<InvalidOperationException>(() => labeled.Item.Min());
@@ -314,7 +314,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void Min_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -339,7 +339,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void Min_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.Min((Func<int, int>)(x => { throw new DeliberateTestException(); })));
@@ -361,7 +361,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
         public static void Min_AggregateException_NotComparable(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<ArgumentException>(() => labeled.Item.Min(x => new NotComparable(x)));

--- a/src/System.Linq.Parallel/tests/QueryOperators/MinTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/MinTests.cs
@@ -24,7 +24,7 @@ namespace System.Linq.Parallel.Tests
         // Min
         //
         [Theory]
-        [MemberData(nameof(MinData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Int(Labeled<ParallelQuery<int>> labeled, int count, int min)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -36,14 +36,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(MinData), (object)(new int[] { 1024 * 32, 1024 * 1024 }))]
+        [MemberData(nameof(MinData), new[] { 1024 * 32, 1024 * 1024 })]
         public static void Min_Int_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int min)
         {
             Min_Int(labeled, count, min);
         }
 
         [Theory]
-        [MemberData(nameof(MinData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Int_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, int min)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -52,7 +52,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MinData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Int_AllNull(Labeled<ParallelQuery<int>> labeled, int count, int min)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -61,7 +61,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MinData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Long(Labeled<ParallelQuery<int>> labeled, int count, long min)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -73,14 +73,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(MinData), (object)(new int[] { 1024 * 32, 1024 * 1024 }))]
+        [MemberData(nameof(MinData), new[] { 1024 * 32, 1024 * 1024 })]
         public static void Min_Long_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, long min)
         {
             Min_Long(labeled, count, min);
         }
 
         [Theory]
-        [MemberData(nameof(MinData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Long_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, long min)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -89,7 +89,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MinData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Long_AllNull(Labeled<ParallelQuery<int>> labeled, int count, long min)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -98,7 +98,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MinData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Float(Labeled<ParallelQuery<int>> labeled, int count, float min)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -114,14 +114,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(MinData), (object)(new int[] { 1024 * 32, 1024 * 1024 }))]
+        [MemberData(nameof(MinData), new[] { 1024 * 32, 1024 * 1024 })]
         public static void Min_Float_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, float min)
         {
             Min_Float(labeled, count, min);
         }
 
         [Theory]
-        [MemberData(nameof(MinData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Float_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, float min)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -130,7 +130,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MinData), (object)(new int[] { 3 }))]
+        [MemberData(nameof(MinData), new[] { 3 })]
         public static void Min_Float_Special(Labeled<ParallelQuery<int>> labeled, int count, float min)
         {
             // Null is defined as 'least' when ordered, but is not the minimum.
@@ -145,7 +145,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MinData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Float_AllNull(Labeled<ParallelQuery<int>> labeled, int count, float min)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -154,7 +154,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MinData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Double(Labeled<ParallelQuery<int>> labeled, int count, double min)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -170,14 +170,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(MinData), (object)(new int[] { 1024 * 32, 1024 * 1024 }))]
+        [MemberData(nameof(MinData), new[] { 1024 * 32, 1024 * 1024 })]
         public static void Min_Double_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, double min)
         {
             Min_Double(labeled, count, min);
         }
 
         [Theory]
-        [MemberData(nameof(MinData), (object)(new int[] { 3 }))]
+        [MemberData(nameof(MinData), new[] { 3 })]
         public static void Min_Double_Special(Labeled<ParallelQuery<int>> labeled, int count, double min)
         {
             // Null is defined as 'least' when ordered, but is not the minimum.
@@ -192,7 +192,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MinData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Double_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, double min)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -201,7 +201,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MinData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Double_AllNull(Labeled<ParallelQuery<int>> labeled, int count, double min)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -210,7 +210,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MinData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Decimal(Labeled<ParallelQuery<int>> labeled, int count, decimal min)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -222,14 +222,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(MinData), (object)(new int[] { 1024 * 32, 1024 * 1024 }))]
+        [MemberData(nameof(MinData), new[] { 1024 * 32, 1024 * 1024 })]
         public static void Min_Decimal_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, decimal min)
         {
             Min_Decimal(labeled, count, min);
         }
 
         [Theory]
-        [MemberData(nameof(MinData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Decimal_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, decimal min)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -238,7 +238,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MinData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Decimal_AllNull(Labeled<ParallelQuery<int>> labeled, int count, decimal min)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -247,7 +247,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MinData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Other(Labeled<ParallelQuery<int>> labeled, int count, int min)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -257,14 +257,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(MinData), (object)(new int[] { 1024 * 32, 1024 * 1024 }))]
+        [MemberData(nameof(MinData), new[] { 1024 * 32, 1024 * 1024 })]
         public static void Min_Other_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int min)
         {
             Min_Other(labeled, count, min);
         }
 
         [Theory]
-        [MemberData(nameof(MinData), (object)(new int[] { 1, }))]
+        [MemberData(nameof(MinData), new[] { 1 })]
         public static void Min_NotComparable(Labeled<ParallelQuery<int>> labeled, int count, int min)
         {
             NotComparable a = new NotComparable(0);
@@ -272,7 +272,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MinData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Other_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, int min)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -281,7 +281,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(MinData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(MinData), new[] { 1, 2, 16 })]
         public static void Min_Other_AllNull(Labeled<ParallelQuery<int>> labeled, int count, int min)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -290,7 +290,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0 }, MemberType = typeof(UnorderedSources))]
         public static void Min_EmptyNullable(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Assert.Null(labeled.Item.Min(x => (int?)x));
@@ -302,7 +302,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0 }, MemberType = typeof(UnorderedSources))]
         public static void Min_InvalidOperationException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Assert.Throws<InvalidOperationException>(() => labeled.Item.Min());
@@ -314,7 +314,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Min_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -339,7 +339,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Min_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.Min((Func<int, int>)(x => { throw new DeliberateTestException(); })));
@@ -361,7 +361,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void Min_AggregateException_NotComparable(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<ArgumentException>(() => labeled.Item.Min(x => new NotComparable(x)));

--- a/src/System.Linq.Parallel/tests/QueryOperators/OfTypeTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/OfTypeTests.cs
@@ -9,7 +9,7 @@ namespace System.Linq.Parallel.Tests
     public class OfTypeTests
     {
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OfType_Unordered_AllValid(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -23,7 +23,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(UnorderedSources))]
         public static void OfType_Unordered_AllValid_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OfType_Unordered_AllValid(labeled, count);
@@ -51,7 +51,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OfType_Unordered_AllValid_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -62,7 +62,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(UnorderedSources))]
         public static void OfType_Unordered_AllValid_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OfType_Unordered_AllValid_NotPipelined(labeled, count);
@@ -88,7 +88,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OfType_NoneValid(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -98,7 +98,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(UnorderedSources))]
         public static void OfType_NoneValid_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OfType_NoneValid(labeled, count);
@@ -106,7 +106,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OfType_NoneValid_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -116,14 +116,14 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(UnorderedSources))]
         public static void OfType_NoneValid_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OfType_NoneValid_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OfType_Unordered_SomeValid(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -137,7 +137,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(UnorderedSources))]
         public static void OfType_Unordered_SomeValid_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OfType_Unordered_SomeValid(labeled, count);
@@ -165,7 +165,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OfType_Unordered_SomeValid_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -176,7 +176,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(UnorderedSources))]
         public static void OfType_Unordered_SomeValid_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OfType_Unordered_SomeValid_NotPipelined(labeled, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/OfTypeTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/OfTypeTests.cs
@@ -9,7 +9,7 @@ namespace System.Linq.Parallel.Tests
     public class OfTypeTests
     {
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OfType_Unordered_AllValid(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -23,14 +23,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 256 }, MemberType = typeof(UnorderedSources))]
         public static void OfType_Unordered_AllValid_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OfType_Unordered_AllValid(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void OfType_AllValid(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -44,14 +44,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 256 }, MemberType = typeof(Sources))]
         public static void OfType_AllValid_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OfType_AllValid(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OfType_Unordered_AllValid_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -62,14 +62,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 256 }, MemberType = typeof(UnorderedSources))]
         public static void OfType_Unordered_AllValid_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OfType_Unordered_AllValid_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void OfType_AllValid_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -80,15 +80,15 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 256 }, MemberType = typeof(Sources))]
         public static void OfType_AllValid_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OfType_AllValid_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OfType_NoneValid(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -97,16 +97,16 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 256 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 256 }, MemberType = typeof(UnorderedSources))]
         public static void OfType_NoneValid_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OfType_NoneValid(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OfType_NoneValid_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -115,15 +115,15 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 256 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 256 }, MemberType = typeof(UnorderedSources))]
         public static void OfType_NoneValid_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OfType_NoneValid_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OfType_Unordered_SomeValid(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -137,14 +137,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 256 }, MemberType = typeof(UnorderedSources))]
         public static void OfType_Unordered_SomeValid_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OfType_Unordered_SomeValid(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void OfType_SomeValid(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -158,14 +158,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 256 }, MemberType = typeof(Sources))]
         public static void OfType_SomeValid_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OfType_SomeValid(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OfType_Unordered_SomeValid_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -176,14 +176,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 256 }, MemberType = typeof(UnorderedSources))]
         public static void OfType_Unordered_SomeValid_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OfType_Unordered_SomeValid_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void OfType_SomeValid_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -194,14 +194,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 256 }, MemberType = typeof(Sources))]
         public static void OfType_SomeValid_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OfType_SomeValid_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void OfType_SomeInvalidNull(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -212,14 +212,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 256 }, MemberType = typeof(Sources))]
         public static void OfType_SomeInvalidNull_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OfType_SomeInvalidNull(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void OfType_SomeValidNull(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -237,14 +237,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 256 }, MemberType = typeof(Sources))]
         public static void OfType_SomeValidNull_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OfType_SomeValidNull(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void OfType_SomeNull(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -262,7 +262,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 256 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 256 }, MemberType = typeof(Sources))]
         public static void OfType_SomeNull_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OfType_SomeNull(labeled, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/OrderByThenByTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/OrderByThenByTests.cs
@@ -64,7 +64,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OrderBy(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -82,7 +82,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void OrderBy_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderBy(labeled, count);
@@ -91,7 +91,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OrderBy_Reversed(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -109,7 +109,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void OrderBy_Reversed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderBy_Reversed(labeled, count);
@@ -118,7 +118,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -136,7 +136,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderByDescending(labeled, count);
@@ -145,7 +145,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_Reversed(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -163,7 +163,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_Reversed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderByDescending_Reversed(labeled, count);
@@ -172,7 +172,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OrderBy_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -185,7 +185,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void OrderBy_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderBy_NotPipelined(labeled, count);
@@ -194,7 +194,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OrderBy_Reversed_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -207,7 +207,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void OrderBy_Reversed_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderBy_Reversed_NotPipelined(labeled, count);
@@ -216,7 +216,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -229,7 +229,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderByDescending_NotPipelined(labeled, count);
@@ -238,7 +238,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_Reversed_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -251,7 +251,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_Reversed_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderByDescending_Reversed_NotPipelined(labeled, count);
@@ -260,7 +260,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OrderBy_CustomComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -278,7 +278,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void OrderBy_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderBy_CustomComparer(labeled, count);
@@ -287,7 +287,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_CustomComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -305,7 +305,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderByDescending_CustomComparer(labeled, count);
@@ -314,7 +314,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OrderBy_NotPipelined_CustomComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -327,7 +327,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void OrderBy_NotPipelined_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderBy_NotPipelined_CustomComparer(labeled, count);
@@ -336,7 +336,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_NotPipelined_CustomComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -349,7 +349,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_NotPipelined_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderByDescending_NotPipelined_CustomComparer(labeled, count);
@@ -358,7 +358,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         // Regression test for the PLINQ version of #2239 - comparer returning max/min value.
         public static void OrderBy_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
@@ -373,7 +373,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         // Regression test for the PLINQ version of #2239 - comparer returning max/min value.
         public static void OrderByDescending_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
@@ -388,7 +388,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OrderBy_NotPipelined_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -398,7 +398,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_NotPipelined_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -408,7 +408,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 2 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
         public static void OrderBy_NotComparable(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item.OrderBy(x => new NotComparable(x));
@@ -419,7 +419,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OrderBy_NotComparable_Comparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -434,7 +434,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OrderBy_NotPipelined_NotComparable_Comparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -445,7 +445,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 2 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_NotComparable(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item.OrderByDescending(x => new NotComparable(x));
@@ -456,7 +456,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_NotComparable_Comparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -471,7 +471,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_NotPipelined_NotComparable_Comparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -531,7 +531,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenBy(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = 0;
@@ -556,7 +556,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void ThenBy_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy(labeled, count);
@@ -565,7 +565,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenBy_Reversed(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = GroupFactor - 1;
@@ -590,7 +590,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void ThenBy_Reversed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy_Reversed(labeled, count);
@@ -599,7 +599,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = GroupFactor - 1;
@@ -624,7 +624,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending(labeled, count);
@@ -633,7 +633,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_Reversed(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = 0;
@@ -658,7 +658,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_Reversed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending_Reversed(labeled, count);
@@ -667,7 +667,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenBy_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = 0;
@@ -693,7 +693,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void ThenBy_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy_NotPipelined(labeled, count);
@@ -702,7 +702,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenBy_Reversed_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = GroupFactor - 1;
@@ -728,7 +728,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void ThenBy_Reversed_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy_Reversed_NotPipelined(labeled, count);
@@ -737,7 +737,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = GroupFactor - 1;
@@ -763,7 +763,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending_NotPipelined(labeled, count);
@@ -772,7 +772,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_Reversed_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = 0;
@@ -798,7 +798,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_Reversed_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending_Reversed_NotPipelined(labeled, count);
@@ -807,7 +807,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenBy_CustomComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = 0;
@@ -832,7 +832,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void ThenBy_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy_CustomComparer(labeled, count);
@@ -841,7 +841,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_CustomComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = GroupFactor - 1;
@@ -866,7 +866,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending_CustomComparer(labeled, count);
@@ -875,7 +875,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenBy_NotPipelined_CustomComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = 0;
@@ -901,7 +901,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void ThenBy_NotPipelined_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy_NotPipelined_CustomComparer(labeled, count);
@@ -910,7 +910,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_NotPipelined_CustomComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = GroupFactor - 1;
@@ -936,7 +936,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_NotPipelined_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending_NotPipelined_CustomComparer(labeled, count);
@@ -945,7 +945,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         // Regression test for the PLINQ version of #2239 - comparer returning max/min value.
         public static void ThenBy_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
@@ -960,7 +960,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         // Regression test for the PLINQ version of #2239 - comparer returning max/min value.
         public static void ThenByDescending_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
@@ -974,7 +974,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenBy_NotPipelined_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -984,7 +984,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_NotPipelined_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -997,7 +997,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenBy_ThenBy(Labeled<ParallelQuery<int>> labeled, int count)
         {
             var prev = KeyValuePair.Create(0, KeyValuePair.Create(0, 0));
@@ -1016,7 +1016,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void ThenBy_ThenBy_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy_ThenBy(labeled, count);
@@ -1025,7 +1025,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_ThenByDescending(Labeled<ParallelQuery<int>> labeled, int count)
         {
             var prev = KeyValuePair.Create(GroupFactor - 1, KeyValuePair.Create(KeyFactor - 1, count - 1));
@@ -1044,7 +1044,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_ThenByDescending_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending_ThenByDescending(labeled, count);
@@ -1053,7 +1053,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenBy_ThenBy_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             var prev = KeyValuePair.Create(0, KeyValuePair.Create(0, 0));
@@ -1073,7 +1073,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void ThenBy_ThenBy_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy_ThenBy_NotPipelined(labeled, count);
@@ -1082,7 +1082,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_ThenByDescending_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             var prev = KeyValuePair.Create(GroupFactor - 1, KeyValuePair.Create(KeyFactor - 1, count - 1));
@@ -1102,7 +1102,7 @@ namespace System.Linq.Parallel.Tests
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_ThenByDescending_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending_ThenByDescending_NotPipelined(labeled, count);
@@ -1111,7 +1111,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 2 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
         public static void ThenBy_NotComparable(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item.OrderBy(x => 0).ThenBy(x => new NotComparable(x));
@@ -1122,7 +1122,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenBy_NotComparable_Comparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -1137,7 +1137,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenBy_NotPipelined_NotComparable_Comparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -1148,7 +1148,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 2 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_NotComparable(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item.OrderBy(x => 0).ThenByDescending(x => new NotComparable(x));
@@ -1159,7 +1159,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_NotComparable_Comparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -1174,7 +1174,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
         [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_NotPipelined_NotComparable_Comparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -1206,7 +1206,7 @@ namespace System.Linq.Parallel.Tests
         //
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void StableSort(Labeled<ParallelQuery<int>> labeled, int count)
         {
             var prev = KeyValuePair.Create(0, KeyValuePair.Create(0, 0));
@@ -1228,7 +1228,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void StableSort_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             StableSort(labeled, count);
@@ -1236,7 +1236,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void StableSort_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             var prev = KeyValuePair.Create(0, KeyValuePair.Create(0, 0));
@@ -1259,7 +1259,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void StableSort_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             StableSort_NotPipelined(labeled, count);
@@ -1267,7 +1267,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void StableSort_Descending(Labeled<ParallelQuery<int>> labeled, int count)
         {
             var prev = KeyValuePair.Create(count, KeyValuePair.Create(count, count / GroupFactor));
@@ -1290,7 +1290,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void StableSort_Descending_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             StableSort_Descending(labeled, count);
@@ -1298,7 +1298,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void StableSort_Descending_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             var prev = KeyValuePair.Create(count, KeyValuePair.Create(count, count / GroupFactor));
@@ -1321,7 +1321,7 @@ namespace System.Linq.Parallel.Tests
         [Theory]
         [OuterLoop]
         [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
         public static void StableSort_Descending_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             StableSort_Descending_NotPipelined(labeled, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/OrderByThenByTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/OrderByThenByTests.cs
@@ -62,9 +62,9 @@ namespace System.Linq.Parallel.Tests
         // OrderBy
         //
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -80,18 +80,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderBy(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_Reversed(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -107,18 +107,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_Reversed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderBy_Reversed(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -134,18 +134,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderByDescending(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_Reversed(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -161,18 +161,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_Reversed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderByDescending_Reversed(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -183,18 +183,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderBy_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_Reversed_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -205,18 +205,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_Reversed_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderBy_Reversed_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -227,18 +227,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderByDescending_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_Reversed_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -249,18 +249,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_Reversed_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderByDescending_Reversed_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_CustomComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -276,18 +276,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderBy_CustomComparer(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_CustomComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -303,18 +303,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderByDescending_CustomComparer(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_NotPipelined_CustomComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -325,18 +325,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_NotPipelined_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderBy_NotPipelined_CustomComparer(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_NotPipelined_CustomComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -347,18 +347,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_NotPipelined_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             OrderByDescending_NotPipelined_CustomComparer(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         // Regression test for the PLINQ version of #2239 - comparer returning max/min value.
         public static void OrderBy_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
@@ -371,9 +371,9 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         // Regression test for the PLINQ version of #2239 - comparer returning max/min value.
         public static void OrderByDescending_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
@@ -386,9 +386,9 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_NotPipelined_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -396,9 +396,9 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_NotPipelined_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -406,9 +406,9 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 2 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 2 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 2 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_NotComparable(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item.OrderBy(x => new NotComparable(x));
@@ -417,9 +417,9 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_NotComparable_Comparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -432,9 +432,9 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OrderBy_NotPipelined_NotComparable_Comparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -443,9 +443,9 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 2 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 2 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 2 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_NotComparable(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item.OrderByDescending(x => new NotComparable(x));
@@ -454,9 +454,9 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_NotComparable_Comparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -469,9 +469,9 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void OrderByDescending_NotPipelined_NotComparable_Comparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -529,9 +529,9 @@ namespace System.Linq.Parallel.Tests
         // Thenby
         //
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = 0;
@@ -554,18 +554,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_Reversed(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = GroupFactor - 1;
@@ -588,18 +588,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_Reversed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy_Reversed(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = GroupFactor - 1;
@@ -622,18 +622,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_Reversed(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = 0;
@@ -656,18 +656,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_Reversed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending_Reversed(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = 0;
@@ -691,18 +691,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_Reversed_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = GroupFactor - 1;
@@ -726,18 +726,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_Reversed_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy_Reversed_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = GroupFactor - 1;
@@ -761,18 +761,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_Reversed_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = 0;
@@ -796,18 +796,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_Reversed_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending_Reversed_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_CustomComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = 0;
@@ -830,18 +830,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy_CustomComparer(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_CustomComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = GroupFactor - 1;
@@ -864,18 +864,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending_CustomComparer(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_NotPipelined_CustomComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = 0;
@@ -899,18 +899,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_NotPipelined_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy_NotPipelined_CustomComparer(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_NotPipelined_CustomComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prevPrimary = GroupFactor - 1;
@@ -934,18 +934,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_NotPipelined_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending_NotPipelined_CustomComparer(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         // Regression test for the PLINQ version of #2239 - comparer returning max/min value.
         public static void ThenBy_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
@@ -958,9 +958,9 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         // Regression test for the PLINQ version of #2239 - comparer returning max/min value.
         public static void ThenByDescending_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
@@ -973,8 +973,8 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_NotPipelined_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -982,9 +982,9 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_NotPipelined_ExtremeComparer(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -995,9 +995,9 @@ namespace System.Linq.Parallel.Tests
         // Due to the use of randomized input, cycles will not start with a known input (and may skip values, etc).
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_ThenBy(Labeled<ParallelQuery<int>> labeled, int count)
         {
             var prev = KeyValuePair.Create(0, KeyValuePair.Create(0, 0));
@@ -1014,18 +1014,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_ThenBy_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy_ThenBy(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_ThenByDescending(Labeled<ParallelQuery<int>> labeled, int count)
         {
             var prev = KeyValuePair.Create(GroupFactor - 1, KeyValuePair.Create(KeyFactor - 1, count - 1));
@@ -1042,18 +1042,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_ThenByDescending_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending_ThenByDescending(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_ThenBy_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             var prev = KeyValuePair.Create(0, KeyValuePair.Create(0, 0));
@@ -1071,18 +1071,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_ThenBy_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenBy_ThenBy_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_ThenByDescending_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             var prev = KeyValuePair.Create(GroupFactor - 1, KeyValuePair.Create(KeyFactor - 1, count - 1));
@@ -1100,18 +1100,18 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 1024, 1024 * 32 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 1024, 1024 * 32 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_ThenByDescending_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ThenByDescending_ThenByDescending_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 2 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 2 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 2 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_NotComparable(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item.OrderBy(x => 0).ThenBy(x => new NotComparable(x));
@@ -1120,9 +1120,9 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_NotComparable_Comparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -1135,9 +1135,9 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenBy_NotPipelined_NotComparable_Comparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = 0;
@@ -1146,9 +1146,9 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 2 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 2 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 2 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_NotComparable(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item.OrderBy(x => 0).ThenByDescending(x => new NotComparable(x));
@@ -1157,9 +1157,9 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_NotComparable_Comparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -1172,9 +1172,9 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(OrderByRandomData), (object)(new[] { 0, 1, 2, 16 }))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(OrderByRandomData), new[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ThenByDescending_NotPipelined_NotComparable_Comparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             int prev = count - 1;
@@ -1205,8 +1205,8 @@ namespace System.Linq.Parallel.Tests
         // Ensures that indices issued during a query are stable, **not** that OrderBy returns a stable result on its own (it does not).
         //
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void StableSort(Labeled<ParallelQuery<int>> labeled, int count)
         {
             var prev = KeyValuePair.Create(0, KeyValuePair.Create(0, 0));
@@ -1227,16 +1227,16 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void StableSort_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             StableSort(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void StableSort_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             var prev = KeyValuePair.Create(0, KeyValuePair.Create(0, 0));
@@ -1258,16 +1258,16 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void StableSort_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             StableSort_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void StableSort_Descending(Labeled<ParallelQuery<int>> labeled, int count)
         {
             var prev = KeyValuePair.Create(count, KeyValuePair.Create(count, count / GroupFactor));
@@ -1289,16 +1289,16 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void StableSort_Descending_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             StableSort_Descending(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void StableSort_Descending_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             var prev = KeyValuePair.Create(count, KeyValuePair.Create(count, count / GroupFactor));
@@ -1320,8 +1320,8 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(Sources))]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 32 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(Sources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 32 }, MemberType = typeof(UnorderedSources))]
         public static void StableSort_Descending_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             StableSort_Descending_NotPipelined(labeled, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/ReverseTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ReverseTests.cs
@@ -9,7 +9,7 @@ namespace System.Linq.Parallel.Tests
     public class ReverseTests
     {
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Reverse_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -23,7 +23,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(UnorderedSources))]
         public static void Reverse_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Reverse_Unordered(labeled, count);
@@ -51,7 +51,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Reverse_Unordered_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -62,7 +62,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(UnorderedSources))]
         public static void Reverse_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Reverse_Unordered_NotPipelined(labeled, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/ReverseTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ReverseTests.cs
@@ -9,7 +9,7 @@ namespace System.Linq.Parallel.Tests
     public class ReverseTests
     {
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Reverse_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -23,14 +23,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 512 }, MemberType = typeof(UnorderedSources))]
         public static void Reverse_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Reverse_Unordered(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void Reverse(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -44,14 +44,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 512 }, MemberType = typeof(Sources))]
         public static void Reverse_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Reverse(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Reverse_Unordered_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -62,14 +62,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 512 }, MemberType = typeof(UnorderedSources))]
         public static void Reverse_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Reverse_Unordered_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void Reverse_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -80,7 +80,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 512 }, MemberType = typeof(Sources))]
         public static void Reverse_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Reverse_NotPipelined(labeled, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/SelectSelectManyTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SelectSelectManyTests.cs
@@ -10,7 +10,7 @@ namespace System.Linq.Parallel.Tests
     public class SelectSelectManyTests
     {
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Select_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -25,14 +25,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Select_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Select_Unordered(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void Select(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -47,14 +47,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 4 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 4 }, MemberType = typeof(Sources))]
         public static void Select_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Select(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Select_Unordered_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -66,14 +66,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Select_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Select_Unordered_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void Select_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -89,7 +89,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 4 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 4 }, MemberType = typeof(Sources))]
         public static void Select_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Select_NotPipelined(labeled, count);
@@ -100,7 +100,7 @@ namespace System.Linq.Parallel.Tests
         // larger input sizes increases the probability that it will.
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Select_Indexed_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             // For unordered collections, which element is at which index isn't actually guaranteed, but an effect of the implementation.
@@ -117,14 +117,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Select_Indexed_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Select_Indexed_Unordered(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void Select_Indexed(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -139,14 +139,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 4 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 4 }, MemberType = typeof(Sources))]
         public static void Select_Indexed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Select_Unordered(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Select_Indexed_Unordered_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             // For unordered collections, which element is at which index isn't actually guaranteed, but an effect of the implementation.
@@ -164,14 +164,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024, 1024 * 4 }, MemberType = typeof(UnorderedSources))]
         public static void Select_Indexed_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Select_Indexed_Unordered_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void Select_Indexed_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -187,7 +187,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 4 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024, 1024 * 4 }, MemberType = typeof(Sources))]
         public static void Select_Indexed_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Select_Indexed_NotPipelined(labeled, count);
@@ -242,7 +242,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SelectManyUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SelectManyUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void SelectMany_Unordered(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -257,14 +257,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SelectManyUnorderedData), (object)(new int[] { 1024, 1024 * 4 }))]
+        [MemberData(nameof(SelectManyUnorderedData), new[] { 1024, 1024 * 4 })]
         public static void SelectMany_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             SelectMany_Unordered(labeled, count, expander, expansion);
         }
 
         [Theory]
-        [MemberData(nameof(SelectManyData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SelectManyData), new[] { 0, 1, 2, 16 })]
         public static void SelectMany(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -279,14 +279,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SelectManyData), (object)(new int[] { 1024, 1024 * 4 }))]
+        [MemberData(nameof(SelectManyData), new[] { 1024, 1024 * 4 })]
         public static void SelectMany_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             SelectMany(labeled, count, expander, expansion);
         }
 
         [Theory]
-        [MemberData(nameof(SelectManyUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SelectManyUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void SelectMany_Unordered_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -298,14 +298,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SelectManyUnorderedData), (object)(new int[] { 1024, 1024 * 4 }))]
+        [MemberData(nameof(SelectManyUnorderedData), new[] { 1024, 1024 * 4 })]
         public static void SelectMany_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             SelectMany_Unordered_NotPipelined(labeled, count, expander, expansion);
         }
 
         [Theory]
-        [MemberData(nameof(SelectManyData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SelectManyData), new[] { 0, 1, 2, 16 })]
         public static void SelectMany_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -317,14 +317,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SelectManyData), (object)(new int[] { 1024, 1024 * 4 }))]
+        [MemberData(nameof(SelectManyData), new[] { 1024, 1024 * 4 })]
         public static void SelectMany_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             SelectMany_NotPipelined(labeled, count, expander, expansion);
         }
 
         [Theory]
-        [MemberData(nameof(SelectManyUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SelectManyUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void SelectMany_Unordered_ResultSelector(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -340,14 +340,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SelectManyUnorderedData), (object)(new int[] { 1024, 1024 * 4 }))]
+        [MemberData(nameof(SelectManyUnorderedData), new[] { 1024, 1024 * 4 })]
         public static void SelectMany_Unordered_ResultSelector_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             SelectMany_Unordered_ResultSelector(labeled, count, expander, expansion);
         }
 
         [Theory]
-        [MemberData(nameof(SelectManyUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SelectManyUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void SelectMany_Unordered_ResultSelector_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -364,14 +364,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SelectManyUnorderedData), (object)(new int[] { 1024, 1024 * 4 }))]
+        [MemberData(nameof(SelectManyUnorderedData), new[] { 1024, 1024 * 4 })]
         public static void SelectMany_Unordered_ResultSelector_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             SelectMany_Unordered_ResultSelector_NotPipelined(labeled, count, expander, expansion);
         }
 
         [Theory]
-        [MemberData(nameof(SelectManyData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SelectManyData), new[] { 0, 1, 2, 16 })]
         public static void SelectMany_ResultSelector(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -387,14 +387,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SelectManyData), (object)(new int[] { 1024, 1024 * 4 }))]
+        [MemberData(nameof(SelectManyData), new[] { 1024, 1024 * 4 })]
         public static void SelectMany_ResultSelector_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             SelectMany_ResultSelector(labeled, count, expander, expansion);
         }
 
         [Theory]
-        [MemberData(nameof(SelectManyData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SelectManyData), new[] { 0, 1, 2, 16 })]
         public static void SelectMany_ResultSelector_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -411,14 +411,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SelectManyData), (object)(new int[] { 1024, 1024 * 4 }))]
+        [MemberData(nameof(SelectManyData), new[] { 1024, 1024 * 4 })]
         public static void SelectMany_ResultSelector_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             SelectMany_ResultSelector_NotPipelined(labeled, count, expander, expansion);
         }
 
         [Theory]
-        [MemberData(nameof(SelectManyUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SelectManyUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void SelectMany_Indexed_Unordered(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             // For unordered collections, which element is at which index isn't actually guaranteed, but an effect of the implementation.
@@ -436,14 +436,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SelectManyUnorderedData), (object)(new int[] { 1024, 1024 * 4 }))]
+        [MemberData(nameof(SelectManyUnorderedData), new[] { 1024, 1024 * 4 })]
         public static void SelectMany_Indexed_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             SelectMany_Indexed_Unordered(labeled, count, expander, expansion);
         }
 
         [Theory]
-        [MemberData(nameof(SelectManyUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SelectManyUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void SelectMany_Indexed_Unordered_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             // For unordered collections, which element is at which index isn't actually guaranteed, but an effect of the implementation.
@@ -462,14 +462,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SelectManyUnorderedData), (object)(new int[] { 1024, 1024 * 4 }))]
+        [MemberData(nameof(SelectManyUnorderedData), new[] { 1024, 1024 * 4 })]
         public static void SelectMany_Indexed_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             SelectMany_Indexed_Unordered_NotPipelined(labeled, count, expander, expansion);
         }
 
         [Theory]
-        [MemberData(nameof(SelectManyData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SelectManyData), new[] { 0, 1, 2, 16 })]
         public static void SelectMany_Indexed(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -485,14 +485,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SelectManyData), (object)(new int[] { 1024, 1024 * 4 }))]
+        [MemberData(nameof(SelectManyData), new[] { 1024, 1024 * 4 })]
         public static void SelectMany_Indexed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             SelectMany_Indexed(labeled, count, expander, expansion);
         }
 
         [Theory]
-        [MemberData(nameof(SelectManyData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SelectManyData), new[] { 0, 1, 2, 16 })]
         public static void SelectMany_Indexed_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -509,14 +509,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SelectManyData), (object)(new int[] { 1024, 1024 * 4 }))]
+        [MemberData(nameof(SelectManyData), new[] { 1024, 1024 * 4 })]
         public static void SelectMany_Indexed_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             SelectMany_Indexed_NotPipelined(labeled, count, expander, expansion);
         }
 
         [Theory]
-        [MemberData(nameof(SelectManyUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SelectManyUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void SelectMany_Indexed_Unordered_ResultSelector(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             // For unordered collections, which element is at which index isn't actually guaranteed, but an effect of the implementation.
@@ -536,14 +536,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SelectManyUnorderedData), (object)(new int[] { 1024, 1024 * 4 }))]
+        [MemberData(nameof(SelectManyUnorderedData), new[] { 1024, 1024 * 4 })]
         public static void SelectMany_Indexed_Unordered_ResultSelector_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             SelectMany_Indexed_Unordered_ResultSelector(labeled, count, expander, expansion);
         }
 
         [Theory]
-        [MemberData(nameof(SelectManyUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SelectManyUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void SelectMany_Indexed_Unordered_ResultSelector_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             // For unordered collections, which element is at which index isn't actually guaranteed, but an effect of the implementation.
@@ -564,14 +564,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SelectManyUnorderedData), (object)(new int[] { 1024, 1024 * 4 }))]
+        [MemberData(nameof(SelectManyUnorderedData), new[] { 1024, 1024 * 4 })]
         public static void SelectMany_Indexed_Unordered_ResultSelector_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             SelectMany_Indexed_Unordered_ResultSelector_NotPipelined(labeled, count, expander, expansion);
         }
 
         [Theory]
-        [MemberData(nameof(SelectManyData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SelectManyData), new[] { 0, 1, 2, 16 })]
         public static void SelectMany_Indexed_ResultSelector(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -589,14 +589,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SelectManyData), (object)(new int[] { 1024, 1024 * 4 }))]
+        [MemberData(nameof(SelectManyData), new[] { 1024, 1024 * 4 })]
         public static void SelectMany_Indexed_ResultSelector_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             SelectMany_Indexed_ResultSelector(labeled, count, expander, expansion);
         }
 
         [Theory]
-        [MemberData(nameof(SelectManyData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SelectManyData), new[] { 0, 1, 2, 16 })]
         public static void SelectMany_Indexed_ResultSelector_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -615,7 +615,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SelectManyData), (object)(new int[] { 1024, 1024 * 4 }))]
+        [MemberData(nameof(SelectManyData), new[] { 1024, 1024 * 4 })]
         public static void SelectMany_Indexed_ResultSelector_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, Labeled<Func<int, int, IEnumerable<int>>> expander, int expansion)
         {
             SelectMany_Indexed_ResultSelector_NotPipelined(labeled, count, expander, expansion);

--- a/src/System.Linq.Parallel/tests/QueryOperators/SelectSelectManyTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SelectSelectManyTests.cs
@@ -10,7 +10,7 @@ namespace System.Linq.Parallel.Tests
     public class SelectSelectManyTests
     {
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Select_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -25,7 +25,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         public static void Select_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Select_Unordered(labeled, count);
@@ -54,7 +54,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Select_Unordered_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -66,7 +66,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         public static void Select_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Select_Unordered_NotPipelined(labeled, count);
@@ -100,7 +100,7 @@ namespace System.Linq.Parallel.Tests
         // larger input sizes increases the probability that it will.
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Select_Indexed_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             // For unordered collections, which element is at which index isn't actually guaranteed, but an effect of the implementation.
@@ -117,7 +117,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         public static void Select_Indexed_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Select_Indexed_Unordered(labeled, count);
@@ -146,7 +146,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Select_Indexed_Unordered_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             // For unordered collections, which element is at which index isn't actually guaranteed, but an effect of the implementation.
@@ -164,7 +164,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024, 1024 * 4 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024, 1024 * 4 }), MemberType = typeof(UnorderedSources))]
         public static void Select_Indexed_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Select_Indexed_Unordered_NotPipelined(labeled, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/SequenceEqualTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SequenceEqualTests.cs
@@ -51,7 +51,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SequenceEqualData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SequenceEqualData), new[] { 0, 1, 2, 16 })]
         public static void SequenceEqual(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -63,14 +63,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SequenceEqualData), (object)(new int[] { 1024 * 4, 1024 * 128 }))]
+        [MemberData(nameof(SequenceEqualData), new[] { 1024 * 4, 1024 * 128 })]
         public static void SequenceEqual_Longrunning(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count)
         {
             SequenceEqual(left, right, count);
         }
 
         [Theory]
-        [MemberData(nameof(SequenceEqualData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SequenceEqualData), new[] { 0, 1, 2, 16 })]
         public static void SequenceEqual_CustomComparator(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -88,14 +88,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SequenceEqualData), (object)(new int[] { 1024 * 4, 1024 * 128 }))]
+        [MemberData(nameof(SequenceEqualData), new[] { 1024 * 4, 1024 * 128 })]
         public static void SequenceEqual_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count)
         {
             SequenceEqual_CustomComparator(left, right, count);
         }
 
         [Theory]
-        [MemberData(nameof(SequenceEqualUnequalSizeData), (object)(new int[] { 0, 4, 16 }))]
+        [MemberData(nameof(SequenceEqualUnequalSizeData), new[] { 0, 4, 16 })]
         public static void SequenceEqual_UnequalSize(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -108,14 +108,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SequenceEqualUnequalSizeData), (object)(new int[] { 1024 * 4, 1024 * 128 }))]
+        [MemberData(nameof(SequenceEqualUnequalSizeData), new[] { 1024 * 4, 1024 * 128 })]
         public static void SequenceEqual_UnequalSize_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             SequenceEqual_UnequalSize(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(SequenceEqualUnequalData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(SequenceEqualUnequalData), new[] { 1, 2, 16 })]
         public static void SequenceEqual_Unequal(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count, int item)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -128,7 +128,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SequenceEqualUnequalData), (object)(new int[] { 1024 * 4, 1024 * 128 }))]
+        [MemberData(nameof(SequenceEqualUnequalData), new[] { 1024 * 4, 1024 * 128 })]
         public static void SequenceEqual_Unequal_Longrunning(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count, int item)
         {
             SequenceEqual_Unequal(left, right, count, item);
@@ -143,7 +143,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SequenceEqualUnequalData), (object)(new int[] { 4 }))]
+        [MemberData(nameof(SequenceEqualUnequalData), new[] { 4 })]
         public static void SequenceEqual_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count, int item)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -157,7 +157,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SequenceEqualUnequalData), (object)(new int[] { 4 }))]
+        [MemberData(nameof(SequenceEqualUnequalData), new[] { 4 })]
         public static void SequenceEqual_AggregateException(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count, int item)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => left.Item.SequenceEqual(right.Item, new FailingEqualityComparer<int>()));
@@ -184,7 +184,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SequenceEqualData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SequenceEqualData), new[] { 0, 1, 2, 16 })]
         public static void SequenceEqual_DisposeException(Labeled<ParallelQuery<int>> left, Labeled<ParallelQuery<int>> right, int count)
         {
             ParallelQuery<int> leftQuery = left.Item;

--- a/src/System.Linq.Parallel/tests/QueryOperators/SingleSingleOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SingleSingleOrDefaultTests.cs
@@ -167,7 +167,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void Single_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -181,7 +181,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void Single_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.Single(x => { throw new DeliberateTestException(); }));

--- a/src/System.Linq.Parallel/tests/QueryOperators/SingleSingleOrDefaultTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SingleSingleOrDefaultTests.cs
@@ -36,7 +36,7 @@ namespace System.Linq.Parallel.Tests
         // Single and SingleOrDefault
         //
         [Theory]
-        [MemberData(nameof(SingleData), new int[] { 0, 2, 16, 1024 * 1024 }, new int[] { 1 })]
+        [MemberData(nameof(SingleData), new[] { 0, 2, 16, 1024 * 1024 }, new[] { 1 })]
         public static void Single(Labeled<ParallelQuery<int>> labeled, int count, int element)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -45,7 +45,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SingleData), new int[] { 0, 2, 16, 1024 * 1024 }, new int[] { 0, 1 })]
+        [MemberData(nameof(SingleData), new[] { 0, 2, 16, 1024 * 1024 }, new[] { 0, 1 })]
         public static void SingleOrDefault(Labeled<ParallelQuery<int>> labeled, int count, int element)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -54,7 +54,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SingleData), new int[] { 0, 1024 * 1024 }, new int[] { 0 })]
+        [MemberData(nameof(SingleData), new[] { 0, 1024 * 1024 }, new[] { 0 })]
         public static void Single_Empty(Labeled<ParallelQuery<int>> labeled, int count, int element)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -63,7 +63,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SingleData), new int[] { 0 }, new int[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(SingleData), new[] { 0 }, new[] { 0, 1, 2, 16 })]
         public static void Single_NoMatch(Labeled<ParallelQuery<int>> labeled, int count, int element)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -74,14 +74,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SingleData), new int[] { 0 }, new int[] { 1024 * 4, 1024 * 1024 })]
+        [MemberData(nameof(SingleData), new[] { 0 }, new[] { 1024 * 4, 1024 * 1024 })]
         public static void Single_NoMatch_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int element)
         {
             Single_NoMatch(labeled, count, element);
         }
 
         [Theory]
-        [MemberData(nameof(SingleData), new int[] { 0 }, new int[] { 0, 1, 2, 16 })]
+        [MemberData(nameof(SingleData), new[] { 0 }, new[] { 0, 1, 2, 16 })]
         public static void SingleOrDefault_NoMatch(Labeled<ParallelQuery<int>> labeled, int count, int element)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -92,14 +92,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SingleData), new int[] { 0 }, new int[] { 1024 * 4, 1024 * 1024 })]
+        [MemberData(nameof(SingleData), new[] { 0 }, new[] { 1024 * 4, 1024 * 1024 })]
         public static void SingleOrDefault_NoMatch_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int element)
         {
             SingleOrDefault_NoMatch(labeled, count, element);
         }
 
         [Theory]
-        [MemberData(nameof(SingleData), new int[] { 0 }, new int[] { 2, 16 })]
+        [MemberData(nameof(SingleData), new[] { 0 }, new[] { 2, 16 })]
         public static void Single_AllMatch(Labeled<ParallelQuery<int>> labeled, int count, int element)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -108,14 +108,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SingleData), new int[] { 0 }, new int[] { 1024 * 4, 1024 * 1024 })]
+        [MemberData(nameof(SingleData), new[] { 0 }, new[] { 1024 * 4, 1024 * 1024 })]
         public static void Single_AllMatch_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int element)
         {
             Single_AllMatch(labeled, count, element);
         }
 
         [Theory]
-        [MemberData(nameof(SingleData), new int[] { 0 }, new int[] { 2, 16 })]
+        [MemberData(nameof(SingleData), new[] { 0 }, new[] { 2, 16 })]
         public static void SingleOrDefault_AllMatch(Labeled<ParallelQuery<int>> labeled, int count, int element)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -124,14 +124,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SingleData), new int[] { 0 }, new int[] { 1024 * 4, 1024 * 1024 })]
+        [MemberData(nameof(SingleData), new[] { 0 }, new[] { 1024 * 4, 1024 * 1024 })]
         public static void SingleOrDefault_AllMatch_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int element)
         {
             SingleOrDefault_AllMatch(labeled, count, element);
         }
 
         [Theory]
-        [MemberData(nameof(SingleSpecificData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(SingleSpecificData), new[] { 1, 2, 16 })]
         public static void Single_OneMatch(Labeled<ParallelQuery<int>> labeled, int count, int element)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -142,14 +142,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SingleSpecificData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
+        [MemberData(nameof(SingleSpecificData), new[] { 1024 * 4, 1024 * 1024 })]
         public static void Single_OneMatch_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int element)
         {
             Single_OneMatch(labeled, count, element);
         }
 
         [Theory]
-        [MemberData(nameof(SingleSpecificData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SingleSpecificData), new[] { 0, 1, 2, 16 })]
         public static void SingleOrDefault_OneMatch(Labeled<ParallelQuery<int>> labeled, int count, int element)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -160,14 +160,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SingleSpecificData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
+        [MemberData(nameof(SingleSpecificData), new[] { 1024 * 4, 1024 * 1024 })]
         public static void SingleOrDefault_OneMatch_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int element)
         {
             SingleOrDefault_OneMatch(labeled, count, element);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Single_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -181,7 +181,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void Single_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.Single(x => { throw new DeliberateTestException(); }));

--- a/src/System.Linq.Parallel/tests/QueryOperators/SkipSkipWhileTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SkipSkipWhileTests.cs
@@ -26,7 +26,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SkipUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SkipUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void Skip_Unordered(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -42,14 +42,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SkipUnorderedData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(SkipUnorderedData), new[] { 1024 * 32 })]
         public static void Skip_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             Skip_Unordered(labeled, count, skip);
         }
 
         [Theory]
-        [MemberData(nameof(SkipData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SkipData), new[] { 0, 1, 2, 16 })]
         public static void Skip(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -63,14 +63,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SkipData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(SkipData), new[] { 1024 * 32 })]
         public static void Skip_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             Skip(labeled, count, skip);
         }
 
         [Theory]
-        [MemberData(nameof(SkipUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SkipUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void Skip_Unordered_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -83,14 +83,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SkipUnorderedData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(SkipUnorderedData), new[] { 1024 * 32 })]
         public static void Skip_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             Skip_Unordered_NotPipelined(labeled, count, skip);
         }
 
         [Theory]
-        [MemberData(nameof(SkipData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SkipData), new[] { 0, 1, 2, 16 })]
         public static void Skip_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -101,7 +101,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SkipData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(SkipData), new[] { 1024 * 32 })]
         public static void Skip_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             Skip_NotPipelined(labeled, count, skip);
@@ -127,7 +127,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SkipUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SkipUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void SkipWhile_Unordered(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -143,14 +143,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SkipUnorderedData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(SkipUnorderedData), new[] { 1024 * 32 })]
         public static void SkipWhile_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             SkipWhile_Unordered(labeled, count, skip);
         }
 
         [Theory]
-        [MemberData(nameof(SkipData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SkipData), new[] { 0, 1, 2, 16 })]
         public static void SkipWhile(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -164,14 +164,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SkipData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(SkipData), new[] { 1024 * 32 })]
         public static void SkipWhile_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             SkipWhile(labeled, count, skip);
         }
 
         [Theory]
-        [MemberData(nameof(SkipUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SkipUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void SkipWhile_Unordered_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -184,14 +184,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SkipUnorderedData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(SkipUnorderedData), new[] { 1024 * 32 })]
         public static void SkipWhile_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             SkipWhile_Unordered_NotPipelined(labeled, count, skip);
         }
 
         [Theory]
-        [MemberData(nameof(SkipData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SkipData), new[] { 0, 1, 2, 16 })]
         public static void SkipWhile_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -202,14 +202,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SkipData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(SkipData), new[] { 1024 * 32 })]
         public static void SkipWhile_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             SkipWhile_NotPipelined(labeled, count, skip);
         }
 
         [Theory]
-        [MemberData(nameof(SkipUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SkipUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void SkipWhile_Indexed_Unordered(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -225,14 +225,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SkipUnorderedData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(SkipUnorderedData), new[] { 1024 * 32 })]
         public static void SkipWhile_Indexed_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             SkipWhile_Indexed_Unordered(labeled, count, skip);
         }
 
         [Theory]
-        [MemberData(nameof(SkipData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SkipData), new[] { 0, 1, 2, 16 })]
         public static void SkipWhile_Indexed(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -246,14 +246,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SkipData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(SkipData), new[] { 1024 * 32 })]
         public static void SkipWhile_Indexed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             SkipWhile_Indexed(labeled, count, skip);
         }
 
         [Theory]
-        [MemberData(nameof(SkipUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SkipUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void SkipWhile_Indexed_Unordered_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -266,14 +266,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SkipUnorderedData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(SkipUnorderedData), new[] { 1024 * 32 })]
         public static void SkipWhile_Indexed_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             SkipWhile_Indexed_Unordered_NotPipelined(labeled, count, skip);
         }
 
         [Theory]
-        [MemberData(nameof(SkipData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SkipData), new[] { 0, 1, 2, 16 })]
         public static void SkipWhile_Indexed_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -284,14 +284,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SkipData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(SkipData), new[] { 1024 * 32 })]
         public static void SkipWhile_Indexed_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             SkipWhile_Indexed_NotPipelined(labeled, count, skip);
         }
 
         [Theory]
-        [MemberData(nameof(SkipData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SkipData), new[] { 0, 1, 2, 16 })]
         public static void SkipWhile_AllFalse(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -302,14 +302,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SkipData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(SkipData), new[] { 1024 * 32 })]
         public static void SkipWhile_AllFalse_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             SkipWhile_AllFalse(labeled, count, skip);
         }
 
         [Theory]
-        [MemberData(nameof(SkipData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SkipData), new[] { 0, 1, 2, 16 })]
         public static void SkipWhile_AllTrue(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -320,14 +320,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SkipData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(SkipData), new[] { 1024 * 32 })]
         public static void SkipWhile_AllTrue_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int skip)
         {
             SkipWhile_AllTrue(labeled, count, skip);
         }
 
         [Theory]
-        [MemberData(nameof(SkipWhileData), (object)(new int[] { 2, 16 }))]
+        [MemberData(nameof(SkipWhileData), new[] { 2, 16 })]
         public static void SkipWhile_SomeTrue(Labeled<ParallelQuery<int>> labeled, int count, IEnumerable<int> skip)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -338,14 +338,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SkipWhileData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(SkipWhileData), new[] { 1024 * 32 })]
         public static void SkipWhile_SomeTrue_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, IEnumerable<int> skip)
         {
             SkipWhile_SomeTrue(labeled, count, skip);
         }
 
         [Theory]
-        [MemberData(nameof(SkipWhileData), (object)(new int[] { 2, 16 }))]
+        [MemberData(nameof(SkipWhileData), new[] { 2, 16 })]
         public static void SkipWhile_SomeFalse(Labeled<ParallelQuery<int>> labeled, int count, IEnumerable<int> skip)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -356,7 +356,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SkipWhileData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(SkipWhileData), new[] { 1024 * 32 })]
         public static void SkipWhile_SomeFalse_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, IEnumerable<int> skip)
         {
             SkipWhile_SomeFalse(labeled, count, skip);

--- a/src/System.Linq.Parallel/tests/QueryOperators/SumTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SumTests.cs
@@ -19,7 +19,7 @@ namespace System.Linq.Parallel.Tests
         // Sum
         //
         [Theory]
-        [MemberData(nameof(SumData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SumData), new[] { 0, 1, 2, 16 })]
         public static void Sum_Int(Labeled<ParallelQuery<int>> labeled, int count, int sum)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -32,7 +32,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SumData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(SumData), new[] { 1, 2, 16 })]
         public static void Sum_Int_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, int sum)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -41,7 +41,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SumData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(SumData), new[] { 1, 2, 16 })]
         public static void Sum_Int_AllNull(Labeled<ParallelQuery<int>> labeled, int count, int sum)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -51,14 +51,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SumData), (object)(new int[] { 1024 * 4, 1024 * 64 }))]
+        [MemberData(nameof(SumData), new[] { 1024 * 4, 1024 * 64 })]
         public static void Sum_Int_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int sum)
         {
             Sum_Int(labeled, count, sum);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void Sum_Int_Overflow(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<OverflowException>(() => labeled.Item.Select(x => x == 0 ? int.MaxValue : x).Sum());
@@ -68,7 +68,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SumData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SumData), new[] { 0, 1, 2, 16 })]
         public static void Sum_Long(Labeled<ParallelQuery<int>> labeled, int count, long sum)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -82,14 +82,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SumData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
+        [MemberData(nameof(SumData), new[] { 1024 * 4, 1024 * 1024 })]
         public static void Sum_Long_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, long sum)
         {
             Sum_Long(labeled, count, sum);
         }
 
         [Theory]
-        [MemberData(nameof(SumData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(SumData), new[] { 1, 2, 16 })]
         public static void Sum_Long_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, long sum)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -98,7 +98,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SumData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(SumData), new[] { 1, 2, 16 })]
         public static void Sum_Long_AllNull(Labeled<ParallelQuery<int>> labeled, int count, long sum)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -107,7 +107,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void Sum_Long_Overflow(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<OverflowException>(() => labeled.Item.Select(x => x == 0 ? long.MaxValue : x).Sum());
@@ -117,7 +117,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SumData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SumData), new[] { 0, 1, 2, 16 })]
         public static void Sum_Float(Labeled<ParallelQuery<int>> labeled, int count, float sum)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -131,14 +131,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SumData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
+        [MemberData(nameof(SumData), new[] { 1024 * 4, 1024 * 1024 })]
         public static void Sum_Float_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, float sum)
         {
             Sum_Float(labeled, count, sum);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void Sum_Float_Overflow(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Assert.Equal(float.PositiveInfinity, labeled.Item.Select(x => float.MaxValue).Sum());
@@ -161,7 +161,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void Sum_Float_NaN(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Assert.Equal(float.NaN, labeled.Item.Select(x => x == 0 ? float.NaN : x).Sum());
@@ -184,7 +184,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SumData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(SumData), new[] { 1, 2, 16 })]
         public static void Sum_Float_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, float sum)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -193,7 +193,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SumData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(SumData), new[] { 1, 2, 16 })]
         public static void Sum_Float_AllNull(Labeled<ParallelQuery<int>> labeled, int count, float sum)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -202,7 +202,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SumData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SumData), new[] { 0, 1, 2, 16 })]
         public static void Sum_Double(Labeled<ParallelQuery<int>> labeled, int count, double sum)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -216,14 +216,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SumData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
+        [MemberData(nameof(SumData), new[] { 1024 * 4, 1024 * 1024 })]
         public static void Sum_Double_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, double sum)
         {
             Sum_Double(labeled, count, sum);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void Sum_Double_Overflow(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Assert.Equal(double.PositiveInfinity, labeled.Item.Select(x => double.MaxValue).Sum());
@@ -246,7 +246,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void Sum_Double_NaN(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Assert.Equal(double.NaN, labeled.Item.Select(x => x == 0 ? double.NaN : x).Sum());
@@ -269,7 +269,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SumData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(SumData), new[] { 1, 2, 16 })]
         public static void Sum_Double_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, double sum)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -278,7 +278,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SumData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(SumData), new[] { 1, 2, 16 })]
         public static void Sum_Double_AllNull(Labeled<ParallelQuery<int>> labeled, int count, double sum)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -287,7 +287,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SumData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(SumData), new[] { 0, 1, 2, 16 })]
         public static void Sum_Decimal(Labeled<ParallelQuery<int>> labeled, int count, decimal sum)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -300,14 +300,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(SumData), (object)(new int[] { 1024 * 4, 1024 * 1024 }))]
+        [MemberData(nameof(SumData), new[] { 1024 * 4, 1024 * 1024 })]
         public static void Sum_Decimal_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, decimal sum)
         {
             Sum_Decimal(labeled, count, sum);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void Sum_Decimal_Overflow(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<OverflowException>(() => labeled.Item.Select(x => x == 0 ? decimal.MaxValue : x).Sum());
@@ -317,7 +317,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SumData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(SumData), new[] { 1, 2, 16 })]
         public static void Sum_Decimal_SomeNull(Labeled<ParallelQuery<int>> labeled, int count, decimal sum)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -326,7 +326,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(SumData), (object)(new int[] { 1, 2, 16 }))]
+        [MemberData(nameof(SumData), new[] { 1, 2, 16 })]
         public static void Sum_Decimal_AllNull(Labeled<ParallelQuery<int>> labeled, int count, decimal sum)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -335,7 +335,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void Sum_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -358,7 +358,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 2 }, MemberType = typeof(UnorderedSources))]
         public static void Sum_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.Sum((Func<int, int>)(x => { throw new DeliberateTestException(); })));

--- a/src/System.Linq.Parallel/tests/QueryOperators/SumTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/SumTests.cs
@@ -58,7 +58,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
         public static void Sum_Int_Overflow(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<OverflowException>(() => labeled.Item.Select(x => x == 0 ? int.MaxValue : x).Sum());
@@ -107,7 +107,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
         public static void Sum_Long_Overflow(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<OverflowException>(() => labeled.Item.Select(x => x == 0 ? long.MaxValue : x).Sum());
@@ -138,7 +138,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
         public static void Sum_Float_Overflow(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Assert.Equal(float.PositiveInfinity, labeled.Item.Select(x => float.MaxValue).Sum());
@@ -161,7 +161,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
         public static void Sum_Float_NaN(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Assert.Equal(float.NaN, labeled.Item.Select(x => x == 0 ? float.NaN : x).Sum());
@@ -223,7 +223,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
         public static void Sum_Double_Overflow(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Assert.Equal(double.PositiveInfinity, labeled.Item.Select(x => double.MaxValue).Sum());
@@ -246,7 +246,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
         public static void Sum_Double_NaN(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Assert.Equal(double.NaN, labeled.Item.Select(x => x == 0 ? double.NaN : x).Sum());
@@ -307,7 +307,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
         public static void Sum_Decimal_Overflow(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<OverflowException>(() => labeled.Item.Select(x => x == 0 ? decimal.MaxValue : x).Sum());
@@ -335,7 +335,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
         public static void Sum_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -358,7 +358,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 2 }), MemberType = typeof(UnorderedSources))]
         public static void Sum_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.Sum((Func<int, int>)(x => { throw new DeliberateTestException(); })));

--- a/src/System.Linq.Parallel/tests/QueryOperators/TakeTakeWhileTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/TakeTakeWhileTests.cs
@@ -25,7 +25,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(TakeUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(TakeUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void Take_Unordered(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -41,14 +41,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(TakeUnorderedData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(TakeUnorderedData), new[] { 1024 * 32 })]
         public static void Take_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             Take_Unordered(labeled, count, take);
         }
 
         [Theory]
-        [MemberData(nameof(TakeData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(TakeData), new[] { 0, 1, 2, 16 })]
         public static void Take(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -62,14 +62,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(TakeData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(TakeData), new[] { 1024 * 32 })]
         public static void Take_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             Take(labeled, count, take);
         }
 
         [Theory]
-        [MemberData(nameof(TakeUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(TakeUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void Take_Unordered_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -82,14 +82,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(TakeUnorderedData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(TakeUnorderedData), new[] { 1024 * 32 })]
         public static void Take_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             Take_Unordered_NotPipelined(labeled, count, take);
         }
 
         [Theory]
-        [MemberData(nameof(TakeData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(TakeData), new[] { 0, 1, 2, 16 })]
         public static void Take_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -100,7 +100,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(TakeData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(TakeData), new[] { 1024 * 32 })]
         public static void Take_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             Take_NotPipelined(labeled, count, take);
@@ -126,7 +126,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(TakeUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(TakeUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void TakeWhile_Unordered(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -142,14 +142,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(TakeUnorderedData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(TakeUnorderedData), new[] { 1024 * 32 })]
         public static void TakeWhile_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             TakeWhile_Unordered(labeled, count, take);
         }
 
         [Theory]
-        [MemberData(nameof(TakeData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(TakeData), new[] { 0, 1, 2, 16 })]
         public static void TakeWhile(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -163,14 +163,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(TakeData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(TakeData), new[] { 1024 * 32 })]
         public static void TakeWhile_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             TakeWhile(labeled, count, take);
         }
 
         [Theory]
-        [MemberData(nameof(TakeUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(TakeUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void TakeWhile_Unordered_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -183,14 +183,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(TakeUnorderedData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(TakeUnorderedData), new[] { 1024 * 32 })]
         public static void TakeWhile_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             TakeWhile_Unordered_NotPipelined(labeled, count, take);
         }
 
         [Theory]
-        [MemberData(nameof(TakeData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(TakeData), new[] { 0, 1, 2, 16 })]
         public static void TakeWhile_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -201,14 +201,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(TakeData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(TakeData), new[] { 1024 * 32 })]
         public static void TakeWhile_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             TakeWhile_NotPipelined(labeled, count, take);
         }
 
         [Theory]
-        [MemberData(nameof(TakeUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(TakeUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void TakeWhile_Indexed_Unordered(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -224,14 +224,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(TakeUnorderedData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(TakeUnorderedData), new[] { 1024 * 32 })]
         public static void TakeWhile_Indexed_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             TakeWhile_Indexed_Unordered(labeled, count, take);
         }
 
         [Theory]
-        [MemberData(nameof(TakeData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(TakeData), new[] { 0, 1, 2, 16 })]
         public static void TakeWhile_Indexed(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -245,14 +245,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(TakeData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(TakeData), new[] { 1024 * 32 })]
         public static void TakeWhile_Indexed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             TakeWhile_Indexed(labeled, count, take);
         }
 
         [Theory]
-        [MemberData(nameof(TakeUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(TakeUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void TakeWhile_Indexed_Unordered_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -265,14 +265,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(TakeUnorderedData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(TakeUnorderedData), new[] { 1024 * 32 })]
         public static void TakeWhile_Indexed_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             TakeWhile_Indexed_Unordered_NotPipelined(labeled, count, take);
         }
 
         [Theory]
-        [MemberData(nameof(TakeData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(TakeData), new[] { 0, 1, 2, 16 })]
         public static void TakeWhile_Indexed_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -283,14 +283,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(TakeData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(TakeData), new[] { 1024 * 32 })]
         public static void TakeWhile_Indexed_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             TakeWhile_Indexed_NotPipelined(labeled, count, take);
         }
 
         [Theory]
-        [MemberData(nameof(TakeUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(TakeUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void TakeWhile_AllFalse(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -299,14 +299,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(TakeUnorderedData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(TakeUnorderedData), new[] { 1024 * 32 })]
         public static void TakeWhile_AllFalse_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             TakeWhile_AllFalse(labeled, count, take);
         }
 
         [Theory]
-        [MemberData(nameof(TakeData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(TakeData), new[] { 0, 1, 2, 16 })]
         public static void TakeWhile_AllTrue(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -317,14 +317,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(TakeData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(TakeData), new[] { 1024 * 32 })]
         public static void TakeWhile_AllTrue_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, int take)
         {
             TakeWhile_AllTrue(labeled, count, take);
         }
 
         [Theory]
-        [MemberData(nameof(TakeWhileData), (object)(new int[] { 2, 16 }))]
+        [MemberData(nameof(TakeWhileData), new[] { 2, 16 })]
         public static void TakeWhile_SomeTrue(Labeled<ParallelQuery<int>> labeled, int count, IEnumerable<int> take)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -335,14 +335,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(TakeWhileData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(TakeWhileData), new[] { 1024 * 32 })]
         public static void TakeWhile_SomeTrue_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, IEnumerable<int> take)
         {
             TakeWhile_SomeTrue(labeled, count, take);
         }
 
         [Theory]
-        [MemberData(nameof(TakeWhileData), (object)(new int[] { 2, 16 }))]
+        [MemberData(nameof(TakeWhileData), new[] { 2, 16 })]
         public static void TakeWhile_SomeFalse(Labeled<ParallelQuery<int>> labeled, int count, IEnumerable<int> take)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -353,7 +353,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(TakeWhileData), (object)(new int[] { 1024 * 32 }))]
+        [MemberData(nameof(TakeWhileData), new[] { 1024 * 32 })]
         public static void TakeWhile_SomeFalse_Longrunning(Labeled<ParallelQuery<int>> labeled, int count, IEnumerable<int> take)
         {
             TakeWhile_SomeFalse(labeled, count, take);

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToArrayTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToArrayTests.cs
@@ -10,7 +10,7 @@ namespace System.Linq.Parallel.Tests
     public class ToArrayTests
     {
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToArray_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -21,7 +21,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(UnorderedSources))]
         public static void ToArray_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToArray_Unordered(labeled, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToArrayTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToArrayTests.cs
@@ -10,7 +10,7 @@ namespace System.Linq.Parallel.Tests
     public class ToArrayTests
     {
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToArray_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -21,14 +21,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 1024 }, MemberType = typeof(UnorderedSources))]
         public static void ToArray_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToArray_Unordered(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void ToArray(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -39,14 +39,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 1024 }, MemberType = typeof(Sources))]
         public static void ToArray_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToArray(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1 }, MemberType = typeof(Sources))]
         [MemberData(nameof(UnorderedSources.ThrowOnFirstEnumeration), MemberType = typeof(UnorderedSources))]
         public static void ToArray_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToDictionaryTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToDictionaryTests.cs
@@ -11,7 +11,7 @@ namespace System.Linq.Parallel.Tests
     public class ToDictionaryTests
     {
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToDictionary(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -23,14 +23,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToDictionary(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_ElementSelector(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -42,14 +42,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_ElementSelector_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToDictionary_ElementSelector(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -61,14 +61,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToDictionary_CustomComparator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_ElementSelector_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -80,14 +80,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_ElementSelector_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToDictionary_ElementSelector_CustomComparator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_UniqueKeys_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -114,14 +114,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_UniqueKeys_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToDictionary_UniqueKeys_CustomComparator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_ElementSelector_UniqueKeys_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -148,7 +148,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_ElementSelector_UniqueKeys_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToDictionary_ElementSelector_UniqueKeys_CustomComparator(labeled, count);
@@ -162,7 +162,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_DuplicateKeys_ElementSelector(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -172,7 +172,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_DuplicateKeys_ElementSelector_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToDictionary_DuplicateKeys_ElementSelector(labeled, count);
@@ -186,7 +186,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_DuplicateKeys_ElementSelector_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -196,14 +196,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_DuplicateKeys_ElementSelector_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToDictionary_DuplicateKeys_ElementSelector_CustomComparator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -216,7 +216,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.ToDictionary((Func<int, int>)(x => { throw new DeliberateTestException(); })));

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToDictionaryTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToDictionaryTests.cs
@@ -11,7 +11,7 @@ namespace System.Linq.Parallel.Tests
     public class ToDictionaryTests
     {
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToDictionary(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -23,14 +23,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToDictionary(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_ElementSelector(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -42,14 +42,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_ElementSelector_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToDictionary_ElementSelector(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -61,14 +61,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToDictionary_CustomComparator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_ElementSelector_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -80,14 +80,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_ElementSelector_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToDictionary_ElementSelector_CustomComparator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_UniqueKeys_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -114,14 +114,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_UniqueKeys_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToDictionary_UniqueKeys_CustomComparator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_ElementSelector_UniqueKeys_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -148,7 +148,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_ElementSelector_UniqueKeys_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToDictionary_ElementSelector_UniqueKeys_CustomComparator(labeled, count);
@@ -162,7 +162,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_DuplicateKeys_ElementSelector(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -172,7 +172,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_DuplicateKeys_ElementSelector_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToDictionary_DuplicateKeys_ElementSelector(labeled, count);
@@ -186,7 +186,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_DuplicateKeys_ElementSelector_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -196,14 +196,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_DuplicateKeys_ElementSelector_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToDictionary_DuplicateKeys_ElementSelector_CustomComparator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -216,7 +216,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void ToDictionary_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.ToDictionary((Func<int, int>)(x => { throw new DeliberateTestException(); })));

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToListTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToListTests.cs
@@ -10,7 +10,7 @@ namespace System.Linq.Parallel.Tests
     public class ToListTests
     {
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToList_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -21,7 +21,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(UnorderedSources))]
         public static void ToList_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToList_Unordered(labeled, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToListTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToListTests.cs
@@ -10,7 +10,7 @@ namespace System.Linq.Parallel.Tests
     public class ToListTests
     {
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToList_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -21,14 +21,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 1024 }, MemberType = typeof(UnorderedSources))]
         public static void ToList_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToList_Unordered(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void ToList(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -39,14 +39,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 1024 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 1024 }, MemberType = typeof(Sources))]
         public static void ToList_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToList(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1 }, MemberType = typeof(Sources))]
         public static void ToList_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToLookupTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToLookupTests.cs
@@ -11,7 +11,7 @@ namespace System.Linq.Parallel.Tests
     public class ToLookupTests
     {
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToLookup(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -25,14 +25,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 128 }, MemberType = typeof(UnorderedSources))]
         public static void ToLookup_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToLookup(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToLookup_ElementSelector(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -46,14 +46,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 128 }, MemberType = typeof(UnorderedSources))]
         public static void ToLookup_ElementSelector_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToLookup_ElementSelector(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToLookup_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -67,14 +67,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 128 }, MemberType = typeof(UnorderedSources))]
         public static void ToLookup_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToLookup_CustomComparator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToLookup_ElementSelector_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -91,14 +91,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 128 }, MemberType = typeof(UnorderedSources))]
         public static void ToLookup_ElementSelector_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToLookup_ElementSelector_CustomComparator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToLookup_DuplicateKeys(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -118,14 +118,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 128 }, MemberType = typeof(UnorderedSources))]
         public static void ToLookup_DuplicateKeys_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToLookup_DuplicateKeys(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToLookup_DuplicateKeys_ElementSelector(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -145,14 +145,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 128 }, MemberType = typeof(UnorderedSources))]
         public static void ToLookup_DuplicateKeys_ElementSelector_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToLookup_DuplicateKeys_ElementSelector(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToLookup_DuplicateKeys_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -175,14 +175,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 128 }, MemberType = typeof(UnorderedSources))]
         public static void ToLookup_DuplicateKeys_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToLookup_DuplicateKeys_CustomComparator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 0, 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void ToLookup_DuplicateKeys_ElementSelector_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -205,14 +205,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 128 }, MemberType = typeof(UnorderedSources))]
         public static void ToLookup_DuplicateKeys_ElementSelector_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToLookup_DuplicateKeys_ElementSelector_CustomComparator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void ToLookup_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -226,7 +226,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1 }, MemberType = typeof(UnorderedSources))]
         public static void ToLookup_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.ToLookup((Func<int, int>)(x => { throw new DeliberateTestException(); })));

--- a/src/System.Linq.Parallel/tests/QueryOperators/ToLookupTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ToLookupTests.cs
@@ -11,7 +11,7 @@ namespace System.Linq.Parallel.Tests
     public class ToLookupTests
     {
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToLookup(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -25,14 +25,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
         public static void ToLookup_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToLookup(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToLookup_ElementSelector(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -46,14 +46,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
         public static void ToLookup_ElementSelector_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToLookup_ElementSelector(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToLookup_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -67,14 +67,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
         public static void ToLookup_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToLookup_CustomComparator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToLookup_ElementSelector_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -91,14 +91,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
         public static void ToLookup_ElementSelector_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToLookup_ElementSelector_CustomComparator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToLookup_DuplicateKeys(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -118,14 +118,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
         public static void ToLookup_DuplicateKeys_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToLookup_DuplicateKeys(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToLookup_DuplicateKeys_ElementSelector(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -145,14 +145,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
         public static void ToLookup_DuplicateKeys_ElementSelector_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToLookup_DuplicateKeys_ElementSelector(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToLookup_DuplicateKeys_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -175,14 +175,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
         public static void ToLookup_DuplicateKeys_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToLookup_DuplicateKeys_CustomComparator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 0, 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void ToLookup_DuplicateKeys_ElementSelector_CustomComparator(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -205,14 +205,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 128 }), MemberType = typeof(UnorderedSources))]
         public static void ToLookup_DuplicateKeys_ElementSelector_CustomComparator_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ToLookup_DuplicateKeys_ElementSelector_CustomComparator(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void ToLookup_OperationCanceledException_PreCanceled(Labeled<ParallelQuery<int>> labeled, int count)
         {
             CancellationTokenSource cs = new CancellationTokenSource();
@@ -226,7 +226,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1 }), MemberType = typeof(UnorderedSources))]
         public static void ToLookup_AggregateException(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Functions.AssertThrowsWrapped<DeliberateTestException>(() => labeled.Item.ToLookup((Func<int, int>)(x => { throw new DeliberateTestException(); })));

--- a/src/System.Linq.Parallel/tests/QueryOperators/UnionTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/UnionTests.cs
@@ -56,7 +56,7 @@ namespace System.Linq.Parallel.Tests
             foreach (int leftCount in counts.Cast<int>())
             {
                 ParallelQuery<int> left = Enumerable.Range(0, leftCount * DuplicateFactor).Select(x => x % leftCount).ToArray().AsParallel();
-                foreach (int rightCount in new int[] { 0, 1, Math.Max(DuplicateFactor, leftCount / 2), Math.Max(DuplicateFactor, leftCount) })
+                foreach (int rightCount in new[] { 0, 1, Math.Max(DuplicateFactor, leftCount / 2), Math.Max(DuplicateFactor, leftCount) })
                 {
                     int rightStart = leftCount - Math.Min(leftCount, rightCount) / 2;
                     ParallelQuery<int> right = Enumerable.Range(0, rightCount * DuplicateFactor).Select(x => x % rightCount + rightStart).ToArray().AsParallel();
@@ -69,7 +69,7 @@ namespace System.Linq.Parallel.Tests
         // Union
         //
         [Theory]
-        [MemberData(nameof(UnionUnorderedData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(UnionUnorderedData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Union_Unordered(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -84,14 +84,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnionUnorderedData), new int[] { 512, 1024 * 8 }, new int[] { 0, 1, 1024, 1024 * 16 })]
+        [MemberData(nameof(UnionUnorderedData), new[] { 512, 1024 * 8 }, new[] { 0, 1, 1024, 1024 * 16 })]
         public static void Union_Unordered_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Union_Unordered(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(UnionData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(UnionData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Union(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -106,14 +106,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnionData), new int[] { 512, 1024 * 8 }, new int[] { 0, 1, 1024, 1024 * 16 })]
+        [MemberData(nameof(UnionData), new[] { 512, 1024 * 8 }, new[] { 0, 1, 1024, 1024 * 16 })]
         public static void Union_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Union(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(UnionFirstOrderedData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(UnionFirstOrderedData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Union_FirstOrdered(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -137,14 +137,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnionFirstOrderedData), new int[] { 512, 1024 * 8 }, new int[] { 0, 1, 1024, 1024 * 16 })]
+        [MemberData(nameof(UnionFirstOrderedData), new[] { 512, 1024 * 8 }, new[] { 0, 1, 1024, 1024 * 16 })]
         public static void Union_FirstOrdered_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Union_FirstOrdered(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(UnionSecondOrderedData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(UnionSecondOrderedData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Union_SecondOrdered(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -168,14 +168,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnionSecondOrderedData), new int[] { 512, 1024 * 8 }, new int[] { 0, 1, 1024, 1024 * 16 })]
+        [MemberData(nameof(UnionSecondOrderedData), new[] { 512, 1024 * 8 }, new[] { 0, 1, 1024, 1024 * 16 })]
         public static void Union_SecondOrdered_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Union_SecondOrdered(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(UnionUnorderedData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(UnionUnorderedData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Union_Unordered_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -187,14 +187,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnionUnorderedData), new int[] { 512, 1024 * 8 }, new int[] { 0, 1, 1024, 1024 * 16 })]
+        [MemberData(nameof(UnionUnorderedData), new[] { 512, 1024 * 8 }, new[] { 0, 1, 1024, 1024 * 16 })]
         public static void Union_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Union_Unordered_NotPipelined(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(UnionData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(UnionData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Union_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -206,14 +206,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnionData), new int[] { 512, 1024 * 8 }, new int[] { 0, 1, 1024, 1024 * 16 })]
+        [MemberData(nameof(UnionData), new[] { 512, 1024 * 8 }, new[] { 0, 1, 1024, 1024 * 16 })]
         public static void Union_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Union_NotPipelined(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(UnionFirstOrderedData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(UnionFirstOrderedData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Union_FirstOrdered_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -231,14 +231,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnionFirstOrderedData), new int[] { 512, 1024 * 8 }, new int[] { 0, 1, 1024, 1024 * 16 })]
+        [MemberData(nameof(UnionFirstOrderedData), new[] { 512, 1024 * 8 }, new[] { 0, 1, 1024, 1024 * 16 })]
         public static void Union_FirstOrdered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Union_FirstOrdered_NotPipelined(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(UnionSecondOrderedData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(UnionSecondOrderedData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Union_SecondOrdered_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -256,14 +256,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnionSecondOrderedData), new int[] { 512, 1024 * 8 }, new int[] { 0, 1, 1024, 1024 * 16 })]
+        [MemberData(nameof(UnionSecondOrderedData), new[] { 512, 1024 * 8 }, new[] { 0, 1, 1024, 1024 * 16 })]
         public static void Union_SecondOrdered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Union_SecondOrdered_NotPipelined(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(UnionUnorderedData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(UnionUnorderedData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Union_Unordered_Distinct(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -282,14 +282,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnionUnorderedData), new int[] { 512, 1024 * 8 }, new int[] { 0, 1, 1024, 1024 * 16 })]
+        [MemberData(nameof(UnionUnorderedData), new[] { 512, 1024 * 8 }, new[] { 0, 1, 1024, 1024 * 16 })]
         public static void Union_Unordered_Distinct_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Union_Unordered_Distinct(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(UnionData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(UnionData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Union_Distinct(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -308,14 +308,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnionData), new int[] { 512, 1024 * 8 }, new int[] { 0, 1, 1024, 1024 * 16 })]
+        [MemberData(nameof(UnionData), new[] { 512, 1024 * 8 }, new[] { 0, 1, 1024, 1024 * 16 })]
         public static void Union_Distinct_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Union_Distinct(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(UnionFirstOrderedData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(UnionFirstOrderedData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Union_FirstOrdered_Distinct(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -344,14 +344,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnionFirstOrderedData), new int[] { 512, 1024 * 8 }, new int[] { 0, 1, 1024, 1024 * 16 })]
+        [MemberData(nameof(UnionFirstOrderedData), new[] { 512, 1024 * 8 }, new[] { 0, 1, 1024, 1024 * 16 })]
         public static void Union_FirstOrdered_Distinct_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Union_FirstOrdered_Distinct(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(UnionSecondOrderedData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(UnionSecondOrderedData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Union_SecondOrdered_Distinct(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -380,14 +380,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnionSecondOrderedData), new int[] { 512, 1024 * 8 }, new int[] { 0, 1, 1024, 1024 * 16 })]
+        [MemberData(nameof(UnionSecondOrderedData), new[] { 512, 1024 * 8 }, new[] { 0, 1, 1024, 1024 * 16 })]
         public static void Union_SecondOrdered_Distinct_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Union_SecondOrdered_Distinct(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(UnionUnorderedData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(UnionUnorderedData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Union_Unordered_Distinct_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -404,14 +404,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnionUnorderedData), new int[] { 512, 1024 * 8 }, new int[] { 0, 1, 1024, 1024 * 16 })]
+        [MemberData(nameof(UnionUnorderedData), new[] { 512, 1024 * 8 }, new[] { 0, 1, 1024, 1024 * 16 })]
         public static void Union_Unordered_Distinct_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Union_Unordered_Distinct_NotPipelined(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(UnionData), new int[] { 0, 1, 2, 16 }, new int[] { 0, 1, 8 })]
+        [MemberData(nameof(UnionData), new[] { 0, 1, 2, 16 }, new[] { 0, 1, 8 })]
         public static void Union_Distinct_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -429,14 +429,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnionData), new int[] { 512, 1024 * 8 }, new int[] { 0, 1, 1024, 1024 * 16 })]
+        [MemberData(nameof(UnionData), new[] { 512, 1024 * 8 }, new[] { 0, 1, 1024, 1024 * 16 })]
         public static void Union_Distinct_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Union_Distinct_NotPipelined(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(UnionSourceMultipleData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(UnionSourceMultipleData), new[] { 0, 1, 2, 16 })]
         public static void Union_Unordered_SourceMultiple(ParallelQuery<int> leftQuery, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int count)
         {
             // The difference between this test and the previous, is that it's not possible to
@@ -450,14 +450,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnionSourceMultipleData), (object)(new int[] { 512, 1024 * 8 }))]
+        [MemberData(nameof(UnionSourceMultipleData), new[] { 512, 1024 * 8 })]
         public static void Union_Unordered_SourceMultiple_Longrunning(ParallelQuery<int> leftQuery, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int count)
         {
             Union_Unordered_SourceMultiple(leftQuery, leftCount, rightQuery, rightCount, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnionSourceMultipleData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(UnionSourceMultipleData), new[] { 0, 1, 2, 16 })]
         public static void Union_SourceMultiple(ParallelQuery<int> leftQuery, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int count)
         {
             int seen = 0;
@@ -467,14 +467,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnionSourceMultipleData), (object)(new int[] { 512, 1024 * 8 }))]
+        [MemberData(nameof(UnionSourceMultipleData), new[] { 512, 1024 * 8 })]
         public static void Union_SourceMultiple_Longrunning(ParallelQuery<int> leftQuery, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int count)
         {
             Union_SourceMultiple(leftQuery, leftCount, rightQuery, rightCount, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnionSourceMultipleData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(UnionSourceMultipleData), new[] { 0, 1, 2, 16 })]
         public static void Union_FirstOrdered_SourceMultiple(ParallelQuery<int> leftQuery, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int count)
         {
             IntegerRangeSet seenUnordered = new IntegerRangeSet(leftCount, count - leftCount);
@@ -496,14 +496,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnionSourceMultipleData), (object)(new int[] { 512, 1024 * 8 }))]
+        [MemberData(nameof(UnionSourceMultipleData), new[] { 512, 1024 * 8 })]
         public static void Union_FirstOrdered_SourceMultiple_Longrunning(ParallelQuery<int> leftQuery, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int count)
         {
             Union_FirstOrdered_SourceMultiple(leftQuery, leftCount, rightQuery, rightCount, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnionSourceMultipleData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(UnionSourceMultipleData), new[] { 0, 1, 2, 16 })]
         public static void Union_SecondOrdered_SourceMultiple(ParallelQuery<int> leftQuery, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int count)
         {
             IntegerRangeSet seenUnordered = new IntegerRangeSet(0, leftCount);
@@ -525,7 +525,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnionSourceMultipleData), (object)(new int[] { 512, 1024 * 8 }))]
+        [MemberData(nameof(UnionSourceMultipleData), new[] { 512, 1024 * 8 })]
         public static void Union_SecondOrdered_SourceMultiple_Longrunning(ParallelQuery<int> leftQuery, int leftCount, ParallelQuery<int> rightQuery, int rightCount, int count)
         {
             Union_SecondOrdered_SourceMultiple(leftQuery, leftCount, rightQuery, rightCount, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/WhereTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/WhereTests.cs
@@ -9,7 +9,7 @@ namespace System.Linq.Parallel.Tests
     public class WhereTests
     {
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Where_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -24,7 +24,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(UnorderedSources))]
         public static void Where_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Where_Unordered(labeled, count);
@@ -52,7 +52,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Where_Unordered_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -63,7 +63,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(UnorderedSources))]
         public static void Where_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Where_Unordered_NotPipelined(labeled, count);
@@ -92,7 +92,7 @@ namespace System.Linq.Parallel.Tests
         // larger input sizes increases the probability that it will.
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Where_Indexed_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -106,7 +106,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(UnorderedSources))]
         public static void Where_Indexed_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Where_Indexed_Unordered(labeled, count);
@@ -134,7 +134,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
         public static void Where_Indexed_Unordered_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -145,7 +145,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(UnorderedSources))]
         public static void Where_Indexed_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Where_Indexed_Unordered_NotPipelined(labeled, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/WhereTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/WhereTests.cs
@@ -9,7 +9,7 @@ namespace System.Linq.Parallel.Tests
     public class WhereTests
     {
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Where_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -24,14 +24,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 512 }, MemberType = typeof(UnorderedSources))]
         public static void Where_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Where_Unordered(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void Where(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -45,14 +45,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 512 }, MemberType = typeof(Sources))]
         public static void Where_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Where(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Where_Unordered_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -63,14 +63,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 512 }, MemberType = typeof(UnorderedSources))]
         public static void Where_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Where_Unordered_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void Where_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -81,7 +81,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 512 }, MemberType = typeof(Sources))]
         public static void Where_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Where_NotPipelined(labeled, count);
@@ -92,7 +92,7 @@ namespace System.Linq.Parallel.Tests
         // larger input sizes increases the probability that it will.
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Where_Indexed_Unordered(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -106,14 +106,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 512 }, MemberType = typeof(UnorderedSources))]
         public static void Where_Indexed_Unordered_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Where_Indexed_Unordered(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void Where_Indexed(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -127,14 +127,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 512 }, MemberType = typeof(Sources))]
         public static void Where_Indexed_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Where_Indexed(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(UnorderedSources))]
         public static void Where_Indexed_Unordered_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -145,14 +145,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(UnorderedSources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(UnorderedSources))]
+        [MemberData(nameof(UnorderedSources.Ranges), new[] { 1024 * 4, 1024 * 512 }, MemberType = typeof(UnorderedSources))]
         public static void Where_Indexed_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Where_Indexed_Unordered_NotPipelined(labeled, count);
         }
 
         [Theory]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1, 2, 16 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1, 2, 16 }, MemberType = typeof(Sources))]
         public static void Where_Indexed_NotPipelined(Labeled<ParallelQuery<int>> labeled, int count)
         {
             ParallelQuery<int> query = labeled.Item;
@@ -163,7 +163,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(Sources.Ranges), (object)(new int[] { 1024 * 4, 1024 * 512 }), MemberType = typeof(Sources))]
+        [MemberData(nameof(Sources.Ranges), new[] { 1024 * 4, 1024 * 512 }, MemberType = typeof(Sources))]
         public static void Where_Indexed_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> labeled, int count)
         {
             Where_Indexed_NotPipelined(labeled, count);

--- a/src/System.Linq.Parallel/tests/QueryOperators/ZipTests.cs
+++ b/src/System.Linq.Parallel/tests/QueryOperators/ZipTests.cs
@@ -48,7 +48,7 @@ namespace System.Linq.Parallel.Tests
         }
 
         [Theory]
-        [MemberData(nameof(ZipUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(ZipUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void Zip_Unordered(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -66,14 +66,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ZipUnorderedData), (object)(new int[] { 1024 * 4, 1024 * 64 }))]
+        [MemberData(nameof(ZipUnorderedData), new[] { 1024 * 4, 1024 * 64 })]
         public static void Zip_Unordered_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Zip_Unordered(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(ZipData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(ZipData), new[] { 0, 1, 2, 16 })]
         public static void Zip(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -89,14 +89,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ZipData), (object)(new int[] { 1024 * 4, 1024 * 64 }))]
+        [MemberData(nameof(ZipData), new[] { 1024 * 4, 1024 * 64 })]
         public static void Zip_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Zip(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(ZipUnorderedData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(ZipUnorderedData), new[] { 0, 1, 2, 16 })]
         public static void Zip_Unordered_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -115,14 +115,14 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ZipUnorderedData), (object)(new int[] { 1024 * 4, 1024 * 64 }))]
+        [MemberData(nameof(ZipUnorderedData), new[] { 1024 * 4, 1024 * 64 })]
         public static void Zip_Unordered_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Zip_Unordered_NotPipelined(left, leftCount, right, rightCount);
         }
 
         [Theory]
-        [MemberData(nameof(ZipData), (object)(new int[] { 0, 1, 2, 16 }))]
+        [MemberData(nameof(ZipData), new[] { 0, 1, 2, 16 })]
         public static void Zip_NotPipelined(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             ParallelQuery<int> leftQuery = left.Item;
@@ -139,7 +139,7 @@ namespace System.Linq.Parallel.Tests
 
         [Theory]
         [OuterLoop]
-        [MemberData(nameof(ZipData), (object)(new int[] { 1024 * 4, 1024 * 64 }))]
+        [MemberData(nameof(ZipData), new[] { 1024 * 4, 1024 * 64 })]
         public static void Zip_NotPipelined_Longrunning(Labeled<ParallelQuery<int>> left, int leftCount, Labeled<ParallelQuery<int>> right, int rightCount)
         {
             Zip_NotPipelined(left, leftCount, right, rightCount);


### PR DESCRIPTION
When the `nameof` update was applied to the PLINQ tests, it referenced the wrong source class in some cases (this would only have broken things if the method was renamed).

This change also removes casting to `object` for source test data (this was previously necessary due to xUnit limitations, but is no longer required).