### PR TITLE
Multiple System.Console fixes

### DIFF
--- a/src/Common/src/Interop/Unix/System.Native/Interop.GetControlCharacters.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.GetControlCharacters.cs
@@ -10,8 +10,8 @@ internal static partial class Interop
     {
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_GetControlCharacters")]
         internal static extern void GetControlCharacters(
-            ControlCharacterNames[] controlCharacterNames, byte[] controlCharacterValues, 
-            int controlCharacterLength);
+            ControlCharacterNames[] controlCharacterNames, byte[] controlCharacterValues, int controlCharacterLength,
+            out byte posixDisableValue);
 
         internal enum ControlCharacterNames : int
         {

--- a/src/Common/src/Interop/Unix/System.Native/Interop.InitializeConsole.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.InitializeConsole.cs
@@ -8,7 +8,10 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_InitializeConsole")]
-        internal static extern void InitializeConsole();
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_InitializeConsole", SetLastError = true)]
+        internal static extern bool InitializeConsole();
+
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_SetKeypadXmit")]
+        internal static extern void SetKeypadXmit(string terminfoString);
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.ReadStdinUnbuffered.cs
@@ -9,7 +9,13 @@ internal static partial class Interop
 {
     internal static partial class Sys
     {
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReadStdinUnbuffered", SetLastError = true)]
-        internal unsafe static extern int ReadStdinUnbuffered(byte* buffer, int bufferSize);
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_ReadStdin", SetLastError = true)]
+        internal unsafe static extern int ReadStdin(byte* buffer, int bufferSize);
+
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_InitializeConsoleBeforeRead")]
+        internal unsafe static extern void InitializeConsoleBeforeRead(byte minChars = 1, byte decisecondsTimeout = 0);
+
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_UninitializeConsoleAfterRead")]
+        internal unsafe static extern void UninitializeConsoleAfterRead();
     }
 }

--- a/src/Common/src/Interop/Unix/System.Native/Interop.RegisterForCtrlC.cs
+++ b/src/Common/src/Interop/Unix/System.Native/Interop.RegisterForCtrlC.cs
@@ -16,8 +16,8 @@ internal partial class Interop
 
         internal delegate bool CtrlCallback(CtrlCode ctrlCode);
 
-        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_RegisterForCtrl", SetLastError = true)]
-        internal static extern bool RegisterForCtrl(CtrlCallback handler);
+        [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_RegisterForCtrl")]
+        internal static extern void RegisterForCtrl(CtrlCallback handler);
 
         [DllImport(Libraries.SystemNative, EntryPoint = "SystemNative_UnregisterForCtrl")]
         internal static extern void UnregisterForCtrl();

--- a/src/Native/System.Native/pal_console.cpp
+++ b/src/Native/System.Native/pal_console.cpp
@@ -41,7 +41,7 @@ extern "C" int32_t SystemNative_IsATty(intptr_t fd)
     return isatty(ToFileDescriptor(fd));
 }
 
-static char* g_keypadXmit; // string used to enable application mode, from terminfo
+static char* g_keypadXmit = nullptr; // string used to enable application mode, from terminfo
 
 static void WriteKeypadXmit() // used in a signal handler, must be signal-safe
 {

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -98,9 +98,9 @@ namespace System
                 throw new InvalidOperationException(SR.InvalidOperation_ConsoleReadKeyOnFile);
             }
 
-            ConsoleKeyInfo keyInfo = StdInReader.ReadKey();
-            if (!intercept) Console.Write(keyInfo.KeyChar);
-
+            bool previouslyProcessed;
+            ConsoleKeyInfo keyInfo = StdInReader.ReadKey(out previouslyProcessed);
+            if (!intercept && !previouslyProcessed) Console.Write(keyInfo.KeyChar);
             return keyInfo;
         }
 
@@ -322,41 +322,49 @@ namespace System
                 // Write out the cursor position report request.
                 WriteStdoutAnsiString(TerminalFormatStrings.CursorPositionReport);
 
