### PR TITLE
Avoid allocations in the default LowLevelDictionary constructor

### DIFF
--- a/src/Common/src/System/Collections/Generic/LowLevelDictionary.cs
+++ b/src/Common/src/System/Collections/Generic/LowLevelDictionary.cs
@@ -26,12 +26,12 @@ namespace System.Collections.Generic
         private const int DefaultSize = 17;
 
         public LowLevelDictionary()
-            : this(DefaultSize, DefaultComparer)
+            : this(DefaultSize, DefaultComparer<TKey>.Cached)
         {
         }
 
         public LowLevelDictionary(int capacity)
-            : this(capacity, DefaultComparer)
+            : this(capacity, DefaultComparer<TKey>.Cached)
         {
         }
 
@@ -229,39 +229,26 @@ namespace System.Collections.Generic
         private int _version;
         private IEqualityComparer<TKey> _comparer;
 
-        // This comparator is used if no comparator is supplied. It emulates the behavior of EqualityComparer<T>.Default
-        // when T implements IEquatable<T>.
-        private sealed class DefaultComparerForIEquatable : IEqualityComparer<TKey>
+        // This comparator is used if no comparator is supplied. It emulates the behavior of EqualityComparer<T>.Default.
+        private sealed class DefaultComparer<T> : IEqualityComparer<T>
         {
-            public bool Equals(TKey x, TKey y)
+            public static readonly DefaultComparer<T> Cached = new DefaultComparer<T>();
+            
+            public bool Equals(T x, T y)
             {
-                return x == null ? y == null : ((IEquatable<TKey>)x).Equals(y);
+                if (x == null)
+                    return y == null;
+                IEquatable<T> iequatable = x as IEquatable<T>;
+                if (iequatable != null)
+                    return iequatable.Equals(y);
+                return ((object)x).Equals(y);
             }
 
-            public int GetHashCode(TKey obj)
+            public int GetHashCode(T obj)
             {
-                return obj.GetHashCode();
+                return ((object)obj).GetHashCode();
             }
         }
-        // This comparator is used if no comparator is supplied. It emulates the behavior of EqualityComparer<T>.Default
-        // when T does not implement IEquatable<T>.
-        private sealed class DefaultComparerForNotIEquatable : IEqualityComparer<TKey>
-        {
-            public bool Equals(TKey x, TKey y)
-            {
-                return x == null ? y == null : x.Equals(y);
-            }
-
-            public int GetHashCode(TKey obj)
-            {
-                return obj.GetHashCode();
-            }
-        }
-        
-        private static readonly IEqualityComparer<TKey> DefaultComparer = 
-            typeof(IEquatable<TKey>).GetTypeInfo().IsAssignableFrom(typeof(TKey)) ? 
-            (IEqualityComparer<TKey>)new DefaultComparerForIEquatable() : 
-            new DefaultComparerForNotIEquatable();
 
         protected sealed class LowLevelDictEnumerator : IEnumerator<KeyValuePair<TKey, TValue>>
         {

--- a/src/Common/src/System/Collections/Generic/LowLevelDictionary.cs
+++ b/src/Common/src/System/Collections/Generic/LowLevelDictionary.cs
@@ -258,7 +258,10 @@ namespace System.Collections.Generic
             }
         }
         
-        private static readonly IEqualityComparer<TKey> DefaultComparer = typeof(IEquatable<TKey>).IsAssignableFrom(typeof(TKey)) ? (IEqualityComparer<TKey>)new DefaultComparerForIEquatable() : new DefaultComparerForNotIEquatable();
+        private static readonly IEqualityComparer<TKey> DefaultComparer = 
+            typeof(IEquatable<TKey>).GetTypeInfo().IsAssignableFrom(typeof(TKey)) ? 
+            (IEqualityComparer<TKey>)new DefaultComparerForIEquatable() : 
+            new DefaultComparerForNotIEquatable();
 
         protected sealed class LowLevelDictEnumerator : IEnumerator<KeyValuePair<TKey, TValue>>
         {


### PR DESCRIPTION
Cherrypicked from #3029. Basically, this change caches a default comparer for the `LowLevelDictionary<K, V>` constructor, so one isn't allocated every time it is called. (Of course, a new comparer will still have to be instantiated for every generic specialization of `K`.)