-                // Read the response.  There's a race condition here if the user is typing,
-                // or if other threads are accessing the console; there's relatively little
-                // we can do about that, but we try not to lose any data.
-                StdInStreamReader r = StdInReader.Inner;
-                const int BufferSize = 1024;
-                byte* bytes = stackalloc byte[BufferSize];
+                Interop.Sys.InitializeConsoleBeforeRead(minChars: 0, decisecondsTimeout: 10);
+                try
+                {
+                    // Read the response.  There's a race condition here if the user is typing,
+                    // or if other threads are accessing the console; there's relatively little
+                    // we can do about that, but we try not to lose any data.
+                    StdInStreamReader r = StdInReader.Inner;
+                    const int BufferSize = 1024;
+                    byte* bytes = stackalloc byte[BufferSize];
 
-                int bytesRead = 0, i = 0;
+                    int bytesRead = 0, i = 0;
 
-                // Response expected in the form "\ESC[row;colR".  However, user typing concurrently
-                // with the request/response sequence can result in other characters, and potentially
-                // other escape sequences (e.g. for an arrow key) being entered concurrently with
-                // the response.  To avoid garbage showing up in the user's input, we are very liberal
-                // with regards to eating all input from this point until all aspects of the sequence
-                // have been consumed.  
+                    // Response expected in the form "\ESC[row;colR".  However, user typing concurrently
+                    // with the request/response sequence can result in other characters, and potentially
+                    // other escape sequences (e.g. for an arrow key) being entered concurrently with
+                    // the response.  To avoid garbage showing up in the user's input, we are very liberal
+                    // with regards to eating all input from this point until all aspects of the sequence
+                    // have been consumed.  
 
-                // Find the ESC as the start of the sequence.
-                ReadStdinUnbufferedUntil(r, bytes, BufferSize, ref bytesRead, ref i, b => b == 0x1B);
-                i++; // move past the ESC
+                    // Find the ESC as the start of the sequence.
+                    if (!ReadStdinUntil(r, bytes, BufferSize, ref bytesRead, ref i, b => b == 0x1B)) return;
+                    i++; // move past the ESC
 
-                // Find the '['
-                ReadStdinUnbufferedUntil(r, bytes, BufferSize, ref bytesRead, ref i, b => b == '[');
+                    // Find the '['
+                    if (!ReadStdinUntil(r, bytes, BufferSize, ref bytesRead, ref i, b => b == '[')) return;
 
-                // Find the first Int32 and parse it.
-                ReadStdinUnbufferedUntil(r, bytes, BufferSize, ref bytesRead, ref i, b => IsDigit((char)b));
-                int row = ParseInt32(bytes, bytesRead, ref i);
-                if (row >= 1) top = row - 1;
+                    // Find the first Int32 and parse it.
+                    if (!ReadStdinUntil(r, bytes, BufferSize, ref bytesRead, ref i, b => IsDigit((char)b))) return;
+                    int row = ParseInt32(bytes, bytesRead, ref i);
+                    if (row >= 1) top = row - 1;
 
-                // Find the second Int32 and parse it.
-                ReadStdinUnbufferedUntil(r, bytes, BufferSize, ref bytesRead, ref i, b => IsDigit((char)b));
-                int col = ParseInt32(bytes, bytesRead, ref i);
-                if (col >= 1) left = col - 1;
+                    // Find the second Int32 and parse it.
+                    if (!ReadStdinUntil(r, bytes, BufferSize, ref bytesRead, ref i, b => IsDigit((char)b))) return;
+                    int col = ParseInt32(bytes, bytesRead, ref i);
+                    if (col >= 1) left = col - 1;
 
-                // Find the ending 'R'
-                ReadStdinUnbufferedUntil(r, bytes, BufferSize, ref bytesRead, ref i, b => b == 'R');
+                    // Find the ending 'R'
+                    if (!ReadStdinUntil(r, bytes, BufferSize, ref bytesRead, ref i, b => b == 'R')) return;
+                }
+                finally
+                {
+                    Interop.Sys.UninitializeConsoleAfterRead();
+                }
             }
         }
 
@@ -371,7 +379,8 @@ namespace System
         }
 
         /// <summary>Reads from the stdin reader, unbuffered, until the specified condition is met.</summary>
-        private static unsafe void ReadStdinUnbufferedUntil(
+        /// <returns>true if the condition was met; otherwise, false.</returns>
+        private static unsafe bool ReadStdinUntil(
             StdInStreamReader reader, 
             byte* buffer, int bufferSize, 
             ref int bytesRead, ref int pos, 
@@ -380,9 +389,10 @@ namespace System
             while (true)
             {
                 for (; pos < bytesRead && !condition(buffer[pos]); pos++) ;
-                if (pos < bytesRead) return;
+                if (pos < bytesRead) return true;
 
-                bytesRead = reader.ReadStdinUnbuffered(buffer, bufferSize);
+                bytesRead = reader.ReadStdin(buffer, bufferSize);
+                if (bytesRead == 0) return false;
                 pos = 0;
             }
         }
@@ -581,7 +591,7 @@ namespace System
             {
                 // Is this an erase / backspace?
                 char c = givenChars[startIndex];
-                if (c != 0 && c == s_veraseCharacter)
+                if (c != s_posixDisableValue && c == s_veraseCharacter)
                 {
                     key = new ConsoleKeyInfo(c, ConsoleKey.Backspace, shift: false, alt: false, control: false);
                     keyLength = 1;
@@ -617,10 +627,18 @@ namespace System
         /// <summary>Whether keypad_xmit has already been written out to the terminal.</summary>
         private static volatile bool s_initialized;
 
+        /// <summary>Value used to indicate that a special character code isn't available.</summary>
+        internal static byte s_posixDisableValue;
         /// <summary>Special control character code used to represent an erase (backspace).</summary>
         private static byte s_veraseCharacter;
+        /// <summary>Special control character that represents the end of a line.</summary>
+        internal static byte s_veolCharacter;
+        /// <summary>Special control character that represents the end of a line.</summary>
+        internal static byte s_veol2Character;
+        /// <summary>Special control character that represents the end of a file.</summary>
+        internal static byte s_veofCharacter;
 
-        /// <summary>Ensures that the console has been initialized for reading.</summary>
+        /// <summary>Ensures that the console has been initialized for use.</summary>
         private static void EnsureInitialized()
         {
             if (!s_initialized)
@@ -629,28 +647,44 @@ namespace System
             }
         }
 
-        /// <summary>Ensures that the console has been initialized for reading.</summary>
+        /// <summary>Ensures that the console has been initialized for use.</summary>
         private static void EnsureInitializedCore()
         {
             lock (Console.Out) // ensure that writing the ANSI string and setting initialized to true are done atomically
             {
                 if (!s_initialized)
                 {
-                    // Ensure the console is configured appropriately
-                    Interop.Sys.InitializeConsole();
-
-                    // Load special control character codes used for input processing
-                    var controlCharacterNames = new[] { Interop.Sys.ControlCharacterNames.VERASE };
-                    var controlCharacterValues = new byte[controlCharacterNames.Length];
-                    Interop.Sys.GetControlCharacters(controlCharacterNames, controlCharacterValues, controlCharacterNames.Length);
-                    s_veraseCharacter = controlCharacterValues[0];
-
-                    // Make sure it's in application mode
-                    if (!Console.IsOutputRedirected)
+                    // Ensure the console is configured appropriately.  This will start
+                    // signal handlers, etc.
+                    if (!Interop.Sys.InitializeConsole())
                     {
-                        WriteStdoutAnsiString(TerminalFormatStrings.Instance.KeypadXmit);
+                        throw Interop.GetExceptionForIoErrno(Interop.Sys.GetLastErrorInfo());
                     }
 
+                    // Provide the native lib with the correct code from the terminfo to transition us into
+                    // "application mode".  This will both transition it immediately, as well as allow
+                    // the native lib later to handle signals that require re-entering the mode.
+                    if (!Console.IsOutputRedirected)
+                    {
+                        Interop.Sys.SetKeypadXmit(TerminalFormatStrings.Instance.KeypadXmit);
+                    }
+
+                    // Load special control character codes used for input processing
+                    var controlCharacterNames = new Interop.Sys.ControlCharacterNames[4] 
+                    {
+                        Interop.Sys.ControlCharacterNames.VERASE,
+                        Interop.Sys.ControlCharacterNames.VEOL,
+                        Interop.Sys.ControlCharacterNames.VEOL2,
+                        Interop.Sys.ControlCharacterNames.VEOF
+                    };
+                    var controlCharacterValues = new byte[controlCharacterNames.Length];
+                    Interop.Sys.GetControlCharacters(controlCharacterNames, controlCharacterValues, controlCharacterNames.Length, out s_posixDisableValue);
+                    s_veraseCharacter = controlCharacterValues[0];
+                    s_veolCharacter = controlCharacterValues[1];
+                    s_veol2Character = controlCharacterValues[2];
+                    s_veofCharacter = controlCharacterValues[3];
+
+                    // Mark us as initialized
                     s_initialized = true;
                 }
             }
@@ -1045,11 +1079,10 @@ namespace System
 
             internal void Register()
             {
+                EnsureInitialized();
+
                 Debug.Assert(!_handlerRegistered);
-                if (!Interop.Sys.RegisterForCtrl(_handler))
-                {
-                    throw Interop.GetExceptionForIoErrno(Interop.Sys.GetLastErrorInfo());
-                }
+                Interop.Sys.RegisterForCtrl(_handler);
                 _handlerRegistered = true;
             }
 

--- a/src/System.Console/src/System/ConsolePal.Unix.cs
+++ b/src/System.Console/src/System/ConsolePal.Unix.cs
@@ -319,12 +319,12 @@ namespace System
             // one thread's get_CursorLeft/Top from providing input to the other's Console.Read*.
             lock (StdInReader) 
             {
-                // Write out the cursor position report request.
-                WriteStdoutAnsiString(TerminalFormatStrings.CursorPositionReport);
-
                 Interop.Sys.InitializeConsoleBeforeRead(minChars: 0, decisecondsTimeout: 10);
                 try
                 {
+                    // Write out the cursor position report request.
+                    WriteStdoutAnsiString(TerminalFormatStrings.CursorPositionReport);
+
                     // Read the response.  There's a race condition here if the user is typing,
                     // or if other threads are accessing the console; there's relatively little
                     // we can do about that, but we try not to lose any data.
@@ -666,7 +666,11 @@ namespace System
                     // the native lib later to handle signals that require re-entering the mode.
                     if (!Console.IsOutputRedirected)
                     {
-                        Interop.Sys.SetKeypadXmit(TerminalFormatStrings.Instance.KeypadXmit);
+                        string keypadXmit = TerminalFormatStrings.Instance.KeypadXmit;
+                        if (keypadXmit != null)
+                        {
+                            Interop.Sys.SetKeypadXmit(keypadXmit);
+                        }
                     }
 
                     // Load special control character codes used for input processing

--- a/src/System.Console/src/System/IO/SyncTextReader.Unix.cs
+++ b/src/System.Console/src/System/IO/SyncTextReader.Unix.cs
@@ -21,11 +21,11 @@ namespace System.IO
             }
         }
 
-        public ConsoleKeyInfo ReadKey()
+        public ConsoleKeyInfo ReadKey(out bool previouslyProcessed)
         {
             lock (this)
             {
-                return Inner.ReadKey();
+                return Inner.ReadKey(out previouslyProcessed);
             }
         }
 
@@ -36,7 +36,7 @@ namespace System.IO
                 lock (this)
                 {
                     StdInStreamReader r = Inner;
-                    return !r.IsExtraBufferEmpty() || r.StdinReady;
+                    return !r.IsUnprocessedBufferEmpty() || r.StdinReady;
                 }
             }
         }


### PR DESCRIPTION
- Lifetime of terminal attribute settings. Previously we were setting up the terminal's attributes (e.g. disabling echo) the first time the console was used, and leaving those settings for the duration of the process.  This has the very bad effect of leaving such settings on the terminal while other code using that terminal runs.  For example, if you launch a process with Process.Start and that process expects input, echo will still be disabled, and you won't be able to see the input.  This commit changes how we do these attributes.  Instead of setting them and leaving them, we only set them while a read operation is in progress, reverting the settings immediately after.  (This does mean that typing prior to a call to Console.ReadKey(intecept: true) will yield visible text, an unfortunate tradeoff, but it seems to be the better of the options.)

- Reapplication of terminal settings upon process resumption.  If the program was suspended with ctrl-z, when it was later resumed, both terminal settings and the application mode settings previously applied were lost.  With this commit, we now properly restore the application mode (which impacts how some keys, such as the arrows, are interpreted).  And if a read was in progress, we also restore the terminal settings.

- EOL.  Typing ctrl-D is supposed to signal an end-of-line.  Previously we weren't doing anything special for it.  Now we look up the EOL characters in the terminal settings and act on them appropriately.

- Console.Read.  This method, like ReadLine, is supposed to block until Enter, but it was only blocking until the first byte was available.  This commit fixes that.  It also makes it respond appropriately to EOL by returning -1.

- Cursor position robustness.  The protocol involved in getting the current cursor position involves writing an escape sequence to stdout and then reading a response that's written by the terminal to stdin.  Since the user can also be providing stdin input concurrently, this can lead to some flakiness, and with the current implementation, if we were to miss some of the input that comes from the terminal, we could end up hanging, waiting indefinitely for that input to arrive.  This commit adds a timeout so we'll only wait for a second on each read before giving up.

cc: @pallavit, @ellismg, @andschwa, @janvorli 
Fixes #5902 
Relies on https://github.com/dotnet/coreclr/pull/3409

@andschwa, I'd appreciate it if you could run this through a variety of your scenarios and verify it does what you hope.